### PR TITLE
abs(double) implementation + unbranching

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsDoubleFunctionFactory.java
@@ -28,13 +28,14 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.AbstractUnaryLongFunction;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.std.ObjList;
 
-public class AbsLongFunctionFactory implements FunctionFactory {
+public class AbsDoubleFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "abs(L)";
+        return "abs(D)";
     }
 
     @Override
@@ -42,14 +43,22 @@ public class AbsLongFunctionFactory implements FunctionFactory {
         return new AbsFunction(position, args.getQuick(0));
     }
 
-    private static class AbsFunction extends AbstractUnaryLongFunction {
-        public AbsFunction(int position, Function arg) {
-            super(position, arg);
+    private static class AbsFunction extends DoubleFunction implements UnaryFunction {
+        final Function function;
+
+        public AbsFunction(int position, Function function) {
+            super(position);
+            this.function = function;
         }
 
         @Override
-        public long getLong(Record rec) {
-            long value = arg.getLong(rec);
+        public Function getArg() {
+            return function;
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            double value = function.getDouble(rec);
             return Math.abs(value);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsIntFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsIntFunctionFactory.java
@@ -60,10 +60,11 @@ public class AbsIntFunctionFactory implements FunctionFactory {
             return arg;
         }
 
+
         @Override
         public int getInt(Record rec) {
             int value = arg.getInt(rec);
-            return value < 0 ? -value : value;
+            return Math.abs(value);
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsShortFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/AbsShortFunctionFactory.java
@@ -59,7 +59,7 @@ public class AbsShortFunctionFactory implements FunctionFactory {
         @Override
         public short getShort(Record rec) {
             short value = function.getShort(rec);
-            return value < 0 ? (short) -value : value;
+            return (short) Math.abs(value);
         }
     }
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -131,6 +131,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.math.AbsIntFunctionFactory,
             io.questdb.griffin.engine.functions.math.AbsShortFunctionFactory,
             io.questdb.griffin.engine.functions.math.AbsLongFunctionFactory,
+            io.questdb.griffin.engine.functions.math.AbsDoubleFunctionFactory,
 //                    # '~=',
             io.questdb.griffin.engine.functions.regex.MatchStrFunctionFactory,
             io.questdb.griffin.engine.functions.regex.MatchCharFunctionFactory,

--- a/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsDoubleFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsDoubleFunctionFactoryTest.java
@@ -24,33 +24,24 @@
 
 package io.questdb.griffin.engine.functions.math;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.AbstractUnaryLongFunction;
-import io.questdb.std.ObjList;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
 
-public class AbsLongFunctionFactory implements FunctionFactory {
-    @Override
-    public String getSignature() {
-        return "abs(L)";
+public class AbsDoubleFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testPositive() throws SqlException {
+        call(13.1).andAssert(13.1, 0.0000000001);
+    }
+
+    @Test
+    public void testNegative() throws SqlException {
+        call(-13.1).andAssert(13.1, 0.0000000001);
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
-        return new AbsFunction(position, args.getQuick(0));
-    }
-
-    private static class AbsFunction extends AbstractUnaryLongFunction {
-        public AbsFunction(int position, Function arg) {
-            super(position, arg);
-        }
-
-        @Override
-        public long getLong(Record rec) {
-            long value = arg.getLong(rec);
-            return Math.abs(value);
-        }
+    protected FunctionFactory getFunctionFactory() { return new AbsDoubleFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsIntFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsIntFunctionFactoryTest.java
@@ -24,33 +24,26 @@
 
 package io.questdb.griffin.engine.functions.math;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.AbstractUnaryLongFunction;
-import io.questdb.std.ObjList;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.std.Numbers;
+import org.junit.Test;
 
-public class AbsLongFunctionFactory implements FunctionFactory {
-    @Override
-    public String getSignature() {
-        return "abs(L)";
+public class AbsIntFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testPositive() throws SqlException {
+        call(1).andAssert(1, 0.0000000001);
+    }
+
+    @Test
+    public void testNegative() throws SqlException {
+        call(-1).andAssert(1, 0.0000000001);
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
-        return new AbsFunction(position, args.getQuick(0));
-    }
-
-    private static class AbsFunction extends AbstractUnaryLongFunction {
-        public AbsFunction(int position, Function arg) {
-            super(position, arg);
-        }
-
-        @Override
-        public long getLong(Record rec) {
-            long value = arg.getLong(rec);
-            return Math.abs(value);
-        }
+    protected FunctionFactory getFunctionFactory() {
+        return new AbsIntFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsLongFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsLongFunctionFactoryTest.java
@@ -24,33 +24,25 @@
 
 package io.questdb.griffin.engine.functions.math;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.AbstractUnaryLongFunction;
-import io.questdb.std.ObjList;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
 
-public class AbsLongFunctionFactory implements FunctionFactory {
-    @Override
-    public String getSignature() {
-        return "abs(L)";
+public class AbsLongFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testPositive() throws SqlException {
+        call(1L).andAssert(1, 0.0000000001);
+    }
+
+    @Test
+    public void testNegative() throws SqlException {
+        call(-1L).andAssert(1, 0.0000000001);
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
-        return new AbsFunction(position, args.getQuick(0));
-    }
-
-    private static class AbsFunction extends AbstractUnaryLongFunction {
-        public AbsFunction(int position, Function arg) {
-            super(position, arg);
-        }
-
-        @Override
-        public long getLong(Record rec) {
-            long value = arg.getLong(rec);
-            return Math.abs(value);
-        }
+    protected FunctionFactory getFunctionFactory() {
+        return new AbsLongFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsShortFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/math/AbsShortFunctionFactoryTest.java
@@ -24,33 +24,24 @@
 
 package io.questdb.griffin.engine.functions.math;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.AbstractUnaryLongFunction;
-import io.questdb.std.ObjList;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
 
-public class AbsLongFunctionFactory implements FunctionFactory {
-    @Override
-    public String getSignature() {
-        return "abs(L)";
+public class AbsShortFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testPositive() throws SqlException {
+        call(1).andAssert(1, 0.0000000001);
+    }
+
+    @Test
+    public void testNegative() throws SqlException {
+        call(-1).andAssert(1, 0.0000000001);
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration) {
-        return new AbsFunction(position, args.getQuick(0));
-    }
-
-    private static class AbsFunction extends AbstractUnaryLongFunction {
-        public AbsFunction(int position, Function arg) {
-            super(position, arg);
-        }
-
-        @Override
-        public long getLong(Record rec) {
-            long value = arg.getLong(rec);
-            return Math.abs(value);
-        }
+    protected FunctionFactory getFunctionFactory() { return new AbsShortFunctionFactory();
     }
 }

--- a/core/src/test/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/test/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -131,6 +131,7 @@ io.questdb.griffin.engine.functions.math.MulIntFunctionFactory
 io.questdb.griffin.engine.functions.math.AbsIntFunctionFactory
 io.questdb.griffin.engine.functions.math.AbsShortFunctionFactory
 io.questdb.griffin.engine.functions.math.AbsLongFunctionFactory
+io.questdb.griffin.engine.functions.math.AbsDoubleFunctionFactory
 
 # '~='
 io.questdb.griffin.engine.functions.regex.MatchStrFunctionFactory

--- a/core/src/test/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/test/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -128,6 +128,7 @@ io.questdb.griffin.engine.functions.math.MulDoubleFunctionFactory
 io.questdb.griffin.engine.functions.math.MulLongFunctionFactory
 io.questdb.griffin.engine.functions.math.MulIntFunctionFactory
 
+# 'abs'
 io.questdb.griffin.engine.functions.math.AbsIntFunctionFactory
 io.questdb.griffin.engine.functions.math.AbsShortFunctionFactory
 io.questdb.griffin.engine.functions.math.AbsLongFunctionFactory


### PR DESCRIPTION
Adding support for `abs(double)`.
Replacing branching `value < 0 ? -value : value` by `Math.abs(value)` intrinsic. 