### PR TITLE
fix(griffin): drop table fix. Fixed #559

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1416,18 +1416,16 @@ public class SqlCompiler implements Closeable {
     }
 
     private CompiledQuery dropTable(SqlExecutionContext executionContext) throws SqlException {
-        CharSequence tok;
         expectKeyword(lexer, "table");
-
         final int tableNamePosition = lexer.getPosition();
 
-        tok = GenericLexer.unquote(expectToken(lexer, "table name"));
-
-        tableExistsOrFail(tableNamePosition, tok, executionContext);
-
-        CharSequence tableName = GenericLexer.immutableOf(tok);
+        CharSequence tableName = GenericLexer.unquote(expectToken(lexer, "table name"));
+        CharSequence tok = SqlUtil.fetchNext(lexer);
+        if (tok != null && !Chars.equals(tok, ';')) {
+            throw SqlException.$(lexer.lastTokenPosition(), "unexpected token");
+        }
+        tableExistsOrFail(tableNamePosition, tableName, executionContext);
         engine.remove(executionContext.getCairoSecurityContext(), path, tableName);
-
         return compiledQuery.ofDrop();
     }
 

--- a/core/src/test/java/io/questdb/griffin/DropTableTest.java
+++ b/core/src/test/java/io/questdb/griffin/DropTableTest.java
@@ -115,6 +115,26 @@ public class DropTableTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testDropWithDotFailure() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            CompiledQuery cc = compiler.compile("create table 'x.csv' (a int)", sqlExecutionContext);
+            Assert.assertEquals(CompiledQuery.CREATE_TABLE, cc.getType());
+
+            try {
+                compiler.compile("drop table x.csv", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(12, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "unexpected token");
+            }
+
+            cc = compiler.compile("drop table 'x.csv'", sqlExecutionContext);
+            Assert.assertEquals(CompiledQuery.DROP, cc.getType());
+
+        });
+    }
+
+    @Test
     public void testDropUtf8Quoted() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             CompiledQuery cc = compiler.compile("create table 'научный руководитель'(a int)", sqlExecutionContext);


### PR DESCRIPTION
do not drop table unless trailing tokens are as expected