### PR TITLE
feat(griffin): timestamp comparison operators

### DIFF
--- a/core/src/main/java/io/questdb/griffin/FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactory.java
@@ -67,6 +67,8 @@ public interface FunctionFactory {
 
     default boolean isCursor() { return false; }
 
+    default boolean isBoolean() { return false; }
+
     Function newInstance(
             @Transient ObjList<Function> args,
             int position,

--- a/core/src/main/java/io/questdb/griffin/FunctionFactoryCache.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactoryCache.java
@@ -69,7 +69,7 @@ public class FunctionFactoryCache {
                                 FunctionFactory greaterThan = createSwappingFactory(">", factory);
                                 // `a < b` == `b > a`
                                 addFactoryToList(factories, greaterThan);
-                                // `b > a` == `b <= a`
+                                // `b > a` == !(`b <= a`)
                                 addFactoryToList(factories, createNegatingFactory("<=", greaterThan));
                                 break;
                         }

--- a/core/src/main/java/io/questdb/griffin/FunctionFactoryCache.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactoryCache.java
@@ -25,6 +25,8 @@
 package io.questdb.griffin;
 
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.griffin.engine.functions.NegatingFunctionFactory;
+import io.questdb.griffin.engine.functions.SwappingArgsFunctionFactory;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.*;
@@ -35,8 +37,6 @@ public class FunctionFactoryCache {
     static final CharSequenceHashSet invalidFunctionNames = new CharSequenceHashSet();
     private static final Log LOG = LogFactory.getLog(FunctionFactoryCache.class);
     private final CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> factories = new CharSequenceObjHashMap<>();
-    private final CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> booleanFactories = new CharSequenceObjHashMap<>();
-    private final CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> commutativeBooleanFactories = new CharSequenceObjHashMap<>();
     private final CharSequenceHashSet groupByFunctionNames = new CharSequenceHashSet();
     private final CharSequenceHashSet cursorFunctionNames = new CharSequenceHashSet();
 
@@ -48,25 +48,29 @@ public class FunctionFactoryCache {
                 try {
                     final FunctionFactoryDescriptor descriptor = new FunctionFactoryDescriptor(factory);
                     final String name = descriptor.getName();
-                    addFactoryToList(factories, name, descriptor);
+                    addFactoryToList(factories, descriptor);
 
                     // Add != counterparts to equality function factories
-                    if (factory instanceof AbstractBooleanFunctionFactory) {
+                    if (factory.isBoolean()) {
                         switch (name) {
                             case "=":
-                                addFactory(booleanFactories, "!=", descriptor);
-                                addFactory(booleanFactories, "<>", descriptor);
+                                addFactoryToList(factories, createNegatingFactory("!=", factory));
+                                addFactoryToList(factories, createNegatingFactory("<>", factory));
+                                if (descriptor.getArgTypeMask(0) != descriptor.getArgTypeMask(1)) {
+                                    FunctionFactory swappingFactory = createSwappingFactory("=", factory);
+                                    addFactoryToList(factories, swappingFactory);
+                                    addFactoryToList(factories, createNegatingFactory("!=", swappingFactory));
+                                    addFactoryToList(factories, createNegatingFactory("<>", swappingFactory));
+                                }
                                 break;
                             case "<":
                                 // `a < b` == `a >= b`
-                                addFactory(booleanFactories, ">=", descriptor);
-                                if (descriptor.getArgTypeMask(0) == descriptor.getArgTypeMask(1)) {
-                                    // `a < b` == `b > a`
-                                    addFactory(commutativeBooleanFactories, ">", descriptor);
-                                    // `a < b` == `b > a` == `b <= a`
-                                    addFactory(booleanFactories, "<=", descriptor);
-                                    addFactory(commutativeBooleanFactories, "<=", descriptor);
-                                }
+                                addFactoryToList(factories, createNegatingFactory(">=", factory));
+                                FunctionFactory greaterThan = createSwappingFactory(">", factory);
+                                // `a < b` == `b > a`
+                                addFactoryToList(factories, greaterThan);
+                                // `b > a` == `b <= a`
+                                addFactoryToList(factories, createNegatingFactory("<=", greaterThan));
                                 break;
                         }
                     } else if (factory.isGroupBy()) {
@@ -81,6 +85,14 @@ public class FunctionFactoryCache {
         }
     }
 
+    private FunctionFactory createNegatingFactory(String name, FunctionFactory factory) throws SqlException {
+        return new NegatingFunctionFactory(name, factory);
+    }
+
+    private FunctionFactory createSwappingFactory(String name, FunctionFactory factory) throws SqlException {
+        return new SwappingArgsFunctionFactory(name, factory);
+    }
+
     public ObjList<FunctionFactoryDescriptor> getOverloadList(CharSequence token) {
         return factories.get(token);
     }
@@ -89,25 +101,16 @@ public class FunctionFactoryCache {
         return cursorFunctionNames.contains(name);
     }
 
-    public boolean isFlipped(CharSequence token) {
-        return commutativeBooleanFactories.get(token) != null;
-    }
-
     public boolean isGroupBy(CharSequence name) {
         return groupByFunctionNames.contains(name);
     }
 
-    public boolean isNegated(CharSequence token) {
-        return booleanFactories.keyIndex(token) < 0;
+    private void addFactoryToList(CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> list, FunctionFactory factory) throws SqlException {
+        addFactoryToList(list, new FunctionFactoryDescriptor(factory));
     }
 
-    // Add a descriptor to `factories` and optionally `extraList`
-    private void addFactory(CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> extraList, String name, FunctionFactoryDescriptor descriptor) {
-        addFactoryToList(factories, name, descriptor);
-        addFactoryToList(extraList, name, descriptor);
-    }
-
-    private void addFactoryToList(CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> list, String name, FunctionFactoryDescriptor descriptor) {
+    private void addFactoryToList(CharSequenceObjHashMap<ObjList<FunctionFactoryDescriptor>> list, FunctionFactoryDescriptor descriptor) {
+        String name = descriptor.getName();
         int index = list.keyIndex(name);
         ObjList<FunctionFactoryDescriptor> overload;
         if (index < 0) {

--- a/core/src/main/java/io/questdb/griffin/FunctionFactoryDescriptor.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactoryDescriptor.java
@@ -196,6 +196,27 @@ public class FunctionFactoryDescriptor {
         return openBraceIndex;
     }
 
+    public static String createSignatureWithSwappedArgs(String name, String signature) throws SqlException {
+        int openBraceIndex = validateSignatureAndGetNameSeparator(signature);
+        StringBuilder signatureBuilder = new StringBuilder(name);
+        signatureBuilder.append('(');
+        for (int i = signature.length() - 2; i > openBraceIndex; i--) {
+            char curr = signature.charAt(i);
+            if (curr == '[') {
+                signatureBuilder.append("[]");
+            } else if (curr != ']') {
+                signatureBuilder.append(curr);
+            }
+        }
+        signatureBuilder.append(')');
+        return signatureBuilder.toString();
+    }
+
+    public static String createSignature(String name, String signature) throws SqlException {
+        int openBraceIndex = validateSignatureAndGetNameSeparator(signature);
+        return name + signature.substring(openBraceIndex);
+    }
+
     public int getArgTypeMask(int index) {
         int arrayIndex = index / 2;
         long mask = argTypes[arrayIndex];

--- a/core/src/main/java/io/questdb/griffin/FunctionFactoryDescriptor.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactoryDescriptor.java
@@ -25,6 +25,8 @@
 package io.questdb.griffin;
 
 import io.questdb.cairo.ColumnType;
+import io.questdb.std.Misc;
+import io.questdb.std.str.StringSink;
 
 public class FunctionFactoryDescriptor {
     private static final int ARRAY_MASK = 1 << 31;
@@ -196,25 +198,29 @@ public class FunctionFactoryDescriptor {
         return openBraceIndex;
     }
 
-    public static String createSignatureWithSwappedArgs(String name, String signature) throws SqlException {
+    public static String replaceSignatureNameAndSwapArgs(String name, String signature) throws SqlException {
         int openBraceIndex = validateSignatureAndGetNameSeparator(signature);
-        StringBuilder signatureBuilder = new StringBuilder(name);
-        signatureBuilder.append('(');
+        StringSink signatureBuilder = Misc.getThreadLocalBuilder();
+        signatureBuilder.put(name);
+        signatureBuilder.put('(');
         for (int i = signature.length() - 2; i > openBraceIndex; i--) {
             char curr = signature.charAt(i);
             if (curr == '[') {
-                signatureBuilder.append("[]");
+                signatureBuilder.put("[]");
             } else if (curr != ']') {
-                signatureBuilder.append(curr);
+                signatureBuilder.put(curr);
             }
         }
-        signatureBuilder.append(')');
+        signatureBuilder.put(')');
         return signatureBuilder.toString();
     }
 
-    public static String createSignature(String name, String signature) throws SqlException {
+    public static String replaceSignatureName(String name, String signature) throws SqlException {
         int openBraceIndex = validateSignatureAndGetNameSeparator(signature);
-        return name + signature.substring(openBraceIndex);
+        StringSink signatureBuilder = Misc.getThreadLocalBuilder();
+        signatureBuilder.put(name);
+        signatureBuilder.put(signature, openBraceIndex, signature.length());
+        return signatureBuilder.toString();
     }
 
     public int getArgTypeMask(int index) {

--- a/core/src/main/java/io/questdb/griffin/FunctionParser.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionParser.java
@@ -349,20 +349,10 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor {
             FunctionFactory factory,
             @Transient ObjList<Function> args,
             int position,
-            CairoConfiguration configuration,
-            boolean isNegated,
-            boolean isFlipped
+            CairoConfiguration configuration
     ) throws SqlException {
         Function function;
         try {
-            if (factory instanceof AbstractBooleanFunctionFactory) {
-                ((AbstractBooleanFunctionFactory) factory).setNegated(isNegated);
-            }
-            if (isFlipped) {
-                Function tmp = args.getQuick(0);
-                args.setQuick(0, args.getQuick(1));
-                args.setQuick(1, tmp);
-            }
             function = factory.newInstance(args, position, configuration, sqlExecutionContext);
         } catch (SqlException e) {
             throw e;
@@ -455,8 +445,6 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor {
 
     private Function createFunction(ExpressionNode node, @Transient ObjList<Function> args) throws SqlException {
         final ObjList<FunctionFactoryDescriptor> overload = functionFactoryCache.getOverloadList(node.token);
-        boolean isNegated = functionFactoryCache.isNegated(node.token);
-        boolean isFlipped = functionFactoryCache.isFlipped(node.token);
         if (overload == null) {
             throw invalidFunction(node, args);
         }
@@ -512,7 +500,7 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor {
 
             if (argCount == 0 && sigArgCount == 0) {
                 // this is no-arg function, match right away
-                return checkAndCreateFunction(factory, args, node.position, configuration, isNegated, isFlipped);
+                return checkAndCreateFunction(factory, args, node.position, configuration);
             }
 
             // otherwise, is number of arguments the same?
@@ -664,7 +652,7 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor {
         }
 
         LOG.debug().$("call ").$(node).$(" -> ").$(candidate.getSignature()).$();
-        return checkAndCreateFunction(candidate, args, node.position, configuration, isNegated, isFlipped);
+        return checkAndCreateFunction(candidate, args, node.position, configuration);
     }
 
     private Function functionToConstant(Function function) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/NegatableBooleanFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/NegatableBooleanFunction.java
@@ -22,12 +22,16 @@
  *
  ******************************************************************************/
 
-package io.questdb.griffin;
+package io.questdb.griffin.engine.functions;
 
-public abstract class AbstractBooleanFunctionFactory {
-    protected boolean isNegated = false;
+public abstract class NegatableBooleanFunction extends BooleanFunction {
+    protected boolean negated = false;
 
-    public void setNegated(boolean isNegated) {
-        this.isNegated = isNegated;
+    public NegatableBooleanFunction(int position) {
+        super(position);
+    }
+
+    void setNegated(boolean negated) {
+        this.negated = negated;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.ObjList;
+
+import static io.questdb.griffin.FunctionFactoryDescriptor.createSignature;
+
+public class NegatingFunctionFactory implements FunctionFactory {
+    private final String signature;
+    private final FunctionFactory delegate;
+
+    public NegatingFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
+        this.signature = createSignature(name, delegate.getSignature());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getSignature() {
+        return signature;
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function function = delegate.newInstance(args, position, configuration, sqlExecutionContext);
+        if (function instanceof NegatableBooleanFunction) {
+            NegatableBooleanFunction negateableFunction = (NegatableBooleanFunction) function;
+            negateableFunction.setNegated(true);
+        }
+        return function;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
@@ -31,14 +31,14 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.ObjList;
 
-import static io.questdb.griffin.FunctionFactoryDescriptor.createSignature;
+import static io.questdb.griffin.FunctionFactoryDescriptor.replaceSignatureName;
 
 public class NegatingFunctionFactory implements FunctionFactory {
     private final String signature;
     private final FunctionFactory delegate;
 
     public NegatingFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
-        this.signature = createSignature(name, delegate.getSignature());
+        this.signature = replaceSignatureName(name, delegate.getSignature());
         this.delegate = delegate;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
@@ -31,14 +31,14 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.ObjList;
 
-import static io.questdb.griffin.FunctionFactoryDescriptor.createSignatureWithSwappedArgs;
+import static io.questdb.griffin.FunctionFactoryDescriptor.replaceSignatureNameAndSwapArgs;
 
 public class SwappingArgsFunctionFactory implements FunctionFactory {
     private final String signature;
     private final FunctionFactory delegate;
 
     public SwappingArgsFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
-        this.signature = createSignatureWithSwappedArgs(name, delegate.getSignature());
+        this.signature = replaceSignatureNameAndSwapArgs(name, delegate.getSignature());
         this.delegate = delegate;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.ObjList;
+
+import static io.questdb.griffin.FunctionFactoryDescriptor.createSignatureWithSwappedArgs;
+
+public class SwappingArgsFunctionFactory implements FunctionFactory {
+    private final String signature;
+    private final FunctionFactory delegate;
+
+    public SwappingArgsFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
+        this.signature = createSignatureWithSwappedArgs(name, delegate.getSignature());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getSignature() {
+        return signature;
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function tmp = args.getQuick(0);
+        args.setQuick(0, args.getQuick(1));
+        args.setQuick(1, tmp);
+        return delegate.newInstance(args, position, configuration, sqlExecutionContext);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqCharCharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqCharCharFunctionFactory.java
@@ -27,17 +27,21 @@ package io.questdb.griffin.engine.functions.eq;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.std.ObjList;
 
-public class EqCharCharFunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class EqCharCharFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "=(AA)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
     }
 
     @Override
@@ -50,19 +54,17 @@ public class EqCharCharFunctionFactory extends AbstractBooleanFunctionFactory im
         Function chrFunc1 = args.getQuick(0);
         Function chrFunc2 = args.getQuick(1);
 
-        return new Func(position, chrFunc1, chrFunc2, isNegated);
+        return new Func(position, chrFunc1, chrFunc2);
     }
 
-    private static class Func extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
         private final Function chrFunc1;
         private final Function chrFunc2;
 
-        public Func(int position, Function chrFunc1, Function chrFunc2, boolean isNegated) {
+        public Func(int position, Function chrFunc1, Function chrFunc2) {
             super(position);
             this.chrFunc1 = chrFunc1;
             this.chrFunc2 = chrFunc2;
-            this.isNegated = isNegated;
         }
 
         @Override
@@ -77,7 +79,7 @@ public class EqCharCharFunctionFactory extends AbstractBooleanFunctionFactory im
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != (chrFunc1.getChar(rec) == chrFunc2.getChar(rec));
+            return negated != (chrFunc1.getChar(rec) == chrFunc2.getChar(rec));
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIntFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIntFunctionFactory.java
@@ -27,39 +27,41 @@ package io.questdb.griffin.engine.functions.eq;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.std.ObjList;
 
-public class EqIntFunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class EqIntFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "=(II)";
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        return new Func(position, args.getQuick(0), args.getQuick(1), isNegated);
+    public boolean isBoolean() {
+        return true;
     }
 
-    private static class Func extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new Func(position, args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
         private final Function left;
         private final Function right;
 
-        public Func(int position, Function left, Function right, boolean isNegated) {
+        public Func(int position, Function left, Function right) {
             super(position);
             this.left = left;
             this.right = right;
-            this.isNegated = isNegated;
         }
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != (left.getInt(rec) == right.getInt(rec));
+            return negated != (left.getInt(rec) == right.getInt(rec));
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqLong256FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqLong256FunctionFactory.java
@@ -27,15 +27,14 @@ package io.questdb.griffin.engine.functions.eq;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.std.Long256;
 import io.questdb.std.ObjList;
 
-public class EqLong256FunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class EqLong256FunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "=(HH)";
@@ -43,26 +42,24 @@ public class EqLong256FunctionFactory extends AbstractBooleanFunctionFactory imp
 
     @Override
     public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        return new Func(position, args.getQuick(0), args.getQuick(1), isNegated);
+        return new Func(position, args.getQuick(0), args.getQuick(1));
     }
 
-    private static class Func extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
         private final Function left;
         private final Function right;
 
-        public Func(int position, Function left, Function right, boolean isNegated) {
+        public Func(int position, Function left, Function right) {
             super(position);
             this.left = left;
             this.right = right;
-            this.isNegated = isNegated;
         }
 
         @Override
         public boolean getBool(Record rec) {
             final Long256 lv = left.getLong256A(rec);
             final Long256 rv = right.getLong256A(rec);
-            return isNegated != lv.equals(rv);
+            return negated != lv.equals(rv);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqLongFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqLongFunctionFactory.java
@@ -27,39 +27,41 @@ package io.questdb.griffin.engine.functions.eq;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.std.ObjList;
 
-public class EqLongFunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class EqLongFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "=(LL)";
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        return new Func(position, args.getQuick(0), args.getQuick(1), isNegated);
+    public boolean isBoolean() {
+        return true;
     }
 
-    private static class Func extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new Func(position, args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
         private final Function left;
         private final Function right;
 
-        public Func(int position, Function left, Function right, boolean isNegated) {
+        public Func(int position, Function left, Function right) {
             super(position);
             this.left = left;
             this.right = right;
-            this.isNegated = isNegated;
         }
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != (left.getLong(rec) == right.getLong(rec));
+            return negated != (left.getLong(rec) == right.getLong(rec));
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymCharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymCharFunctionFactory.java
@@ -29,21 +29,25 @@ import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.SymbolTableSource;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.std.Chars;
 import io.questdb.std.ObjList;
 import io.questdb.std.str.SingleCharCharSequence;
 
-public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class EqSymCharFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "=(KA)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
     }
 
     @Override
@@ -62,25 +66,23 @@ public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory imp
         if (chrFunc.isConstant()) {
             final char constValue = chrFunc.getChar(null);
             if (symFunc.getStaticSymbolTable() != null) {
-                return new ConstCheckColumnFunc(position, symFunc, constValue, isNegated);
+                return new ConstCheckColumnFunc(position, symFunc, constValue);
             } else {
-                return new ConstCheckFunc(position, symFunc, constValue, isNegated);
+                return new ConstCheckFunc(position, symFunc, constValue);
             }
         }
 
-        return new Func(position, symFunc, chrFunc, isNegated);
+        return new Func(position, symFunc, chrFunc);
     }
 
-    private static class ConstCheckFunc extends BooleanFunction implements UnaryFunction {
-        private final boolean isNegated;
+    private static class ConstCheckFunc extends NegatableBooleanFunction implements UnaryFunction {
         private final Function arg;
         private final char constant;
 
-        public ConstCheckFunc(int position, Function arg, char constant, boolean isNegated) {
+        public ConstCheckFunc(int position, Function arg, char constant) {
             super(position);
             this.arg = arg;
             this.constant = constant;
-            this.isNegated = isNegated;
         }
 
         @Override
@@ -90,21 +92,19 @@ public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory imp
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != Chars.equalsNc(arg.getSymbol(rec), constant);
+            return negated != Chars.equalsNc(arg.getSymbol(rec), constant);
         }
     }
 
-    private static class ConstCheckColumnFunc extends BooleanFunction implements UnaryFunction {
-        private final boolean isNegated;
+    private static class ConstCheckColumnFunc extends NegatableBooleanFunction implements UnaryFunction {
         private final SymbolFunction arg;
         private final char constant;
         private int valueIndex;
 
-        public ConstCheckColumnFunc(int position, SymbolFunction arg, char constant, boolean isNegated) {
+        public ConstCheckColumnFunc(int position, SymbolFunction arg, char constant) {
             super(position);
             this.arg = arg;
             this.constant = constant;
-            this.isNegated = isNegated;
         }
 
         @Override
@@ -114,7 +114,7 @@ public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory imp
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != (arg.getInt(rec) == valueIndex);
+            return negated != (arg.getInt(rec) == valueIndex);
         }
 
         @Override
@@ -126,16 +126,14 @@ public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory imp
         }
     }
 
-    private static class Func extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
         private final Function symFunc;
         private final Function chrFunc;
 
-        public Func(int position, Function symFunc, Function chrFunc, boolean isNegated) {
+        public Func(int position, Function symFunc, Function chrFunc) {
             super(position);
             this.symFunc = symFunc;
             this.chrFunc = chrFunc;
-            this.isNegated = isNegated;
         }
 
         @Override
@@ -150,7 +148,7 @@ public class EqSymCharFunctionFactory extends AbstractBooleanFunctionFactory imp
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated != Chars.equalsNc(symFunc.getSymbol(rec), chrFunc.getChar(rec));
+            return negated != Chars.equalsNc(symFunc.getSymbol(rec), chrFunc.getChar(rec));
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqTimestampStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqTimestampStrFunctionFactory.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.eq;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.model.IntervalOperation;
+import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.std.LongList;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.TIMESTAMP_FORMAT_MIN_LENGTH;
+
+public class EqTimestampStrFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "=(NS)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function rightFn = args.getQuick(1);
+        if (rightFn.isConstant()) {
+            try {
+                return new EqTimestampStrConstantFunction(position, args.getQuick(0), rightFn.getStr(null));
+            } catch (NumericException e) {
+                throw SqlException.$(position, "could not parse timestamp [value='").put(rightFn.getStr(null)).put("']");
+            }
+        }
+        return new EqTimestampStrFunction(position, args.getQuick(0), rightFn);
+    }
+
+    private static class EqTimestampStrConstantFunction extends NegatableBooleanFunction implements UnaryFunction {
+        private final Function left;
+        private final long beginning;
+        private final long end;
+
+        public EqTimestampStrConstantFunction(int position, Function left, CharSequence right) throws NumericException {
+            super(position);
+            this.left = left;
+            if (right.length() >= TIMESTAMP_FORMAT_MIN_LENGTH) {
+                beginning = end = TimestampFormatUtils.parseTimestamp(right);
+            } else {
+                LongList out = new LongList();
+                IntervalUtils.parseInterval(right, 0, right.length(), IntervalOperation.INTERSECT, out);
+                beginning = IntervalUtils.getEncodedPeriodLo(out, 0);
+                end = IntervalUtils.getEncodedPeriodHi(out, 0);
+            }
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated != isTimestampInRange(left.getTimestamp(rec), beginning, end);
+        }
+
+        @Override
+        public Function getArg() {
+            return left;
+        }
+    }
+
+    private static class EqTimestampStrFunction extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function left;
+        private final Function right;
+        private final LongList intervals = new LongList();
+
+        public EqTimestampStrFunction(int position, Function left, Function right) {
+            super(position);
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            CharSequence timestampAsString = right.getStr(rec);
+            try {
+                intervals.clear();
+                long beginning;
+                long end;
+                if (timestampAsString.length() >= TIMESTAMP_FORMAT_MIN_LENGTH) {
+                    beginning = end = TimestampFormatUtils.parseTimestamp(timestampAsString);
+                } else {
+                    IntervalUtils.parseInterval(timestampAsString, 0, timestampAsString.length(), IntervalOperation.INTERSECT, intervals);
+                    beginning = IntervalUtils.getEncodedPeriodLo(intervals, 0);
+                    end = IntervalUtils.getEncodedPeriodHi(intervals, 0);
+                }
+                return negated != isTimestampInRange(left.getTimestamp(rec), beginning, end);
+            } catch (NumericException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public Function getLeft() {
+            return left;
+        }
+
+        @Override
+        public Function getRight() {
+            return right;
+        }
+    }
+
+    private static boolean isTimestampInRange(long timestamp, long begin, long end) {
+        return timestamp >= begin && timestamp <= end;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtDoubleVVFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtDoubleVVFunctionFactory.java
@@ -27,39 +27,42 @@ package io.questdb.griffin.engine.functions.lt;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.AbstractBooleanFunctionFactory;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
 import io.questdb.std.ObjList;
 
-public class LtDoubleVVFunctionFactory extends AbstractBooleanFunctionFactory implements FunctionFactory {
+public class LtDoubleVVFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "<(DD)";
     }
 
     @Override
-    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        return new FuncVV(position, args.getQuick(0), args.getQuick(1), isNegated);
+    public boolean isBoolean() {
+        return true;
     }
 
-    private static class FuncVV extends BooleanFunction implements BinaryFunction {
-        private final boolean isNegated;
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new FuncVV(position, args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class FuncVV extends NegatableBooleanFunction implements BinaryFunction {
         private final Function left;
         private final Function right;
 
-        public FuncVV(int position, Function left, Function right, boolean isNegated) {
+        public FuncVV(int position, Function left, Function right) {
             super(position);
             this.left = left;
             this.right = right;
-            this.isNegated = isNegated;
         }
 
         @Override
         public boolean getBool(Record rec) {
-            return isNegated
+            return negated
                     ? left.getDouble(rec) >= right.getDouble(rec)
                     : left.getDouble(rec) < right.getDouble(rec);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrTimestampFunctionFactory.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.TIMESTAMP_FORMAT_MIN_LENGTH;
+
+public class LtStrTimestampFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "<(SN)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function leftFn = args.getQuick(0);
+        if (leftFn.isConstant()) {
+            try {
+                long leftTimestamp = parseFullOrPartialTimestamp(leftFn.getStr(null));
+                return new LtStrConstantTimestampFunction(position, leftTimestamp, args.getQuick(1));
+            } catch (NumericException e) {
+                throw SqlException.$(position, "could not parse timestamp [value='").put(leftFn.getStr(null)).put("']");
+            }
+        }
+        return new LtStrTimestampFunction(position, leftFn, args.getQuick(1));
+    }
+
+    private static long parseFullOrPartialTimestamp(CharSequence seq) throws NumericException {
+        if (seq.length() >= TIMESTAMP_FORMAT_MIN_LENGTH) {
+            return TimestampFormatUtils.parseTimestamp(seq);
+        } else {
+            return IntervalUtils.parseCCPartialDate(seq) - 1;
+        }
+    }
+
+    private static class LtStrConstantTimestampFunction extends NegatableBooleanFunction implements UnaryFunction {
+        private final long left;
+        private final Function right;
+
+        public LtStrConstantTimestampFunction(int position, long left, Function right) {
+            super(position);
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated
+                    ? left >= right.getTimestamp(rec)
+                    : left < right.getTimestamp(rec);
+        }
+
+        @Override
+        public Function getArg() {
+            return right;
+        }
+    }
+
+    private static class LtStrTimestampFunction extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function left;
+        private final Function right;
+
+        public LtStrTimestampFunction(int position, Function left, Function right) {
+            super(position);
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            CharSequence timestampAsString = left.getStr(rec);
+            try {
+                long leftTimestamp = parseFullOrPartialTimestamp(timestampAsString);
+                return negated
+                        ? leftTimestamp >= right.getTimestamp(rec)
+                        : leftTimestamp < right.getTimestamp(rec);
+            } catch (NumericException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public Function getLeft() {
+            return left;
+        }
+
+        @Override
+        public Function getRight() {
+            return right;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtTimestampFunctionFactory.java
@@ -22,24 +22,22 @@
  *
  ******************************************************************************/
 
-package io.questdb.griffin.engine.functions.eq;
+package io.questdb.griffin.engine.functions.lt;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
-import io.questdb.griffin.engine.functions.UnaryFunction;
-import io.questdb.griffin.engine.functions.constants.ConstantFunction;
-import io.questdb.std.Numbers;
-import io.questdb.std.NumericException;
 import io.questdb.std.ObjList;
 
-public class EqIntStrCFunctionFactory implements FunctionFactory {
+public class LtTimestampFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
-        return "=(Is)";
+        return "<(NN)";
     }
 
     @Override
@@ -49,47 +47,34 @@ public class EqIntStrCFunctionFactory implements FunctionFactory {
 
     @Override
     public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        try {
-            final CharSequence value = args.getQuick(1).getStr(null);
-            if (value == null) {
-                return new Func(position, args.getQuick(0), Numbers.INT_NaN);
-            }
-            return new Func(position, args.getQuick(0), Numbers.parseInt(value));
-        } catch (NumericException e) {
-            return new NegatedAwareBooleanConstantFunc(args.getQuick(1).getPosition());
-        }
+        return new LtTimestampFunction(position, args.getQuick(0), args.getQuick(1));
     }
 
-    private static class Func extends NegatableBooleanFunction implements UnaryFunction {
+    private static class LtTimestampFunction extends NegatableBooleanFunction implements BinaryFunction {
         private final Function left;
-        private final int right;
+        private final Function right;
 
-        public Func(int position, Function left, int right) {
+        public LtTimestampFunction(int position, Function left, Function right) {
             super(position);
             this.left = left;
             this.right = right;
         }
 
         @Override
-        public Function getArg() {
+        public boolean getBool(Record rec) {
+            return negated
+                    ? left.getTimestamp(rec) >= right.getTimestamp(rec)
+                    : left.getTimestamp(rec) < right.getTimestamp(rec);
+        }
+
+        @Override
+        public Function getLeft() {
             return left;
         }
 
         @Override
-        public boolean getBool(Record rec) {
-            return negated != (left.getInt(rec) == right);
-        }
-    }
-
-    private static class NegatedAwareBooleanConstantFunc extends NegatableBooleanFunction implements ConstantFunction {
-
-        public NegatedAwareBooleanConstantFunc(int position) {
-            super(position);
-        }
-
-        @Override
-        public boolean getBool(Record rec) {
-            return negated;
+        public Function getRight() {
+            return right;
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtTimestampStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtTimestampStrFunctionFactory.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.TIMESTAMP_FORMAT_MIN_LENGTH;
+
+public class LtTimestampStrFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "<(NS)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function rightFn = args.getQuick(1);
+        if (rightFn.isConstant()) {
+            try {
+                long rightTimestamp = parseFullOrPartialTimestamp(rightFn.getStr(null));
+                return new LtTimestampStrConstantFunction(position, args.getQuick(0), rightTimestamp);
+            } catch (NumericException e) {
+                throw SqlException.$(position, "could not parse timestamp [value='").put(rightFn.getStr(null)).put("']");
+            }
+        }
+        return new LtTimestampStrFunction(position, args.getQuick(0), rightFn);
+    }
+
+    private static long parseFullOrPartialTimestamp(CharSequence seq) throws NumericException {
+        if (seq.length() >= TIMESTAMP_FORMAT_MIN_LENGTH) {
+            return TimestampFormatUtils.parseTimestamp(seq);
+        } else {
+            return IntervalUtils.parseFloorPartialDate(seq);
+        }
+    }
+
+    private static class LtTimestampStrConstantFunction extends NegatableBooleanFunction implements UnaryFunction {
+        private final Function left;
+        private final long right;
+
+        public LtTimestampStrConstantFunction(int position, Function left, long right) {
+            super(position);
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated
+                    ? left.getTimestamp(rec) >= right
+                    : left.getTimestamp(rec) < right;
+        }
+
+        @Override
+        public Function getArg() {
+            return left;
+        }
+    }
+
+    private static class LtTimestampStrFunction extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function left;
+        private final Function right;
+
+        public LtTimestampStrFunction(int position, Function left, Function right) {
+            super(position);
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            CharSequence timestampAsString = right.getStr(rec);
+            try {
+                long rightTimestamp = parseFullOrPartialTimestamp(timestampAsString);
+                return negated
+                        ? left.getTimestamp(rec) >= rightTimestamp
+                        : left.getTimestamp(rec) < rightTimestamp;
+            } catch (NumericException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public Function getLeft() {
+            return left;
+        }
+
+        @Override
+        public Function getRight() {
+            return right;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -673,7 +673,7 @@ public final class IntervalUtils {
         replaceHiLoInterval(lo, hi, 0, (char) 0, 1, operation, out);
     }
 
-    static void parseInterval(CharSequence seq, int pos, int lim, short operation, LongList out) throws NumericException {
+    public static void parseInterval(CharSequence seq, int pos, int lim, short operation, LongList out) throws NumericException {
         if (lim - pos < 4) {
             throw NumericException.INSTANCE;
         }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
@@ -24,10 +24,7 @@
 
 package io.questdb.std.datetime.microtime;
 
-import io.questdb.std.Chars;
-import io.questdb.std.Numbers;
-import io.questdb.std.NumericException;
-import io.questdb.std.Os;
+import io.questdb.std.*;
 import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.DateLocaleFactory;
@@ -53,6 +50,12 @@ public class TimestampFormatUtils {
 
     public static final String UTC_PATTERN = "yyyy-MM-ddTHH:mm:ss.SSSz";
     public static final DateLocale enLocale = DateLocaleFactory.INSTANCE.getLocale("en");
+    public static final int TIMESTAMP_FORMAT_MIN_LENGTH;
+    private static final String PG_TIMESTAMP_MILLI_TIME_Z_PATTERN = "y-MM-dd HH:mm:ss.SSSz";
+    private static final String GREEDY_MILLIS1_UTC_PATTERN = "yyyy-MM-ddTHH:mm:ss.Sz";
+    private static final String USEC_UTC_PATTERN = "yyyy-MM-ddTHH:mm:ss.SSSUUUz";
+    private static final String SEC_UTC_PATTERN = "yyyy-MM-ddTHH:mm:ssz";
+    private static final String GREEDY_MILLIS2_UTC_PATTERN = "yyyy-MM-ddTHH:mm:ss.SSz";
     private static final DateFormat HTTP_FORMAT;
     private static final DateFormat[] FORMATS;
     static long referenceYear;
@@ -365,24 +368,36 @@ public class TimestampFormatUtils {
     static {
         updateReferenceYear(Os.currentTimeMicros());
         TimestampFormatCompiler compiler = new TimestampFormatCompiler();
-        UTC_FORMAT = compiler.compile(UTC_PATTERN);
         HTTP_FORMAT = compiler.compile("E, d MMM yyyy HH:mm:ss Z");
-        USEC_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ss.SSSUUUz");
-        SEC_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ssz");
-        GREEDY_MILLIS1_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ss.Sz");
-        GREEDY_MILLIS2_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ss.SSz");
         PG_TIMESTAMP_FORMAT = compiler.compile("y-MM-dd HH:mm:ss.SSSUUU");
         PG_TIMESTAMPZ_FORMAT = compiler.compile("y-MM-ddTHH:mm:ss.SSSUUU");
         PG_TIMESTAMP_TIME_Z_FORMAT = compiler.compile("y-MM-dd HH:mm:ssz");
-        PG_TIMESTAMP_MILLI_TIME_Z_FORMAT = compiler.compile("y-MM-dd HH:mm:ss.SSSz");
         NANOS_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ss.SSSUUUNNNz");
-        FORMATS = new DateFormat[]{
-                PG_TIMESTAMP_MILLI_TIME_Z_FORMAT,
-                GREEDY_MILLIS1_UTC_FORMAT,
-                USEC_UTC_FORMAT,
-                SEC_UTC_FORMAT,
-                GREEDY_MILLIS2_UTC_FORMAT,
-                UTC_FORMAT
+
+        String[] patterns = new String[]{
+                PG_TIMESTAMP_MILLI_TIME_Z_PATTERN,
+                GREEDY_MILLIS1_UTC_PATTERN,
+                USEC_UTC_PATTERN,
+                SEC_UTC_PATTERN,
+                GREEDY_MILLIS2_UTC_PATTERN,
+                UTC_PATTERN
         };
+        FORMATS = new DateFormat[patterns.length];
+        CharSequenceObjHashMap<DateFormat> dateFormats = new CharSequenceObjHashMap<>();
+        int patternMinLength = Integer.MAX_VALUE;
+        for (int i = 0; i < patterns.length; i++) {
+            String pattern = patterns[i];
+            DateFormat format = compiler.compile(pattern);
+            dateFormats.put(pattern, format);
+            FORMATS[i] = format;
+            patternMinLength = Math.min(patternMinLength, pattern.length());
+        }
+        TIMESTAMP_FORMAT_MIN_LENGTH = patternMinLength;
+        PG_TIMESTAMP_MILLI_TIME_Z_FORMAT = dateFormats.get(PG_TIMESTAMP_MILLI_TIME_Z_PATTERN);
+        GREEDY_MILLIS1_UTC_FORMAT = dateFormats.get(GREEDY_MILLIS1_UTC_PATTERN);
+        USEC_UTC_FORMAT = dateFormats.get(USEC_UTC_PATTERN);
+        SEC_UTC_FORMAT = dateFormats.get(SEC_UTC_PATTERN);
+        GREEDY_MILLIS2_UTC_FORMAT = dateFormats.get(GREEDY_MILLIS2_UTC_PATTERN);
+        UTC_FORMAT = dateFormats.get(UTC_PATTERN);
     }
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -109,12 +109,18 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.eq.EqSymCharFunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqCharCharFunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqIntStrCFunctionFactory,
+            io.questdb.griffin.engine.functions.eq.EqTimestampStrFunctionFactory,
+            io.questdb.griffin.engine.functions.eq.EqTimestampFunctionFactory,
 
             //nullif
             io.questdb.griffin.engine.functions.eq.NullIfCharCharFunctionFactory,
 
 //                   '<' operator
             io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory,
+            io.questdb.griffin.engine.functions.lt.LtTimestampStrFunctionFactory,
+            io.questdb.griffin.engine.functions.lt.LtStrTimestampFunctionFactory,
+            io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory,
+
 //                   '+' operator
             io.questdb.griffin.engine.functions.math.AddByteFunctionFactory,
             io.questdb.griffin.engine.functions.math.AddShortFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -26,12 +26,17 @@ io.questdb.griffin.engine.functions.eq.EqSymStrFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqSymCharFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqCharCharFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqIntStrCFunctionFactory
+io.questdb.griffin.engine.functions.eq.EqTimestampStrFunctionFactory
+io.questdb.griffin.engine.functions.eq.EqTimestampFunctionFactory
 
 #nullif
 io.questdb.griffin.engine.functions.eq.NullIfCharCharFunctionFactory
 
 # '<' operator
 io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory
+io.questdb.griffin.engine.functions.lt.LtTimestampStrFunctionFactory
+io.questdb.griffin.engine.functions.lt.LtStrTimestampFunctionFactory
+io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory
 
 # '+' operator
 io.questdb.griffin.engine.functions.math.AddByteFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/AbstractFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/AbstractFunctionFactoryTest.java
@@ -68,7 +68,15 @@ public abstract class AbstractFunctionFactoryTest extends BaseFunctionFactoryTes
         return callCustomised(false, true, args);
     }
 
+    protected Invocation callBySignature(String signature, Object... args) throws SqlException {
+        return callCustomised(signature, false, true, args);
+    }
+
     protected Invocation callCustomised(boolean forceConstant, boolean argTypeFromSig, Object... args) throws SqlException {
+        return callCustomised(null, forceConstant, argTypeFromSig, args);
+    }
+
+    private Invocation callCustomised(String signature, boolean forceConstant, boolean argTypeFromSig, Object... args) throws SqlException {
         setUp2();
         toShortRefs = 0;
         toByteRefs = 0;
@@ -76,7 +84,9 @@ public abstract class AbstractFunctionFactoryTest extends BaseFunctionFactoryTes
         toDateRefs = 0;
 
         final FunctionFactory functionFactory = getFactory0();
-        final String signature = functionFactory.getSignature();
+        if (signature == null) {
+            signature = functionFactory.getSignature();
+        }
 
         // validate signature first
         final int pos = FunctionFactoryDescriptor.validateSignatureAndGetNameSeparator(signature);

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqTimestampFunctionFactoryTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.eq;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.std.NumericException;
+import org.junit.Test;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.parseUTCTimestamp;
+
+public class EqTimestampFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testEquals() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature("=(NN)", t1, t1).andAssert(true);
+        callBySignature("=(NN)", t1, t2).andAssert(false);
+    }
+
+    @Test
+    public void testNotEquals() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature("<>(NN)", t1, t1).andAssert(false);
+        callBySignature("<>(NN)", t1, t2).andAssert(true);
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new EqTimestampFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqTimestampStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqTimestampStrFunctionFactoryTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.eq;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.griffin.engine.functions.columns.StrColumn;
+import io.questdb.griffin.engine.functions.columns.TimestampColumn;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.parseUTCTimestamp;
+
+public class EqTimestampStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testTimestampStringEquals() throws SqlException, NumericException {
+        String t1 = "2020-12-31T23:59:59.000000Z";
+        String t2 = "2020-12-31T23:59:59.000001Z";
+        callBySignature("=(NS)", parseUTCTimestamp(t1), t1).andAssert(true);
+        callBySignature("=(NS)", parseUTCTimestamp(t1), t2).andAssert(false);
+        callBySignature("=(NS)", parseUTCTimestamp(t1), "2020").andAssert(true);
+        callBySignature("=(NS)", parseUTCTimestamp(t1), "2019").andAssert(false);
+    }
+
+    @Test
+    public void testStringTimestampEquals() throws SqlException, NumericException {
+        String t1 = "2020-12-31T23:59:59.000000Z";
+        String t2 = "2020-12-31T23:59:59.000001Z";
+        callBySignature("=(SN)", t1, parseUTCTimestamp(t1)).andAssert(true);
+        callBySignature("=(SN)", t1, parseUTCTimestamp(t2)).andAssert(false);
+        callBySignature("=(SN)", "2020", parseUTCTimestamp(t1)).andAssert(true);
+        callBySignature("=(SN)", "2019", parseUTCTimestamp(t1)).andAssert(false);
+    }
+
+    @Test
+    public void testTimestampStringNotEquals() throws SqlException, NumericException {
+        String t1 = "2020-12-31T23:59:59.000000Z";
+        String t2 = "2020-12-31T23:59:59.000001Z";
+        callBySignature("<>(NS)", parseUTCTimestamp(t1), t1).andAssert(false);
+        callBySignature("<>(NS)", parseUTCTimestamp(t1), t2).andAssert(true);
+        callBySignature("<>(NS)", parseUTCTimestamp(t1), "2020").andAssert(false);
+        callBySignature("<>(NS)", parseUTCTimestamp(t1), "2019").andAssert(true);
+    }
+
+    @Test
+    public void testStringTimestampNotEquals() throws SqlException, NumericException {
+        String t1 = "2020-12-31T23:59:59.000000Z";
+        String t2 = "2020-12-31T23:59:59.000001Z";
+        callBySignature("<>(SN)", t1, parseUTCTimestamp(t1)).andAssert(false);
+        callBySignature("<>(SN)", t1, parseUTCTimestamp(t2)).andAssert(true);
+        callBySignature("<>(SN)", "2020", parseUTCTimestamp(t1)).andAssert(false);
+        callBySignature("<>(SN)", "2019", parseUTCTimestamp(t1)).andAssert(true);
+    }
+
+    @Test
+    public void testFailureWhenConstantStringIsNotValidTimestamp() throws NumericException {
+        assertFailure(true, 36, "could not parse timestamp [value='abc']", parseUTCTimestamp("2020-12-31T23:59:59.000000Z"), "abc");
+    }
+
+    @Test
+    public void testFalseWhenVariableStringIsNotValidTimestamp() throws SqlException, NumericException {
+        long timestamp = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        CharSequence invalidTimestamp = "abc";
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new TimestampColumn(0, 0));
+        args.add(new StrColumn(1, 5));
+        Function function = factory.newInstance(args, 3, configuration, sqlExecutionContext);
+        Assert.assertFalse(function.getBool(new Record() {
+            @Override
+            public CharSequence getStr(int col) {
+                return invalidTimestamp;
+            }
+
+            @Override
+            public long getTimestamp(int col) {
+                return timestamp;
+            }
+        }));
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new EqTimestampStrFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtStrTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtStrTimestampFunctionFactoryTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.griffin.engine.functions.columns.StrColumn;
+import io.questdb.griffin.engine.functions.columns.TimestampColumn;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.parseUTCTimestamp;
+
+public class LtStrTimestampFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testFullTimestampLessThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<(SN)", "2020-12-31T23:59:59.999999Z", t1).andAssert(false);
+        callBySignature("<(SN)", "2020-12-31T23:59:58.999998Z", t1).andAssert(true);
+        callBySignature("<(SN)", "2021-01-01T00:00:00.000001Z", t1).andAssert(false);
+    }
+
+    @Test
+    public void testPartialTimestampLessThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<(SN)", "2020", t1).andAssert(false);
+        callBySignature("<(SN)", "2020", t2).andAssert(false);
+        callBySignature("<(SN)", "2020", t3).andAssert(false);
+        callBySignature("<(SN)", "2019", t1).andAssert(true);
+        callBySignature("<(SN)", "2019", t2).andAssert(true);
+        callBySignature("<(SN)", "2019", t3).andAssert(true);
+        callBySignature("<(SN)", "2021", t1).andAssert(false);
+        callBySignature("<(SN)", "2021", t2).andAssert(false);
+        callBySignature("<(SN)", "2021", t3).andAssert(false);
+    }
+
+    @Test
+    public void testLessThanOrEqualToFullTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<=(NS)", t1, "2020-12-31T23:59:59.999999Z").andAssert(true);
+        callBySignature("<=(NS)", t1, "2020-12-31T23:59:58.999998Z").andAssert(false);
+        callBySignature("<=(NS)", t1, "2021-01-01T00:00:00.000001Z").andAssert(true);
+    }
+
+    @Test
+    public void testLessThanOrEqualToPartialTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<=(NS)", t1, "2020").andAssert(true);
+        callBySignature("<=(NS)", t2, "2020").andAssert(true);
+        callBySignature("<=(NS)", t3, "2020").andAssert(true);
+        callBySignature("<=(NS)", t1, "2019").andAssert(false);
+        callBySignature("<=(NS)", t2, "2019").andAssert(false);
+        callBySignature("<=(NS)", t3, "2019").andAssert(false);
+        callBySignature("<=(NS)", t1, "2021").andAssert(true);
+        callBySignature("<=(NS)", t2, "2021").andAssert(true);
+        callBySignature("<=(NS)", t3, "2021").andAssert(true);
+    }
+
+    @Test
+    public void testGreaterThanFullTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">(NS)", t1, "2020-12-31T23:59:59.999999Z").andAssert(false);
+        callBySignature(">(NS)", t1, "2020-12-31T23:59:58.999998Z").andAssert(true);
+        callBySignature(">(NS)", t1, "2021-01-01T00:00:00.000001Z").andAssert(false);
+    }
+
+    @Test
+    public void testGreaterThanPartialTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">(NS)", t1, "2020").andAssert(false);
+        callBySignature(">(NS)", t2, "2020").andAssert(false);
+        callBySignature(">(NS)", t3, "2020").andAssert(false);
+        callBySignature(">(NS)", t1, "2019").andAssert(true);
+        callBySignature(">(NS)", t2, "2019").andAssert(true);
+        callBySignature(">(NS)", t3, "2019").andAssert(true);
+        callBySignature(">(NS)", t1, "2021").andAssert(false);
+        callBySignature(">(NS)", t2, "2021").andAssert(false);
+        callBySignature(">(NS)", t3, "2021").andAssert(false);
+    }
+
+    @Test
+    public void testFullTimestampGreaterThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">=(SN)", "2020-12-31T23:59:59.999999Z", t1).andAssert(true);
+        callBySignature(">=(SN)", "2020-12-31T23:59:58.999998Z", t1).andAssert(false);
+        callBySignature(">=(SN)", "2021-01-01T00:00:00.000001Z", t1).andAssert(true);
+    }
+
+    @Test
+    public void testPartialTimestampGreaterThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">=(SN)", "2020", t1).andAssert(true);
+        callBySignature(">=(SN)", "2020", t2).andAssert(true);
+        callBySignature(">=(SN)", "2020", t3).andAssert(true);
+        callBySignature(">=(SN)", "2019", t1).andAssert(false);
+        callBySignature(">=(SN)", "2019", t2).andAssert(false);
+        callBySignature(">=(SN)", "2019", t3).andAssert(false);
+        callBySignature(">=(SN)", "2021", t1).andAssert(true);
+        callBySignature(">=(SN)", "2021", t2).andAssert(true);
+        callBySignature(">=(SN)", "2021", t3).andAssert(true);
+    }
+
+    @Test
+    public void testFailureWhenConstantStringIsNotValidTimestamp() throws NumericException {
+        assertFailure(true, 6, "could not parse timestamp [value='abc']", "abc", parseUTCTimestamp("2020-12-31T23:59:59.000000Z"));
+    }
+
+    @Test
+    public void testFalseWhenVariableStringIsNotValidTimestamp() throws SqlException, NumericException {
+        long timestamp = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        CharSequence invalidTimestamp = "abc";
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new StrColumn(0, 0));
+        args.add(new TimestampColumn(1, 5));
+        Function function = factory.newInstance(args, 3, configuration, sqlExecutionContext);
+        Assert.assertFalse(function.getBool(new Record() {
+            @Override
+            public CharSequence getStr(int col) {
+                return invalidTimestamp;
+            }
+
+            @Override
+            public long getTimestamp(int col) {
+                return timestamp;
+            }
+        }));
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new LtStrTimestampFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtTimestampFunctionFactoryTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.std.NumericException;
+import org.junit.Test;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.parseUTCTimestamp;
+
+public class LtTimestampFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testLessThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature("<(NN)", t1, t1).andAssert(false);
+        callBySignature("<(NN)", t1, t2).andAssert(true);
+        callBySignature("<(NN)", t2, t1).andAssert(false);
+    }
+
+    @Test
+    public void testLessThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature("<=(NN)", t1, t1).andAssert(true);
+        callBySignature("<=(NN)", t1, t2).andAssert(true);
+        callBySignature("<=(NN)", t2, t1).andAssert(false);
+    }
+
+    @Test
+    public void testGreaterThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature(">(NN)", t1, t1).andAssert(false);
+        callBySignature(">(NN)", t1, t2).andAssert(false);
+        callBySignature(">(NN)", t2, t1).andAssert(true);
+    }
+
+    @Test
+    public void testGreaterThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        long t2 = parseUTCTimestamp("2020-12-31T23:59:59.000001Z");
+        callBySignature(">=(NN)", t1, t1).andAssert(true);
+        callBySignature(">=(NN)", t1, t2).andAssert(false);
+        callBySignature(">=(NN)", t2, t1).andAssert(true);
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new LtTimestampFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtTimestampStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/lt/LtTimestampStrFunctionFactoryTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.AbstractFunctionFactoryTest;
+import io.questdb.griffin.engine.functions.columns.StrColumn;
+import io.questdb.griffin.engine.functions.columns.TimestampColumn;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.std.datetime.microtime.TimestampFormatUtils.parseUTCTimestamp;
+
+public class LtTimestampStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testLessThanFullTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<(NS)", t1, "2020-12-31T23:59:59.999999Z").andAssert(false);
+        callBySignature("<(NS)", t1, "2020-12-31T23:59:58.999998Z").andAssert(false);
+        callBySignature("<(NS)", t1, "2021-01-01T00:00:00.000001Z").andAssert(true);
+    }
+
+    @Test
+    public void testLessThanPartialTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<(NS)", t1, "2020").andAssert(false);
+        callBySignature("<(NS)", t2, "2020").andAssert(false);
+        callBySignature("<(NS)", t3, "2020").andAssert(false);
+        callBySignature("<(NS)", t1, "2019").andAssert(false);
+        callBySignature("<(NS)", t2, "2019").andAssert(false);
+        callBySignature("<(NS)", t3, "2019").andAssert(false);
+        callBySignature("<(NS)", t1, "2021").andAssert(true);
+        callBySignature("<(NS)", t2, "2021").andAssert(true);
+        callBySignature("<(NS)", t3, "2021").andAssert(true);
+    }
+
+    @Test
+    public void testFullTimestampLessThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<=(SN)", "2020-12-31T23:59:59.999999Z", t1).andAssert(true);
+        callBySignature("<=(SN)", "2020-12-31T23:59:58.999998Z", t1).andAssert(true);
+        callBySignature("<=(SN)", "2021-01-01T00:00:00.000001Z", t1).andAssert(false);
+    }
+
+    @Test
+    public void testPartialTimestampLessThanOrEqualTo() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature("<=(SN)", "2020", t1).andAssert(true);
+        callBySignature("<=(SN)", "2020", t2).andAssert(true);
+        callBySignature("<=(SN)", "2020", t3).andAssert(true);
+        callBySignature("<=(SN)", "2019", t1).andAssert(true);
+        callBySignature("<=(SN)", "2019", t2).andAssert(true);
+        callBySignature("<=(SN)", "2019", t3).andAssert(true);
+        callBySignature("<=(SN)", "2021", t1).andAssert(false);
+        callBySignature("<=(SN)", "2021", t2).andAssert(false);
+        callBySignature("<=(SN)", "2021", t3).andAssert(false);
+    }
+
+    @Test
+    public void testFullTimestampGreaterThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">(SN)", "2020-12-31T23:59:59.999999Z", t1).andAssert(false);
+        callBySignature(">(SN)", "2020-12-31T23:59:58.999998Z", t1).andAssert(false);
+        callBySignature(">(SN)", "2021-01-01T00:00:00.000001Z", t1).andAssert(true);
+    }
+
+    @Test
+    public void testPartialTimestampGreaterThan() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">(SN)", "2020", t1).andAssert(false);
+        callBySignature(">(SN)", "2020", t2).andAssert(false);
+        callBySignature(">(SN)", "2020", t3).andAssert(false);
+        callBySignature(">(SN)", "2019", t1).andAssert(false);
+        callBySignature(">(SN)", "2019", t2).andAssert(false);
+        callBySignature(">(SN)", "2019", t3).andAssert(false);
+        callBySignature(">(SN)", "2021", t1).andAssert(true);
+        callBySignature(">(SN)", "2021", t2).andAssert(true);
+        callBySignature(">(SN)", "2021", t3).andAssert(true);
+    }
+
+    @Test
+    public void testGreaterThanOrEqualToFullTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">=(NS)", t1, "2020-12-31T23:59:59.999999Z").andAssert(true);
+        callBySignature(">=(NS)", t1, "2020-12-31T23:59:58.999998Z").andAssert(true);
+        callBySignature(">=(NS)", t1, "2021-01-01T00:00:00.000001Z").andAssert(false);
+    }
+
+    @Test
+    public void testGreaterThanOrEqualToPartialTimestamp() throws SqlException, NumericException {
+        long t1 = parseUTCTimestamp("2020-01-01T00:00:00.000000Z");
+        long t2 = parseUTCTimestamp("2020-06-30T23:59:59.999999Z");
+        long t3 = parseUTCTimestamp("2020-12-31T23:59:59.999999Z");
+        callBySignature(">=(NS)", t1, "2020").andAssert(true);
+        callBySignature(">=(NS)", t2, "2020").andAssert(true);
+        callBySignature(">=(NS)", t3, "2020").andAssert(true);
+        callBySignature(">=(NS)", t1, "2019").andAssert(true);
+        callBySignature(">=(NS)", t2, "2019").andAssert(true);
+        callBySignature(">=(NS)", t3, "2019").andAssert(true);
+        callBySignature(">=(NS)", t1, "2021").andAssert(false);
+        callBySignature(">=(NS)", t2, "2021").andAssert(false);
+        callBySignature(">=(NS)", t3, "2021").andAssert(false);
+    }
+
+    @Test
+    public void testFailureWhenConstantStringIsNotValidTimestamp() throws NumericException {
+        assertFailure(true, 36, "could not parse timestamp [value='abc']", parseUTCTimestamp("2020-12-31T23:59:59.000000Z"), "abc");
+    }
+
+    @Test
+    public void testFalseWhenVariableStringIsNotValidTimestamp() throws SqlException, NumericException {
+        long timestamp = parseUTCTimestamp("2020-12-31T23:59:59.000000Z");
+        CharSequence invalidTimestamp = "abc";
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new TimestampColumn(0, 0));
+        args.add(new StrColumn(1, 5));
+        Function function = factory.newInstance(args, 3, configuration, sqlExecutionContext);
+        Assert.assertFalse(function.getBool(new Record() {
+            @Override
+            public CharSequence getStr(int col) {
+                return invalidTimestamp;
+            }
+
+            @Override
+            public long getTimestamp(int col) {
+                return timestamp;
+            }
+        }));
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new LtTimestampStrFunctionFactory();
+    }
+}


### PR DESCRIPTION
Resolves #582.

I’ve made two decisions that might not be obvious, so please let me know if they are correct:

1. Parsing variable string errors are silently ignored. For example:
```SQL
create table sample_table( t1 timestamp, t2 timestamp, s1 string) timestamp(t2);
insert into sample_table values(systimestamp(), systimestamp(), '2020');
insert into sample_table values(systimestamp(), systimestamp(), 'abc');
```

Even though `abc` is not a valid timestamp the following query wouldn't fail, instead it will return only matched results: 
```SQL
select * from sample_table where t1 = s1;
```

2. Currently operators `=` and `!=` handle [Exact timestamp](https://questdb.io/docs/reference/sql/where/#exact-timestamp) and [Time range](https://questdb.io/docs/reference/sql/where/#time-range). [Time range with modifier](https://questdb.io/docs/reference/sql/where/#time-range-with-modifier) and [Explicit range](https://questdb.io/docs/reference/sql/where/#explicit-range) are not supported - I am not sure if they are in the scope of the issue. 

Additional changes:
* In my opinion, the previous implementation of creating negated operators had a bug. Because of the fact that function factories are shared between threads using the flag `isNegated` from `AbstractBooleanFunctionFactory` may lead to race conditions. This PR fixes it.   


