### PR TITLE
fix(console): add extra checks on TouchEvent to prevent issues on Firefox (fixes #410)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10334,6 +10334,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,6 +47,7 @@
     "react-transition-group": "4.4.1",
     "redux": "4.0.5",
     "redux-observable": "1.2.0",
+    "resize-observer-polyfill": "1.5.1",
     "rxjs": "6.5.5",
     "slim-select": "1.26.0",
     "styled-components": "5.1.1",

--- a/ui/src/components/Splitter/index.tsx
+++ b/ui/src/components/Splitter/index.tsx
@@ -129,7 +129,7 @@ export const Splitter = ({
       const side = direction === "horizontal" ? "outerWidth" : "outerHeight"
       let position = 0
 
-      if (event instanceof TouchEvent) {
+      if (window.TouchEvent && event instanceof TouchEvent) {
         position = event.touches[0][clientPosition]
       }
 
@@ -168,7 +168,7 @@ export const Splitter = ({
         ]
         let position = 0
 
-        if (event.nativeEvent instanceof TouchEvent) {
+        if (window.TouchEvent && event.nativeEvent instanceof TouchEvent) {
           position = event.nativeEvent.touches[0][clientPosition]
         }
 

--- a/ui/src/scenes/Editor/Ace/index.tsx
+++ b/ui/src/scenes/Editor/Ace/index.tsx
@@ -2,6 +2,7 @@ import { Range } from "ace-builds"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import ReactAce from "react-ace"
 import { useDispatch, useSelector } from "react-redux"
+import ResizeObserver from "resize-observer-polyfill"
 import styled from "styled-components"
 
 import { PaneContent, Text } from "components"


### PR DESCRIPTION
We also use the ResizeObserver ponyfill for older versions of FF.