### PR TITLE
Add timestamp to long

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/ToLongTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/ToLongTimestampFunctionFactory.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.cast;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.engine.functions.LongFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.LongConstant;
+import io.questdb.std.ObjList;
+
+public class ToLongTimestampFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_long(N)";
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
+        Function var = args.getQuick(0);
+        if (var.isConstant()) {
+            return new LongConstant(position, var.getTimestamp(null));
+        }
+        return new Func(position, var);
+    }
+
+    private static class Func extends LongFunction implements UnaryFunction {
+        private final Function arg;
+
+        public Func(int position, Function arg) {
+            super(position);
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public long getLong(Record rec) {
+            return arg.getTimestamp(rec);
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -260,6 +260,7 @@ io.questdb.griffin.engine.functions.cast.ToDateLongFunctionFactory
 io.questdb.griffin.engine.functions.cast.ToTimestampLongFunctionFactory
 io.questdb.griffin.engine.functions.cast.ToIntDoubleFunctionFactory
 io.questdb.griffin.engine.functions.cast.ToIntLongFunctionFactory
+io.questdb.griffin.engine.functions.cast.ToLongTimestampFunctionFactory
 
 # 'in'
 io.questdb.griffin.engine.functions.str.SymbolInCursorFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/functions/cast/ToLongTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/cast/ToLongTimestampFunctionFactoryTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.cast;
+
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.griffin.CompiledQuery;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.griffin.engine.functions.rnd.SharedRandom;
+import io.questdb.std.Numbers;
+import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+public class ToLongTimestampFunctionFactoryTest extends AbstractFunctionFactoryTest {
+    static long testValue = 1262596503400000L;
+
+    @Test
+    public void testNan() throws SqlException {
+        call(Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN);
+    }
+
+    @Test
+    public void testLong() throws SqlException {
+        call(testValue).andAssert(testValue);
+    }
+
+    @Test
+    public void testFullQuery() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            CompiledQuery res = compiler.compile("select to_long(to_timestamp(" + testValue  + "L)) from long_sequence(1)");
+            RecordCursor cursor = res.getRecordCursorFactory().getCursor();
+            Record record = cursor.getRecord();
+            assert record.getLong(0) == testValue;
+            engine.releaseAllWriters();
+            engine.releaseAllReaders();
+        });
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new ToLongTimestampFunctionFactory();
+    }
+}


### PR DESCRIPTION
Add web console `to_long` function. Tested with `select to_long(to_timestamp(1262596503400000L)) from long_sequence(1)`