### PR TITLE
fix(console): do not prevent the browser from using the history API

### DIFF
--- a/ui/src/js/console/index.js
+++ b/ui/src/js/console/index.js
@@ -15,12 +15,6 @@ import "./import-detail"
 import "./quick-vis"
 import "./splitter"
 
-// Disable "back" button.
-history.pushState(null, null, "index.html")
-window.addEventListener("popstate", function () {
-  history.pushState(null, null, "index.html")
-})
-
 let messageBus = $({})
 window.bus = messageBus
 


### PR DESCRIPTION
The rationale for doing this was to prevent macOS users from going back when scrolling the grid horizontally. This PR removes this for now, in the future, we will implement a better solution that does not mess with the History API.