### PR TITLE
fix(docker): add --add-exports flag to Docker base command - fixes #475

### DIFF
--- a/core/Dockerfile-linux
+++ b/core/Dockerfile-linux
@@ -42,4 +42,4 @@ EXPOSE 9000/tcp
 EXPOSE 8812/tcp
 
 # Run questdb when the container launches
-CMD ["/app/bin/java", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb"]
+CMD ["/app/bin/java", "--add-exports", "java.base/jdk.internal.math=io.questdb", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb"]

--- a/core/Dockerfile-windows
+++ b/core/Dockerfile-windows
@@ -44,4 +44,4 @@ RUN mkdir C:\questdb
 VOLUME C:/questdb/db
 
 # Run questdb when the container launches
-CMD ["/app/rt-windows-amd64/bin/java", "-m", "io.questdb/io.questdb.ServerMain", "-d", "c:/questdb"]
+CMD ["/app/rt-windows-amd64/bin/java", "--add-exports", "java.base/jdk.internal.math=io.questdb", "-m", "io.questdb/io.questdb.ServerMain", "-d", "c:/questdb"]


### PR DESCRIPTION
The Docker base CMD was missing `--add-exports` which is causing issues at
runtime (cf. #475).