### PR TITLE
chore: maven build refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: mvn compile -DskipTests -Dprofile.install-local-nodejs
+      - run: mvn clean compile -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
 
       - save_cache:
           paths:
@@ -38,4 +38,4 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn integration-test -Dprofile.install-local-nodejs
+      - run: mvn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git to make build of development process Java-centric and simplified.
 
 JAVA_HOME is required by Maven. It is possible to have multiple version of Java on the same platform. Please
 set up JAVA_HOME to point to Java 11. Other versions of Java may not work. If you are new to Java please
-check JAVA_HOME is pointing to the root of Java directory. For example, I installed Java here `C:\Users\Vlad\dev\jdk-11.0.8`.
+check that JAVA_HOME is pointing to the root of Java directory: `C:\Users\me\dev\jdk-11.0.8` and *not* `C:\Users\me\dev\jdk-11.0.8\bin\java`.
 JAVA_HOME needs to be `C:\Users\Vlad\dev\jdk-11.0.8` and *not* `C:\Users\Vlad\dev\jdk-11.0.8\bin\java` however tempting this is.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@ git to make build of development process Java-centric and simplified.
 JAVA_HOME is required by Maven. It is possible to have multiple version of Java on the same platform. Please
 set up JAVA_HOME to point to Java 11. Other versions of Java may not work. If you are new to Java please
 check that JAVA_HOME is pointing to the root of Java directory: `C:\Users\me\dev\jdk-11.0.8` and *not* `C:\Users\me\dev\jdk-11.0.8\bin\java`.
-JAVA_HOME needs to be `C:\Users\Vlad\dev\jdk-11.0.8` and *not* `C:\Users\Vlad\dev\jdk-11.0.8\bin\java` however tempting this is.
 
 
 Linux/OSX

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ git to make build of development process Java-centric and simplified.
 
 ## Setup Java and JAVA_HOME
 
-JAVA_HOME is require by Maven. It is possible to have multiple version of Java on the same platform. Please
+JAVA_HOME is required by Maven. It is possible to have multiple version of Java on the same platform. Please
 set up JAVA_HOME to point to Java 11. Java versions above or below may not work. If you are new to Java please
 check JAVA_HOME is pointing to the root of Java directory. For example, I installed Java here `C:\Users\Vlad\dev\jdk-11.0.8`.
 JAVA_HOME needs to be `C:\Users\Vlad\dev\jdk-11.0.8` and *not* `C:\Users\Vlad\dev\jdk-11.0.8\bin\java` however tempting this is.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ git to make build of development process Java-centric and simplified.
 ## Setup Java and JAVA_HOME
 
 JAVA_HOME is required by Maven. It is possible to have multiple version of Java on the same platform. Please
-set up JAVA_HOME to point to Java 11. Java versions above or below may not work. If you are new to Java please
+set up JAVA_HOME to point to Java 11. Other versions of Java may not work. If you are new to Java please
 check JAVA_HOME is pointing to the root of Java directory. For example, I installed Java here `C:\Users\Vlad\dev\jdk-11.0.8`.
 JAVA_HOME needs to be `C:\Users\Vlad\dev\jdk-11.0.8` and *not* `C:\Users\Vlad\dev\jdk-11.0.8\bin\java` however tempting this is.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,8 @@ deep diving into the code base.
 
 ### Requirements
 
-- Operating system - **x86-64**: Windows, Linux, FreeBSD and OSX / **ARM
-  (AArch64/A64)**: Linux
-- Java 11 64-bit. We recommend Oracle Java 11, but OpenJDK 11 will also work
-  (although a little slower)
+- Operating system - **x86-64**: Windows, Linux, FreeBSD and OSX
+- Java 11 64-bit
 - Maven 3 (from your package manager on Linux / OSX
   ([Homebrew](https://github.com/Homebrew/brew)) or
   [from the jar](https://maven.apache.org/install.html) for any OS)
@@ -45,13 +43,11 @@ git to make build of development process Java-centric and simplified.
 
 ## Setup Java and JAVA_HOME
 
-Java versions above 8 are not yet supported. It is possible to build QuestDB
-with Java 11, but this requires backward incompatible changes. If your java
-version is above 8 you can download & install JDK8 and use the absolute path to
-the java executable instead of "`java`".
+JAVA_HOME is require by Maven. It is possible to have multiple version of Java on the same platform. Please
+set up JAVA_HOME to point to Java 11. Java versions above or below may not work. If you are new to Java please
+check JAVA_HOME is pointing to the root of Java directory. For example, I installed Java here `C:\Users\Vlad\dev\jdk-11.0.8`.
+JAVA_HOME needs to be `C:\Users\Vlad\dev\jdk-11.0.8` and *not* `C:\Users\Vlad\dev\jdk-11.0.8\bin\java` however tempting this is.
 
-Unless your default Java is 11 you may want to set `JAVA_HOME` to the Java 11
-directory before running `maven`:
 
 Linux/OSX
 
@@ -67,36 +63,36 @@ set JAVA_HOME="c:\path\to\java directory"
 
 ## Compiling Java and frontend code
 
-Compiling the database + the web console is done with:
+Compiling the database + the web console can be done with:
 
 ```bash
-mvn clean package
+mvn clean package -DskipTests -P build-web-console
 ```
 
 You can then run QuestDB with:
 
 ```bash
-java -cp core/target/core-4.2.1-SNAPSHOT.jar io.questdb.ServerMain -d <root_dir>
+java -p core/target/questdb-5.0.4-SNAPSHOT.jar -m io.questdb/io.questdb.ServerMain -d <root_dir>
 ```
 
 The web console will available at [localhost:9000](http://localhost:9000).
 
 ## Compiling C-libraries
 
-C-libraries will have to be compiled for each platform separately. The following
-commands will compile on Linux/OSX:
+C-libraries will have to be compiled for each platform separately. Cmake will also need JAVA_HOME to be set. The following
+commands will compile on Linux/OSX.
 
 ```text
 cmake
 make
 ```
 
-on Windows we use Intellij CLion, which can open cmake files.
+For C development we use Intellij CLion. This IDEA "understands" cmake files and will make compilation easier.
 
-The artifacts are distributed as follow:
+The build will copy artifacts as follows:
 
 ```
-core/src/main/c -> core/src/main/resources/binaries
+core/src/main/c -> core/src/main/resources/io/questdb/bin
 ```
 
 # Local setup for frontend development
@@ -114,18 +110,21 @@ rebuild the artifacts and restart QuestDB. Instead, we use `webpack-dev-server`:
 The web console should now be accessible at
 [localhost:9999](http://localhost:9999)
 
-## Building the artifacts
+Development server running on port 9999 will monitor for web console file changes and will rebuild/deploy on the fly. The 
+web console front end will be connecting to QuestDB REST API on port 9000. Keep QuestDB server running. 
+
+## Building web console bundle into questdb.jar
 
 Run the command:
 
 ```bash
-mvn clean package
+mvn clean package -DskipTests -P build-web-console
 ```
 
-The artifacts are distributed as follow:
+The build will copy artifacts as follows:
 
 ```
-ui -> core/src/main/resources/site/public
+ui -> core/src/main/resources/io/questdb/site/public.zip
 ```
 
 # Testing
@@ -133,14 +132,14 @@ ui -> core/src/main/resources/site/public
 We have a lot of unit tests, most of which are of "integration" type, e.g. test
 starts a server, interacts with it and asserts the outcome. We expect all
 contributors to submit PRs with tests. Please reach out to us via slack if you
-uncertain on how to test or you think existing test is inadequate and should be
+uncertain on how to test, or you think existing test is inadequate and should be
 removed.
 
 # Dependencies
 
 QuestDB does not have dependencies. This may sound unorthodox but in reality we
-try not to reinvent the wheel but rather than using libraries we implement best
-algorithms ourselves to ensure perfect fit with existing code. With that in mind
+try not to reinvent the wheel but rather than using libraries we implement algorithms on first principles
+to ensure perfect fit with existing code. With that in mind
 we expect contributions that do not add third-party dependencies.
 
 # Allocations, "new" operator and garbage collection
@@ -183,11 +182,14 @@ really helpful and keeps our repository concise and clean.
 
 # FAQ
 
-#### Everything works fine but I get a `404` on [localhost:9000](http://localhost:9000)
+#### Everything works fine, but I get a `404` on [localhost:9000](http://localhost:9000)
 
-This means that the frontend artifacts are not present in
-`core/src/main/resources/site/public`. To fix this, you can simply run `mvn
-clean package#.
+This means that the web console artifacts are not present in
+`core/src/main/resources/io/questdb/site/public.zip`. To fix this, you can simply run: 
+
+```bash
+mvn clean package -DskipTests -P build-web-console
+```
 
 #### I do not want to install `Node.js` and/or it is clashing with my system installation of `Node.js`
 
@@ -198,8 +200,8 @@ multiple active versions.
 Otherwise, you can use the dedicated `maven` profile to build the code:
 
 ```bash
-mvn clean package -Dprofile.install-local-nodejs
+mvn clean package -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
 ```
 
 That way, `maven` will install `node` on the fly in `ui/node` so you don't have
-to install it locall.
+to install it locally.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ milliseconds.
 
 ## Web Console
 
-Interactive console to import data (drag and drop) and start querying right
+The interactive console to import data (drag and drop) and start querying right
 away. Check our Web Console guide to get started:
 
 <div align="center">
@@ -148,13 +148,31 @@ git clone git@github.com:questdb/questdb.git
 
 #### (c) Build the Code
 
+Commands below will create JAR without assembling executable binaries nor building web console.
+
 ```script
 cd questdb
 mvn clean package -DskipTests
 ```
 
-The build should take around 2 minutes. You can remove `-DskipTests` to run the
-3000+ unit tests. The tests take 3-5 minutes to run.
+To package web console with the jar use the following command:
+
+```script
+mvn clean package -DskipTests -P build-web-console
+```
+
+To build executable binaries use the following command:
+
+```script
+mvn clean package -DskipTests -P build-web-console,build-binaries
+```
+
+To run tests it is not required to have binaries built nor web console. There are over 4000 tests that should complete
+without 2-6 minutes depending on the system.
+
+```script
+mvn clean test
+```
 
 #### (d) Run QuestDB
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -30,8 +30,7 @@
     <artifactId>benchmarks</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
-
-    <name>JMH benchmark sample: Java</name>
+    <name>JMH benchmarks for QuestDB</name>
 
     <!--
        This is the demo/sample template build script for building Java benchmarks with JMH.

--- a/core/Dockerfile-linux
+++ b/core/Dockerfile-linux
@@ -11,7 +11,7 @@ RUN curl -L "https://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.
 
 WORKDIR /build/questdb
 
-RUN ../apache-maven-3.6.3/bin/mvn clean package -DskipTests -Dprofile.install-local-nodejs
+RUN ../apache-maven-3.6.3/bin/mvn clean package -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
 
 WORKDIR /build/questdb/core/target
 

--- a/core/Dockerfile-windows
+++ b/core/Dockerfile-windows
@@ -18,7 +18,7 @@ WORKDIR c:/questdb
 
 ## build from source
 
-RUN c:\apache-maven-3.6.3\bin\mvn clean package -DskipTests -Dprofile.install-local-nodejs
+RUN c:\apache-maven-3.6.3\bin\mvn clean package -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
 
 ## unpack the runtime
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,8 +25,8 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <name>QuestDB Core</name>
-    <description>QuestDB is High Performance Time Series Database</description>
+    <name>QuestDB core</name>
+    <description>QuestDB is high performance time series SQL database</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -42,8 +42,7 @@
     <artifactId>questdb</artifactId>
     <packaging>jar</packaging>
 
-
-    <url>https://www.questdb.io/</url>
+    <url>https://questdb.io/</url>
     <licenses>
         <license>
             <name>Apache 2.0</name>
@@ -63,6 +62,17 @@
         <url>scm:git:https://github.com/questdb/questdb.git</url>
     </scm>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>central</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>central</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>
@@ -78,70 +88,6 @@
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <configuration>
-                    <longModulepath>false</longModulepath>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>npm-install</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <executable>${nodejs.npm.cmd}</executable>
-                            <arguments>
-                                <argument>install</argument>
-                                <argument>--no-fund</argument>
-                                <argument>--scripts-prepend-node-path=auto</argument>
-                            </arguments>
-                            <workingDirectory>../ui</workingDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm-run-build</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <executable>${nodejs.npm.cmd}</executable>
-                            <arguments>
-                                <argument>run</argument>
-                                <argument>build</argument>
-                                <argument>--scripts-prepend-node-path=auto</argument>
-                            </arguments>
-                            <workingDirectory>../ui</workingDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jlink</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <executable>${java.home}/bin/jlink</executable>
-                            <arguments>
-                                <argument>--module-path</argument>
-                                <argument>${build.outputDirectory}</argument>
-                                <argument>--add-modules</argument>
-                                <argument>io.questdb</argument>
-                                <argument>--output</argument>
-                                <argument>${build.directory}/runtime</argument>
-                                <argument>--no-header-files</argument>
-                                <argument>--no-man-pages</argument>
-                                <argument>--compress=2</argument>
-                            </arguments>
-                            <workingDirectory>../core</workingDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -162,42 +108,6 @@
                         </manifest>
                     </archive>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <tarLongFileMode>posix</tarLongFileMode>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>create-binary</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/binaries.xml</descriptor>
-                            </descriptors>
-                            <finalName>questdb</finalName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>create-runtime</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>${runtime.assembly}</descriptor>
-                            </descriptors>
-                            <finalName>questdb</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -222,18 +132,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- disable stock deploy plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>release</name>
-                    <value>true</value>
-                </property>
-            </activation>
+            <id>maven-central-release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -262,8 +174,6 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <arg>--add-exports</arg>
-                            <arg>java.base/jdk.internal.math=io.questdb</arg>
                             <additionalJOptions>
                                 <additionalJOption>--add-exports</additionalJOption>
                                 <additionalJOption>java.base/jdk.internal.math=io.questdb</additionalJOption>
@@ -288,15 +198,20 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.7</version>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.5.1</version>
+                        <executions>
+                            <execution>
+                                <id>default-deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                         <configuration>
-                            <formats>
-                                <format>html</format>
-                                <format>xml</format>
-                            </formats>
-                            <check/>
+                            <serverId>central</serverId>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -307,11 +222,6 @@
             <properties>
                 <nodejs.npm.cmd>${project.basedir}/node/npm</nodejs.npm.cmd>
             </properties>
-            <activation>
-                <property>
-                    <name>profile.install-local-nodejs</name>
-                </property>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -335,18 +245,129 @@
             </build>
         </profile>
         <profile>
-            <id>platform-windows-amd64-node</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-                <property>
-                    <name>profile.install-local-nodejs</name>
-                </property>
-            </activation>
-            <properties>
-                <nodejs.npm.cmd>${project.basedir}/node/npm.cmd</nodejs.npm.cmd>
-            </properties>
+            <id>build-web-console</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <configuration>
+                            <longModulepath>false</longModulepath>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>npm-install</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <executable>${nodejs.npm.cmd}</executable>
+                                    <arguments>
+                                        <argument>install</argument>
+                                        <argument>--no-fund</argument>
+                                        <argument>--scripts-prepend-node-path=auto</argument>
+                                    </arguments>
+                                    <workingDirectory>../ui</workingDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-run-build</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <executable>${nodejs.npm.cmd}</executable>
+                                    <arguments>
+                                        <argument>run</argument>
+                                        <argument>build</argument>
+                                        <argument>--scripts-prepend-node-path=auto</argument>
+                                    </arguments>
+                                    <workingDirectory>../ui</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>build-binaries</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <configuration>
+                            <longModulepath>false</longModulepath>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>jlink</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <executable>${java.home}/bin/jlink</executable>
+                                    <arguments>
+                                        <argument>--module-path</argument>
+                                        <argument>${project.build.outputDirectory}</argument>
+                                        <argument>--add-modules</argument>
+                                        <argument>io.questdb</argument>
+                                        <argument>--output</argument>
+                                        <argument>${project.build.directory}/runtime</argument>
+                                        <argument>--no-header-files</argument>
+                                        <argument>--no-man-pages</argument>
+                                        <argument>--compress=2</argument>
+                                    </arguments>
+                                    <workingDirectory>../core</workingDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <configuration>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>create-binary</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/binaries.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>questdb</finalName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>create-runtime</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>${runtime.assembly}</descriptor>
+                                    </descriptors>
+                                    <finalName>questdb</finalName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>platform-windows-amd64</id>
@@ -359,6 +380,7 @@
                 <archive.name>${project.version}-rt-windows-amd64</archive.name>
                 <runtime.name>questdb-${project.version}-rt-windows-amd64</runtime.name>
                 <runtime.assembly>src/main/assembly/windows-runtime.xml</runtime.assembly>
+                <nodejs.npm.cmd>${project.basedir}/node/npm.cmd</nodejs.npm.cmd>
             </properties>
         </profile>
         <profile>
@@ -372,6 +394,20 @@
             <properties>
                 <archive.name>${project.version}-rt-linux-amd64</archive.name>
                 <runtime.name>questdb-${project.version}-rt-linux-amd64</runtime.name>
+                <runtime.assembly>src/main/assembly/linux-runtime.xml</runtime.assembly>
+            </properties>
+        </profile>
+        <profile>
+            <id>platform-freebsd-amd64</id>
+            <activation>
+                <os>
+                    <family>FreeBSD</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <archive.name>${project.version}-rt-freebsd-amd64</archive.name>
+                <runtime.name>questdb-${project.version}-rt-freebsd-amd64</runtime.name>
                 <runtime.assembly>src/main/assembly/linux-runtime.xml</runtime.assembly>
             </properties>
         </profile>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,6 +132,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- remove web console package on "clean" -->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>src/main/resources/io/questdb/site/</directory>
+                            <includes>
+                                <include>public.zip</include>
+                            </includes>
+                            <followSymlinks>false</followSymlinks>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
             <!-- disable stock deploy plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -218,7 +234,7 @@
             </build>
         </profile>
         <profile>
-            <id>install-local-nodejs</id>
+            <id>use-built-in-nodejs</id>
             <properties>
                 <nodejs.npm.cmd>${project.basedir}/node/npm</nodejs.npm.cmd>
             </properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <name>QuestDB core</name>
-    <description>QuestDB is high performance time series SQL database</description>
+    <description>QuestDB is high performance SQL time series database</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/core/src/main/java/io/questdb/std/Long256HashSet.java
+++ b/core/src/main/java/io/questdb/std/Long256HashSet.java
@@ -57,7 +57,7 @@ public class Long256HashSet implements Mutable {
         if (loadFactor <= 0d || loadFactor >= 1d) {
             throw new IllegalArgumentException("0 < loadFactor < 1");
         }
-        this.capacity = initialCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : initialCapacity;
+        this.capacity = Math.max(initialCapacity, MIN_INITIAL_CAPACITY);
         int len = Numbers.ceilPow2((int) (this.capacity / loadFactor));
         this.loadFactor = loadFactor;
         this.keys = alloc(len);
@@ -66,9 +66,12 @@ public class Long256HashSet implements Mutable {
     }
 
     /**
-     * Adds key to hash set preserving key uniqueness.
+     * Adds key to hash set preserving key uniqueness. 256 bit long encoded in 4 64-bit values
      *
-     * @param k0,k1,k2,k3 - 256 bit long
+     * @param k0 0-63 bit
+     * @param k1 64-127 bit
+     * @param k2 128-191 bit
+     * @param k3 192-256 bit
      * @return false if key is already in the set and true otherwise.
      */
     public boolean add(long k0, long k1, long k2, long k3) {


### PR DESCRIPTION
- building binaries from maven profile
- building web console (nodejs) from maven profile
- removed profile activation elements; profiles must now be included on `mvn` command using `-P profile1,profile2`
- added profile for FreeBSD
- `mvn clean` will remove public.zip. If someone wants to build JAR without web console, they can do that without worrying that build might pick up residual artifact
- web console builds in the correct order with respect to packaging the JAR
- added Maven Central deployment configuration. The remaining artifacts are username, password and PGP key
- updated README and CONTRIBUTING documents to reflect the above changes and move them into Java 11 reality
