### PR TITLE
chore(maven): use system version of nodejs/npm to fix the build on FreeBSD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
     - image: circleci/openjdk:8u171-jdk
-      
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -19,7 +19,7 @@ jobs:
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
-    
+
     steps:
       - checkout
 
@@ -30,13 +30,12 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: mvn compile -DskipTests
+      - run: mvn compile -DskipTests -Dprofile.install-local-nodejs
 
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-        
-      # run tests!
-      - run: mvn integration-test
 
+      # run tests!
+      - run: mvn integration-test -Dprofile.install-local-nodejs

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 out
 benchmarks/target
 core/target
+core/node
 core/src/main/resources/site/public
 *.iml
 deploy*.bat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,100 +1,205 @@
 ## Contributing to QuestDB
 
-### Raise an Issue
+## Raise an Issue
 
-Raising **[issues](https://github.com/questdb/questdb/issues)** on GitHub is super welcome. We aim to respond quickly and thoughtfully. This is a good place to start before deep diving into the code base.
+Raising **[issues](https://github.com/questdb/questdb/issues)** is welcome. We
+aim to respond quickly and thoughtfully. This is a good place to start before
+deep diving into the code base.
 
-### Contribute a PR
+## Contribute a PR
 
-#### Requirements
+### Requirements
 
-- Java 8. You can use either Oracle JDK 8 or OpenJDK 8. Newer versions of Java are not yet supported.
-- Maven 3 (https://maven.apache.org/download.cgi)
-- C-compiler, CMake - to contribute to C libraries.
-- Java IDE
-- 64-bit Operating System (OSX, Windows or Linux) - QuestDB does not work on 32-bit platforms.
+- Operating system - **x86-64**: Windows, Linux, FreeBSD and OSX / **ARM
+  (AArch64/A64)**: Linux
+- Java 8 64-bit. We recommend Oracle Java 8, but OpenJDK8 will also work
+  (although a little slower)
+- Maven 3 (from your package manager on Linux / OSX
+  ([Homebrew](https://github.com/Homebrew/brew)) or
+  [from the jar](https://maven.apache.org/install.html) for any OS)
+- Node.js 12 / npm 6 (to manage your Node.js versions we recommend
+  [nvm](https://github.com/nvm-sh/nvm) for OSX/Linux/windows WSL, and
+  [nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows) -
+  OPTIONAL
+- C-compiler, CMake - to contribute to C libraries - OPTIONAL
 
-### Repository overview
+## Repository overview
 
-Repository contains three components:
-- QuestDB database and libraries source in Java (core/src/main/java)
-- QuestDN database tests (core/src/test/java)
-- QuestDB libraries in C (core/src/main/c)
-- QuestDB Windows service wrapper (win64svc/)
-- QuestDB Web Console (ui/)
-- Micro benchmarks (benchmarks/)
+- QuestDB database and libraries source in Java:
+  [`core/src/main/java/`](https://github.com/questdb/questdb/tree/master/core/src/main/java)
+- QuestDB database tests:
+  [`core/src/test/java/`](https://github.com/questdb/questdb/tree/master/core/src/test/java)
+- QuestDB libraries in C:
+  [`core/src/main/c/`](https://github.com/questdb/questdb/tree/master/core/src/main/c)
+- QuestDB Windows service wrapper:
+  [`win64svc/`](https://github.com/questdb/questdb/tree/master/win64svc/)
+- QuestDB web console (frontend):
+  [`ui/`](https://github.com/questdb/questdb/tree/master/ui/)
+- Micro benchmarks:
+  [`benchmarks/`](https://github.com/questdb/questdb/tree/master/benchmarks/)
 
-QuestDB is packaged with maven, which packages everything under (core/src/). For this reason compilation output of
-other packages is distributed as follows:
+Compiled binaries (for C libraries and Windows service wrapper) are committed to
+git to make build of development process Java-centric and simplified.
 
-core/src/main/c -> core/src/main/resources/binaries
-ui -> core/src/main/resources/site/public
-win64svc -> core/src/main/bin
+# Local setup
 
-Compiled binaries are committed to git to make builk of development process Java-centric and simplified.
+## Setup Java and JAVA_HOME
 
-## Compiling Java
+Java versions above 8 are not yet supported. It is possible to build QuestDB
+with Java 11, but this requires backward incompatible changes. If your java
+version is above 8 you can download & install JDK8 and use the absolute path to
+the java executable instead of "`java`".
 
-Unless your default Java is Java8 you may want to set JAVA_HOME to Java8 directory before running maven:
+Unless your default Java is 8 you may want to set `JAVA_HOME` to the Java 8
+directory before running `maven`:
 
 Linux/OSX
-```text
-export JAVA_HOME=/path/to/java/
-mvn clean package
+
+```bash
+export JAVA_HOME="/path/to/java/"
 ```
 
 Windows
-```text
+
+```bash
 set JAVA_HOME="c:\path\to\java directory"
+```
+
+## Compiling Java and frontend code
+
+Compiling the database + the web console is done with:
+
+```bash
 mvn clean package
 ```
 
+You can then run QuestDB with:
+
+```bash
+java -cp core/target/core-4.2.1-SNAPSHOT.jar io.questdb.ServerMain -d <root_dir>
+```
+
+The web console will available at [localhost:9000](http://localhost:9000).
+
 ## Compiling C-libraries
 
-C-libraries will have to be compiled for each platform separately. The following commands will compile on Linux/OSX:
+C-libraries will have to be compiled for each platform separately. The following
+commands will compile on Linux/OSX:
 
 ```text
-export JAVA_HOME=/path/to/java
 cmake
 make
 ```
 
 on Windows we use Intellij CLion, which can open cmake files.
 
-## Testing
+The artifacts are distributed as follow:
 
-We have a lot of unit tests, most of which are of "integration" type, e.g. test starts a server, interacts with it and asserts the outcome. We expect all contributors to submit PRs with tests. Please reach out to us via slack if you uncertain on how to test or you think existing test is inadequate and should be removed.
+```
+core/src/main/c -> core/src/main/resources/binaries
+```
 
-## Dependencies
+# Local setup for frontend development
 
-QuestDB does not have dependencies. This may sound unorthodox but in reality we try not to reinvent the wheel but rather than using libraries we
-implement best algorithms ourselves to ensure perfect fit with existing code. With that in mind we expect contributions that do not add third-party dependencies.
+## Development server
 
-## Allocations, "new" operator and garbage collection
+This is useful when you want to work on the web console without having to
+rebuild the artifacts and restart QuestDB. Instead, we use `webpack-dev-server`:
 
-QuestDB is zero-GC along data pipelines. We expect contributions not to allocate if possible. That said we would like to help you to
-contribute zero-GC code, do not hesitate to reach out!
+0. Make sure QuestDB is running
+1. `cd ui/`
+2. Install the dependencies with `npm install`
+3. Start the development web server with `npm start`
 
-## Committing
+The web console should now be accessible at
+[localhost:9999](http://localhost:9999)
 
-We use [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to auto-generate release notes. We require all commit comments to conform. To that end commits have to be granular enough to be successfully described using this method.
+## Building the artifacts
 
-## Squashing commits
+Run the command:
 
-When submitting a pull request to QuestDB, we ask that you squash your commits before we merge.
+```bash
+mvn clean package
+```
 
-Some applications that interact with git repos will provide a user interface for squashing. Refer to your application's document for more information.
+The artifacts are distributed as follow:
 
-If you're familiar with Terminal, you can do the following:
+```
+ui -> core/src/main/resources/site/public
+```
 
-* Make sure your branch is up to date with the master branch.
-* Run `git rebase -i master`.
-* You should see a list of commits, each commit starting with the word "pick".
-* Make sure the first commit says "pick" and change the rest from "pick" to "squash".
--- This will squash each commit into the previous commit, which will continue until every commit is squashed into the first commit.
-* Save and close the editor.
-* It will give you the opportunity to change the commit message. 
-* Save and close the editor again.
-* Then you have to force push the final, squashed commit: `git push --force-with-lease origin`.
+# Testing
 
-Squashing commits can be a tricky process but once you figure it out, it's really helpful and keeps our repo concise and clean.
+We have a lot of unit tests, most of which are of "integration" type, e.g. test
+starts a server, interacts with it and asserts the outcome. We expect all
+contributors to submit PRs with tests. Please reach out to us via slack if you
+uncertain on how to test or you think existing test is inadequate and should be
+removed.
+
+# Dependencies
+
+QuestDB does not have dependencies. This may sound unorthodox but in reality we
+try not to reinvent the wheel but rather than using libraries we implement best
+algorithms ourselves to ensure perfect fit with existing code. With that in mind
+we expect contributions that do not add third-party dependencies.
+
+# Allocations, "new" operator and garbage collection
+
+QuestDB is zero-GC along data pipelines. We expect contributions not to allocate
+if possible. That said we would like to help you to contribute zero-GC code, do
+not hesitate to reach out!
+
+# Committing
+
+We use [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to
+auto-generate release notes. We require all commit comments to conform. To that
+end, commits have to be granular enough to be successfully described using this
+method.
+
+# Squashing commits
+
+When submitting a pull request to QuestDB, we ask that you squash your commits
+before we merge.
+
+Some applications that interact with git repos will provide a user interface for
+squashing. Refer to your application's document for more information.
+
+If you're familiar with the terminal, you can do the following:
+
+- Make sure your branch is up to date with the master branch.
+- Run `git rebase -i master`.
+- You should see a list of commits, each commit starting with the word "pick".
+- Make sure the first commit says "pick" and change the rest from "pick" to
+  "squash". -- This will squash each commit into the previous commit, which will
+  continue until every commit is squashed into the first commit.
+- Save and close the editor.
+- It will give you the opportunity to change the commit message.
+- Save and close the editor again.
+- Then you have to force push the final, squashed commit:
+  `git push --force-with-lease origin`.
+
+Squashing commits can be a tricky process but once you figure it out, it is
+really helpful and keeps our repository concise and clean.
+
+# FAQ
+
+#### Everything works fine but I get a `404` on [localhost:9000](http://localhost:9000)
+
+This means that the frontend artifacts are not present in
+`core/src/main/resources/site/public`. To fix this, you can simply run `mvn
+clean package#.
+
+#### I do not want to install `Node.js` and/or it is clashing with my system installation of `Node.js`
+
+You can use [nvm](https://github.com/nvm-sh/nvm) for OSX/Linux/windows WSL, and
+[nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows. To have
+multiple active versions.
+
+Otherwise, you can use the dedicated `maven` profile to build the code:
+
+```bash
+mvn clean package -Dprofile.install-local-nodejs
+```
+
+That way, `maven` will install `node` on the fly in `ui/node` so you don't have
+to install it locall.

--- a/README.md
+++ b/README.md
@@ -9,42 +9,49 @@
   <a href="https://serieux-saucisson-79115.herokuapp.com/"><img src="https://serieux-saucisson-79115.herokuapp.com/badge.svg"></a>
   <a href="https://github.com/questdb/questdb/releases/download/4.2.0/questdb-4.2.0-bin.tar.gz"><img src="https://img.shields.io/github/downloads/questdb/questdb/total"></a>
   <a href="https://search.maven.org/search?q=g:org.questdb"><img src="https://img.shields.io/maven-central/v/org.questdb/core"></a>
-</p
-
-<p/>
 
 ## What is QuestDB
 
-QuestDB is an open-source NewSQL relational database designed to process time-series data, faster. Our approach comes from low-latency trading; QuestDB’s stack is engineered from scratch, zero-GC Java and dependency-free.
+QuestDB is an open-source NewSQL relational database designed to process
+time-series data, faster. Our approach comes from low-latency trading; QuestDB’s
+stack is engineered from scratch, zero-GC Java and dependency-free.
 
-QuestDB ingests data via HTTP, PostgreSQL wire protocol, Influx line protocol or directly from Java. Reading data is done using SQL via HTTP,
-PostgreSQL wire protocol or via Java API. The whole database and console fits in a 3.5Mb package.
+QuestDB ingests data via HTTP, PostgreSQL wire protocol, Influx line protocol or
+directly from Java. Reading data is done using SQL via HTTP, PostgreSQL wire
+protocol or via Java API. The whole database and console fits in a 3.5Mb
+package.
 
 ## Project goals
 
-- Treat time-series as first class citizen within a relational database framework.
+- Treat time-series as first class citizen within a relational database
+  framework.
 
-- Minimise hardware resources through software optimisation. Don’t waste CPU cycles, memory nor storage.
+- Minimise hardware resources through software optimisation. Don’t waste CPU
+  cycles, memory nor storage.
 
 - Be a reliable and trustworthy store of critical data.
 
-- Low friction operation. Empower developers with SQL. Simplify every database interaction.
+- Low friction operation. Empower developers with SQL. Simplify every database
+  interaction.
 
-- Operate efficiently at both extremes: allow users to prioritise performance over data loss, and vice versa.
+- Operate efficiently at both extremes: allow users to prioritise performance
+  over data loss, and vice versa.
 
 - Be both embedded and standalone.
 
 ## Getting Started
 
-See our [My First Database](https://www.questdb.io/docs/myFirstDatabase) tutorial.
-The easiest way to get started is to play with our
-web [console](https://www.questdb.io/docs/usingWebConsole). This will allow you to import
-and query data using an intuitive interface.
+See our [My First Database](https://www.questdb.io/docs/myFirstDatabase)
+tutorial. The easiest way to get started is to play with our web
+[console](https://www.questdb.io/docs/usingWebConsole). This will allow you to
+import and query data using an intuitive interface.
 
-You may also take a look at our [storage model](https://www.questdb.io/docs/storageModel). In short,
-we are a column-oriented database, which partitions data by time intervals.
+You may also take a look at our
+[storage model](https://www.questdb.io/docs/storageModel). In short, we are a
+column-oriented database, which partitions data by time intervals.
 
-You can find more documentation [here](https://www.questdb.io/docs/documentationOverview)
+You can find our documentation
+[here](https://www.questdb.io/docs/documentationOverview)
 
 ## Support / Contact
 
@@ -56,55 +63,55 @@ Our roadmap is [here](https://github.com/questdb/questdb/projects/2)
 
 ## Building from source
 
-### Pre-requitites:
+### Pre-requisites
 
-- Java 8 64-bit. We recommend Oracle Java 8, but OpenJDK8 will also work (although a little slower).
-- Maven 3
-- Compatible 64-bit Operating System: Windows, Linux, OSX or ARM Linux
-- Configure JAVA_HOME environment variable
-- Add Maven "bin" directory to PATH environment variable
+- Operating system - **x86-64**: Windows, Linux, FreeBSD and OSX / **ARM
+  (AArch64/A64)**: Linux
+- Java 8 64-bit. We recommend Oracle Java 8, but OpenJDK8 will also work
+  (although a little slower)
+- Maven 3 (from your package manager on Linux / OSX
+  ([Homebrew](https://github.com/Homebrew/brew)) or
+  [from the jar](https://maven.apache.org/install.html) for any OS)
+- Node.js 12 / npm 6 (to manage your Node.js versions we recommend
+  [nvm](https://github.com/nvm-sh/nvm) for OSX/Linux/windows WSL, and
+  [nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows) -
+  OPTIONAL
 
-```
-Note: Java versions above 8 are not yet supported. It is possible to build QuestDB with Java 11,
-but this requires backward incompatible source code changes.
-```
+> Java versions above 8 are not yet supported. It is possible to build QuestDB
+> with Java 11, but this requires backward incompatible changes. If your java
+> version is above 8 you can download & install JDK8 and use the absolute path
+> to the java executable instead of "`java`".
 
 ### Building & Running
 
-```
-git clone https://github.com/questdb/questdb.git
+```bash
+git clone git@github.com:questdb/questdb.git
 cd questdb
 
-# check java version
-# output should be similar to:
+# Check the java version, the output should be similar to:
 #
 # java version "1.8.0_212"
 # Java(TM) SE Runtime Environment (build 1.8.0_212-b10)
 # Java HotSpot(TM) 64-Bit Server VM (build 25.212-b10, mixed mode)
-#
-# if your java version is above 8 you can download & install JDK8 and use absolute
-# path to java executable instead of 'java'
-
 java -version
 
 # remove 'skipTests' if you want to run all tests (3000+ unit tests, 3-5 mins)
 mvn clean package -DskipTests
 
-# check contents of 'core/target' directory to find QuestDB's current version number
-
-# create QuestDB root directory if one does not exist already
-# replace <root_dir> with actual directory name
+# replace <root_dir> with the actual directory name, example "out"
 mkdir <root_dir>
 
-# <version> is QuestDB's current version from pom.xml
-# <root_dir> is the root directory created at the previous step
-java -cp core/target/core-<version>.jar io.questdb.ServerMain -d <dir>
+java -cp core/target/core-4.2.1-SNAPSHOT.jar io.questdb.ServerMain -d <root_dir>
 ```
 
-QuestDB will start the HTTP server on 0:9000, which you can visit from your browser: http://localhost:9000. HTTP server is constrained by directory specified as program argument (-d). Additionally QuestDB will start PostgreSQL's server on 0:8812, default login credentials are admin/quest. Both HTTP and PostresSQL server reference database in `<root_directory>/db`
-
+QuestDB will start an HTTP server with the web console available at
+[localhost:9000](http://localhost:9000). Additionally, a PostgreSQL server will
+be started and available on port 8812, the default login credentials are
+`admin`/`quest`. Both the HTTP and PostresSQL servers reference the database in
+`<root_directory>/db`.
 
 ## Contribution
 
-Feel free to contribute to the project by forking the repository and submitting pull requests.
-Please make sure you have read our [contributing guide](https://github.com/questdb/questdb/blob/master/CONTRIBUTING.md).
+Feel free to contribute to the project by forking the repository and submitting
+pull requests. Please make sure you have read our
+[contributing guide](https://github.com/questdb/questdb/blob/master/CONTRIBUTING.md).

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,9 +28,11 @@
     <name>QuestDB Core</name>
     <description>QuestDB is High Performance Time Series Database</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<nodejs.npm.cmd>npm</nodejs.npm.cmd>
+		<nodejs.version>v12.16.2</nodejs.version>
+	</properties>
 
     <version>4.2.1-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
@@ -74,46 +76,43 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>com.github.eirslett</groupId>
-              <artifactId>frontend-maven-plugin</artifactId>
-              <version>1.9.1</version>
-
-              <executions>
-                <execution>
-                  <id>install node and npm</id>
-                  <goals>
-                    <goal>install-node-and-npm</goal>
-                  </goals>
-                  <phase>generate-resources</phase>
-                </execution>
-
-                <execution>
-                  <id>npm install</id>
-                  <goals>
-                    <goal>npm</goal>
-                  </goals>
-                  <phase>generate-resources</phase>
-                  <configuration>
-                    <arguments>install --no-fund</arguments>
-                  </configuration>
-                </execution>
-
-                <execution>
-                  <id>npm run build</id>
-                  <goals>
-                    <goal>npm</goal>
-                  </goals>
-                  <phase>generate-resources</phase>
-                  <configuration>
-                    <arguments>run build</arguments>
-                  </configuration>
-                </execution>
-              </executions>
-
-              <configuration>
-                <nodeVersion>v12.16.2</nodeVersion>
-                <workingDirectory>../ui</workingDirectory>
-              </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>npm-install</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>${nodejs.npm.cmd}</executable>
+                            <arguments>
+                                <argument>install</argument>
+                                <argument>--no-fund</argument>
+                                <argument>--scripts-prepend-node-path=auto</argument>
+                            </arguments>
+                            <workingDirectory>../ui</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-run-build</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>${nodejs.npm.cmd}</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>build</argument>
+                                <argument>--scripts-prepend-node-path=auto</argument>
+                            </arguments>
+                            <workingDirectory>../ui</workingDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -252,6 +251,52 @@
                     </plugin>
                 </plugins>
             </build>
+	      </profile>
+		    <profile>
+            <id>install-local-nodejs</id>
+            <properties>
+                <nodejs.npm.cmd>${project.basedir}/node/npm</nodejs.npm.cmd>
+            </properties>
+            <activation>
+                <property>
+                    <name>profile.install-local-nodejs</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <nodeVersion>${nodejs.version}</nodeVersion>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+		    </profile>
+        <profile>
+            <id>platform-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+                <property>
+                    <name>profile.install-local-nodejs</name>
+                </property>
+            </activation>
+            <properties>
+                <nodejs.npm.cmd>${project.basedir}/node/npm.cmd</nodejs.npm.cmd>
+            </properties>
         </profile>
     </profiles>
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,10 +2,9 @@
 
 ## Prerequisites
 
-- NodeJS LTS (version 12) with npm (yarn should work too)
-
-[nvm](https://github.com/nvm-sh/nvm) can be used to prevent potential conflicts
-with your system version of NodeJS.
+- Node.js 12 / npm 6 (to manage your Node.js versions we recommend
+  [nvm](https://github.com/nvm-sh/nvm) for OSX/Linux/windows WSL, and
+  [nvm-windows](https://github.com/coreybutler/nvm-windows) for Windows)
 
 ## Local development
 
@@ -14,7 +13,7 @@ Make sure that QuestDB is running, please check the instructions [here](../READM
 1. Install the dependencies with `npm install`
 2. Start the development web server with `npm start`
 
-The Console should now be accessible at [http://localhost:9001](http://localhost:9001)
+The web console should now be accessible at [localhost:9999](http://localhost:9999)
 
 ## Building the artifacts
 

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -6,7 +6,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin")
 const AnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 
-const PORT = 9001
+const PORT = 9999
 const BACKEND_PORT = 9000
 const isProdBuild = process.env.NODE_ENV === "production"
 const runBundleAnalyzer = process.env.ANALYZE
@@ -107,7 +107,7 @@ module.exports = {
   plugins: [
     ...basePlugins,
     ...(isProdBuild ? prodPlugins : devPlugins),
-    ...(runBundleAnalyzer ? [new AnalyzerPlugin({ analyzerPort: 9999 })] : []),
+    ...(runBundleAnalyzer ? [new AnalyzerPlugin({ analyzerPort: 9998 })] : []),
   ],
   stats: {
     all: false,


### PR DESCRIPTION
This commit also adds a new `maven` profile to keep the possibility of running
`maven` tasks without having to install `Node.js` locally`.

Documentation changes:

1. README.md

- Update requirements
- Simplify "Building & Running"
- Fix typos

2. CONTRIBUTING.md

- Update repository overview
- Update artificats creation
- Add section for Local frontend development
- Add FAQ
- Update requirements
- Fix typos

3. ui/README.md

- Coordinate changes on requirements with the rest of the documentation

Notes:
Thanks to @patrickSpaceSurfer for his work on `pom.xml`, he wrote the new `install-local-nodejs` profile (the commit is now squashed).