### PR TITLE
fix(console): use pointer-events to prevent Chrome from triggering wrong events on mouseleave for tooltips (PopperHover)

### DIFF
--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -47,6 +47,7 @@ const baseStyles = css<ButtonProps>`
   outline: 0;
   line-height: 1.15;
   ${bezierTransition};
+  ${({ disabled }) => disabled && "pointer-events: none;"};
 
   svg + span {
     margin-left: 0.5rem;

--- a/ui/src/components/Hooks/useTransition.ts
+++ b/ui/src/components/Hooks/useTransition.ts
@@ -6,12 +6,17 @@ export const useTransition = (
   element: HTMLElement,
   _active: boolean,
   timeoutId: MutableRefObject<number | undefined>,
+  update?: (() => void) | null,
 ) => {
   useEffect(() => {
     clearTimeout(timeoutId.current)
 
     if (_active && !document.body.contains(element)) {
       document.body.appendChild(element)
+      if (update) {
+        update()
+      }
+      return
     }
 
     if (!_active) {
@@ -19,5 +24,5 @@ export const useTransition = (
         document.body.contains(element) && document.body.removeChild(element)
       }, TransitionDuration.REG)
     }
-  }, [_active, element, timeoutId])
+  }, [_active, element, timeoutId, update])
 }

--- a/ui/src/components/PopperToggle/index.tsx
+++ b/ui/src/components/PopperToggle/index.tsx
@@ -11,7 +11,7 @@ import { usePopper } from "react-popper"
 import { CSSTransition } from "react-transition-group"
 
 import { usePopperStyles, useTransition } from "../Hooks"
-import { createGlobalFadeTransition, TransitionDuration } from "../Transition"
+import { TransitionDuration } from "../Transition"
 
 type Props = Readonly<{
   active?: boolean
@@ -21,11 +21,6 @@ type Props = Readonly<{
   onToggle?: (_active: boolean) => void
   trigger: ReactNode
 }>
-
-const GlobalTransitionStyles = createGlobalFadeTransition(
-  "popper-toggle-fade",
-  TransitionDuration.REG,
-)
 
 export const PopperToggle = ({
   active,
@@ -102,8 +97,6 @@ export const PopperToggle = ({
 
   return (
     <>
-      <GlobalTransitionStyles />
-
       {React.isValidElement(trigger) &&
         React.cloneElement(trigger, {
           onClick: handleClick,
@@ -112,7 +105,7 @@ export const PopperToggle = ({
 
       {React.isValidElement(children) && (
         <CSSTransition
-          classNames="popper-toggle-fade"
+          classNames="popper-fade"
           in={_active}
           timeout={TransitionDuration.REG}
           unmountOnExit

--- a/ui/src/components/ToggleButton/index.tsx
+++ b/ui/src/components/ToggleButton/index.tsx
@@ -42,6 +42,7 @@ const baseStyles = css<Props>`
   ${({ direction }) =>
     `border-${direction || defaultProps.direction}: 2px solid transparent;`};
   ${bezierTransition};
+  ${({ disabled }) => disabled && "pointer-events: none;"};
 
   svg + span {
     margin-left: 1rem;

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -8,7 +8,11 @@ import { applyMiddleware, compose, createStore } from "redux"
 import { createEpicMiddleware } from "redux-observable"
 import { ThemeProvider } from "styled-components"
 
-import { ScreenSizeProvider } from "components"
+import {
+  createGlobalFadeTransition,
+  ScreenSizeProvider,
+  TransitionDuration,
+} from "components"
 import { actions, rootEpic, rootReducer } from "store"
 import { StoreAction, StoreShape } from "types"
 
@@ -26,10 +30,16 @@ const store = createStore(rootReducer, compose(applyMiddleware(epicMiddleware)))
 epicMiddleware.run(rootEpic)
 store.dispatch(actions.console.bootstrap())
 
+const GlobalTransitionStyles = createGlobalFadeTransition(
+  "popper-fade",
+  TransitionDuration.REG,
+)
+
 ReactDOM.render(
   <ScreenSizeProvider>
     <Provider store={store}>
       <ThemeProvider theme={theme}>
+        <GlobalTransitionStyles />
         <Layout />
       </ThemeProvider>
     </Provider>

--- a/ui/src/scenes/Schema/index.tsx
+++ b/ui/src/scenes/Schema/index.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
+import { useSelector } from "react-redux"
 import { from, combineLatest, of } from "rxjs"
 import { delay, startWith } from "rxjs/operators"
 import styled, { css } from "styled-components"
@@ -23,6 +24,7 @@ import {
   Text,
   Tooltip,
 } from "components"
+import { selectors } from "store"
 import { color } from "utils"
 import * as QuestDB from "utils/questdb"
 
@@ -84,6 +86,7 @@ const Schema = ({
   const [tables, setTables] = useState<QuestDB.Table[]>()
   const [opened, setOpened] = useState<string>()
   const [refresh, setRefresh] = useState(Date.now())
+  const { readOnly } = useSelector(selectors.console.getConfiguration)
 
   const handleChange = useCallback((name: string) => {
     setOpened(name)
@@ -116,17 +119,19 @@ const Schema = ({
           Tables
         </Header>
 
-        <PopperHover
-          delay={350}
-          placement="bottom"
-          trigger={
-            <SecondaryButton onClick={fetchTables}>
-              <Refresh size="18px" />
-            </SecondaryButton>
-          }
-        >
-          <Tooltip>Refresh</Tooltip>
-        </PopperHover>
+        {readOnly === false && (
+          <PopperHover
+            delay={350}
+            placement="bottom"
+            trigger={
+              <SecondaryButton onClick={fetchTables}>
+                <Refresh size="18px" />
+              </SecondaryButton>
+            }
+          >
+            <Tooltip>Refresh</Tooltip>
+          </PopperHover>
+        )}
       </Menu>
 
       <Content _loading={loading}>

--- a/ui/src/store/Console/reducers.ts
+++ b/ui/src/store/Console/reducers.ts
@@ -10,7 +10,6 @@ export const initialState: ConsoleStateShape = {
 }
 
 export const defaultConfiguration: ConfigurationShape = {
-  readOnly: false,
   savedQueries: [],
 }
 

--- a/ui/src/store/Console/types.ts
+++ b/ui/src/store/Console/types.ts
@@ -4,7 +4,7 @@ export type QueryShape = Readonly<{
 }>
 
 export type ConfigurationShape = Readonly<{
-  readOnly: boolean
+  readOnly?: boolean
   savedQueries: QueryShape[]
 }>
 


### PR DESCRIPTION
----

#