### PR TITLE
chore(sql): we used map with capacity too big for finding out distinc…

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -200,6 +200,8 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long instanceHashHi;
     private final int sqlTxnScoreboardEntryCount;
     private final boolean o3QuickSortEnabled;
+    private final int sqlDistinctTimestampKeyCapacity;
+    private final double sqlDistinctTimestampLoadFactor;
     private boolean httpAllowDeflateBeforeSend;
     private int[] httpWorkerAffinity;
     private int[] httpMinWorkerAffinity;
@@ -607,6 +609,8 @@ public class PropServerConfiguration implements ServerConfiguration {
             if (this.locale == null) {
                 throw new ServerConfigurationException("cairo.date.locale", dateLocale);
             }
+            this.sqlDistinctTimestampKeyCapacity = getInt(properties, env, "cairo.sql.distinct.timestamp.key.capacity", 512);
+            this.sqlDistinctTimestampLoadFactor = getDouble(properties, env, "cairo.sql.distinct.timestamp.load.factor", 0.5);
 
             this.inputFormatConfiguration = new InputFormatConfiguration(
                     new DateFormatFactory(),
@@ -1595,6 +1599,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getSqlMapPageSize() {
             return sqlMapPageSize;
+        }
+
+        @Override
+        public int getSqlDistinctTimestampKeyCapacity() {
+            return sqlDistinctTimestampKeyCapacity;
+        }
+
+        @Override
+        public double getSqlDistinctTimestampLoadFactor() {
+            return sqlDistinctTimestampLoadFactor;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -120,6 +120,10 @@ public interface CairoConfiguration {
 
     int getSqlMapPageSize();
 
+    int getSqlDistinctTimestampKeyCapacity();
+
+    double getSqlDistinctTimestampLoadFactor();
+
     int getSqlMapMaxPages();
 
     int getSqlMapMaxResizes();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -65,6 +65,16 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getO3PurgeDiscoveryQueueCapacity() {
+        return 1024;
+    }
+
+    @Override
+    public int getO3PurgeQueueCapacity() {
+        return 1024;
+    }
+
+    @Override
     public int getSqlCopyBufferSize() {
         return 1024 * 1024;
     }
@@ -212,11 +222,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public boolean isO3QuickSortEnabled() {
-        return false;
-    }
-
-    @Override
     public int getSqlCharacterStoreSequencePoolCapacity() {
         return 64;
     }
@@ -259,6 +264,16 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getSqlMapPageSize() {
         return 16 * Numbers.SIZE_1MB;
+    }
+
+    @Override
+    public int getSqlDistinctTimestampKeyCapacity() {
+        return 256;
+    }
+
+    @Override
+    public double getSqlDistinctTimestampLoadFactor() {
+        return 0.5;
     }
 
     @Override
@@ -512,16 +527,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public int getO3PurgeDiscoveryQueueCapacity() {
-        return 1024;
-    }
-
-    @Override
-    public int getO3PurgeQueueCapacity() {
-        return 1024;
-    }
-
-    @Override
     public int getTxnScoreboardEntryCount() {
         return 8192;
     }
@@ -534,5 +539,10 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public long getCommitLag() {
         return 0;
+    }
+
+    @Override
+    public boolean isO3QuickSortEnabled() {
+        return false;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctTimeSeriesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctTimeSeriesRecordCursorFactory.java
@@ -24,13 +24,8 @@
 
 package io.questdb.griffin.engine.groupby;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.EntityColumnFilter;
-import io.questdb.cairo.RecordSink;
-import io.questdb.cairo.RecordSinkFactory;
-import io.questdb.cairo.map.Map;
-import io.questdb.cairo.map.MapFactory;
-import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.*;
+import io.questdb.cairo.map.*;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.BytecodeAssembler;
@@ -59,7 +54,14 @@ public class DistinctTimeSeriesRecordCursorFactory implements RecordCursorFactor
         // sink will be storing record columns to map key
         columnFilter.of(metadata.getColumnCount());
         RecordSink recordSink = RecordSinkFactory.getInstance(asm, metadata, columnFilter, false);
-        this.dataMap = MapFactory.createMap(configuration, metadata);
+        this.dataMap = new FastMap(
+                configuration.getSqlMapPageSize(),
+                metadata,
+                configuration.getSqlDistinctTimestampKeyCapacity(),
+                configuration.getSqlDistinctTimestampLoadFactor(),
+                Integer.MAX_VALUE
+        ) ;
+
         this.base = base;
         this.metadata = metadata;
         this.cursor = new DistinctTimeSeriesRecordCursor(

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -530,6 +530,9 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(2_000_000, configuration.getCairoConfiguration().getCommitLag());
             Assert.assertEquals(100000, configuration.getCairoConfiguration().getMaxUncommittedRows());
 
+            Assert.assertEquals(256, configuration.getCairoConfiguration().getSqlDistinctTimestampKeyCapacity());
+            Assert.assertEquals(0.4, configuration.getCairoConfiguration().getSqlDistinctTimestampLoadFactor(), 0.001);
+
             Assert.assertEquals(167903521, configuration.getLineUdpReceiverConfiguration().getBindIPv4Address());
             Assert.assertEquals(9915, configuration.getLineUdpReceiverConfiguration().getPort());
             Assert.assertEquals(-536805119, configuration.getLineUdpReceiverConfiguration().getGroupIPv4Address());

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -109,6 +109,9 @@ cairo.sql.float.cast.scale=3
 cairo.sql.append.page.size=32M
 cairo.sql.bind.variable.pool.size=16
 
+cairo.sql.distinct.timestamp.key.capacity=256
+cairo.sql.distinct.timestamp.load.factor=0.4
+
 cairo.commit.lag=2000
 cairo.max.uncommitted.rows=100000
 


### PR DESCRIPTION
…t rows in table with timestamp

Introduced separate configuration setting for distinct queries that involve timestamped tables