### PR TITLE
feat(imports): add partitionBy and timestampIndex

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -286,8 +286,6 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 throw ServerDisconnectException.INSTANCE;
             }
 
-            CharSequence timestampIndexCol = rh.getUrlParam("timestamp");
-
             CharSequence partitionedBy = rh.getUrlParam("partitionBy");
             if (partitionedBy == null) {
                 partitionedBy = "NONE";
@@ -297,6 +295,8 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 transientContext.simpleResponse().sendStatus(400, "invalid partitionBy");
                 throw ServerDisconnectException.INSTANCE;
             }
+
+            CharSequence timestampIndexCol = rh.getUrlParam("timestamp");
             if (partitionBy != PartitionBy.NONE && timestampIndexCol == null) {
                 transientContext.simpleResponse().sendStatus(400, "when specifying partitionBy you must also specify timestamp");
                 throw ServerDisconnectException.INSTANCE;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -286,12 +286,26 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 throw ServerDisconnectException.INSTANCE;
             }
 
+            CharSequence partitionedBy = rh.getUrlParam("partitionBy");
+            if (partitionedBy == null) {
+                partitionedBy = "NONE";
+            }
+            int partitionBy = PartitionBy.fromString(partitionedBy);
+            if (partitionBy == -1) {
+                transientContext.simpleResponse().sendStatus(400, "invalid partitionBy");
+                throw ServerDisconnectException.INSTANCE;
+            }
+
+            CharSequence timestampIndexCol = rh.getUrlParam("timestampIndex");
+
             transientState.analysed = false;
             transientState.textLoader.configureDestination(
                     name,
                     Chars.equalsNc("true", rh.getUrlParam("overwrite")),
                     Chars.equalsNc("true", rh.getUrlParam("durable")),
-                    getAtomicity(rh.getUrlParam("atomicity"))
+                    getAtomicity(rh.getUrlParam("atomicity")),
+                    partitionBy,
+                    timestampIndexCol
             );
             transientState.textLoader.setForceHeaders(Chars.equalsNc("true", rh.getUrlParam("forceHeader")));
             transientState.textLoader.setSkipRowsWithExtraValues(Chars.equalsNc("true", rh.getUrlParam("skipLev")));

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -286,6 +286,8 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 throw ServerDisconnectException.INSTANCE;
             }
 
+            CharSequence timestampIndexCol = rh.getUrlParam("timestamp");
+
             CharSequence partitionedBy = rh.getUrlParam("partitionBy");
             if (partitionedBy == null) {
                 partitionedBy = "NONE";
@@ -295,8 +297,10 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 transientContext.simpleResponse().sendStatus(400, "invalid partitionBy");
                 throw ServerDisconnectException.INSTANCE;
             }
-
-            CharSequence timestampIndexCol = rh.getUrlParam("timestampIndex");
+            if (partitionBy != PartitionBy.NONE && timestampIndexCol == null) {
+                transientContext.simpleResponse().sendStatus(400, "when specifying partitionBy you must also specify timestamp");
+                throw ServerDisconnectException.INSTANCE;
+            }
 
             transientState.analysed = false;
             transientState.textLoader.configureDestination(

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -128,7 +128,7 @@ public class CairoTextWriter implements TextLexer.Listener, Closeable, Mutable {
     @Override
     public void onFields(long line, ObjList<DirectByteCharSequence> values, int valuesLength) {
         long timestamp = 0L;
-        if (timestampIndex != -1) {
+        if (timestampAdapter != null) {
             final DirectByteCharSequence dbcs = values.getQuick(timestampIndex);
             try {
                 timestamp = timestampAdapter.getTimestamp(dbcs);
@@ -139,7 +139,7 @@ public class CairoTextWriter implements TextLexer.Listener, Closeable, Mutable {
         }
         final TableWriter.Row w = writer.newRow(timestamp);
         for (int i = 0; i < valuesLength; i++) {
-            if (i == timestampIndex) {
+            if (timestampAdapter != null && i == timestampIndex) {
                 continue;
             }
             final DirectByteCharSequence dbcs = values.getQuick(i);
@@ -275,7 +275,9 @@ public class CairoTextWriter implements TextLexer.Listener, Closeable, Mutable {
         }
         _size = writer.size();
         columnErrorCounts.seed(writer.getMetadata().getColumnCount(), 0);
-        timestampAdapter = (TimestampAdapter) types.getQuick(timestampIndex);
+        if (timestampIndex != -1 && types.getQuick(timestampIndex).getType() == ColumnType.TIMESTAMP) {
+            timestampAdapter = (TimestampAdapter) types.getQuick(timestampIndex);
+        }
     }
 
     private class TableStructureAdapter implements TableStructure {

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -127,7 +127,7 @@ public class CairoTextWriter implements TextLexer.Listener, Closeable, Mutable {
     @Override
     public void onFields(long line, ObjList<DirectByteCharSequence> values, int valuesLength) {
         long timestamp = 0L;
-        if (timestampIndex != -1) {
+        if (timestampIndex != -1 && types.getQuick(timestampIndex).getType() == ColumnType.TIMESTAMP) {
             TimestampAdapter adapter = (TimestampAdapter) types.getQuick(timestampIndex);
             final DirectByteCharSequence dbcs = values.getQuick(timestampIndex);
             try {
@@ -138,7 +138,7 @@ public class CairoTextWriter implements TextLexer.Listener, Closeable, Mutable {
         }
         final TableWriter.Row w = writer.newRow(timestamp);
         for (int i = 0; i < valuesLength; i++) {
-            if (i == timestampIndex) {
+            if (i == timestampIndex && types.getQuick(timestampIndex).getType() == ColumnType.TIMESTAMP) {
                 continue;
             }
             final DirectByteCharSequence dbcs = values.getQuick(i);

--- a/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
@@ -106,8 +106,8 @@ public class TextLoader implements Closeable, Mutable {
         assert this.columnDelimiter > 0;
     }
 
-    public void configureDestination(CharSequence tableName, boolean overwrite, boolean durable, int atomicity) {
-        textWriter.of(tableName, overwrite, durable, atomicity);
+    public void configureDestination(CharSequence tableName, boolean overwrite, boolean durable, int atomicity, int partitionBy, CharSequence timestampIndexCol) {
+        textWriter.of(tableName, overwrite, durable, atomicity, partitionBy, timestampIndexCol);
         textDelimiterScanner.setTableName(tableName);
         textMetadataParser.setTableName(tableName);
         textLexer.setTableName(tableName);

--- a/core/src/main/java/io/questdb/cutlass/text/TextMetadataParser.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextMetadataParser.java
@@ -250,7 +250,7 @@ public class TextMetadataParser implements JsonParser, Mutable, Closeable {
 
                 // timestamp pattern is required
                 if (pattern == null) {
-                    throw JsonException.$(0, "DATE format pattern is required");
+                    throw JsonException.$(0, "TIMESTAMP format pattern is required");
                 }
                 columnTypes.add(typeManager.nextTimestampAdapter(utf8, timestampFormatFactory.get(pattern), timestampLocale));
                 break;

--- a/core/src/main/java/io/questdb/cutlass/text/types/TimestampAdapter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/TimestampAdapter.java
@@ -62,6 +62,10 @@ public class TimestampAdapter extends AbstractTypeAdapter implements Mutable {
         row.putDate(column, format.parse(value, locale));
     }
 
+    public long getTimestamp(DirectByteCharSequence value) throws NumericException {
+        return format.parse(value, locale);
+    }
+
     public TimestampAdapter of(TimestampFormat format, TimestampLocale locale) {
         this.format = format;
         this.locale = locale;

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1566,7 +1566,7 @@ public class SqlCompiler implements Closeable {
         // todo: configure the following
         //   - when happens when data row errors out, max errors may be?
         //   - we should be able to skip X rows from top, dodgy headers etc.
-        textLoader.configureDestination(model.getTableName().token, false, false, Atomicity.SKIP_ROW, PartitionBy.NONE, "");
+        textLoader.configureDestination(model.getTableName().token, false, false, Atomicity.SKIP_ROW, PartitionBy.NONE, null);
     }
 
     private CompiledQuery sqlBackup(SqlExecutionContext executionContext) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1566,7 +1566,7 @@ public class SqlCompiler implements Closeable {
         // todo: configure the following
         //   - when happens when data row errors out, max errors may be?
         //   - we should be able to skip X rows from top, dodgy headers etc.
-        textLoader.configureDestination(model.getTableName().token, false, false, Atomicity.SKIP_ROW);
+        textLoader.configureDestination(model.getTableName().token, false, false, Atomicity.SKIP_ROW, PartitionBy.NONE, "");
     }
 
     private CompiledQuery sqlBackup(SqlExecutionContext executionContext) throws SqlException {

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -1001,8 +1001,8 @@ public class IODispatcherTest {
                         "Transfer-Encoding: chunked\r\n" +
                         "Content-Type: application/json; charset=utf-8\r\n" +
                         "\r\n" +
-                        "2c\r\n" +
-                        "{\"status\":\"DATE format pattern is required\"}\r\n" +
+                        "31\r\n" +
+                        "{\"status\":\"TIMESTAMP format pattern is required\"}\r\n" +
                         "00\r\n" +
                         "\r\n",
                 "POST /upload?fmt=json&overwrite=true&forceHeader=true&name=clipboard-157200856 HTTP/1.1\r\n" +

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -2338,6 +2338,61 @@ public class TextLoaderTest extends AbstractGriffinTest {
         });
     }
 
+    @Test
+    public void testImportTimestampPartitionByDay() throws Exception {
+        final TextConfiguration textConfiguration = new DefaultTextConfiguration() {
+            @Override
+            public int getTextAnalysisMaxLines() {
+                return 3;
+            }
+        };
+
+        CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
+            @Override
+            public TextConfiguration getTextConfiguration() {
+                return textConfiguration;
+            }
+        };
+        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            assertNoLeak(
+                engine,
+                textLoader -> {
+                    String expected = "StrSym\tts\n" +
+                            "CMP1\t2015-01-13T19:15:09.000000Z\n" +
+                            "CMP2\t2015-01-14T19:15:09.000234Z\n" +
+                            "CMP1\t2015-01-15T19:15:09.000455Z\n" +
+                            "CMP2\t2015-01-16T19:15:09.000754Z\n" +
+                            "CMP1\t2015-01-17T19:15:09.000903Z\n";
+
+
+                    String csv = "StrSym,ts\n" +
+                            "CMP1,2015-01-13T19:15:09.000000Z\n" +
+                            "CMP2,2015-01-14T19:15:09.000234Z\n" +
+                            "CMP1,2015-01-15T19:15:09.000455Z\n" +
+                            "CMP2,2015-01-16T19:15:09.000754Z\n" +
+                            "CMP1,2015-01-17T19:15:09.000903Z\n";
+
+                    configureLoaderDefaults(textLoader, (byte) ',', 0, false, PartitionBy.DAY, "ts");
+                    textLoader.setForceHeaders(false);
+                    playText(
+                            engine,
+                            textLoader,
+                            csv,
+                            1024,
+                            expected,
+                            "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"StrSym\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"ts\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":1}",
+                            5,
+                            5
+                    );
+
+                    try (TableReader r = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "test")) {
+                        Assert.assertEquals(PartitionBy.DAY, r.getPartitionedBy());
+                    }
+                }
+            );
+        }
+    }
+
     private void assertNoLeak(TestCode code) throws Exception {
         assertNoLeak(engine, code);
     }
@@ -2376,6 +2431,10 @@ public class TextLoaderTest extends AbstractGriffinTest {
         configureLoaderDefaults(textLoader, columnSeparator, Atomicity.SKIP_ROW);
     }
 
+    private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity) {
+        configureLoaderDefaults(textLoader, columnSeparator, atomicity, false);
+    }
+
     private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity, boolean overwrite) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
         textLoader.configureDestination("test", overwrite, false, atomicity, PartitionBy.NONE, "");
@@ -2384,8 +2443,12 @@ public class TextLoaderTest extends AbstractGriffinTest {
         }
     }
 
-    private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity) {
-        configureLoaderDefaults(textLoader, columnSeparator, atomicity, false);
+    private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity, boolean overwrite, int partitionBy, CharSequence timestampIndexCol) {
+        textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
+        textLoader.configureDestination("test", overwrite, false, atomicity, partitionBy, timestampIndexCol);
+        if (columnSeparator > 0) {
+            textLoader.configureColumnDelimiter(columnSeparator);
+        }
     }
 
     private void playJson(TextLoader textLoader, String jsonStr) throws TextException {

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -2437,7 +2437,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
 
     private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity, boolean overwrite) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        textLoader.configureDestination("test", overwrite, false, atomicity, PartitionBy.NONE, "");
+        textLoader.configureDestination("test", overwrite, false, atomicity, PartitionBy.NONE, null);
         if (columnSeparator > 0) {
             textLoader.configureColumnDelimiter(columnSeparator);
         }

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -2378,7 +2378,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
 
     private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity, boolean overwrite) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        textLoader.configureDestination("test", overwrite, false, atomicity);
+        textLoader.configureDestination("test", overwrite, false, atomicity, PartitionBy.NONE, "");
         if (columnSeparator > 0) {
             textLoader.configureColumnDelimiter(columnSeparator);
         }


### PR DESCRIPTION
Allow specifying partition type and their indexes from the `/imp` rest endpoint via query string parameters `partitionBy={DAY,MONTH,YEAR,NONE}` and `timestamp=columnName`.

Example command:
```sh
curl -i -F schema='[{"name": "date", "type": "TIMESTAMP", "pattern": "yyyy-MM-dd"}]' -F data=@agg1d.csv 'http://localhost:9000/imp?name=agg1d&partitionBy=YEAR&timestamp=date&overwrite=true'
```