### PR TITLE
fix(server): always copy conf/date.formats when not present, fix regression introduced in #445

### DIFF
--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -277,7 +277,9 @@ public class ServerMain {
                 log.error().$("could not find site [resource=").$(publicZip).$(']').$();
             }
         }
+        copyConfResource(dir, false, buffer, "conf/date.formats", log);
         copyConfResource(dir, force, buffer, "conf/mime.types", log);
+        copyConfResource(dir, false, buffer, "conf/server.conf", log);
     }
 
     private static void copyConfResource(String dir, boolean force, byte[] buffer, String res, Log log) throws IOException {


### PR DESCRIPTION
This also fixes one of the issues detailed in #457.