### PR TITLE
fix(griffin) - prevent invalid characters in column name when creating table or adding column. Fixed #412

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -727,6 +727,10 @@ public class SqlCompiler implements Closeable {
 
             CharSequence columnName = GenericLexer.immutableOf(tok);
 
+            if (Chars.indexOf(tok, '\\') > -1 || Chars.indexOf(tok, '.') > -1 || Chars.indexOf(tok, '/') > -1) {
+                throw SqlException.$(lexer.lastTokenPosition(), " new column name contains invalid characters '\\', '.' or '/'");
+            }
+
             tok = expectToken(lexer, "column type");
 
             int type = ColumnType.columnTypeOf(tok);

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -727,8 +727,8 @@ public class SqlCompiler implements Closeable {
 
             CharSequence columnName = GenericLexer.immutableOf(tok);
 
-            if (Chars.indexOf(tok, '\\') > -1 || Chars.indexOf(tok, '.') > -1 || Chars.indexOf(tok, '/') > -1) {
-                throw SqlException.$(lexer.lastTokenPosition(), " new column name contains invalid characters '\\', '.' or '/'");
+            if (!SqlKeywords.isValidColumnName(columnName)) {
+                throw SqlException.$(lexer.lastTokenPosition(), " new column name contains invalid characters");
             }
 
             tok = expectToken(lexer, "column type");

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -691,4 +691,34 @@ public class SqlKeywords {
                 && (tok.charAt(i) | 32) == 's';
         // @formatter:on
     }
+
+    public static boolean isValidColumnName(CharSequence seq) {
+        for (int i = 0, l = seq.length(); i < l; i++) {
+            char c = seq.charAt(i);
+            switch (c) {
+                case ' ':
+                case '?':
+                case '.':
+                case ',':
+                case '\'':
+                case '\"':
+                case '\\':
+                case '/':
+                case '\0':
+                case ':':
+                case ')':
+                case '(':
+                case '+':
+                case '-':
+                case '*':
+                case '%':
+                case '~':
+                case 0xfeff: // UTF-8 BOM (Byte Order Mark) can appear at the beginning of a character stream
+                    return false;
+                default:
+
+            }
+        }
+        return true;
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -487,8 +487,8 @@ public final class SqlParser {
             final CharSequence name = GenericLexer.immutableOf(GenericLexer.unquote(notTermTok(lexer)));
             final int type = toColumnType(lexer, notTermTok(lexer));
 
-            if (Chars.indexOf(name, '.') > -1) {
-                throw SqlException.$(position, "Column name cannot have character '.'");
+            if (!SqlKeywords.isValidColumnName(name)) {
+                throw SqlException.$(position, " new column name contains invalid characters");
             }
 
             if (!model.addColumn(name, type, configuration.getDefaultSymbolCapacity())) {

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -487,6 +487,10 @@ public final class SqlParser {
             final CharSequence name = GenericLexer.immutableOf(GenericLexer.unquote(notTermTok(lexer)));
             final int type = toColumnType(lexer, notTermTok(lexer));
 
+            if (Chars.indexOf(name, '.') > -1) {
+                throw SqlException.$(position, "Column name cannot have character '.'");
+            }
+
             if (!model.addColumn(name, type, configuration.getDefaultSymbolCapacity())) {
                 throw SqlException.$(position, "Duplicate column");
             }

--- a/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
@@ -53,18 +53,18 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testAddBadColumnNameBackSlash() throws Exception {
+        assertFailure("alter table x add column \\", 25, "new column name contains invalid characters");
+    }
+
+    @Test
     public void testAddBadColumnNameDot() throws Exception {
-        assertFailure("alter table x add column .", 25, "new column name contains invalid characters '\\', '.' or '/'");
+        assertFailure("alter table x add column .", 25, "new column name contains invalid characters");
     }
 
     @Test
     public void testAddBadColumnNameFwdSlash() throws Exception {
-        assertFailure("alter table x add column /", 25, "new column name contains invalid characters '\\', '.' or '/'");
-    }
-
-    @Test
-    public void testAddBadColumnNameBackSlash() throws Exception {
-        assertFailure("alter table x add column \\", 25, "new column name contains invalid characters '\\', '.' or '/'");
+        assertFailure("alter table x add column /", 25, "new column name contains invalid characters");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
@@ -53,6 +53,21 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testAddBadColumnNameDot() throws Exception {
+        assertFailure("alter table x add column .", 25, "new column name contains invalid characters '\\', '.' or '/'");
+    }
+
+    @Test
+    public void testAddBadColumnNameFwdSlash() throws Exception {
+        assertFailure("alter table x add column /", 25, "new column name contains invalid characters '\\', '.' or '/'");
+    }
+
+    @Test
+    public void testAddBadColumnNameBackSlash() throws Exception {
+        assertFailure("alter table x add column \\", 25, "new column name contains invalid characters '\\', '.' or '/'");
+    }
+
+    @Test
     public void testAddBusyTable() throws Exception {
         assertMemoryLeak(() -> {
             CountDownLatch allHaltLatch = new CountDownLatch(1);

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -2330,7 +2330,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
 
     @Test
     public void testColumnNameWithDot() throws Exception {
-        assertFailure(27, "Column name cannot have character '.'",
+        assertFailure(27, "new column name contains invalid characters",
                 "create table x (" +
                         "t TIMESTAMP, " +
                         "`bool.flag` BOOLEAN) " +

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -2329,6 +2329,16 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testColumnNameWithDot() throws Exception {
+        assertFailure(27, "Column name cannot have character '.'",
+                "create table x (" +
+                        "t TIMESTAMP, " +
+                        "`bool.flag` BOOLEAN) " +
+                        "timestamp(t) " +
+                        "partition by MONTH");
+    }
+
+    @Test
     public void testEmptyQuery() {
         try {
             compiler.compile("                        ", sqlExecutionContext);


### PR DESCRIPTION
similar logic to the one used when renaming columns