### PR TITLE
fix(console): improve query picker styles

### DIFF
--- a/ui/src/scenes/Editor/Menu/index.tsx
+++ b/ui/src/scenes/Editor/Menu/index.tsx
@@ -26,10 +26,11 @@ import { color } from "utils"
 
 import QueryPicker from "../QueryPicker"
 
-const Wrapper = styled(PaneMenu)`
+const Wrapper = styled(PaneMenu)<{ _display: string }>`
   z-index: 15;
 
   .algolia-autocomplete {
+    display: ${({ _display }) => _display} !important;
     flex: 0 1 168px;
   }
 `
@@ -38,8 +39,7 @@ const Separator = styled.div`
   flex: 1;
 `
 
-const DocsearchInput = styled(Input)<{ _display: string }>`
-  display: ${({ _display }) => _display};
+const DocsearchInput = styled(Input)`
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -61,7 +61,6 @@ const CloseIcon = styled(_CloseIcon)`
 
 const SideMenuMenuButton = styled(TransparentButton)`
   padding: 0;
-  margin-left: 1rem;
 
   .fade-enter {
     opacity: 0;
@@ -133,7 +132,7 @@ const Menu = () => {
   }, [dispatch, opened, sm])
 
   return (
-    <Wrapper>
+    <Wrapper _display={sm ? "none" : "inline"}>
       {running && (
         <ErrorButton onClick={handleClick}>
           <Stop size="18px" />
@@ -167,7 +166,6 @@ const Menu = () => {
       <Separator />
 
       <DocsearchInput
-        _display={sm ? "none" : "inline"}
         id="docsearch-input"
         placeholder="Search documentation"
         title="Search..."

--- a/ui/src/scenes/Editor/QueryPicker/Row/index.tsx
+++ b/ui/src/scenes/Editor/QueryPicker/Row/index.tsx
@@ -17,7 +17,7 @@ const activeStyles = css`
   background: ${color("draculaSelection")};
 `
 
-const QueryWrapper = styled.div<{ active: boolean }>`
+const Wrapper = styled.div<{ active: boolean }>`
   display: flex;
   height: 2.4rem;
   padding: 0 0.6rem;
@@ -28,10 +28,13 @@ const QueryWrapper = styled.div<{ active: boolean }>`
   user-select: none;
 
   ${({ active }) => active && activeStyles};
+
+  > span:not(:last-child) {
+    margin-right: 0.6rem;
+  }
 `
 
 const Query = styled(Text)`
-  margin-left: 0.6rem;
   flex: 1 1 auto;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -63,7 +66,7 @@ const Row = ({ active, hidePicker, onHover, query }: Props) => {
   }, [onHover])
 
   return (
-    <QueryWrapper
+    <Wrapper
       active={active}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
@@ -71,14 +74,16 @@ const Row = ({ active, hidePicker, onHover, query }: Props) => {
     >
       <FileIcon size="12px" />
 
-      <Name color="draculaForeground" size="sm">
-        {query.name}
-      </Name>
+      {query.name && (
+        <Name color="draculaForeground" size="sm">
+          {query.name}
+        </Name>
+      )}
 
-      <Query color="draculaForeground" size="xs">
+      <Query color="draculaForeground" size="sm">
         {query.value}
       </Query>
-    </QueryWrapper>
+    </Wrapper>
   )
 }
 

--- a/ui/src/store/Console/types.ts
+++ b/ui/src/store/Console/types.ts
@@ -1,5 +1,5 @@
 export type QueryShape = Readonly<{
-  name: string
+  name?: string
   value: string
 }>
 


### PR DESCRIPTION
The QueryPicker button "Example Queries" is now properly aligned (center).
The Rows in QueryPicker aligns text vertically, without an offset for the code.
When there no name for a query, we also remove its margin to avoid adding
unnecessary gaps.