### PR TITLE
chore: typo blog publish date

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ case with up to fourteen workers on an AWS EC2 `m5.8xlarge` instance with
 sixteen cores:
 
 <div align="center">
-  <a href="https://questdb.io/blog/2021/05/05/questdb-release-6-0-tsbs-benchmark/">
+  <a href="https://questdb.io/blog/2021/05/10/questdb-release-6-0-tsbs-benchmark/">
     <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." src=".github/tsbs-results.png" width="700"/>
   </a>
 </div>


### PR DESCRIPTION
Update the TSBS link to point to the blog announcement describing the changes