### PR TITLE
Error while running JMH benchmark #503

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -95,6 +95,13 @@
                 <configuration>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
JMH annotation processor was not picked up automatically. Added it explicitly. Tested on IDE as well as terminal, working as expected.