### PR TITLE
feat(sql): to_timezone() and to_utc() timestamp functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/OffsetTimestampFunctionFromOffset.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/OffsetTimestampFunctionFromOffset.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+
+class OffsetTimestampFunctionFromOffset extends TimestampFunction implements UnaryFunction {
+    private final Function timestamp;
+    private final long offset;
+
+    public OffsetTimestampFunctionFromOffset(Function timestamp, long offset) {
+        this.timestamp = timestamp;
+        this.offset = offset;
+    }
+
+    @Override
+    public Function getArg() {
+        return timestamp;
+    }
+
+    @Override
+    public long getTimestamp(Record rec) {
+        return timestamp.getTimestamp(rec) + offset;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/OffsetTimestampFunctionFromRules.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/OffsetTimestampFunctionFromRules.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.datetime.TimeZoneRules;
+
+class OffsetTimestampFunctionFromRules extends TimestampFunction implements UnaryFunction {
+    private final Function timestamp;
+    private final TimeZoneRules rules;
+    private final int multiplier;
+
+    public OffsetTimestampFunctionFromRules(Function timestamp, TimeZoneRules rules, int multiplier) {
+        this.timestamp = timestamp;
+        this.rules = rules;
+        this.multiplier = multiplier;
+    }
+
+    @Override
+    public Function getArg() {
+        return timestamp;
+    }
+
+    @Override
+    public long getTimestamp(Record rec) {
+        final long utc = timestamp.getTimestamp(rec);
+        return utc + multiplier * rules.getOffset(utc);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactory.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.*;
+import io.questdb.std.datetime.TimeZoneRules;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+
+import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
+
+public class ToTimezoneTimestampFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_timezone(NS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        Function timestamp = args.getQuick(0);
+        Function timezone = args.getQuick(1);
+
+        if (timezone.isConstant()) {
+
+            CharSequence tz = timezone.getStr(null);
+            final int hi = tz.length();
+            final long l = Timestamps.parseOffset(tz, 0, hi);
+            if (l == Long.MIN_VALUE) {
+
+                try {
+                    return new OffsetTimestampFunctionFromRules(
+                            timestamp,
+                            TimestampFormatUtils.enLocale.getZoneRules(
+                                    Numbers.decodeLowInt(TimestampFormatUtils.enLocale.matchZone(tz, 0, hi)), RESOLUTION_MICROS
+                            ),
+                            1
+                    );
+                } catch (NumericException e) {
+                    Misc.free(timestamp);
+                    throw SqlException.$(argPositions.getQuick(1), "invalid timezone name");
+                }
+
+            } else {
+
+                return new OffsetTimestampFunctionFromOffset(
+                        timestamp,
+                        Numbers.decodeLowInt(l) * Timestamps.MINUTE_MICROS
+                );
+            }
+
+        } else {
+            return new ToTimezoneFunctionVar(timestamp, timezone);
+        }
+    }
+
+    private static class ToTimezoneFunctionVar extends TimestampFunction implements BinaryFunction {
+        private final Function timestamp;
+        private final Function timezone;
+
+        public ToTimezoneFunctionVar(Function timestamp, Function timezone) {
+            this.timestamp = timestamp;
+            this.timezone = timezone;
+        }
+
+        @Override
+        public Function getLeft() {
+            return timestamp;
+        }
+
+        @Override
+        public Function getRight() {
+            return timezone;
+        }
+
+        @Override
+        public long getTimestamp(Record rec) {
+            final long timestampValue = timestamp.getTimestamp(rec);
+            try {
+                return Timestamps.toTimezone(timestampValue, TimestampFormatUtils.enLocale, timezone.getStr(rec));
+            } catch (NumericException e) {
+                return timestampValue;
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactory.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.std.*;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+
+import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
+
+public class ToUTCTimestampFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_utc(NS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        Function timestamp = args.getQuick(0);
+        Function timezone = args.getQuick(1);
+
+        if (timezone.isConstant()) {
+
+            CharSequence tz = timezone.getStr(null);
+            final int hi = tz.length();
+            final long l = Timestamps.parseOffset(tz, 0, hi);
+            if (l == Long.MIN_VALUE) {
+
+                try {
+                    return new OffsetTimestampFunctionFromRules(
+                            timestamp,
+                            TimestampFormatUtils.enLocale.getZoneRules(
+                                    Numbers.decodeLowInt(TimestampFormatUtils.enLocale.matchZone(tz, 0, hi)), RESOLUTION_MICROS
+                            ),
+                            -1
+                    );
+                } catch (NumericException e) {
+                    Misc.free(timestamp);
+                    throw SqlException.$(argPositions.getQuick(1), "invalid timezone name");
+                }
+
+            } else {
+
+                return new OffsetTimestampFunctionFromOffset(
+                        timestamp,
+                        -Numbers.decodeLowInt(l) * Timestamps.MINUTE_MICROS
+                );
+            }
+
+        } else {
+            return new ToTimezoneFunctionVar(timestamp, timezone);
+        }
+    }
+
+    private static class ToTimezoneFunctionVar extends TimestampFunction implements BinaryFunction {
+        private final Function timestamp;
+        private final Function timezone;
+
+        public ToTimezoneFunctionVar(Function timestamp, Function timezone) {
+            this.timestamp = timestamp;
+            this.timezone = timezone;
+        }
+
+        @Override
+        public Function getLeft() {
+            return timestamp;
+        }
+
+        @Override
+        public Function getRight() {
+            return timezone;
+        }
+
+        @Override
+        public long getTimestamp(Record rec) {
+            final long timestampValue = timestamp.getTimestamp(rec);
+            try {
+                return Timestamps.toUTC(timestampValue, TimestampFormatUtils.enLocale, timezone.getStr(rec));
+            } catch (NumericException e) {
+                return timestampValue;
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/std/datetime/DateLocale.java
+++ b/core/src/main/java/io/questdb/std/datetime/DateLocale.java
@@ -25,8 +25,11 @@
 package io.questdb.std.datetime;
 
 import io.questdb.std.*;
+import io.questdb.std.datetime.microtime.Timestamps;
 
 import java.text.DateFormatSymbols;
+
+import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
 public class DateLocale {
     private final IntObjHashMap<ObjList<CharSequence>> months = new IntObjHashMap<>();
@@ -198,7 +201,7 @@ public class DateLocale {
                 continue;
             }
 
-            for (int k = 1, m = zNames.length; k < m; k++) {
+            for (int k = 0, m = zNames.length; k < m; k++) {
                 String name = zNames[k];
                 // we already added this name, skip
                 if (cache.add(name)) {

--- a/core/src/main/java/io/questdb/std/datetime/DateLocale.java
+++ b/core/src/main/java/io/questdb/std/datetime/DateLocale.java
@@ -25,11 +25,8 @@
 package io.questdb.std.datetime;
 
 import io.questdb.std.*;
-import io.questdb.std.datetime.microtime.Timestamps;
 
 import java.text.DateFormatSymbols;
-
-import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
 public class DateLocale {
     private final IntObjHashMap<ObjList<CharSequence>> months = new IntObjHashMap<>();

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -28,7 +28,10 @@ import io.questdb.std.Chars;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
+import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.str.CharSink;
+
+import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
 final public class Timestamps {
 
@@ -620,6 +623,52 @@ final public class Timestamps {
         CharSink sink = Misc.getThreadLocalBuilder();
         TimestampFormatUtils.appendDateTime(sink, micros);
         return sink.toString();
+    }
+
+    public static long toTimezone(long utcTimestamp, DateLocale locale, CharSequence timezone) throws NumericException {
+        return toTimezone(utcTimestamp, locale, timezone, 0, timezone.length());
+    }
+
+    public static long toTimezone(
+            long utc,
+            DateLocale locale,
+            CharSequence timezone,
+            int lo,
+            int hi
+    ) throws NumericException {
+        final long offset;
+        long l = parseOffset(timezone, lo, hi);
+        if (l == Long.MIN_VALUE) {
+            return utc + locale.getZoneRules(
+                    Numbers.decodeLowInt(locale.matchZone(timezone, lo, hi)), RESOLUTION_MICROS
+            ).getOffset(utc);
+
+        }
+        offset = Numbers.decodeLowInt(l) * MINUTE_MICROS;
+        return utc + offset;
+    }
+
+    public static long toUTC(long timestampWithTimezone, DateLocale locale, CharSequence timezone) throws NumericException {
+        return toUTC(timestampWithTimezone, locale, timezone, 0, timezone.length());
+    }
+
+    public static long toUTC(
+            long timestampWithTimezone,
+            DateLocale locale,
+            CharSequence timezone,
+            int lo,
+            int hi
+    ) throws NumericException {
+        final long offset;
+        long l = parseOffset(timezone, lo, hi);
+        if (l == Long.MIN_VALUE) {
+            return timestampWithTimezone - locale.getZoneRules(
+                    Numbers.decodeLowInt(locale.matchZone(timezone, lo, hi)), RESOLUTION_MICROS
+            ).getOffset(timestampWithTimezone);
+
+        }
+        offset = Numbers.decodeLowInt(l) * MINUTE_MICROS;
+        return timestampWithTimezone - offset;
     }
 
     /**

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -543,6 +543,9 @@ open module io.questdb {
             BitwiseAndIntFunctionFactory,
             BitwiseOrIntFunctionFactory,
             BitwiseNotIntFunctionFactory,
-            BitwiseXorIntFunctionFactory
+            BitwiseXorIntFunctionFactory,
+
+            io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory,
+            io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory
             ;
 }

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -508,3 +508,7 @@ io.questdb.griffin.engine.functions.math.BitwiseAndIntFunctionFactory
 io.questdb.griffin.engine.functions.math.BitwiseOrIntFunctionFactory
 io.questdb.griffin.engine.functions.math.BitwiseXorIntFunctionFactory
 io.questdb.griffin.engine.functions.math.BitwiseNotIntFunctionFactory
+
+# timezone conversion
+io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory
+io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactoryTest.java
@@ -51,6 +51,19 @@ public class ToTimezoneTimestampFunctionFactoryTest extends AbstractGriffinTest 
     }
 
     @Test
+    public void testNullConstantTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_timezone(0, null)", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(22, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "timezone must not be null");
+            }
+        });
+    }
+
+    @Test
     public void testInvalidConstantOffset() throws Exception {
         assertMemoryLeak(() -> {
             try {
@@ -91,6 +104,14 @@ public class ToTimezoneTimestampFunctionFactoryTest extends AbstractGriffinTest 
     public void testVarInvalidTimezone() throws Exception {
         assertToTimezone(
                 "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select 'XU' zone)",
+                "2020-03-12T15:30:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarNullTimezone() throws Exception {
+        assertToTimezone(
+                "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select null zone)",
                 "2020-03-12T15:30:00.000000Z\n"
         );
     }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/ToTimezoneTimestampFunctionFactoryTest.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ToTimezoneTimestampFunctionFactoryTest extends AbstractGriffinTest {
+
+    @Test
+    public void testAreaName() throws Exception {
+        assertToTimezone("select to_timezone(0, 'Europe/Prague')", "1970-01-01T01:00:00.000000Z\n");
+    }
+
+    @Test
+    public void testInvalidConstantTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_timezone(0, 'UUU')", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(22, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone name");
+            }
+        });
+    }
+
+    @Test
+    public void testInvalidConstantOffset() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_timezone(0, '25:40')", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(22, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone name");
+            }
+        });
+    }
+
+    @Test
+    public void testZoneName() throws Exception {
+        assertToTimezone(
+                "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), 'PST')",
+                "2020-03-12T08:30:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testTimeOffset() throws Exception {
+        assertToTimezone(
+                "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), '-07:40')",
+                        "2020-03-12T07:50:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarTimezone() throws Exception {
+        assertToTimezone(
+                "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select '-07:40' zone)",
+                "2020-03-12T07:50:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarInvalidTimezone() throws Exception {
+        assertToTimezone(
+                "select to_timezone(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select 'XU' zone)",
+                "2020-03-12T15:30:00.000000Z\n"
+        );
+    }
+
+    private void assertToTimezone(String sql, String expected) throws Exception {
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                sql,
+                sink,
+                "to_timezone\n" +
+                        expected
+        ));
+    }
+
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactoryTest.java
@@ -51,6 +51,19 @@ public class ToUTCTimestampFunctionFactoryTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testNullConstantTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_utc(0, null)", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(17, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "timezone must not be null");
+            }
+        });
+    }
+
+    @Test
     public void testInvalidConstantOffset() throws Exception {
         assertMemoryLeak(() -> {
             try {
@@ -91,6 +104,14 @@ public class ToUTCTimestampFunctionFactoryTest extends AbstractGriffinTest {
     public void testVarInvalidTimezone() throws Exception {
         assertToUTC(
                 "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select 'XU' zone)",
+                "2020-03-12T15:30:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarNullTimezone() throws Exception {
+        assertToUTC(
+                "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select null zone)",
                 "2020-03-12T15:30:00.000000Z\n"
         );
     }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/date/ToUTCTimestampFunctionFactoryTest.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ToUTCTimestampFunctionFactoryTest extends AbstractGriffinTest {
+
+    @Test
+    public void testAreaName() throws Exception {
+        assertToUTC("select to_utc(0, 'Europe/Prague')", "1969-12-31T23:00:00.000000Z\n");
+    }
+
+    @Test
+    public void testInvalidConstantTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_utc(0, 'UUU')", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(17, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone name");
+            }
+        });
+    }
+
+    @Test
+    public void testInvalidConstantOffset() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                compiler.compile("select to_utc(0, '25:40')", sqlExecutionContext);
+                Assert.fail();
+            } catch (SqlException e) {
+                Assert.assertEquals(17, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone name");
+            }
+        });
+    }
+
+    @Test
+    public void testZoneName() throws Exception {
+        assertToUTC(
+                "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), 'PST')",
+                "2020-03-12T22:30:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testTimeOffset() throws Exception {
+        assertToUTC(
+                "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), '-07:40')",
+                        "2020-03-12T23:10:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarTimezone() throws Exception {
+        assertToUTC(
+                "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select '-07:40' zone)",
+                "2020-03-12T23:10:00.000000Z\n"
+        );
+    }
+
+    @Test
+    public void testVarInvalidTimezone() throws Exception {
+        assertToUTC(
+                "select to_utc(cast('2020-03-12T15:30:00.000000Z' as timestamp), zone) from (select 'XU' zone)",
+                "2020-03-12T15:30:00.000000Z\n"
+        );
+    }
+
+    private void assertToUTC(String sql, String expected) throws Exception {
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                sql,
+                sink,
+                "to_utc\n" +
+                        expected
+        ));
+    }
+
+}


### PR DESCRIPTION
List of supported time zone names is the same as by Java itself, we use the same database:

https://code2care.org/pages/java-timezone-list-utc-gmt-offset