### PR TITLE
chore: simplified embedded API

### DIFF
--- a/benchmarks/src/main/java/org/questdb/TableWriteBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableWriteBenchmark.java
@@ -52,7 +52,7 @@ public class TableWriteBenchmark {
 
     public static void main(String[] args) throws RunnerException {
         try (CairoEngine engine = new CairoEngine(configuration)) {
-            SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(null, 1, engine).with(AllowAllCairoSecurityContext.INSTANCE, null, null, -1, null);
+            SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1, null).with(AllowAllCairoSecurityContext.INSTANCE, null, null, -1, null);
             try (SqlCompiler compiler = new SqlCompiler(engine)) {
                 compiler.compile("create table test1(f long)", sqlExecutionContext);
             } catch (SqlException e) {

--- a/core/src/main/java/io/questdb/DefaultServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultServerConfiguration.java
@@ -42,7 +42,6 @@ public class DefaultServerConfiguration implements ServerConfiguration {
     private final DefaultLineUdpReceiverConfiguration lineUdpReceiverConfiguration = new DefaultLineUdpReceiverConfiguration();
     private final DefaultLineTcpReceiverConfiguration lineTcpReceiverConfiguration = new DefaultLineTcpReceiverConfiguration();
     private final DefaultPGWireConfiguration pgWireConfiguration = new DefaultPGWireConfiguration();
-    private final DefaultTelemetryConfiguration telemetryConfiguration = new DefaultTelemetryConfiguration();
 
     public DefaultServerConfiguration(CharSequence root) {
         this.cairoConfiguration = new DefaultCairoConfiguration(root);
@@ -76,10 +75,5 @@ public class DefaultServerConfiguration implements ServerConfiguration {
     @Override
     public PGWireConfiguration getPGWireConfiguration() {
         return pgWireConfiguration;
-    }
-
-    @Override
-    public TelemetryConfiguration getTelemetryConfiguration() {
-        return telemetryConfiguration;
     }
 }

--- a/core/src/main/java/io/questdb/DefaultTelemetryConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultTelemetryConfiguration.java
@@ -27,7 +27,7 @@ package io.questdb;
 public class DefaultTelemetryConfiguration implements TelemetryConfiguration {
     @Override
     public boolean getEnabled() {
-        return false;
+        return true;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/MessageBus.java
+++ b/core/src/main/java/io/questdb/MessageBus.java
@@ -24,11 +24,10 @@
 
 package io.questdb;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.mp.RingQueue;
-import io.questdb.mp.SCSequence;
 import io.questdb.mp.Sequence;
 import io.questdb.tasks.ColumnIndexerTask;
-import io.questdb.tasks.TelemetryTask;
 import io.questdb.tasks.VectorAggregateTask;
 
 public interface MessageBus {
@@ -44,11 +43,5 @@ public interface MessageBus {
 
     Sequence getVectorAggregateSubSequence();
 
-    RingQueue<TelemetryTask> getTelemetryQueue();
-
-    Sequence getTelemetryPubSequence();
-
-    SCSequence getTelemetrySubSequence();
-
-    ServerConfiguration getConfiguration();
+    CairoConfiguration getConfiguration();
 }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -532,24 +532,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private LineProtoTimestampAdapter getLineTimestampAdaptor(Properties properties, String propNm) {
-        final String lineUdpTimestampSwitch = getString(properties, propNm, "n");
-        switch (lineUdpTimestampSwitch) {
-            case "u":
-                return LineProtoMicroTimestampAdapter.INSTANCE;
-            case "ms":
-                return LineProtoMilliTimestampAdapter.INSTANCE;
-            case "s":
-                return LineProtoSecondTimestampAdapter.INSTANCE;
-            case "m":
-                return LineProtoMinuteTimestampAdapter.INSTANCE;
-            case "h":
-                return LineProtoHourTimestampAdapter.INSTANCE;
-            default:
-                return LineProtoNanoTimestampAdapter.INSTANCE;
-        }
-    }
-
     @Override
     public CairoConfiguration getCairoConfiguration() {
         return cairoConfiguration;
@@ -578,11 +560,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     @Override
     public PGWireConfiguration getPGWireConfiguration() {
         return pgWireConfiguration;
-    }
-
-    @Override
-    public TelemetryConfiguration getTelemetryConfiguration() {
-        return telemetryConfiguration;
     }
 
     private int[] getAffinity(Properties properties, String key, int httpWorkerCount) throws ServerConfigurationException {
@@ -667,6 +644,24 @@ public class PropServerConfiguration implements ServerConfiguration {
             return value != null ? Numbers.parseIntSize(value) : defaultValue;
         } catch (NumericException e) {
             throw new ServerConfigurationException(key, value);
+        }
+    }
+
+    private LineProtoTimestampAdapter getLineTimestampAdaptor(Properties properties, String propNm) {
+        final String lineUdpTimestampSwitch = getString(properties, propNm, "n");
+        switch (lineUdpTimestampSwitch) {
+            case "u":
+                return LineProtoMicroTimestampAdapter.INSTANCE;
+            case "ms":
+                return LineProtoMilliTimestampAdapter.INSTANCE;
+            case "s":
+                return LineProtoSecondTimestampAdapter.INSTANCE;
+            case "m":
+                return LineProtoMinuteTimestampAdapter.INSTANCE;
+            case "h":
+                return LineProtoHourTimestampAdapter.INSTANCE;
+            default:
+                return LineProtoNanoTimestampAdapter.INSTANCE;
         }
     }
 
@@ -937,16 +932,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private class PropHttpServerConfiguration implements HttpServerConfiguration {
 
         @Override
-        public boolean getServerKeepAlive() {
-            return httpServerKeepAlive;
-        }
-
-        @Override
-        public String getHttpVersion() {
-            return httpVersion;
-        }
-
-        @Override
         public int getConnectionPoolInitialCapacity() {
             return connectionPoolInitialCapacity;
         }
@@ -1032,21 +1017,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int[] getWorkerAffinity() {
-            return httpWorkerAffinity;
-        }
-
-        @Override
-        public int getWorkerCount() {
-            return httpWorkerCount;
-        }
-
-        @Override
-        public boolean haltOnError() {
-            return httpWorkerHaltOnError;
-        }
-
-        @Override
         public boolean readOnlySecurityContext() {
             return readOnlySecurityContext;
         }
@@ -1064,6 +1034,31 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getInterruptorBufferSize() {
             return interruptorBufferSize;
+        }
+
+        @Override
+        public boolean getServerKeepAlive() {
+            return httpServerKeepAlive;
+        }
+
+        @Override
+        public String getHttpVersion() {
+            return httpVersion;
+        }
+
+        @Override
+        public int[] getWorkerAffinity() {
+            return httpWorkerAffinity;
+        }
+
+        @Override
+        public int getWorkerCount() {
+            return httpWorkerCount;
+        }
+
+        @Override
+        public boolean haltOnError() {
+            return httpWorkerHaltOnError;
         }
     }
 
@@ -1127,11 +1122,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getIndexValueBlockSize() {
             return indexValueBlockSize;
-        }
-
-        @Override
-        public boolean enableTestFactories() {
-            return false;
         }
 
         @Override
@@ -1418,6 +1408,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         public int getGroupByMapCapacity() {
             return sqlGroupByMapCapacity;
         }
+
+        @Override
+        public boolean enableTestFactories() {
+            return false;
+        }
+
+        @Override
+        public TelemetryConfiguration getTelemetryConfiguration() {
+            return telemetryConfiguration;
+        }
     }
 
     private class PropLineUdpReceiverConfiguration implements LineUdpReceiverConfiguration {
@@ -1500,11 +1500,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private class PropLineTcpReceiverIODispatcherConfiguration implements IODispatcherConfiguration {
 
         @Override
-        public String getDispatcherLogName() {
-            return "line-server";
-        }
-
-        @Override
         public int getActiveConnectionLimit() {
             return lineTcpNetActiveConnectionLimit;
         }
@@ -1522,6 +1517,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public MillisecondClock getClock() {
             return MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public String getDispatcherLogName() {
+            return "line-server";
         }
 
         @Override
@@ -1737,11 +1737,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private class PropPGWireDispatcherConfiguration implements IODispatcherConfiguration {
 
         @Override
-        public String getDispatcherLogName() {
-            return "pg-server";
-        }
-
-        @Override
         public int getActiveConnectionLimit() {
             return pgNetActiveConnectionLimit;
         }
@@ -1759,6 +1754,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public MillisecondClock getClock() {
             return MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public String getDispatcherLogName() {
+            return "pg-server";
         }
 
         @Override
@@ -1910,11 +1910,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean isEnabled() {
-            return pgEnabled;
-        }
-
-        @Override
         public int[] getWorkerAffinity() {
             return pgWorkerAffinity;
         }
@@ -1932,6 +1927,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isDaemonPool() {
             return pgDaemonPool;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return pgEnabled;
         }
     }
 

--- a/core/src/main/java/io/questdb/ServerConfiguration.java
+++ b/core/src/main/java/io/questdb/ServerConfiguration.java
@@ -44,6 +44,4 @@ public interface ServerConfiguration {
     WorkerPoolConfiguration getWorkerPoolConfiguration();
 
     PGWireConfiguration getPGWireConfiguration();
-
-    TelemetryConfiguration getTelemetryConfiguration();
 }

--- a/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
+++ b/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
@@ -71,7 +71,6 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
             Log log,
             CairoEngine cairoEngine,
             ServerFactory<T, C> factory,
-            MessageBus messageBus,
             FunctionFactoryCache functionFactoryCache
     ) {
         final T server;
@@ -79,7 +78,7 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
 
             final WorkerPool localPool = configureWorkerPool(configuration, sharedWorkerPool);
             final boolean local = localPool != sharedWorkerPool;
-            final MessageBus bus = local ? new MessageBusImpl(messageBus.getConfiguration()) : messageBus;
+            final MessageBus bus = local ? new MessageBusImpl(cairoEngine.getConfiguration()) : cairoEngine.getMessageBus();
 
             server = factory.create(configuration, cairoEngine, localPool, local, bus, functionFactoryCache);
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo;
 
+import io.questdb.TelemetryConfiguration;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.NanosecondClock;
@@ -181,4 +182,6 @@ public interface CairoConfiguration {
     int getGroupByMapCapacity();
 
     boolean enableTestFactories();
+
+    TelemetryConfiguration getTelemetryConfiguration();
 }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -24,6 +24,8 @@
 
 package io.questdb.cairo;
 
+import io.questdb.DefaultTelemetryConfiguration;
+import io.questdb.TelemetryConfiguration;
 import io.questdb.cutlass.text.DefaultTextConfiguration;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.std.*;
@@ -37,6 +39,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
 
     private final CharSequence root;
     private final TextConfiguration textConfiguration = new DefaultTextConfiguration();
+    private final DefaultTelemetryConfiguration telemetryConfiguration = new DefaultTelemetryConfiguration();
 
     public DefaultCairoConfiguration(CharSequence root) {
         this.root = Chars.toString(root);
@@ -50,11 +53,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getCopyPoolCapacity() {
         return 16;
-    }
-
-    @Override
-    public boolean enableTestFactories() {
-        return true;
     }
 
     @Override
@@ -105,6 +103,16 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getIndexValueBlockSize() {
         return 256;
+    }
+
+    @Override
+    public int getDoubleToStrCastScale() {
+        return Numbers.MAX_SCALE;
+    }
+
+    @Override
+    public int getFloatToStrCastScale() {
+        return 4;
     }
 
     @Override
@@ -370,16 +378,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public int getDoubleToStrCastScale() {
-        return Numbers.MAX_SCALE;
-    }
-
-    @Override
-    public int getFloatToStrCastScale() {
-        return 4;
-    }
-
-    @Override
     public int getGroupByPoolCapacity() {
         return 1024;
     }
@@ -393,4 +391,15 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     public int getGroupByMapCapacity() {
         return 1024;
     }
+
+    @Override
+    public boolean enableTestFactories() {
+        return true;
+    }
+
+    @Override
+    public TelemetryConfiguration getTelemetryConfiguration() {
+        return telemetryConfiguration;
+    }
+
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -106,7 +106,6 @@ public class HttpServer implements Closeable {
             WorkerPool sharedWorkerPool,
             Log workerPoolLog,
             CairoEngine cairoEngine,
-            MessageBus messageBus,
             @Nullable FunctionFactoryCache functionFactoryCache
     ) {
         return WorkerPoolAwareConfiguration.create(
@@ -115,7 +114,6 @@ public class HttpServer implements Closeable {
                 workerPoolLog,
                 cairoEngine,
                 CREATE0,
-                messageBus,
                 functionFactoryCache
         );
     }
@@ -125,15 +123,13 @@ public class HttpServer implements Closeable {
             HttpServerConfiguration configuration,
             WorkerPool sharedWorkerPool,
             Log workerPoolLog,
-            CairoEngine cairoEngine,
-            MessageBus messageBus
+            CairoEngine cairoEngine
     ) {
         return create(
                 configuration,
                 sharedWorkerPool,
                 workerPoolLog,
                 cairoEngine,
-                messageBus,
                 null
         );
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -89,7 +89,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         this.queryExecutors.extendAndSet(CompiledQuery.INSERT_AS_SELECT, sendConfirmation);
         this.queryExecutors.extendAndSet(CompiledQuery.COPY_REMOTE, JsonQueryProcessor::cannotCopyRemote);
         this.queryExecutors.extendAndSet(CompiledQuery.BACKUP_TABLE, sendConfirmation);
-        this.sqlExecutionContext = new SqlExecutionContextImpl(messageBus, workerCount, engine);
+        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount, messageBus);
         this.nanosecondClock = engine.getConfiguration().getNanosecondClock();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -85,7 +85,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         this.compiler = new SqlCompiler(engine, messageBus, functionFactoryCache);
         this.floatScale = configuration.getFloatScale();
         this.clock = configuration.getClock();
-        this.sqlExecutionContext = new SqlExecutionContextImpl(messageBus, workerCount, engine);
+        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount, messageBus);
         this.doubleScale = configuration.getDoubleScale();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -152,7 +152,7 @@ public class PGConnectionContext implements IOContext, Mutable {
         this.authenticator = new PGBasicAuthenticator(configuration.getDefaultUsername(), configuration.getDefaultPassword());
         this.dateLocale = configuration.getDefaultDateLocale();
         this.timestampLocale = configuration.getDefaultTimestampLocale();
-        this.sqlExecutionContext = new SqlExecutionContextImpl(messageBus, workerCount, engine);
+        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount, messageBus);
         populateAppender();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -98,7 +98,6 @@ public class PGWireServer implements Closeable {
             WorkerPool sharedWorkerPool,
             Log log,
             CairoEngine cairoEngine,
-            MessageBus messageBus,
             FunctionFactoryCache functionFactoryCache
     ) {
         return WorkerPoolAwareConfiguration.create(
@@ -107,7 +106,6 @@ public class PGWireServer implements Closeable {
                 log,
                 cairoEngine,
                 (conf, engine, workerPool, local, bus, functionFactoryCache1) -> new PGWireServer(conf, cairoEngine, workerPool, bus, functionFactoryCache1),
-                messageBus,
                 functionFactoryCache
         );
     }

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -123,11 +123,7 @@ public class SqlCompiler implements Closeable {
     };
 
     public SqlCompiler(CairoEngine engine) {
-        this(engine, null);
-    }
-
-    public SqlCompiler(CairoEngine engine, MessageBus bus) {
-        this(engine, bus, null);
+        this(engine, engine.getMessageBus(), null);
     }
 
     public SqlCompiler(CairoEngine engine, @Nullable MessageBus messageBus, @Nullable FunctionFactoryCache functionFactoryCache) {

--- a/core/src/test/java/io/questdb/EmbeddedApiTest.java
+++ b/core/src/test/java/io/questdb/EmbeddedApiTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.std.Os;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class EmbeddedApiTest {
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void testReadWrite() throws Exception {
+        final CairoConfiguration configuration = new DefaultCairoConfiguration(temp.getRoot().getAbsolutePath());
+
+        TestUtils.assertMemoryLeak(() -> {
+            // the write part
+            try (CairoEngine engine = new CairoEngine(configuration)) {
+                final SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1);
+                try (SqlCompiler compiler = new SqlCompiler(engine)) {
+
+                    compiler.compile("create table abc (a int, b byte, c short, d long, e float, g double, h date, i symbol, j string, k boolean, ts timestamp) timestamp(ts)", ctx);
+
+                    try (TableWriter writer = engine.getWriter(ctx.getCairoSecurityContext(), "abc")) {
+                        for (int i = 0; i < 10; i++) {
+                            TableWriter.Row row = writer.newRow(Os.currentTimeMicros());
+                            row.putInt(0, 123);
+                            row.putByte(1, (byte) 1111);
+                            row.putShort(2, (short) 222);
+                            row.putLong(3, 333);
+                            row.putFloat(4, 4.44f);
+                            row.putDouble(5, 5.55);
+                            row.putDate(6, System.currentTimeMillis());
+                            row.putSym(7, "xyz");
+                            row.putStr(8, "abc");
+                            row.putBool(9, true);
+                            row.append();
+                        }
+                        writer.commit();
+                    }
+
+                    try (RecordCursorFactory factory = compiler.compile("abc", ctx).getRecordCursorFactory()) {
+                        try (RecordCursor cursor = factory.getCursor(ctx)) {
+                            final Record record = cursor.getRecord();
+                            while (cursor.hasNext()) {
+                                // access 'record' instance for field values
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -496,8 +496,8 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(100000, configuration.getLineTcpReceiverConfiguration().getMaxUncommittedRows());
             Assert.assertEquals(1000, configuration.getLineTcpReceiverConfiguration().getMaintenanceJobHysteresisInMs());
 
-            Assert.assertTrue(configuration.getTelemetryConfiguration().getEnabled());
-            Assert.assertEquals(512, configuration.getTelemetryConfiguration().getQueueCapacity());
+            Assert.assertTrue(configuration.getCairoConfiguration().getTelemetryConfiguration().getEnabled());
+            Assert.assertEquals(512, configuration.getCairoConfiguration().getTelemetryConfiguration().getQueueCapacity());
 
             Assert.assertFalse(configuration.getHttpServerConfiguration().getServerKeepAlive());
             Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpVersion());

--- a/core/src/test/java/io/questdb/TelemetryTest.java
+++ b/core/src/test/java/io/questdb/TelemetryTest.java
@@ -24,15 +24,16 @@
 
 package io.questdb;
 
-import io.questdb.cairo.*;
-import io.questdb.std.*;
+import io.questdb.cairo.AbstractCairoTest;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.TableUtils;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.Misc;
 import io.questdb.std.str.Path;
-import io.questdb.test.tools.*;
-
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Properties;
 
 public class TelemetryTest extends AbstractCairoTest {
     private final static FilesFacade FF = FilesFacadeImpl.INSTANCE;
@@ -50,9 +51,8 @@ public class TelemetryTest extends AbstractCairoTest {
     @Test
     public void testTelemetryCreatesTablesWhenEnabled() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
-                final TelemetryJob telemetryJob = new TelemetryJob(serverConfiguration, engine, messageBus, null);
-
+            try (CairoEngine engine = new CairoEngine(configuration)) {
+                final TelemetryJob telemetryJob = new TelemetryJob(engine, null);
                 try (Path path = new Path()) {
                     Assert.assertEquals(TableUtils.TABLE_EXISTS, TableUtils.exists(FF, path, root, "telemetry"));
                     Assert.assertEquals(TableUtils.TABLE_EXISTS, TableUtils.exists(FF, path, root, "telemetry_config"));
@@ -66,27 +66,18 @@ public class TelemetryTest extends AbstractCairoTest {
     @Test
     public void testTelemetryStoresUpAndDownEvents() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            serverConfiguration = new PropServerConfiguration(temp.getRoot().getAbsolutePath(), new Properties()) {
-                @Override
-                public CairoConfiguration getCairoConfiguration() {
-                    return configuration;
-                }
-            };
-            configuration = serverConfiguration.getCairoConfiguration();
-            messageBus = new MessageBusImpl(serverConfiguration);
-            CairoEngine engine = new CairoEngine(configuration, messageBus);
-            TelemetryJob telemetryJob = new TelemetryJob(serverConfiguration, engine, messageBus, null);
-            Misc.free(telemetryJob);
+            try (CairoEngine engine = new CairoEngine(configuration)) {
+                TelemetryJob telemetryJob = new TelemetryJob(engine);
+                Misc.free(telemetryJob);
 
-            final String expectedEvent = "100\n" +
-                    "101\n";
-            assertColumn(expectedEvent, "telemetry", 1);
+                final String expectedEvent = "100\n" +
+                        "101\n";
+                assertColumn(expectedEvent, "telemetry", 1);
 
-            final String expectedOrigin = "1\n" +
-                    "1\n";
-            assertColumn(expectedOrigin, "telemetry", 2);
-
-            Misc.free(engine);
+                final String expectedOrigin = "1\n" +
+                        "1\n";
+                assertColumn(expectedOrigin, "telemetry", 2);
+            }
         });
     }
 }

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -24,13 +24,8 @@
 
 package io.questdb.cairo;
 
-import io.questdb.MessageBus;
-import io.questdb.MessageBusImpl;
-import io.questdb.PropServerConfiguration;
-import io.questdb.ServerConfigurationException;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cutlass.json.JsonException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.Files;
@@ -44,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.util.Properties;
 
 public class AbstractCairoTest {
 
@@ -55,11 +49,9 @@ public class AbstractCairoTest {
     public static TemporaryFolder temp = new TemporaryFolder();
     protected static CharSequence root;
     protected static CairoConfiguration configuration;
-    protected static PropServerConfiguration serverConfiguration;
-    protected static MessageBus messageBus;
 
     @BeforeClass
-    public static void setUp() throws IOException, JsonException, ServerConfigurationException {
+    public static void setUp() throws IOException {
         // it is necessary to initialise logger before tests start
         // logger doesn't relinquish memory until JVM stops
         // which causes memory leak detector to fail should logger be
@@ -67,15 +59,6 @@ public class AbstractCairoTest {
         LOG.info().$("begin").$();
         root = temp.newFolder("dbRoot").getAbsolutePath();
         configuration = new DefaultCairoConfiguration(root);
-        TestUtils.copyMimeTypes(temp.getRoot().getAbsolutePath());
-        serverConfiguration = new PropServerConfiguration(temp.getRoot().getAbsolutePath(), new Properties()) {
-            @Override
-            public CairoConfiguration getCairoConfiguration() {
-                return configuration;
-            }
-        };
-        configuration = serverConfiguration.getCairoConfiguration();
-        messageBus = new MessageBusImpl(serverConfiguration);
     }
 
     @Before

--- a/core/src/test/java/io/questdb/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/cairo/CairoEngineTest.java
@@ -114,7 +114,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         createX();
 
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", TableUtils.ANY_TABLE_VERSION)) {
                     Assert.assertNotNull(reader);
                     Assert.assertFalse(engine.lock(AllowAllCairoSecurityContext.INSTANCE, "x"));
@@ -130,7 +130,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         createX();
 
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 engine.rename(AllowAllCairoSecurityContext.INSTANCE, path, "x", otherPath, "y");
 
                 assertWriter(engine, "y");
@@ -144,7 +144,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             createX();
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 assertReader(engine, "x");
                 assertWriter(engine, "x");
                 engine.remove(AllowAllCairoSecurityContext.INSTANCE, path, "x");
@@ -170,7 +170,7 @@ public class CairoEngineTest extends AbstractCairoTest {
 
         createX();
 
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             engine.remove(AllowAllCairoSecurityContext.INSTANCE, path, "x");
             Assert.assertEquals(TableUtils.TABLE_DOES_NOT_EXIST, engine.getStatus(AllowAllCairoSecurityContext.INSTANCE, path, "x"));
         }
@@ -180,7 +180,7 @@ public class CairoEngineTest extends AbstractCairoTest {
     public void testRemoveNonExisting() throws Exception {
         createY(); // this will create root dir at least
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try {
                     engine.remove(AllowAllCairoSecurityContext.INSTANCE, path, "x");
                     Assert.fail();
@@ -196,7 +196,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             createX();
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", TableUtils.ANY_TABLE_VERSION)) {
                     Assert.assertNotNull(reader);
                     try {
@@ -214,7 +214,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             createX();
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "x")) {
                     Assert.assertNotNull(writer);
                     try {
@@ -232,7 +232,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         createX();
 
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 assertWriter(engine, "x");
                 assertReader(engine, "x");
 
@@ -254,7 +254,7 @@ public class CairoEngineTest extends AbstractCairoTest {
 
             try (TableWriter ignored1 = new TableWriter(configuration, "x")) {
 
-                try (CairoEngine engine = new CairoEngine(configuration, null)) {
+                try (CairoEngine engine = new CairoEngine(configuration)) {
                     try {
                         engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "x");
                         Assert.fail();
@@ -298,7 +298,7 @@ public class CairoEngineTest extends AbstractCairoTest {
                 }
             };
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 assertReader(engine, "x");
                 assertWriter(engine, "x");
                 try {
@@ -328,7 +328,7 @@ public class CairoEngineTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 engine.rename(AllowAllCairoSecurityContext.INSTANCE, path, "x", otherPath, "y");
                 Assert.fail();
             } catch (CairoException e) {
@@ -344,7 +344,7 @@ public class CairoEngineTest extends AbstractCairoTest {
             createX();
             createY();
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 assertWriter(engine, "x");
                 assertReader(engine, "x");
                 try {
@@ -367,7 +367,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         createX();
 
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 assertWriter(engine, "x");
                 try {
                     engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", 2);

--- a/core/src/test/java/io/questdb/cairo/FullBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullBwdDataFrameCursorTest.java
@@ -85,7 +85,7 @@ public class FullBwdDataFrameCursorTest extends AbstractCairoTest {
                 }
                 w.commit();
 
-                try (CairoEngine engine = new CairoEngine(configuration, null)) {
+                try (CairoEngine engine = new CairoEngine(configuration)) {
                     FullBwdDataFrameCursorFactory factory = new FullBwdDataFrameCursorFactory(engine, "x", 0);
                     final TableReaderRecord record = new TableReaderRecord();
 

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorFactoryTest.java
@@ -72,7 +72,7 @@ public class FullFwdDataFrameCursorFactoryTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 FullFwdDataFrameCursorFactory factory = new FullFwdDataFrameCursorFactory(engine, "x", 0);
                 long count = 0;
                 try (DataFrameCursor cursor = factory.getCursor(AllowAllCairoSecurityContext.INSTANCE)) {

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -25,7 +25,6 @@
 package io.questdb.cairo;
 
 import io.questdb.MessageBus;
-import io.questdb.PropServerConfiguration;
 import io.questdb.cairo.sql.*;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -36,7 +35,6 @@ import io.questdb.std.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.StringSink;
 import io.questdb.tasks.ColumnIndexerTask;
-import io.questdb.tasks.TelemetryTask;
 import io.questdb.tasks.VectorAggregateTask;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -2450,7 +2448,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
         }
 
         @Override
-        public PropServerConfiguration getConfiguration() {
+        public CairoConfiguration getConfiguration() {
             return null;
         }
 
@@ -2481,21 +2479,6 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
         @Override
         public Sequence getVectorAggregateSubSequence() {
-            return null;
-        }
-
-        @Override
-        public RingQueue<TelemetryTask> getTelemetryQueue() {
-            return null;
-        }
-
-        @Override
-        public Sequence getTelemetryPubSequence() {
-            return null;
-        }
-
-        @Override
-        public SCSequence getTelemetrySubSequence() {
             return null;
         }
     }

--- a/core/src/test/java/io/questdb/cairo/IntervalBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/IntervalBwdDataFrameCursorTest.java
@@ -383,7 +383,7 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseDateTime("1980-01-01T00:00:00.000Z");
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 final int timestampIndex;
                 try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x")) {
                     timestampIndex = reader.getMetadata().getTimestampIndex();

--- a/core/src/test/java/io/questdb/cairo/IntervalFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/IntervalFwdDataFrameCursorTest.java
@@ -398,7 +398,7 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseDateTime("1980-01-01T00:00:00.000Z");
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 final int timestampIndex;
                 try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x")) {
                     timestampIndex = reader.getMetadata().getTimestampIndex();

--- a/core/src/test/java/io/questdb/cairo/TableReaderRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderRecordCursorFactoryTest.java
@@ -83,7 +83,7 @@ public class TableReaderRecordCursorFactoryTest extends AbstractCairoTest {
             }
 
 
-            try (CairoEngine engine = new CairoEngine(configuration, messageBus)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
 
                 final RecordMetadata metadata;
                 try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", -1)) {
@@ -107,16 +107,14 @@ public class TableReaderRecordCursorFactoryTest extends AbstractCairoTest {
                         false
                 )) {
                     long count = 0;
-                    final SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(
-                            messageBus,
-                            1,
-                            engine).with(
-                            AllowAllCairoSecurityContext.INSTANCE,
-                            new BindVariableService(),
+                    final SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
+                            .with(
+                                    AllowAllCairoSecurityContext.INSTANCE,
+                                    new BindVariableService(),
                                     null,
                                     -1,
-                            null
-                    );
+                                    null
+                            );
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final Record record = cursor.getRecord();
                         rnd.reset();

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -24,13 +24,14 @@
 
 package io.questdb.cutlass.http;
 
-import io.questdb.*;
+import io.questdb.MessageBus;
+import io.questdb.MessageBusImpl;
+import io.questdb.TelemetryJob;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cutlass.NetUtils;
 import io.questdb.cutlass.http.processors.*;
-import io.questdb.cutlass.json.JsonException;
 import io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -49,10 +50,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,48 +65,6 @@ public class IODispatcherTest {
     public TemporaryFolder temp = new TemporaryFolder();
 
     private long configuredMaxQueryResponseRowLimit = Long.MAX_VALUE;
-
-    private static void assertDownloadResponse(long fd, Rnd rnd, long buffer, int len, int nonRepeatedContentLength, String expectedResponseHeader, long expectedResponseLen) {
-        int expectedHeaderLen = expectedResponseHeader.length();
-        int headerCheckRemaining = expectedResponseHeader.length();
-        long downloadedSoFar = 0;
-        int contentRemaining = 0;
-        while (downloadedSoFar < expectedResponseLen) {
-            int contentOffset = 0;
-            int n = Net.recv(fd, buffer, len);
-            Assert.assertTrue(n > -1);
-            if (n > 0) {
-                if (headerCheckRemaining > 0) {
-                    for (int i = 0; i < n && headerCheckRemaining > 0; i++) {
-                        if (expectedResponseHeader.charAt(expectedHeaderLen - headerCheckRemaining) != (char) Unsafe.getUnsafe().getByte(buffer + i)) {
-                            Assert.fail("at " + (expectedHeaderLen - headerCheckRemaining));
-                        }
-                        headerCheckRemaining--;
-                        contentOffset++;
-                    }
-                }
-
-                if (headerCheckRemaining == 0) {
-                    for (int i = contentOffset; i < n; i++) {
-                        if (contentRemaining == 0) {
-                            contentRemaining = nonRepeatedContentLength;
-                            rnd.reset();
-                        }
-                        Assert.assertEquals(rnd.nextByte(), Unsafe.getUnsafe().getByte(buffer + i));
-                        contentRemaining--;
-                    }
-
-                }
-                downloadedSoFar += n;
-            }
-        }
-    }
-
-    private static void sendRequest(String request, long fd, long buffer) {
-        final int requestLen = request.length();
-        Chars.asciiStrCpy(request, requestLen, buffer);
-        Assert.assertEquals(requestLen, Net.send(fd, buffer, requestLen));
-    }
 
     public static void createTestTable(CairoConfiguration configuration, int n) {
         try (TableModel model = new TableModel(configuration, "y", PartitionBy.NONE)) {
@@ -424,7 +381,7 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testHttpLong256AndCharImport() throws IOException, JsonException, ServerConfigurationException {
+    public void testHttpLong256AndCharImport() {
         // this script uploads text file:
         // 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060,a
         // 0x19f1df2c7ee6b464720ad28e903aeda1a5ad8780afc22f0b960827bd4fcf656d,b
@@ -443,12 +400,9 @@ public class IODispatcherTest {
         final String expectedTableMetadata = "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"LONG256\"},{\"index\":1,\"name\":\"f1\",\"type\":\"CHAR\"}],\"timestampIndex\":-1}";
 
         final String baseDir = temp.getRoot().getAbsolutePath();
-        TestUtils.copyMimeTypes(baseDir);
-        final PropServerConfiguration serverConfiguration = new PropServerConfiguration(baseDir, new Properties());
-        final MessageBus workScheduler = new MessageBusImpl(serverConfiguration);
-
+        final CairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
         try (
-                CairoEngine cairoEngine = new CairoEngine(new DefaultCairoConfiguration(baseDir), workScheduler);
+                CairoEngine cairoEngine = new CairoEngine(configuration);
                 HttpServer ignored = HttpServer.create(
                         new DefaultHttpServerConfiguration() {
                             @Override
@@ -458,8 +412,7 @@ public class IODispatcherTest {
                         },
                         null,
                         LOG,
-                        cairoEngine,
-                        workScheduler
+                        cairoEngine
                 )) {
 
             // upload file
@@ -494,7 +447,7 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testHttpLong256AndCharImportLimitColumns() throws IOException, ServerConfigurationException, JsonException {
+    public void testHttpLong256AndCharImportLimitColumns() {
         // this script uploads text file:
         // 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060,a
         // 0x19f1df2c7ee6b464720ad28e903aeda1a5ad8780afc22f0b960827bd4fcf656d,b
@@ -513,12 +466,9 @@ public class IODispatcherTest {
         final String expectedTableMetadata = "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"LONG256\"},{\"index\":1,\"name\":\"f1\",\"type\":\"CHAR\"}],\"timestampIndex\":-1}";
 
         final String baseDir = temp.getRoot().getAbsolutePath();
-        TestUtils.copyMimeTypes(baseDir);
-        final PropServerConfiguration serverConfiguration = new PropServerConfiguration(baseDir, new Properties());
-        final MessageBus workScheduler = new MessageBusImpl(serverConfiguration);
-
+        final CairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
         try (
-                CairoEngine cairoEngine = new CairoEngine(new DefaultCairoConfiguration(baseDir), workScheduler);
+                CairoEngine cairoEngine = new CairoEngine(configuration);
                 HttpServer ignored = HttpServer.create(
                         new DefaultHttpServerConfiguration() {
                             @Override
@@ -528,8 +478,7 @@ public class IODispatcherTest {
                         },
                         null,
                         LOG,
-                        cairoEngine,
-                        workScheduler
+                        cairoEngine
                 )) {
 
             // upload file
@@ -580,7 +529,7 @@ public class IODispatcherTest {
                 }
             });
 
-            try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
+            try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
                  HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -689,6 +638,162 @@ public class IODispatcherTest {
                 NetworkFacadeImpl.INSTANCE,
                 true,
                 1
+        );
+    }
+
+    @Test
+    public void testImportColumnMismatch() throws Exception {
+        testImport(
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: text/plain; charset=utf-8\r\n" +
+                        "\r\n" +
+                        "05d7\r\n" +
+                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
+                        "|      Location:  |                          fhv_tripdata_2017-02.csv  |        Pattern  | Locale  |    Errors  |\r\n" +
+                        "|   Partition by  |                                              NONE  |                 |         |            |\r\n" +
+                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
+                        "|   Rows handled  |                                                24  |                 |         |            |\r\n" +
+                        "|  Rows imported  |                                                24  |                 |         |            |\r\n" +
+                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
+                        "|              0  |                                DispatchingBaseNum  |                   STRING  |         0  |\r\n" +
+                        "|              1  |                                    PickupDateTime  |                     DATE  |         0  |\r\n" +
+                        "|              2  |                                   DropOffDatetime  |                   STRING  |         0  |\r\n" +
+                        "|              3  |                                      PUlocationID  |                   STRING  |         0  |\r\n" +
+                        "|              4  |                                      DOlocationID  |                   STRING  |         0  |\r\n" +
+                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
+                        "\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+                ,
+                "POST /upload HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.64.0\r\n" +
+                        "Accept: */*\r\n" +
+                        "Content-Length: 437760673\r\n" +
+                        "Content-Type: multipart/form-data; boundary=------------------------27d997ca93d2689d\r\n" +
+                        "Expect: 100-continue\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d\r\n" +
+                        "Content-Disposition: form-data; name=\"schema\"; filename=\"schema.json\"\r\n" +
+                        "Content-Type: application/octet-stream\r\n" +
+                        "\r\n" +
+                        "[\r\n" +
+                        "  {\r\n" +
+                        "    \"name\": \"date\",\r\n" +
+                        "    \"type\": \"DATE\",\r\n" +
+                        "    \"pattern\": \"d MMMM y.\",\r\n" +
+                        "    \"locale\": \"ru-RU\"\r\n" +
+                        "  }\r\n" +
+                        "]\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"; filename=\"fhv_tripdata_2017-02.csv\"\r\n" +
+                        "Content-Type: application/octet-stream\r\n" +
+                        "\r\n" +
+                        "Dispatching_base_num,Pickup_DateTime,DropOff_datetime,PUlocationID,DOlocationID\r\n" +
+                        "B00008,2017-02-01 00:30:00,,,\r\n" +
+                        "B00008,2017-02-01 00:40:00,,,\r\n" +
+                        "B00009,2017-02-01 00:30:00,,,\r\n" +
+                        "B00013,2017-02-01 00:11:00,,,\r\n" +
+                        "B00013,2017-02-01 00:41:00,,,\r\n" +
+                        "B00013,2017-02-01 00:00:00,,,\r\n" +
+                        "B00013,2017-02-01 00:53:00,,,\r\n" +
+                        "B00013,2017-02-01 00:44:00,,,\r\n" +
+                        "B00013,2017-02-01 00:05:00,,,\r\n" +
+                        "B00013,2017-02-01 00:54:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "B00014,2017-02-01 00:46:00,,,\r\n" +
+                        "B00014,2017-02-01 00:54:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "B00014,2017-02-01 00:26:00,,,\r\n" +
+                        "B00014,2017-02-01 00:55:00,,,\r\n" +
+                        "B00014,2017-02-01 00:47:00,,,\r\n" +
+                        "B00014,2017-02-01 00:05:00,,,\r\n" +
+                        "B00014,2017-02-01 00:58:00,,,\r\n" +
+                        "B00014,2017-02-01 00:33:00,,,\r\n" +
+                        "B00014,2017-02-01 00:45:00,,,\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d--"
+                , NetworkFacadeImpl.INSTANCE
+                , false
+                , 1
+        );
+
+        // append different data structure to the same table
+
+        testImport(
+                "HTTP/1.1 400 Bad request\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: text/plain; charset=utf-8\r\n" +
+                        "\r\n" +
+                        "5d\r\n" +
+                        "column count mismatch [textColumnCount=6, tableColumnCount=5, table=fhv_tripdata_2017-02.csv]\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+                ,
+                "POST /upload?overwrite=false HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.64.0\r\n" +
+                        "Accept: */*\r\n" +
+                        "Content-Length: 437760673\r\n" +
+                        "Content-Type: multipart/form-data; boundary=------------------------27d997ca93d2689d\r\n" +
+                        "Expect: 100-continue\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d\r\n" +
+                        "Content-Disposition: form-data; name=\"schema\"; filename=\"schema.json\"\r\n" +
+                        "Content-Type: application/octet-stream\r\n" +
+                        "\r\n" +
+                        "[\r\n" +
+                        "  {\r\n" +
+                        "    \"name\": \"date\",\r\n" +
+                        "    \"type\": \"DATE\",\r\n" +
+                        "    \"pattern\": \"d MMMM y.\",\r\n" +
+                        "    \"locale\": \"ru-RU\"\r\n" +
+                        "  }\r\n" +
+                        "]\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"; filename=\"fhv_tripdata_2017-02.csv\"\r\n" +
+                        "Content-Type: application/octet-stream\r\n" +
+                        "\r\n" +
+                        "Dispatching_base_num,DropOff_datetime,PUlocationID,DOlocationID,x,y\r\n" +
+                        "B00008,,,,,\r\n" +
+                        "B00008,,,,,\r\n" +
+                        "B00009,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00013,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "B00014,,,,,\r\n" +
+                        "\r\n" +
+                        "--------------------------27d997ca93d2689d--"
+                , NetworkFacadeImpl.INSTANCE
+                , false
+                , 1
         );
     }
 
@@ -983,162 +1088,6 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testImportColumnMismatch() throws Exception {
-        testImport(
-                "HTTP/1.1 200 OK\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: text/plain; charset=utf-8\r\n" +
-                        "\r\n" +
-                        "05d7\r\n" +
-                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
-                        "|      Location:  |                          fhv_tripdata_2017-02.csv  |        Pattern  | Locale  |    Errors  |\r\n" +
-                        "|   Partition by  |                                              NONE  |                 |         |            |\r\n" +
-                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
-                        "|   Rows handled  |                                                24  |                 |         |            |\r\n" +
-                        "|  Rows imported  |                                                24  |                 |         |            |\r\n" +
-                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
-                        "|              0  |                                DispatchingBaseNum  |                   STRING  |         0  |\r\n" +
-                        "|              1  |                                    PickupDateTime  |                     DATE  |         0  |\r\n" +
-                        "|              2  |                                   DropOffDatetime  |                   STRING  |         0  |\r\n" +
-                        "|              3  |                                      PUlocationID  |                   STRING  |         0  |\r\n" +
-                        "|              4  |                                      DOlocationID  |                   STRING  |         0  |\r\n" +
-                        "+---------------------------------------------------------------------------------------------------------------+\r\n" +
-                        "\r\n" +
-                        "00\r\n" +
-                        "\r\n"
-                ,
-                "POST /upload HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "User-Agent: curl/7.64.0\r\n" +
-                        "Accept: */*\r\n" +
-                        "Content-Length: 437760673\r\n" +
-                        "Content-Type: multipart/form-data; boundary=------------------------27d997ca93d2689d\r\n" +
-                        "Expect: 100-continue\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d\r\n" +
-                        "Content-Disposition: form-data; name=\"schema\"; filename=\"schema.json\"\r\n" +
-                        "Content-Type: application/octet-stream\r\n" +
-                        "\r\n" +
-                        "[\r\n" +
-                        "  {\r\n" +
-                        "    \"name\": \"date\",\r\n" +
-                        "    \"type\": \"DATE\",\r\n" +
-                        "    \"pattern\": \"d MMMM y.\",\r\n" +
-                        "    \"locale\": \"ru-RU\"\r\n" +
-                        "  }\r\n" +
-                        "]\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d\r\n" +
-                        "Content-Disposition: form-data; name=\"data\"; filename=\"fhv_tripdata_2017-02.csv\"\r\n" +
-                        "Content-Type: application/octet-stream\r\n" +
-                        "\r\n" +
-                        "Dispatching_base_num,Pickup_DateTime,DropOff_datetime,PUlocationID,DOlocationID\r\n" +
-                        "B00008,2017-02-01 00:30:00,,,\r\n" +
-                        "B00008,2017-02-01 00:40:00,,,\r\n" +
-                        "B00009,2017-02-01 00:30:00,,,\r\n" +
-                        "B00013,2017-02-01 00:11:00,,,\r\n" +
-                        "B00013,2017-02-01 00:41:00,,,\r\n" +
-                        "B00013,2017-02-01 00:00:00,,,\r\n" +
-                        "B00013,2017-02-01 00:53:00,,,\r\n" +
-                        "B00013,2017-02-01 00:44:00,,,\r\n" +
-                        "B00013,2017-02-01 00:05:00,,,\r\n" +
-                        "B00013,2017-02-01 00:54:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "B00014,2017-02-01 00:46:00,,,\r\n" +
-                        "B00014,2017-02-01 00:54:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "B00014,2017-02-01 00:26:00,,,\r\n" +
-                        "B00014,2017-02-01 00:55:00,,,\r\n" +
-                        "B00014,2017-02-01 00:47:00,,,\r\n" +
-                        "B00014,2017-02-01 00:05:00,,,\r\n" +
-                        "B00014,2017-02-01 00:58:00,,,\r\n" +
-                        "B00014,2017-02-01 00:33:00,,,\r\n" +
-                        "B00014,2017-02-01 00:45:00,,,\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d--"
-                , NetworkFacadeImpl.INSTANCE
-                , false
-                , 1
-        );
-
-        // append different data structure to the same table
-
-        testImport(
-                "HTTP/1.1 400 Bad request\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: text/plain; charset=utf-8\r\n" +
-                        "\r\n" +
-                        "5d\r\n" +
-                        "column count mismatch [textColumnCount=6, tableColumnCount=5, table=fhv_tripdata_2017-02.csv]\r\n" +
-                        "00\r\n" +
-                        "\r\n"
-                ,
-                "POST /upload?overwrite=false HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "User-Agent: curl/7.64.0\r\n" +
-                        "Accept: */*\r\n" +
-                        "Content-Length: 437760673\r\n" +
-                        "Content-Type: multipart/form-data; boundary=------------------------27d997ca93d2689d\r\n" +
-                        "Expect: 100-continue\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d\r\n" +
-                        "Content-Disposition: form-data; name=\"schema\"; filename=\"schema.json\"\r\n" +
-                        "Content-Type: application/octet-stream\r\n" +
-                        "\r\n" +
-                        "[\r\n" +
-                        "  {\r\n" +
-                        "    \"name\": \"date\",\r\n" +
-                        "    \"type\": \"DATE\",\r\n" +
-                        "    \"pattern\": \"d MMMM y.\",\r\n" +
-                        "    \"locale\": \"ru-RU\"\r\n" +
-                        "  }\r\n" +
-                        "]\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d\r\n" +
-                        "Content-Disposition: form-data; name=\"data\"; filename=\"fhv_tripdata_2017-02.csv\"\r\n" +
-                        "Content-Type: application/octet-stream\r\n" +
-                        "\r\n" +
-                        "Dispatching_base_num,DropOff_datetime,PUlocationID,DOlocationID,x,y\r\n" +
-                        "B00008,,,,,\r\n" +
-                        "B00008,,,,,\r\n" +
-                        "B00009,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00013,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "B00014,,,,,\r\n" +
-                        "\r\n" +
-                        "--------------------------27d997ca93d2689d--"
-                , NetworkFacadeImpl.INSTANCE
-                , false
-                , 1
-        );
-    }
-
-    @Test
     public void testImportMultipleOnSameConnectionFragmented() throws Exception {
         testImport(
                 "HTTP/1.1 200 OK\r\n" +
@@ -1253,7 +1202,7 @@ public class IODispatcherTest {
                 }
             });
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
                     HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -1623,7 +1572,7 @@ public class IODispatcherTest {
                 }
             });
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
                     HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -1772,141 +1721,6 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testJsonQueryWithInterruption() throws Exception {
-        assertMemoryLeak(() -> {
-            final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
-            final String baseDir = temp.getRoot().getAbsolutePath();
-            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(nf, baseDir, 128,
-                    false, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return new int[]{-1};
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            });
-            try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
-                 HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new StaticContentProcessor(httpConfiguration);
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
-                    }
-                });
-
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new JsonQueryProcessor(httpConfiguration.getJsonQueryProcessorConfiguration(), engine,
-                                null, workerPool.getWorkerCount());
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return "/query";
-                    }
-                });
-
-                final AtomicBoolean clientClosed = new AtomicBoolean(false);
-                final AtomicBoolean serverClosed = new AtomicBoolean(false);
-                HttpClientStateListener clientStateListener = new HttpClientStateListener() {
-                    @Override
-                    public void onReceived(int nBytes) {
-                        LOG.info().$("Client received ").$(nBytes).$(" bytes").$();
-                    }
-
-                    @Override
-                    public void onClosed() {
-                        clientClosed.set(true);
-
-                    }
-                };
-                workerPool.start(LOG);
-
-                try {
-                    // create table with all column types
-                    CairoTestUtils.createTestTable(engine.getConfiguration(), 10000, new Rnd(),
-                            new TestRecord.ArrayBinarySequence());
-
-                    // send multipart request to server
-
-                    final String request = "GET /query?query=select+distinct+a+from+x+where+test_latched_counter() HTTP/1.1\r\n"
-                            + "Host: localhost:9001\r\n" + "Connection: keep-alive\r\n" + "Cache-Control: max-age=0\r\n"
-                            + "Upgrade-Insecure-Requests: 1\r\n"
-                            + "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n"
-                            + "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n"
-                            + "Accept-Encoding: gzip, deflate, br\r\n"
-                            + "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" + "\r\n";
-
-                    String expectedResponse = "HTTP/1.1 200 OK\r\n" + "Server: questDB/1.0\r\n"
-                            + "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" + "Transfer-Encoding: chunked\r\n"
-                            + "Content-Type: application/json; charset=utf-8\r\n"
-                            + "Keep-Alive: timeout=5, max=10000\r\n" + "\r\n" + "7e\r\n" + "{\"query\":\"s" + "\r\n";
-                    TestLatchedCounterFunctionFactory.reset(new TestLatchedCounterFunctionFactory.Callback() {
-                        @Override
-                        public boolean onGet(Record record, int count) {
-                            if (count == 4) {
-                                while (!clientClosed.get()) {
-                                    LockSupport.parkNanos(1);
-                                }
-                            }
-                            return true;
-                        }
-
-                        @Override
-                        public void onClose() {
-                            serverClosed.set(true);
-                        }
-                    });
-                    long fd = nf.socketTcp(true);
-                    try {
-                        long sockAddr = nf.sockaddr("127.0.0.1", 9001);
-                        try {
-                            Assert.assertTrue(fd > -1);
-                            Assert.assertEquals(0, nf.connect(fd, sockAddr));
-                            Assert.assertEquals(0, nf.setTcpNoDelay(fd, true));
-
-                            byte[] expectedResponse1 = expectedResponse.getBytes();
-                            long bufLen = request.length();
-                            long ptr = Unsafe.malloc(bufLen);
-                            try {
-                                sendAndReceive(nf, request, 0, false, true, fd, expectedResponse1, 200, ptr, clientStateListener);
-                            } finally {
-                                Unsafe.free(ptr, bufLen);
-                            }
-                        } finally {
-                            nf.freeSockAddr(sockAddr);
-                        }
-                    } finally {
-                        nf.close(fd);
-                        clientStateListener.onClosed();
-                    }
-                    while (!serverClosed.get()) {
-                        LockSupport.parkNanos(1);
-                    }
-                    Assert.assertEquals(6, TestLatchedCounterFunctionFactory.getCount());
-                } finally {
-                    workerPool.halt();
-                }
-            }
-        });
-    }
-
-    @Test
     public void testJsonQueryBadUtf8() throws Exception {
         testJsonQuery(
                 20,
@@ -1932,103 +1746,6 @@ public class IODispatcherTest {
                         "00\r\n" +
                         "\r\n"
         );
-    }
-
-    @Test
-    public void testJsonQueryJsonReplaceZero() throws Exception {
-        testJsonQuery0(2, engine -> {
-            // create table with all column types
-            createTestTable(
-                    engine.getConfiguration(),
-                    20
-            );
-            sendAndReceive(
-                    NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=y HTTP/1.1\r\n" +
-                            "Host: localhost:9001\r\n" +
-                            "Connection: keep-alive\r\n" +
-                            "Cache-Control: max-age=0\r\n" +
-                            "Upgrade-Insecure-Requests: 1\r\n" +
-                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                            "Accept-Encoding: gzip, deflate, br\r\n" +
-                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                            "\r\n",
-                    "HTTP/1.1 200 OK\r\n" +
-                            "Server: questDB/1.0\r\n" +
-                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                            "Transfer-Encoding: chunked\r\n" +
-                            "Content-Type: application/json; charset=utf-8\r\n" +
-                            "Keep-Alive: timeout=5, max=10000\r\n" +
-                            "\r\n" +
-                            "0101\r\n" +
-                            "{\"query\":\"y\",\"columns\":[{\"name\":\"j\",\"type\":\"SYMBOL\"}],\"dataset\":[[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"]],\"count\":20}\r\n" +
-                            "00\r\n" +
-                            "\r\n",
-                    100,
-                    0,
-                    false
-            );
-        }, false);
-    }
-
-    @Test
-    public void testMissingURL() throws Exception {
-        testJsonQuery0(2, engine -> {
-            long fd = NetworkFacadeImpl.INSTANCE.socketTcp(true);
-            try {
-                long sockAddr = NetworkFacadeImpl.INSTANCE.sockaddr("127.0.0.1", 9001);
-                try {
-                    Assert.assertTrue(fd > -1);
-                    Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.connect(fd, sockAddr));
-                    Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.setTcpNoDelay(fd, true));
-
-                    final String request = "GET HTTP/1.1\r\n" +
-                            "Host: localhost:9001\r\n" +
-                            "Connection: keep-alive\r\n" +
-                            "Cache-Control: max-age=0\r\n" +
-                            "Upgrade-Insecure-Requests: 1\r\n" +
-                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                            "Accept-Encoding: gzip, deflate, br\r\n" +
-                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                            "\r\n";
-                    final int len = request.length() * 2;
-                    final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
-                    long ptr = Unsafe.malloc(len);
-                    try {
-                        int sent = 0;
-                        int reqLen = request.length();
-                        Chars.asciiStrCpy(request, reqLen, ptr);
-                        boolean disconnected = false;
-                        while (sent < reqLen) {
-                            int n = nf.send(fd, ptr + sent, reqLen - sent);
-                            if (n < 0) {
-                                disconnected = true;
-                                break;
-                            }
-                            if (n > 0) {
-                                sent += n;
-                            }
-                        }
-                        if (!disconnected) {
-                            while (true) {
-                                int n = nf.recv(fd, ptr, len);
-                                if (n < 0) {
-                                    break;
-                                }
-                            }
-                        }
-                    } finally {
-                        Unsafe.free(ptr, len);
-                    }
-                } finally {
-                    NetworkFacadeImpl.INSTANCE.freeSockAddr(sockAddr);
-                }
-            } finally {
-                NetworkFacadeImpl.INSTANCE.close(fd);
-            }
-        }, false);
     }
 
     @Test
@@ -2252,6 +1969,128 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testJsonQueryDataError() throws Exception {
+        assertMemoryLeak(() -> {
+            final String baseDir = temp.getRoot().getAbsolutePath();
+            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
+            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public int[] getWorkerAffinity() {
+                    return new int[]{-1};
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+
+                @Override
+                public boolean haltOnError() {
+                    return false;
+                }
+            });
+
+            try (
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+            ) {
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new StaticContentProcessor(httpConfiguration);
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                    }
+                });
+
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new JsonQueryProcessor(
+                                httpConfiguration.getJsonQueryProcessorConfiguration(),
+                                engine,
+                                null,
+                                workerPool.getWorkerCount()
+                        );
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return "/query";
+                    }
+                });
+
+                workerPool.start(LOG);
+
+                try {
+
+                    // send multipart request to server
+                    final String request = "GET /query?limit=0%2C1000&count=true&src=con&query=select%20npe()%20from%20long_sequence(1)&timings=true HTTP/1.1\r\n" +
+                            "Host: localhost:9000\r\n" +
+                            "Connection: keep-alive\r\n" +
+                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36\r\n" +
+                            "Accept: */*\r\n" +
+                            "Sec-Fetch-Site: same-origin\r\n" +
+                            "Sec-Fetch-Mode: cors\r\n" +
+                            "Sec-Fetch-Dest: empty\r\n" +
+                            "Referer: http://localhost:9000/index.html\r\n" +
+                            "Accept-Encoding: gzip, deflate, br\r\n" +
+                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                            "Cookie: _ga=GA1.1.2124932001.1573824669; _hjid=f2db90b2-18cf-4956-8870-fcdcde56f3ca; _hjIncludedInSample=1; _gid=GA1.1.697400188.1591597903\r\n" +
+                            "\r\n";
+
+                    long fd = NetworkFacadeImpl.INSTANCE.socketTcp(true);
+                    try {
+                        long sockAddr = NetworkFacadeImpl.INSTANCE.sockaddr("127.0.0.1", 9001);
+                        try {
+                            Assert.assertTrue(fd > -1);
+                            Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.connect(fd, sockAddr));
+                            Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.setTcpNoDelay(fd, true));
+
+                            final int len = request.length() * 2;
+                            long ptr = Unsafe.malloc(len);
+                            try {
+                                int sent = 0;
+                                int reqLen = request.length();
+                                Chars.asciiStrCpy(request, reqLen, ptr);
+                                while (sent < reqLen) {
+                                    int n = NetworkFacadeImpl.INSTANCE.send(fd, ptr + sent, reqLen - sent);
+                                    Assert.assertTrue(n > -1);
+                                    sent += n;
+                                }
+
+                                Thread.sleep(1);
+
+                                NetworkFacadeImpl.INSTANCE.configureNonBlocking(fd);
+                                long t = System.currentTimeMillis();
+                                boolean disconnected = true;
+                                while (NetworkFacadeImpl.INSTANCE.recv(fd, ptr, 1) > -1) {
+                                    if (t + 20000 < System.currentTimeMillis()) {
+                                        disconnected = false;
+                                        break;
+                                    }
+                                }
+                                Assert.assertTrue("disconnect expected", disconnected);
+                            } finally {
+                                Unsafe.free(ptr, len);
+                            }
+                        } finally {
+                            NetworkFacadeImpl.INSTANCE.freeSockAddr(sockAddr);
+                        }
+                    } finally {
+                        NetworkFacadeImpl.INSTANCE.close(fd);
+                    }
+                } finally {
+                    workerPool.halt();
+                }
+            }
+        });
+    }
+
+    @Test
     public void testJsonQueryDropTable() throws Exception {
         testJsonQuery(
                 20,
@@ -2409,6 +2248,44 @@ public class IODispatcherTest {
                         "{\"query\":\"x\",\"error\":'invalid column in list: l2'}\r\n" +
                         "00\r\n" +
                         "\r\n", 20);
+    }
+
+    @Test
+    public void testJsonQueryJsonReplaceZero() throws Exception {
+        testJsonQuery0(2, engine -> {
+            // create table with all column types
+            createTestTable(
+                    engine.getConfiguration(),
+                    20
+            );
+            sendAndReceive(
+                    NetworkFacadeImpl.INSTANCE,
+                    "GET /query?query=y HTTP/1.1\r\n" +
+                            "Host: localhost:9001\r\n" +
+                            "Connection: keep-alive\r\n" +
+                            "Cache-Control: max-age=0\r\n" +
+                            "Upgrade-Insecure-Requests: 1\r\n" +
+                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                            "Accept-Encoding: gzip, deflate, br\r\n" +
+                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                            "\r\n",
+                    "HTTP/1.1 200 OK\r\n" +
+                            "Server: questDB/1.0\r\n" +
+                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                            "Transfer-Encoding: chunked\r\n" +
+                            "Content-Type: application/json; charset=utf-8\r\n" +
+                            "Keep-Alive: timeout=5, max=10000\r\n" +
+                            "\r\n" +
+                            "0101\r\n" +
+                            "{\"query\":\"y\",\"columns\":[{\"name\":\"j\",\"type\":\"SYMBOL\"}],\"dataset\":[[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"],[\"okok\"]],\"count\":20}\r\n" +
+                            "00\r\n" +
+                            "\r\n",
+                    100,
+                    0,
+                    false
+            );
+        }, false);
     }
 
     @Test
@@ -2797,6 +2674,34 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testJsonQueryResponseLimit() throws Exception {
+        configuredMaxQueryResponseRowLimit = 2;
+        testJsonQuery(
+                20,
+                "GET /query?query=x&limit=10,14 HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "02a6\r\n" +
+                        "{\"query\":\"x\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"}],\"dataset\":[[37,7618,null,-9219078548506735248,\"286623354-12-11T19:15:45.735Z\",\"197633-02-20T09:12:49.579955Z\",null,0.8001632261203552,null,\"KFM\",false,[]],[109,-8207,-485549586,null,\"278802275-11-05T23:22:18.593Z\",\"122137-10-05T20:22:21.831563Z\",0.5780819,0.18586435581637295,\"DYOPH\",\"IMY\",false,[]]],\"count\":11}\r\n" +
+                        "00\r\n" +
+                        "\r\n");
+    }
+
+    @Test
     public void testJsonQuerySelectAlterSelect() throws Exception {
         testJsonQuery0(1, engine -> {
 
@@ -2986,230 +2891,6 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testJsonQuerySyntaxError() throws Exception {
-        assertMemoryLeak(() -> {
-            final String baseDir = temp.getRoot().getAbsolutePath();
-            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return new int[]{-1};
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            });
-
-            try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
-            ) {
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new StaticContentProcessor(httpConfiguration);
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
-                    }
-                });
-
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new JsonQueryProcessor(
-                                httpConfiguration.getJsonQueryProcessorConfiguration(),
-                                engine,
-                                null,
-                                workerPool.getWorkerCount()
-                        );
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return "/query";
-                    }
-                });
-
-                workerPool.start(LOG);
-
-                // create table with all column types
-                CairoTestUtils.createTestTable(
-                        engine.getConfiguration(),
-                        20,
-                        new Rnd(),
-                        new TestRecord.ArrayBinarySequence());
-
-                // send multipart request to server
-                final String request = "GET /query?query=x%20where2%20i%20%3D%20(%27EHNRX%27) HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "Connection: keep-alive\r\n" +
-                        "Cache-Control: max-age=0\r\n" +
-                        "Upgrade-Insecure-Requests: 1\r\n" +
-                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                        "Accept-Encoding: gzip, deflate, br\r\n" +
-                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                        "\r\n";
-
-                String expectedResponse = "HTTP/1.1 400 Bad request\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: application/json; charset=utf-8\r\n" +
-                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                        "\r\n" +
-                        "4d\r\n" +
-                        "{\"query\":\"x where2 i = ('EHNRX')\",\"error\":\"unexpected token: i\",\"position\":9}\r\n" +
-                        "00\r\n" +
-                        "\r\n";
-
-                sendAndReceive(
-                        NetworkFacadeImpl.INSTANCE,
-                        request,
-                        expectedResponse,
-                        10,
-                        0,
-                        false
-                );
-
-                workerPool.halt();
-            }
-        });
-    }
-
-    @Test
-    public void testJsonQueryDataError() throws Exception {
-        assertMemoryLeak(() -> {
-            final String baseDir = temp.getRoot().getAbsolutePath();
-            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return new int[]{-1};
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            });
-
-            try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
-            ) {
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new StaticContentProcessor(httpConfiguration);
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
-                    }
-                });
-
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new JsonQueryProcessor(
-                                httpConfiguration.getJsonQueryProcessorConfiguration(),
-                                engine,
-                                null,
-                                workerPool.getWorkerCount()
-                        );
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return "/query";
-                    }
-                });
-
-                workerPool.start(LOG);
-
-                try {
-
-                    // send multipart request to server
-                    final String request = "GET /query?limit=0%2C1000&count=true&src=con&query=select%20npe()%20from%20long_sequence(1)&timings=true HTTP/1.1\r\n" +
-                            "Host: localhost:9000\r\n" +
-                            "Connection: keep-alive\r\n" +
-                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36\r\n" +
-                            "Accept: */*\r\n" +
-                            "Sec-Fetch-Site: same-origin\r\n" +
-                            "Sec-Fetch-Mode: cors\r\n" +
-                            "Sec-Fetch-Dest: empty\r\n" +
-                            "Referer: http://localhost:9000/index.html\r\n" +
-                            "Accept-Encoding: gzip, deflate, br\r\n" +
-                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                            "Cookie: _ga=GA1.1.2124932001.1573824669; _hjid=f2db90b2-18cf-4956-8870-fcdcde56f3ca; _hjIncludedInSample=1; _gid=GA1.1.697400188.1591597903\r\n" +
-                            "\r\n";
-
-                    long fd = NetworkFacadeImpl.INSTANCE.socketTcp(true);
-                    try {
-                        long sockAddr = NetworkFacadeImpl.INSTANCE.sockaddr("127.0.0.1", 9001);
-                        try {
-                            Assert.assertTrue(fd > -1);
-                            Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.connect(fd, sockAddr));
-                            Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.setTcpNoDelay(fd, true));
-
-                            final int len = request.length() * 2;
-                            long ptr = Unsafe.malloc(len);
-                            try {
-                                int sent = 0;
-                                int reqLen = request.length();
-                                Chars.asciiStrCpy(request, reqLen, ptr);
-                                while (sent < reqLen) {
-                                    int n = NetworkFacadeImpl.INSTANCE.send(fd, ptr + sent, reqLen - sent);
-                                    Assert.assertTrue(n > -1);
-                                    sent += n;
-                                }
-
-                                Thread.sleep(1);
-
-                                NetworkFacadeImpl.INSTANCE.configureNonBlocking(fd);
-                                long t = System.currentTimeMillis();
-                                boolean disconnected = true;
-                                while (NetworkFacadeImpl.INSTANCE.recv(fd, ptr, 1) > -1) {
-                                    if (t + 20000 < System.currentTimeMillis()) {
-                                        disconnected = false;
-                                        break;
-                                    }
-                                }
-                                Assert.assertTrue("disconnect expected", disconnected);
-                            } finally {
-                                Unsafe.free(ptr, len);
-                            }
-                        } finally {
-                            NetworkFacadeImpl.INSTANCE.freeSockAddr(sockAddr);
-                        }
-                    } finally {
-                        NetworkFacadeImpl.INSTANCE.close(fd);
-                    }
-                } finally {
-                    workerPool.halt();
-                }
-            }
-        });
-    }
-
-    @Test
     public void testJsonQueryStoresTelemetryEvent() throws Exception {
         testJsonQuery(
                 0,
@@ -3292,6 +2973,108 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testJsonQuerySyntaxError() throws Exception {
+        assertMemoryLeak(() -> {
+            final String baseDir = temp.getRoot().getAbsolutePath();
+            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
+            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public int[] getWorkerAffinity() {
+                    return new int[]{-1};
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+
+                @Override
+                public boolean haltOnError() {
+                    return false;
+                }
+            });
+
+            try (
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+            ) {
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new StaticContentProcessor(httpConfiguration);
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                    }
+                });
+
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new JsonQueryProcessor(
+                                httpConfiguration.getJsonQueryProcessorConfiguration(),
+                                engine,
+                                null,
+                                workerPool.getWorkerCount()
+                        );
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return "/query";
+                    }
+                });
+
+                workerPool.start(LOG);
+
+                // create table with all column types
+                CairoTestUtils.createTestTable(
+                        engine.getConfiguration(),
+                        20,
+                        new Rnd(),
+                        new TestRecord.ArrayBinarySequence());
+
+                // send multipart request to server
+                final String request = "GET /query?query=x%20where2%20i%20%3D%20(%27EHNRX%27) HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n";
+
+                String expectedResponse = "HTTP/1.1 400 Bad request\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "4d\r\n" +
+                        "{\"query\":\"x where2 i = ('EHNRX')\",\"error\":\"unexpected token: i\",\"position\":9}\r\n" +
+                        "00\r\n" +
+                        "\r\n";
+
+                sendAndReceive(
+                        NetworkFacadeImpl.INSTANCE,
+                        request,
+                        expectedResponse,
+                        10,
+                        0,
+                        false
+                );
+
+                workerPool.halt();
+            }
+        });
+    }
+
+    @Test
     public void testJsonQueryTopLimit() throws Exception {
         testJsonQuery(
                 20,
@@ -3314,6 +3097,34 @@ public class IODispatcherTest {
                         "\r\n" +
                         "06ac\r\n" +
                         "{\"query\":\"x\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"}],\"dataset\":[[80,24814,-727724771,8920866532787660373,\"-169665660-01-09T01:58:28.119Z\",\"-51129-02-11T06:38:29.397464Z\",null,null,\"EHNRX\",\"ZSX\",false,[]],[30,32312,-303295973,6854658259142399220,null,\"273652-10-24T01:16:04.499209Z\",0.38179755,0.9687423276940171,\"EDRQQ\",\"LOF\",false,[]],[-79,-21442,1985398001,7522482991756933150,\"279864478-12-31T01:58:35.932Z\",\"20093-07-24T16:56:53.198086Z\",null,0.05384400312338511,\"HVUVS\",\"OTS\",true,[]],[70,-29572,-1966408995,-2406077911451945242,null,\"-254163-09-17T05:33:54.251307Z\",0.81233966,null,\"IKJSM\",\"SUQ\",false,[]],[-97,15913,2011884585,4641238585508069993,\"-277437004-09-03T08:55:41.803Z\",\"186548-11-05T05:57:55.827139Z\",0.89989215,0.6583311519893554,\"ZIMNZ\",\"RMF\",false,[]],[-9,5991,-907794648,null,null,null,0.13264287,null,\"OHNZH\",null,false,[]],[-94,30598,-1510166985,6056145309392106540,null,null,0.54669005,null,\"MZVQE\",\"NDC\",true,[]],[-97,-11913,null,750145151786158348,\"-144112168-08-02T20:50:38.542Z\",\"-279681-08-19T06:26:33.186955Z\",0.8977236,0.5691053034055052,\"WIFFL\",\"BRO\",false,[]],[58,7132,null,6793615437970356479,\"63572238-04-24T11:00:13.287Z\",\"171291-08-24T10:16:32.229138Z\",null,0.7215959171612961,\"KWZLU\",\"GXH\",false,[]],[37,7618,null,-9219078548506735248,\"286623354-12-11T19:15:45.735Z\",\"197633-02-20T09:12:49.579955Z\",null,0.8001632261203552,null,\"KFM\",false,[]]],\"count\":10}\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    @Test
+    public void testJsonQueryTopLimitAndCount() throws Exception {
+        testJsonQuery(
+                20,
+                "GET /query?query=x&limit=10&count=true HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "06ac\r\n" +
+                        "{\"query\":\"x\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"}],\"dataset\":[[80,24814,-727724771,8920866532787660373,\"-169665660-01-09T01:58:28.119Z\",\"-51129-02-11T06:38:29.397464Z\",null,null,\"EHNRX\",\"ZSX\",false,[]],[30,32312,-303295973,6854658259142399220,null,\"273652-10-24T01:16:04.499209Z\",0.38179755,0.9687423276940171,\"EDRQQ\",\"LOF\",false,[]],[-79,-21442,1985398001,7522482991756933150,\"279864478-12-31T01:58:35.932Z\",\"20093-07-24T16:56:53.198086Z\",null,0.05384400312338511,\"HVUVS\",\"OTS\",true,[]],[70,-29572,-1966408995,-2406077911451945242,null,\"-254163-09-17T05:33:54.251307Z\",0.81233966,null,\"IKJSM\",\"SUQ\",false,[]],[-97,15913,2011884585,4641238585508069993,\"-277437004-09-03T08:55:41.803Z\",\"186548-11-05T05:57:55.827139Z\",0.89989215,0.6583311519893554,\"ZIMNZ\",\"RMF\",false,[]],[-9,5991,-907794648,null,null,null,0.13264287,null,\"OHNZH\",null,false,[]],[-94,30598,-1510166985,6056145309392106540,null,null,0.54669005,null,\"MZVQE\",\"NDC\",true,[]],[-97,-11913,null,750145151786158348,\"-144112168-08-02T20:50:38.542Z\",\"-279681-08-19T06:26:33.186955Z\",0.8977236,0.5691053034055052,\"WIFFL\",\"BRO\",false,[]],[58,7132,null,6793615437970356479,\"63572238-04-24T11:00:13.287Z\",\"171291-08-24T10:16:32.229138Z\",null,0.7215959171612961,\"KWZLU\",\"GXH\",false,[]],[37,7618,null,-9219078548506735248,\"286623354-12-11T19:15:45.735Z\",\"197633-02-20T09:12:49.579955Z\",null,0.8001632261203552,null,\"KFM\",false,[]]],\"count\":20}\r\n" +
                         "00\r\n" +
                         "\r\n"
         );
@@ -3363,31 +3174,138 @@ public class IODispatcherTest {
     }
 
     @Test
-    public void testJsonQueryTopLimitAndCount() throws Exception {
-        testJsonQuery(
-                20,
-                "GET /query?query=x&limit=10&count=true HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "Connection: keep-alive\r\n" +
-                        "Cache-Control: max-age=0\r\n" +
-                        "Upgrade-Insecure-Requests: 1\r\n" +
-                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                        "Accept-Encoding: gzip, deflate, br\r\n" +
-                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                        "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: application/json; charset=utf-8\r\n" +
-                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                        "\r\n" +
-                        "06ac\r\n" +
-                        "{\"query\":\"x\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"}],\"dataset\":[[80,24814,-727724771,8920866532787660373,\"-169665660-01-09T01:58:28.119Z\",\"-51129-02-11T06:38:29.397464Z\",null,null,\"EHNRX\",\"ZSX\",false,[]],[30,32312,-303295973,6854658259142399220,null,\"273652-10-24T01:16:04.499209Z\",0.38179755,0.9687423276940171,\"EDRQQ\",\"LOF\",false,[]],[-79,-21442,1985398001,7522482991756933150,\"279864478-12-31T01:58:35.932Z\",\"20093-07-24T16:56:53.198086Z\",null,0.05384400312338511,\"HVUVS\",\"OTS\",true,[]],[70,-29572,-1966408995,-2406077911451945242,null,\"-254163-09-17T05:33:54.251307Z\",0.81233966,null,\"IKJSM\",\"SUQ\",false,[]],[-97,15913,2011884585,4641238585508069993,\"-277437004-09-03T08:55:41.803Z\",\"186548-11-05T05:57:55.827139Z\",0.89989215,0.6583311519893554,\"ZIMNZ\",\"RMF\",false,[]],[-9,5991,-907794648,null,null,null,0.13264287,null,\"OHNZH\",null,false,[]],[-94,30598,-1510166985,6056145309392106540,null,null,0.54669005,null,\"MZVQE\",\"NDC\",true,[]],[-97,-11913,null,750145151786158348,\"-144112168-08-02T20:50:38.542Z\",\"-279681-08-19T06:26:33.186955Z\",0.8977236,0.5691053034055052,\"WIFFL\",\"BRO\",false,[]],[58,7132,null,6793615437970356479,\"63572238-04-24T11:00:13.287Z\",\"171291-08-24T10:16:32.229138Z\",null,0.7215959171612961,\"KWZLU\",\"GXH\",false,[]],[37,7618,null,-9219078548506735248,\"286623354-12-11T19:15:45.735Z\",\"197633-02-20T09:12:49.579955Z\",null,0.8001632261203552,null,\"KFM\",false,[]]],\"count\":20}\r\n" +
-                        "00\r\n" +
-                        "\r\n"
-        );
+    public void testJsonQueryWithInterruption() throws Exception {
+        assertMemoryLeak(() -> {
+            final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
+            final String baseDir = temp.getRoot().getAbsolutePath();
+            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(nf, baseDir, 128,
+                    false, false);
+            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public int[] getWorkerAffinity() {
+                    return new int[]{-1};
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+
+                @Override
+                public boolean haltOnError() {
+                    return false;
+                }
+            });
+            try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                 HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new StaticContentProcessor(httpConfiguration);
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                    }
+                });
+
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new JsonQueryProcessor(httpConfiguration.getJsonQueryProcessorConfiguration(), engine,
+                                null, workerPool.getWorkerCount());
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return "/query";
+                    }
+                });
+
+                final AtomicBoolean clientClosed = new AtomicBoolean(false);
+                final AtomicBoolean serverClosed = new AtomicBoolean(false);
+                HttpClientStateListener clientStateListener = new HttpClientStateListener() {
+                    @Override
+                    public void onClosed() {
+                        clientClosed.set(true);
+
+                    }
+
+                    @Override
+                    public void onReceived(int nBytes) {
+                        LOG.info().$("Client received ").$(nBytes).$(" bytes").$();
+                    }
+                };
+                workerPool.start(LOG);
+
+                try {
+                    // create table with all column types
+                    CairoTestUtils.createTestTable(engine.getConfiguration(), 10000, new Rnd(),
+                            new TestRecord.ArrayBinarySequence());
+
+                    // send multipart request to server
+
+                    final String request = "GET /query?query=select+distinct+a+from+x+where+test_latched_counter() HTTP/1.1\r\n"
+                            + "Host: localhost:9001\r\n" + "Connection: keep-alive\r\n" + "Cache-Control: max-age=0\r\n"
+                            + "Upgrade-Insecure-Requests: 1\r\n"
+                            + "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n"
+                            + "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n"
+                            + "Accept-Encoding: gzip, deflate, br\r\n"
+                            + "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" + "\r\n";
+
+                    String expectedResponse = "HTTP/1.1 200 OK\r\n" + "Server: questDB/1.0\r\n"
+                            + "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" + "Transfer-Encoding: chunked\r\n"
+                            + "Content-Type: application/json; charset=utf-8\r\n"
+                            + "Keep-Alive: timeout=5, max=10000\r\n" + "\r\n" + "7e\r\n" + "{\"query\":\"s" + "\r\n";
+                    TestLatchedCounterFunctionFactory.reset(new TestLatchedCounterFunctionFactory.Callback() {
+                        @Override
+                        public boolean onGet(Record record, int count) {
+                            if (count == 4) {
+                                while (!clientClosed.get()) {
+                                    LockSupport.parkNanos(1);
+                                }
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public void onClose() {
+                            serverClosed.set(true);
+                        }
+                    });
+                    long fd = nf.socketTcp(true);
+                    try {
+                        long sockAddr = nf.sockaddr("127.0.0.1", 9001);
+                        try {
+                            Assert.assertTrue(fd > -1);
+                            Assert.assertEquals(0, nf.connect(fd, sockAddr));
+                            Assert.assertEquals(0, nf.setTcpNoDelay(fd, true));
+
+                            byte[] expectedResponse1 = expectedResponse.getBytes();
+                            long bufLen = request.length();
+                            long ptr = Unsafe.malloc(bufLen);
+                            try {
+                                sendAndReceive(nf, request, 0, false, true, fd, expectedResponse1, 200, ptr, clientStateListener);
+                            } finally {
+                                Unsafe.free(ptr, bufLen);
+                            }
+                        } finally {
+                            nf.freeSockAddr(sockAddr);
+                        }
+                    } finally {
+                        nf.close(fd);
+                        clientStateListener.onClosed();
+                    }
+                    while (!serverClosed.get()) {
+                        LockSupport.parkNanos(1);
+                    }
+                    Assert.assertEquals(6, TestLatchedCounterFunctionFactory.getCount());
+                } finally {
+                    workerPool.halt();
+                }
+            }
+        });
     }
 
     @Test
@@ -3671,6 +3589,65 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testMissingURL() throws Exception {
+        testJsonQuery0(2, engine -> {
+            long fd = NetworkFacadeImpl.INSTANCE.socketTcp(true);
+            try {
+                long sockAddr = NetworkFacadeImpl.INSTANCE.sockaddr("127.0.0.1", 9001);
+                try {
+                    Assert.assertTrue(fd > -1);
+                    Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.connect(fd, sockAddr));
+                    Assert.assertEquals(0, NetworkFacadeImpl.INSTANCE.setTcpNoDelay(fd, true));
+
+                    final String request = "GET HTTP/1.1\r\n" +
+                            "Host: localhost:9001\r\n" +
+                            "Connection: keep-alive\r\n" +
+                            "Cache-Control: max-age=0\r\n" +
+                            "Upgrade-Insecure-Requests: 1\r\n" +
+                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                            "Accept-Encoding: gzip, deflate, br\r\n" +
+                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                            "\r\n";
+                    final int len = request.length() * 2;
+                    final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
+                    long ptr = Unsafe.malloc(len);
+                    try {
+                        int sent = 0;
+                        int reqLen = request.length();
+                        Chars.asciiStrCpy(request, reqLen, ptr);
+                        boolean disconnected = false;
+                        while (sent < reqLen) {
+                            int n = nf.send(fd, ptr + sent, reqLen - sent);
+                            if (n < 0) {
+                                disconnected = true;
+                                break;
+                            }
+                            if (n > 0) {
+                                sent += n;
+                            }
+                        }
+                        if (!disconnected) {
+                            while (true) {
+                                int n = nf.recv(fd, ptr, len);
+                                if (n < 0) {
+                                    break;
+                                }
+                            }
+                        }
+                    } finally {
+                        Unsafe.free(ptr, len);
+                    }
+                } finally {
+                    NetworkFacadeImpl.INSTANCE.freeSockAddr(sockAddr);
+                }
+            } finally {
+                NetworkFacadeImpl.INSTANCE.close(fd);
+            }
+        }, false);
+    }
+
+    @Test
     public void testSCPConnectDownloadDisconnect() throws Exception {
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
@@ -3855,6 +3832,173 @@ public class IODispatcherTest {
                         } finally {
                             Net.freeSockAddr(sockAddr);
                         }
+                        workerPool.halt();
+                    } finally {
+                        Files.remove(path);
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSCPFullDownload() throws Exception {
+        assertMemoryLeak(() -> {
+            final String baseDir = temp.getRoot().getAbsolutePath();
+            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
+            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public int[] getWorkerAffinity() {
+                    return new int[]{-1, -1};
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 2;
+                }
+
+                @Override
+                public boolean haltOnError() {
+                    return false;
+                }
+            });
+            try (HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+                httpServer.bind(new HttpRequestProcessorFactory() {
+                    @Override
+                    public HttpRequestProcessor newInstance() {
+                        return new StaticContentProcessor(httpConfiguration);
+                    }
+
+                    @Override
+                    public String getUrl() {
+                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                    }
+                });
+
+                workerPool.start(LOG);
+
+                // create 20Mb file in /tmp directory
+                try (Path path = new Path().of(baseDir).concat("questdb-temp.txt").$()) {
+                    try {
+                        Rnd rnd = new Rnd();
+                        final int diskBufferLen = 1024 * 1024;
+
+                        writeRandomFile(path, rnd, 122222212222L, diskBufferLen);
+
+                        long fd = Net.socketTcp(true);
+                        try {
+                            long sockAddr = Net.sockaddr("127.0.0.1", 9001);
+                            try {
+                                Assert.assertTrue(fd > -1);
+                                Assert.assertEquals(0, Net.connect(fd, sockAddr));
+
+                                int netBufferLen = 4 * 1024;
+                                long buffer = Unsafe.calloc(netBufferLen);
+                                try {
+
+                                    // send request to server to download file we just created
+                                    final String request = "GET /questdb-temp.txt HTTP/1.1\r\n" +
+                                            "Host: localhost:9000\r\n" +
+                                            "Connection: keep-alive\r\n" +
+                                            "Cache-Control: max-age=0\r\n" +
+                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
+                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
+                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
+                                            "Accept-Language: en-US,en;q=0.8\r\n" +
+                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
+                                            "\r\n";
+
+                                    String expectedResponseHeader = "HTTP/1.1 200 OK\r\n" +
+                                            "Server: questDB/1.0\r\n" +
+                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                            "Content-Length: 20971520\r\n" +
+                                            "Content-Type: text/plain\r\n" +
+                                            "ETag: \"122222212222\"\r\n" + // this is last modified timestamp on the file, we set this value when we created file
+                                            "\r\n";
+
+                                    for (int j = 0; j < 10; j++) {
+                                        sendRequest(request, fd, buffer);
+                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, diskBufferLen, expectedResponseHeader, 20971670);
+                                    }
+//
+                                    // send few requests to receive 304
+                                    final String request2 = "GET /questdb-temp.txt HTTP/1.1\r\n" +
+                                            "Host: localhost:9000\r\n" +
+                                            "Connection: keep-alive\r\n" +
+                                            "Cache-Control: max-age=0\r\n" +
+                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
+                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
+                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
+                                            "Accept-Language: en-US,en;q=0.8\r\n" +
+                                            "If-None-Match: \"122222212222\"\r\n" + // this header should make static processor return 304
+                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
+                                            "\r\n";
+
+                                    String expectedResponseHeader2 = "HTTP/1.1 304 Not Modified\r\n" +
+                                            "Server: questDB/1.0\r\n" +
+                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                            "Content-Type: text/html; charset=utf-8\r\n" +
+                                            "\r\n";
+
+                                    for (int i = 0; i < 3; i++) {
+                                        sendRequest(request2, fd, buffer);
+                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader2, 126);
+                                    }
+
+                                    // couple more full downloads after 304
+                                    for (int j = 0; j < 2; j++) {
+                                        sendRequest(request, fd, buffer);
+                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, diskBufferLen, expectedResponseHeader, 20971670);
+                                    }
+
+                                    // get a 404 now
+                                    final String request3 = "GET /questdb-temp_!.txt HTTP/1.1\r\n" +
+                                            "Host: localhost:9000\r\n" +
+                                            "Connection: keep-alive\r\n" +
+                                            "Cache-Control: max-age=0\r\n" +
+                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
+                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
+                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
+                                            "Accept-Language: en-US,en;q=0.8\r\n" +
+                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
+                                            "\r\n";
+
+                                    String expectedResponseHeader3 = "HTTP/1.1 404 Not Found\r\n" +
+                                            "Server: questDB/1.0\r\n" +
+                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                            "Transfer-Encoding: chunked\r\n" +
+                                            "Content-Type: text/html; charset=utf-8\r\n" +
+                                            "\r\n" +
+                                            "0b\r\n" +
+                                            "Not Found\r\n" +
+                                            "\r\n" +
+                                            "00\r\n" +
+                                            "\r\n";
+
+
+                                    for (int i = 0; i < 4; i++) {
+                                        sendRequest(request3, fd, buffer);
+                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader3, expectedResponseHeader3.length());
+                                    }
+
+                                    // and few more 304s
+
+                                    for (int i = 0; i < 3; i++) {
+                                        sendRequest(request2, fd, buffer);
+                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader2, 126);
+                                    }
+
+                                } finally {
+                                    Unsafe.free(buffer, netBufferLen);
+                                }
+                            } finally {
+                                Net.freeSockAddr(sockAddr);
+                            }
+                        } finally {
+                            Net.close(fd);
+                            LOG.info().$("closed [fd=").$(fd).$(']').$();
+                        }
+
                         workerPool.halt();
                     } finally {
                         Files.remove(path);
@@ -4053,173 +4197,6 @@ public class IODispatcherTest {
                             Net.freeSockAddr(sockAddr);
                             workerPool.halt();
                         }
-                    } finally {
-                        Files.remove(path);
-                    }
-                }
-            }
-        });
-    }
-
-    @Test
-    public void testSCPFullDownload() throws Exception {
-        assertMemoryLeak(() -> {
-            final String baseDir = temp.getRoot().getAbsolutePath();
-            final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            });
-            try (HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new StaticContentProcessor(httpConfiguration);
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
-                    }
-                });
-
-                workerPool.start(LOG);
-
-                // create 20Mb file in /tmp directory
-                try (Path path = new Path().of(baseDir).concat("questdb-temp.txt").$()) {
-                    try {
-                        Rnd rnd = new Rnd();
-                        final int diskBufferLen = 1024 * 1024;
-
-                        writeRandomFile(path, rnd, 122222212222L, diskBufferLen);
-
-                        long fd = Net.socketTcp(true);
-                        try {
-                            long sockAddr = Net.sockaddr("127.0.0.1", 9001);
-                            try {
-                                Assert.assertTrue(fd > -1);
-                                Assert.assertEquals(0, Net.connect(fd, sockAddr));
-
-                                int netBufferLen = 4 * 1024;
-                                long buffer = Unsafe.calloc(netBufferLen);
-                                try {
-
-                                    // send request to server to download file we just created
-                                    final String request = "GET /questdb-temp.txt HTTP/1.1\r\n" +
-                                            "Host: localhost:9000\r\n" +
-                                            "Connection: keep-alive\r\n" +
-                                            "Cache-Control: max-age=0\r\n" +
-                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
-                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
-                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
-                                            "Accept-Language: en-US,en;q=0.8\r\n" +
-                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
-                                            "\r\n";
-
-                                    String expectedResponseHeader = "HTTP/1.1 200 OK\r\n" +
-                                            "Server: questDB/1.0\r\n" +
-                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                                            "Content-Length: 20971520\r\n" +
-                                            "Content-Type: text/plain\r\n" +
-                                            "ETag: \"122222212222\"\r\n" + // this is last modified timestamp on the file, we set this value when we created file
-                                            "\r\n";
-
-                                    for (int j = 0; j < 10; j++) {
-                                        sendRequest(request, fd, buffer);
-                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, diskBufferLen, expectedResponseHeader, 20971670);
-                                    }
-//
-                                    // send few requests to receive 304
-                                    final String request2 = "GET /questdb-temp.txt HTTP/1.1\r\n" +
-                                            "Host: localhost:9000\r\n" +
-                                            "Connection: keep-alive\r\n" +
-                                            "Cache-Control: max-age=0\r\n" +
-                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
-                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
-                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
-                                            "Accept-Language: en-US,en;q=0.8\r\n" +
-                                            "If-None-Match: \"122222212222\"\r\n" + // this header should make static processor return 304
-                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
-                                            "\r\n";
-
-                                    String expectedResponseHeader2 = "HTTP/1.1 304 Not Modified\r\n" +
-                                            "Server: questDB/1.0\r\n" +
-                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                                            "Content-Type: text/html; charset=utf-8\r\n" +
-                                            "\r\n";
-
-                                    for (int i = 0; i < 3; i++) {
-                                        sendRequest(request2, fd, buffer);
-                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader2, 126);
-                                    }
-
-                                    // couple more full downloads after 304
-                                    for (int j = 0; j < 2; j++) {
-                                        sendRequest(request, fd, buffer);
-                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, diskBufferLen, expectedResponseHeader, 20971670);
-                                    }
-
-                                    // get a 404 now
-                                    final String request3 = "GET /questdb-temp_!.txt HTTP/1.1\r\n" +
-                                            "Host: localhost:9000\r\n" +
-                                            "Connection: keep-alive\r\n" +
-                                            "Cache-Control: max-age=0\r\n" +
-                                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
-                                            "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36\r\n" +
-                                            "Accept-Encoding: gzip,deflate,sdch\r\n" +
-                                            "Accept-Language: en-US,en;q=0.8\r\n" +
-                                            "Cookie: textwrapon=false; textautoformat=false; wysiwyg=textarea\r\n" +
-                                            "\r\n";
-
-                                    String expectedResponseHeader3 = "HTTP/1.1 404 Not Found\r\n" +
-                                            "Server: questDB/1.0\r\n" +
-                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                                            "Transfer-Encoding: chunked\r\n" +
-                                            "Content-Type: text/html; charset=utf-8\r\n" +
-                                            "\r\n" +
-                                            "0b\r\n" +
-                                            "Not Found\r\n" +
-                                            "\r\n" +
-                                            "00\r\n" +
-                                            "\r\n";
-
-
-                                    for (int i = 0; i < 4; i++) {
-                                        sendRequest(request3, fd, buffer);
-                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader3, expectedResponseHeader3.length());
-                                    }
-
-                                    // and few more 304s
-
-                                    for (int i = 0; i < 3; i++) {
-                                        sendRequest(request2, fd, buffer);
-                                        assertDownloadResponse(fd, rnd, buffer, netBufferLen, 0, expectedResponseHeader2, 126);
-                                    }
-
-                                } finally {
-                                    Unsafe.free(buffer, netBufferLen);
-                                }
-                            } finally {
-                                Net.freeSockAddr(sockAddr);
-                            }
-                        } finally {
-                            Net.close(fd);
-                            LOG.info().$("closed [fd=").$(fd).$(']').$();
-                        }
-
-                        workerPool.halt();
                     } finally {
                         Files.remove(path);
                     }
@@ -4744,6 +4721,39 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testTextQueryResponseLimit() throws Exception {
+        configuredMaxQueryResponseRowLimit = 3;
+        testJsonQuery(
+                20,
+                "GET /exp?query=select+rnd_symbol(%27a%27%2C%27b%27%2C%27c%27)+sym+from+long_sequence(10%2C+33%2C+55)&limit=0%2C1000&count=true&src=con HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: text/csv; charset=utf-8\r\n" +
+                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "16\r\n" +
+                        "\"sym\"\r\n" +
+                        "\"c\"\r\n" +
+                        "\"c\"\r\n" +
+                        "\"c\"\r\n" +
+                        "\r\n" +
+                        "00\r\n" +
+                        "\r\n");
+    }
+
+    @Test
     // this test is ignore for the time being because it is unstable on OSX and I
     // have not figured out the reason yet. I would like to see if this test
     // runs any different on Linux, just to narrow the problem down to either
@@ -4949,7 +4959,7 @@ public class IODispatcherTest {
             });
 
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), null);
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
                     HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -5001,65 +5011,63 @@ public class IODispatcherTest {
         });
     }
 
-    @Test
-    public void testJsonQueryResponseLimit() throws Exception {
-        configuredMaxQueryResponseRowLimit = 2;
-        testJsonQuery(
-                20,
-                "GET /query?query=x&limit=10,14 HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "Connection: keep-alive\r\n" +
-                        "Cache-Control: max-age=0\r\n" +
-                        "Upgrade-Insecure-Requests: 1\r\n" +
-                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                        "Accept-Encoding: gzip, deflate, br\r\n" +
-                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                        "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: application/json; charset=utf-8\r\n" +
-                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                        "\r\n" +
-                        "02a6\r\n" +
-                        "{\"query\":\"x\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"}],\"dataset\":[[37,7618,null,-9219078548506735248,\"286623354-12-11T19:15:45.735Z\",\"197633-02-20T09:12:49.579955Z\",null,0.8001632261203552,null,\"KFM\",false,[]],[109,-8207,-485549586,null,\"278802275-11-05T23:22:18.593Z\",\"122137-10-05T20:22:21.831563Z\",0.5780819,0.18586435581637295,\"DYOPH\",\"IMY\",false,[]]],\"count\":11}\r\n" +
-                        "00\r\n" +
-                        "\r\n");
+    private static void assertDownloadResponse(long fd, Rnd rnd, long buffer, int len, int nonRepeatedContentLength, String expectedResponseHeader, long expectedResponseLen) {
+        int expectedHeaderLen = expectedResponseHeader.length();
+        int headerCheckRemaining = expectedResponseHeader.length();
+        long downloadedSoFar = 0;
+        int contentRemaining = 0;
+        while (downloadedSoFar < expectedResponseLen) {
+            int contentOffset = 0;
+            int n = Net.recv(fd, buffer, len);
+            Assert.assertTrue(n > -1);
+            if (n > 0) {
+                if (headerCheckRemaining > 0) {
+                    for (int i = 0; i < n && headerCheckRemaining > 0; i++) {
+                        if (expectedResponseHeader.charAt(expectedHeaderLen - headerCheckRemaining) != (char) Unsafe.getUnsafe().getByte(buffer + i)) {
+                            Assert.fail("at " + (expectedHeaderLen - headerCheckRemaining));
+                        }
+                        headerCheckRemaining--;
+                        contentOffset++;
+                    }
+                }
+
+                if (headerCheckRemaining == 0) {
+                    for (int i = contentOffset; i < n; i++) {
+                        if (contentRemaining == 0) {
+                            contentRemaining = nonRepeatedContentLength;
+                            rnd.reset();
+                        }
+                        Assert.assertEquals(rnd.nextByte(), Unsafe.getUnsafe().getByte(buffer + i));
+                        contentRemaining--;
+                    }
+
+                }
+                downloadedSoFar += n;
+            }
+        }
     }
 
-    @Test
-    public void testTextQueryResponseLimit() throws Exception {
-        configuredMaxQueryResponseRowLimit = 3;
-        testJsonQuery(
-                20,
-                "GET /exp?query=select+rnd_symbol(%27a%27%2C%27b%27%2C%27c%27)+sym+from+long_sequence(10%2C+33%2C+55)&limit=0%2C1000&count=true&src=con HTTP/1.1\r\n" +
-                        "Host: localhost:9001\r\n" +
-                        "Connection: keep-alive\r\n" +
-                        "Cache-Control: max-age=0\r\n" +
-                        "Upgrade-Insecure-Requests: 1\r\n" +
-                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
-                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
-                        "Accept-Encoding: gzip, deflate, br\r\n" +
-                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
-                        "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
-                        "Server: questDB/1.0\r\n" +
-                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                        "Transfer-Encoding: chunked\r\n" +
-                        "Content-Type: text/csv; charset=utf-8\r\n" +
-                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
-                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                        "\r\n" +
-                        "16\r\n" +
-                        "\"sym\"\r\n" +
-                        "\"c\"\r\n" +
-                        "\"c\"\r\n" +
-                        "\"c\"\r\n" +
-                        "\r\n" +
-                        "00\r\n" +
-                        "\r\n");
+    private static void sendRequest(String request, long fd, long buffer) {
+        final int requestLen = request.length();
+        Chars.asciiStrCpy(request, requestLen, buffer);
+        Assert.assertEquals(requestLen, Net.send(fd, buffer, requestLen));
+    }
+
+    private void assertColumn(CharSequence expected, CharSequence tableName, int index) {
+        final String baseDir = temp.getRoot().getAbsolutePath();
+        DefaultCairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
+
+        try (TableReader reader = new TableReader(configuration, tableName)) {
+            final StringSink sink = new StringSink();
+            final RecordCursorPrinter printer = new RecordCursorPrinter(sink);
+            sink.clear();
+            printer.printFullColumn(reader.getCursor(), reader.getMetadata(), index, false);
+            TestUtils.assertEquals(expected, sink);
+            reader.getCursor().toTop();
+            sink.clear();
+            printer.printFullColumn(reader.getCursor(), reader.getMetadata(), index, false);
+            TestUtils.assertEquals(expected, sink);
+        }
     }
 
     @NotNull
@@ -5171,16 +5179,6 @@ public class IODispatcherTest {
             };
 
             @Override
-            public boolean getServerKeepAlive() {
-                return serverKeepAlive;
-            }
-
-            @Override
-            public String getHttpVersion() {
-                return httpProtocolVersion;
-            }
-
-            @Override
             public MillisecondClock getClock() {
                 return () -> 0;
             }
@@ -5193,6 +5191,11 @@ public class IODispatcherTest {
             @Override
             public StaticContentProcessorConfiguration getStaticContentProcessorConfiguration() {
                 return staticContentProcessorConfiguration;
+            }
+
+            @Override
+            public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
+                return jsonQueryProcessorConfiguration;
             }
 
             @Override
@@ -5211,8 +5214,13 @@ public class IODispatcherTest {
             }
 
             @Override
-            public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
-                return jsonQueryProcessorConfiguration;
+            public boolean getServerKeepAlive() {
+                return serverKeepAlive;
+            }
+
+            @Override
+            public String getHttpVersion() {
+                return httpProtocolVersion;
             }
         };
     }
@@ -5385,20 +5393,13 @@ public class IODispatcherTest {
             DefaultCairoConfiguration cairoConfiguration = new DefaultCairoConfiguration(baseDir);
 
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration, null);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration);
                     HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
             ) {
                 TelemetryJob telemetryJob = null;
-                TestUtils.copyMimeTypes(baseDir);
-                final PropServerConfiguration serverConfiguration = new PropServerConfiguration(baseDir, new Properties()) {
-                    @Override
-                    public CairoConfiguration getCairoConfiguration() {
-                        return cairoConfiguration;
-                    }
-                };
-                final MessageBus messageBus = new MessageBusImpl(serverConfiguration);
+                final MessageBus messageBus = new MessageBusImpl(cairoConfiguration);
                 if (telemetry) {
-                    telemetryJob = new TelemetryJob(serverConfiguration, engine, messageBus, null);
+                    telemetryJob = new TelemetryJob(engine);
                 }
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -5474,23 +5475,6 @@ public class IODispatcherTest {
         });
     }
 
-    private void assertColumn(CharSequence expected, CharSequence tableName, int index) {
-        final String baseDir = temp.getRoot().getAbsolutePath();
-        DefaultCairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
-
-        try (TableReader reader = new TableReader(configuration, tableName)) {
-            final StringSink sink = new StringSink();
-            final RecordCursorPrinter printer = new RecordCursorPrinter(sink);
-            sink.clear();
-            printer.printFullColumn(reader.getCursor(), reader.getMetadata(), index, false);
-            TestUtils.assertEquals(expected, sink);
-            reader.getCursor().toTop();
-            sink.clear();
-            printer.printFullColumn(reader.getCursor(), reader.getMetadata(), index, false);
-            TestUtils.assertEquals(expected, sink);
-        }
-    }
-
     private void writeRandomFile(Path path, Rnd rnd, long lastModified, int bufLen) {
         if (Files.exists(path)) {
             Assert.assertTrue(Files.remove(path));
@@ -5517,9 +5501,9 @@ public class IODispatcherTest {
     }
 
     private interface HttpClientStateListener {
-        void onReceived(int nBytes);
-
         void onClosed();
+
+        void onReceived(int nBytes);
     }
 
     private static class HelloContext implements IOContext {

--- a/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserTest.java
@@ -552,7 +552,7 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
 
     private void assertThat(String expected, String lines, CharSequence tableName, CairoConfiguration configuration) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (CairoLineProtoParser parser = new CairoLineProtoParser(engine, AllowAllCairoSecurityContext.INSTANCE, LineProtoNanoTimestampAdapter.INSTANCE)) {
                     byte[] bytes = lines.getBytes(StandardCharsets.UTF_8);
                     int len = bytes.length;

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -812,7 +812,7 @@ public class LineTcpConnectionContextTest extends AbstractCairoTest {
 
     private void runInContext(Runnable r, Runnable onCommitNewEvent) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 setupContext(engine, onCommitNewEvent);
                 try {
                     r.run();
@@ -851,7 +851,7 @@ public class LineTcpConnectionContextTest extends AbstractCairoTest {
                 Arrays.fill(affinityByThread, -1);
             }
         });
-        scheduler = new LineTcpMeasurementScheduler(configuration, lineTcpConfiguration, engine, workerPool) {
+        scheduler = new LineTcpMeasurementScheduler(lineTcpConfiguration, engine, workerPool) {
             @Override
             void commitNewEvent(LineTcpMeasurementEvent event, boolean complete) {
                 if (null != onCommitNewEvent) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
@@ -118,14 +118,14 @@ public class LineTcpServerTest extends AbstractCairoTest {
         };
 
         final int nRows = 1000;
-        final String[] tables = { "weather1", "weather2", "weather3" };
-        final String[] locations = { "london", "paris", "rome" };
+        final String[] tables = {"weather1", "weather2", "weather3"};
+        final String[] locations = {"london", "paris", "rome"};
 
         final Random rand = new Random(0);
         final StringBuilder[] expectedSbs = new StringBuilder[tables.length];
 
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
-            LineTcpServer tcpServer = LineTcpServer.create(configuration, lineConfiguration, sharedWorkerPool, LOG, engine, messageBus);
+        try (CairoEngine engine = new CairoEngine(configuration)) {
+            LineTcpServer tcpServer = LineTcpServer.create(lineConfiguration, sharedWorkerPool, LOG, engine);
 
             SOCountDownLatch tablesCreated = new SOCountDownLatch();
             tablesCreated.setCount(tables.length);

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineProtoReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineProtoReceiverTest.java
@@ -203,7 +203,7 @@ public class LinuxLineProtoReceiverTest extends AbstractCairoTest {
     }
 
     private void assertConstructorFail(LineUdpReceiverConfiguration receiverCfg, ReceiverFactory factory) {
-        try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(root), null)) {
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             try {
                 factory.create(receiverCfg, engine, null, true, null, null);
                 Assert.fail();
@@ -236,7 +236,7 @@ public class LinuxLineProtoReceiverTest extends AbstractCairoTest {
                     "blue\tsquare\t3.4000000000000004\t1970-01-01T00:01:40.000000Z\n" +
                     "blue\tsquare\t3.4000000000000004\t1970-01-01T00:01:40.000000Z\n";
 
-            try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(root), null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
 
 
                 try (AbstractLineProtoReceiver receiver = factory.create(receiverCfg, engine, null, false, null, null)) {

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -3036,7 +3036,7 @@ public class PGJobContextTest extends AbstractGriffinTest {
 
                 LOG.info().$("listening [fd=").$(fd).$(']').$();
 
-                try (PGJobContext PGJobContext = new PGJobContext(configuration, engine, messageBus, null)) {
+                try (PGJobContext PGJobContext = new PGJobContext(configuration, engine, engine.getMessageBus(), null)) {
                     SharedRandom.RANDOM.set(new Rnd());
                     try {
                         barrier.await();

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -868,7 +868,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
             };
 
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration, null);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration);
                     TextLoader loader = new TextLoader(engine)
             ) {
                 configureLoaderDefaults(loader, (byte) ',');
@@ -999,7 +999,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
                 return textConfiguration;
             }
         };
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             assertNoLeak(
                     engine,
                     textLoader -> {
@@ -1085,7 +1085,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
                 return textConfiguration;
             }
         };
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             assertNoLeak(
                     engine,
                     textLoader -> {
@@ -1121,70 +1121,58 @@ public class TextLoaderTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testLineRoll() throws Exception {
-        assertNoLeak(textLoader -> {
-            String expected = "f0\tf1\tf2\tf3\tf4\tf5\tf6\tf7\tf8\tf9\n" +
-                    "\"CMP2\t8\t8000\t2.27636352181435\t2015-01-29T19:15:09.000Z\t2015-01-29T19:15:09.000Z\t2015-01-29T00:00:00.000Z\t323\ttrue\t14925407\n" +
-                    "CMP1\t2\t1581\t9.01423481060192\t2015-01-30T19:15:09.000Z\t2015-01-30T19:15:09.000Z\t2015-01-30T00:00:00.000Z\t9138\tfalse\t68225213\n" +
-                    "CMP2\t8\t7067\t9.6284336107783\t2015-01-31T19:15:09.000Z\t2015-01-31T19:15:09.000Z\t2015-01-31T00:00:00.000Z\t8197\ttrue\t58403960\n" +
-                    "CMP1\t8\t5313\t8.87764661805704\t2015-02-01T19:15:09.000Z\t2015-02-01T19:15:09.000Z\t2015-02-01T00:00:00.000Z\t2733\tfalse\t69698373\n" +
-                    "\t4\t3883\t7.96873019309714\t2015-02-02T19:15:09.000Z\t2015-02-02T19:15:09.000Z\t2015-02-02T00:00:00.000Z\t6912\ttrue\t91147394\n" +
-                    "CMP1\t7\t4256\t2.46553522534668\t2015-02-03T19:15:09.000Z\t2015-02-03T19:15:09.000Z\t2015-02-03T00:00:00.000Z\t9453\tfalse\t50278940\n" +
-                    "CMP2\t4\t155\t5.08547495584935\t2015-02-04T19:15:09.000Z\t2015-02-04T19:15:09.000Z\t2015-02-04T00:00:00.000Z\t8919\ttrue\t8671995\n" +
-                    "CMP1\t7\t4486\tNaN\t2015-02-05T19:15:09.000Z\t2015-02-05T19:15:09.000Z\t2015-02-05T00:00:00.000Z\t8670\tfalse\t751877\n" +
-                    "CMP2\t2\t6641\t0.0381825352087617\t2015-02-06T19:15:09.000Z\t2015-02-06T19:15:09.000Z\t2015-02-06T00:00:00.000Z\t8331\ttrue\t40909232527\n" +
-                    "CMP1\t1\t3579\t0.849663221742958\t2015-02-07T19:15:09.000Z\t2015-02-07T19:15:09.000Z\t2015-02-07T00:00:00.000Z\t9592\tfalse\t11490662\n" +
-                    "CMP2\t2\t4770\t2.85092033445835\t2015-02-08T19:15:09.000Z\t2015-02-08T19:15:09.000Z\t2015-02-08T00:00:00.000Z\t253\ttrue\t33766814\n" +
-                    "CMP1\t5\t4938\t4.42754498450086\t2015-02-09T19:15:09.000Z\t2015-02-09T19:15:09.000Z\t2015-02-09T00:00:00.000Z\t7817\tfalse\t61983099\n";
-
-            String csv = "\"\"\"CMP2\",8,8000,2.27636352181435,2015-01-29T19:15:09.000Z,2015-01-29 19:15:09,01/29/2015,323,TRUE,14925407\n" +
-                    "CMP1,2,1581,9.01423481060192,2015-01-30T19:15:09.000Z,2015-01-30 19:15:09,01/30/2015,9138,FALSE,68225213\n" +
-                    "CMP2,8,7067,9.6284336107783,2015-01-31T19:15:09.000Z,2015-01-31 19:15:09,01/31/2015,8197,TRUE,58403960\n" +
-                    "CMP1,8,5313,8.87764661805704,2015-02-01T19:15:09.000Z,2015-02-01 19:15:09,02/01/2015,2733,FALSE,69698373\n" +
-                    ",4,3883,7.96873019309714,2015-02-02T19:15:09.000Z,2015-02-02 19:15:09,02/02/2015,6912,TRUE,91147394\n" +
-                    "CMP1,7,4256,2.46553522534668,2015-02-03T19:15:09.000Z,2015-02-03 19:15:09,02/03/2015,9453,FALSE,50278940\n" +
-                    "CMP2,4,155,5.08547495584935,2015-02-04T19:15:09.000Z,2015-02-04 19:15:09,02/04/2015,8919,TRUE,8671995\n" +
-                    "\"CMP1\",7,4486,,2015-02-05T19:15:09.000Z,2015-02-05 19:15:09,02/05/2015,8670,FALSE,751877\n" +
-                    "CMP2,2,6641,0.0381825352087617,2015-02-06T19:15:09.000Z,2015-02-06 19:15:09,02/06/2015,8331,TRUE,40909232527\n" +
-                    "CMP1,1,3579,0.849663221742958,2015-02-07T19:15:09.000Z,2015-02-07 19:15:09,02/07/2015,9592,FALSE,11490662\n" +
-                    "CMP2,2,4770,2.85092033445835,2015-02-08T19:15:09.000Z,2015-02-08 19:15:09,02/08/2015,253,TRUE,33766814\n" +
-                    "CMP1,5,4938,4.42754498450086,2015-02-09T19:15:09.000Z,2015-02-09 19:15:09,02/09/2015,7817,FALSE,61983099\n";
-
-            TextConfiguration textConfiguration = new DefaultTextConfiguration() {
-                @Override
-                public int getRollBufferLimit() {
-                    return 128;
-                }
-
-                @Override
-                public int getRollBufferSize() {
-                    return 32;
-                }
-            };
-
-            final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
-                @Override
-                public TextConfiguration getTextConfiguration() {
-                    return textConfiguration;
-                }
-            };
-
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
-                try (TextLoader loader = new TextLoader(engine)) {
-                    configureLoaderDefaults(loader, (byte) ',');
-                    playText(
-                            engine,
-                            loader,
-                            csv,
-                            1024,
-                            expected,
-                            "{\"columnCount\":10,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"f1\",\"type\":\"INT\"},{\"index\":2,\"name\":\"f2\",\"type\":\"INT\"},{\"index\":3,\"name\":\"f3\",\"type\":\"DOUBLE\"},{\"index\":4,\"name\":\"f4\",\"type\":\"DATE\"},{\"index\":5,\"name\":\"f5\",\"type\":\"DATE\"},{\"index\":6,\"name\":\"f6\",\"type\":\"DATE\"},{\"index\":7,\"name\":\"f7\",\"type\":\"INT\"},{\"index\":8,\"name\":\"f8\",\"type\":\"BOOLEAN\"},{\"index\":9,\"name\":\"f9\",\"type\":\"LONG\"}],\"timestampIndex\":-1}",
-                            12,
-                            12
-                    );
-                }
+    public void testImportTimestampPartitionByDay() throws Exception {
+        final TextConfiguration textConfiguration = new DefaultTextConfiguration() {
+            @Override
+            public int getTextAnalysisMaxLines() {
+                return 3;
             }
-        });
+        };
+
+        CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
+            @Override
+            public TextConfiguration getTextConfiguration() {
+                return textConfiguration;
+            }
+        };
+        try (CairoEngine engine = new CairoEngine(configuration)) {
+            assertNoLeak(
+                    engine,
+                    textLoader -> {
+                        String expected = "StrSym\tts\n" +
+                                "CMP1\t2015-01-13T19:15:09.000000Z\n" +
+                                "CMP2\t2015-01-14T19:15:09.000234Z\n" +
+                                "CMP1\t2015-01-15T19:15:09.000455Z\n" +
+                                "CMP2\t2015-01-16T19:15:09.000754Z\n" +
+                                "CMP1\t2015-01-17T19:15:09.000903Z\n";
+
+
+                        String csv = "StrSym,ts\n" +
+                                "CMP1,2015-01-13T19:15:09.000000Z\n" +
+                                "CMP2,2015-01-14T19:15:09.000234Z\n" +
+                                "CMP1,2015-01-15T19:15:09.000455Z\n" +
+                                "CMP2,2015-01-16T19:15:09.000754Z\n" +
+                                "CMP1,2015-01-17T19:15:09.000903Z\n";
+
+                        configureLoaderDefaults(textLoader, (byte) ',', 0, false, PartitionBy.DAY, "ts");
+                        textLoader.setForceHeaders(false);
+                        playText(
+                                engine,
+                                textLoader,
+                                csv,
+                                1024,
+                                expected,
+                                "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"StrSym\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"ts\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":1}",
+                                5,
+                                5
+                        );
+
+                        try (TableReader r = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "test")) {
+                            Assert.assertEquals(PartitionBy.DAY, r.getPartitionedBy());
+                        }
+                    }
+            );
+        }
     }
 
     @Test
@@ -1715,53 +1703,70 @@ public class TextLoaderTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testReduceLinesForStats() throws Exception {
-        final TextConfiguration textConfiguration = new DefaultTextConfiguration() {
-            @Override
-            public int getTextAnalysisMaxLines() {
-                return 3;
+    public void testLineRoll() throws Exception {
+        assertNoLeak(textLoader -> {
+            String expected = "f0\tf1\tf2\tf3\tf4\tf5\tf6\tf7\tf8\tf9\n" +
+                    "\"CMP2\t8\t8000\t2.27636352181435\t2015-01-29T19:15:09.000Z\t2015-01-29T19:15:09.000Z\t2015-01-29T00:00:00.000Z\t323\ttrue\t14925407\n" +
+                    "CMP1\t2\t1581\t9.01423481060192\t2015-01-30T19:15:09.000Z\t2015-01-30T19:15:09.000Z\t2015-01-30T00:00:00.000Z\t9138\tfalse\t68225213\n" +
+                    "CMP2\t8\t7067\t9.6284336107783\t2015-01-31T19:15:09.000Z\t2015-01-31T19:15:09.000Z\t2015-01-31T00:00:00.000Z\t8197\ttrue\t58403960\n" +
+                    "CMP1\t8\t5313\t8.87764661805704\t2015-02-01T19:15:09.000Z\t2015-02-01T19:15:09.000Z\t2015-02-01T00:00:00.000Z\t2733\tfalse\t69698373\n" +
+                    "\t4\t3883\t7.96873019309714\t2015-02-02T19:15:09.000Z\t2015-02-02T19:15:09.000Z\t2015-02-02T00:00:00.000Z\t6912\ttrue\t91147394\n" +
+                    "CMP1\t7\t4256\t2.46553522534668\t2015-02-03T19:15:09.000Z\t2015-02-03T19:15:09.000Z\t2015-02-03T00:00:00.000Z\t9453\tfalse\t50278940\n" +
+                    "CMP2\t4\t155\t5.08547495584935\t2015-02-04T19:15:09.000Z\t2015-02-04T19:15:09.000Z\t2015-02-04T00:00:00.000Z\t8919\ttrue\t8671995\n" +
+                    "CMP1\t7\t4486\tNaN\t2015-02-05T19:15:09.000Z\t2015-02-05T19:15:09.000Z\t2015-02-05T00:00:00.000Z\t8670\tfalse\t751877\n" +
+                    "CMP2\t2\t6641\t0.0381825352087617\t2015-02-06T19:15:09.000Z\t2015-02-06T19:15:09.000Z\t2015-02-06T00:00:00.000Z\t8331\ttrue\t40909232527\n" +
+                    "CMP1\t1\t3579\t0.849663221742958\t2015-02-07T19:15:09.000Z\t2015-02-07T19:15:09.000Z\t2015-02-07T00:00:00.000Z\t9592\tfalse\t11490662\n" +
+                    "CMP2\t2\t4770\t2.85092033445835\t2015-02-08T19:15:09.000Z\t2015-02-08T19:15:09.000Z\t2015-02-08T00:00:00.000Z\t253\ttrue\t33766814\n" +
+                    "CMP1\t5\t4938\t4.42754498450086\t2015-02-09T19:15:09.000Z\t2015-02-09T19:15:09.000Z\t2015-02-09T00:00:00.000Z\t7817\tfalse\t61983099\n";
+
+            String csv = "\"\"\"CMP2\",8,8000,2.27636352181435,2015-01-29T19:15:09.000Z,2015-01-29 19:15:09,01/29/2015,323,TRUE,14925407\n" +
+                    "CMP1,2,1581,9.01423481060192,2015-01-30T19:15:09.000Z,2015-01-30 19:15:09,01/30/2015,9138,FALSE,68225213\n" +
+                    "CMP2,8,7067,9.6284336107783,2015-01-31T19:15:09.000Z,2015-01-31 19:15:09,01/31/2015,8197,TRUE,58403960\n" +
+                    "CMP1,8,5313,8.87764661805704,2015-02-01T19:15:09.000Z,2015-02-01 19:15:09,02/01/2015,2733,FALSE,69698373\n" +
+                    ",4,3883,7.96873019309714,2015-02-02T19:15:09.000Z,2015-02-02 19:15:09,02/02/2015,6912,TRUE,91147394\n" +
+                    "CMP1,7,4256,2.46553522534668,2015-02-03T19:15:09.000Z,2015-02-03 19:15:09,02/03/2015,9453,FALSE,50278940\n" +
+                    "CMP2,4,155,5.08547495584935,2015-02-04T19:15:09.000Z,2015-02-04 19:15:09,02/04/2015,8919,TRUE,8671995\n" +
+                    "\"CMP1\",7,4486,,2015-02-05T19:15:09.000Z,2015-02-05 19:15:09,02/05/2015,8670,FALSE,751877\n" +
+                    "CMP2,2,6641,0.0381825352087617,2015-02-06T19:15:09.000Z,2015-02-06 19:15:09,02/06/2015,8331,TRUE,40909232527\n" +
+                    "CMP1,1,3579,0.849663221742958,2015-02-07T19:15:09.000Z,2015-02-07 19:15:09,02/07/2015,9592,FALSE,11490662\n" +
+                    "CMP2,2,4770,2.85092033445835,2015-02-08T19:15:09.000Z,2015-02-08 19:15:09,02/08/2015,253,TRUE,33766814\n" +
+                    "CMP1,5,4938,4.42754498450086,2015-02-09T19:15:09.000Z,2015-02-09 19:15:09,02/09/2015,7817,FALSE,61983099\n";
+
+            TextConfiguration textConfiguration = new DefaultTextConfiguration() {
+                @Override
+                public int getRollBufferLimit() {
+                    return 128;
+                }
+
+                @Override
+                public int getRollBufferSize() {
+                    return 32;
+                }
+            };
+
+            final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
+                @Override
+                public TextConfiguration getTextConfiguration() {
+                    return textConfiguration;
+                }
+            };
+
+            try (CairoEngine engine = new CairoEngine(configuration)) {
+                try (TextLoader loader = new TextLoader(engine)) {
+                    configureLoaderDefaults(loader, (byte) ',');
+                    playText(
+                            engine,
+                            loader,
+                            csv,
+                            1024,
+                            expected,
+                            "{\"columnCount\":10,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"f1\",\"type\":\"INT\"},{\"index\":2,\"name\":\"f2\",\"type\":\"INT\"},{\"index\":3,\"name\":\"f3\",\"type\":\"DOUBLE\"},{\"index\":4,\"name\":\"f4\",\"type\":\"DATE\"},{\"index\":5,\"name\":\"f5\",\"type\":\"DATE\"},{\"index\":6,\"name\":\"f6\",\"type\":\"DATE\"},{\"index\":7,\"name\":\"f7\",\"type\":\"INT\"},{\"index\":8,\"name\":\"f8\",\"type\":\"BOOLEAN\"},{\"index\":9,\"name\":\"f9\",\"type\":\"LONG\"}],\"timestampIndex\":-1}",
+                            12,
+                            12
+                    );
+                }
             }
-        };
-
-        final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
-            @Override
-            public TextConfiguration getTextConfiguration() {
-                return textConfiguration;
-            }
-        };
-
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
-            assertNoLeak(
-                    engine,
-                    textLoader -> {
-                        String expected = "StrSym\tIntSym\tIntCol\tDoubleCol\tIsoDate\tFmt1Date\tFmt2Date\tPhone\tboolean\tlong\n" +
-                                "CMP1\t7\t8284\t3.2045788760297\t2015-01-13T19:15:09.000Z\t2015-01-13T19:15:09.000Z\t2015-01-13T00:00:00.000Z\t8284\ttrue\t10239799\n" +
-                                "CMP2\t3\t1066\t7.5186683377251\t2015-01-14T19:15:09.000Z\t2015-01-14T19:15:09.000Z\t2015-01-14T00:00:00.000Z\t1066\tfalse\t23331405\n" +
-                                "CMP1\t4\t6938\t5.11407712241635\t2015-01-15T19:15:09.000Z\t2015-01-15T19:15:09.000Z\t2015-01-15T00:00:00.000Z\t(099)889-776\ttrue\t55296137\n" +
-                                "CMP1\t7\t6460\t6.39910243218765\t2015-01-17T19:15:09.000Z\t2015-01-17T19:15:09.000Z\t2015-01-17T00:00:00.000Z\t5142\ttrue\t69744070\n";
-
-
-                        String csv = "StrSym,Int Sym,Int_Col,DoubleCol,IsoDate,Fmt1Date,Fmt2Date,Phone,boolean,long\n" +
-                                "CMP1,7,8284,3.2045788760297,2015-01-13T19:15:09.000Z,2015-01-13 19:15:09,01/13/2015,8284,TRUE,10239799\n" +
-                                "CMP2,3,1066,7.5186683377251,2015-01-14T19:15:09.000Z,2015-01-14 19:15:09,01/14/2015,1066,FALSE,23331405\n" +
-                                "CMP1,4,6938,5.11407712241635,2015-01-15T19:15:09.000Z,2015-01-15 19:15:09,01/15/2015,(099)889-776,TRUE,55296137\n" +
-                                ",6.2,4527,2.48986426275223,2015-01-16T19:15:09.000Z,2015-01-16 19:15:09,01/16/2015,2719,FALSE,67489936\n" +
-                                "CMP1,7,6460,6.39910243218765,2015-01-17T19:15:09.000Z,2015-01-17 19:15:09,01/17/2015,5142,TRUE,69744070\n";
-
-                        configureLoaderDefaults(textLoader, (byte) ',');
-                        textLoader.setForceHeaders(false);
-                        playText(
-                                engine,
-                                textLoader,
-                                csv,
-                                1024,
-                                expected,
-                                "{\"columnCount\":10,\"columns\":[{\"index\":0,\"name\":\"StrSym\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"IntSym\",\"type\":\"INT\"},{\"index\":2,\"name\":\"IntCol\",\"type\":\"INT\"},{\"index\":3,\"name\":\"DoubleCol\",\"type\":\"DOUBLE\"},{\"index\":4,\"name\":\"IsoDate\",\"type\":\"DATE\"},{\"index\":5,\"name\":\"Fmt1Date\",\"type\":\"DATE\"},{\"index\":6,\"name\":\"Fmt2Date\",\"type\":\"DATE\"},{\"index\":7,\"name\":\"Phone\",\"type\":\"STRING\"},{\"index\":8,\"name\":\"boolean\",\"type\":\"BOOLEAN\"},{\"index\":9,\"name\":\"long\",\"type\":\"INT\"}],\"timestampIndex\":-1}",
-                                5,
-                                4
-                        );
-                    });
-        }
+        });
     }
 
     @Test
@@ -2526,7 +2531,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testImportTimestampPartitionByDay() throws Exception {
+    public void testReduceLinesForStats() throws Exception {
         final TextConfiguration textConfiguration = new DefaultTextConfiguration() {
             @Override
             public int getTextAnalysisMaxLines() {
@@ -2534,49 +2539,44 @@ public class TextLoaderTest extends AbstractGriffinTest {
             }
         };
 
-        CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
+        final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
             @Override
             public TextConfiguration getTextConfiguration() {
                 return textConfiguration;
             }
         };
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             assertNoLeak(
-                engine,
-                textLoader -> {
-                    String expected = "StrSym\tts\n" +
-                            "CMP1\t2015-01-13T19:15:09.000000Z\n" +
-                            "CMP2\t2015-01-14T19:15:09.000234Z\n" +
-                            "CMP1\t2015-01-15T19:15:09.000455Z\n" +
-                            "CMP2\t2015-01-16T19:15:09.000754Z\n" +
-                            "CMP1\t2015-01-17T19:15:09.000903Z\n";
+                    engine,
+                    textLoader -> {
+                        String expected = "StrSym\tIntSym\tIntCol\tDoubleCol\tIsoDate\tFmt1Date\tFmt2Date\tPhone\tboolean\tlong\n" +
+                                "CMP1\t7\t8284\t3.2045788760297\t2015-01-13T19:15:09.000Z\t2015-01-13T19:15:09.000Z\t2015-01-13T00:00:00.000Z\t8284\ttrue\t10239799\n" +
+                                "CMP2\t3\t1066\t7.5186683377251\t2015-01-14T19:15:09.000Z\t2015-01-14T19:15:09.000Z\t2015-01-14T00:00:00.000Z\t1066\tfalse\t23331405\n" +
+                                "CMP1\t4\t6938\t5.11407712241635\t2015-01-15T19:15:09.000Z\t2015-01-15T19:15:09.000Z\t2015-01-15T00:00:00.000Z\t(099)889-776\ttrue\t55296137\n" +
+                                "CMP1\t7\t6460\t6.39910243218765\t2015-01-17T19:15:09.000Z\t2015-01-17T19:15:09.000Z\t2015-01-17T00:00:00.000Z\t5142\ttrue\t69744070\n";
 
 
-                    String csv = "StrSym,ts\n" +
-                            "CMP1,2015-01-13T19:15:09.000000Z\n" +
-                            "CMP2,2015-01-14T19:15:09.000234Z\n" +
-                            "CMP1,2015-01-15T19:15:09.000455Z\n" +
-                            "CMP2,2015-01-16T19:15:09.000754Z\n" +
-                            "CMP1,2015-01-17T19:15:09.000903Z\n";
+                        String csv = "StrSym,Int Sym,Int_Col,DoubleCol,IsoDate,Fmt1Date,Fmt2Date,Phone,boolean,long\n" +
+                                "CMP1,7,8284,3.2045788760297,2015-01-13T19:15:09.000Z,2015-01-13 19:15:09,01/13/2015,8284,TRUE,10239799\n" +
+                                "CMP2,3,1066,7.5186683377251,2015-01-14T19:15:09.000Z,2015-01-14 19:15:09,01/14/2015,1066,FALSE,23331405\n" +
+                                "CMP1,4,6938,5.11407712241635,2015-01-15T19:15:09.000Z,2015-01-15 19:15:09,01/15/2015,(099)889-776,TRUE,55296137\n" +
+                                ",6.2,4527,2.48986426275223,2015-01-16T19:15:09.000Z,2015-01-16 19:15:09,01/16/2015,2719,FALSE,67489936\n" +
+                                "CMP1,7,6460,6.39910243218765,2015-01-17T19:15:09.000Z,2015-01-17 19:15:09,01/17/2015,5142,TRUE,69744070\n";
 
-                    configureLoaderDefaults(textLoader, (byte) ',', 0, false, PartitionBy.DAY, "ts");
-                    textLoader.setForceHeaders(false);
-                    playText(
-                            engine,
-                            textLoader,
-                            csv,
-                            1024,
-                            expected,
-                            "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"StrSym\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"ts\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":1}",
-                            5,
-                            5
-                    );
-
-                    try (TableReader r = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "test")) {
-                        Assert.assertEquals(PartitionBy.DAY, r.getPartitionedBy());
-                    }
-                }
-            );
+                        configureLoaderDefaults(textLoader, (byte) ',');
+                        textLoader.setForceHeaders(false);
+                        playText(
+                                engine,
+                                textLoader,
+                                csv,
+                                1024,
+                                expected,
+                                "{\"columnCount\":10,\"columns\":[{\"index\":0,\"name\":\"StrSym\",\"type\":\"STRING\"},{\"index\":1,\"name\":\"IntSym\",\"type\":\"INT\"},{\"index\":2,\"name\":\"IntCol\",\"type\":\"INT\"},{\"index\":3,\"name\":\"DoubleCol\",\"type\":\"DOUBLE\"},{\"index\":4,\"name\":\"IsoDate\",\"type\":\"DATE\"},{\"index\":5,\"name\":\"Fmt1Date\",\"type\":\"DATE\"},{\"index\":6,\"name\":\"Fmt2Date\",\"type\":\"DATE\"},{\"index\":7,\"name\":\"Phone\",\"type\":\"STRING\"},{\"index\":8,\"name\":\"boolean\",\"type\":\"BOOLEAN\"},{\"index\":9,\"name\":\"long\",\"type\":\"INT\"}],\"timestampIndex\":-1}",
+                                5,
+                                4
+                        );
+                    });
         }
     }
 

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -42,8 +42,8 @@ import org.junit.BeforeClass;
 
 public class AbstractGriffinTest extends AbstractCairoTest {
     protected static final BindVariableService bindVariableService = new BindVariableService();
-    protected static SqlExecutionContext sqlExecutionContext;
     private static final LongList rows = new LongList();
+    protected static SqlExecutionContext sqlExecutionContext;
     protected static CairoEngine engine;
     protected static SqlCompiler compiler;
 
@@ -96,17 +96,16 @@ public class AbstractGriffinTest extends AbstractCairoTest {
 
     @BeforeClass
     public static void setUp2() {
-        engine = new CairoEngine(configuration, messageBus);
+        engine = new CairoEngine(configuration);
         compiler = new SqlCompiler(engine);
         sqlExecutionContext = new SqlExecutionContextImpl(
-                messageBus,
-                1, engine)
-                        .with(
-                                AllowAllCairoSecurityContext.INSTANCE,
-                                bindVariableService,
-                                null,
-                                -1,
-                                null);
+                engine, 1)
+                .with(
+                        AllowAllCairoSecurityContext.INSTANCE,
+                        bindVariableService,
+                        null,
+                        -1,
+                        null);
         bindVariableService.clear();
     }
 

--- a/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
@@ -199,7 +199,7 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
                         }
                     };
 
-                    try (CairoEngine engine = new CairoEngine(configuration, null)) {
+                    try (CairoEngine engine = new CairoEngine(configuration)) {
                         try (SqlCompiler compiler = new SqlCompiler(engine)) {
                             Assert.assertEquals(ALTER, compiler.compile("alter table x add column meh symbol cache", sqlExecutionContext).getType());
 
@@ -343,45 +343,6 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testAddSymbolWithoutSpecifyingCapacityOrCacheWhenDefaultSymbolCacheConfigIsSetToTrue() throws Exception {
-        assertMemoryLeak(
-                () -> {
-                    createX();
-
-                    engine.releaseAllWriters();
-                    engine.releaseAllReaders();
-
-                    CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
-                        @Override
-                        public boolean getDefaultSymbolCacheFlag() {
-                            return true;
-                        }
-                    };
-
-                    try (CairoEngine engine = new CairoEngine(configuration, null)) {
-                        try (SqlCompiler compiler = new SqlCompiler(engine)) {
-                            Assert.assertEquals(ALTER, compiler.compile("alter table x add column meh symbol", sqlExecutionContext).getType());
-
-                            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", TableUtils.ANY_TABLE_VERSION)) {
-                                SymbolMapReader smr = reader.getSymbolMapReader(16);
-                                Assert.assertNotNull(smr);
-                                Assert.assertEquals(configuration.getDefaultSymbolCapacity(), smr.getSymbolCapacity());
-                                Assert.assertFalse(reader.getMetadata().isColumnIndexed(16));
-                                Assert.assertEquals(configuration.getIndexValueBlockSize(), reader.getMetadata().getIndexValueBlockCapacity(16));
-                                //check that both configuration and new column have cached  == true
-                                Assert.assertTrue(engine.getConfiguration().getDefaultSymbolCacheFlag());
-                                Assert.assertTrue(smr.isCached());
-                            }
-
-                            Assert.assertEquals(0, engine.getBusyWriterCount());
-                            Assert.assertEquals(0, engine.getBusyReaderCount());
-                        }
-                    }
-                }
-        );
-    }
-
-    @Test
     public void testAddSymbolWithoutSpecifyingCapacityOrCacheWhenDefaultSymbolCacheConfigIsSetToFalse() throws Exception {
         assertMemoryLeak(
                 () -> {
@@ -397,7 +358,7 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
                         }
                     };
 
-                    try (CairoEngine engine = new CairoEngine(configuration, null)) {
+                    try (CairoEngine engine = new CairoEngine(configuration)) {
                         try (SqlCompiler compiler = new SqlCompiler(engine)) {
                             Assert.assertEquals(ALTER, compiler.compile("alter table x add column meh symbol", sqlExecutionContext).getType());
 
@@ -410,6 +371,45 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
                                 //check that both configuration and new column have cached  == true
                                 Assert.assertFalse(engine.getConfiguration().getDefaultSymbolCacheFlag());
                                 Assert.assertFalse(smr.isCached());
+                            }
+
+                            Assert.assertEquals(0, engine.getBusyWriterCount());
+                            Assert.assertEquals(0, engine.getBusyReaderCount());
+                        }
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testAddSymbolWithoutSpecifyingCapacityOrCacheWhenDefaultSymbolCacheConfigIsSetToTrue() throws Exception {
+        assertMemoryLeak(
+                () -> {
+                    createX();
+
+                    engine.releaseAllWriters();
+                    engine.releaseAllReaders();
+
+                    CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
+                        @Override
+                        public boolean getDefaultSymbolCacheFlag() {
+                            return true;
+                        }
+                    };
+
+                    try (CairoEngine engine = new CairoEngine(configuration)) {
+                        try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                            Assert.assertEquals(ALTER, compiler.compile("alter table x add column meh symbol", sqlExecutionContext).getType());
+
+                            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "x", TableUtils.ANY_TABLE_VERSION)) {
+                                SymbolMapReader smr = reader.getSymbolMapReader(16);
+                                Assert.assertNotNull(smr);
+                                Assert.assertEquals(configuration.getDefaultSymbolCapacity(), smr.getSymbolCapacity());
+                                Assert.assertFalse(reader.getMetadata().isColumnIndexed(16));
+                                Assert.assertEquals(configuration.getIndexValueBlockSize(), reader.getMetadata().getIndexValueBlockCapacity(16));
+                                //check that both configuration and new column have cached  == true
+                                Assert.assertTrue(engine.getConfiguration().getDefaultSymbolCacheFlag());
+                                Assert.assertTrue(smr.isCached());
                             }
 
                             Assert.assertEquals(0, engine.getBusyWriterCount());

--- a/core/src/test/java/io/questdb/griffin/CopyTest.java
+++ b/core/src/test/java/io/questdb/griffin/CopyTest.java
@@ -24,14 +24,9 @@
 
 package io.questdb.griffin;
 
-import io.questdb.MessageBus;
-import io.questdb.MessageBusImpl;
-import io.questdb.PropServerConfiguration;
-import io.questdb.ServerConfigurationException;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.*;
-import io.questdb.cutlass.json.JsonException;
 import io.questdb.griffin.engine.functions.bind.BindVariableService;
 import io.questdb.std.*;
 import io.questdb.test.tools.TestUtils;
@@ -41,7 +36,6 @@ import org.junit.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
 
 public class CopyTest extends AbstractCairoTest {
 
@@ -91,7 +85,7 @@ public class CopyTest extends AbstractCairoTest {
     }
 
     @BeforeClass
-    public static void setUp2() throws IOException, ServerConfigurationException, JsonException {
+    public static void setUp2() throws IOException {
         final String path = new File(".").getAbsolutePath();
         CairoConfiguration configuration = new DefaultCairoConfiguration(AbstractCairoTest.configuration.getRoot()) {
             @Override
@@ -100,14 +94,12 @@ public class CopyTest extends AbstractCairoTest {
             }
         };
         TestUtils.copyMimeTypes(path);
-        final PropServerConfiguration serverConfiguration = new PropServerConfiguration(path, new Properties());
-        MessageBus messageBus = new MessageBusImpl(serverConfiguration);
-        engine = new CairoEngine(configuration, messageBus);
+        engine = new CairoEngine(configuration);
         compiler = new SqlCompiler(engine);
-        sqlExecutionContext = new SqlExecutionContextImpl(messageBus, 1, engine)
+        sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
                 .with(
-                AllowAllCairoSecurityContext.INSTANCE,
-                bindVariableService,
+                        AllowAllCairoSecurityContext.INSTANCE,
+                        bindVariableService,
                         null, -1, null);
         bindVariableService.clear();
     }

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -105,9 +105,8 @@ public class InsertTest extends AbstractGriffinTest {
             }
 
             BindVariableService bindVariableService = new BindVariableService();
-            SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(messageBus,
-                    1,
-                    engine).with(AllowAllCairoSecurityContext.INSTANCE, bindVariableService, null, -1, null);
+            SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
+                    .with(AllowAllCairoSecurityContext.INSTANCE, bindVariableService, null, -1, null);
 
             bindVariableService.setDouble("bal", 56.4);
 
@@ -127,20 +126,6 @@ public class InsertTest extends AbstractGriffinTest {
                         "1\tGBP\t56.4\n",
                 sink
         );
-    }
-
-    @Test
-    public void testInsertInvalidColumn() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
-            try {
-                compiler.compile("insert into balances(cust_id, ccy2, balance) values (1, 'GBP', 356.12)", sqlExecutionContext);
-                Assert.fail();
-            } catch (SqlException e) {
-                Assert.assertEquals(30, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "Invalid column");
-            }
-        });
     }
 
     @Test
@@ -198,6 +183,125 @@ public class InsertTest extends AbstractGriffinTest {
 
             String expected = "timestamp\tfield\tvalue\n" +
                     "2019-12-04T13:20:49.000000Z\tX\t123.33\n";
+
+            sink.clear();
+            try (TableReader reader = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), insert.getTableName())) {
+                printer.print(reader.getCursor(), reader.getMetadata(), true);
+                TestUtils.assertEquals(expected, sink);
+            }
+        });
+    }
+
+    @Test
+    public void testInsertInvalidColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
+            try {
+                compiler.compile("insert into balances(cust_id, ccy2, balance) values (1, 'GBP', 356.12)", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(30, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "Invalid column");
+            }
+        });
+    }
+
+    @Test
+    public void testInsertNoSelfReference() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("CREATE TABLE trades_aapl (ts TIMESTAMP, px INT, qty int, side STRING) TIMESTAMP(ts)", sqlExecutionContext);
+            try {
+                compiler.compile("insert into trades_aapl (ts) values (ts)", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(37, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "Invalid column");
+            }
+        });
+    }
+
+    @Test
+    public void testInsertNoTimestamp() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
+            CompiledQuery cq = compiler.compile("insert into balances values (1, 'USD', 356.12)", sqlExecutionContext);
+            Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
+            InsertStatement insert = cq.getInsertStatement();
+            try (InsertMethod method = insert.createMethod(sqlExecutionContext)) {
+                method.execute();
+                method.commit();
+            }
+
+            String expected = "cust_id\tccy\tbalance\n" +
+                    "1\tUSD\t356.12\n";
+
+            sink.clear();
+            try (TableReader reader = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), insert.getTableName())) {
+                printer.print(reader.getCursor(), reader.getMetadata(), true);
+                TestUtils.assertEquals(expected, sink);
+            }
+        });
+    }
+
+    @Test
+    public void testInsertNotEnoughFields() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
+            try {
+                compiler.compile("insert into balances values (1, 'USD')", sqlExecutionContext);
+            } catch (SqlException e) {
+                Assert.assertEquals(37, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "not enough values");
+            }
+        });
+    }
+
+    @Test
+    public void testInsertSingleAndMultipleCharacterSymbols() throws Exception {
+        final String expected = "sym\tid\tts\n" +
+                "A\t315515118\t1970-01-03T00:00:00.000000Z\n" +
+                "BB\t-727724771\t1970-01-03T00:06:00.000000Z\n" +
+                "BB\t-948263339\t1970-01-03T00:12:00.000000Z\n" +
+                "CC\t592859671\t1970-01-03T00:18:00.000000Z\n" +
+                "CC\t-847531048\t1970-01-03T00:24:00.000000Z\n" +
+                "A\t-2041844972\t1970-01-03T00:30:00.000000Z\n" +
+                "CC\t-1575378703\t1970-01-03T00:36:00.000000Z\n" +
+                "BB\t1545253512\t1970-01-03T00:42:00.000000Z\n" +
+                "A\t1573662097\t1970-01-03T00:48:00.000000Z\n" +
+                "BB\t339631474\t1970-01-03T00:54:00.000000Z\n";
+
+        assertQuery(
+                "sym\tid\tts\n",
+                "x",
+                "create table x (\n" +
+                        "    sym symbol index,\n" +
+                        "    id int,\n" +
+                        "    ts timestamp\n" +
+                        ") timestamp(ts) partition by DAY",
+                "ts",
+                "insert into x select * from (select rnd_symbol('A', 'BB', 'CC', 'DDD') sym, \n" +
+                        "        rnd_int() id, \n" +
+                        "        timestamp_sequence(172800000000, 360000000) ts \n" +
+                        "    from long_sequence(10)) timestamp (ts)",
+                expected,
+                true
+        );
+    }
+
+    @Test
+    public void testInsertSingleCharacterSymbol() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table ww (id int, sym symbol)", sqlExecutionContext);
+            CompiledQuery cq = compiler.compile("insert into ww VALUES ( 2, 'A')", sqlExecutionContext);
+            Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
+            InsertStatement insert = cq.getInsertStatement();
+            try (InsertMethod method = insert.createMethod(sqlExecutionContext)) {
+                method.execute();
+                method.commit();
+            }
+
+            String expected = "id\tsym\n" +
+                    "2\tA\n";
 
             sink.clear();
             try (TableReader reader = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), insert.getTableName())) {
@@ -297,113 +401,6 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testInsertNoSelfReference() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("CREATE TABLE trades_aapl (ts TIMESTAMP, px INT, qty int, side STRING) TIMESTAMP(ts)", sqlExecutionContext);
-            try {
-                compiler.compile("insert into trades_aapl (ts) values (ts)", sqlExecutionContext);
-                Assert.fail();
-            } catch (SqlException e) {
-                Assert.assertEquals(37, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "Invalid column");
-            }
-        });
-    }
-
-    @Test
-    public void testInsertNoTimestamp() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
-            CompiledQuery cq = compiler.compile("insert into balances values (1, 'USD', 356.12)", sqlExecutionContext);
-            Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
-            InsertStatement insert = cq.getInsertStatement();
-            try (InsertMethod method = insert.createMethod(sqlExecutionContext)) {
-                method.execute();
-                method.commit();
-            }
-
-            String expected = "cust_id\tccy\tbalance\n" +
-                    "1\tUSD\t356.12\n";
-
-            sink.clear();
-            try (TableReader reader = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), insert.getTableName())) {
-                printer.print(reader.getCursor(), reader.getMetadata(), true);
-                TestUtils.assertEquals(expected, sink);
-            }
-        });
-    }
-
-    @Test
-    public void testInsertSingleCharacterSymbol() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table ww (id int, sym symbol)", sqlExecutionContext);
-            CompiledQuery cq = compiler.compile("insert into ww VALUES ( 2, 'A')", sqlExecutionContext);
-            Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
-            InsertStatement insert = cq.getInsertStatement();
-            try (InsertMethod method = insert.createMethod(sqlExecutionContext)) {
-                method.execute();
-                method.commit();
-            }
-
-            String expected = "id\tsym\n" +
-                    "2\tA\n";
-
-            sink.clear();
-            try (TableReader reader = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), insert.getTableName())) {
-                printer.print(reader.getCursor(), reader.getMetadata(), true);
-                TestUtils.assertEquals(expected, sink);
-            }
-        });
-    }
-
-    @Test
-    public void testInsertSingleAndMultipleCharacterSymbols() throws Exception {
-        final String expected = "sym\tid\tts\n" +
-                "A\t315515118\t1970-01-03T00:00:00.000000Z\n" +
-                "BB\t-727724771\t1970-01-03T00:06:00.000000Z\n" +
-                "BB\t-948263339\t1970-01-03T00:12:00.000000Z\n" +
-                "CC\t592859671\t1970-01-03T00:18:00.000000Z\n" +
-                "CC\t-847531048\t1970-01-03T00:24:00.000000Z\n" +
-                "A\t-2041844972\t1970-01-03T00:30:00.000000Z\n" +
-                "CC\t-1575378703\t1970-01-03T00:36:00.000000Z\n" +
-                "BB\t1545253512\t1970-01-03T00:42:00.000000Z\n" +
-                "A\t1573662097\t1970-01-03T00:48:00.000000Z\n" +
-                "BB\t339631474\t1970-01-03T00:54:00.000000Z\n";
-
-        assertQuery(
-                "sym\tid\tts\n",
-                "x",
-                "create table x (\n" +
-                        "    sym symbol index,\n" +
-                        "    id int,\n" +
-                        "    ts timestamp\n" +
-                        ") timestamp(ts) partition by DAY",
-                "ts",
-                "insert into x select * from (select rnd_symbol('A', 'BB', 'CC', 'DDD') sym, \n" +
-                        "        rnd_int() id, \n" +
-                        "        timestamp_sequence(172800000000, 360000000) ts \n" +
-                        "    from long_sequence(10)) timestamp (ts)",
-                expected,
-                true
-        );
-    }
-
-
-
-    @Test
-    public void testInsertNotEnoughFields() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
-            try {
-                compiler.compile("insert into balances values (1, 'USD')", sqlExecutionContext);
-            } catch (SqlException e) {
-                Assert.assertEquals(37, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "not enough values");
-            }
-        });
-    }
-
-    @Test
     public void testInsertValueCannotReferenceTableColumn() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
@@ -427,14 +424,27 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testInsertWrongTypeConstant() throws Exception {
+    public void testInsertWithLessColumnsThanExistingTable() throws Exception {
         assertMemoryLeak(() -> {
-            compiler.compile("create table test (a timestamp)", sqlExecutionContext);
+            compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
             try {
-                compiler.compile("insert into test values ('2013')", sqlExecutionContext);
+                compiler.compile("insert into tab select x ac  from long_sequence(10)", sqlExecutionContext);
             } catch (SqlException e) {
-                Assert.assertEquals(25, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible types: STRING -> TIMESTAMP");
+                Assert.assertEquals(12, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "select clause must provide timestamp column");
+            }
+        });
+    }
+
+    @Test
+    public void testInsertWithWrongNominatedColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
+            try {
+                compiler.compile("insert into tab select * from (select  timestamp_sequence(0, x) ts, x ac from long_sequence(10)) timestamp(ts)", sqlExecutionContext);
+            } catch (SqlException e) {
+                Assert.assertEquals(12, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "nominated column of existing table");
             }
         });
     }
@@ -458,25 +468,11 @@ public class InsertTest extends AbstractGriffinTest {
                 "tab",
                 "create table tab(seq long, ts timestamp) timestamp(ts);",
                 "ts",
-                    "insert into tab select x ac, timestamp_sequence(0, x) ts from long_sequence(10)",
+                "insert into tab select x ac, timestamp_sequence(0, x) ts from long_sequence(10)",
                 expected,
                 true
         );
     }
-
-    @Test
-    public void testInsertWithLessColumnsThanExistingTable() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
-            try {
-                compiler.compile("insert into tab select x ac  from long_sequence(10)", sqlExecutionContext);
-            } catch (SqlException e) {
-                Assert.assertEquals(12, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "select clause must provide timestamp column");
-            }
-        });
-    }
-
 
     @Test
     public void testInsertWithoutNominatedTimestampAndTypeDoesNotMatch() throws Exception {
@@ -492,14 +488,14 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testInsertWithWrongNominatedColumn() throws Exception {
+    public void testInsertWrongTypeConstant() throws Exception {
         assertMemoryLeak(() -> {
-            compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
+            compiler.compile("create table test (a timestamp)", sqlExecutionContext);
             try {
-                compiler.compile("insert into tab select * from (select  timestamp_sequence(0, x) ts, x ac from long_sequence(10)) timestamp(ts)", sqlExecutionContext);
+                compiler.compile("insert into test values ('2013')", sqlExecutionContext);
             } catch (SqlException e) {
-                Assert.assertEquals(12, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "nominated column of existing table");
+                Assert.assertEquals(25, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible types: STRING -> TIMESTAMP");
             }
         });
     }

--- a/core/src/test/java/io/questdb/griffin/MemoryLeakTest.java
+++ b/core/src/test/java/io/questdb/griffin/MemoryLeakTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.griffin;
 
-import io.questdb.DefaultServerConfiguration;
 import io.questdb.MessageBusImpl;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.TableWriter;
@@ -42,8 +41,6 @@ import org.junit.Test;
 
 public class MemoryLeakTest extends AbstractGriffinTest {
 
-    private final static DefaultServerConfiguration serverConfiguration = new DefaultServerConfiguration(AbstractGriffinTest.configuration.getRoot());
-
     @Test
     public void testQuestDbForLeaks() throws Exception {
         testForLeaks(() -> {
@@ -54,7 +51,7 @@ public class MemoryLeakTest extends AbstractGriffinTest {
                 bindVariableService.setLong("low", 0L);
                 bindVariableService.setLong("high", 0L);
                 final SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(
-                        new MessageBusImpl(serverConfiguration), 1, engine).with(AllowAllCairoSecurityContext.INSTANCE,
+                        engine, 1, new MessageBusImpl(configuration)).with(AllowAllCairoSecurityContext.INSTANCE,
                         bindVariableService,
                         null);
                 StringSink sink = new StringSink();
@@ -76,7 +73,7 @@ public class MemoryLeakTest extends AbstractGriffinTest {
 
     private void populateUsersTable(CairoEngine engine, int n) throws SqlException {
         try (SqlCompiler compiler = new SqlCompiler(engine)) {
-            final SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(new MessageBusImpl(serverConfiguration), 1, engine).with(AllowAllCairoSecurityContext.INSTANCE,
+            final SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1, new MessageBusImpl(configuration)).with(AllowAllCairoSecurityContext.INSTANCE,
                     new BindVariableService(),
                     null);
             compiler.compile("create table users (sequence long, event binary, timestamp timestamp, id long) timestamp(timestamp)", executionContext);

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -4212,7 +4212,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testVectorSumAvgDoubleRndColumnWithNullsParallel() throws Exception {
 
-        Sequence seq = messageBus.getVectorAggregateSubSequence();
+        Sequence seq = engine.getMessageBus().getVectorAggregateSubSequence();
         // consume sequence fully and do nothing
         // this might be needed to make sure we don't consume things other tests publish here
         while (true) {
@@ -4226,7 +4226,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
 
         final AtomicBoolean running = new AtomicBoolean(true);
         final SOCountDownLatch haltLatch = new SOCountDownLatch(1);
-        final GroupByNotKeyedJob job = new GroupByNotKeyedJob(messageBus);
+        final GroupByNotKeyedJob job = new GroupByNotKeyedJob(engine.getMessageBus());
         new Thread(() -> {
             while (running.get()) {
                 job.run(0);

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -109,7 +109,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
             }
         };
 
-        CairoEngine engine = new CairoEngine(configuration, null);
+        CairoEngine engine = new CairoEngine(configuration);
         SqlCompiler compiler = new SqlCompiler(engine);
 
         try {
@@ -1664,6 +1664,16 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testColumnNameWithDot() throws Exception {
+        assertFailure(27, "new column name contains invalid characters",
+                "create table x (" +
+                        "t TIMESTAMP, " +
+                        "`bool.flag` BOOLEAN) " +
+                        "timestamp(t) " +
+                        "partition by MONTH");
+    }
+
+    @Test
     public void testCompileSet() throws Exception {
         String query = "SET x = y";
         TestUtils.assertMemoryLeak(() -> {
@@ -1833,7 +1843,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 };
 
                 try (
-                        CairoEngine engine = new CairoEngine(configuration, null);
+                        CairoEngine engine = new CairoEngine(configuration);
                         SqlCompiler compiler = new SqlCompiler(engine)
                 ) {
                     try {
@@ -1890,7 +1900,10 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                     }
                 };
 
-                try (CairoEngine engine = new CairoEngine(configuration, null); SqlCompiler compiler = new SqlCompiler(engine)) {
+                try (
+                        CairoEngine engine = new CairoEngine(configuration);
+                        SqlCompiler compiler = new SqlCompiler(engine)
+                ) {
                     try {
                         compiler.compile(sql, sqlExecutionContext);
                         Assert.fail();
@@ -2246,7 +2259,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
 
         TestUtils.assertMemoryLeak(() -> {
             try (
-                    CairoEngine engine = new CairoEngine(configuration, null);
+                    CairoEngine engine = new CairoEngine(configuration);
                     SqlCompiler compiler = new SqlCompiler(engine)
             ) {
                 try {
@@ -2324,16 +2337,6 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "create table x (" +
                         "t TIMESTAMP, " +
                         "y BOOLEAN) " +
-                        "timestamp(t) " +
-                        "partition by MONTH");
-    }
-
-    @Test
-    public void testColumnNameWithDot() throws Exception {
-        assertFailure(27, "new column name contains invalid characters",
-                "create table x (" +
-                        "t TIMESTAMP, " +
-                        "`bool.flag` BOOLEAN) " +
                         "timestamp(t) " +
                         "partition by MONTH");
     }
@@ -2960,7 +2963,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
         };
 
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, null) {
+            try (CairoEngine engine = new CairoEngine(configuration) {
                 @Override
                 public TableReader getReader(CairoSecurityContext cairoSecurityContext, CharSequence tableName, long version) {
                     fiddler.run(this);
@@ -3376,7 +3379,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 sqlExecutionContext
         );
 
-        try (CairoEngine engine = new CairoEngine(configuration, null) {
+        try (CairoEngine engine = new CairoEngine(configuration) {
             @Override
             public TableReader getReader(CairoSecurityContext cairoSecurityContext, CharSequence tableName, long tableVersion) {
                 fiddler.run(this);
@@ -3422,7 +3425,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
             }
         };
 
-        try (CairoEngine engine = new CairoEngine(configuration, null)) {
+        try (CairoEngine engine = new CairoEngine(configuration)) {
             try (SqlCompiler compiler = new SqlCompiler(engine)) {
 
                 compiler.compile("create table x (a INT, b INT)", sqlExecutionContext);

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/TimestampSequenceFunctionFactoryTest.java
@@ -32,8 +32,8 @@ import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.AbstractGriffinTest;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContextImpl;
-import io.questdb.test.tools.StationaryMicrosClock;
 import io.questdb.std.microtime.MicrosecondClock;
+import io.questdb.test.tools.StationaryMicrosClock;
 import io.questdb.test.tools.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -42,15 +42,14 @@ public class TimestampSequenceFunctionFactoryTest extends AbstractGriffinTest {
 
     @BeforeClass
     public static void setUp2() {
-        engine = new CairoEngine(new StaticClockCairoConfiguration(root), messageBus);
+        engine = new CairoEngine(new StaticClockCairoConfiguration(root));
         compiler = new SqlCompiler(engine);
         sqlExecutionContext = new SqlExecutionContextImpl(
-                messageBus,
-                1, engine)
+                engine, 1)
                 .with(
                         AllowAllCairoSecurityContext.INSTANCE,
                         bindVariableService,
-                                null, -1, null);
+                        null, -1, null);
         bindVariableService.clear();
     }
 

--- a/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
@@ -420,7 +420,7 @@ public class SampleByTest extends AbstractGriffinTest {
                 }
             };
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (SqlCompiler compiler = new SqlCompiler(engine)) {
                     try {
                         try (RecordCursorFactory factory = compiler.compile("select c, sum_t(d) from x", sqlExecutionContext).getRecordCursorFactory()) {
@@ -1418,7 +1418,7 @@ public class SampleByTest extends AbstractGriffinTest {
                 }
             };
 
-            try (CairoEngine engine = new CairoEngine(configuration, null)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (SqlCompiler compiler = new SqlCompiler(engine)) {
                     try {
                         compiler.compile("select b, sum(a), k from x sample by 3h fill(linear)", sqlExecutionContext);

--- a/core/src/test/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactoryTest.java
@@ -77,7 +77,7 @@ public class DataFrameRecordCursorFactoryTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, messageBus)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 String value = symbols[N - 10];
                 int columnIndex;
                 int symbolKey;
@@ -95,7 +95,7 @@ public class DataFrameRecordCursorFactoryTest extends AbstractCairoTest {
                     columnIndexes.add(i);
                 }
                 DataFrameRecordCursorFactory factory = new DataFrameRecordCursorFactory(metadata, dataFrameFactory, symbolIndexRowCursorFactory, false, null, false, columnIndexes, null);
-                SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(messageBus, 1, engine).with(AllowAllCairoSecurityContext.INSTANCE, null, null, -1, null);
+                SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1).with(AllowAllCairoSecurityContext.INSTANCE, null, null, -1, null);
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     Record record = cursor.getRecord();
                     while (cursor.hasNext()) {


### PR DESCRIPTION
I had to move telemetry queue and sequences to CairoEngine. Leaving them on MessageBus would cause problem when various components run with local pools. In this scenario there are multiple copies of MessageBus and it would be unnacceptable to have multiple queues for telemetry. Only one queue would be consumed and all others stalling.

Additionally requiring PropServerConfiguration for very simple embedded setup was unreasonable. Telemetry should be ok with CairoConfiguration.

I moved MessageBus instance inside CairoEngine. They are created based on the same configuration now and they are used in 1-to-1 combination most of the time. Except of course for those pesky local pools. The components that can have local thread pool use separate instance of MessageBus.