### PR TITLE
docs: minor edit to translation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   </a>
 </p>
 
+English | [简体中文](./i18n/README.zh-cn.md)
+
 # QuestDB
 
 QuestDB is a high-performance, open-source SQL database for applications in
@@ -108,11 +110,6 @@ The following table shows query execution time of a billion rows run on a
   bug reports and feature requests.
 - [The product roadmap](https://github.com/questdb/questdb/projects/3) lists the
   tasks and features we're currently working on.
-
-## Translations
-
-- [English](https://github.com/questdb/questdb)
-- [Simplified Chinese / 简体中文](./i18n/README.zh-cn.md)
 
 ## Contribute
 

--- a/i18n/README.zh-cn.md
+++ b/i18n/README.zh-cn.md
@@ -15,6 +15,8 @@
   </a>
 </p>
 
+简体中文 | [English](https://github.com/questdb/questdb)
+
 # QuestDB
 
 QuestDB 是一个高性能、开源的 SQL 数据库，适用于金融服务、物联网、机器学习
@@ -97,10 +99,6 @@ brew services start questdb
   能请求。
 - [产品路线图](https://github.com/questdb/questdb/projects/3)列出了我们目前正在
   进行的任务和功能。
-
-## 翻译
-
-- [翻译列表](./languages.md)
 
 ## 贡献
 


### PR DESCRIPTION
This PR removes the Translations section and adds a language switcher to the top of the README