### PR TITLE
fix(console): do not truncate error messages in toast notification

### DIFF
--- a/ui/src/scenes/Editor/Ace/index.tsx
+++ b/ui/src/scenes/Editor/Ace/index.tsx
@@ -131,11 +131,7 @@ const Ace = () => {
             dispatch(actions.query.stopRunning())
             dispatch(
               actions.query.addNotification({
-                line1: (
-                  <Text color="draculaForeground" ellipsis>
-                    {error.error}
-                  </Text>
-                ),
+                line1: <Text color="draculaForeground">{error.error}</Text>,
                 title: (
                   <Text color="draculaForeground" ellipsis>
                     {request.query}


### PR DESCRIPTION
This fixes quite a big issue discovered by @TheTanc, currently error message look like:

![2020-06-14-161929_grim](https://user-images.githubusercontent.com/5734722/84597303-035e7380-ae5b-11ea-9646-cdb9a63a7b4d.png)

This remove the overflow truncation and the full message is now displayed:

![2020-06-14-161902_grim](https://user-images.githubusercontent.com/5734722/84597307-0e190880-ae5b-11ea-8449-5771035b5402.png)
