### PR TITLE
fix(griffin) - insert as select without nominating timestamp - fixed #364 #349

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -24,88 +24,28 @@
 
 package io.questdb.griffin;
 
-import static io.questdb.griffin.SqlKeywords.isCapacityKeyword;
-import static io.questdb.griffin.SqlKeywords.isColumnsKeyword;
-import static io.questdb.griffin.SqlKeywords.isDatabaseKeyword;
-import static io.questdb.griffin.SqlKeywords.isFromKeyword;
-import static io.questdb.griffin.SqlKeywords.isOnlyKeyword;
-import static io.questdb.griffin.SqlKeywords.isTableKeyword;
-import static io.questdb.griffin.SqlKeywords.isTablesKeyword;
-
-import java.io.Closeable;
-import java.util.ServiceLoader;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import io.questdb.MessageBus;
-import io.questdb.cairo.AppendMemory;
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.CairoEngine;
-import io.questdb.cairo.CairoError;
-import io.questdb.cairo.CairoException;
-import io.questdb.cairo.CairoSecurityContext;
-import io.questdb.cairo.ColumnFilter;
-import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.ColumnTypes;
-import io.questdb.cairo.DefaultLifecycleManager;
-import io.questdb.cairo.EntityColumnFilter;
-import io.questdb.cairo.GenericRecordMetadata;
-import io.questdb.cairo.ListColumnFilter;
-import io.questdb.cairo.PartitionBy;
-import io.questdb.cairo.SymbolMapReader;
-import io.questdb.cairo.SymbolMapWriter;
-import io.questdb.cairo.TableReader;
-import io.questdb.cairo.TableReaderMetadata;
-import io.questdb.cairo.TableStructure;
-import io.questdb.cairo.TableUtils;
-import io.questdb.cairo.TableWriter;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.ReaderOutOfDateException;
-import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.RecordCursor;
-import io.questdb.cairo.sql.RecordCursorFactory;
-import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.VirtualRecord;
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.*;
 import io.questdb.cutlass.text.Atomicity;
 import io.questdb.cutlass.text.TextException;
 import io.questdb.cutlass.text.TextLoader;
 import io.questdb.griffin.engine.table.ShowColumnsRecordCursorFactory;
 import io.questdb.griffin.engine.table.TableListRecordCursorFactory;
-import io.questdb.griffin.model.ColumnCastModel;
-import io.questdb.griffin.model.CopyModel;
-import io.questdb.griffin.model.CreateTableModel;
-import io.questdb.griffin.model.ExecutionModel;
-import io.questdb.griffin.model.ExpressionNode;
-import io.questdb.griffin.model.InsertModel;
-import io.questdb.griffin.model.QueryColumn;
-import io.questdb.griffin.model.QueryModel;
-import io.questdb.griffin.model.RenameTableModel;
+import io.questdb.griffin.model.*;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.BytecodeAssembler;
-import io.questdb.std.CharSequenceHashSet;
-import io.questdb.std.CharSequenceObjHashMap;
-import io.questdb.std.Chars;
-import io.questdb.std.Files;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.FindVisitor;
-import io.questdb.std.GenericLexer;
-import io.questdb.std.IntIntHashMap;
-import io.questdb.std.IntList;
-import io.questdb.std.Misc;
-import io.questdb.std.Numbers;
-import io.questdb.std.NumericException;
-import io.questdb.std.ObjHashSet;
-import io.questdb.std.ObjList;
-import io.questdb.std.ObjectPool;
-import io.questdb.std.Os;
-import io.questdb.std.Sinkable;
-import io.questdb.std.Transient;
-import io.questdb.std.Unsafe;
+import io.questdb.std.*;
 import io.questdb.std.microtime.TimestampFormat;
 import io.questdb.std.str.NativeLPSZ;
 import io.questdb.std.str.Path;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.ServiceLoader;
+
+import static io.questdb.griffin.SqlKeywords.*;
 
 
 public class SqlCompiler implements Closeable {
@@ -1464,7 +1404,7 @@ public class SqlCompiler implements Closeable {
             final int cursorTimestampIndex = cursorMetadata.getTimestampIndex();
 
             // fail when target table requires chronological data and cursor cannot provide it
-            if (writerTimestampIndex > -1 && cursorTimestampIndex == -1) {
+            if (writerTimestampIndex > -1 && cursorTimestampIndex == -1 && cursorMetadata.getColumnType(writerTimestampIndex) != ColumnType.TIMESTAMP) {
                 throw SqlException.$(name.position, "select clause must provide timestamp column");
             }
 
@@ -1537,7 +1477,7 @@ public class SqlCompiler implements Closeable {
                     if (writerTimestampIndex == -1) {
                         copyUnordered(cursor, writer, copier);
                     } else {
-                        copyOrdered(writer, cursor, copier, cursorTimestampIndex);
+                        copyOrdered(writer, cursor, copier, writerTimestampIndex);
                     }
                 } catch (CairoException e) {
                     // rollback data when system error occurs

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1402,9 +1402,10 @@ public class SqlCompiler implements Closeable {
             final RecordMetadata writerMetadata = writer.getMetadata();
             final int writerTimestampIndex = writerMetadata.getTimestampIndex();
             final int cursorTimestampIndex = cursorMetadata.getTimestampIndex();
+            final int cursorColumnCount = cursorMetadata.getColumnCount();
 
             // fail when target table requires chronological data and cursor cannot provide it
-            if (writerTimestampIndex > -1 && cursorTimestampIndex == -1 && cursorMetadata.getColumnType(writerTimestampIndex) != ColumnType.TIMESTAMP) {
+            if (writerTimestampIndex > -1 && cursorTimestampIndex == -1 && (cursorColumnCount <= writerTimestampIndex || cursorMetadata.getColumnType(writerTimestampIndex) != ColumnType.TIMESTAMP)) {
                 throw SqlException.$(name.position, "select clause must provide timestamp column");
             }
 

--- a/core/src/main/java/io/questdb/std/StationaryMicrosClock.java
+++ b/core/src/main/java/io/questdb/std/StationaryMicrosClock.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import io.questdb.std.microtime.MicrosecondClock;
+
+public class StationaryMicrosClock implements MicrosecondClock {
+    public static final StationaryMicrosClock INSTANCE = new StationaryMicrosClock();
+
+    @Override
+    public long getTicks() {
+        return 0;
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/FunctionParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/FunctionParserTest.java
@@ -998,7 +998,7 @@ public class FunctionParserTest extends BaseFunctionFactoryTest {
         functions.add(new SysdateFunctionFactory());
         final GenericRecordMetadata metadata = new GenericRecordMetadata();
         metadata.add(new TableColumnMetadata("a", ColumnType.BOOLEAN));
-        assertFail(7, "unknown function", "a or   sysdate(a)", metadata);
+        assertFail(7, "unexpected argument", "a or   sysdate(a)", metadata);
     }
 
     @Test
@@ -1030,7 +1030,7 @@ public class FunctionParserTest extends BaseFunctionFactoryTest {
             Assert.fail();
         } catch (SqlException e) {
             Assert.assertEquals(0, e.getPosition());
-            TestUtils.assertContains(e.getMessage(), "unknown function");
+            TestUtils.assertContains(e.getMessage(), "unexpected argument");
         }
     }
 
@@ -1055,7 +1055,8 @@ public class FunctionParserTest extends BaseFunctionFactoryTest {
             Assert.fail();
         } catch (SqlException e) {
             Assert.assertEquals(0, e.getPosition());
-            TestUtils.assertContains(e.getMessage(), "unknown function");
+            TestUtils.assertContains(e.getMessage(), "unexpected argument");
+            TestUtils.assertContains(e.getMessage(), "constant");
         }
     }
 

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -425,6 +425,32 @@ public class InsertTest extends AbstractGriffinTest {
         });
     }
 
+    //TODO test systimestamp as a variable but with testeable results
+//    @Test
+//    public void testInsertWithoutNominatedTimestamp() throws Exception {
+//        final String expected = "seq\tts\n" +
+//                "1\t1970-01-01T00:00:00.000000Z\n" +
+//                "2\t1970-01-01T00:00:00.000001Z\n" +
+//                "3\t1970-01-01T00:00:00.000003Z\n" +
+//                "4\t1970-01-01T00:00:00.000006Z\n" +
+//                "5\t1970-01-01T00:00:00.000010Z\n" +
+//                "6\t1970-01-01T00:00:00.000015Z\n" +
+//                "7\t1970-01-01T00:00:00.000021Z\n" +
+//                "8\t1970-01-01T00:00:00.000028Z\n" +
+//                "9\t1970-01-01T00:00:00.000036Z\n" +
+//                "10\t1970-01-01T00:00:00.000045Z\n";
+//
+//        assertQuery(
+//                "seq\tts\n",
+//                "tab",
+//                "create table tab(seq long, ts timestamp) timestamp(ts);",
+//                "ts",
+//                    "insert into tab select x ac, timestamp_sequence(0, x) ts from long_sequence(10)",
+//                expected,
+//                true
+//        );
+//    }
+
     @Test
     public void testSimpleCannedInsert() {
     }

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -425,31 +425,30 @@ public class InsertTest extends AbstractGriffinTest {
         });
     }
 
-    //TODO test systimestamp as a variable but with testeable results
-//    @Test
-//    public void testInsertWithoutNominatedTimestamp() throws Exception {
-//        final String expected = "seq\tts\n" +
-//                "1\t1970-01-01T00:00:00.000000Z\n" +
-//                "2\t1970-01-01T00:00:00.000001Z\n" +
-//                "3\t1970-01-01T00:00:00.000003Z\n" +
-//                "4\t1970-01-01T00:00:00.000006Z\n" +
-//                "5\t1970-01-01T00:00:00.000010Z\n" +
-//                "6\t1970-01-01T00:00:00.000015Z\n" +
-//                "7\t1970-01-01T00:00:00.000021Z\n" +
-//                "8\t1970-01-01T00:00:00.000028Z\n" +
-//                "9\t1970-01-01T00:00:00.000036Z\n" +
-//                "10\t1970-01-01T00:00:00.000045Z\n";
-//
-//        assertQuery(
-//                "seq\tts\n",
-//                "tab",
-//                "create table tab(seq long, ts timestamp) timestamp(ts);",
-//                "ts",
-//                    "insert into tab select x ac, timestamp_sequence(0, x) ts from long_sequence(10)",
-//                expected,
-//                true
-//        );
-//    }
+    @Test
+    public void testInsertWithoutNominatedTimestamp() throws Exception {
+        final String expected = "seq\tts\n" +
+                "1\t1970-01-01T00:00:00.000000Z\n" +
+                "2\t1970-01-01T00:00:00.000001Z\n" +
+                "3\t1970-01-01T00:00:00.000003Z\n" +
+                "4\t1970-01-01T00:00:00.000006Z\n" +
+                "5\t1970-01-01T00:00:00.000010Z\n" +
+                "6\t1970-01-01T00:00:00.000015Z\n" +
+                "7\t1970-01-01T00:00:00.000021Z\n" +
+                "8\t1970-01-01T00:00:00.000028Z\n" +
+                "9\t1970-01-01T00:00:00.000036Z\n" +
+                "10\t1970-01-01T00:00:00.000045Z\n";
+
+        assertQuery(
+                "seq\tts\n",
+                "tab",
+                "create table tab(seq long, ts timestamp) timestamp(ts);",
+                "ts",
+                    "insert into tab select x ac, timestamp_sequence(0, x) ts from long_sequence(10)",
+                expected,
+                true
+        );
+    }
 
     @Test
     public void testSimpleCannedInsert() {

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
@@ -75,8 +75,31 @@ public class TimestampSequenceFunctionFactoryTest extends AbstractFunctionFactor
     }
 
     @Test
-    public void testNaN() throws SqlException {
-        call(Numbers.LONG_NaN, 1000L).andAssertTimestamp(Numbers.LONG_NaN);
+    public void testTimestampSequenceWithSystimestampCall() throws Exception {
+        final String expected = "ac\tts\n" +
+                "1\t2020-06-05T13:27:54.334742Z\n" +
+                "2\t2020-06-05T13:27:54.334795Z\n" +
+                "3\t2020-06-05T13:27:54.334803Z\n" +
+                "4\t2020-06-05T13:27:54.334810Z\n" +
+                "5\t2020-06-05T13:27:54.334817Z\n" +
+                "6\t2020-06-05T13:27:54.334823Z\n" +
+                "7\t2020-06-05T13:27:54.334830Z\n" +
+                "8\t2020-06-05T13:27:54.334836Z\n" +
+                "9\t2020-06-05T13:27:54.334843Z\n" +
+                "10\t2020-06-05T13:27:54.334859Z\n";
+
+        assertMemoryLeak(() -> {
+            try (RecordCursorFactory factory = compiler.compile("select x ac, timestamp_sequence(systimestamp(), 0) ts from long_sequence(10)",
+                    sqlExecutionContext).getRecordCursorFactory()) {
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    sink.clear();
+                    printer.print(cursor, factory.getMetadata(), true);
+                    TestUtils.assertEquals(expected, sink);
+                }
+            } finally {
+                sqlExecutionContext.setRandom(null);
+            }
+        });
     }
 
     @Override

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
@@ -24,23 +24,34 @@
 
 package io.questdb.griffin.engine.functions.date;
 
-import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
-import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.SqlException;
-import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
-import io.questdb.griffin.engine.functions.math.NegIntFunctionFactory;
-import io.questdb.std.Numbers;
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.std.StationaryMicrosClock;
+import io.questdb.std.microtime.MicrosecondClock;
 import io.questdb.test.tools.TestUtils;
-import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TimestampSequenceFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class TimestampSequenceFunctionFactoryTest extends AbstractGriffinTest {
 
-    @Test
-    public void testIncrement2() throws SqlException {
-        assertFunction(call(0L, 1000L).getFunction2());
+    @BeforeClass
+    public static void setUp2() {
+        engine = new CairoEngine(new StaticClockCairoConfiguration(root), messageBus);
+        compiler = new SqlCompiler(engine);
+        sqlExecutionContext = new SqlExecutionContextImpl(
+                messageBus,
+                1, engine)
+                .with(
+                        AllowAllCairoSecurityContext.INSTANCE,
+                        bindVariableService,
+                        null);
+        bindVariableService.clear();
     }
 
     @Test
@@ -77,19 +88,19 @@ public class TimestampSequenceFunctionFactoryTest extends AbstractFunctionFactor
     @Test
     public void testTimestampSequenceWithSystimestampCall() throws Exception {
         final String expected = "ac\tts\n" +
-                "1\t2020-06-05T13:27:54.334742Z\n" +
-                "2\t2020-06-05T13:27:54.334795Z\n" +
-                "3\t2020-06-05T13:27:54.334803Z\n" +
-                "4\t2020-06-05T13:27:54.334810Z\n" +
-                "5\t2020-06-05T13:27:54.334817Z\n" +
-                "6\t2020-06-05T13:27:54.334823Z\n" +
-                "7\t2020-06-05T13:27:54.334830Z\n" +
-                "8\t2020-06-05T13:27:54.334836Z\n" +
-                "9\t2020-06-05T13:27:54.334843Z\n" +
-                "10\t2020-06-05T13:27:54.334859Z\n";
+                "1\t1970-01-01T00:00:00.000000Z\n" +
+                "2\t1970-01-01T00:00:00.001000Z\n" +
+                "3\t1970-01-01T00:00:00.002000Z\n" +
+                "4\t1970-01-01T00:00:00.003000Z\n" +
+                "5\t1970-01-01T00:00:00.004000Z\n" +
+                "6\t1970-01-01T00:00:00.005000Z\n" +
+                "7\t1970-01-01T00:00:00.006000Z\n" +
+                "8\t1970-01-01T00:00:00.007000Z\n" +
+                "9\t1970-01-01T00:00:00.008000Z\n" +
+                "10\t1970-01-01T00:00:00.009000Z\n";
 
         assertMemoryLeak(() -> {
-            try (RecordCursorFactory factory = compiler.compile("select x ac, timestamp_sequence(systimestamp(), 0) ts from long_sequence(10)",
+            try (RecordCursorFactory factory = compiler.compile("select x ac, timestamp_sequence(systimestamp(), 1000) ts from long_sequence(10)",
                     sqlExecutionContext).getRecordCursorFactory()) {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     sink.clear();
@@ -102,21 +113,42 @@ public class TimestampSequenceFunctionFactoryTest extends AbstractFunctionFactor
         });
     }
 
-    @Override
-    protected void addExtraFunctions() {
-        functions.add(new NegIntFunctionFactory());
+    @Test
+    public void testTimestampSequenceWithZeroStartValue() throws Exception {
+        final String expected = "ac\tts\n" +
+                "1\t1970-01-01T00:00:00.000000Z\n" +
+                "2\t1970-01-01T00:00:00.001000Z\n" +
+                "3\t1970-01-01T00:00:00.002000Z\n" +
+                "4\t1970-01-01T00:00:00.003000Z\n" +
+                "5\t1970-01-01T00:00:00.004000Z\n" +
+                "6\t1970-01-01T00:00:00.005000Z\n" +
+                "7\t1970-01-01T00:00:00.006000Z\n" +
+                "8\t1970-01-01T00:00:00.007000Z\n" +
+                "9\t1970-01-01T00:00:00.008000Z\n" +
+                "10\t1970-01-01T00:00:00.009000Z\n";
+
+        assertMemoryLeak(() -> {
+            try (RecordCursorFactory factory = compiler.compile("select x ac, timestamp_sequence(0, 1000) ts from long_sequence(10)",
+                    sqlExecutionContext).getRecordCursorFactory()) {
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    sink.clear();
+                    printer.print(cursor, factory.getMetadata(), true);
+                    TestUtils.assertEquals(expected, sink);
+                }
+            } finally {
+                sqlExecutionContext.setRandom(null);
+            }
+        });
     }
 
-    @Override
-    protected FunctionFactory getFunctionFactory() {
-        return new TimestampSequenceFunctionFactory();
-    }
+    private final static class StaticClockCairoConfiguration extends DefaultCairoConfiguration {
 
-    private void assertFunction(Function function) {
-        long next = 0;
-        for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(next, function.getTimestamp(null));
-            next += 1000L;
+        public StaticClockCairoConfiguration(CharSequence root) {
+            super(root);
+        }
+
+        public MicrosecondClock getMicrosecondClock() {
+            return StationaryMicrosClock.INSTANCE;
         }
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
@@ -32,7 +32,7 @@ import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.AbstractGriffinTest;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContextImpl;
-import io.questdb.std.StationaryMicrosClock;
+import io.questdb.test.tools.StationaryMicrosClock;
 import io.questdb.std.microtime.MicrosecondClock;
 import io.questdb.test.tools.TestUtils;
 import org.junit.BeforeClass;

--- a/core/src/test/java/io/questdb/test/tools/StationaryMicrosClock.java
+++ b/core/src/test/java/io/questdb/test/tools/StationaryMicrosClock.java
@@ -22,7 +22,7 @@
  *
  ******************************************************************************/
 
-package io.questdb.std;
+package io.questdb.test.tools;
 
 import io.questdb.std.microtime.MicrosecondClock;
 


### PR DESCRIPTION
To summarise, this is what it's fixed on  the PR:
1. insert as select without nominating timestamp
2. timestamp_sequence can take systimestamp()
3. invalid argument(s) for function is not longer reported as unknown function