### PR TITLE
fix: removed GC logging

### DIFF
--- a/core/src/main/bin/questdb.sh
+++ b/core/src/main/bin/questdb.sh
@@ -175,7 +175,7 @@ function start {
     -XX:+AlwaysPreTouch
     -XX:+UseParallelOldGC
     --add-exports java.base/jdk.internal.math=io.questdb
-    -Xlog:gc*,gc+ref=debug,gc+heap=debug,gc+age=trace:file=$QDB_LOG/questdb-%p-%t.gc:tags,uptime,time,level"
+    "
 
     JAVA_MAIN="io.questdb/io.questdb.ServerMain"
     DATE=`date +%Y-%m-%dT%H-%M-%S`


### PR DESCRIPTION
following reported issue with Java 11 on OSX producing error:
```
JAVA: /Library/Java/JavaVirtualMachines/jdk-11.0.8.jdk/Contents/Home/bin/java
Invalid -Xlog option '-Xlog:gc*,gc+ref=debug,gc+heap=debug,gc+age=trace:file=var/"questdb"/log/questdb-%p-%t.gc:tags,uptime,time,level', see error log for details.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```