### PR TITLE
chore(build): update AmazonLinux2 Dockerfile to new syntax + add missing node

### DIFF
--- a/artifacts/amazonlinux/Dockerfile
+++ b/artifacts/amazonlinux/Dockerfile
@@ -9,8 +9,10 @@ ENV PATH="/mvn/$MVN/bin":$PATH
 WORKDIR /mvn
 
 RUN \
-  yum update -y -q \
+  curl -sL https://rpm.nodesource.com/setup_12.x | bash - \
+  && yum update -y -q \
   && yum install -y -q \
+  nodejs \
   java-11-amazon-corretto-headless \
   git \
   tar \
@@ -22,4 +24,4 @@ WORKDIR /app
 
 RUN \
   git clone --depth 1 https://github.com/questdb/questdb.git "$(pwd)" \
-  && mvn clean package -Dprofile.install-local-nodejs -DskipTests
+  && mvn clean package -B -DskipTests -P build-web-console,build-binaries

--- a/artifacts/amazonlinux/run
+++ b/artifacts/amazonlinux/run
@@ -2,4 +2,4 @@
 
 docker build .
 id=$(docker images --format='{{.ID}}' | head -1)
-docker cp $(docker create "$id"):/app/core/target/questdb-5.0.3-rt-linux-amd64.tar.gz .
+docker cp $(docker create "$id"):/app/core/target/questdb-5.0.4-rt-linux-amd64.tar.gz .


### PR DESCRIPTION
The Dockerfile for Amazon Linux 2 was relying on the old maven syntax, this is now fixed.