### PR TITLE
feat(http): min http server for health monitoring

### DIFF
--- a/core/src/main/java/io/questdb/DefaultServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultServerConfiguration.java
@@ -27,6 +27,7 @@ package io.questdb;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpMinServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.line.tcp.DefaultLineTcpReceiverConfiguration;
 import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
@@ -55,6 +56,11 @@ public class DefaultServerConfiguration implements ServerConfiguration {
     @Override
     public HttpServerConfiguration getHttpServerConfiguration() {
         return httpServerConfiguration;
+    }
+
+    @Override
+    public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -28,6 +28,8 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoSecurityContext;
 import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cutlass.http.HttpContextConfiguration;
+import io.questdb.cutlass.http.HttpMinServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.MimeTypesCache;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
@@ -57,7 +59,7 @@ import java.util.Properties;
 
 public class PropServerConfiguration implements ServerConfiguration {
     public static final String CONFIG_DIRECTORY = "conf";
-    private final IODispatcherConfiguration httpIODispatcherConfiguration = new HttpIODispatcherConfiguration();
+    private final IODispatcherConfiguration httpIODispatcherConfiguration = new PropHttpIODispatcherConfiguration();
     private final StaticContentProcessorConfiguration staticContentProcessorConfiguration = new PropStaticContentProcessorConfiguration();
     private final HttpServerConfiguration httpServerConfiguration = new PropHttpServerConfiguration();
     private final TextConfiguration textConfiguration = new PropTextConfiguration();
@@ -157,8 +159,14 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final IODispatcherConfiguration lineTcpReceiverDispatcherConfiguration = new PropLineTcpReceiverIODispatcherConfiguration();
     private final boolean lineTcpEnabled;
     private final WorkerPoolAwareConfiguration lineTcpWorkerPoolConfiguration = new PropLineTcpWorkerPoolConfiguration();
+    private final Log log;
+    private final PropHttpMinServerConfiguration httpMinServerConfiguration = new PropHttpMinServerConfiguration();
+    private final PropHttpContextConfiguration httpContextConfiguration = new PropHttpContextConfiguration();
+    private final boolean httpMinServerEnabled;
+    private final PropHttpMinIODispatcherConfiguration httpMinIODispatcherConfiguration = new PropHttpMinIODispatcherConfiguration();
     private boolean httpAllowDeflateBeforeSend;
     private int[] httpWorkerAffinity;
+    private int[] httpMinWorkerAffinity;
     private int connectionPoolInitialCapacity;
     private int connectionStringPoolCapacity;
     private int multipartHeaderBufferSize;
@@ -172,14 +180,14 @@ public class PropServerConfiguration implements ServerConfiguration {
     private int sendBufferSize;
     private CharSequence indexFileName;
     private String publicDirectory;
-    private int activeConnectionLimit;
-    private int eventCapacity;
-    private int ioQueueCapacity;
-    private long idleConnectionTimeout;
-    private int interestQueueCapacity;
-    private int listenBacklog;
-    private int sndBufSize;
-    private int rcvBufSize;
+    private int httpActiveConnectionLimit;
+    private int httpEventCapacity;
+    private int httpIOQueueCapacity;
+    private long httpIdleConnectionTimeout;
+    private int httpInterestQueueCapacity;
+    private int httpListenBacklog;
+    private int httpSndBufSize;
+    private int httpRcvBufSize;
     private int dateAdapterPoolCapacity;
     private int jsonCacheLimit;
     private int jsonCacheSize;
@@ -195,8 +203,8 @@ public class PropServerConfiguration implements ServerConfiguration {
     private MimeTypesCache mimeTypesCache;
     private String databaseRoot;
     private String keepAliveHeader;
-    private int bindIPv4Address;
-    private int bindPort;
+    private int httpBindIPv4Address;
+    private int httpBindPort;
     private int lineUdpBindIPV4Address;
     private int lineUdpPort;
     private int jsonQueryFloatScale;
@@ -259,7 +267,17 @@ public class PropServerConfiguration implements ServerConfiguration {
     private long lineTcpMaintenanceJobHysteresisInMs;
     private String lineTcpAuthDbPath;
     private String httpVersion;
-    private final Log log;
+    private int httpMinWorkerCount;
+    private boolean httpMinWorkerHaltOnError;
+    private int httpMinBindIPv4Address;
+    private int httpMinBindPort;
+    private int httpMinEventCapacity;
+    private int httpMinIOQueueCapacity;
+    private long httpMinIdleConnectionTimeout;
+    private int httpMinInterestQueueCapacity;
+    private int httpMinListenBacklog;
+    private int httpMinRcvBufSize;
+    private int httpMinSndBufSize;
 
     public PropServerConfiguration(
             String root,
@@ -271,6 +289,26 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.sharedWorkerCount = getInt(properties, env, "shared.worker.count", Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
         this.sharedWorkerAffinity = getAffinity(properties, env, "shared.worker.affinity", sharedWorkerCount);
         this.sharedWorkerHaltOnError = getBoolean(properties, env, "shared.worker.haltOnError", false);
+        this.httpMinServerEnabled = getBoolean(properties, env, "http.min.enabled", true);
+        if (httpMinServerEnabled) {
+            this.httpMinWorkerAffinity = getAffinity(properties, env, "http.min.worker.affinity", httpWorkerCount);
+            this.httpMinWorkerHaltOnError = getBoolean(properties, env, "http.min.worker.haltOnError", false);
+            this.httpMinWorkerCount = getInt(properties, env, "http.min.worker.count", 0);
+
+            parseBindTo(properties, env, "http.min.bind.to", "0.0.0.0:9003", (a, p) -> {
+                httpMinBindIPv4Address = a;
+                httpMinBindPort = p;
+            });
+
+            this.httpMinEventCapacity = getInt(properties, env, "http.min.net.event.capacity", 16);
+            this.httpMinIOQueueCapacity = getInt(properties, env, "http.min.net.io.queue.capacity", 16);
+            this.httpMinIdleConnectionTimeout = getLong(properties, env, "http.min.net.idle.connection.timeout", 5 * 60 * 1000L);
+            this.httpMinInterestQueueCapacity = getInt(properties, env, "http.min.net.interest.queue.capacity", 16);
+            this.httpMinListenBacklog = getInt(properties, env, "http.min.net.listen.backlog", 64);
+            this.httpMinSndBufSize = getIntSize(properties, env, "http.min.net.snd.buf.size", 1024);
+            this.httpMinRcvBufSize = getIntSize(properties, env, "http.net.rcv.buf.size", 1024);
+        }
+
         this.httpServerEnabled = getBoolean(properties, env, "http.enabled", true);
         if (httpServerEnabled) {
             this.connectionPoolInitialCapacity = getInt(properties, env, "http.connection.pool.initial.capacity", 16);
@@ -318,14 +356,14 @@ public class PropServerConfiguration implements ServerConfiguration {
                 this.databaseRoot = new File(root, databaseRoot).getAbsolutePath();
             }
 
-            this.activeConnectionLimit = getInt(properties, env, "http.net.active.connection.limit", 256);
-            this.eventCapacity = getInt(properties, env, "http.net.event.capacity", 1024);
-            this.ioQueueCapacity = getInt(properties, env, "http.net.io.queue.capacity", 1024);
-            this.idleConnectionTimeout = getLong(properties, env, "http.net.idle.connection.timeout", 5 * 60 * 1000L);
-            this.interestQueueCapacity = getInt(properties, env, "http.net.interest.queue.capacity", 1024);
-            this.listenBacklog = getInt(properties, env, "http.net.listen.backlog", 256);
-            this.sndBufSize = getIntSize(properties, env, "http.net.snd.buf.size", 2 * 1024 * 1024);
-            this.rcvBufSize = getIntSize(properties, env, "http.net.rcv.buf.size", 2 * 1024 * 1024);
+            this.httpActiveConnectionLimit = getInt(properties, env, "http.net.active.connection.limit", 256);
+            this.httpEventCapacity = getInt(properties, env, "http.net.event.capacity", 1024);
+            this.httpIOQueueCapacity = getInt(properties, env, "http.net.io.queue.capacity", 1024);
+            this.httpIdleConnectionTimeout = getLong(properties, env, "http.net.idle.connection.timeout", 5 * 60 * 1000L);
+            this.httpInterestQueueCapacity = getInt(properties, env, "http.net.interest.queue.capacity", 1024);
+            this.httpListenBacklog = getInt(properties, env, "http.net.listen.backlog", 256);
+            this.httpSndBufSize = getIntSize(properties, env, "http.net.snd.buf.size", 2 * 1024 * 1024);
+            this.httpRcvBufSize = getIntSize(properties, env, "http.net.rcv.buf.size", 2 * 1024 * 1024);
             this.dateAdapterPoolCapacity = getInt(properties, env, "http.text.date.adapter.pool.capacity", 16);
             this.jsonCacheLimit = getIntSize(properties, env, "http.text.json.cache.limit", 16384);
             this.jsonCacheSize = getIntSize(properties, env, "http.text.json.cache.size", 8192);
@@ -350,8 +388,8 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.interruptorBufferSize = getInt(properties, env, "http.security.interruptor.buffer.size", 64);
 
             parseBindTo(properties, env, "http.bind.to", "0.0.0.0:9000", (a, p) -> {
-                bindIPv4Address = a;
-                bindPort = p;
+                httpBindIPv4Address = a;
+                httpBindPort = p;
             });
 
             // load mime types
@@ -564,6 +602,11 @@ public class PropServerConfiguration implements ServerConfiguration {
     @Override
     public HttpServerConfiguration getHttpServerConfiguration() {
         return httpServerConfiguration;
+    }
+
+    @Override
+    public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+        return httpMinServerConfiguration;
     }
 
     @Override
@@ -804,20 +847,20 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private class HttpIODispatcherConfiguration implements IODispatcherConfiguration {
+    private class PropHttpIODispatcherConfiguration implements IODispatcherConfiguration {
         @Override
         public int getActiveConnectionLimit() {
-            return activeConnectionLimit;
+            return httpActiveConnectionLimit;
         }
 
         @Override
         public int getBindIPv4Address() {
-            return bindIPv4Address;
+            return httpBindIPv4Address;
         }
 
         @Override
         public int getBindPort() {
-            return bindPort;
+            return httpBindPort;
         }
 
         @Override
@@ -837,17 +880,17 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public int getEventCapacity() {
-            return eventCapacity;
+            return httpEventCapacity;
         }
 
         @Override
         public int getIOQueueCapacity() {
-            return ioQueueCapacity;
+            return httpIOQueueCapacity;
         }
 
         @Override
         public long getIdleConnectionTimeout() {
-            return idleConnectionTimeout;
+            return httpIdleConnectionTimeout;
         }
 
         @Override
@@ -857,12 +900,12 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public int getInterestQueueCapacity() {
-            return interestQueueCapacity;
+            return httpInterestQueueCapacity;
         }
 
         @Override
         public int getListenBacklog() {
-            return listenBacklog;
+            return httpListenBacklog;
         }
 
         @Override
@@ -872,7 +915,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public int getRcvBufSize() {
-            return rcvBufSize;
+            return httpRcvBufSize;
         }
 
         @Override
@@ -882,7 +925,89 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public int getSndBufSize() {
-            return sndBufSize;
+            return httpSndBufSize;
+        }
+    }
+
+    private class PropHttpMinIODispatcherConfiguration implements IODispatcherConfiguration {
+        @Override
+        public int getActiveConnectionLimit() {
+            return httpActiveConnectionLimit;
+        }
+
+        @Override
+        public int getBindIPv4Address() {
+            return httpMinBindIPv4Address;
+        }
+
+        @Override
+        public int getBindPort() {
+            return httpMinBindPort;
+        }
+
+        @Override
+        public MillisecondClock getClock() {
+            return MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public String getDispatcherLogName() {
+            return "http-min-server";
+        }
+
+        @Override
+        public EpollFacade getEpollFacade() {
+            return EpollFacadeImpl.INSTANCE;
+        }
+
+        @Override
+        public int getEventCapacity() {
+            return httpMinEventCapacity;
+        }
+
+        @Override
+        public int getIOQueueCapacity() {
+            return httpMinIOQueueCapacity;
+        }
+
+        @Override
+        public long getIdleConnectionTimeout() {
+            return httpMinIdleConnectionTimeout;
+        }
+
+        @Override
+        public int getInitialBias() {
+            return IOOperation.READ;
+        }
+
+        @Override
+        public int getInterestQueueCapacity() {
+            return httpMinInterestQueueCapacity;
+        }
+
+        @Override
+        public int getListenBacklog() {
+            return httpMinListenBacklog;
+        }
+
+        @Override
+        public NetworkFacade getNetworkFacade() {
+            return NetworkFacadeImpl.INSTANCE;
+        }
+
+        @Override
+        public int getRcvBufSize() {
+            return httpMinRcvBufSize;
+        }
+
+        @Override
+        public SelectFacade getSelectFacade() {
+            return SelectFacadeImpl.INSTANCE;
+        }
+
+        @Override
+        public int getSndBufSize() {
+            return httpMinSndBufSize;
         }
     }
 
@@ -964,7 +1089,22 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private class PropHttpServerConfiguration implements HttpServerConfiguration {
+    private class PropHttpContextConfiguration implements HttpContextConfiguration {
+
+        @Override
+        public NetworkFacade getNetworkFacade() {
+            return NetworkFacadeImpl.INSTANCE;
+        }
+
+        @Override
+        public boolean allowDeflateBeforeSend() {
+            return httpAllowDeflateBeforeSend;
+        }
+
+        @Override
+        public MillisecondClock getClock() {
+            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
+        }
 
         @Override
         public int getConnectionPoolInitialCapacity() {
@@ -974,6 +1114,26 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getConnectionStringPoolCapacity() {
             return connectionStringPoolCapacity;
+        }
+
+        @Override
+        public boolean getDumpNetworkTraffic() {
+            return false;
+        }
+
+        @Override
+        public String getHttpVersion() {
+            return httpVersion;
+        }
+
+        @Override
+        public int getInterruptorBufferSize() {
+            return interruptorBufferSize;
+        }
+
+        @Override
+        public int getInterruptorNIterationsPerCheck() {
+            return interruptorNIterationsPerCheck;
         }
 
         @Override
@@ -1002,6 +1162,34 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public int getSendBufferSize() {
+            return sendBufferSize;
+        }
+
+        @Override
+        public boolean getServerKeepAlive() {
+            return httpServerKeepAlive;
+        }
+
+        @Override
+        public boolean isInterruptOnClosedConnection() {
+            return interruptOnClosedConnection;
+        }
+
+        @Override
+        public boolean readOnlySecurityContext() {
+            return readOnlySecurityContext;
+        }
+    }
+
+    private class PropHttpServerConfiguration implements HttpServerConfiguration {
+
+        @Override
+        public IODispatcherConfiguration getDispatcherConfiguration() {
+            return httpIODispatcherConfiguration;
+        }
+
+        @Override
         public int getQueryCacheBlocks() {
             return sqlCacheBlocks;
         }
@@ -1009,16 +1197,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getQueryCacheRows() {
             return sqlCacheRows;
-        }
-
-        @Override
-        public MillisecondClock getClock() {
-            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
-        }
-
-        @Override
-        public IODispatcherConfiguration getDispatcherConfiguration() {
-            return httpIODispatcherConfiguration;
         }
 
         @Override
@@ -1032,53 +1210,13 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getSendBufferSize() {
-            return sendBufferSize;
-        }
-
-        @Override
         public boolean isEnabled() {
             return httpServerEnabled;
         }
 
         @Override
-        public boolean getDumpNetworkTraffic() {
-            return false;
-        }
-
-        @Override
-        public boolean allowDeflateBeforeSend() {
-            return httpAllowDeflateBeforeSend;
-        }
-
-        @Override
-        public boolean readOnlySecurityContext() {
-            return readOnlySecurityContext;
-        }
-
-        @Override
-        public boolean isInterruptOnClosedConnection() {
-            return interruptOnClosedConnection;
-        }
-
-        @Override
-        public int getInterruptorNIterationsPerCheck() {
-            return interruptorNIterationsPerCheck;
-        }
-
-        @Override
-        public int getInterruptorBufferSize() {
-            return interruptorBufferSize;
-        }
-
-        @Override
-        public boolean getServerKeepAlive() {
-            return httpServerKeepAlive;
-        }
-
-        @Override
-        public String getHttpVersion() {
-            return httpVersion;
+        public HttpContextConfiguration getHttpContextConfiguration() {
+            return httpContextConfiguration;
         }
 
         @Override
@@ -1623,7 +1761,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         public int getSndBufSize() {
             return -1;
         }
-
     }
 
     private class PropLineTcpWorkerPoolConfiguration implements WorkerPoolAwareConfiguration {
@@ -2000,6 +2137,39 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getQueueCapacity() {
             return telemetryQueueCapacity;
+        }
+    }
+
+    private class PropHttpMinServerConfiguration implements HttpMinServerConfiguration {
+
+        @Override
+        public IODispatcherConfiguration getDispatcherConfiguration() {
+            return httpMinIODispatcherConfiguration;
+        }
+
+        @Override
+        public HttpContextConfiguration getHttpContextConfiguration() {
+            return httpContextConfiguration;
+        }
+
+        @Override
+        public int[] getWorkerAffinity() {
+            return httpMinWorkerAffinity;
+        }
+
+        @Override
+        public int getWorkerCount() {
+            return httpMinWorkerCount;
+        }
+
+        @Override
+        public boolean haltOnError() {
+            return httpMinWorkerHaltOnError;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return httpMinServerEnabled;
         }
     }
 }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -42,6 +42,7 @@ import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
 import io.questdb.cutlass.pgwire.PGWireConfiguration;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.cutlass.text.types.InputFormatConfiguration;
+import io.questdb.griffin.SqlInterruptorConfiguration;
 import io.questdb.log.Log;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.*;
@@ -164,6 +165,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final PropHttpContextConfiguration httpContextConfiguration = new PropHttpContextConfiguration();
     private final boolean httpMinServerEnabled;
     private final PropHttpMinIODispatcherConfiguration httpMinIODispatcherConfiguration = new PropHttpMinIODispatcherConfiguration();
+    private final PropSqlInterruptorConfiguration interruptorConfiguration = new PropSqlInterruptorConfiguration();
     private boolean httpAllowDeflateBeforeSend;
     private int[] httpWorkerAffinity;
     private int[] httpMinWorkerAffinity;
@@ -1089,12 +1091,29 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private class PropHttpContextConfiguration implements HttpContextConfiguration {
+    private class PropSqlInterruptorConfiguration implements SqlInterruptorConfiguration {
+        @Override
+        public int getBufferSize() {
+            return interruptorBufferSize;
+        }
+
+        @Override
+        public int getCountOfIterationsPerCheck() {
+            return interruptorNIterationsPerCheck;
+        }
 
         @Override
         public NetworkFacade getNetworkFacade() {
             return NetworkFacadeImpl.INSTANCE;
         }
+
+        @Override
+        public boolean isEnabled() {
+            return interruptOnClosedConnection;
+        }
+    }
+
+    private class PropHttpContextConfiguration implements HttpContextConfiguration {
 
         @Override
         public boolean allowDeflateBeforeSend() {
@@ -1127,16 +1146,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getInterruptorBufferSize() {
-            return interruptorBufferSize;
-        }
-
-        @Override
-        public int getInterruptorNIterationsPerCheck() {
-            return interruptorNIterationsPerCheck;
-        }
-
-        @Override
         public int getMultipartHeaderBufferSize() {
             return multipartHeaderBufferSize;
         }
@@ -1144,6 +1153,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getMultipartIdleSpinCount() {
             return multipartIdleSpinCount;
+        }
+
+        @Override
+        public NetworkFacade getNetworkFacade() {
+            return NetworkFacadeImpl.INSTANCE;
         }
 
         @Override
@@ -1172,11 +1186,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean isInterruptOnClosedConnection() {
-            return interruptOnClosedConnection;
-        }
-
-        @Override
         public boolean readOnlySecurityContext() {
             return readOnlySecurityContext;
         }
@@ -1187,6 +1196,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public IODispatcherConfiguration getDispatcherConfiguration() {
             return httpIODispatcherConfiguration;
+        }
+
+        @Override
+        public HttpContextConfiguration getHttpContextConfiguration() {
+            return httpContextConfiguration;
+        }
+
+        @Override
+        public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
+            return jsonQueryProcessorConfiguration;
         }
 
         @Override
@@ -1205,18 +1224,8 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
-            return jsonQueryProcessorConfiguration;
-        }
-
-        @Override
         public boolean isEnabled() {
             return httpServerEnabled;
-        }
-
-        @Override
-        public HttpContextConfiguration getHttpContextConfiguration() {
-            return httpContextConfiguration;
         }
 
         @Override
@@ -1906,6 +1915,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getMaxQueryResponseRowLimit() {
             return maxHttpQueryResponseRowLimit;
+        }
+
+        @Override
+        public SqlInterruptorConfiguration getInterruptorConfiguration() {
+            return interruptorConfiguration;
         }
     }
 

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -28,7 +28,6 @@ import io.questdb.cairo.CairoEngine;
 import io.questdb.cutlass.http.HttpServer;
 import io.questdb.cutlass.json.JsonException;
 import io.questdb.cutlass.line.tcp.LineTcpServer;
-import io.questdb.cutlass.line.udp.AbstractLineProtoReceiver;
 import io.questdb.cutlass.line.udp.LineProtoReceiver;
 import io.questdb.cutlass.line.udp.LinuxMMLineProtoReceiver;
 import io.questdb.cutlass.pgwire.PGWireServer;
@@ -41,7 +40,6 @@ import io.questdb.mp.WorkerPool;
 import io.questdb.network.NetworkError;
 import io.questdb.std.*;
 import io.questdb.std.time.Dates;
-import org.jetbrains.annotations.Nullable;
 import sun.misc.Signal;
 
 import java.io.*;
@@ -55,30 +53,8 @@ import java.util.zip.ZipInputStream;
 
 public class ServerMain {
     private static final String VERSION_TXT = "version.txt";
-
-    public static void deleteOrException(File file) {
-        if (!file.exists()) {
-            return;
-        }
-        deleteDirContentsOrException(file);
-
-        int retryCount = 3;
-        boolean deleted = false;
-        while (retryCount > 0 && !(deleted = file.delete())) {
-            retryCount--;
-            Thread.yield();
-        }
-
-        if (!deleted) {
-            throw new RuntimeException("Cannot delete file " + file);
-        }
-    }
-
-    public static void main(String[] args) throws Exception {
-        new ServerMain(args);
-    }
-
     protected PropServerConfiguration configuration;
+
     public ServerMain(String[] args) throws Exception {
         System.err.printf("QuestDB server %s%nCopyright (C) 2014-%d, all rights reserved.%n%n", getVersion(), Dates.getYear(System.currentTimeMillis()));
         if (args.length < 1) {
@@ -151,13 +127,17 @@ public class ServerMain {
 
         final WorkerPool workerPool = new WorkerPool(configuration.getWorkerPoolConfiguration());
         final FunctionFactoryCache functionFactoryCache = new FunctionFactoryCache(configuration.getCairoConfiguration(), ServiceLoader.load(FunctionFactory.class));
+        final ObjList<Closeable> instancesToClean = new ObjList<>();
 
         LogFactory.configureFromSystemProperties(workerPool);
         final CairoEngine cairoEngine = new CairoEngine(configuration.getCairoConfiguration());
         workerPool.assign(cairoEngine.getWriterMaintenanceJob());
+        instancesToClean.add(cairoEngine);
+
         // The TelemetryJob is always needed (even when telemetry is off) because it is responsible for
         // updating the telemetry_config table.
         final TelemetryJob telemetryJob = new TelemetryJob(cairoEngine, functionFactoryCache);
+        instancesToClean.add(telemetryJob);
 
         if (configuration.getCairoConfiguration().getTelemetryConfiguration().getEnabled()) {
             workerPool.assign(telemetryJob);
@@ -165,49 +145,44 @@ public class ServerMain {
 
         try {
             initQuestDb(workerPool, cairoEngine, log);
-            final HttpServer httpServer = createHttpServer(workerPool, log, cairoEngine, functionFactoryCache);
 
-            final PGWireServer pgWireServer;
+            instancesToClean.add(createHttpServer(workerPool, log, cairoEngine, functionFactoryCache));
+            instancesToClean.add(createMinHttpServer(workerPool, log, cairoEngine, functionFactoryCache));
 
             if (configuration.getPGWireConfiguration().isEnabled()) {
-                pgWireServer = PGWireServer.create(
+                instancesToClean.add(PGWireServer.create(
                         configuration.getPGWireConfiguration(),
                         workerPool,
                         log,
                         cairoEngine,
                         functionFactoryCache
-                );
-            } else {
-                pgWireServer = null;
+                ));
             }
-
-            final AbstractLineProtoReceiver lineUdpServer;
 
             if (configuration.getLineUdpReceiverConfiguration().isEnabled()) {
                 if (Os.type == Os.LINUX_AMD64 || Os.type == Os.LINUX_ARM64) {
-                    lineUdpServer = new LinuxMMLineProtoReceiver(
+                    instancesToClean.add(new LinuxMMLineProtoReceiver(
                             configuration.getLineUdpReceiverConfiguration(),
                             cairoEngine,
                             workerPool
-                    );
+                    ));
                 } else {
-                    lineUdpServer = new LineProtoReceiver(
+                    instancesToClean.add(new LineProtoReceiver(
                             configuration.getLineUdpReceiverConfiguration(),
                             cairoEngine,
                             workerPool
-                    );
+                    ));
                 }
-            } else {
-                lineUdpServer = null;
             }
 
-            LineTcpServer lineTcpServer = LineTcpServer.create(
+            instancesToClean.add(LineTcpServer.create(
                     configuration.getLineTcpReceiverConfiguration(),
                     workerPool,
                     log,
                     cairoEngine
-            );
-            startQuestDb(workerPool, cairoEngine, lineUdpServer, log);
+            ));
+
+            startQuestDb(workerPool, cairoEngine, log);
             logWebConsoleUrls(log, configuration);
 
             System.gc();
@@ -220,15 +195,7 @@ public class ServerMain {
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 System.err.println(new Date() + " QuestDB is shutting down");
-                shutdownQuestDb(
-                        workerPool,
-                        cairoEngine,
-                        httpServer,
-                        pgWireServer,
-                        lineUdpServer,
-                        telemetryJob,
-                        lineTcpServer
-                );
+                shutdownQuestDb(workerPool, instancesToClean);
                 System.err.println(new Date() + " QuestDB is down");
             }));
         } catch (NetworkError e) {
@@ -238,14 +205,36 @@ public class ServerMain {
         }
     }
 
+    public static void deleteOrException(File file) {
+        if (!file.exists()) {
+            return;
+        }
+        deleteDirContentsOrException(file);
+
+        int retryCount = 3;
+        boolean deleted = false;
+        while (retryCount > 0 && !(deleted = file.delete())) {
+            retryCount--;
+            Thread.yield();
+        }
+
+        if (!deleted) {
+            throw new RuntimeException("Cannot delete file " + file);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new ServerMain(args);
+    }
+
     private static void logWebConsoleUrls(Log log, PropServerConfiguration configuration) throws SocketException {
         final LogRecord record = log.info().$("web console URL(s):").$('\n').$('\n');
         final int httpBindIP = configuration.getHttpServerConfiguration().getDispatcherConfiguration().getBindIPv4Address();
         final int httpBindPort = configuration.getHttpServerConfiguration().getDispatcherConfiguration().getBindPort();
         if (httpBindIP == 0) {
             Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
-            for (NetworkInterface netint : Collections.list(nets)) {
-                Enumeration<InetAddress> inetAddresses = netint.getInetAddresses();
+            for (NetworkInterface networkInterface : Collections.list(nets)) {
+                Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
                 for (InetAddress inetAddress : Collections.list(inetAddresses)) {
                     if (inetAddress instanceof Inet4Address) {
                         record.$('\t').$("http:/").$(inetAddress).$(':').$(httpBindPort).$('\n');
@@ -256,19 +245,6 @@ public class ServerMain {
         } else {
             record.$('\t').$("http://").$ip(httpBindIP).$(':').$(httpBindPort).$('\n').$();
         }
-    }
-
-    protected HttpServer createHttpServer(final WorkerPool workerPool, final Log log, final CairoEngine cairoEngine, FunctionFactoryCache functionFactoryCache) {
-        return HttpServer.create(
-                configuration.getHttpServerConfiguration(),
-                workerPool,
-                log,
-                cairoEngine,
-                functionFactoryCache);
-    }
-
-    protected void readServerConfiguration(final String rootDirectory, final Properties properties, Log log) throws ServerConfigurationException, JsonException {
-        configuration = new PropServerConfiguration(rootDirectory, properties, System.getenv(), log);
     }
 
     private static CharSequenceObjHashMap<String> hashArgs(String[] args) {
@@ -431,23 +407,29 @@ public class ServerMain {
         return "[DEVELOPMENT]";
     }
 
-    protected static void shutdownQuestDb(
-            final WorkerPool workerPool,
-            final CairoEngine cairoEngine,
-            final HttpServer httpServer,
-            final PGWireServer pgWireServer,
-            @Nullable final AbstractLineProtoReceiver lineProtocolReceiver,
-            final TelemetryJob telemetryJob,
-            final LineTcpServer lineTcpServer
-    ) {
-        Misc.free(lineProtocolReceiver);
-        Misc.free(telemetryJob);
+    protected static void shutdownQuestDb(final WorkerPool workerPool, final ObjList<? extends Closeable> instancesToClean) {
         workerPool.halt();
-        Misc.free(pgWireServer);
-        Misc.free(httpServer);
-        Misc.free(cairoEngine);
-        Misc.free(lineProtocolReceiver);
-        Misc.free(lineTcpServer);
+        Misc.freeObjList(instancesToClean);
+    }
+
+    protected HttpServer createHttpServer(final WorkerPool workerPool, final Log log, final CairoEngine cairoEngine, FunctionFactoryCache functionFactoryCache) {
+        return HttpServer.create(
+                configuration.getHttpServerConfiguration(),
+                workerPool,
+                log,
+                cairoEngine,
+                functionFactoryCache
+        );
+    }
+
+    protected HttpServer createMinHttpServer(final WorkerPool workerPool, final Log log, final CairoEngine cairoEngine, FunctionFactoryCache functionFactoryCache) {
+        return HttpServer.createMin(
+                configuration.getHttpMinServerConfiguration(),
+                workerPool,
+                log,
+                cairoEngine,
+                functionFactoryCache
+        );
     }
 
     protected void initQuestDb(
@@ -458,15 +440,15 @@ public class ServerMain {
         // For extension
     }
 
+    protected void readServerConfiguration(final String rootDirectory, final Properties properties, Log log) throws ServerConfigurationException, JsonException {
+        configuration = new PropServerConfiguration(rootDirectory, properties, System.getenv(), log);
+    }
+
     protected void startQuestDb(
             final WorkerPool workerPool,
             final CairoEngine cairoEngine,
-            @Nullable final AbstractLineProtoReceiver lineProtocolReceiver,
             final Log log
     ) {
         workerPool.start(log);
-        if (lineProtocolReceiver != null) {
-            lineProtocolReceiver.start();
-        }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
@@ -31,6 +31,16 @@ import io.questdb.std.time.MillisecondClockImpl;
 
 public class DefaultHttpContextConfiguration implements HttpContextConfiguration {
     @Override
+    public boolean allowDeflateBeforeSend() {
+        return false;
+    }
+
+    @Override
+    public MillisecondClock getClock() {
+        return MillisecondClockImpl.INSTANCE;
+    }
+
+    @Override
     public int getConnectionPoolInitialCapacity() {
         return 16;
     }
@@ -41,6 +51,17 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     }
 
     @Override
+    public boolean getDumpNetworkTraffic() {
+        return false;
+    }
+
+    @Override
+    public String getHttpVersion() {
+        // trailing space is important
+        return "HTTP/1.1 ";
+    }
+
+    @Override
     public int getMultipartHeaderBufferSize() {
         return 512;
     }
@@ -48,6 +69,11 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     @Override
     public long getMultipartIdleSpinCount() {
         return 10_000;
+    }
+
+    @Override
+    public NetworkFacade getNetworkFacade() {
+        return NetworkFacadeImpl.INSTANCE;
     }
 
     @Override
@@ -71,53 +97,12 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     }
 
     @Override
-    public boolean getDumpNetworkTraffic() {
-        return false;
-    }
-
-    @Override
-    public boolean allowDeflateBeforeSend() {
-        return false;
-    }
-
-    @Override
-    public boolean readOnlySecurityContext() {
-        return false;
-    }
-
-    @Override
-    public boolean isInterruptOnClosedConnection() {
-        return true;
-    }
-
-    @Override
-    public int getInterruptorNIterationsPerCheck() {
-        return 5;
-    }
-
-    @Override
-    public int getInterruptorBufferSize() {
-        return 64;
-    }
-
-    @Override
     public boolean getServerKeepAlive() {
         return true;
     }
 
     @Override
-    public String getHttpVersion() {
-        // trailing space is important
-        return "HTTP/1.1 ";
-    }
-
-    @Override
-    public NetworkFacade getNetworkFacade() {
-        return NetworkFacadeImpl.INSTANCE;
-    }
-
-    @Override
-    public MillisecondClock getClock() {
-        return MillisecondClockImpl.INSTANCE;
+    public boolean readOnlySecurityContext() {
+        return false;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.http;
+
+import io.questdb.network.NetworkFacade;
+import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.time.MillisecondClock;
+import io.questdb.std.time.MillisecondClockImpl;
+
+public class DefaultHttpContextConfiguration implements HttpContextConfiguration {
+    @Override
+    public int getConnectionPoolInitialCapacity() {
+        return 16;
+    }
+
+    @Override
+    public int getConnectionStringPoolCapacity() {
+        return 128;
+    }
+
+    @Override
+    public int getMultipartHeaderBufferSize() {
+        return 512;
+    }
+
+    @Override
+    public long getMultipartIdleSpinCount() {
+        return 10_000;
+    }
+
+    @Override
+    public int getRecvBufferSize() {
+        return 1024 * 1024;
+    }
+
+    @Override
+    public int getRequestHeaderBufferSize() {
+        return 1024;
+    }
+
+    @Override
+    public int getResponseHeaderBufferSize() {
+        return 1024;
+    }
+
+    @Override
+    public int getSendBufferSize() {
+        return 1024 * 1024;
+    }
+
+    @Override
+    public boolean getDumpNetworkTraffic() {
+        return false;
+    }
+
+    @Override
+    public boolean allowDeflateBeforeSend() {
+        return false;
+    }
+
+    @Override
+    public boolean readOnlySecurityContext() {
+        return false;
+    }
+
+    @Override
+    public boolean isInterruptOnClosedConnection() {
+        return true;
+    }
+
+    @Override
+    public int getInterruptorNIterationsPerCheck() {
+        return 5;
+    }
+
+    @Override
+    public int getInterruptorBufferSize() {
+        return 64;
+    }
+
+    @Override
+    public boolean getServerKeepAlive() {
+        return true;
+    }
+
+    @Override
+    public String getHttpVersion() {
+        // trailing space is important
+        return "HTTP/1.1 ";
+    }
+
+    @Override
+    public NetworkFacade getNetworkFacade() {
+        return NetworkFacadeImpl.INSTANCE;
+    }
+
+    @Override
+    public MillisecondClock getClock() {
+        return MillisecondClockImpl.INSTANCE;
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -26,6 +26,8 @@ package io.questdb.cutlass.http;
 
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
+import io.questdb.griffin.DefaultSqlInterruptorConfiguration;
+import io.questdb.griffin.SqlInterruptorConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.std.FilesFacade;
@@ -39,6 +41,8 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     protected final MimeTypesCache mimeTypesCache;
     private final IODispatcherConfiguration dispatcherConfiguration = new DefaultIODispatcherConfiguration();
     private final HttpContextConfiguration httpContextConfiguration;
+    private final SqlInterruptorConfiguration interruptorConfiguration;
+
     private final StaticContentProcessorConfiguration staticContentProcessorConfiguration = new StaticContentProcessorConfiguration() {
         @Override
         public FilesFacade getFilesFacade() {
@@ -100,6 +104,11 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
         public long getMaxQueryResponseRowLimit() {
             return Long.MAX_VALUE;
         }
+
+        @Override
+        public SqlInterruptorConfiguration getInterruptorConfiguration() {
+            return interruptorConfiguration;
+        }
     };
 
     public DefaultHttpServerConfiguration() {
@@ -117,11 +126,22 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
             this.mimeTypesCache = new MimeTypesCache(FilesFacadeImpl.INSTANCE, path);
         }
         this.httpContextConfiguration = httpContextConfiguration;
+        this.interruptorConfiguration = new DefaultSqlInterruptorConfiguration();
     }
 
     @Override
     public IODispatcherConfiguration getDispatcherConfiguration() {
         return dispatcherConfiguration;
+    }
+
+    @Override
+    public HttpContextConfiguration getHttpContextConfiguration() {
+        return httpContextConfiguration;
+    }
+
+    @Override
+    public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
+        return jsonQueryProcessorConfiguration;
     }
 
     @Override
@@ -140,18 +160,8 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     @Override
-    public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
-        return jsonQueryProcessorConfiguration;
-    }
-
-    @Override
     public boolean isEnabled() {
         return true;
-    }
-
-    @Override
-    public HttpContextConfiguration getHttpContextConfiguration() {
-        return httpContextConfiguration;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -34,11 +34,11 @@ import io.questdb.std.Numbers;
 import io.questdb.std.Os;
 import io.questdb.std.str.Path;
 import io.questdb.std.time.MillisecondClock;
-import io.questdb.std.time.MillisecondClockImpl;
 
 public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     protected final MimeTypesCache mimeTypesCache;
     private final IODispatcherConfiguration dispatcherConfiguration = new DefaultIODispatcherConfiguration();
+    private final HttpContextConfiguration httpContextConfiguration;
     private final StaticContentProcessorConfiguration staticContentProcessorConfiguration = new StaticContentProcessorConfiguration() {
         @Override
         public FilesFacade getFilesFacade() {
@@ -65,11 +65,10 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
             return null;
         }
     };
-
     private final JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new JsonQueryProcessorConfiguration() {
         @Override
         public MillisecondClock getClock() {
-            return DefaultHttpServerConfiguration.this.getClock();
+            return httpContextConfiguration.getClock();
         }
 
         @Override
@@ -104,6 +103,10 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     };
 
     public DefaultHttpServerConfiguration() {
+        this(new DefaultHttpContextConfiguration());
+    }
+
+    public DefaultHttpServerConfiguration(HttpContextConfiguration httpContextConfiguration) {
         String defaultFilePath = this.getClass().getResource("/site/conf/mime.types").getFile();
         if (Os.type == Os.WINDOWS) {
             // on Windows Java returns "/C:/dir/file". This leading slash is Java specific and doesn't bode well
@@ -113,46 +116,12 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
         try (Path path = new Path().of(defaultFilePath).$()) {
             this.mimeTypesCache = new MimeTypesCache(FilesFacadeImpl.INSTANCE, path);
         }
+        this.httpContextConfiguration = httpContextConfiguration;
     }
 
     @Override
-    public int getConnectionPoolInitialCapacity() {
-        return 16;
-    }
-
-    @Override
-    public int getConnectionStringPoolCapacity() {
-        return 128;
-    }
-
-    @Override
-    public int getMultipartHeaderBufferSize() {
-        return 512;
-    }
-
-    @Override
-    public long getMultipartIdleSpinCount() {
-        return 10_000;
-    }
-
-    @Override
-    public int getRecvBufferSize() {
-        return 1024 * 1024;
-    }
-
-    @Override
-    public int getRequestHeaderBufferSize() {
-        return 1024;
-    }
-
-    @Override
-    public int getResponseHeaderBufferSize() {
-        return 1024;
-    }
-
-    @Override
-    public int getQueryCacheRows() {
-        return 32;
+    public IODispatcherConfiguration getDispatcherConfiguration() {
+        return dispatcherConfiguration;
     }
 
     @Override
@@ -161,13 +130,8 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     @Override
-    public MillisecondClock getClock() {
-        return MillisecondClockImpl.INSTANCE;
-    }
-
-    @Override
-    public IODispatcherConfiguration getDispatcherConfiguration() {
-        return dispatcherConfiguration;
+    public int getQueryCacheRows() {
+        return 32;
     }
 
     @Override
@@ -181,23 +145,13 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     @Override
-    public int getSendBufferSize() {
-        return 1024 * 1024;
-    }
-
-    @Override
     public boolean isEnabled() {
         return true;
     }
 
     @Override
-    public boolean getDumpNetworkTraffic() {
-        return false;
-    }
-
-    @Override
-    public boolean allowDeflateBeforeSend() {
-        return false;
+    public HttpContextConfiguration getHttpContextConfiguration() {
+        return httpContextConfiguration;
     }
 
     @Override
@@ -213,36 +167,5 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     @Override
     public boolean haltOnError() {
         return false;
-    }
-
-    @Override
-    public boolean readOnlySecurityContext() {
-        return false;
-    }
-
-    @Override
-    public boolean isInterruptOnClosedConnection() {
-        return true;
-    }
-
-    @Override
-    public int getInterruptorNIterationsPerCheck() {
-        return 5;
-    }
-
-    @Override
-    public int getInterruptorBufferSize() {
-        return 64;
-    }
-
-    @Override
-    public boolean getServerKeepAlive() {
-        return true;
-    }
-
-    @Override
-    public String getHttpVersion() {
-        // trailing space is important
-        return "HTTP/1.1 ";
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
@@ -22,29 +22,46 @@
  *
  ******************************************************************************/
 
-package io.questdb;
+package io.questdb.cutlass.http;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
-import io.questdb.cutlass.http.HttpServerConfiguration;
-import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
-import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
-import io.questdb.cutlass.pgwire.PGWireConfiguration;
-import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.network.NetworkFacade;
+import io.questdb.std.time.MillisecondClock;
 
-public interface ServerConfiguration {
+public interface HttpContextConfiguration {
 
-    CairoConfiguration getCairoConfiguration();
+    NetworkFacade getNetworkFacade();
 
-    HttpServerConfiguration getHttpServerConfiguration();
+    boolean allowDeflateBeforeSend();
 
-    HttpMinServerConfiguration getHttpMinServerConfiguration();
+    MillisecondClock getClock();
 
-    LineUdpReceiverConfiguration getLineUdpReceiverConfiguration();
+    int getConnectionPoolInitialCapacity();
 
-    LineTcpReceiverConfiguration getLineTcpReceiverConfiguration();
+    int getConnectionStringPoolCapacity();
 
-    WorkerPoolConfiguration getWorkerPoolConfiguration();
+    boolean getDumpNetworkTraffic();
 
-    PGWireConfiguration getPGWireConfiguration();
+    String getHttpVersion();
+
+    int getInterruptorBufferSize();
+
+    int getInterruptorNIterationsPerCheck();
+
+    int getMultipartHeaderBufferSize();
+
+    long getMultipartIdleSpinCount();
+
+    int getRecvBufferSize();
+
+    int getRequestHeaderBufferSize();
+
+    int getResponseHeaderBufferSize();
+
+    int getSendBufferSize();
+
+    boolean getServerKeepAlive();
+
+    boolean isInterruptOnClosedConnection();
+
+    boolean readOnlySecurityContext();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
@@ -29,8 +29,6 @@ import io.questdb.std.time.MillisecondClock;
 
 public interface HttpContextConfiguration {
 
-    NetworkFacade getNetworkFacade();
-
     boolean allowDeflateBeforeSend();
 
     MillisecondClock getClock();
@@ -43,13 +41,11 @@ public interface HttpContextConfiguration {
 
     String getHttpVersion();
 
-    int getInterruptorBufferSize();
-
-    int getInterruptorNIterationsPerCheck();
-
     int getMultipartHeaderBufferSize();
 
     long getMultipartIdleSpinCount();
+
+    NetworkFacade getNetworkFacade();
 
     int getRecvBufferSize();
 
@@ -60,8 +56,6 @@ public interface HttpContextConfiguration {
     int getSendBufferSize();
 
     boolean getServerKeepAlive();
-
-    boolean isInterruptOnClosedConnection();
 
     boolean readOnlySecurityContext();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfiguration.java
@@ -22,29 +22,14 @@
  *
  ******************************************************************************/
 
-package io.questdb;
+package io.questdb.cutlass.http;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
-import io.questdb.cutlass.http.HttpServerConfiguration;
-import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
-import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
-import io.questdb.cutlass.pgwire.PGWireConfiguration;
-import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.WorkerPoolAwareConfiguration;
+import io.questdb.network.IODispatcherConfiguration;
 
-public interface ServerConfiguration {
+public interface HttpMinServerConfiguration extends WorkerPoolAwareConfiguration {
 
-    CairoConfiguration getCairoConfiguration();
+    IODispatcherConfiguration getDispatcherConfiguration();
 
-    HttpServerConfiguration getHttpServerConfiguration();
-
-    HttpMinServerConfiguration getHttpMinServerConfiguration();
-
-    LineUdpReceiverConfiguration getLineUdpReceiverConfiguration();
-
-    LineTcpReceiverConfiguration getLineTcpReceiverConfiguration();
-
-    WorkerPoolConfiguration getWorkerPoolConfiguration();
-
-    PGWireConfiguration getPGWireConfiguration();
+    HttpContextConfiguration getHttpContextConfiguration();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -95,9 +95,9 @@ public class HttpResponseSink implements Closeable, Mutable {
     private long totalBytesSent = 0;
     private final boolean connectionCloseHeader;
 
-    public HttpResponseSink(HttpServerConfiguration configuration) {
+    public HttpResponseSink(HttpContextConfiguration configuration) {
         this.responseBufferSize = Numbers.ceilPow2(configuration.getSendBufferSize());
-        this.nf = configuration.getDispatcherConfiguration().getNetworkFacade();
+        this.nf = configuration.getNetworkFacade();
         this.out = Unsafe.calloc(responseBufferSize);
         this.headerImpl = new HttpResponseHeaderImpl(configuration.getResponseHeaderBufferSize(), configuration.getClock());
         // size is 32bit int, as hex string max 8 bytes

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfiguration.java
@@ -27,56 +27,20 @@ package io.questdb.cutlass.http;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
-import io.questdb.network.IODispatcherConfiguration;
-import io.questdb.std.time.MillisecondClock;
 
-public interface HttpServerConfiguration extends WorkerPoolAwareConfiguration {
+public interface HttpServerConfiguration extends WorkerPoolAwareConfiguration, HttpMinServerConfiguration {
     String DEFAULT_PROCESSOR_URL = "*";
 
-    int getConnectionPoolInitialCapacity();
+    HttpContextConfiguration getHttpContextConfiguration();
 
-    int getConnectionStringPoolCapacity();
-
-    int getMultipartHeaderBufferSize();
-
-    long getMultipartIdleSpinCount();
-
-    int getRecvBufferSize();
-
-    int getRequestHeaderBufferSize();
-
-    int getResponseHeaderBufferSize();
+    JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration();
 
     int getQueryCacheBlocks();
 
     int getQueryCacheRows();
 
-    MillisecondClock getClock();
-
-    IODispatcherConfiguration getDispatcherConfiguration();
-
     StaticContentProcessorConfiguration getStaticContentProcessorConfiguration();
-
-    JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration();
-
-    int getSendBufferSize();
 
     @Override
     boolean isEnabled();
-
-    boolean getDumpNetworkTraffic();
-
-    boolean allowDeflateBeforeSend();
-
-    boolean readOnlySecurityContext();
-
-    boolean isInterruptOnClosedConnection();
-
-    int getInterruptorNIterationsPerCheck();
-
-    int getInterruptorBufferSize();
-
-    boolean getServerKeepAlive();
-
-    String getHttpVersion();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
@@ -22,29 +22,20 @@
  *
  ******************************************************************************/
 
-package io.questdb;
+package io.questdb.cutlass.http.processors;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
-import io.questdb.cutlass.http.HttpServerConfiguration;
-import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
-import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
-import io.questdb.cutlass.pgwire.PGWireConfiguration;
-import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.cutlass.http.HttpChunkedResponseSocket;
+import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpRequestProcessor;
+import io.questdb.network.PeerDisconnectedException;
+import io.questdb.network.PeerIsSlowToReadException;
 
-public interface ServerConfiguration {
-
-    CairoConfiguration getCairoConfiguration();
-
-    HttpServerConfiguration getHttpServerConfiguration();
-
-    HttpMinServerConfiguration getHttpMinServerConfiguration();
-
-    LineUdpReceiverConfiguration getLineUdpReceiverConfiguration();
-
-    LineTcpReceiverConfiguration getLineTcpReceiverConfiguration();
-
-    WorkerPoolConfiguration getWorkerPoolConfiguration();
-
-    PGWireConfiguration getPGWireConfiguration();
+public class HealthCheckProcessor implements HttpRequestProcessor {
+    @Override
+    public void onRequestComplete(HttpConnectionContext context) throws PeerDisconnectedException, PeerIsSlowToReadException {
+        HttpChunkedResponseSocket r = context.getChunkedResponseSocket();
+        r.status(200, "text/plain");
+        r.sendHeader();
+        r.done();
+    }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/StaticContentProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/StaticContentProcessor.java
@@ -54,7 +54,7 @@ public class StaticContentProcessor implements HttpRequestProcessor, Closeable {
         this.indexFileName = configuration.getStaticContentProcessorConfiguration().getIndexFileName();
         this.ff = configuration.getStaticContentProcessorConfiguration().getFilesFacade();
         this.keepAliveHeader = configuration.getStaticContentProcessorConfiguration().getKeepAliveHeader();
-        this.httpProtocolVersion = configuration.getHttpVersion();
+        this.httpProtocolVersion = configuration.getHttpContextConfiguration().getHttpVersion();
     }
 
     private static void sendStatusWithDefaultMessage(HttpConnectionContext context, int code) throws PeerDisconnectedException, PeerIsSlowToReadException {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
@@ -189,7 +189,7 @@ public class LineTcpServer implements Closeable {
             } else {
                 context.of(-1, null);
                 contextPool.get().push(context);
-                LOG.info().$("pushed").$();
+                LOG.debug().$("pushed").$();
             }
         }
 

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineProtoReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineProtoReceiver.java
@@ -39,6 +39,7 @@ public class LineProtoReceiver extends AbstractLineProtoReceiver {
     ) {
         super(configuration, engine, workerPool);
         this.buf = Unsafe.malloc(this.bufLen = configuration.getMsgBufferSize());
+        start();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LinuxMMLineProtoReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LinuxMMLineProtoReceiver.java
@@ -40,6 +40,7 @@ public class LinuxMMLineProtoReceiver extends AbstractLineProtoReceiver {
         super(configuration, engine, workerPool);
         this.msgCount = configuration.getMsgCount();
         msgVec = nf.msgHeaders(configuration.getMsgBufferSize(), msgCount);
+        start();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -142,7 +142,7 @@ public class PGWireServer implements Closeable {
             } else {
                 context.of(-1, null);
                 contextPool.get().push(context);
-                LOG.info().$("pushed").$();
+                LOG.debug().$("pushed").$();
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/DefaultSqlInterruptorConfiguration.java
+++ b/core/src/main/java/io/questdb/griffin/DefaultSqlInterruptorConfiguration.java
@@ -22,27 +22,29 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.http.processors;
+package io.questdb.griffin;
 
-import io.questdb.griffin.SqlInterruptorConfiguration;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.time.MillisecondClock;
+import io.questdb.network.NetworkFacade;
+import io.questdb.network.NetworkFacadeImpl;
 
-public interface JsonQueryProcessorConfiguration {
+public class DefaultSqlInterruptorConfiguration implements SqlInterruptorConfiguration {
+    @Override
+    public int getBufferSize() {
+        return 64;
+    }
 
-    MillisecondClock getClock();
+    @Override
+    public int getCountOfIterationsPerCheck() {
+        return 5;
+    }
 
-    int getConnectionCheckFrequency();
+    @Override
+    public NetworkFacade getNetworkFacade() {
+        return NetworkFacadeImpl.INSTANCE;
+    }
 
-    FilesFacade getFilesFacade();
-
-    int getFloatScale();
-
-    int getDoubleScale();
-
-    CharSequence getKeepAliveHeader();
-
-    long getMaxQueryResponseRowLimit();
-
-    SqlInterruptorConfiguration getInterruptorConfiguration();
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/HttpSqlExecutionInterruptor.java
+++ b/core/src/main/java/io/questdb/griffin/HttpSqlExecutionInterruptor.java
@@ -14,11 +14,17 @@ public class HttpSqlExecutionInterruptor implements SqlExecutionInterruptor, Clo
     private int nIterationsSinceCheck;
     private long fd = -1;
 
-    public HttpSqlExecutionInterruptor(NetworkFacade nf, int nIterationsPerCheck, int bufferSize) {
-        super();
-        this.nf = nf;
-        this.nIterationsPerCheck = nIterationsPerCheck;
-        this.bufferSize = bufferSize;
+    public static HttpSqlExecutionInterruptor create(SqlInterruptorConfiguration configuration) {
+        if(configuration.isEnabled()) {
+            return new HttpSqlExecutionInterruptor(configuration);
+        }
+        return null;
+    }
+
+    public HttpSqlExecutionInterruptor(SqlInterruptorConfiguration configuration) {
+        this.nf = configuration.getNetworkFacade();
+        this.nIterationsPerCheck = configuration.getCountOfIterationsPerCheck();
+        this.bufferSize = configuration.getBufferSize();
         buffer = Unsafe.malloc(bufferSize);
     }
 

--- a/core/src/main/java/io/questdb/griffin/SqlInterruptorConfiguration.java
+++ b/core/src/main/java/io/questdb/griffin/SqlInterruptorConfiguration.java
@@ -22,27 +22,16 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.http.processors;
+package io.questdb.griffin;
 
-import io.questdb.griffin.SqlInterruptorConfiguration;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.time.MillisecondClock;
+import io.questdb.network.NetworkFacade;
 
-public interface JsonQueryProcessorConfiguration {
+public interface SqlInterruptorConfiguration {
+    int getBufferSize();
 
-    MillisecondClock getClock();
+    int getCountOfIterationsPerCheck();
 
-    int getConnectionCheckFrequency();
+    NetworkFacade getNetworkFacade();
 
-    FilesFacade getFilesFacade();
-
-    int getFloatScale();
-
-    int getDoubleScale();
-
-    CharSequence getKeepAliveHeader();
-
-    long getMaxQueryResponseRowLimit();
-
-    SqlInterruptorConfiguration getInterruptorConfiguration();
+    boolean isEnabled();
 }

--- a/core/src/main/resources/qlog.conf
+++ b/core/src/main/resources/qlog.conf
@@ -1,5 +1,5 @@
 # list of configured writers
-writers=file,stdout
+writers=file,stdout,http.min
 
 # file writer
 #w.file.class=io.questdb.log.LogFileWriter
@@ -9,3 +9,9 @@ writers=file,stdout
 # stdout
 w.stdout.class=io.questdb.log.LogConsoleWriter
 w.stdout.level=INFO,ERROR
+
+# disable logging out of min http server, which is supposed to be used
+# for frequent monitoring
+w.http.min.class=io.questdb.log.LogConsoleWriter
+w.http.min.level=ERROR
+w.http.min.scope=http-min-server

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -72,22 +72,22 @@ public class PropServerConfigurationTest {
     public void testAllDefaults() throws ServerConfigurationException, JsonException {
         Properties properties = new Properties();
         PropServerConfiguration configuration = new PropServerConfiguration(configPath, properties, null, LOG);
-        Assert.assertEquals(16, configuration.getHttpServerConfiguration().getConnectionPoolInitialCapacity());
-        Assert.assertEquals(128, configuration.getHttpServerConfiguration().getConnectionStringPoolCapacity());
-        Assert.assertEquals(512, configuration.getHttpServerConfiguration().getMultipartHeaderBufferSize());
-        Assert.assertEquals(10_000, configuration.getHttpServerConfiguration().getMultipartIdleSpinCount());
-        Assert.assertEquals(1048576, configuration.getHttpServerConfiguration().getRecvBufferSize());
-        Assert.assertEquals(64448, configuration.getHttpServerConfiguration().getRequestHeaderBufferSize());
-        Assert.assertEquals(32768, configuration.getHttpServerConfiguration().getResponseHeaderBufferSize());
+        Assert.assertEquals(16, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getConnectionPoolInitialCapacity());
+        Assert.assertEquals(128, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getConnectionStringPoolCapacity());
+        Assert.assertEquals(512, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartHeaderBufferSize());
+        Assert.assertEquals(10_000, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartIdleSpinCount());
+        Assert.assertEquals(1048576, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getRecvBufferSize());
+        Assert.assertEquals(64448, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getRequestHeaderBufferSize());
+        Assert.assertEquals(32768, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getResponseHeaderBufferSize());
         Assert.assertEquals(0, configuration.getHttpServerConfiguration().getWorkerCount());
         Assert.assertFalse(configuration.getHttpServerConfiguration().haltOnError());
         Assert.assertArrayEquals(new int[]{}, configuration.getHttpServerConfiguration().getWorkerAffinity());
         Assert.assertFalse(configuration.getHttpServerConfiguration().haltOnError());
-        Assert.assertEquals(2097152, configuration.getHttpServerConfiguration().getSendBufferSize());
+        Assert.assertEquals(2097152, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getSendBufferSize());
         Assert.assertEquals("index.html", configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getIndexFileName());
         Assert.assertTrue(configuration.getHttpServerConfiguration().isEnabled());
-        Assert.assertFalse(configuration.getHttpServerConfiguration().getDumpNetworkTraffic());
-        Assert.assertFalse(configuration.getHttpServerConfiguration().allowDeflateBeforeSend());
+        Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getDumpNetworkTraffic());
+        Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().allowDeflateBeforeSend());
         Assert.assertEquals(16, configuration.getHttpServerConfiguration().getQueryCacheRows());
         Assert.assertEquals(4, configuration.getHttpServerConfiguration().getQueryCacheBlocks());
 
@@ -127,11 +127,11 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(12, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getDoubleScale());
         Assert.assertEquals("Keep-Alive: timeout=5, max=10000" + Misc.EOL, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getKeepAliveHeader());
 
-        Assert.assertFalse(configuration.getHttpServerConfiguration().readOnlySecurityContext());
+        Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
         Assert.assertEquals(Long.MAX_VALUE, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());
-        Assert.assertTrue(configuration.getHttpServerConfiguration().isInterruptOnClosedConnection());
-        Assert.assertEquals(2_000_000, configuration.getHttpServerConfiguration().getInterruptorNIterationsPerCheck());
-        Assert.assertEquals(64, configuration.getHttpServerConfiguration().getInterruptorBufferSize());
+        Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().isInterruptOnClosedConnection());
+        Assert.assertEquals(2_000_000, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorNIterationsPerCheck());
+        Assert.assertEquals(64, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorBufferSize());
 
         Assert.assertEquals(CommitMode.NOSYNC, configuration.getCairoConfiguration().getCommitMode());
         Assert.assertEquals(2097152, configuration.getCairoConfiguration().getSqlCopyBufferSize());
@@ -203,7 +203,7 @@ public class PropServerConfigurationTest {
         // statics
         Assert.assertSame(FilesFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getFilesFacade());
         Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getClock());
-        Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getClock());
+        Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getClock());
         Assert.assertSame(NetworkFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getNetworkFacade());
         Assert.assertSame(EpollFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getEpollFacade());
         Assert.assertSame(SelectFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getSelectFacade());
@@ -243,8 +243,8 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(1000, configuration.getLineTcpReceiverConfiguration().getMaxUncommittedRows());
         Assert.assertEquals(250, configuration.getLineTcpReceiverConfiguration().getMaintenanceJobHysteresisInMs());
 
-        Assert.assertTrue(configuration.getHttpServerConfiguration().getServerKeepAlive());
-        Assert.assertEquals("HTTP/1.1 ", configuration.getHttpServerConfiguration().getHttpVersion());
+        Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
+        Assert.assertEquals("HTTP/1.1 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
         Assert.assertEquals(16777216, configuration.getCairoConfiguration().getAppendPageSize());
     }
 
@@ -289,13 +289,13 @@ public class PropServerConfigurationTest {
 
         PropServerConfiguration configuration = new PropServerConfiguration(configPath, properties, env, LOG);
         Assert.assertEquals(1.5, configuration.getCairoConfiguration().getTextConfiguration().getMaxRequiredDelimiterStdDev(), 0.000001);
-        Assert.assertEquals(3000, configuration.getHttpServerConfiguration().getConnectionStringPoolCapacity());
-        Assert.assertEquals("2.0 ", configuration.getHttpServerConfiguration().getHttpVersion());
+        Assert.assertEquals(3000, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getConnectionStringPoolCapacity());
+        Assert.assertEquals("2.0 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
         Assert.assertEquals(3, configuration.getWorkerPoolConfiguration().getWorkerCount());
         Assert.assertArrayEquals(new int[]{5, 6, 7}, configuration.getWorkerPoolConfiguration().getWorkerAffinity());
-        Assert.assertEquals(12288, configuration.getHttpServerConfiguration().getSendBufferSize());
-        Assert.assertEquals(900, configuration.getHttpServerConfiguration().getMultipartIdleSpinCount());
-        Assert.assertFalse(configuration.getHttpServerConfiguration().readOnlySecurityContext());
+        Assert.assertEquals(12288, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getSendBufferSize());
+        Assert.assertEquals(900, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartIdleSpinCount());
+        Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
         Assert.assertEquals(9663676416L, configuration.getCairoConfiguration().getAppendPageSize());
     }
 
@@ -405,32 +405,32 @@ public class PropServerConfigurationTest {
             properties.load(is);
 
             PropServerConfiguration configuration = new PropServerConfiguration(configPath, properties, null, LOG);
-            Assert.assertEquals(64, configuration.getHttpServerConfiguration().getConnectionPoolInitialCapacity());
-            Assert.assertEquals(512, configuration.getHttpServerConfiguration().getConnectionStringPoolCapacity());
-            Assert.assertEquals(256, configuration.getHttpServerConfiguration().getMultipartHeaderBufferSize());
-            Assert.assertEquals(100_000, configuration.getHttpServerConfiguration().getMultipartIdleSpinCount());
-            Assert.assertEquals(4096, configuration.getHttpServerConfiguration().getRecvBufferSize());
-            Assert.assertEquals(2048, configuration.getHttpServerConfiguration().getRequestHeaderBufferSize());
-            Assert.assertEquals(9012, configuration.getHttpServerConfiguration().getResponseHeaderBufferSize());
+            Assert.assertEquals(64, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getConnectionPoolInitialCapacity());
+            Assert.assertEquals(512, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getConnectionStringPoolCapacity());
+            Assert.assertEquals(256, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartHeaderBufferSize());
+            Assert.assertEquals(100_000, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartIdleSpinCount());
+            Assert.assertEquals(4096, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getRecvBufferSize());
+            Assert.assertEquals(2048, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getRequestHeaderBufferSize());
+            Assert.assertEquals(9012, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getResponseHeaderBufferSize());
             Assert.assertEquals(6, configuration.getHttpServerConfiguration().getWorkerCount());
             Assert.assertArrayEquals(new int[]{1, 2, 3, 4, 5, 6}, configuration.getHttpServerConfiguration().getWorkerAffinity());
             Assert.assertTrue(configuration.getHttpServerConfiguration().haltOnError());
-            Assert.assertEquals(128, configuration.getHttpServerConfiguration().getSendBufferSize());
+            Assert.assertEquals(128, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getSendBufferSize());
             Assert.assertEquals("index2.html", configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getIndexFileName());
             Assert.assertEquals(32, configuration.getHttpServerConfiguration().getQueryCacheRows());
             Assert.assertEquals(16, configuration.getHttpServerConfiguration().getQueryCacheBlocks());
 
-            Assert.assertTrue(configuration.getHttpServerConfiguration().readOnlySecurityContext());
+            Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
             Assert.assertEquals(50000, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());
-            Assert.assertFalse(configuration.getHttpServerConfiguration().isInterruptOnClosedConnection());
-            Assert.assertEquals(500, configuration.getHttpServerConfiguration().getInterruptorNIterationsPerCheck());
-            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getInterruptorBufferSize());
+            Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().isInterruptOnClosedConnection());
+            Assert.assertEquals(500, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorNIterationsPerCheck());
+            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorBufferSize());
 
             Assert.assertEquals(new File(configPath, "public_ok").getAbsolutePath(),
                     configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getPublicDirectory());
 
             Assert.assertEquals("Keep-Alive: timeout=10, max=50000" + Misc.EOL, configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getKeepAliveHeader());
-            Assert.assertTrue(configuration.getHttpServerConfiguration().allowDeflateBeforeSend());
+            Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().allowDeflateBeforeSend());
 
             Assert.assertEquals(64, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getActiveConnectionLimit());
             Assert.assertEquals(2048, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getEventCapacity());
@@ -553,8 +553,8 @@ public class PropServerConfigurationTest {
             Assert.assertTrue(configuration.getCairoConfiguration().getTelemetryConfiguration().getEnabled());
             Assert.assertEquals(512, configuration.getCairoConfiguration().getTelemetryConfiguration().getQueueCapacity());
 
-            Assert.assertFalse(configuration.getHttpServerConfiguration().getServerKeepAlive());
-            Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpVersion());
+            Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
+            Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
             Assert.assertEquals(33554432L, configuration.getCairoConfiguration().getAppendPageSize());
         }
     }

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -129,9 +129,9 @@ public class PropServerConfigurationTest {
 
         Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
         Assert.assertEquals(Long.MAX_VALUE, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());
-        Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().isInterruptOnClosedConnection());
-        Assert.assertEquals(2_000_000, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorNIterationsPerCheck());
-        Assert.assertEquals(64, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorBufferSize());
+        Assert.assertTrue(configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().isEnabled());
+        Assert.assertEquals(2_000_000, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().getCountOfIterationsPerCheck());
+        Assert.assertEquals(64, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().getBufferSize());
 
         Assert.assertEquals(CommitMode.NOSYNC, configuration.getCairoConfiguration().getCommitMode());
         Assert.assertEquals(2097152, configuration.getCairoConfiguration().getSqlCopyBufferSize());
@@ -422,9 +422,9 @@ public class PropServerConfigurationTest {
 
             Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
             Assert.assertEquals(50000, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());
-            Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().isInterruptOnClosedConnection());
-            Assert.assertEquals(500, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorNIterationsPerCheck());
-            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getInterruptorBufferSize());
+            Assert.assertFalse(configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().isEnabled());
+            Assert.assertEquals(500, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().getCountOfIterationsPerCheck());
+            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getInterruptorConfiguration().getBufferSize());
 
             Assert.assertEquals(new File(configPath, "public_ok").getAbsolutePath(),
                     configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getPublicDirectory());

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -32,6 +32,8 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cutlass.NetUtils;
 import io.questdb.cutlass.http.processors.*;
+import io.questdb.griffin.DefaultSqlInterruptorConfiguration;
+import io.questdb.griffin.SqlInterruptorConfiguration;
 import io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -5220,8 +5222,13 @@ public class IODispatcherTest {
         return new DefaultHttpServerConfiguration(
                 new DefaultHttpContextConfiguration() {
                     @Override
-                    public int getSendBufferSize() {
-                        return sendBufferSize;
+                    public boolean allowDeflateBeforeSend() {
+                        return allowDeflateBeforeSend;
+                    }
+
+                    @Override
+                    public MillisecondClock getClock() {
+                        return () -> 0;
                     }
 
                     @Override
@@ -5230,23 +5237,18 @@ public class IODispatcherTest {
                     }
 
                     @Override
-                    public boolean allowDeflateBeforeSend() {
-                        return allowDeflateBeforeSend;
-                    }
-
-                    @Override
-                    public boolean getServerKeepAlive() {
-                        return serverKeepAlive;
-                    }
-
-                    @Override
                     public String getHttpVersion() {
                         return httpProtocolVersion;
                     }
 
                     @Override
-                    public MillisecondClock getClock() {
-                        return () -> 0;
+                    public int getSendBufferSize() {
+                        return sendBufferSize;
+                    }
+
+                    @Override
+                    public boolean getServerKeepAlive() {
+                        return serverKeepAlive;
                     }
                 }
         ) {
@@ -5278,6 +5280,9 @@ public class IODispatcherTest {
             };
 
             private final JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new JsonQueryProcessorConfiguration() {
+
+                private final DefaultSqlInterruptorConfiguration sqlInterruptorConfiguration = new DefaultSqlInterruptorConfiguration();
+
                 @Override
                 public MillisecondClock getClock() {
                     return () -> 0;
@@ -5312,6 +5317,11 @@ public class IODispatcherTest {
                 public long getMaxQueryResponseRowLimit() {
                     return configuredMaxQueryResponseRowLimit;
                 }
+
+                @Override
+                public SqlInterruptorConfiguration getInterruptorConfiguration() {
+                    return sqlInterruptorConfiguration;
+                }
             };
 
             @Override
@@ -5320,13 +5330,13 @@ public class IODispatcherTest {
             }
 
             @Override
-            public StaticContentProcessorConfiguration getStaticContentProcessorConfiguration() {
-                return staticContentProcessorConfiguration;
+            public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
+                return jsonQueryProcessorConfiguration;
             }
 
             @Override
-            public JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration() {
-                return jsonQueryProcessorConfiguration;
+            public StaticContentProcessorConfiguration getStaticContentProcessorConfiguration() {
+                return staticContentProcessorConfiguration;
             }
         };
     }


### PR DESCRIPTION
- Refactored server-main to use list of objects that need to be released instead of having them as individual class members.
- Introduced min http server running on port 9003 are returning HTTP 200 to every request.
- I had to refactor configuration quite a lot so that min http server can be nicely configured
- I spotted that "interruptor" was part of HttpContext, which we have one instance per connection. This is excessive and I decided to move "interruptor" inside JsonProcessor and TextProcessor, which we have one instance per thread rather than connection. This also improved usage locality.
