### PR TITLE
chore: add amazonlinux instructions + sh script to produce QuestDB's binary

### DIFF
--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,0 +1,8 @@
+# QuestDB artifacts
+
+These containers produce QuestDB artifacts for popular Linux flavors.
+
+# How does it work?
+
+Simply execute the "run" script, after waiting for compilation to finish you
+will get the binary ready alongside its Dockerfile.

--- a/artifacts/amazonlinux/Dockerfile
+++ b/artifacts/amazonlinux/Dockerfile
@@ -1,0 +1,25 @@
+FROM amazonlinux:2
+
+ENV MVN_VERSION="3.6.3"
+ENV MVN="apache-maven-$MVN_VERSION"
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto.x86_64
+ENV PATH=$JAVA_HOME/bin:$PATH
+ENV PATH="/mvn/$MVN/bin":$PATH
+
+WORKDIR /mvn
+
+RUN \
+  yum update -y -q \
+  && yum install -y -q \
+  java-11-amazon-corretto-headless \
+  git \
+  tar \
+  wget \
+  && wget -q http://apache.mirror.anlx.net/maven/maven-3/"$MVN_VERSION"/binaries/"$MVN"-bin.tar.gz \
+  && tar xf "$MVN"-bin.tar.gz
+
+WORKDIR /app
+
+RUN \
+  git clone --depth 1 https://github.com/questdb/questdb.git "$(pwd)" \
+  && mvn clean package -Dprofile.install-local-nodejs -DskipTests

--- a/artifacts/amazonlinux/run
+++ b/artifacts/amazonlinux/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker build .
+id=$(docker images --format='{{.ID}}' | head -1)
+docker cp $(docker create "$id"):/app/core/target/questdb-5.0.3-rt-linux-amd64.tar.gz .


### PR DESCRIPTION
This will be done by CI soon, in the meantime, it is possible to manually trigger the build using this Dockerfile/sh script.