### PR TITLE
chore(sql): renamed all instances of 'o3CommitHysteresisInMicros' to …

### DIFF
--- a/core/src/main/java/io/questdb/cairo/EngineMigration.java
+++ b/core/src/main/java/io/questdb/cairo/EngineMigration.java
@@ -264,7 +264,7 @@ public class EngineMigration {
             }
 
             Unsafe.getUnsafe().putLong(tempMem, migrationContext.getConfiguration().getO3CommitHysteresis());
-            if (ff.write(migrationContext.metadataFd, tempMem, Long.BYTES, META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS) != Long.BYTES) {
+            if (ff.write(migrationContext.metadataFd, tempMem, Long.BYTES, META_OFFSET_O3_COMMIT_HYSTERESIS) != Long.BYTES) {
                 throw CairoException.instance(ff.errno()).put("Cannot update metadata [path=").put(path).put(']');
             }
         }

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -268,8 +268,8 @@ public class TableReaderMetadata extends BaseRecordMetadata implements Closeable
         return metaMem.getInt(TableUtils.META_OFFSET_O3_MAX_UNCOMMITTED_ROWS);
     }
 
-    public long getO3CommitHysteresisMicros() {
-        return metaMem.getLong(TableUtils.META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS);
+    public long getO3CommitHysteresis() {
+        return metaMem.getLong(TableUtils.META_OFFSET_O3_COMMIT_HYSTERESIS);
     }
 
     private TableColumnMetadata moveMetadata(int index, TableColumnMetadata metadata) {

--- a/core/src/main/java/io/questdb/cairo/TableStructure.java
+++ b/core/src/main/java/io/questdb/cairo/TableStructure.java
@@ -49,5 +49,5 @@ public interface TableStructure {
 
     int getO3MaxUncommittedRows();
 
-    long getO3CommitHysteresisInMicros();
+    long getO3CommitHysteresis();
 }

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -61,7 +61,7 @@ public final class TableUtils {
     public static final long META_OFFSET_VERSION = 12;
     public static final long META_OFFSET_TABLE_ID = 16;
     public static final long META_OFFSET_O3_MAX_UNCOMMITTED_ROWS = 20;
-    public static final long META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS = 24;
+    public static final long META_OFFSET_O3_COMMIT_HYSTERESIS = 24;
     public static final String FILE_SUFFIX_I = ".i";
     public static final String FILE_SUFFIX_D = ".d";
     public static final int LONGS_PER_TX_ATTACHED_PARTITION = 4;
@@ -160,7 +160,7 @@ public final class TableUtils {
             mem.putInt(tableVersion);
             mem.putInt(tableId);
             mem.putInt(structure.getO3MaxUncommittedRows());
-            mem.putLong(structure.getO3CommitHysteresisInMicros());
+            mem.putLong(structure.getO3CommitHysteresis());
             mem.jumpTo(TableUtils.META_OFFSET_COLUMN_TYPES);
 
             for (int i = 0; i < count; i++) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -673,7 +673,7 @@ public class TableWriter implements Closeable {
         return true;
     }
     public void commitHysteresis() {
-        commit(defaultCommitMode, metadata.getO3CommitHysteresisInMicros());
+        commit(defaultCommitMode, metadata.getO3CommitHysteresis());
     }
 
     public void commitHysteresis(long lastTimestampHysteresisInMicros) {
@@ -1023,21 +1023,21 @@ public class TableWriter implements Closeable {
         this.lifecycleManager = lifecycleManager;
     }
 
-    public void setMetaO3CommitHysteresis(long o3CommitHysteresisInMicros) {
+    public void setMetaO3CommitHysteresis(long o3CommitHysteresis) {
         try {
             commit();
             long metaSize = copyMetadataAndUpdateVersion();
             openMetaSwapFileByIndex(ff, ddlMem, path, rootLen, this.metaSwapIndex);
             try {
-                ddlMem.jumpTo(META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS);
-                ddlMem.putLong(o3CommitHysteresisInMicros);
+                ddlMem.jumpTo(META_OFFSET_O3_COMMIT_HYSTERESIS);
+                ddlMem.putLong(o3CommitHysteresis);
                 ddlMem.jumpTo(metaSize);
             } finally {
                 ddlMem.close();
             }
 
             finishMetaSwapUpdate();
-            metadata.setO3CommitHysteresisInMicros(o3CommitHysteresisInMicros);
+            metadata.setO3CommitHysteresis(o3CommitHysteresis);
         } finally {
             ddlMem.close();
         }
@@ -1535,7 +1535,7 @@ public class TableWriter implements Closeable {
         ddlMem.putInt(ColumnType.VERSION);
         ddlMem.putInt(metaMem.getInt(META_OFFSET_TABLE_ID));
         ddlMem.putInt(metaMem.getInt(META_OFFSET_O3_MAX_UNCOMMITTED_ROWS));
-        ddlMem.putInt(metaMem.getInt(META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS));
+        ddlMem.putInt(metaMem.getInt(META_OFFSET_O3_COMMIT_HYSTERESIS));
     }
 
     private void bumpMasterRef() {
@@ -1939,7 +1939,7 @@ public class TableWriter implements Closeable {
             ddlMem.putInt(metaMem.getInt(META_OFFSET_TIMESTAMP_INDEX));
             copyVersionAndHysteresis();
             ddlMem.putInt(metaMem.getInt(META_OFFSET_O3_MAX_UNCOMMITTED_ROWS));
-            ddlMem.putLong(metaMem.getInt(META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS));
+            ddlMem.putLong(metaMem.getInt(META_OFFSET_O3_COMMIT_HYSTERESIS));
             ddlMem.jumpTo(META_OFFSET_COLUMN_TYPES);
             for (int i = 0; i < columnCount; i++) {
                 writeColumnEntry(i);

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -36,7 +36,7 @@ public class TableWriterMetadata extends BaseRecordMetadata {
     private int version;
     private final int id;
     private int o3MaxUncommittedRows;
-    private long o3CommitHysteresisInMicros;
+    private long o3CommitHysteresis;
 
     public TableWriterMetadata(FilesFacade ff, MappedReadOnlyMemory metaMem) {
         this.columnCount = metaMem.getInt(TableUtils.META_OFFSET_COUNT);
@@ -44,7 +44,7 @@ public class TableWriterMetadata extends BaseRecordMetadata {
         this.version = metaMem.getInt(TableUtils.META_OFFSET_VERSION);
         this.id = metaMem.getInt(TableUtils.META_OFFSET_TABLE_ID);
         this.o3MaxUncommittedRows = metaMem.getInt(TableUtils.META_OFFSET_O3_MAX_UNCOMMITTED_ROWS);
-        this.o3CommitHysteresisInMicros = metaMem.getLong(TableUtils.META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS);
+        this.o3CommitHysteresis = metaMem.getLong(TableUtils.META_OFFSET_O3_COMMIT_HYSTERESIS);
         TableUtils.validate(ff, metaMem, columnNameIndexMap);
         this.timestampIndex = metaMem.getInt(TableUtils.META_OFFSET_TIMESTAMP_INDEX);
         this.columnMetadata = new ObjList<>(this.columnCount);
@@ -142,15 +142,15 @@ public class TableWriterMetadata extends BaseRecordMetadata {
         return o3MaxUncommittedRows;
     }
 
-    public long getO3CommitHysteresisInMicros() {
-        return o3CommitHysteresisInMicros;
+    public long getO3CommitHysteresis() {
+        return o3CommitHysteresis;
     }
 
     public void setO3MaxUncommittedRows(int rows) {
         this.o3MaxUncommittedRows = rows;
     }
 
-    public void setO3CommitHysteresisInMicros(long micros) {
-        this.o3CommitHysteresisInMicros = micros;
+    public void setO3CommitHysteresis(long micros) {
+        this.o3CommitHysteresis = micros;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -1312,7 +1312,7 @@ class LineTcpMeasurementScheduler implements Closeable {
         }
 
         @Override
-        public long getO3CommitHysteresisInMicros() {
+        public long getO3CommitHysteresis() {
             return cairoConfiguration.getO3CommitHysteresis();
         }
 

--- a/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
@@ -567,7 +567,7 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
         }
 
         @Override
-        public long getO3CommitHysteresisInMicros() {
+        public long getO3CommitHysteresis() {
             return configuration.getO3CommitHysteresis();
         }
 

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -396,7 +396,7 @@ public class CairoTextWriter implements Closeable, Mutable {
         }
 
         @Override
-        public long getO3CommitHysteresisInMicros() {
+        public long getO3CommitHysteresis() {
             return configuration.getO3CommitHysteresis();
         }
 

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -867,11 +867,11 @@ public class SqlCompiler implements Closeable {
             }
             writer.setMetaO3MaxUncommittedRows(maxUncommittedRows);
         } else if (isO3CommitHysteresis(paramName)) {
-            long o3CommitHysteresisInMicros = SqlUtil.expectMicros(value, paramNameNamePosition);
-            if (o3CommitHysteresisInMicros < 0) {
+            long o3CommitHysteresis = SqlUtil.expectMicros(value, paramNameNamePosition);
+            if (o3CommitHysteresis < 0) {
                 throw SqlException.$(paramNameNamePosition, "O3CommitHysteresis must be non negative");
             }
-            writer.setMetaO3CommitHysteresis(o3CommitHysteresisInMicros);
+            writer.setMetaO3CommitHysteresis(o3CommitHysteresis);
         } else {
             throw SqlException.$(paramNameNamePosition, "unknown parameter '").put(paramName).put('\'');
         }
@@ -2409,8 +2409,8 @@ public class SqlCompiler implements Closeable {
         }
 
         @Override
-        public long getO3CommitHysteresisInMicros() {
-            return model.getO3CommitHysteresisInMicros();
+        public long getO3CommitHysteresis() {
+            return model.getO3CommitHysteresis();
         }
 
         TableStructureAdapter of(CreateTableModel model, RecordMetadata metadata, IntIntHashMap typeCast) {

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -424,7 +424,7 @@ public final class SqlParser {
         }
 
         int o3MaxUncommittedRows = configuration.getO3MaxUncommittedRows();
-        long o3CommitHysteresisInMicros = configuration.getO3CommitHysteresis();
+        long o3CommitHysteresis = configuration.getO3CommitHysteresis();
 
         ExpressionNode partitionBy = parseCreateTablePartition(lexer, tok);
         if (partitionBy != null) {
@@ -444,7 +444,7 @@ public final class SqlParser {
                                 throw SqlException.position(lexer.getPosition()).put(" could not parse o3MaxUncommittedRows value \"").put(expr.rhs.token).put('"');
                             }
                         } else if (isO3CommitHysteresis(expr.lhs.token)) {
-                            o3CommitHysteresisInMicros = SqlUtil.expectMicros(expr.rhs.token, lexer.getPosition());
+                            o3CommitHysteresis = SqlUtil.expectMicros(expr.rhs.token, lexer.getPosition());
                         } else {
                             throw SqlException.position(lexer.getPosition()).put(" unrecognized ").put(expr.lhs.token).put(" after WITH");
                         }
@@ -460,7 +460,7 @@ public final class SqlParser {
         }
 
         model.setO3MaxUncommittedRows(o3MaxUncommittedRows);
-        model.setO3CommitHysteresisInMicros(o3CommitHysteresisInMicros);
+        model.setO3CommitHysteresis(o3CommitHysteresis);
 
         if (tok == null || Chars.equals(tok, ';')) {
             return model;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
@@ -47,7 +47,7 @@ public class TableMetadataCursorFactory implements FunctionFactory {
     private static final int nameColumn;
     private static final int partitionByColumn;
     private static final int maxUncommittedRowsColumn;
-    private static final int o3CommitHysteresisMicroSecColumn;
+    private static final int o3CommitHysteresisColumn;
     private static final int designatedTimestampColumn;
     private static final Log LOG = LogFactory.getLog(TableMetadataCursorFactory.class);
 
@@ -63,8 +63,8 @@ public class TableMetadataCursorFactory implements FunctionFactory {
         partitionByColumn = metadata.getColumnCount() - 1;
         metadata.add(new TableColumnMetadata("o3MaxUncommittedRows", ColumnType.INT, null));
         maxUncommittedRowsColumn = metadata.getColumnCount() - 1;
-        metadata.add(new TableColumnMetadata("o3CommitHysteresisMicros", ColumnType.LONG, null));
-        o3CommitHysteresisMicroSecColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("o3CommitHysteresis", ColumnType.LONG, null));
+        o3CommitHysteresisColumn = metadata.getColumnCount() - 1;
         METADATA = metadata;
     }
 
@@ -192,7 +192,7 @@ public class TableMetadataCursorFactory implements FunctionFactory {
             public class TableListRecord implements Record {
                 private int tableId;
                 private int maxUncommittedRows;
-                private long o3CommitHysteresisMicroSec;
+                private long o3CommitHysteresis;
                 private int partitionBy;
 
                 @Override
@@ -229,8 +229,8 @@ public class TableMetadataCursorFactory implements FunctionFactory {
 
                 @Override
                 public long getLong(int col) {
-                    if (col == o3CommitHysteresisMicroSecColumn) {
-                        return o3CommitHysteresisMicroSec;
+                    if (col == o3CommitHysteresisColumn) {
+                        return o3CommitHysteresis;
                     }
                     return Numbers.LONG_NaN;
                 }
@@ -249,7 +249,7 @@ public class TableMetadataCursorFactory implements FunctionFactory {
                         // Pre-read as much as possible to skip record instead of failing on column fetch
                         tableId = metaReader.getId();
                         maxUncommittedRows = metaReader.getMaxUncommittedRows();
-                        o3CommitHysteresisMicroSec = metaReader.getO3CommitHysteresisMicros();
+                        o3CommitHysteresis = metaReader.getO3CommitHysteresis();
                         partitionBy = metaReader.getPartitionBy();
                     } catch (CairoException e) {
                         // perhaps this folder is not a table

--- a/core/src/main/java/io/questdb/griffin/model/CreateTableModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/CreateTableModel.java
@@ -43,7 +43,7 @@ public class CreateTableModel implements Mutable, ExecutionModel, Sinkable, Tabl
     private ExpressionNode timestamp;
     private ExpressionNode partitionBy;
     private int o3MaxUncommittedRows;
-    private long o3CommitHysteresisInMicros;
+    private long o3CommitHysteresisIn;
     private boolean ignoreIfExists = false;
 
     private CreateTableModel() {
@@ -324,11 +324,11 @@ public class CreateTableModel implements Mutable, ExecutionModel, Sinkable, Tabl
     }
 
     @Override
-    public long getO3CommitHysteresisInMicros() {
-        return o3CommitHysteresisInMicros;
+    public long getO3CommitHysteresis() {
+        return o3CommitHysteresisIn;
     }
 
-    public void setO3CommitHysteresisInMicros(long lineTcpCommitHysteresisInMicros) {
-        this.o3CommitHysteresisInMicros = lineTcpCommitHysteresisInMicros;
+    public void setO3CommitHysteresis(long micros) {
+        this.o3CommitHysteresisIn = micros;
     }
 }

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -57,7 +57,7 @@ public class AbstractCairoTest {
     protected static CairoEngine engine;
     protected static String inputRoot = null;
     protected static FilesFacade ff;
-    protected static long configOverrideO3CommitHysteresisInMicros = -1;
+    protected static long configOverrideO3CommitHysteresis = -1;
     protected static int configOverrideMaxUncommittedRows = -1;
 
     @Rule
@@ -96,7 +96,7 @@ public class AbstractCairoTest {
 
             @Override
             public long getO3CommitHysteresis() {
-                if (configOverrideO3CommitHysteresisInMicros >= 0) return configOverrideO3CommitHysteresisInMicros;
+                if (configOverrideO3CommitHysteresis >= 0) return configOverrideO3CommitHysteresis;
                 return super.getO3CommitHysteresis();
             }
 
@@ -130,7 +130,7 @@ public class AbstractCairoTest {
         engine.clear();
         TestUtils.removeTestPath(root);
         configOverrideMaxUncommittedRows = -1;
-        configOverrideO3CommitHysteresisInMicros = -1;
+        configOverrideO3CommitHysteresis = -1;
         currentMicros = -1;
     }
 

--- a/core/src/test/java/io/questdb/cairo/EngineMigrationTest.java
+++ b/core/src/test/java/io/questdb/cairo/EngineMigrationTest.java
@@ -339,7 +339,7 @@ public class EngineMigrationTest extends AbstractGriffinTest {
     @Test
     public void testMigrateTableSimple() throws Exception {
         configOverrideMaxUncommittedRows = 50001;
-        configOverrideO3CommitHysteresisInMicros = 777777;
+        configOverrideO3CommitHysteresis = 777777;
 
         assertMemoryLeak(() -> {
             try (TableModel src = new TableModel(configuration, "src", PartitionBy.NONE)) {
@@ -357,7 +357,7 @@ public class EngineMigrationTest extends AbstractGriffinTest {
     @Test
     public void testCannotUpdateHysteresisMetadata1() throws Exception {
         configOverrideMaxUncommittedRows = 1231231;
-        configOverrideO3CommitHysteresisInMicros = 85754;
+        configOverrideO3CommitHysteresis = 85754;
         assertMemoryLeak(() -> {
             try (TableModel src = new TableModel(configuration, "src", PartitionBy.NONE)) {
                 createPopulateTable(
@@ -385,7 +385,7 @@ public class EngineMigrationTest extends AbstractGriffinTest {
                 ff = new FilesFacadeImpl() {
                     @Override
                     public long write(long fd, long buf, long len, long offset) {
-                        if (META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS == offset) {
+                        if (META_OFFSET_O3_COMMIT_HYSTERESIS == offset) {
                             return 0;
                         }
                         return super.write(fd, buf, len, offset);
@@ -437,9 +437,9 @@ public class EngineMigrationTest extends AbstractGriffinTest {
         new EngineMigration(engine, configuration).migrateEngineTo(ColumnType.VERSION);
         TestUtils.assertEquals(expected, executeSql(queryNew));
 
-        assertSql("select o3maxUncommittedRows, o3CommitHysteresisMicros from tables where name = '" + src.getName() + "'",
-                "o3maxUncommittedRows\to3CommitHysteresisMicros\n" +
-                        +configOverrideMaxUncommittedRows + "\t" + configOverrideO3CommitHysteresisInMicros + "\n");
+        assertSql("select o3maxUncommittedRows, o3CommitHysteresis from tables where name = '" + src.getName() + "'",
+                "o3maxUncommittedRows\to3CommitHysteresis\n" +
+                        +configOverrideMaxUncommittedRows + "\t" + configOverrideO3CommitHysteresis + "\n");
     }
 
     private void downgradeMetaDataFile(TableModel tableModel) {
@@ -457,7 +457,7 @@ public class EngineMigrationTest extends AbstractGriffinTest {
             ff.close(fd);
             try (PagedMappedReadWriteMemory rwTx = new PagedMappedReadWriteMemory(ff, path.$(), fileSize)) {
                 rwTx.putInt(META_OFFSET_O3_MAX_UNCOMMITTED_ROWS, 0);
-                rwTx.putLong(META_OFFSET_O3_COMMIT_HYSTERESIS_IN_MICROS, 0);
+                rwTx.putLong(META_OFFSET_O3_COMMIT_HYSTERESIS, 0);
                 rwTx.jumpTo(fileSize);
             }
 

--- a/core/src/test/java/io/questdb/cairo/TableModel.java
+++ b/core/src/test/java/io/questdb/cairo/TableModel.java
@@ -186,7 +186,7 @@ public class TableModel implements TableStructure, Closeable {
     }
 
     @Override
-    public long getO3CommitHysteresisInMicros() {
+    public long getO3CommitHysteresis() {
         return cairoCfg.getO3CommitHysteresis();
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -210,7 +210,7 @@ public class LineTcpConnectionContextTest extends AbstractCairoTest {
             }
             try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "weather")) {
                 Assert.assertEquals(3, reader.getMetadata().getMaxUncommittedRows());
-                Assert.assertEquals(250_000, reader.getMetadata().getO3CommitHysteresisMicros());
+                Assert.assertEquals(250_000, reader.getMetadata().getO3CommitHysteresis());
             }
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n" +
                     "weather,location=us-midwest temperature=83 1465839830100500200\n" +
@@ -236,7 +236,7 @@ public class LineTcpConnectionContextTest extends AbstractCairoTest {
             assertTable(expected, "weather");
             try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "weather")) {
                 Assert.assertEquals(3, reader.getMetadata().getMaxUncommittedRows());
-                Assert.assertEquals(250_000, reader.getMetadata().getO3CommitHysteresisMicros());
+                Assert.assertEquals(250_000, reader.getMetadata().getO3CommitHysteresis());
             }
         });
     }

--- a/core/src/test/java/io/questdb/griffin/AlterTableHysteresisTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableHysteresisTest.java
@@ -88,10 +88,10 @@ public class AlterTableHysteresisTest extends AbstractGriffinTest {
                 String alterCommand = "ALTER TABLE " + tableName + " SET PARAM o3CommitHysteresis = 111s";
                 compiler.compile(alterCommand, sqlExecutionContext);
 
-                assertSql("SELECT o3CommitHysteresisMicros FROM tables() WHERE name = '" + tableName + "'",
-                        "o3CommitHysteresisMicros\n111000000\n");
+                assertSql("SELECT o3CommitHysteresis FROM tables() WHERE name = '" + tableName + "'",
+                        "o3CommitHysteresis\n111000000\n");
                 rdr.reload();
-                Assert.assertEquals(111000000L, rdr.getMetadata().getO3CommitHysteresisMicros());
+                Assert.assertEquals(111000000L, rdr.getMetadata().getO3CommitHysteresis());
             }
             assertX(tableName);
         });

--- a/core/src/test/java/io/questdb/griffin/HysteresisRetentionTest.java
+++ b/core/src/test/java/io/questdb/griffin/HysteresisRetentionTest.java
@@ -100,7 +100,7 @@ public class HysteresisRetentionTest extends AbstractGriffinTest {
                 sqlExecutionContext,
                 "tables()",
                 sink,
-                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresis\n" +
                         "1\tmy_table\ttimestamp\tDAY\t250000\t240000000\n"
         );
     }

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -2180,7 +2180,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                     "{\"columnCount\":3,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"INT\"},{\"index\":1,\"name\":\"t\",\"type\":\"TIMESTAMP\"},{\"index\":2,\"name\":\"y\",\"type\":\"BOOLEAN\"}],\"timestampIndex\":1}",
                     sink);
             Assert.assertEquals(10000, metadata.getO3MaxUncommittedRows());
-            Assert.assertEquals(250000, metadata.getO3CommitHysteresisInMicros());
+            Assert.assertEquals(250000, metadata.getO3CommitHysteresis());
         }
     }
 

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactoryTest.java
@@ -49,7 +49,7 @@ public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
 
         assertSql(
                 "tables order by id desc",
-                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresis\n" +
                         "2\ttable2\tts2\tNONE\t1000\t0\n" +
                         "1\ttable1\tts1\tDAY\t1000\t0\n"
         );
@@ -58,7 +58,7 @@ public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
     @Test
     public void testMetadataQueryDefaultHysterisysParams() throws Exception {
         configOverrideMaxUncommittedRows = 83737;
-        configOverrideO3CommitHysteresisInMicros = 28291;
+        configOverrideO3CommitHysteresis = 28291;
 
         try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
             tm1.col("abc", ColumnType.STRING);
@@ -68,7 +68,7 @@ public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
 
         assertSql(
                 "tables",
-                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresis\n" +
                         "1\ttable1\tts1\tDAY\t83737\t28291\n"
         );
     }
@@ -87,7 +87,7 @@ public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
 
         assertSql(
                 "tables where name = 'table1'",
-                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresis\n" +
                         "1\ttable1\tts1\tDAY\t1000\t0\n"
         );
     }
@@ -133,7 +133,7 @@ public class TableMetadataCursorFactoryTest extends AbstractGriffinTest {
         }
         assertSql(
                 "tables",
-                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresisMicros\n" +
+                "id\tname\tdesignatedTimestamp\tpartitionBy\to3MaxUncommittedRows\to3CommitHysteresis\n" +
                         "2\ttable2\tts2\tNONE\t1000\t0\n"
         );
     }


### PR DESCRIPTION
…'o3CommitHysteresis' for consistency