### PR TITLE
fix(griffin): maven test runner (surefire) was picking up default encoding and thus failing tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -204,6 +204,7 @@
                 <version>2.19</version>
                 <configuration>
                     <argLine>-Xmx512m --add-exports java.base/jdk.internal.math=ALL-UNNAMED</argLine>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/core/src/main/java/io/questdb/griffin/OperatorExpression.java
+++ b/core/src/main/java/io/questdb/griffin/OperatorExpression.java
@@ -49,7 +49,6 @@ public final class OperatorExpression {
         add(new OperatorExpression("!=", 7, true, BINARY));
         add(new OperatorExpression("<>", 7, true, BINARY));
         add(new OperatorExpression("!~", 7, true, BINARY));
-        add(new OperatorExpression("~=", 7, true, BINARY));
         add(new OperatorExpression("in", 7, true, SET, false));
         add(new OperatorExpression("and", 11, true, BINARY, false));
         add(new OperatorExpression("or", 11, true, BINARY, false));


### PR DESCRIPTION
Also removed duplicate operator expression.