### PR TITLE
fix(readme): prevent logo from being squeezed on mobile devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h4 align="center">
-  <img height="180px" src="https://raw.githubusercontent.com/questdb/questdb/master/.github/logo-readme.png"/>
+  <img style="max-width: 505px;" src="https://raw.githubusercontent.com/questdb/questdb/master/.github/logo-readme.png"/>
 </h4>
 
 <p align="center">


### PR DESCRIPTION
Before:
![2020-05-30-122922_grim](https://user-images.githubusercontent.com/5734722/83327102-4f14f880-a271-11ea-8151-1e6e926e56a6.png)

After:
![2020-05-30-122914_grim](https://user-images.githubusercontent.com/5734722/83327107-520fe900-a271-11ea-810d-a00122ada274.png)
