### PR TITLE
fix(griffin): few SQL fixes detailed below

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReaderSelectedColumnRecordCursor.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderSelectedColumnRecordCursor.java
@@ -70,7 +70,7 @@ public class TableReaderSelectedColumnRecordCursor implements RecordCursor {
 
     @Override
     public boolean hasNext() {
-        if (recordA.getRecordIndex() < maxRecordIndex || switchPartition()) {
+        if (recordA.getAdjustedRecordIndex() < maxRecordIndex || switchPartition()) {
             recordA.incrementRecordIndex();
             return true;
         }

--- a/core/src/main/java/io/questdb/cairo/sql/Record.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Record.java
@@ -30,6 +30,10 @@ import io.questdb.std.str.CharSink;
 
 public interface Record {
 
+    CharSequenceFunction GET_STR = Record::getStr;
+
+    CharSequenceFunction GET_SYM = Record::getSym;
+
     default BinarySequence getBin(int col) {
         throw new UnsupportedOperationException();
     }
@@ -43,6 +47,10 @@ public interface Record {
     }
 
     default byte getByte(int col) {
+        throw new UnsupportedOperationException();
+    }
+
+    default char getChar(int col) {
         throw new UnsupportedOperationException();
     }
 
@@ -66,26 +74,6 @@ public interface Record {
         throw new UnsupportedOperationException();
     }
 
-    default long getRowId() {
-        throw new UnsupportedOperationException();
-    }
-
-    default short getShort(int col) {
-        throw new UnsupportedOperationException();
-    }
-
-    default char getChar(int col) {
-        throw new UnsupportedOperationException();
-    }
-
-    default CharSequence getStr(int col) {
-        throw new UnsupportedOperationException();
-    }
-
-    default void getStr(int col, CharSink sink) {
-        sink.put(getStr(col));
-    }
-
     default void getLong256(int col, CharSink sink) {
         throw new UnsupportedOperationException();
     }
@@ -96,6 +84,22 @@ public interface Record {
 
     default Long256 getLong256B(int col) {
         throw new UnsupportedOperationException();
+    }
+
+    default long getRowId() {
+        throw new UnsupportedOperationException();
+    }
+
+    default short getShort(int col) {
+        throw new UnsupportedOperationException();
+    }
+
+    default CharSequence getStr(int col) {
+        throw new UnsupportedOperationException();
+    }
+
+    default void getStr(int col, CharSink sink) {
+        sink.put(getStr(col));
     }
 
     default CharSequence getStrB(int col) {
@@ -112,5 +116,10 @@ public interface Record {
 
     default long getTimestamp(int col) {
         return getLong(col);
+    }
+
+    @FunctionalInterface
+    interface CharSequenceFunction {
+        CharSequence get(Record record, int col);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1032,6 +1032,7 @@ public class SqlCompiler implements Closeable {
 
         // lexer would have parsed first token to determine direction of execution flow
         lexer.unparse();
+        codeGenerator.clear();
 
         ExecutionModel executionModel = compileExecutionModel(executionContext);
         switch (executionModel.getModelType()) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/SymbolFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/SymbolFunction.java
@@ -113,22 +113,22 @@ public abstract class SymbolFunction implements Function, SymbolTable {
 
     @Override
     public final CharSequence getStr(Record rec) {
-        return getSymbol(rec);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public final void getStr(Record rec, CharSink sink) {
-        sink.put(getSymbol(rec));
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public final CharSequence getStrB(Record rec) {
-        return getSymbol(rec);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public final int getStrLen(Record rec) {
-        return getSymbol(rec).length();
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
@@ -43,13 +43,15 @@ public class FilterOnSubQueryRecordCursorFactory extends AbstractDataFrameRecord
     private final IntObjHashMap<RowCursorFactory> factoriesB = new IntObjHashMap<>(64, 0.5, -5);
     private final RecordCursorFactory recordCursorFactory;
     private IntObjHashMap<RowCursorFactory> factories;
+    private final Record.CharSequenceFunction func;
 
     public FilterOnSubQueryRecordCursorFactory(
             @NotNull RecordMetadata metadata,
             @NotNull DataFrameCursorFactory dataFrameCursorFactory,
             @NotNull RecordCursorFactory recordCursorFactory,
             int columnIndex,
-            @Nullable Function filter
+            @Nullable Function filter,
+            @NotNull Record.CharSequenceFunction func
     ) {
         super(metadata, dataFrameCursorFactory);
         this.recordCursorFactory = recordCursorFactory;
@@ -58,6 +60,7 @@ public class FilterOnSubQueryRecordCursorFactory extends AbstractDataFrameRecord
         this.factories = factoriesA;
         cursorFactories = new ObjList<>();
         this.cursor = new DataFrameRecordCursor(new HeapRowCursorFactory(cursorFactories), false, filter);
+        this.func = func;
     }
 
     @Override
@@ -92,7 +95,7 @@ public class FilterOnSubQueryRecordCursorFactory extends AbstractDataFrameRecord
         try (RecordCursor cursor = recordCursorFactory.getCursor(executionContext)) {
             final Record record = cursor.getRecord();
             while (cursor.hasNext()) {
-                final CharSequence symbol = record.getStr(0);
+                final CharSequence symbol = func.get(record, 0);
                 int symbolKey = symbolTable.keyOf(symbol);
                 if (symbolKey != SymbolTable.VALUE_NOT_FOUND) {
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestBySubQueryRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestBySubQueryRecordCursorFactory.java
@@ -40,6 +40,7 @@ public class LatestBySubQueryRecordCursorFactory extends AbstractTreeSetRecordCu
     private final IntHashSet symbolKeys = new IntHashSet();
     private final RecordCursorFactory recordCursorFactory;
     private final Function filter;
+    private final Record.CharSequenceFunction func;
 
     public LatestBySubQueryRecordCursorFactory(
             @NotNull CairoConfiguration configuration,
@@ -48,7 +49,8 @@ public class LatestBySubQueryRecordCursorFactory extends AbstractTreeSetRecordCu
             int columnIndex,
             @NotNull RecordCursorFactory recordCursorFactory,
             @Nullable Function filter,
-            boolean indexed
+            boolean indexed,
+            @NotNull Record.CharSequenceFunction func
     ) {
         super(metadata, dataFrameCursorFactory, configuration);
         if (indexed) {
@@ -67,6 +69,7 @@ public class LatestBySubQueryRecordCursorFactory extends AbstractTreeSetRecordCu
         this.columnIndex = columnIndex;
         this.recordCursorFactory = recordCursorFactory;
         this.filter = filter;
+        this.func = func;
     }
 
     @Override
@@ -88,7 +91,7 @@ public class LatestBySubQueryRecordCursorFactory extends AbstractTreeSetRecordCu
         try (RecordCursor cursor = recordCursorFactory.getCursor(executionContext)) {
             final Record record = cursor.getRecord();
             while (cursor.hasNext()) {
-                int symbolKey = symbolTable.keyOf(record.getSym(0));
+                int symbolKey = symbolTable.keyOf(func.get(record, 0));
                 if (symbolKey != SymbolTable.VALUE_NOT_FOUND) {
                     symbolKeys.add(TableUtils.toIndexKey(symbolKey));
                 }

--- a/core/src/test/java/io/questdb/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderTest.java
@@ -2768,7 +2768,7 @@ public class TableReaderTest extends AbstractCairoTest {
                         if (counter < N) {
                             // roll random generator to make sure it returns same values
                             rnd.nextChars(15);
-                            Assert.assertNull(record.getSym(1));
+                            Assert.assertNull(record.getStr(1));
                         } else {
                             Assert.assertEquals(rnd.nextChars(15), record.getStr(1));
                         }

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -218,6 +218,22 @@ public class SqlParserTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testWhereClauseInsideInSubQuery() throws SqlException {
+        assertQuery(
+                "select-choose ts, sym, bid, ask from (select [ts, sym, bid, ask] from trades timestamp (ts) where ts = '2010-01-04' and sym in (select-choose sym from (select [sym, isNewSymbol] from symbols where not(isNewSymbol))))",
+                "select * from trades where ts='2010-01-04' and sym in (select sym from symbols where NOT isNewSymbol);",
+                modelOf("trades")
+                        .timestamp("ts")
+                        .col("sym", ColumnType.SYMBOL)
+                        .col("bid", ColumnType.DOUBLE)
+                        .col("ask", ColumnType.DOUBLE),
+                modelOf("symbols")
+                        .col("sym", ColumnType.SYMBOL)
+                        .col("isNewSymbol", ColumnType.BOOLEAN)
+        );
+    }
+
+    @Test
     public void testCaseAndLimit() throws SqlException {
         assertQuery("select-virtual 'table' kind from (tab) limit 10",
                 "    select case a \n" +

--- a/core/src/test/java/io/questdb/griffin/engine/functions/SymbolFunctionTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/SymbolFunctionTest.java
@@ -27,8 +27,6 @@ package io.questdb.griffin.engine.functions;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.std.str.StringSink;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,18 +35,17 @@ public class SymbolFunctionTest {
 
     private static final SymbolFunction function = new SymbolFunction(25) {
         @Override
+        public int getInt(Record rec) {
+            return 0;
+        }
+
+        @Override
         public CharSequence getSymbol(Record rec) {
             return "XYZ";
         }
 
         @Override
-        public CharSequence valueOf(int symbolKey) {
-            return "XYZ";
-        }
-
-        @Override
-        public int getInt(Record rec) {
-            return 0;
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
         }
 
         @Override
@@ -57,9 +54,15 @@ public class SymbolFunctionTest {
         }
 
         @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+        public CharSequence valueOf(int symbolKey) {
+            return "XYZ";
         }
     };
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testChar() {
+        function.getChar(null);
+    }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testGetBin() {
@@ -107,23 +110,6 @@ public class SymbolFunctionTest {
     }
 
     @Test
-    public void testGetStr() {
-        Assert.assertEquals("XYZ", function.getStr(null));
-    }
-
-    @Test
-    public void testGetStrB() {
-        Assert.assertEquals("XYZ", function.getStrB(null));
-    }
-
-    @Test
-    public void testGetStrSink() {
-        StringSink sink = new StringSink();
-        function.getStr(null, sink);
-        TestUtils.assertEquals("XYZ", sink);
-    }
-
-    @Test
     public void testGetPosition() {
         Assert.assertEquals(25, function.getPosition());
     }
@@ -138,18 +124,28 @@ public class SymbolFunctionTest {
         function.getShort(null);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetStr() {
+        Assert.assertEquals("XYZ", function.getStr(null));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetStrB() {
+        Assert.assertEquals("XYZ", function.getStrB(null));
+    }
+
     public void testGetStrLen() {
         Assert.assertEquals(3, function.getStrLen(null));
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testGetTimestamp() {
-        function.getTimestamp(null);
+    public void testGetStrSink() {
+        function.getStr(null, null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testChar() {
-        function.getChar(null);
+    public void testGetTimestamp() {
+        function.getTimestamp(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/core/src/test/java/io/questdb/mp/SOUnboundedCountDownLatchTest.java
+++ b/core/src/test/java/io/questdb/mp/SOUnboundedCountDownLatchTest.java
@@ -26,6 +26,7 @@ package io.questdb.mp;
 
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.std.time.Dates;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,6 +75,7 @@ public class SOUnboundedCountDownLatchTest {
     private void doTest(SPSequence pubSeq, SCSequence subSeq, SOUnboundedCountDownLatch latch, AtomicInteger dc, int count, int s) {
         new Thread() {
             int doneCount = 0;
+            long time = System.currentTimeMillis();
 
             @Override
             public void run() {
@@ -87,6 +89,16 @@ public class SOUnboundedCountDownLatchTest {
                         latch.countDown();
                         Assert.assertEquals(last + 1, c);
                         last = c;
+                    }
+                    if (System.currentTimeMillis() - time > Dates.MINUTE_MILLIS) {
+                        LOG.error()
+                                .$("so_latch_state [doneCount=").$(doneCount)
+                                .$(", count=").$(count)
+                                .$(", seq.current").$(subSeq.current())
+                                .$(", seq.cache=").$(pubSeq.cache)
+                                .$(", latch.count=").$(latch.getCount())
+                                .$(']').$();
+                        time = System.currentTimeMillis();
                     }
                 }
             }


### PR DESCRIPTION
- WhereClauseParser parser was not cleared, which caused unwanted "where" clause being applied at a wrong level. Fixed #214 
- removed branching from TableReaderRecord to improve read performance
- hardened convention that Symbol function and field do not implement getStr() interface
- fixed sub-query based filters to deal with both String and Symbol columns in a systemic way