### PR TITLE
refactoring add_period(NAI) to dateadd(AIN)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/DateAddFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/DateAddFunctionFactory.java
@@ -37,86 +37,85 @@ import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.microtime.Timestamps;
 
-public class AddPeriodToTimestampFunctionFactory implements FunctionFactory {
+public class DateAddFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "add_period(NAI)";
+        return "dateadd(AIN)";
     }
 
     @Override
     public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
 
-        Function period = args.getQuick(1);
-        Function interval = args.getQuick(2);
+        Function period = args.getQuick(0);
+        Function interval = args.getQuick(1);
         if (period.isConstant()) {
             char periodValue = period.getChar(null);
             if (periodValue == 's') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncSecondConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncSecondConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncSecondConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncSecondConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'm') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncMinuteConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncMinuteConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncMinuteConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncMinuteConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'h') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncHourConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncHourConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncHourConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncHourConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'd') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncDayConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncDayConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncDayConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncDayConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'w') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncWeekConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncWeekConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncWeekConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncWeekConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'M') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncMonthConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncMonthConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncMonthConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncMonthConstant(position, args.getQuick(2), args.getQuick(1));
             }
             if (periodValue == 'y') {
                 if (interval.isConstant()) {
                     if (interval.getInt(null) != Numbers.INT_NaN) {
-                        return new AddLongFuncYearConstantPeriodConstant(position, args.getQuick(0), interval.getInt(null));
+                        return new AddLongFuncYearConstantPeriodConstant(position, args.getQuick(2), interval.getInt(null));
                     }
                     return new TimestampConstant(position, Numbers.LONG_NaN);
                 }
-                return new AddLongFuncYearConstant(position, args.getQuick(0), args.getQuick(2));
+                return new AddLongFuncYearConstant(position, args.getQuick(2), args.getQuick(1));
             }
-            return new AddLongFunc(position, args.getQuick(0), args.getQuick(1), args.getQuick(2));
+            return new AddLongFunc(position, args.getQuick(2), args.getQuick(0), args.getQuick(1));
         }
-
-        return new AddLongFunc(position, args.getQuick(0), args.getQuick(1), args.getQuick(2));
+        return new AddLongFunc(position, args.getQuick(2), args.getQuick(0), args.getQuick(1));
     }
 
     private static class AddLongFuncSecondConstant extends TimestampFunction implements BinaryFunction {

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -203,7 +203,7 @@ io.questdb.griffin.engine.functions.date.DaysBetweenFunctionFactory
 io.questdb.griffin.engine.functions.date.MonthsBetweenFunctionFactory
 io.questdb.griffin.engine.functions.date.YearsBetweenFunctionFactory
 io.questdb.griffin.engine.functions.date.IsLeapYearFunctionFactory
-io.questdb.griffin.engine.functions.date.AddPeriodToTimestampFunctionFactory
+io.questdb.griffin.engine.functions.date.DateAddFunctionFactory
 
 
 io.questdb.griffin.engine.functions.date.ToDateFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/DateAddFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/DateAddFunctionFactoryTest.java
@@ -30,171 +30,171 @@ import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
 import io.questdb.std.Numbers;
 import org.junit.Test;
 
-public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class DateAddFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
 
     @Test
     public void testDaySimple() throws SqlException {
-        call(1587275359886758L, 'd', 5).andAssert(1587707359886758L, 0.0001);
+        call('d', 5, 1587275359886758L).andAssert(1587707359886758L, 0.0001);
     }
 
     @Test
     public void testWeekSimple() throws SqlException {
-        call(1587275359886758L, 'w', 5).andAssert(1590299359886758L, 0.0001);
+        call('w', 5, 1587275359886758L).andAssert(1590299359886758L, 0.0001);
     }
 
     @Test
     public void testHourSimple() throws SqlException {
-        call(1587275359886758L, 'h', 5).andAssert(1587293359886758L, 0.0001);
+        call('h', 5, 1587275359886758L).andAssert(1587293359886758L, 0.0001);
     }
 
     @Test
     public void testSecondSimple() throws SqlException {
-        call(1587275359886758L, 's', 5).andAssert(1587275364886758L, 0.0001);
+        call('s', 5, 1587275359886758L).andAssert(1587275364886758L, 0.0001);
     }
 
     @Test
     public void testMinuteSimple() throws SqlException {
-        call(1587275359886758L, 'm', 5).andAssert(1587275659886758L, 0.0001);
+        call('m', 5, 1587275359886758L).andAssert(1587275659886758L, 0.0001);
     }
 
     @Test
     public void testMonthSimple() throws SqlException {
-        call(1587275359886758L, 'M', 5).andAssert(1600494559886758L, 0.0001);
+        call('M', 5, 1587275359886758L).andAssert(1600494559886758L, 0.0001);
     }
 
     @Test
     public void testYearsSimple() throws SqlException {
-        call(1587275359886758L, 'y', 5).andAssert(1745041759886758L, 0.0001);
+        call('y', 5, 1587275359886758L).andAssert(1745041759886758L, 0.0001);
     }
 
     @Test
     public void testDaySimpleNeg() throws SqlException {
-        call(1587275359886758L, 'd', -5).andAssert(1586843359886758L, 0.0001);
+        call('d', -5, 1587275359886758L).andAssert(1586843359886758L, 0.0001);
     }
 
     @Test
     public void testWeekSimpleNeg() throws SqlException {
-        call(1587275359886758L, 'w', -5).andAssert(1584251359886758L, 0.0001);
+        call('w', -5, 1587275359886758L).andAssert(1584251359886758L, 0.0001);
     }
 
     @Test
     public void testHourSimpleNeg() throws SqlException {
-        call(1587275359886758L, 'h', -5).andAssert(1587257359886758L, 0.0001);
+        call('h', -5, 1587275359886758L).andAssert(1587257359886758L, 0.0001);
     }
 
     @Test
     public void testSecondSimpleNeg() throws SqlException {
-        call(1587275359886758L, 's', -5).andAssert(1587275354886758L, 0.0001);
+        call('s', -5, 1587275359886758L).andAssert(1587275354886758L, 0.0001);
     }
 
     @Test
     public void testMinuteSimpleNeg() throws SqlException {
-        call(1587275359886758L, 'm', -5).andAssert(1587275059886758L, 0.0001);
+        call('m', -5, 1587275359886758L).andAssert(1587275059886758L, 0.0001);
     }
 
     @Test
     public void testMonthSimpleNeg() throws SqlException {
-        call(1587275359886758L, 'M', -5).andAssert(1574142559886758L, 0.0001);
+        call('M', -5, 1587275359886758L).andAssert(1574142559886758L, 0.0001);
     }
 
     @Test
     public void testYearsSimpleNeg() throws SqlException {
-        call(1587275359886758L, 'y', -5).andAssert(1429422559886758L, 0.0001);
+        call('y', -5, 1587275359886758L).andAssert(1429422559886758L, 0.0001);
     }
 
     @Test
     public void testLeftNan() throws SqlException {
-        call(Numbers.LONG_NaN, 'd', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call( 'd', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testCenterEmptyChar() throws SqlException {
-        call(1587275359886758L, Character.MIN_VALUE, 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call( Character.MIN_VALUE, 5, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
     
     @Test
     public void testUnknownPeriod() throws SqlException {
-        call(1587275359886758L, 'q', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('q', 5, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNSecond() throws SqlException {
-        call(1587275359886758L, 's', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('s', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNMinute() throws SqlException {
-        call(1587275359886758L, 'm', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('m', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNHour() throws SqlException {
-        call(1587275359886758L, 'h', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('h', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNDay() throws SqlException {
-        call(1587275359886758L, 'd', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('d', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNWeek() throws SqlException {
-        call(1587275359886758L, 'w', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('w', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNMonth() throws SqlException {
-        call(1587275359886758L, 'M', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('M', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testRightNaNYear() throws SqlException {
-        call(1587275359886758L, 'y', Numbers.INT_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('y', Numbers.INT_NaN, 1587275359886758L).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNSecond() throws SqlException {
-        call(Numbers.LONG_NaN, 's', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('s', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNMinute() throws SqlException {
-        call(Numbers.LONG_NaN, 'm', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('m', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNHour() throws SqlException {
-        call(Numbers.LONG_NaN, 'h', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('h', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNDay() throws SqlException {
-        call(Numbers.LONG_NaN, 'd', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('d', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNWeek() throws SqlException {
-        call(Numbers.LONG_NaN, 'w', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('w', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNMonth() throws SqlException {
-        call(Numbers.LONG_NaN, 'M', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('M', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testLeftNaNYear() throws SqlException {
-        call(Numbers.LONG_NaN, 'y', 5).andAssert(Numbers.LONG_NaN, 0.0001);
+        call('y', 5, Numbers.LONG_NaN).andAssert(Numbers.LONG_NaN, 0.0001);
     }
 
     @Test
     public void testIntervalConstantPeriodVariableSecondLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 's', cast(x as int)) from long_sequence(2)",
+                "select dateadd('s', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -203,10 +203,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableMinuteLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'm', cast(x as int)) from long_sequence(2)",
+                "select dateadd('m', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -215,10 +215,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableHourLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'h', cast(x as int)) from long_sequence(2)",
+                "select dateadd('h', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -227,10 +227,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableDayLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'd', cast(x as int)) from long_sequence(2)",
+                "select dateadd('d', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -239,10 +239,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableWeekLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'w', cast(x as int)) from long_sequence(2)",
+                "select dateadd('w', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -251,10 +251,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableMonthLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'M', cast(x as int)) from long_sequence(2)",
+                "select dateadd('M', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -263,10 +263,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableYearLeftNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "\n" +
                         "\n",
-                "select add_period(Cast(NaN as Long), 'y', cast(x as int)) from long_sequence(2)",
+                "select dateadd('y', cast(x as int), Cast(NaN as Long)) from long_sequence(2)",
                 null,
                 true
         );
@@ -275,10 +275,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableSecondRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-04-19T05:49:20.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 's', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('s', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -287,10 +287,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableMinuteRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-04-19T05:50:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'm', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('m', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -299,10 +299,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableHourRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-04-19T06:49:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'h', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('h', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -311,10 +311,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableDayRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-04-20T05:49:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'd', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('d', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -323,10 +323,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableWeekRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-04-26T05:49:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'w', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('w', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -335,10 +335,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableMonthRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2020-05-19T05:49:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'M', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('M', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -347,10 +347,10 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
     @Test
     public void testIntervalConstantPeriodVariableYearRightNaN() throws SqlException {
         assertQuery(
-                "add_period\n" +
+                "dateadd\n" +
                         "2021-04-19T05:49:19.886758Z\n" +
                         "\n",
-                "select add_period(1587275359886758L, 'y', case when x = 1 then cast(x as int) else Cast(NaN as int) end) from long_sequence(2)",
+                "select dateadd('y', case when x = 1 then cast(x as int) else Cast(NaN as int) end, 1587275359886758L) from long_sequence(2)",
                 null,
                 true
         );
@@ -358,7 +358,7 @@ public class AddPeriodToTimestampFunctionFactoryTest extends AbstractFunctionFac
 
     @Override
     protected FunctionFactory getFunctionFactory() {
-        return new AddPeriodToTimestampFunctionFactory();
+        return new DateAddFunctionFactory();
     }
 
 }


### PR DESCRIPTION
Refactoring to match function name and argument order used by sql server. So 
`add_period(systimestamp(), 'd', 5)` becomes `dateadd('d', 5, systimestamp())`. 
