### PR TITLE
fix(std/IntList): avoid a complete scan of the list in the binarySearch

### DIFF
--- a/core/src/main/java/io/questdb/std/DirectLongList.java
+++ b/core/src/main/java/io/questdb/std/DirectLongList.java
@@ -72,7 +72,7 @@ public class DirectLongList implements Mutable, Closeable {
         while (low <= high) {
 
             if (high - low < 65) {
-                return scanSearch(v);
+                return scanSearch(v, low, high);
             }
 
             int mid = (low + high) >>> 1;
@@ -109,9 +109,8 @@ public class DirectLongList implements Mutable, Closeable {
         return Unsafe.getUnsafe().getLong(start + (p << 3));
     }
 
-    public int scanSearch(long v) {
-        int sz = size();
-        for (int i = 0; i < sz; i++) {
+    public int scanSearch(long v, int low, int high) {
+        for (int i = low; i < high; i++) {
             long f = get(i);
             if (f == v) {
                 return i;
@@ -120,7 +119,7 @@ public class DirectLongList implements Mutable, Closeable {
                 return -(i + 1);
             }
         }
-        return -(sz + 1);
+        return -(high + 1);
     }
 
     public void set(long p, long v) {

--- a/core/src/main/java/io/questdb/std/IntList.java
+++ b/core/src/main/java/io/questdb/std/IntList.java
@@ -65,7 +65,7 @@ public class IntList implements Mutable {
         while (low < high) {
 
             if (high - low < 65) {
-                return scanSearch(v);
+                return scanSearch(v, low, high);
             }
 
             int mid = (low + high - 1) >>> 1;
@@ -268,9 +268,8 @@ public class IntList implements Mutable {
         return true;
     }
 
-    private int scanSearch(int v) {
-        int sz = size();
-        for (int i = 0; i < sz; i++) {
+    private int scanSearch(int v, int low, int high) {
+        for (int i = low; i < high; i++) {
             long f = getQuick(i);
             if (f == v) {
                 return i;
@@ -279,7 +278,7 @@ public class IntList implements Mutable {
                 return -(i + 1);
             }
         }
-        return -(sz + 1);
+        return -(high + 1);
     }
 
 }

--- a/core/src/test/java/io/questdb/std/IntListTest.java
+++ b/core/src/test/java/io/questdb/std/IntListTest.java
@@ -41,5 +41,6 @@ public class IntListTest {
         Assert.assertEquals(-66, list.binarySearch(70));
         Assert.assertEquals(65, list.binarySearch(76));
         Assert.assertEquals(-67, list.binarySearch(950));
+        Assert.assertEquals(-70, list.binarySearch(2500));
     }
 }


### PR DESCRIPTION
## What?

When the `binarySearch` function reaches a range smaller than 65 elements, the function `scanSearch` is called to scan sequentially the elements which is fast than continuing the binary search.

But the scanSearch doesn't take in account the current range considered `[low, high[` and completely scan the list which defeats the purpose of the binary search algorithm.