### PR TITLE
fix(Console): display notifications for 2 minutes (rather than 15 secs)

### DIFF
--- a/ui/src/scenes/Notifications/Notification/index.tsx
+++ b/ui/src/scenes/Notifications/Notification/index.tsx
@@ -68,7 +68,7 @@ const Out = styled.div<{ animationPlay: AnimationPlay }>`
   width: 100%;
   height: 1px;
   background: ${color("gray2")};
-  animation: ${disappear} 15s linear 0s 1 normal forwards;
+  animation: ${disappear} 120s linear 0s 1 normal forwards;
   animation-play-state: ${({ animationPlay }) => animationPlay};
 `
 


### PR DESCRIPTION
Given that the row count is only shown in notifications, we need to display them
for longer so the users can have time to access the information.

This is a short term fix, the row count will be shown next to the refresh button
in the next iteration of the React refactor of the codebase.


----

#