### PR TITLE
When table lock not successful wait instead of failing the request

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -332,7 +332,7 @@ public class CairoEngine implements Closeable {
             }
         } else {
             LOG.error().$("cannot lock and rename [from='").$(tableName).$("', to='").$(newName).$("']").$();
-            throw CairoException.instance(0).put("Cannot lock [table=").put(tableName).put(']');
+            throw EntryUnavailableException.INSTANCE.put("Cannot lock [table=").put(tableName).put(']');
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/EntryUnavailableException.java
+++ b/core/src/main/java/io/questdb/cairo/EntryUnavailableException.java
@@ -22,9 +22,7 @@
  *
  ******************************************************************************/
 
-package io.questdb.cairo.pool.ex;
-
-import io.questdb.cairo.CairoException;
+package io.questdb.cairo;
 
 public class EntryUnavailableException extends CairoException {
     public static final EntryUnavailableException INSTANCE;

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -28,7 +28,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.pool.ex.EntryLockedException;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -27,7 +27,7 @@ package io.questdb.cairo.pool;
 import io.questdb.MessageBus;
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.ex.EntryLockedException;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -34,7 +34,7 @@ import io.questdb.Telemetry;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoError;
 import io.questdb.cairo.CairoException;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cutlass.http.ex.RetryOperationException;
 import io.questdb.cairo.sql.InsertMethod;
 import io.questdb.cairo.sql.InsertStatement;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -25,7 +25,7 @@
 package io.questdb.cutlass.http.processors;
 
 import io.questdb.cairo.*;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.cutlass.http.*;
 import io.questdb.cutlass.http.ex.RetryOperationException;

--- a/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
@@ -26,7 +26,7 @@ package io.questdb.cairo.pool;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.ex.EntryLockedException;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;

--- a/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
@@ -26,7 +26,7 @@ package io.questdb.cairo.pool;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.ex.EntryLockedException;
-import io.questdb.cairo.pool.ex.EntryUnavailableException;
+import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.std.Chars;
 import io.questdb.std.FilesFacade;


### PR DESCRIPTION
Throw EntryUnavailableException so that the operation to be retried, similarly as writing is retried.
Move EntryUnavailableException up on cairo package level.