### PR TITLE
feat(ilp): configurable socket read retry count 

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /build
 
 RUN curl -L "https://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip" --output maven.zip \
   && unzip maven.zip \
-  && git clone --depth=1 --progress --verbose https://github.com/questdb/questdb.git
+  && git clone --progress https://github.com/questdb/questdb.git
+  && git checkout --track origin/fix_docker
 
 WORKDIR /build/questdb
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -7,9 +7,7 @@ WORKDIR /build
 
 RUN curl -L "https://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip" --output maven.zip \
   && unzip maven.zip \
-  && git clone --progress https://github.com/questdb/questdb.git \
-  && cd questdb \
-  && git checkout fix_docker
+  && git clone --depth=1 --progress --verbose https://github.com/questdb/questdb.git
 
 WORKDIR /build/questdb
 
@@ -54,4 +52,4 @@ EXPOSE 9009/tcp
 #
 # then one can create 'log.conf' in the 'conf' dir and override logger fully
 #
-CMD ["/app/bin/java", "-Debug", "-Dout=conf/log.conf", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb", "-f"]
+CMD ["/app/bin/java", "-Dout=conf/log.conf", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb", "-f"]

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /build
 
 RUN curl -L "https://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip" --output maven.zip \
   && unzip maven.zip \
-  && git clone --progress https://github.com/questdb/questdb.git
-  && git checkout --track origin/fix_docker
+  && git clone --progress https://github.com/questdb/questdb.git \
+  && cd questdb \
+  && git checkout fix_docker
 
 WORKDIR /build/questdb
 
@@ -53,4 +54,4 @@ EXPOSE 9009/tcp
 #
 # then one can create 'log.conf' in the 'conf' dir and override logger fully
 #
-CMD ["/app/bin/java", "-Dout=conf/log.conf", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb", "-f"]
+CMD ["/app/bin/java", "-Debug", "-Dout=conf/log.conf", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb", "-f"]

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -729,7 +729,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 if (null != lineTcpAuthDbPath) {
                     this.lineTcpAuthDbPath = new File(root, this.lineTcpAuthDbPath).getAbsolutePath();
                 }
-                this.lineTcpAggressiveRecv = getBoolean(properties, env, "line.tcp.io.aggressive.recv", true);
+                this.lineTcpAggressiveRecv = getBoolean(properties, env, "line.tcp.io.aggressive.recv", false);
                 this.minIdleMsBeforeWriterRelease = getLong(properties, env, "line.tcp.min.idle.ms.before.writer.release", 10_000);
             }
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -729,7 +729,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 if (null != lineTcpAuthDbPath) {
                     this.lineTcpAuthDbPath = new File(root, this.lineTcpAuthDbPath).getAbsolutePath();
                 }
-                this.lineTcpAggressiveRecv = getBoolean(properties, env, "line.tcp.io.aggressive.recv", false);
+                this.lineTcpAggressiveRecv = getBoolean(properties, env, "line.tcp.io.aggressive.recv", true);
                 this.minIdleMsBeforeWriterRelease = getLong(properties, env, "line.tcp.min.idle.ms.before.writer.release", 10_000);
             }
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -321,7 +321,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private long lineTcpMaintenanceInterval;
     private String lineTcpAuthDbPath;
     private int lineDefaultPartitionBy;
-    private boolean lineTcpAggressiveRecv;
+    private int lineTcpAggressiveReadRetryCount;
     private long minIdleMsBeforeWriterRelease;
     private String httpVersion;
     private int httpMinWorkerCount;
@@ -729,7 +729,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 if (null != lineTcpAuthDbPath) {
                     this.lineTcpAuthDbPath = new File(root, this.lineTcpAuthDbPath).getAbsolutePath();
                 }
-                this.lineTcpAggressiveRecv = getBoolean(properties, env, "line.tcp.io.aggressive.recv", false);
+                this.lineTcpAggressiveReadRetryCount = getInt(properties, env, "line.tcp.aggressive.read.retry.count", 0);
                 this.minIdleMsBeforeWriterRelease = getLong(properties, env, "line.tcp.min.idle.ms.before.writer.release", 10_000);
             }
 
@@ -2223,8 +2223,8 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean isIOAggressiveRecv() {
-            return lineTcpAggressiveRecv;
+        public int getAggressiveReadRetryCount() {
+            return lineTcpAggressiveReadRetryCount;
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -211,7 +211,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
 
     @Override
     public long getSpinLockTimeoutUs() {
-        return 1000000;
+        return 5000000;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/AggressiveRecvLineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/AggressiveRecvLineTcpConnectionContext.java
@@ -13,7 +13,25 @@ public class AggressiveRecvLineTcpConnectionContext extends LineTcpConnectionCon
         read();
         do {
             rc = parseMeasurements(netIoJob);
-        } while (rc == IOContextResult.NEEDS_READ && read());
+        } while (rc == IOContextResult.NEEDS_READ && (read()));
         return rc;
+    }
+
+    @Override
+    protected boolean read() {
+        if (super.read()) {
+            return true;
+        }
+
+        long remaining = 10_000;
+
+        while (remaining > 0) {
+            if (super.read()) {
+                return true;
+            }
+            remaining--;
+        }
+
+        return false;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -133,12 +133,12 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
     }
 
     @Override
-    public boolean isIOAggressiveRecv() {
-        return false;
+    public long getWriterIdleTimeout() {
+        return 30_000;
     }
 
     @Override
-    public long getWriterIdleTimeout() {
-        return 30_000;
+    public int getAggressiveReadRetryCount() {
+        return 0;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -212,7 +212,7 @@ class LineTcpConnectionContext implements IOContext, Mutable {
         return this;
     }
 
-    protected final boolean read() {
+    protected boolean read() {
         int bufferRemaining = (int) (recvBufEnd - recvBufPos);
         final int orig = bufferRemaining;
         if (bufferRemaining > 0 && !peerDisconnected) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
@@ -77,5 +77,5 @@ public interface LineTcpReceiverConfiguration {
 
     boolean isEnabled();
 
-    boolean isIOAggressiveRecv();
+    int getAggressiveReadRetryCount();
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
@@ -120,7 +120,7 @@ public class LineTcpServer implements Closeable {
         public LineTcpConnectionContextFactory(LineTcpReceiverConfiguration configuration) {
             ObjectFactory<LineTcpConnectionContext> factory;
             if (null == configuration.getAuthDbPath()) {
-                if (configuration.isIOAggressiveRecv()) {
+                if (configuration.getAggressiveReadRetryCount() > 0) {
                     LOG.info().$("using aggressive context").$();
                     factory = () -> new AggressiveRecvLineTcpConnectionContext(configuration, scheduler);
                 } else {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpServer.java
@@ -121,11 +121,14 @@ public class LineTcpServer implements Closeable {
             ObjectFactory<LineTcpConnectionContext> factory;
             if (null == configuration.getAuthDbPath()) {
                 if (configuration.isIOAggressiveRecv()) {
+                    LOG.info().$("using aggressive context").$();
                     factory = () -> new AggressiveRecvLineTcpConnectionContext(configuration, scheduler);
                 } else {
+                    LOG.info().$("using default context").$();
                     factory = () -> new LineTcpConnectionContext(configuration, scheduler);
                 }
             } else {
+                LOG.info().$("using authenticating context").$();
                 AuthDb authDb = new AuthDb(configuration);
                 factory = () -> new LineTcpAuthConnectionContext(configuration, authDb, scheduler);
             }

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -334,12 +334,21 @@
 #line.tcp.writer.worker.yield.threshold=10
 #line.tcp.writer.worker.sleep.threshold=10000
 #line.tcp.writer.halt.on.error=false
+
 #line.tcp.io.worker.count=0
 #line.tcp.io.worker.affinity=
 #line.tcp.io.worker.yield.threshold=10
 #line.tcp.io.worker.sleep.threshold=10000
 #line.tcp.io.halt.on.error=false
-#line.tcp.io.aggressive.recv=false
+
+# Controls how readily TCP server releases the socket to 'epoll'
+# when socket is not sending. Default value is 0, which means
+# socket is enqueued as soon as it stops sending. Setting this value to
+# positive integer forces server to keep trying to read given amount of times
+# before enqueuing the socket. Under heavy load setting this value to 100 or so
+# might produce more consistent throughput figures. If you are happy with
+# ILP throughput as it is - leave this value unchanged
+#line.tcp.aggressive.read.retry.count=0
 
 # Number of updates (per table) between attempts to rebalance the load between the writer workers
 #line.tcp.n.updates.per.load.balance=10000

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -248,7 +248,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(1.9, configuration.getLineTcpReceiverConfiguration().getMaxLoadRatio(), 0.001);
         Assert.assertEquals(30_000, configuration.getLineTcpReceiverConfiguration().getMaintenanceInterval());
         Assert.assertEquals(PartitionBy.DAY, configuration.getLineTcpReceiverConfiguration().getDefaultPartitionBy());
-        Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().isIOAggressiveRecv());
+        Assert.assertEquals(0, configuration.getLineTcpReceiverConfiguration().getAggressiveReadRetryCount());
         Assert.assertEquals(10_000, configuration.getLineTcpReceiverConfiguration().getWriterIdleTimeout());
 
         Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
@@ -576,7 +576,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(1.5, configuration.getLineTcpReceiverConfiguration().getMaxLoadRatio(), 0.001);
             Assert.assertEquals(1000, configuration.getLineTcpReceiverConfiguration().getMaintenanceInterval());
             Assert.assertEquals(PartitionBy.MONTH, configuration.getLineTcpReceiverConfiguration().getDefaultPartitionBy());
-            Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().isIOAggressiveRecv());
+            Assert.assertEquals(10_000, configuration.getLineTcpReceiverConfiguration().getAggressiveReadRetryCount());
             Assert.assertEquals(5_000, configuration.getLineTcpReceiverConfiguration().getWriterIdleTimeout());
 
             Assert.assertTrue(configuration.getCairoConfiguration().getTelemetryConfiguration().getEnabled());

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -154,7 +154,7 @@ line.tcp.n.updates.per.load.balance=100000
 line.tcp.max.load.ratio=1.5
 line.tcp.maintenance.job.interval=1000
 line.tcp.default.partition.by=MONTH
-line.tcp.io.aggressive.recv=true
+line.tcp.aggressive.read.retry.count=10000
 line.tcp.min.idle.ms.before.writer.release=5000
 
 telemetry.enabled=true


### PR DESCRIPTION
This is socket use is unfair in terms of CPU scheduling but it deals with high load volumes more consistently than "fair" method. By default "fair" method is used and there is no change for end-user.