### PR TITLE
 feat: add engine migration for table metadata to add hysteresis params

### DIFF
--- a/core/src/main/java/io/questdb/cairo/EngineMigration.java
+++ b/core/src/main/java/io/questdb/cairo/EngineMigration.java
@@ -40,6 +40,7 @@ import static io.questdb.cairo.TableUtils.*;
 
 public class EngineMigration {
     public static final int VERSION_TX_STRUCT_UPDATE_1 = 418;
+    public static final int VERSION_TBL_META_HYSTERESIS = 419;
 
     // All offsets hardcoded here in case TableUtils offset calculation changes
     // in future code version
@@ -47,6 +48,7 @@ public class EngineMigration {
     public static final long TX_STRUCT_UPDATE_1_META_OFFSET_PARTITION_BY = 4;
     public static final String TX_STRUCT_UPDATE_1_ARCHIVE_FILE_NAME = "_archive";
     public static final String TX_STRUCT_UPDATE_1_BACKUP_NAME = TXN_FILE_NAME + ".v" + (VERSION_TX_STRUCT_UPDATE_1 - 1);
+    public static final String META_UPDATE_1_BACKUP_NAME = META_FILE_NAME + ".v" + (VERSION_TBL_META_HYSTERESIS - 1);
 
     private static final Log LOG = LogFactory.getLog(EngineMigration.class);
     private static final ObjList<MigrationAction> MIGRATIONS = new ObjList<>();
@@ -224,6 +226,27 @@ public class EngineMigration {
     }
 
     private static class MigrationActions {
+        public static void addTblMetaHysteresis(MigrationContext migrationContext) {
+            Path path = migrationContext.getTablePath();
+            final FilesFacade ff = migrationContext.getFf();
+            path.concat(META_FILE_NAME).$();
+            if (!ff.exists(path)) {
+                LOG.error().$("meta file does not exist, nothing to migrate [path=").$(path).I$();
+                return;
+            }
+            backupFile(ff, path, migrationContext.getTablePath2(), META_UPDATE_1_BACKUP_NAME);
+            long tempMem = migrationContext.getTempMemory(8);
+            Unsafe.getUnsafe().putInt(tempMem, migrationContext.getConfiguration().getO3MaxUncommittedRows());
+            if (ff.write(migrationContext.metadataFd, tempMem, Integer.BYTES, META_OFFSET_O3_MAX_UNCOMMITTED_ROWS) != Integer.BYTES) {
+                CairoException.instance(ff.errno()).put("Cannot update metadata [path=").put(path).put(']');
+            }
+
+            Unsafe.getUnsafe().putLong(tempMem, migrationContext.getConfiguration().getO3CommitHysteresisInMicros());
+            if (ff.write(migrationContext.metadataFd, tempMem, Long.BYTES, META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS) != Long.BYTES) {
+                CairoException.instance(ff.errno()).put("Cannot update metadata [path=").put(path).put(']');
+            }
+        }
+
         private static void assignTableId(MigrationContext migrationContext) {
             long mem = migrationContext.getTempMemory(8);
             FilesFacade ff = migrationContext.getFf();
@@ -251,22 +274,7 @@ public class EngineMigration {
                 LOG.error().$("tx file does not exist, nothing to migrate [path=").$(path).I$();
                 return;
             }
-
-            // make a copy
-            Path copyPath = migrationContext.getTablePath2();
-            copyPath.concat(TX_STRUCT_UPDATE_1_BACKUP_NAME).$();
-            if (ff.exists(copyPath)) {
-                LOG.info().$("back tx file exists, [path=").$(copyPath).I$();
-                int copyPathLen = copyPath.length();
-                for (int i = 1; ff.exists(copyPath.$()); i++) {
-                    copyPath.trimTo(copyPathLen);
-                    copyPath.put(".").put(i);
-                }
-            }
-            LOG.info().$("back up coping tx file [from=").$(path).$(",to=").$(copyPath).I$();
-            if (ff.copy(path, copyPath) < 0) {
-                throw CairoException.instance(ff.errno()).put("Cannot backup transaction file [to=").put(copyPath).put(']');
-            }
+            backupFile(ff, path, migrationContext.getTablePath2(), TX_STRUCT_UPDATE_1_BACKUP_NAME);
 
             LOG.debug().$("opening for rw [path=").$(path).I$();
             MappedReadWriteMemory txMem = migrationContext.createRwMemoryOf(ff, path.$(), ff.getPageSize());
@@ -311,6 +319,28 @@ public class EngineMigration {
                 assert updateSize == 0;
             } finally {
                 txMem.close();
+            }
+        }
+
+        private static void backupFile(FilesFacade ff, Path src, Path toTemp, String backupName) {
+            // make a copy
+            int copyPathLen = toTemp.length();
+            try {
+                toTemp.concat(backupName).$();
+                if (ff.exists(toTemp)) {
+                    LOG.info().$("back up file exists, [path=").$(toTemp).I$();
+                    for (int i = 1; ff.exists(toTemp.$()); i++) {
+                        toTemp.trimTo(copyPathLen);
+                        toTemp.put(".").put(i);
+                    }
+                }
+
+                LOG.info().$("back up coping file [from=").$(src).$(",to=").$(toTemp).I$();
+                if (ff.copy(src, toTemp) < 0) {
+                    throw CairoException.instance(ff.errno()).put("Cannot backup transaction file [to=").put(toTemp).put(']');
+                }
+            } finally {
+                toTemp.trimTo(copyPathLen);
             }
         }
 
@@ -386,6 +416,10 @@ public class EngineMigration {
             this.rwMemory = rwMemory;
         }
 
+        public CairoConfiguration getConfiguration() {
+            return configuration;
+        }
+
         public FilesFacade getFf() {
             return configuration.getFilesFacade();
         }
@@ -440,5 +474,6 @@ public class EngineMigration {
         MIGRATIONS.extendAndSet(ColumnType.VERSION - MIGRATIONS_LIST_OFFSET, null);
         setByVersion(VERSION_THAT_ADDED_TABLE_ID, MigrationActions::assignTableId, 1);
         setByVersion(VERSION_TX_STRUCT_UPDATE_1, MigrationActions::rebuildTransactionFile, 0);
+        setByVersion(VERSION_TBL_META_HYSTERESIS, MigrationActions::addTblMetaHysteresis, 0);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -38,20 +38,32 @@ public class TableReaderMetadata extends BaseRecordMetadata implements Closeable
     private final Path path;
     private final FilesFacade ff;
     private final CharSequenceIntHashMap tmpValidationMap = new CharSequenceIntHashMap();
-    private final int id;
+    private int id;
     private MappedReadOnlyMemory transitionMeta;
 
-    public TableReaderMetadata(FilesFacade ff, Path path) {
+    public TableReaderMetadata(FilesFacade ff) {
+        this.path = new Path();
         this.ff = ff;
-        this.path = new Path().of(path).$();
+        this.metaMem = new SinglePageMappedReadOnlyPageMemory();
+        this.columnMetadata = new ObjList<>(columnCount);
+        this.columnNameIndexMap = new CharSequenceIntHashMap();
+    }
+
+    public TableReaderMetadata(FilesFacade ff, Path path) {
+        this(ff);
+        of(path);
+    }
+
+    public TableReaderMetadata of(Path path) {
+        this.path.of(path).$();
         try {
-            this.metaMem = new SinglePageMappedReadOnlyPageMemory(ff, path, ff.length(path));
+            this.metaMem.of(ff, path, ff.length(path));
             this.columnCount = metaMem.getInt(TableUtils.META_OFFSET_COUNT);
-            this.columnNameIndexMap = new CharSequenceIntHashMap(columnCount);
+            this.columnNameIndexMap.clear();
             TableUtils.validate(ff, metaMem, this.columnNameIndexMap);
             this.timestampIndex = metaMem.getInt(TableUtils.META_OFFSET_TIMESTAMP_INDEX);
             this.id = metaMem.getInt(TableUtils.META_OFFSET_TABLE_ID);
-            this.columnMetadata = new ObjList<>(columnCount);
+            this.columnMetadata.clear();
             long offset = TableUtils.getColumnNameOffset(columnCount);
 
             // don't create strings in this loop, we already have them in columnNameIndexMap
@@ -74,6 +86,7 @@ public class TableReaderMetadata extends BaseRecordMetadata implements Closeable
             close();
             throw e;
         }
+        return this;
     }
 
     public static void freeTransitionIndex(long address) {
@@ -249,6 +262,14 @@ public class TableReaderMetadata extends BaseRecordMetadata implements Closeable
 
     public int getVersion() {
         return metaMem.getInt(TableUtils.META_OFFSET_VERSION);
+    }
+
+    public int getMaxUncommittedRows() {
+        return metaMem.getInt(TableUtils.META_OFFSET_O3_MAX_UNCOMMITTED_ROWS);
+    }
+
+    public long getO3CommitHysteresisMicros() {
+        return metaMem.getLong(TableUtils.META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS);
     }
 
     private TableColumnMetadata moveMetadata(int index, TableColumnMetadata metadata) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
@@ -1,0 +1,268 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.*;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.NativeLPSZ;
+import io.questdb.std.str.Path;
+
+import static io.questdb.cairo.TableUtils.META_FILE_NAME;
+
+public class TableMetadataCursorFactory implements FunctionFactory {
+    private static final RecordMetadata METADATA;
+    private static final int idColumn;
+    private static final int nameColumn;
+    private static final int partitionByColumn;
+    private static final int maxUncommittedRowsColumn;
+    private static final int o3CommitHysteresisMicroSecColumn;
+    private static final int designatedTimestampColumn;
+    private static final Log LOG = LogFactory.getLog(TableMetadataCursorFactory.class);
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(new TableColumnMetadata("id", ColumnType.INT, null));
+        idColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("name", ColumnType.STRING, null));
+        nameColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("designatedTimestamp", ColumnType.STRING, null));
+        designatedTimestampColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("partitionBy", ColumnType.STRING, null));
+        partitionByColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("maxUncommittedRows", ColumnType.INT, null));
+        maxUncommittedRowsColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("o3CommitHysteresisMicros", ColumnType.LONG, null));
+        o3CommitHysteresisMicroSecColumn = metadata.getColumnCount() - 1;
+        METADATA = metadata;
+    }
+
+    @Override
+    public String getSignature() {
+        return "tables()";
+    }
+
+    @Override
+    public Function newInstance(ObjList<Function> args, int position, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new CursorFunction(
+                position,
+                new TableMetadataCursor(configuration.getFilesFacade(), configuration.getRoot())
+        );
+    }
+
+    private static class TableMetadataCursor implements RecordCursorFactory {
+        private final FilesFacade ff;
+        private Path path;
+        private final TableListRecordCursor cursor;
+
+        public TableMetadataCursor(FilesFacade ff, CharSequence dbRoot) {
+            this.ff = ff;
+            path = new Path().of(dbRoot).$();
+            cursor = new TableListRecordCursor();
+        }
+
+        @Override
+        public RecordCursor getCursor(SqlExecutionContext executionContext) {
+            return cursor.of(executionContext);
+        }
+
+        @Override
+        public RecordMetadata getMetadata() {
+            return METADATA;
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+            if (null != path) {
+                path.close();
+                path = null;
+            }
+        }
+
+        private class TableListRecordCursor implements RecordCursor {
+            private final NativeLPSZ nativeLPSZ = new NativeLPSZ();
+            private final TableListRecord record = new TableListRecord();
+            private long findPtr = 0;
+            private TableReaderMetadata metaReader;
+
+            @Override
+            public void close() {
+                if (findPtr > 0) {
+                    ff.findClose(findPtr);
+                    findPtr = 0;
+                }
+                if (metaReader != null) {
+                    metaReader.close();
+                }
+            }
+
+            @Override
+            public Record getRecord() {
+                return record;
+            }
+
+            @Override
+            public boolean hasNext() {
+                while (true) {
+                    if (findPtr == 0) {
+                        findPtr = ff.findFirst(path);
+                        if (findPtr <= 0) {
+                            return false;
+                        }
+                    } else {
+                        if (ff.findNext(findPtr) <= 0) {
+                            return false;
+                        }
+                    }
+                    nativeLPSZ.of(ff.findName(findPtr));
+                    int type = ff.findType(findPtr);
+                    if (type == Files.DT_DIR && nativeLPSZ.charAt(0) != '.') {
+                        if (record.open(nativeLPSZ)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            public TableListRecordCursor of(SqlExecutionContext executionContext) {
+                toTop();
+                if (metaReader == null) {
+                    // Assuming FilesFacade does not chang in real execution
+                    metaReader = new TableReaderMetadata(executionContext.getCairoEngine().getConfiguration().getFilesFacade());
+                }
+                return this;
+            }
+
+            @Override
+            public Record getRecordB() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void recordAt(Record record, long atRowId) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void toTop() {
+                close();
+            }
+
+            @Override
+            public long size() {
+                return -1;
+            }
+
+            public class TableListRecord implements Record {
+                private int tableId;
+                private int maxUncommittedRows;
+                private long o3CommitHysteresisMicroSec;
+                private int partitionBy;
+
+                @Override
+                public CharSequence getStr(int col) {
+                    if (col == nameColumn) {
+                        return nativeLPSZ;
+                    }
+                    if (col == partitionByColumn) {
+                        return PartitionBy.toString(partitionBy);
+                    }
+                    if (col == designatedTimestampColumn) {
+                        if (metaReader.getTimestampIndex() > -1) {
+                            return metaReader.getColumnName(metaReader.getTimestampIndex());
+                        }
+                    }
+                    return null;
+                }
+
+                @Override
+                public CharSequence getStrB(int col) {
+                    return getStr(col);
+                }
+
+                @Override
+                public int getInt(int col) {
+                    if (col == idColumn) {
+                        return tableId;
+                    }
+                    if (col == maxUncommittedRowsColumn) {
+                        return maxUncommittedRows;
+                    }
+                    return Numbers.INT_NaN;
+                }
+
+                @Override
+                public long getLong(int col) {
+                    if (col == o3CommitHysteresisMicroSecColumn) {
+                        return o3CommitHysteresisMicroSec;
+                    }
+                    return Numbers.LONG_NaN;
+                }
+
+                @Override
+                public int getStrLen(int col) {
+                    return getStr(col).length();
+                }
+
+                public boolean open(NativeLPSZ tableName) {
+                    int pathLen = path.length();
+                    try {
+                        path.chop$().concat(tableName).concat(META_FILE_NAME).$();
+                        metaReader.of(path);
+
+                        // Pre-read as much as possible to skip record instead of failing on column fetch
+                        tableId = metaReader.getId();
+                        maxUncommittedRows = metaReader.getMaxUncommittedRows();
+                        o3CommitHysteresisMicroSec = metaReader.getO3CommitHysteresisMicros();
+                        partitionBy = metaReader.getPartitionBy();
+                    } catch (CairoException e) {
+                        // perhaps this folder is not a table
+                        // remove it from the result set
+                        LOG.info().$("cannot query table metadata [table=").$(tableName).$(", error=").$(e.getFlyweightMessage()).I$();
+                        return false;
+                    } finally {
+                        path.trimTo(pathLen);
+                    }
+
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
@@ -41,6 +41,7 @@ public class ShowColumnsRecordCursorFactory implements RecordCursorFactory {
     private static final int N_INDEX_BLOCK_CAPACITY_COL = 3;
     private static final int N_SYMBOL_CACHED_COL = 4;
     private static final int N_SYMBOL_CAPACITY_COL = 5;
+    private static final int N_DESIGNATED_COL = 6;
     static {
         final GenericRecordMetadata metadata = new GenericRecordMetadata();
         metadata.add(new TableColumnMetadata("column", ColumnType.STRING, null));
@@ -49,6 +50,7 @@ public class ShowColumnsRecordCursorFactory implements RecordCursorFactory {
         metadata.add(new TableColumnMetadata("indexBlockCapacity", ColumnType.INT, null));
         metadata.add(new TableColumnMetadata("symbolCached", ColumnType.BOOLEAN, null));
         metadata.add(new TableColumnMetadata("symbolCapacity", ColumnType.INT, null));
+        metadata.add(new TableColumnMetadata("designated", ColumnType.BOOLEAN, null));
         METADATA = metadata;
     }
 
@@ -161,6 +163,16 @@ public class ShowColumnsRecordCursorFactory implements RecordCursorFactory {
                     } else {
                         return false;
                     }
+                }
+                if (col == N_SYMBOL_CACHED_COL) {
+                    if (reader.getMetadata().getColumnType(columnIndex) == ColumnType.SYMBOL) {
+                        return reader.getSymbolMapReader(columnIndex).isCached();
+                    } else {
+                        return false;
+                    }
+                }
+                if (col == N_DESIGNATED_COL) {
+                    return reader.getMetadata().getTimestampIndex() == columnIndex;
                 }
                 throw new UnsupportedOperationException();
             }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -510,6 +510,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.ProcCatalogueFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.RangeCatalogueFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.TableMetadataCursorFactory,
 //                  concat()
             io.questdb.griffin.engine.functions.str.ConcatFunctionFactory,
             // replace()

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -463,6 +463,7 @@ io.questdb.griffin.engine.functions.catalogue.FormatTypeFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.ProcCatalogueFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.RangeCatalogueFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.TableMetadataCursorFactory
 
 # concat()
 io.questdb.griffin.engine.functions.str.ConcatFunctionFactory

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -24,19 +24,6 @@
 
 package io.questdb.cairo;
 
-import java.io.IOException;
-
-import org.jetbrains.annotations.Nullable;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
-
 import io.questdb.MessageBus;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordMetadata;
@@ -47,6 +34,12 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
+import org.jetbrains.annotations.Nullable;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
 
 public class AbstractCairoTest {
 
@@ -64,6 +57,8 @@ public class AbstractCairoTest {
     protected static CairoEngine engine;
     protected static String inputRoot = null;
     protected static FilesFacade ff;
+    protected static long configOverrideO3CommitHysteresisInMicros = -1;
+    protected static int configOverrideMaxUncommittedRows = -1;
 
     @Rule
     public TestName testName = new TestName();
@@ -98,6 +93,18 @@ public class AbstractCairoTest {
             public CharSequence getInputRoot() {
                 return inputRoot;
             }
+
+            @Override
+            public long getO3CommitHysteresisInMicros() {
+                if (configOverrideO3CommitHysteresisInMicros >= 0) return configOverrideO3CommitHysteresisInMicros;
+                return super.getO3CommitHysteresisInMicros();
+            }
+
+            @Override
+            public int getO3MaxUncommittedRows() {
+                if (configOverrideMaxUncommittedRows >= 0) return configOverrideMaxUncommittedRows;
+                return super.getO3MaxUncommittedRows();
+            }
         };
         engine = new CairoEngine(configuration);
         messageBus = engine.getMessageBus();
@@ -122,6 +129,8 @@ public class AbstractCairoTest {
         engine.freeTableId();
         engine.clear();
         TestUtils.removeTestPath(root);
+        configOverrideMaxUncommittedRows = -1;
+        configOverrideO3CommitHysteresisInMicros = -1;
     }
 
     protected static void assertMemoryLeak(TestUtils.LeakProneCode code) throws Exception {

--- a/core/src/test/java/io/questdb/cairo/EngineMigrationTest.java
+++ b/core/src/test/java/io/questdb/cairo/EngineMigrationTest.java
@@ -39,8 +39,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.questdb.cairo.EngineMigration.TX_STRUCT_UPDATE_1_OFFSET_MAP_WRITER_COUNT;
-import static io.questdb.cairo.EngineMigration.VERSION_TX_STRUCT_UPDATE_1;
+import static io.questdb.cairo.EngineMigration.*;
 import static io.questdb.cairo.TableUtils.*;
 
 public class EngineMigrationTest extends AbstractGriffinTest {
@@ -337,6 +336,114 @@ public class EngineMigrationTest extends AbstractGriffinTest {
         });
     }
 
+    @Test
+    public void testMigrateTableSimple() throws Exception {
+        configOverrideMaxUncommittedRows = 50001;
+        configOverrideO3CommitHysteresisInMicros = 777777;
+
+        assertMemoryLeak(() -> {
+            try (TableModel src = new TableModel(configuration, "src", PartitionBy.NONE)) {
+                createPopulateTable(
+                        src.col("c1", ColumnType.INT).col("ts", ColumnType.TIMESTAMP).timestamp(),
+                        100, "2020-01-01", 0
+                );
+
+                String query = "select sum(c1) from src";
+                assertMetadataMigration(src, query);
+            }
+        });
+    }
+
+    private void assertMetadataMigration(TableModel src, String query) throws SqlException {
+        assertMetadataMigration(src, query, query);
+    }
+
+    private void assertMetadataMigration(TableModel src, String queryOld, String queryNew) throws SqlException {
+        CharSequence expected = executeSql(queryOld).toString();
+        if (!queryOld.equals(queryNew)) {
+            // if queries are different they must produce different results
+            CharSequence expectedNewEquivalent = executeSql(queryNew).toString();
+            Assert.assertNotEquals(expected, expectedNewEquivalent);
+        }
+
+        // Downgrade version meta
+        downgradeMetaDataFile(src);
+
+        // Act
+        new EngineMigration(engine, configuration).migrateEngineTo(ColumnType.VERSION);
+
+        // Verify
+        TestUtils.assertEquals(expected, executeSql(queryNew));
+
+        // Second run of migration should not do anything
+        new EngineMigration(engine, configuration).migrateEngineTo(ColumnType.VERSION);
+        TestUtils.assertEquals(expected, executeSql(queryNew));
+
+        // Third time, downgrade and migrate
+        downgradeMetaDataFile(src);
+        new EngineMigration(engine, configuration).migrateEngineTo(ColumnType.VERSION);
+        TestUtils.assertEquals(expected, executeSql(queryNew));
+
+        assertSql("select maxUncommittedRows, o3CommitHysteresisMicros from tables where name = '" + src.getName() + "'",
+                "maxUncommittedRows\to3CommitHysteresisMicros\n" +
+                        +configOverrideMaxUncommittedRows + "\t" + configOverrideO3CommitHysteresisInMicros + "\n");
+    }
+
+    private void downgradeMetaDataFile(TableModel tableModel) {
+        engine.clear();
+        FilesFacade ff = configuration.getFilesFacade();
+
+        try (Path path = new Path()) {
+            setMetadataVersion(tableModel, ff, path, VERSION_TBL_META_HYSTERESIS);
+
+            path.concat(root).concat(tableModel.getName()).concat(TableUtils.META_FILE_NAME);
+            long fd = ff.openRO(path.$());
+            Assert.assertTrue(fd >= 0);
+
+            long fileSize = ff.length(fd);
+            ff.close(fd);
+            try (PagedMappedReadWriteMemory rwTx = new PagedMappedReadWriteMemory(ff, path.$(), fileSize)) {
+                rwTx.putInt(META_OFFSET_O3_MAX_UNCOMMITTED_ROWS, 0);
+                rwTx.putLong(META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS, 0);
+                rwTx.jumpTo(fileSize);
+            }
+
+            setMetadataVersion(tableModel, ff, path, VERSION_TBL_META_HYSTERESIS);
+            downgradeUpdateFileTo(ff, path, VERSION_TBL_META_HYSTERESIS);
+        }
+    }
+
+    private void setMetadataVersion(TableModel tableModel, FilesFacade ff, Path path, int version) {
+        int pathLen = path.length();
+
+        try {
+            path.trimTo(0).concat(root).concat(tableModel.getName()).concat(TableUtils.META_FILE_NAME);
+            long fd = ff.openRO(path.$());
+            Assert.assertTrue(fd >= 0);
+
+            long fileSize = ff.length(fd);
+            ff.close(fd);
+            try (PagedMappedReadWriteMemory rwTx = new PagedMappedReadWriteMemory(ff, path.$(), fileSize)) {
+                if (rwTx.getInt(META_OFFSET_VERSION) > version - 1) {
+                    rwTx.putInt(META_OFFSET_VERSION, version - 1);
+                    rwTx.jumpTo(fileSize);
+                }
+            }
+        } finally {
+            path.trimTo(pathLen);
+        }
+    }
+
+    private void downgradeUpdateFileTo(FilesFacade ff, Path path, int version) {
+        path.trimTo(0).concat(root).concat(UPGRADE_FILE_NAME);
+        if (ff.exists(path.$())) {
+            try (PagedMappedReadWriteMemory rwTx = new PagedMappedReadWriteMemory(ff, path.$(), 8)) {
+                rwTx.putInt(0, version - 1);
+                rwTx.jumpTo(Integer.BYTES);
+            }
+        }
+    }
+
     private FilesFacadeImpl failToWriteMetaOffset(final long metaOffsetVersion, final String filename) {
         return new FilesFacadeImpl() {
             private long metaFd = -1;
@@ -414,15 +521,11 @@ public class EngineMigrationTest extends AbstractGriffinTest {
 
     private void downgradeTxFile(TableModel src, LongList removedPartitions) {
         engine.clear();
+        downgradeMetaDataFile(src);
 
         try (Path path = new Path()) {
             path.concat(root).concat(src.getName()).concat(TableUtils.META_FILE_NAME);
             FilesFacade ff = configuration.getFilesFacade();
-            try (PagedMappedReadWriteMemory rwTx = new PagedMappedReadWriteMemory(ff, path.$(), ff.getPageSize())) {
-                if (rwTx.getInt(META_OFFSET_VERSION) >= VERSION_TX_STRUCT_UPDATE_1 - 1) {
-                    rwTx.putInt(META_OFFSET_VERSION, VERSION_TX_STRUCT_UPDATE_1 - 1);
-                }
-            }
 
             // Read current symbols list
             IntList symbolCounts = new IntList();
@@ -477,6 +580,8 @@ public class EngineMigrationTest extends AbstractGriffinTest {
                     }
                 }
             }
+
+            setMetadataVersion(src, ff, path, VERSION_TX_STRUCT_UPDATE_1);
 
             path.trimTo(0).concat(root).concat(UPGRADE_FILE_NAME);
             if (ff.exists(path.$())) {

--- a/core/src/test/java/io/questdb/griffin/ShowTablesTest.java
+++ b/core/src/test/java/io/questdb/griffin/ShowTablesTest.java
@@ -53,7 +53,10 @@ public class ShowTablesTest extends AbstractGriffinTest {
         assertMemoryLeak(() -> {
             compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
             assertQuery(
-                    "column\ttype\tindexed\tindexBlockCapacity\tsymbolCached\tsymbolCapacity\ncust_id\tINT\tfalse\t0\tfalse\t0\nccy\tSYMBOL\tfalse\t256\ttrue\t128\nbalance\tDOUBLE\tfalse\t0\tfalse\t0\n",
+                    "column\ttype\tindexed\tindexBlockCapacity\tsymbolCached\tsymbolCapacity\tdesignated\n" +
+                            "cust_id\tINT\tfalse\t0\tfalse\t0\tfalse\n" +
+                            "ccy\tSYMBOL\tfalse\t256\ttrue\t128\tfalse\n" +
+                            "balance\tDOUBLE\tfalse\t0\tfalse\t0\tfalse\n",
                     "show columns from balances", null, false, sqlExecutionContext, false);
         });
     }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactoryTest.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableModel;
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.std.str.Path;
+import org.junit.Test;
+
+import static io.questdb.cairo.TableUtils.META_FILE_NAME;
+
+public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
+    @Test
+    public void testMetadataQuery() throws Exception {
+        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
+            tm1.col("abc", ColumnType.STRING);
+            tm1.timestamp("ts1");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
+            tm1.timestamp("ts2");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+
+        assertSql(
+                "tables",
+                "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                        "2\ttable2\tts2\tNONE\t1000\t0\n" +
+                        "1\ttable1\tts1\tDAY\t1000\t0\n"
+        );
+    }
+
+    @Test
+    public void testMetadataQueryDefaultHysterisysParams() throws Exception {
+        configOverrideMaxUncommittedRows = 83737;
+        configOverrideO3CommitHysteresisInMicros = 28291;
+
+        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
+            tm1.col("abc", ColumnType.STRING);
+            tm1.timestamp("ts1");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+
+        assertSql(
+                "tables",
+                "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                        "1\ttable1\tts1\tDAY\t83737\t28291\n"
+        );
+    }
+
+    @Test
+    public void testMetadataQueryWithWhere() throws Exception {
+        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
+            tm1.col("abc", ColumnType.STRING);
+            tm1.timestamp("ts1");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
+            tm1.timestamp("ts2");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+
+        assertSql(
+                "tables where name = 'table1'",
+                "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                        "1\ttable1\tts1\tDAY\t1000\t0\n"
+        );
+    }
+
+    @Test
+    public void testMetadataQueryWithWhereAndSelect() throws Exception {
+        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
+            tm1.col("abc", ColumnType.STRING);
+            tm1.timestamp("ts1");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
+            tm1.timestamp("ts2");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+
+        assertSql(
+                "select designatedTimestamp from tables where name = 'table1'",
+                "designatedTimestamp\n" +
+                        "ts1\n"
+        );
+    }
+
+    @Test
+    public void testMetadataQueryMissingMetaFile() throws Exception {
+        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
+            tm1.col("abc", ColumnType.STRING);
+            tm1.timestamp("ts1");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
+            tm1.timestamp("ts2");
+            createPopulateTable(tm1, 0, "2020-01-01", 0);
+        }
+
+        try (Path path = new Path()) {
+            path.concat(configuration.getRoot()).concat("table1").concat(META_FILE_NAME).$();
+            configuration.getFilesFacade().remove(path);
+        }
+        assertSql(
+                "tables",
+                "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                        "2\ttable2\tts2\tNONE\t1000\t0\n"
+        );
+    }
+}


### PR DESCRIPTION
feat: add 'tables' cursor function to return table metadata