### PR TITLE
fix(console): remove webpack-resolver to fix regression when bundling the app

### DIFF
--- a/ui/src/js/console/index.js
+++ b/ui/src/js/console/index.js
@@ -1,5 +1,5 @@
 import "ace-builds"
-import "ace-builds/webpack-resolver"
+import "ace-builds/src-min-noconflict/theme-dracula"
 import "echarts/lib/chart/bar"
 import "echarts/lib/chart/line"
 import "echarts/lib/component/tooltip"


### PR DESCRIPTION
Before:

``` shell
= du -h dist
19M     dist
```

After:

``` shell
= du -h dist
4.8M    dist
```