### PR TITLE
fix(griffin): where clause is not moved inside nested query if the query has limit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -1673,7 +1673,7 @@ class SqlOptimiser {
                     }
 
                     final QueryModel nested = parent.getNestedModel();
-                    if (nested == null || nested.getLatestBy().size() > 0) {
+                    if (nested == null || nested.getLatestBy().size() > 0 || nested.getLimitLo() != null || nested.getLimitHi() != null) {
                         // there is no nested model for this table, keep where clause element with this model
                         addWhereNode(parent, node);
                     } else {

--- a/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
+++ b/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
@@ -54,6 +54,27 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
         });
     }
 
+    @Test
+    public void testNotSelectDeletedByLimit() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table state_table(time timestamp, id int, state symbol);", sqlExecutionContext);
+            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertStatement());
+            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertStatement());
+            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertStatement());
+            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertStatement());
+            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'ON');", sqlExecutionContext).getInsertStatement());
+
+            CompiledQuery cc = compiler.compile("(select state from state_table latest by state limit -1) where state != 'ON';", sqlExecutionContext);
+            Assert.assertNotNull(cc.getRecordCursorFactory());
+
+            try (RecordCursorFactory factory = cc.getRecordCursorFactory()) {
+                sink.clear();
+                printer.print(factory.getCursor(sqlExecutionContext), factory.getMetadata(), true);
+                TestUtils.assertEquals("state\n", sink);
+            }
+        });
+    }
+
     private static void execInsert(InsertStatement statement) {
         try (InsertMethod m = statement.createMethod(sqlExecutionContext)) {
             m.execute();

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -5150,7 +5150,7 @@ public class SqlParserTest extends AbstractGriffinTest {
     @Test
     public void testSubQueryLimitLoHi() throws Exception {
         assertQuery(
-                "select-choose x, y from (select-choose [x, y] x, y from (select [x, y, z] from tab where x > z and x = y) limit 100,200) limit 150",
+                "select-choose x, y from (select [x, y] from (select-choose [y, x] x, y from (select [y, x, z] from tab where x > z) limit 100,200) _xQdbA1 where x = y) limit 150",
                 "(select x x, y y from tab where x > z limit 100,200) where x = y limit 150",
                 modelOf("tab").col("x", ColumnType.INT).col("y", ColumnType.INT).col("z", ColumnType.INT)
         );


### PR DESCRIPTION
Fixes #904 