### PR TITLE
Fix PSQL port in docker container and documentation (8892 -> 8812).

### DIFF
--- a/core/Dockerfile-linux
+++ b/core/Dockerfile-linux
@@ -43,7 +43,7 @@ RUN echo "PS1='🐳  \[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\] \[\033[1;36
 
 # Make port 9000 available to the world outside this container
 EXPOSE 9000/tcp
-EXPOSE 8892/tcp
+EXPOSE 8812/tcp
 
 # Run questdb when the container launches
 CMD ["/app/jre/bin/java", "-cp", "/app/questdb/questdb.jar", "io.questdb.ServerMain", "-d", "/root/.questdb"]

--- a/core/Dockerfile-linux-arm64
+++ b/core/Dockerfile-linux-arm64
@@ -39,7 +39,7 @@ RUN echo "PS1='🐳  \[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\] \[\033[1;36
 
 # Make port 9000 available to the world outside this container
 EXPOSE 9000/tcp
-EXPOSE 8892/tcp
+EXPOSE 8812/tcp
 
 # Run questdb when the container launches
 CMD ["/app/jre/bin/java", "-cp", "/app/questdb/questdb.jar", "io.questdb.ServerMain", "-d", "/root/.questdb"]

--- a/core/Dockerfile-windows
+++ b/core/Dockerfile-windows
@@ -28,7 +28,7 @@ WORKDIR /app/questdb-${QUESTDB_VERSION}
 
 # Make port 9000 available to the world outside this container
 EXPOSE 9000/tcp
-EXPOSE 8892/tcp
+EXPOSE 8812/tcp
 
 # create QuestDB root directory
 RUN mkdir C:\questdb

--- a/core/README.md
+++ b/core/README.md
@@ -97,13 +97,13 @@ docker pull questdb/questdb:4.0.0
 
 To run QuestDB as interactive sandbox:
 ```
-docker run --rm -it -p 9000:9000 -p 8892:8892 questdb/questdb:4.0.0
+docker run --rm -it -p 9000:9000 -p 8812:8812 questdb/questdb:4.0.0
 ```
 You can Ctrl+C QuestDB. Container and all the data is removed when container stops.
 
 To run QuestDB sensibly, create container without running it:
 ```
-docker create --name questdb -p 9000:9000 -p 8892:8892 questdb/questdb:4.0.0
+docker create --name questdb -p 9000:9000 -p 8812:8812 questdb/questdb:4.0.0
 ```
 
 Start QuestDB


### PR DESCRIPTION
A typo? The correct server port is 8812.

I will fix this in questdb.io as well, once this is approved.