### PR TITLE
fix(console): disable warning for end of line check

### DIFF
--- a/ui/prettier.config.js
+++ b/ui/prettier.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   arrowParens: "always",
+  endOfLine: "auto",
   proseWrap: "always",
   trailingComma: "all",
   semi: false,


### PR DESCRIPTION
By default prettier (through ESLint) checks that the line ending is "lf". By
default, Git on Windows converts line endings on checkout to "crlf". This causes
many warnings since Prettier will see this as incorrect.

This change sets the check to `auto`.