### PR TITLE
feat(ilp): fix various edge cases, behaviour of type parsers tcp/udp is closer, allow empty field value as null, support other types

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -130,6 +130,10 @@ public final class ColumnType {
         return columnType == BINARY;
     }
 
+    public static boolean isLong256(int columnType) {
+        return columnType == LONG256;
+    }
+
     public static boolean isBoolean(int columnType) {
         return columnType == ColumnType.BOOLEAN;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -69,120 +69,119 @@ public class CairoLineProtoParserSupport {
             CharSequence value,
             int storageColumnType
     ) throws BadCastException {
-        if (!SqlKeywords.isNullKeyword(value)) {
-            try {
-                switch (ColumnType.tagOf(columnType)) {
-                    case ColumnType.LONG:
-                        row.putLong(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                        break;
-                    case ColumnType.BOOLEAN:
-                        row.putBool(columnIndex, isTrue(value));
-                        break;
-                    case ColumnType.STRING:
-                        row.putStr(columnIndex, value, 1, value.length() - 2);
-                        break;
-                    case ColumnType.SYMBOL:
-                        row.putSym(columnIndex, value);
-                        break;
-                    case ColumnType.DOUBLE:
-                        row.putDouble(columnIndex, Numbers.parseDouble(value));
-                        break;
-                    case ColumnType.FLOAT:
-                        row.putFloat(columnIndex, Numbers.parseFloat(value));
-                        break;
-                    case ColumnType.INT:
-                        row.putInt(columnIndex, Numbers.parseInt(value, 0, value.length() - 1));
-                        break;
-                    case ColumnType.SHORT:
-                        row.putShort(columnIndex, Numbers.parseShort(value, 0, value.length() - 1));
-                        break;
-                    case ColumnType.BYTE:
-                        long v = Numbers.parseLong(value, 0, value.length() - 1);
-                        if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
-                            throw CairoException.instance(0)
-                                    .put("line protocol integer is out of byte bounds [columnIndex=")
-                                    .put(columnIndex)
-                                    .put(", v=")
-                                    .put(v)
-                                    .put(']');
-                        }
-                        row.putByte(columnIndex, (byte) v);
-                        break;
-                    case ColumnType.DATE:
-                        row.putDate(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                        break;
-                    case ColumnType.LONG256:
-                        int limit = value.length() - 1;
-                        if (value.charAt(limit) != 'i') {
-                            limit++;
-                        }
-                        row.putLong256(columnIndex, value, 2, limit);
-                        break;
-                    case ColumnType.TIMESTAMP:
-                        row.putTimestamp(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                        break;
-                    case ColumnType.CHAR:
-                        row.putChar(columnIndex, value.length() == 2 ? (char) 0 : value.charAt(1)); // skip quotes
-                        break;
-                    case ColumnType.GEOBYTE:
-                        row.putByte(
-                                columnIndex,  // skip quotes
-                                (byte) GeoHashes.fromStringTruncatingNl(
-                                        value,
-                                        1,
-                                        value.length() - 1,
-                                        columnTypeMeta
-                                )
-                        );
-                        break;
-                    case ColumnType.GEOSHORT:
-                        row.putShort(
-                                columnIndex,
-                                (short) GeoHashes.fromStringTruncatingNl(
-                                        value,
-                                        1,
-                                        value.length() - 1,
-                                        columnTypeMeta
-                                )
-                        );
-                        break;
-                    case ColumnType.GEOINT:
-                        row.putInt(
-                                columnIndex,
-                                (int) GeoHashes.fromStringTruncatingNl(
-                                        value,
-                                        1,
-                                        value.length() - 1,
-                                        columnTypeMeta
-                                )
-                        );
-                        break;
-                    case ColumnType.GEOLONG:
-                        row.putLong(
-                                columnIndex,
-                                GeoHashes.fromStringTruncatingNl(
-                                        value,
-                                        1,
-                                        value.length() - 1,
-                                        columnTypeMeta
-                                )
-                        );
-                        break;
-                    default:
-                        // unsupported types are ignored
-                        break;
-                }
-            } catch (NumericException e) {
-                LOG.info()
-                        .$("cast error [value=")
-                        .$(value).$(", toType=")
-                        .$(ColumnType.nameOf(columnType))
-                        .$(']')
-                        .$();
-            }
-        }
-        else {
+        if (SqlKeywords.isNullKeyword(value)) {
             putNullValue(row, columnIndex, storageColumnType);
+            return;
+        }
+        try {
+            switch (ColumnType.tagOf(columnType)) {
+                case ColumnType.LONG:
+                    row.putLong(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                    break;
+                case ColumnType.BOOLEAN:
+                    row.putBool(columnIndex, isTrue(value));
+                    break;
+                case ColumnType.STRING:
+                    row.putStr(columnIndex, value, 1, value.length() - 2);
+                    break;
+                case ColumnType.SYMBOL:
+                    row.putSym(columnIndex, value);
+                    break;
+                case ColumnType.DOUBLE:
+                    row.putDouble(columnIndex, Numbers.parseDouble(value));
+                    break;
+                case ColumnType.FLOAT:
+                    row.putFloat(columnIndex, Numbers.parseFloat(value));
+                    break;
+                case ColumnType.INT:
+                    row.putInt(columnIndex, Numbers.parseInt(value, 0, value.length() - 1));
+                    break;
+                case ColumnType.SHORT:
+                    row.putShort(columnIndex, Numbers.parseShort(value, 0, value.length() - 1));
+                    break;
+                case ColumnType.BYTE:
+                    long v = Numbers.parseLong(value, 0, value.length() - 1);
+                    if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
+                        throw CairoException.instance(0)
+                                .put("line protocol integer is out of byte bounds [columnIndex=")
+                                .put(columnIndex)
+                                .put(", v=")
+                                .put(v)
+                                .put(']');
+                    }
+                    row.putByte(columnIndex, (byte) v);
+                    break;
+                case ColumnType.DATE:
+                    row.putDate(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                    break;
+                case ColumnType.LONG256:
+                    int limit = value.length() - 1;
+                    if (value.charAt(limit) != 'i') {
+                        limit++;
+                    }
+                    row.putLong256(columnIndex, value, 2, limit);
+                    break;
+                case ColumnType.TIMESTAMP:
+                    row.putTimestamp(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                    break;
+                case ColumnType.CHAR:
+                    row.putChar(columnIndex, value.length() == 2 ? (char) 0 : value.charAt(1)); // skip quotes
+                    break;
+                case ColumnType.GEOBYTE:
+                    row.putByte(
+                            columnIndex,  // skip quotes
+                            (byte) GeoHashes.fromStringTruncatingNl(
+                                    value,
+                                    1,
+                                    value.length() - 1,
+                                    columnTypeMeta
+                            )
+                    );
+                    break;
+                case ColumnType.GEOSHORT:
+                    row.putShort(
+                            columnIndex,
+                            (short) GeoHashes.fromStringTruncatingNl(
+                                    value,
+                                    1,
+                                    value.length() - 1,
+                                    columnTypeMeta
+                            )
+                    );
+                    break;
+                case ColumnType.GEOINT:
+                    row.putInt(
+                            columnIndex,
+                            (int) GeoHashes.fromStringTruncatingNl(
+                                    value,
+                                    1,
+                                    value.length() - 1,
+                                    columnTypeMeta
+                            )
+                    );
+                    break;
+                case ColumnType.GEOLONG:
+                    row.putLong(
+                            columnIndex,
+                            GeoHashes.fromStringTruncatingNl(
+                                    value,
+                                    1,
+                                    value.length() - 1,
+                                    columnTypeMeta
+                            )
+                    );
+                    break;
+                default:
+                    // unsupported types are ignored
+                    break;
+            }
+        } catch (NumericException e) {
+            LOG.info()
+                    .$("cast error [value=")
+                    .$(value).$(", toType=")
+                    .$(ColumnType.nameOf(columnType))
+                    .$(']')
+                    .$();
         }
     }
 
@@ -252,9 +251,6 @@ public class CairoLineProtoParserSupport {
 
     private static void putNullValue(TableWriter.Row row, int columnIndex, int storageColumnType) {
         switch (ColumnType.tagOf(storageColumnType)) {
-            case ColumnType.LONG:
-                row.putLong(columnIndex, Numbers.LONG_NaN);
-                break;
             case ColumnType.BOOLEAN:
                 row.putBool(columnIndex, false);
                 break;
@@ -270,6 +266,9 @@ public class CairoLineProtoParserSupport {
             case ColumnType.FLOAT:
                 row.putFloat(columnIndex, Float.NaN);
                 break;
+            case ColumnType.LONG:
+                row.putLong(columnIndex, Numbers.LONG_NaN);
+                break;
             case ColumnType.INT:
                 row.putInt(columnIndex, Numbers.INT_NaN);
                 break;
@@ -279,17 +278,17 @@ public class CairoLineProtoParserSupport {
             case ColumnType.BYTE:
                 row.putByte(columnIndex, (byte) 0);
                 break;
+            case ColumnType.CHAR:
+                row.putChar(columnIndex, (char) 0);
+                break;
             case ColumnType.DATE:
                 row.putDate(columnIndex, Numbers.LONG_NaN);
-                break;
-            case ColumnType.LONG256:
-                row.putLong256(columnIndex, "");
                 break;
             case ColumnType.TIMESTAMP:
                 row.putTimestamp(columnIndex, Numbers.LONG_NaN);
                 break;
-            case ColumnType.CHAR:
-                row.putChar(columnIndex, (char) 0);
+            case ColumnType.LONG256:
+                row.putLong256(columnIndex, "");
                 break;
             case ColumnType.GEOBYTE:
                 row.putByte(columnIndex, GeoHashes.BYTE_NULL);
@@ -301,7 +300,7 @@ public class CairoLineProtoParserSupport {
                 row.putInt(columnIndex, GeoHashes.INT_NULL);
                 break;
             case ColumnType.GEOLONG:
-                row.putLong(columnIndex, GeoHashes.INT_NULL);
+                row.putLong(columnIndex, GeoHashes.NULL);
                 break;
             default:
                 // unsupported types are ignored

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -172,7 +172,6 @@ public class CairoLineProtoParserSupport {
         } else {
             putNullValue(row, columnIndex, columnType);
         }
-
     }
 
     public static class BadCastException extends Exception {
@@ -182,7 +181,7 @@ public class CairoLineProtoParserSupport {
     public static int getValueType(CharSequence value) {
         // method called for inbound ilp messages on each value.
         // returning UNDEFINED makes the whole line be skipped.
-        // 0 len values, null, should result in a skip of the insert.
+        // 0 len values, return null type.
         // the goal of this method is to guess the potential type
         // and then it will be parsed accordingly by 'putValue'.
         int valueLen = value.length();
@@ -219,7 +218,6 @@ public class CairoLineProtoParserSupport {
                     return ColumnType.STRING;
                 default:
                     char first = value.charAt(0);
-                    // TODO: speed this up
                     if (last >= '0' && last <= '9' && ((first >= '0' && first <= '9') || first == '-' || first == '.')) {
                         return ColumnType.DOUBLE;
                     }

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -37,28 +37,17 @@ import io.questdb.std.NumericException;
 public class CairoLineProtoParserSupport {
     private final static Log LOG = LogFactory.getLog(CairoLineProtoParserSupport.class);
 
-    public static void putValue(
-            TableWriter.Row row,
-            int columnType,
-            int columnTypeMeta,
-            int columnIndex,
-            CharSequence value
-    ) throws BadCastException {
-        putValue(row, columnType, columnTypeMeta, columnIndex, value, ColumnType.UNDEFINED);
-    }
-
     /**
      * Writes column value to table row. CharSequence value is interpreted depending on
      * column type and written to column, identified by columnIndex. If value cannot be
      * cast to column type, #BadCastException is thrown.
      *
-     * @param row               table row
-     * @param columnType        column type value will be cast to
-     * @param columnTypeMeta    if columnType's tag is GeoHash it contains bits precision (low short)
-     *                          and tag size (high short negative), otherwise -1
-     * @param columnIndex       index of column to write value to
-     * @param value             value characters
-     * @param storageColumnType column storage type when table exists, otherwise UNDEFINED
+     * @param row            table row
+     * @param columnType     column type value will be cast to
+     * @param columnTypeMeta if columnType's tag is GeoHash it contains bits precision (low short)
+     *                       and tag size (high short negative), otherwise -1
+     * @param columnIndex    index of column to write value to
+     * @param value          value characters
      * @throws BadCastException when value cannot be cast to the give type
      */
     public static void putValue(
@@ -66,13 +55,8 @@ public class CairoLineProtoParserSupport {
             int columnType,
             int columnTypeMeta,
             int columnIndex,
-            CharSequence value,
-            int storageColumnType
+            CharSequence value
     ) throws BadCastException {
-        if (SqlKeywords.isNullKeyword(value)) {
-            putNullValue(row, columnIndex, storageColumnType);
-            return;
-        }
         try {
             switch (ColumnType.tagOf(columnType)) {
                 case ColumnType.LONG:
@@ -242,14 +226,14 @@ public class CairoLineProtoParserSupport {
                     return ColumnType.SYMBOL;
             }
         }
-        return len == 0 ? ColumnType.NULL : ColumnType.UNDEFINED;
+        return ColumnType.NULL;
     }
 
     private static boolean isTrue(CharSequence value) {
         return (value.charAt(0) | 32) == 't';
     }
 
-    private static void putNullValue(TableWriter.Row row, int columnIndex, int storageColumnType) {
+    public static void putNullValue(TableWriter.Row row, int columnIndex, int storageColumnType) {
         switch (ColumnType.tagOf(storageColumnType)) {
             case ColumnType.BOOLEAN:
                 row.putBool(columnIndex, false);

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -57,136 +57,143 @@ public class CairoLineProtoParserSupport {
             int columnIndex,
             CharSequence value
     ) throws BadCastException {
-        try {
-            switch (ColumnType.tagOf(columnType)) {
-                case ColumnType.LONG:
-                    row.putLong(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                    break;
-                case ColumnType.BOOLEAN:
-                    row.putBool(columnIndex, isTrue(value));
-                    break;
-                case ColumnType.STRING:
-                    row.putStr(columnIndex, value, 1, value.length() - 2);
-                    break;
-                case ColumnType.SYMBOL:
-                    row.putSym(columnIndex, value);
-                    break;
-                case ColumnType.DOUBLE:
-                    row.putDouble(columnIndex, Numbers.parseDouble(value));
-                    break;
-                case ColumnType.FLOAT:
-                    row.putFloat(columnIndex, Numbers.parseFloat(value));
-                    break;
-                case ColumnType.INT:
-                    row.putInt(columnIndex, Numbers.parseInt(value, 0, value.length() - 1));
-                    break;
-                case ColumnType.SHORT:
-                    row.putShort(columnIndex, Numbers.parseShort(value, 0, value.length() - 1));
-                    break;
-                case ColumnType.BYTE:
-                    long v = Numbers.parseLong(value, 0, value.length() - 1);
-                    if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
-                        throw CairoException.instance(0)
-                                .put("line protocol integer is out of byte bounds [columnIndex=")
-                                .put(columnIndex)
-                                .put(", v=")
-                                .put(v)
-                                .put(']');
-                    }
-                    row.putByte(columnIndex, (byte) v);
-                    break;
-                case ColumnType.DATE:
-                    row.putDate(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                    break;
-                case ColumnType.LONG256:
-                    int limit = value.length() - 1;
-                    if (value.charAt(limit) != 'i') {
-                        limit++;
-                    }
-                    row.putLong256(columnIndex, value, 2, limit);
-                    break;
-                case ColumnType.TIMESTAMP:
-                    row.putTimestamp(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
-                    break;
-                case ColumnType.CHAR:
-                    row.putChar(columnIndex, value.length() == 2 ? (char) 0 : value.charAt(1)); // skip quotes
-                    break;
-                case ColumnType.GEOBYTE:
-                    row.putByte(
-                            columnIndex,  // skip quotes
-                            (byte) GeoHashes.fromStringTruncatingNl(
-                                    value,
-                                    1,
-                                    value.length() - 1,
-                                    columnTypeMeta
-                            )
-                    );
-                    break;
-                case ColumnType.GEOSHORT:
-                    row.putShort(
-                            columnIndex,
-                            (short) GeoHashes.fromStringTruncatingNl(
-                                    value,
-                                    1,
-                                    value.length() - 1,
-                                    columnTypeMeta
-                            )
-                    );
-                    break;
-                case ColumnType.GEOINT:
-                    row.putInt(
-                            columnIndex,
-                            (int) GeoHashes.fromStringTruncatingNl(
-                                    value,
-                                    1,
-                                    value.length() - 1,
-                                    columnTypeMeta
-                            )
-                    );
-                    break;
-                case ColumnType.GEOLONG:
-                    row.putLong(
-                            columnIndex,
-                            GeoHashes.fromStringTruncatingNl(
-                                    value,
-                                    1,
-                                    value.length() - 1,
-                                    columnTypeMeta
-                            )
-                    );
-                    break;
-                default:
-                    // unsupported types are ignored
-                    break;
+        if (value.length() > 0) {
+            try {
+                switch (ColumnType.tagOf(columnType)) {
+                    case ColumnType.LONG:
+                        row.putLong(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                        break;
+                    case ColumnType.BOOLEAN:
+                        row.putBool(columnIndex, isTrue(value));
+                        break;
+                    case ColumnType.STRING:
+                        row.putStr(columnIndex, value, 1, value.length() - 2);
+                        break;
+                    case ColumnType.SYMBOL:
+                        row.putSym(columnIndex, value);
+                        break;
+                    case ColumnType.DOUBLE:
+                        row.putDouble(columnIndex, Numbers.parseDouble(value));
+                        break;
+                    case ColumnType.FLOAT:
+                        row.putFloat(columnIndex, Numbers.parseFloat(value));
+                        break;
+                    case ColumnType.INT:
+                        row.putInt(columnIndex, Numbers.parseInt(value, 0, value.length() - 1));
+                        break;
+                    case ColumnType.SHORT:
+                        row.putShort(columnIndex, Numbers.parseShort(value, 0, value.length() - 1));
+                        break;
+                    case ColumnType.BYTE:
+                        long v = Numbers.parseLong(value, 0, value.length() - 1);
+                        if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
+                            throw CairoException.instance(0)
+                                    .put("line protocol integer is out of byte bounds [columnIndex=")
+                                    .put(columnIndex)
+                                    .put(", v=")
+                                    .put(v)
+                                    .put(']');
+                        }
+                        row.putByte(columnIndex, (byte) v);
+                        break;
+                    case ColumnType.DATE:
+                        row.putDate(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                        break;
+                    case ColumnType.LONG256:
+                        int limit = value.length() - 1;
+                        if (value.charAt(limit) != 'i') {
+                            limit++;
+                        }
+                        row.putLong256(columnIndex, value, 2, limit);
+                        break;
+                    case ColumnType.TIMESTAMP:
+                        row.putTimestamp(columnIndex, Numbers.parseLong(value, 0, value.length() - 1));
+                        break;
+                    case ColumnType.CHAR:
+                        row.putChar(columnIndex, value.length() == 2 ? (char) 0 : value.charAt(1)); // skip quotes
+                        break;
+                    case ColumnType.GEOBYTE:
+                        row.putByte(
+                                columnIndex,  // skip quotes
+                                (byte) GeoHashes.fromStringTruncatingNl(
+                                        value,
+                                        1,
+                                        value.length() - 1,
+                                        columnTypeMeta
+                                )
+                        );
+                        break;
+                    case ColumnType.GEOSHORT:
+                        row.putShort(
+                                columnIndex,
+                                (short) GeoHashes.fromStringTruncatingNl(
+                                        value,
+                                        1,
+                                        value.length() - 1,
+                                        columnTypeMeta
+                                )
+                        );
+                        break;
+                    case ColumnType.GEOINT:
+                        row.putInt(
+                                columnIndex,
+                                (int) GeoHashes.fromStringTruncatingNl(
+                                        value,
+                                        1,
+                                        value.length() - 1,
+                                        columnTypeMeta
+                                )
+                        );
+                        break;
+                    case ColumnType.GEOLONG:
+                        row.putLong(
+                                columnIndex,
+                                GeoHashes.fromStringTruncatingNl(
+                                        value,
+                                        1,
+                                        value.length() - 1,
+                                        columnTypeMeta
+                                )
+                        );
+                        break;
+                    case ColumnType.NULL:
+                    default:
+                        // unsupported types and null are ignored
+                        break;
+                }
+            } catch (NumericException e) {
+                LOG.info()
+                        .$("cast error [value=")
+                        .$(value).$(", toType=")
+                        .$(ColumnType.nameOf(columnType))
+                        .$(']')
+                        .$();
             }
-        } catch (NumericException e) {
-            LOG.info()
-                    .$("cast error [value=")
-                    .$(value).$(", toType=")
-                    .$(ColumnType.nameOf(columnType))
-                    .$(']')
-                    .$();
+        } else {
+            putNullValue(row, columnIndex, columnType);
         }
+
     }
 
     public static class BadCastException extends Exception {
         public static final BadCastException INSTANCE = new BadCastException();
     }
 
-    public static int getValueType(CharSequence token) {
+    public static int getValueType(CharSequence value) {
         // method called for inbound ilp messages on each value.
         // returning UNDEFINED makes the whole line be skipped.
+        // 0 len values, null, should result in a skip of the insert.
         // the goal of this method is to guess the potential type
         // and then it will be parsed accordingly by 'putValue'.
-        int len = token.length();
-        if (len > 0) {
-            char lastChar = token.charAt(len - 1); // see LineProtoSender.field methods
-            switch (lastChar) {
+        int valueLen = value.length();
+        if (valueLen > 0) {
+            char last = value.charAt(valueLen - 1); // see LineProtoSender.field methods
+            switch (last) {
                 case 'i':
-                    if (len > 3 && token.charAt(0) == '0' && token.charAt(1) == 'x') {
+                    if (valueLen > 3 && value.charAt(0) == '0' && value.charAt(1) == 'x') {
                         return ColumnType.LONG256;
                     }
-                    return len == 1 ? ColumnType.SYMBOL : ColumnType.LONG;
+                    return valueLen == 1 ? ColumnType.SYMBOL : ColumnType.LONG;
                 case 'e':
                 case 'E':
                     // tru(e)
@@ -199,28 +206,27 @@ public class CairoLineProtoParserSupport {
                 case 'F':
                     // f
                     // F
-                    if (len == 1) {
-                        return lastChar != 'e' ? ColumnType.BOOLEAN : ColumnType.SYMBOL;
+                    if (valueLen == 1) {
+                        return last != 'e' ? ColumnType.BOOLEAN : ColumnType.SYMBOL;
                     }
-                    return SqlKeywords.isTrueKeyword(token) || SqlKeywords.isFalseKeyword(token) ?
+                    return SqlKeywords.isTrueKeyword(value) || SqlKeywords.isFalseKeyword(value) ?
                             ColumnType.BOOLEAN : ColumnType.SYMBOL;
                 case '"':
-                    if (len < 2 || token.charAt(0) != '\"') {
-                        LOG.error().$("incorrectly quoted string: ").$(token).$();
+                    if (valueLen < 2 || value.charAt(0) != '\"') {
+                        LOG.error().$("incorrectly quoted string: ").$(value).$();
                         return ColumnType.UNDEFINED;
                     }
                     return ColumnType.STRING;
-                case 'l':
-                case 'L': // null
-                    return SqlKeywords.isNullKeyword(token) ? ColumnType.NULL : ColumnType.SYMBOL;
                 default:
-                    if (lastChar >= '0' && lastChar <= '9') {
-                        if (len > 2 && token.charAt(0) == '0' && token.charAt(1) == 'x') {
-                            return ColumnType.LONG256;
-                        }
+                    char first = value.charAt(0);
+                    // TODO: speed this up
+                    if (last >= '0' && last <= '9' && ((first >= '0' && first <= '9') || first == '-' || first == '.')) {
                         return ColumnType.DOUBLE;
                     }
-                    if (token.charAt(0) == '"') {
+                    if (SqlKeywords.isNanKeyword(value)) {
+                        return ColumnType.DOUBLE;
+                    }
+                    if (value.charAt(0) == '"') {
                         return ColumnType.UNDEFINED;
                     }
                     return ColumnType.SYMBOL;
@@ -233,8 +239,8 @@ public class CairoLineProtoParserSupport {
         return (value.charAt(0) | 32) == 't';
     }
 
-    public static void putNullValue(TableWriter.Row row, int columnIndex, int storageColumnType) {
-        switch (ColumnType.tagOf(storageColumnType)) {
+    private static void putNullValue(TableWriter.Row row, int columnIndex, int columnType) {
+        switch (ColumnType.tagOf(columnType)) {
             case ColumnType.BOOLEAN:
                 row.putBool(columnIndex, false);
                 break;

--- a/core/src/main/java/io/questdb/cutlass/line/LineProtoLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineProtoLexer.java
@@ -190,7 +190,6 @@ public class LineProtoLexer implements Mutable, Closeable {
                     throw LineProtoException.INSTANCE;
             }
         }
-        escapeQuote = false;
     }
 
     private void onEquals() {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -473,6 +473,7 @@ class LineTcpMeasurementScheduler implements Closeable {
             for (int nEntity = 0; nEntity < nEntities; nEntity++) {
                 assert bufPos < (bufLo + bufSize + 6);
                 ProtoEntity entity = protoParser.getEntity(nEntity);
+                System.out.printf("TRD[%s] localDetails.isNull? %b, entityName.isNull? %b%n", Thread.currentThread().getName(), localDetails == null, entity.getName() == null);
                 int colIndex = localDetails.getColumnIndex(entity.getName());
                 if (colIndex < 0) {
                     int colNameLen = entity.getName().length();
@@ -525,6 +526,7 @@ class LineTcpMeasurementScheduler implements Closeable {
                         break;
                     }
                     case NewLineProtoParser.ENTITY_TYPE_STRING:
+                    case NewLineProtoParser.ENTITY_TYPE_SYMBOL:
                     case NewLineProtoParser.ENTITY_TYPE_LONG256: {
                         final int colTypeMeta = localDetails.getColumnTypeMeta(colIndex);
                         if (colTypeMeta == 0) { // not a geohash
@@ -533,7 +535,7 @@ class LineTcpMeasurementScheduler implements Closeable {
                             int l = entity.getValue().length();
                             Unsafe.getUnsafe().putInt(bufPos, l);
                             bufPos += Integer.BYTES;
-                            long hi = bufPos + 2L * l;
+                            long hi = bufPos + 2L * l; // unquote
                             floatingCharSink.of(bufPos, hi);
                             if (!Chars.utf8Decode(entity.getValue().getLo(), entity.getValue().getHi(), floatingCharSink)) {
                                 throw CairoException.instance(0).put("invalid UTF8 in value for ").put(entity.getName());
@@ -585,6 +587,14 @@ class LineTcpMeasurementScheduler implements Closeable {
                         bufPos += Byte.BYTES;
                         break;
                     }
+                    case NewLineProtoParser.ENTITY_TYPE_NULL: {
+                        Unsafe.getUnsafe().putByte(bufPos, entity.getType());
+                        bufPos += Byte.BYTES;
+                        break;
+                    }
+                    default:
+                        // unsupported types are ignored
+                        break;
                 }
             }
             threadId = tableUpdateDetails.writerThreadId;
@@ -689,7 +699,9 @@ class LineTcpMeasurementScheduler implements Closeable {
                                     break;
 
                                 case ColumnType.INT:
-                                    if (v < Integer.MIN_VALUE || v > Integer.MAX_VALUE) {
+                                    if (v == Numbers.LONG_NaN) {
+                                        v = Numbers.INT_NaN;
+                                    } else if (v < Integer.MIN_VALUE || v > Integer.MAX_VALUE) {
                                         throw CairoException.instance(0)
                                                 .put("line protocol integer is out of int bounds [columnIndex=").put(colIndex)
                                                 .put(", v=").put(v)
@@ -699,7 +711,9 @@ class LineTcpMeasurementScheduler implements Closeable {
                                     break;
 
                                 case ColumnType.SHORT:
-                                    if (v < Short.MIN_VALUE || v > Short.MAX_VALUE) {
+                                    if (v == Numbers.LONG_NaN) {
+                                        v = (short) 0;
+                                    } else if (v < Short.MIN_VALUE || v > Short.MAX_VALUE) {
                                         throw CairoException.instance(0)
                                                 .put("line protocol integer is out of short bounds [columnIndex=").put(colIndex)
                                                 .put(", v=").put(v)
@@ -709,7 +723,9 @@ class LineTcpMeasurementScheduler implements Closeable {
                                     break;
 
                                 case ColumnType.BYTE:
-                                    if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
+                                    if (v == Numbers.LONG_NaN) {
+                                        v = (byte) 0;
+                                    } else if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
                                         throw CairoException.instance(0)
                                                 .put("line protocol integer is out of byte bounds [columnIndex=").put(colIndex)
                                                 .put(", v=").put(v)
@@ -773,9 +789,29 @@ class LineTcpMeasurementScheduler implements Closeable {
                             final int colType = writer.getMetadata().getColumnType(colIndex);
                             if (ColumnType.isString(colType)) {
                                 row.putStr(colIndex, job.floatingCharSink);
+                            } else if (ColumnType.isChar(colType)) {
+                                row.putChar(colIndex, job.floatingCharSink.charAt(0));
                             } else {
                                 throw CairoException.instance(0)
                                         .put("cast error for line protocol string [columnIndex=").put(colIndex)
+                                        .put(", columnType=").put(ColumnType.nameOf(colType))
+                                        .put(']');
+                            }
+                            break;
+                        }
+
+                        case NewLineProtoParser.ENTITY_TYPE_SYMBOL: {
+                            int len = Unsafe.getUnsafe().getInt(bufPos);
+                            bufPos += Integer.BYTES;
+                            long hi = bufPos + 2L * len;
+                            job.floatingCharSink.asCharSequence(bufPos, hi);
+                            bufPos = hi;
+                            final int colType = writer.getMetadata().getColumnType(colIndex);
+                            if (ColumnType.isSymbol(colType)) {
+                                row.putSym(colIndex, job.floatingCharSink);
+                            } else {
+                                throw CairoException.instance(0)
+                                        .put("cast error for line protocol symbol [columnIndex=").put(colIndex)
                                         .put(", columnType=").put(ColumnType.nameOf(colType))
                                         .put(']');
                             }
@@ -787,8 +823,16 @@ class LineTcpMeasurementScheduler implements Closeable {
                             bufPos += Integer.BYTES;
                             long hi = bufPos + 2L * len;
                             job.floatingCharSink.asCharSequence(bufPos, hi);
-                            row.putLong256(colIndex, job.floatingCharSink);
                             bufPos = hi;
+                            final int colType = writer.getMetadata().getColumnType(colIndex);
+                            if (ColumnType.isLong256(colType)) {
+                                row.putLong256(colIndex, job.floatingCharSink);
+                            } else {
+                                throw CairoException.instance(0)
+                                        .put("cast error for line protocol long256 [columnIndex=").put(colIndex)
+                                        .put(", columnType=").put(ColumnType.nameOf(colType))
+                                        .put(']');
+                            }
                             break;
                         }
 
@@ -817,6 +861,11 @@ class LineTcpMeasurementScheduler implements Closeable {
                             byte geohash = Unsafe.getUnsafe().getByte(bufPos);
                             bufPos += Byte.BYTES;
                             row.putByte(colIndex, geohash);
+                            break;
+                        }
+
+                        case NewLineProtoParser.ENTITY_TYPE_NULL: {
+                            // ignored, default nulls is used
                             break;
                         }
 
@@ -859,6 +908,7 @@ class LineTcpMeasurementScheduler implements Closeable {
             localDetailsArray = new ThreadLocalDetails[n];
             for (int i = 0; i < n; i++) {
                 localDetailsArray[i] = new ThreadLocalDetails(netIoJobs[i].getUnusedSymbolCaches());
+                System.out.printf("%d: isNull? %b%n", i, localDetailsArray[i] == null);
             }
             lastCommitMillis = milliClock.getTicks();
         }
@@ -955,6 +1005,7 @@ class LineTcpMeasurementScheduler implements Closeable {
         }
 
         ThreadLocalDetails startNewMeasurementEvent(int workerId) {
+            System.out.printf("TRD[%s]startNewMeasurementEvent(%d)%n", Thread.currentThread().getName(), workerId);
             ThreadLocalDetails localDetails = localDetailsArray[workerId];
             lastMeasurementMillis = milliClock.getTicks();
             return localDetails;
@@ -1476,10 +1527,12 @@ class LineTcpMeasurementScheduler implements Closeable {
     }
 
     static {
+        // if not set it defaults to ColumnType.UNDEFINED
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_TAG] = ColumnType.SYMBOL;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_FLOAT] = ColumnType.DOUBLE;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_INTEGER] = ColumnType.LONG;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_STRING] = ColumnType.STRING;
+        DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_SYMBOL] = ColumnType.SYMBOL;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_BOOLEAN] = ColumnType.BOOLEAN;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_LONG256] = ColumnType.LONG256;
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_GEOBYTE] = ColumnType.getGeoHashTypeWithBits(8);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -473,7 +473,6 @@ class LineTcpMeasurementScheduler implements Closeable {
             for (int nEntity = 0; nEntity < nEntities; nEntity++) {
                 assert bufPos < (bufLo + bufSize + 6);
                 ProtoEntity entity = protoParser.getEntity(nEntity);
-                System.out.printf("TRD[%s] localDetails.isNull? %b, entityName.isNull? %b%n", Thread.currentThread().getName(), localDetails == null, entity.getName() == null);
                 int colIndex = localDetails.getColumnIndex(entity.getName());
                 if (colIndex < 0) {
                     int colNameLen = entity.getName().length();
@@ -908,7 +907,6 @@ class LineTcpMeasurementScheduler implements Closeable {
             localDetailsArray = new ThreadLocalDetails[n];
             for (int i = 0; i < n; i++) {
                 localDetailsArray[i] = new ThreadLocalDetails(netIoJobs[i].getUnusedSymbolCaches());
-                System.out.printf("%d: isNull? %b%n", i, localDetailsArray[i] == null);
             }
             lastCommitMillis = milliClock.getTicks();
         }
@@ -1005,7 +1003,6 @@ class LineTcpMeasurementScheduler implements Closeable {
         }
 
         ThreadLocalDetails startNewMeasurementEvent(int workerId) {
-            System.out.printf("TRD[%s]startNewMeasurementEvent(%d)%n", Thread.currentThread().getName(), workerId);
             ThreadLocalDetails localDetails = localDetailsArray[workerId];
             lastMeasurementMillis = milliClock.getTicks();
             return localDetails;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/NewLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/NewLineProtoParser.java
@@ -425,11 +425,6 @@ public class NewLineProtoParser implements Closeable {
         private boolean parse(byte last, int valueLen) {
             switch (last) {
                 case 'i':
-                    if (valueLen > 3 && value.charAt(0) == '0' && (value.charAt(1) | 32) == 'x') {
-                        value.decHi(); // remove 'i'
-                        type = ENTITY_TYPE_LONG256;
-                        return true;
-                    }
                     if (valueLen > 1 && value.charAt(1) != 'x') {
                         try {
                             charSeq.of(value.getLo(), value.getHi() - 1);
@@ -439,6 +434,11 @@ public class NewLineProtoParser implements Closeable {
                         } catch (NumericException notANumber) {
                             type = ENTITY_TYPE_SYMBOL;
                         }
+                        return true;
+                    }
+                    if (valueLen > 3 && value.charAt(0) == '0' && (value.charAt(1) | 32) == 'x') {
+                        value.decHi(); // remove 'i'
+                        type = ENTITY_TYPE_LONG256;
                         return true;
                     }
                     type = ENTITY_TYPE_SYMBOL;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/NewLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/NewLineProtoParser.java
@@ -35,7 +35,6 @@ import java.io.Closeable;
 
 public class NewLineProtoParser implements Closeable {
     public static final long NULL_TIMESTAMP = Numbers.LONG_NaN;
-    public static final int MAX_ALLOWED_STRING_LEN = 152; // 150 bytes plus quotes
     public static final byte ENTITY_TYPE_NULL = 0;
     public static final byte ENTITY_TYPE_TAG = 1;
     public static final byte ENTITY_TYPE_FLOAT = 2;
@@ -275,9 +274,8 @@ public class NewLineProtoParser implements Closeable {
         // the next completeEntity call, moving butAt to the next '"'
         entityLo = openQuoteIdx; // from the quote
         boolean scape = false;
-        final long limit = Math.min(bufHi, entityLo + MAX_ALLOWED_STRING_LEN + 1); // limit the size of strings
         bufAt += 2; // go to first byte of the string, past the '"'
-        while (bufAt < limit) { // consume until the next quote, '\n', or eof
+        while (bufAt < bufHi) { // consume until the next quote, '\n', or eof
             switch (Unsafe.getUnsafe().getByte(bufAt)) {
                 case (byte) '\\':
                     scape = !scape;

--- a/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoReceiver.java
@@ -45,7 +45,7 @@ public abstract class AbstractLineProtoReceiver extends SynchronizedJob implemen
     protected final CairoLineProtoParser parser;
     protected final NetworkFacade nf;
     private final AtomicBoolean running = new AtomicBoolean(false);
-    private final SOCountDownLatch started = new SOCountDownLatch();
+    private final SOCountDownLatch started = new SOCountDownLatch(1);
     private final SOCountDownLatch halted = new SOCountDownLatch(1);
     private final LineUdpReceiverConfiguration configuration;
     protected long fd;
@@ -120,6 +120,7 @@ public abstract class AbstractLineProtoReceiver extends SynchronizedJob implemen
     public void start() {
         if (configuration.ownThread() && running.compareAndSet(false, true)) {
             new Thread(() -> {
+                started.countDown();
                 if (configuration.ownThreadAffinity() != -1) {
                     Os.setCurrentThreadAffinity(configuration.ownThreadAffinity());
                 }
@@ -130,7 +131,6 @@ public abstract class AbstractLineProtoReceiver extends SynchronizedJob implemen
                 LOG.info().$("shutdown").$();
                 halted.countDown();
             }).start();
-            started.countDown();
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.line.*;
 import io.questdb.cutlass.line.CairoLineProtoParserSupport.BadCastException;
-import io.questdb.griffin.SqlKeywords;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.*;
@@ -127,7 +126,6 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
 
     @Override
     public void onEvent(CachedCharSequence token, int eventType, CharSequenceCache cache) {
-
         switch (eventType) {
             case EVT_MEASUREMENT:
                 int wrtIndex = writerCache.keyIndex(token);
@@ -214,17 +212,14 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
             for (int i = 0; i < columnCount; i++) {
                 final long valueIdxAndType = columnIndexAndType.getQuick(i);
                 CharSequence value = cache.get(columnValues.getQuick(i));
-                if (!SqlKeywords.isNullKeyword(value)) {
-                    CairoLineProtoParserSupport.putValue(
-                            row,
-                            Numbers.decodeHighInt(valueIdxAndType),
-                            geohashBitsSizeByColIdx.getQuick(i),
-                            Numbers.decodeLowInt(valueIdxAndType),
-                            value
-                    );
-                } else {
-                    CairoLineProtoParserSupport.putNullValue(row, columnIndex, metadata.getColumnType(i));
-                }
+                // values of len 0, null, are ignored, not inserted
+                CairoLineProtoParserSupport.putValue(
+                        row,
+                        Numbers.decodeHighInt(valueIdxAndType),
+                        geohashBitsSizeByColIdx.getQuick(i),
+                        Numbers.decodeLowInt(valueIdxAndType),
+                        value
+                );
             }
             row.append();
         } catch (BadCastException ignore) {

--- a/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
@@ -126,6 +126,7 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
 
     @Override
     public void onEvent(CachedCharSequence token, int eventType, CharSequenceCache cache) {
+
         switch (eventType) {
             case EVT_MEASUREMENT:
                 int wrtIndex = writerCache.keyIndex(token);
@@ -210,15 +211,13 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
 
         try {
             for (int i = 0; i < columnCount; i++) {
-                final long valueIdxAndType = columnIndexAndType.getQuick(i);
-                CharSequence value = cache.get(columnValues.getQuick(i));
-                // values of len 0, null, are ignored, not inserted
+                final long value = columnIndexAndType.getQuick(i);
                 CairoLineProtoParserSupport.putValue(
                         row,
-                        Numbers.decodeHighInt(valueIdxAndType),
+                        Numbers.decodeHighInt(value),
                         geohashBitsSizeByColIdx.getQuick(i),
-                        Numbers.decodeLowInt(valueIdxAndType),
-                        value
+                        Numbers.decodeLowInt(value),
+                        cache.get(columnValues.getQuick(i))
                 );
             }
             row.append();

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -779,6 +779,7 @@ public class SqlCompiler implements Closeable {
                 && toTag <= ColumnType.DOUBLE
                 && fromTag < toTag)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOBYTE)
+                || (fromTag == ColumnType.BOOLEAN && toTag == ColumnType.GEOBYTE)
                 || (fromTag == ColumnType.CHAR && toTag == ColumnType.GEOBYTE && ColumnType.getGeoHashBits(to) < 6)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOSHORT)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOINT)

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -779,7 +779,6 @@ public class SqlCompiler implements Closeable {
                 && toTag <= ColumnType.DOUBLE
                 && fromTag < toTag)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOBYTE)
-                || (fromTag == ColumnType.BOOLEAN && toTag == ColumnType.GEOBYTE)
                 || (fromTag == ColumnType.CHAR && toTag == ColumnType.GEOBYTE && ColumnType.getGeoHashBits(to) < 6)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOSHORT)
                 || (fromTag == ColumnType.STRING && toTag == ColumnType.GEOINT)

--- a/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
@@ -183,10 +183,16 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
 
     @Test
     public void testGetValueType() {
+        Assert.assertEquals(ColumnType.NULL, CairoLineProtoParserSupport.getValueType(""));
+        Assert.assertEquals(ColumnType.NULL, CairoLineProtoParserSupport.getValueType("null"));
+        Assert.assertEquals(ColumnType.NULL, CairoLineProtoParserSupport.getValueType("NULL"));
+        Assert.assertEquals(ColumnType.NULL, CairoLineProtoParserSupport.getValueType("NulL"));
+
+        Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("skull"));
+        Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("skulL"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("1.6x"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("aa\"aa"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("tre"));
-        Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("\"aaa"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("''"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("oX"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("0x"));
@@ -216,7 +222,7 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1"));
 
         Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("aaa\""));
-        Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType(""));
+        Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("\"aaa"));
 
         // the type is guessed, and the parser (CairoLineProtoParserSupport.parseFieldValue) will fail
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x123a4"));

--- a/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
@@ -262,7 +262,7 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
                     try (LineProtoSender sender = createLineProtoSender()) {
                         senderConsumer.accept(sender);
                     }
-                    assertReader(tableName, expected);
+                    assertReader(engine, tableName, expected);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
@@ -202,6 +202,7 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("aTTTT"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("aFFF"));
         Assert.assertEquals(ColumnType.SYMBOL, CairoLineProtoParserSupport.getValueType("e"));
+
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("t"));
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("T"));
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("f"));
@@ -210,12 +211,16 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("false"));
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("FalSe"));
         Assert.assertEquals(ColumnType.BOOLEAN, CairoLineProtoParserSupport.getValueType("tRuE"));
+
         Assert.assertEquals(ColumnType.STRING, CairoLineProtoParserSupport.getValueType("\"0x123a4\""));
+
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x123i"));
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x1i"));
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x1"));
+
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("123i"));
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("1i"));
+
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1.45"));
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1e-13"));
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1.0"));
@@ -224,15 +229,18 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
         Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("aaa\""));
         Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("\"aaa"));
 
-        // the type is guessed, and the parser (CairoLineProtoParserSupport.parseFieldValue) will fail
+        // in these edge examples, type is guessed as best as possible, later the parser would fail
+        // (CairoLineProtoParserSupport.parseFieldValue):
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x123a4"));
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x123a4i"));
         Assert.assertEquals(ColumnType.LONG256, CairoLineProtoParserSupport.getValueType("0x1"));
+
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("123a4i"));
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("oxi"));
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("xi"));
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("oXi"));
         Assert.assertEquals(ColumnType.LONG, CairoLineProtoParserSupport.getValueType("0xi"));
+
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("123a4"));
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("ox1"));
     }

--- a/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
@@ -282,7 +282,7 @@ public class LineProtoLexerTest {
         assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n", "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n");
     }
 
-    private void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
+    protected void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
         byte[] bytes = line.toString().getBytes(StandardCharsets.UTF_8);
         long mem = Unsafe.malloc(bytes.length, MemoryTag.NATIVE_DEFAULT);
         try {
@@ -306,11 +306,11 @@ public class LineProtoLexerTest {
         }
     }
 
-    private void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
+    protected void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
         assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    private void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
+    protected void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
         final int len = line.length;
         long mem = Unsafe.malloc(line.length, MemoryTag.NATIVE_DEFAULT);
         try {

--- a/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
@@ -145,12 +145,12 @@ public class LineProtoLexerTest {
 
     @Test
     public void testNoFieldValue2() {
-        assertError("measurement,tag=x f= 10000", LineProtoParser.EVT_FIELD_VALUE, LineProtoParser.ERROR_EMPTY, 20);
+        assertError("measurement,tag=x f= 10000", 0, 0, 0);
     }
 
     @Test
     public void testNoFieldValue3() {
-        assertError("measurement,tag=x f=, 10000", LineProtoParser.EVT_FIELD_VALUE, LineProtoParser.ERROR_EMPTY, 20);
+        assertError("measurement,tag=x f=, 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 21);
     }
 
     @Test
@@ -235,13 +235,14 @@ public class LineProtoLexerTest {
 
     @Test
     public void testSimpleParse() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
+                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
     }
 
     @Test
     public void testSkipLine() {
         assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
-                        "measurement,tag=value3,tag2=value2 field=-- error --\n" +
+                        "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
                         "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n",
                 "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
                         "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
@@ -303,7 +304,7 @@ public class LineProtoLexerTest {
         }
     }
 
-    private void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
+    protected void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
         assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
     }
 
@@ -402,7 +403,7 @@ public class LineProtoLexerTest {
 
         @Override
         public void onLineEnd(CharSequenceCache cache) {
-           sink.put('\n');
+            sink.put('\n');
 
             // assert that cached token match
             for (Map.Entry<Long, String> e : tokens.entrySet()) {

--- a/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/LineProtoLexerTest.java
@@ -146,6 +146,7 @@ public class LineProtoLexerTest {
     @Test
     public void testNoFieldValue2() {
         assertError("measurement,tag=x f= 10000", 0, 0, 0);
+        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f= 10000\n");
     }
 
     @Test
@@ -235,17 +236,18 @@ public class LineProtoLexerTest {
 
     @Test
     public void testSimpleParse() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
-                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
     }
 
     @Test
     public void testSkipLine() {
         assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
                         "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
+                        "measurement,tag=value3,tag2=value2 field=-- error --\n" +
                         "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n",
                 "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
                         "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
+                        "measurement,tag=value3,tag2=value2 field= field2=\"not ok\"\n" +
                         "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n");
     }
 
@@ -280,7 +282,7 @@ public class LineProtoLexerTest {
         assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n", "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n");
     }
 
-    protected void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
+    private void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
         byte[] bytes = line.toString().getBytes(StandardCharsets.UTF_8);
         long mem = Unsafe.malloc(bytes.length, MemoryTag.NATIVE_DEFAULT);
         try {
@@ -304,11 +306,11 @@ public class LineProtoLexerTest {
         }
     }
 
-    protected void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
+    private void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
         assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    protected void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
+    private void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
         final int len = line.length;
         long mem = Unsafe.malloc(line.length, MemoryTag.NATIVE_DEFAULT);
         try {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -100,10 +100,6 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                 Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("cast"));
                 Assert.assertEquals(ColumnType.TIMESTAMP, meta.getColumnType("timestamp"));
                 Assert.assertEquals(ColumnType.DOUBLE, meta.getColumnType("humidity"));
-                for (int i = 0; i < meta.getColumnCount(); i++) {
-                    System.out.printf("%d) %d %s%n", i, meta.getColumnType(i), meta.getColumnName(i));
-
-                }
             }
         });
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertByteGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertByteGeoHashTest.java
@@ -29,19 +29,35 @@ import org.junit.Test;
 
 public class LineTcpInsertByteGeoHashTest extends LineTcpInsertGeoHashTest {
     @Test
-    public void testInsertNullGeoHash() throws Exception {
-        for (int b = 5; b <= ColumnType.GEO_HASH_MAX_BITS_LENGTH; b += 5) {
-            if (b > 5) {
-                setUp();
-            }
-            // NewLineProtoParser.putValue does not accept zero len entity values
-            System.out.printf("round %d%n", b);
-            assertGeoHash(b,
-                    "tracking geohash=,here=\"no\" 1000000000\n",
-                    "geohash\ttimestamp\there\n" +
-                            "\t1970-01-01T00:00:01.000000Z\tno\n");
-            tearDown();
-        }
+    public void testInsertNoValueByteGeoHash() throws Exception {
+        assertGeoHash(5,
+                "tracking geohash=,here=\"no\" 1000000000\n",
+                "geohash\ttimestamp\there\n" +
+                        "\t1970-01-01T00:00:01.000000Z\tno\n");
+    }
+
+    @Test
+    public void testInsertNoValueShortGeoHash() throws Exception {
+        assertGeoHash(10,
+                "tracking geohash=,here=\"no\" 1000000000\n",
+                "geohash\ttimestamp\there\n" +
+                        "\t1970-01-01T00:00:01.000000Z\tno\n");
+    }
+
+    @Test
+    public void testInsertNoValueIntGeoHash() throws Exception {
+        assertGeoHash(30,
+                "tracking geohash=,here=\"no\" 1000000000\n",
+                "geohash\ttimestamp\there\n" +
+                        "\t1970-01-01T00:00:01.000000Z\tno\n");
+    }
+
+    @Test
+    public void testInsertNoValueLongGeoHash() throws Exception {
+        assertGeoHash(60,
+                "tracking geohash=,here=\"no\" 1000000000\n",
+                "geohash\ttimestamp\there\n" +
+                        "\t1970-01-01T00:00:01.000000Z\tno\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertByteGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertByteGeoHashTest.java
@@ -29,17 +29,27 @@ import org.junit.Test;
 
 public class LineTcpInsertByteGeoHashTest extends LineTcpInsertGeoHashTest {
     @Test
-    public void testInsertMissingGeoHashHasNoEffect() throws Exception {
+    public void testInsertNullGeoHash() throws Exception {
         for (int b = 5; b <= ColumnType.GEO_HASH_MAX_BITS_LENGTH; b += 5) {
             if (b > 5) {
                 setUp();
             }
             // NewLineProtoParser.putValue does not accept zero len entity values
+            System.out.printf("round %d%n", b);
             assertGeoHash(b,
                     "tracking geohash=,here=\"no\" 1000000000\n",
-                    "geohash\ttimestamp\n");
+                    "geohash\ttimestamp\there\n" +
+                            "\t1970-01-01T00:00:01.000000Z\tno\n");
             tearDown();
         }
+    }
+
+    @Test
+    public void test() throws Exception {
+        assertGeoHash(10,
+                "tracking geohash=,here=\"no\" 1000000000\n",
+                "geohash\ttimestamp\there\n" +
+                        "\t1970-01-01T00:00:01.000000Z\tno\n");
     }
 
     @Override

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
@@ -611,8 +611,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
     public void testInsertTooLargeAStringTableExists() throws Exception {
         Rnd rnd = new Rnd();
         assertType(ColumnType.STRING,
-                "value\ttimestamp\n" +
-                        "\t1970-01-01T00:00:02.000000Z\n",
+                "value\ttimestamp\n",
                 new CharSequence[]{
                         "\"" + rnd.nextString(NewLineProtoParser.MAX_ALLOWED_STRING_LEN + 1) + "\"", // discarded too long
                         "" // valid null

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
@@ -25,7 +25,6 @@
 package io.questdb.cutlass.line.tcp;
 
 import io.questdb.cairo.*;
-import io.questdb.std.Rnd;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -599,44 +598,6 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "@plant2", // discarded bad type symbol
                         "" // valid null
                 });
-    }
-
-    @Test
-    public void testInsertTooLargeAStringTableExists() throws Exception {
-        Rnd rnd = new Rnd();
-        assertType(ColumnType.STRING,
-                "value\ttimestamp\n",
-                new CharSequence[]{
-                        "\"" + rnd.nextString(NewLineProtoParser.MAX_ALLOWED_STRING_LEN + 1) + "\"", // discarded too long
-                        "" // valid null
-                });
-    }
-
-    @Test
-    public void testInsertTooLargeAStringTableDoesNotExist() throws Exception {
-        Rnd rnd = new Rnd();
-        runInContext(() -> {
-            sink.clear();
-            sink.put(table)
-                    .put(' ')
-                    .put(targetColumnName)
-                    .put("=\"")
-                    .put(rnd.nextString(NewLineProtoParser.MAX_ALLOWED_STRING_LEN + 1))
-                    .put("\" ")
-                    .put(1000000000)
-                    .put('\n');
-            recvBuffer = sink.toString();
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            try (TableReader ignored = new TableReader(new DefaultCairoConfiguration(root), table)) {
-                Assert.fail("table should have not been created");
-            } catch (CairoException expected) {
-                Assert.assertTrue(expected.getMessage().contains("[0] File not found:"));
-            }
-        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 
 import io.questdb.std.MemoryTag;
 import io.questdb.cutlass.line.LineProtoLexer;
+import io.questdb.cutlass.line.LineProtoLexerTest;
 import io.questdb.cutlass.line.LineProtoParser;
 import org.junit.Assert;
 
@@ -295,11 +296,11 @@ public class NewLineProtocolParserLexerTest {
         assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n", "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n");
     }
 
-    protected void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
+    private void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
         assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    protected void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
+    private void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
         final int len = line.length;
         final boolean endWithEOL = line[len - 1] == '\n' || line[len - 1] == '\r';
         long mem = Unsafe.malloc(line.length + 1, MemoryTag.NATIVE_DEFAULT);
@@ -356,7 +357,7 @@ public class NewLineProtocolParserLexerTest {
         }
     }
 
-    protected void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
+    private void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
         byte[] bytes = line.toString().getBytes(StandardCharsets.UTF_8);
         int len = bytes.length;
         final boolean endWithEOL = bytes[len - 1] == '\n' || bytes[len - 1] == '\r';

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
@@ -198,7 +198,10 @@ public class NewLineProtocolParserLexerTest extends LineProtoLexerTest {
                     Chars.utf8Decode(entity.getValue().getLo(), entity.getValue().getHi(), sink);
                     sink.put('"');
                     break;
-
+                    case NewLineProtoParser.ENTITY_TYPE_INTEGER:
+                case NewLineProtoParser.ENTITY_TYPE_LONG256:
+                        sink.put(entity.getValue()).put('i');
+                        break;
                 default:
                     sink.put(entity.getValue());
             }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
@@ -27,10 +27,11 @@ package io.questdb.cutlass.line.tcp;
 import java.nio.charset.StandardCharsets;
 
 import io.questdb.std.MemoryTag;
+import io.questdb.cutlass.line.LineProtoLexer;
+import io.questdb.cutlass.line.LineProtoParser;
 import org.junit.Assert;
 
 import io.questdb.cutlass.line.LineProtoException;
-import io.questdb.cutlass.line.LineProtoLexerTest;
 import io.questdb.cutlass.line.tcp.NewLineProtoParser.ErrorCode;
 import io.questdb.cutlass.line.tcp.NewLineProtoParser.ParseResult;
 import io.questdb.cutlass.line.tcp.NewLineProtoParser.ProtoEntity;
@@ -39,14 +40,265 @@ import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
 
-public class NewLineProtocolParserLexerTest extends LineProtoLexerTest {
+public class NewLineProtocolParserLexerTest {
+    private final static LineProtoLexer lexer = new LineProtoLexer(4096);
     private final NewLineProtoParser protoParser = new NewLineProtoParser();
+    protected final StringSink sink = new StringSink();
     private ErrorCode lastErrorCode;
     private boolean onErrorLine;
     private long startOfLineAddr;
 
-    @Override
+    @Before
+    public void setUp() {
+        lexer.clear();
+    }
+
+    @Test
+    public void testCommaInTagName() {
+        assertThat(
+                "measurement,t,ag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
+                "measurement,t\\,ag=value,tag2=value field=10000i,field2=\"str\" 100000\n"
+        );
+    }
+
+    @Test
+    public void testCommaInTagValue() {
+        assertThat("measurement,tag=value,tag2=va,lue field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=va\\,lue field=10000i,field2=\"str\" 100000\n");
+    }
+
+    @Test
+    public void testCorruptUtf8Sequence() {
+        byte[] bytesA = "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n".getBytes(StandardCharsets.UTF_8);
+        byte[] bytesB = {-116, -76, -55, 55, -34, 0, -11, 15, 13};
+        byte[] bytesC = "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n".getBytes(StandardCharsets.UTF_8);
+
+        byte[] bytes = new byte[bytesA.length + bytesB.length + bytesC.length];
+        System.arraycopy(bytesA, 0, bytes, 0, bytesA.length);
+        System.arraycopy(bytesB, 0, bytes, bytesA.length, bytesB.length);
+        System.arraycopy(bytesC, 0, bytes, bytesA.length + bytesB.length, bytesC.length);
+        assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n" +
+                        "-- error --\n" +
+                        "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
+                bytes);
+    }
+
+    @Test
+    public void testDanglingCommaOnTag() {
+        assertThat("measurement,tag=value field=x 10000\n", "measurement,tag=value, field=x 10000\n");
+    }
+
+    @Test
+    public void testEmptyLine() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n",
+                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "\n" +
+                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n");
+    }
+
+    @Test
+    public void testMissingFields() {
+        assertThat("measurement,field=10000i,field2=str\n", "measurement,field=10000i,field2=str");
+    }
+
+    @Test
+    public void testMissingFields2() {
+        assertThat("measurement,field=10000i,field2=str\n", "measurement,field=10000i,field2=str\n");
+    }
+
+    @Test
+    public void testMissingLineEnd() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000");
+    }
+
+    @Test
+    public void testMissingTags() {
+        assertThat("measurement field=10000i,field2=\"str\"\n", "measurement field=10000i,field2=\"str\"");
+    }
+
+    @Test
+    public void testMissingTimestamp() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\"\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\"");
+    }
+
+    @Test
+    public void testMultiLines() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n",
+                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n");
+    }
+
+    @Test
+    public void testNoFieldName1() {
+        assertError("measurement,tag=x f=10i,f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 26);
+    }
+
+    @Test
+    public void testNoFieldName2() {
+        assertError("measurement,tag=x f=10i,=f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EMPTY, 24);
+    }
+
+    @Test
+    public void testNoFieldName3() {
+        assertError("measurement,tag=x =10i,=f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EMPTY, 18);
+    }
+
+    @Test
+    public void testNoFieldValue1() {
+        assertError("measurement,tag=x f 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 19);
+    }
+
+    @Test
+    public void testNoFieldValue2() {
+        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f= 10000\n");
+    }
+
+    @Test
+    public void testNoFieldValue3() {
+        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f=, 10000\n");
+    }
+
+    @Test
+    public void testNoFields1() {
+        assertError("measurement  \n", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoFields2() {
+        assertError("measurement  ", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoFields3() {
+        assertError("measurement  10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoFields4() {
+        assertError("measurement,tag=x 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 23);
+    }
+
+    @Test
+    public void testNoMeasure1() {
+        assertError("tag=value field=x 10000\n", LineProtoParser.EVT_MEASUREMENT, LineProtoParser.ERROR_EXPECTED, 3);
+    }
+
+    @Test
+    public void testNoMeasure2() {
+        assertError("tag=value field=x 10000\n", LineProtoParser.EVT_MEASUREMENT, LineProtoParser.ERROR_EXPECTED, 3);
+    }
+
+    @Test
+    public void testNoTag4() {
+        assertError("measurement, \n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoTagEquals1() {
+        assertError("measurement,tag field=x 10000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 15);
+    }
+
+    @Test
+    public void testNoTagEquals2() {
+        assertError("measurement,tag, field=x 10000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 15);
+    }
+
+    @Test
+    public void testNoTagValue1() {
+        assertThat("measurement,tag= field=x 10000\n", "measurement,tag= field=x 10000\n");
+    }
+
+    @Test
+    public void testNoTagValue2() {
+        assertThat("measurement,tag= field=x 10000\n", "measurement,tag=, field=x 10000\n");
+    }
+
+    @Test
+    public void testNoTagValue3() {
+        assertThat("measurement,tag=\n", "measurement,tag=");
+    }
+
+    @Test
+    public void testNoTagValue4() {
+        assertThat("measurement,tag=\n", "measurement,tag=\n");
+    }
+
+    @Test
+    public void testNoTags1() {
+        assertError("measurement,", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoTags2() {
+        assertError("measurement,\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testNoTags3() {
+        assertError("measurement, 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testStringsInTag() {
+        assertError("measurement,tag=\"james\" 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+        assertError("measurement,tag=\"\" 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
+    }
+
+    @Test
+    public void testSimpleParse() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
+                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+    }
+
+    @Test
+    public void testSkipLine() {
+        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
+                        "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n",
+                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
+                        "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
+                        "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n");
+    }
+
+    @Test
+    public void testSpaceTagName() {
+        assertThat("measurement,t ag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,t\\ ag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+    }
+
+    @Test
+    public void testSpaceTagValue() {
+        assertThat("measurement,tag=value,tag2=valu e field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=valu\\ e field=10000i,field2=\"str\" 100000\n");
+    }
+
+    @Test
+    public void testTrailingSpace() {
+        assertError("measurement,tag=value,tag2=value field=10000i,field2=\"str\" \n" +
+                "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n", LineProtoParser.EVT_TIMESTAMP, LineProtoParser.ERROR_EMPTY, 59);
+    }
+
+    @Test
+    public void testUtf8() {
+        assertThat("меморандум,кроме=никто,этом=комитета находился=10000i,вышел=\"Александр\" 100000\n", "меморандум,кроме=никто,этом=комитета находился=10000i,вышел=\"Александр\" 100000\n");
+    }
+
+    @Test
+    public void testUtf8Measurement() {
+        assertThat("меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+    }
+
+    @Test
+    public void testUtf8ThreeBytes() {
+        assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n", "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n");
+    }
+
+    protected void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
+        assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
     protected void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
         final int len = line.length;
         final boolean endWithEOL = line[len - 1] == '\n' || line[len - 1] == '\r';
@@ -104,7 +356,6 @@ public class NewLineProtocolParserLexerTest extends LineProtoLexerTest {
         }
     }
 
-    @Override
     protected void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
         byte[] bytes = line.toString().getBytes(StandardCharsets.UTF_8);
         int len = bytes.length;

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserLexerTest.java
@@ -27,9 +27,7 @@ package io.questdb.cutlass.line.tcp;
 import java.nio.charset.StandardCharsets;
 
 import io.questdb.std.MemoryTag;
-import io.questdb.cutlass.line.LineProtoLexer;
 import io.questdb.cutlass.line.LineProtoLexerTest;
-import io.questdb.cutlass.line.LineProtoParser;
 import org.junit.Assert;
 
 import io.questdb.cutlass.line.LineProtoException;
@@ -41,221 +39,35 @@ import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
 
-public class NewLineProtocolParserLexerTest {
-    private final static LineProtoLexer lexer = new LineProtoLexer(4096);
+public class NewLineProtocolParserLexerTest extends LineProtoLexerTest {
+
     private final NewLineProtoParser protoParser = new NewLineProtoParser();
-    protected final StringSink sink = new StringSink();
     private ErrorCode lastErrorCode;
     private boolean onErrorLine;
     private long startOfLineAddr;
 
-    @Before
-    public void setUp() {
-        lexer.clear();
-    }
-
-    @Test
-    public void testCommaInTagName() {
-        assertThat(
-                "measurement,t,ag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
-                "measurement,t\\,ag=value,tag2=value field=10000i,field2=\"str\" 100000\n"
-        );
-    }
-
-    @Test
-    public void testCommaInTagValue() {
-        assertThat("measurement,tag=value,tag2=va,lue field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=va\\,lue field=10000i,field2=\"str\" 100000\n");
-    }
-
-    @Test
-    public void testCorruptUtf8Sequence() {
-        byte[] bytesA = "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n".getBytes(StandardCharsets.UTF_8);
-        byte[] bytesB = {-116, -76, -55, 55, -34, 0, -11, 15, 13};
-        byte[] bytesC = "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n".getBytes(StandardCharsets.UTF_8);
-
-        byte[] bytes = new byte[bytesA.length + bytesB.length + bytesC.length];
-        System.arraycopy(bytesA, 0, bytes, 0, bytesA.length);
-        System.arraycopy(bytesB, 0, bytes, bytesA.length, bytesB.length);
-        System.arraycopy(bytesC, 0, bytes, bytesA.length + bytesB.length, bytesC.length);
-        assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n" +
-                        "-- error --\n" +
-                        "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
-                bytes);
-    }
-
-    @Test
-    public void testDanglingCommaOnTag() {
-        assertThat("measurement,tag=value field=x 10000\n", "measurement,tag=value, field=x 10000\n");
-    }
-
-    @Test
-    public void testEmptyLine() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
-                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n",
-                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
-                        "\n" +
-                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n");
-    }
-
-    @Test
-    public void testMissingFields() {
-        assertThat("measurement,field=10000i,field2=str\n", "measurement,field=10000i,field2=str");
-    }
-
-    @Test
-    public void testMissingFields2() {
-        assertThat("measurement,field=10000i,field2=str\n", "measurement,field=10000i,field2=str\n");
-    }
-
-    @Test
-    public void testMissingLineEnd() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000");
-    }
-
-    @Test
-    public void testMissingTags() {
-        assertThat("measurement field=10000i,field2=\"str\"\n", "measurement field=10000i,field2=\"str\"");
-    }
-
-    @Test
-    public void testMissingTimestamp() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\"\n", "measurement,tag=value,tag2=value field=10000i,field2=\"str\"");
-    }
-
-    @Test
-    public void testMultiLines() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
-                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n",
-                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
-                        "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n");
-    }
-
-    @Test
-    public void testNoFieldName1() {
-        assertError("measurement,tag=x f=10i,f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 26);
-    }
-
-    @Test
-    public void testNoFieldName2() {
-        assertError("measurement,tag=x f=10i,=f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EMPTY, 24);
-    }
-
-    @Test
-    public void testNoFieldName3() {
-        assertError("measurement,tag=x =10i,=f2 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EMPTY, 18);
-    }
-
-    @Test
-    public void testNoFieldValue1() {
-        assertError("measurement,tag=x f 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 19);
-    }
-
-    @Test
-    public void testNoFieldValue2() {
-        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f= 10000\n");
-    }
-
-    @Test
-    public void testNoFieldValue3() {
-        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f=, 10000\n");
-    }
-
-    @Test
-    public void testNoFields1() {
-        assertError("measurement  \n", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoFields2() {
-        assertError("measurement  ", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoFields3() {
-        assertError("measurement  10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoFields4() {
-        assertError("measurement,tag=x 10000", LineProtoParser.EVT_FIELD_NAME, LineProtoParser.ERROR_EXPECTED, 23);
-    }
-
-    @Test
-    public void testNoMeasure1() {
-        assertError("tag=value field=x 10000\n", LineProtoParser.EVT_MEASUREMENT, LineProtoParser.ERROR_EXPECTED, 3);
-    }
-
-    @Test
-    public void testNoMeasure2() {
-        assertError("tag=value field=x 10000\n", LineProtoParser.EVT_MEASUREMENT, LineProtoParser.ERROR_EXPECTED, 3);
-    }
-
-    @Test
-    public void testNoTag4() {
-        assertError("measurement, \n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoTagEquals1() {
-        assertError("measurement,tag field=x 10000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 15);
-    }
-
-    @Test
-    public void testNoTagEquals2() {
-        assertError("measurement,tag, field=x 10000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 15);
-    }
-
-    @Test
+    @Override
     public void testNoTagValue1() {
         assertThat("measurement,tag= field=x 10000\n", "measurement,tag= field=x 10000\n");
     }
 
-    @Test
+    @Override
     public void testNoTagValue2() {
         assertThat("measurement,tag= field=x 10000\n", "measurement,tag=, field=x 10000\n");
     }
 
-    @Test
+    @Override
     public void testNoTagValue3() {
         assertThat("measurement,tag=\n", "measurement,tag=");
     }
 
-    @Test
+    @Override
     public void testNoTagValue4() {
         assertThat("measurement,tag=\n", "measurement,tag=\n");
     }
 
-    @Test
-    public void testNoTags1() {
-        assertError("measurement,", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoTags2() {
-        assertError("measurement,\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testNoTags3() {
-        assertError("measurement, 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testStringsInTag() {
-        assertError("measurement,tag=\"james\" 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-        assertError("measurement,tag=\"\" 100000\n", LineProtoParser.EVT_TAG_NAME, LineProtoParser.ERROR_EXPECTED, 12);
-    }
-
-    @Test
-    public void testSimpleParse() {
-        assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n",
-                "measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
-    }
-
-    @Test
+    @Override
     public void testSkipLine() {
         assertThat("measurement,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n" +
                         "measurement,tag=value3,tag2=value2 field=,field2=\"ok\"\n" +
@@ -265,42 +77,24 @@ public class NewLineProtocolParserLexerTest {
                         "measurement,tag=value4,tag2=value4 field=200i,field2=\"super\"\n");
     }
 
-    @Test
-    public void testSpaceTagName() {
-        assertThat("measurement,t ag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "measurement,t\\ ag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
+    @Override
+    public void testNoFieldValue2() {
+        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f= 10000\n");
     }
 
-    @Test
-    public void testSpaceTagValue() {
-        assertThat("measurement,tag=value,tag2=valu e field=10000i,field2=\"str\" 100000\n", "measurement,tag=value,tag2=valu\\ e field=10000i,field2=\"str\" 100000\n");
+    @Override
+    public void testNoFieldValue3() {
+        assertThat("measurement,tag=x f= 10000\n", "measurement,tag=x f=, 10000\n");
     }
 
-    @Test
-    public void testTrailingSpace() {
-        assertError("measurement,tag=value,tag2=value field=10000i,field2=\"str\" \n" +
-                "measurement,tag=value3,tag2=value2 field=100i,field2=\"ok\"\n", LineProtoParser.EVT_TIMESTAMP, LineProtoParser.ERROR_EMPTY, 59);
+
+    @Override
+    public void testDanglingCommaOnTag() {
+        assertThat("measurement,tag=value field=x 10000\n", "measurement,tag=value, field=x 10000\n");
     }
 
-    @Test
-    public void testUtf8() {
-        assertThat("меморандум,кроме=никто,этом=комитета находился=10000i,вышел=\"Александр\" 100000\n", "меморандум,кроме=никто,этом=комитета находился=10000i,вышел=\"Александр\" 100000\n");
-    }
-
-    @Test
-    public void testUtf8Measurement() {
-        assertThat("меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n", "меморандум,tag=value,tag2=value field=10000i,field2=\"str\" 100000\n");
-    }
-
-    @Test
-    public void testUtf8ThreeBytes() {
-        assertThat("违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n", "违法违,控网站漏洞风=不一定代,网站可能存在=комитета 的风险=10000i,вышел=\"险\" 100000\n");
-    }
-
-    private void assertThat(CharSequence expected, CharSequence line) throws LineProtoException {
-        assertThat(expected, line.toString().getBytes(StandardCharsets.UTF_8));
-    }
-
-    private void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
+    @Override
+    protected void assertThat(CharSequence expected, byte[] line) throws LineProtoException {
         final int len = line.length;
         final boolean endWithEOL = line[len - 1] == '\n' || line[len - 1] == '\r';
         long mem = Unsafe.malloc(line.length + 1, MemoryTag.NATIVE_DEFAULT);
@@ -357,7 +151,8 @@ public class NewLineProtocolParserLexerTest {
         }
     }
 
-    private void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
+    @Override
+    protected void assertError(CharSequence line, int state, int code, int position) throws LineProtoException {
         byte[] bytes = line.toString().getBytes(StandardCharsets.UTF_8);
         int len = bytes.length;
         final boolean endWithEOL = bytes[len - 1] == '\n' || bytes[len - 1] == '\r';

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line.tcp;
+
+import io.questdb.std.Unsafe;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class NewLineProtocolParserTest extends BaseLineTcpContextTest {
+    private final static NewLineProtoParser protoParser = new NewLineProtoParser();
+
+    @Test
+    public void testGetValueType() throws Exception {
+        assertType(NewLineProtoParser.ENTITY_TYPE_NULL, "");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "null");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "NULL");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "NulL");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "skull");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "skulL");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "1.6x");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "aa\"aa");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "tre");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "''");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "oX");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "0x");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "a");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "i");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "aflse");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "aTTTT");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "aFFF");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "e");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "t");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "T");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "f");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "F");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "true");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "false");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "FalSe");
+        assertType(NewLineProtoParser.ENTITY_TYPE_BOOLEAN, "tRuE");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_STRING, "\"0x123a4\"");
+        assertType(NewLineProtoParser.ENTITY_TYPE_STRING, "\"0x123a4 looks \\\" like=long256,\\\n but tis not!\"");
+        assertType(NewLineProtoParser.ENTITY_TYPE_STRING, "\"0x123a4 looks like=long256, but tis not!\"");
+        assertType(NewLineProtoParser.ENTITY_TYPE_NONE, "\"0x123a4 looks \\\" like=long256,\\\n but tis not!",
+                NewLineProtoParser.ParseResult.ERROR); // missing closing '"'
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "0x123a4 looks \\\" like=long256,\\\n but tis not!\"",
+                NewLineProtoParser.ParseResult.ERROR); // wanted to be a string, missing opening '"'
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_LONG256, "0x123i");
+        assertType(NewLineProtoParser.ENTITY_TYPE_LONG256, "0x1i");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_INTEGER, "123i");
+        assertType(NewLineProtoParser.ENTITY_TYPE_INTEGER, "1i");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_FLOAT, "1.45");
+        assertType(NewLineProtoParser.ENTITY_TYPE_FLOAT, "1e-13");
+        assertType(NewLineProtoParser.ENTITY_TYPE_FLOAT, "1.0");
+        assertType(NewLineProtoParser.ENTITY_TYPE_FLOAT, "1");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_NONE, "aaa\"", NewLineProtoParser.ParseResult.ERROR);
+        assertType(NewLineProtoParser.ENTITY_TYPE_NONE, "\"aaa", NewLineProtoParser.ParseResult.ERROR);
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "123a4i");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "oxi");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "xi");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "oXi");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "0xi");
+
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "123a4");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "ox1");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "0x1");
+        assertType(NewLineProtoParser.ENTITY_TYPE_SYMBOL, "0x123a4");
+
+        // in this edge case, type is guessed as best as possible, later the parser would fail, its a feature
+        assertType(NewLineProtoParser.ENTITY_TYPE_LONG256, "0x123a4i");
+    }
+
+    private static void assertType(int type, String value) throws Exception {
+        assertType(type, value, NewLineProtoParser.ParseResult.MEASUREMENT_COMPLETE);
+    }
+
+    private static void assertType(int type,
+                                   String value,
+                                   NewLineProtoParser.ParseResult expectedParseResult) throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            sink.clear();
+            sink.put("t v=").put(value).put('\n');
+            byte[] bytes = sink.toString().getBytes(StandardCharsets.UTF_8);
+            final int len = bytes.length;
+            long mem = Unsafe.malloc(bytes.length);
+            try {
+                for (int i = 0; i < bytes.length; i++) {
+                    Unsafe.getUnsafe().putByte(mem + i, bytes[i]);
+                }
+                protoParser.of(mem);
+                Assert.assertEquals(expectedParseResult, protoParser.parseMeasurement(mem + len));
+                NewLineProtoParser.ProtoEntity entity = protoParser.getEntity(0);
+                Assert.assertEquals(type, entity.getType());
+                Assert.assertEquals("v", entity.getName().toString());
+                if (expectedParseResult == NewLineProtoParser.ParseResult.MEASUREMENT_COMPLETE) {
+                    switch (type) {
+                        case NewLineProtoParser.ENTITY_TYPE_STRING:
+                            Assert.assertEquals(value, "\"" + entity.getValue().toString() + "\"");
+                            break;
+                        case NewLineProtoParser.ENTITY_TYPE_INTEGER:
+                        case NewLineProtoParser.ENTITY_TYPE_LONG256:
+                            Assert.assertEquals(value, entity.getValue().toString() + "i");
+                            break;
+                        default:
+                            Assert.assertEquals(value, entity.getValue().toString());
+                    }
+                }
+            } finally {
+                Unsafe.free(mem, bytes.length);
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/NewLineProtocolParserTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.line.tcp;
 
+import io.questdb.std.MemoryTag;
 import io.questdb.std.Unsafe;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -114,7 +115,7 @@ public class NewLineProtocolParserTest extends BaseLineTcpContextTest {
             sink.put("t v=").put(value).put('\n');
             byte[] bytes = sink.toString().getBytes(StandardCharsets.UTF_8);
             final int len = bytes.length;
-            long mem = Unsafe.malloc(bytes.length);
+            long mem = Unsafe.malloc(bytes.length, MemoryTag.NATIVE_DEFAULT);
             try {
                 for (int i = 0; i < bytes.length; i++) {
                     Unsafe.getUnsafe().putByte(mem + i, bytes[i]);
@@ -138,7 +139,7 @@ public class NewLineProtocolParserTest extends BaseLineTcpContextTest {
                     }
                 }
             } finally {
-                Unsafe.free(mem, bytes.length);
+                Unsafe.free(mem, bytes.length, MemoryTag.NATIVE_DEFAULT);
             }
         });
     }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
@@ -48,7 +48,7 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
                 "abc\txyz\t10000\t9.034\tstr\ttrue\t1970-01-01T00:01:40.000000Z\tNaN\n" +
                 "woopsie\tdaisy\t2000\t3.0889100000000003\tcomment\ttrue\t1970-01-01T00:01:40.000000Z\tNaN\n" +
                 "444\td555\t510\t1.4000000000000001\tcomment\ttrue\t1970-01-01T00:01:40.000000Z\t55\n" +
-                "666\t777\t410\t1.1\tcomment X\tfalse\t1970-01-01T00:01:40.000000Z\tNaN\n";
+                "666\t777\t410\t1.1\tcomment\\ X\tfalse\t1970-01-01T00:01:40.000000Z\tNaN\n";
 
         final String lines = "tab,tag=abc,tag2=xyz field=10000i,f4=9.034,field2=\"str\",fx=true 100000000000\n" +
                 "tab,tag=woopsie,tag2=daisy field=2000i,f4=3.08891,field2=\"comment\",fx=true 100000000000\n" +
@@ -165,7 +165,8 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
                 .timestamp()) {
             CairoTestUtils.create(model);
         }
-        assertThat("char\ttimestamp\n",
+        assertThat("char\ttimestamp\n" +
+                        "\t1970-01-01T00:00:00.000000Z\n",
                 "x char=\n",
                 "x",
                 new DefaultCairoConfiguration(root) {
@@ -550,11 +551,12 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
         final String expected1 = "sym2\tdouble\tint\tbool\tstr\ttimestamp\tsym1\n" +
                 "xyz\t1.6\t15\ttrue\tstring1\t2017-10-03T10:00:00.000000Z\t\n" +
                 "\t1.3\t11\tfalse\tstring2\t2017-10-03T10:00:00.010000Z\tabc\n" +
-                "\t0.30000000000000004\t91\ttrue\tstring4\t2017-10-03T10:00:00.040000Z\trow4\n";
+                "\tNaN\t6\tfalse\tstring3\t2017-10-03T10:00:00.030000Z\trow3\n" +
+                "\t0.30000000000000004\t91\ttrue\tstring4\t2017-10-03T10:00:00.050000Z\trow4\n";
 
         final String expected2 = "asym1\tasym2\tadouble\ttimestamp\n" +
                 "55\tbox\t5.9\t2017-10-03T10:00:00.020000Z\n" +
-                "66\tbox\t7.9\t2017-10-03T10:00:00.030000Z\n";
+                "66\tbox\t7.9\t2017-10-03T10:00:00.040000Z\n";
 
         String lines = "x,sym2=xyz double=1.6,int=15i,bool=true,str=\"string1\"\n" +
                 "x,sym1=abc double=1.3,int=11i,bool=false,str=\"string2\"\n" +

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
@@ -122,8 +122,10 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 1);
                     receiver.start();
                     sendGeoHashLine("");
+                    sendGeoHashLine("null");
                     assertReader(tableName,
                             "geohash\ttimestamp\n" +
+                                    "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
             }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
@@ -66,7 +66,7 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
                         sender.metric(tableName).field("carrots", "j").$(3000000000L);
                         sender.flush();
                     }
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\tcarrots\n" +
                                     "\t1970-01-01T00:00:01.000000Z\t9\n" +
                                     "\t1970-01-01T00:00:02.000000Z\t4\n" +
@@ -85,7 +85,7 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 4);
                     receiver.start();
                     sendGeoHashLine("9v1s8hm7wpkssv1h");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "0100\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -106,7 +106,7 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 1);
                     receiver.start();
                     sendGeoHashLine("@");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -123,7 +123,7 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
                     receiver.start();
                     sendGeoHashLine("");
                     sendGeoHashLine("null");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertByteGeoHashTest.java
@@ -25,8 +25,6 @@
 package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.*;
-import io.questdb.cutlass.line.LineProtoSender;
-import io.questdb.test.tools.TestUtils;
 
 public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
     @Override
@@ -55,42 +53,33 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
 
     @Override
     public void testTableHasGeoHashMessageDoesNot() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 4);
-                    receiver.start();
-                    try (LineProtoSender sender = createLineProtoSender()) {
-                        sender.metric(tableName).field("carrots", "9").$(1000000000L);
-                        sender.metric(tableName).field("carrots", "4").$(2000000000L);
-                        sender.metric(tableName).field("carrots", "j").$(3000000000L);
-                        sender.flush();
-                    }
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\tcarrots\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\t9\n" +
-                                    "\t1970-01-01T00:00:02.000000Z\t4\n" +
-                                    "\t1970-01-01T00:00:03.000000Z\tj\n",
-                            "carrots");
-                }
-            }
-        });
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(4),
+                "geohash\ttimestamp\tcarrots\n" +
+                        "\t1970-01-01T00:00:01.000000Z\t9\n" +
+                        "\t1970-01-01T00:00:02.000000Z\t4\n" +
+                        "\t1970-01-01T00:00:03.000000Z\tj\n",
+                sender -> {
+                    sender.metric(tableName).field("carrots", "9").$(1000000000L);
+                    sender.metric(tableName).field("carrots", "4").$(2000000000L);
+                    sender.metric(tableName).field("carrots", "j").$(3000000000L);
+                },
+                "carrots"
+        );
     }
 
     @Override
     public void testExcessivelyLongGeoHashesAreTruncated() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 4);
-                    receiver.start();
-                    sendGeoHashLine("9v1s8hm7wpkssv1h");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "0100\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(4),
+                "geohash\ttimestamp\n" +
+                        "0100\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "9v1s8hm7wpkssv1h").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 
     @Override
@@ -100,35 +89,29 @@ public class LineUdpInsertByteGeoHashTest extends LineUdpInsertGeoHashTest {
 
     @Override
     public void testWrongCharGeoHashes() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 1);
-                    receiver.start();
-                    sendGeoHashLine("@");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(1),
+                "geohash\ttimestamp\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "@").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 
     @Override
     public void testNullGeoHash() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 1);
-                    receiver.start();
-                    sendGeoHashLine("");
-                    sendGeoHashLine("null");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(1),
+                "geohash\ttimestamp\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "").$(1_000_000_000);
+                    sender.metric(tableName).field(targetColumnName, "null").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertGeoHashTest.java
@@ -68,7 +68,7 @@ abstract class LineUdpInsertGeoHashTest extends LineUdpInsertTest {
                     createTable(engine, columnBits);
                     receiver.start();
                     sendGeoHashLines(numLines, lineGeoSizeChars);
-                    assertReader(tableName, expected);
+                    assertReader(engine, tableName, expected);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
@@ -24,9 +24,7 @@
 
 package io.questdb.cutlass.line.udp;
 
-import io.questdb.cairo.CairoEngine;
-import io.questdb.cutlass.line.LineProtoSender;
-import io.questdb.test.tools.TestUtils;
+import io.questdb.cairo.*;
 
 public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
     @Override
@@ -59,44 +57,33 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
 
     @Override
     public void testTableHasGeoHashMessageDoesNot() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 28);
-                    receiver.start();
-                    try (LineProtoSender sender = createLineProtoSender()) {
-                        sender.metric(tableName).field("location", "9").$(1000000000L);
-                        sender.metric(tableName).field("location", "4").$(2000000000L);
-                        sender.metric(tableName).field("location", "j").field("in", "yes").$(3000000000L);
-                        sender.flush();
-                    }
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\tlocation\tin\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\t9\t\n" +
-                                    "\t1970-01-01T00:00:02.000000Z\t4\t\n" +
-                                    "\t1970-01-01T00:00:03.000000Z\tj\tyes\n",
-                            "location", "in");
-
-                    receiver.halt();
-                }
-            }
-        });
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(28),
+                "geohash\ttimestamp\tcarrots\n" +
+                        "\t1970-01-01T00:00:01.000000Z\t9\n" +
+                        "\t1970-01-01T00:00:02.000000Z\t4\n" +
+                        "\t1970-01-01T00:00:03.000000Z\tj\n",
+                sender -> {
+                    sender.metric(tableName).field("carrots", "9").$(1000000000L);
+                    sender.metric(tableName).field("carrots", "4").$(2000000000L);
+                    sender.metric(tableName).field("carrots", "j").$(3000000000L);
+                },
+                "carrots"
+        );
     }
 
     @Override
     public void testExcessivelyLongGeoHashesAreTruncated() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 20);
-                    receiver.start();
-                    sendGeoHashLine("sp052w92p1p8187");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "sp05\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(20),
+                "geohash\ttimestamp\n" +
+                        "9v1s\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "9v1s8hm7wpkssv1h").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 
     @Override
@@ -115,35 +102,29 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
 
     @Override
     public void testWrongCharGeoHashes() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 31);
-                    receiver.start();
-                    sendGeoHashLine("sp018*");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(31),
+                "geohash\ttimestamp\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "sp018*").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 
     @Override
     public void testNullGeoHash() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    createTable(engine, 30);
-                    receiver.start();
-                    sendGeoHashLine("");
-                    sendGeoHashLine("null");
-                    assertReader(engine, tableName,
-                            "geohash\ttimestamp\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n" +
-                                    "\t1970-01-01T00:00:01.000000Z\n");
+        assertType(tableName,
+                targetColumnName,
+                ColumnType.getGeoHashTypeWithBits(30),
+                "geohash\ttimestamp\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n" +
+                        "\t1970-01-01T00:00:01.000000Z\n",
+                sender -> {
+                    sender.metric(tableName).field(targetColumnName, "").$(1_000_000_000);
+                    sender.metric(tableName).field(targetColumnName, "null").$(1_000_000_000);
                 }
-            }
-        });
+        );
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
@@ -137,8 +137,10 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 30);
                     receiver.start();
                     sendGeoHashLine("");
+                    sendGeoHashLine("null");
                     assertReader(tableName,
                             "geohash\ttimestamp\n" +
+                                    "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
             }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertIntGeoHashTest.java
@@ -70,7 +70,7 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
                         sender.metric(tableName).field("location", "j").field("in", "yes").$(3000000000L);
                         sender.flush();
                     }
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\tlocation\tin\n" +
                                     "\t1970-01-01T00:00:01.000000Z\t9\t\n" +
                                     "\t1970-01-01T00:00:02.000000Z\t4\t\n" +
@@ -91,7 +91,7 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 20);
                     receiver.start();
                     sendGeoHashLine("sp052w92p1p8187");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "sp05\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -121,7 +121,7 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 31);
                     receiver.start();
                     sendGeoHashLine("sp018*");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -138,7 +138,7 @@ public class LineUdpInsertIntGeoHashTest extends LineUdpInsertGeoHashTest {
                     receiver.start();
                     sendGeoHashLine("");
                     sendGeoHashLine("null");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertLongGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertLongGeoHashTest.java
@@ -72,7 +72,7 @@ public class LineUdpInsertLongGeoHashTest extends LineUdpInsertGeoHashTest {
                         sender.flush();
                     }
                     Os.sleep(50); // let things settle
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\tcarrots\tonions\n" +
                                     "\t1970-01-01T00:00:01.000000Z\t9\t\n" +
                                     "\t1970-01-01T00:00:02.000000Z\t4\t\n" +
@@ -92,7 +92,7 @@ public class LineUdpInsertLongGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 57);
                     receiver.start();
                     sendGeoHashLine("9v1s8hm7wpkssv1h");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "010011101100001110000100010000100110011111100101011001011\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -121,7 +121,7 @@ public class LineUdpInsertLongGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 58);
                     receiver.start();
                     sendGeoHashLine("sp018sp0!18*");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -138,7 +138,7 @@ public class LineUdpInsertLongGeoHashTest extends LineUdpInsertGeoHashTest {
                     receiver.start();
                     sendGeoHashLine("");
                     sendGeoHashLine("null");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertLongGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertLongGeoHashTest.java
@@ -137,8 +137,10 @@ public class LineUdpInsertLongGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 30);
                     receiver.start();
                     sendGeoHashLine("");
+                    sendGeoHashLine("null");
                     assertReader(tableName,
                             "geohash\ttimestamp\n" +
+                                    "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
             }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -489,7 +489,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                 new CharSequence[]{
                         "", // discarded, empty line
                         "\"null\"", // actual string
-                        "0x1234", //  discarded, bad type long256
+                        "0x123t4", //  discarded, bad type long256
                 });
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -34,7 +34,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     static final String targetColumnName = "value";
 
     @Test
-    public void testInsertLong() throws Exception {
+    public void testInsertLongTableExists() throws Exception {
         assertType(ColumnType.LONG,
                 "value\ttimestamp\n" +
                         "0\t1970-01-01T00:00:01.000000Z\n" +
@@ -42,7 +42,10 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0\t1970-01-01T00:00:03.000000Z\n" +
                         "-100\t1970-01-01T00:00:04.000000Z\n" +
                         "9223372036854775807\t1970-01-01T00:00:05.000000Z\n" +
-                        "-9223372036854775807\t1970-01-01T00:00:06.000000Z\n",
+                        "-9223372036854775807\t1970-01-01T00:00:06.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:07.000000Z\n" +
+                        "-2147483647\t1970-01-01T00:00:13.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:15.000000Z\n",
                 new CharSequence[]{
                         "0i",
                         "100i",
@@ -50,11 +53,45 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-100i",
                         "9223372036854775807i",
                         "-9223372036854775807i",
+                        "-9223372036854775808i", // NaN, same as null
+                        "0", // ignored missing i
+                        "100", // ignored missing i
+                        "-0", // ignored missing i
+                        "-100", // ignored missing i
+                        "2147483647", // ignored missing i
+                        "-2147483647i",
+                        "", // ignored empty line
+                        "null" // NaN
+                });
+    }
+
+    @Test
+    public void testInsertLongTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0\t1970-01-01T00:00:01.000000Z\n" +
+                        "100\t1970-01-01T00:00:02.000000Z\n" +
+                        "0\t1970-01-01T00:00:03.000000Z\n" +
+                        "-100\t1970-01-01T00:00:04.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:05.000000Z\n" +
+                        "9223372036854775807\t1970-01-01T00:00:06.000000Z\n" +
+                        "-9223372036854775807\t1970-01-01T00:00:07.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:08.000000Z\n" +
+                        "2147483647\t1970-01-01T00:00:14.000000Z\n",
+                new CharSequence[]{
+                        "0i",
+                        "100i",
+                        "-0i",
+                        "-100i",
+                        "-9223372036854775808i",
+                        "9223372036854775807i",
+                        "-9223372036854775807i",
+                        "null",
+                        "\"null\"",
                         "0",
                         "100",
                         "-0",
                         "-100",
-                        "2147483647",
+                        "2147483647i",
                         "-2147483647",
                         "NaN",
                         ""
@@ -62,68 +99,148 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertTimestamp() throws Exception {
+    public void testInsertTimestampTableExists() throws Exception {
         assertType(ColumnType.TIMESTAMP,
                 "value\ttimestamp\n" +
                         "1970-01-19T21:02:13.921000Z\t1970-01-01T00:00:01.000000Z\n" +
                         "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:04.000000Z\n" +
-                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:06.000000Z\n" +
-                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:07.000000Z\n",
+                        "\t1970-01-01T00:00:05.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:07.000000Z\n" +
+                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:08.000000Z\n" +
+                        "\t1970-01-01T00:00:10.000000Z\n",
                 new CharSequence[]{
                         "1630933921000i",
-                        "1630933921000",
-                        "\"1970-01-01T00:00:05.000000Z\"",
+                        "1630933921000", // discarded missing i
+                        "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
                         "0i",
-                        "",
+                        "-9223372036854775808i", // NaN
+                        "", // discarded empty line
                         "-0i",
                         "9223372036854775807i",
-                        "NaN",
-                        "1970-01-01T00:00:05.000000Z"
+                        "NaN", // discarded bad value
+                        "null", // null value
+                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
                 });
     }
 
     @Test
-    public void testInsertDate() throws Exception {
+    public void testInsertTimestampTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "1630933921000\t1970-01-01T00:00:01.000000Z\n" +
+                        "0\t1970-01-01T00:00:04.000000Z\n" +
+                        "0\t1970-01-01T00:00:06.000000Z\n" +
+                        "9223372036854775807\t1970-01-01T00:00:07.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:09.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:10.000000Z\n",
+                new CharSequence[]{
+                        "1630933921000i", // no longer a timestamp, rather a long
+                        "1630933921000", // discarded missing i
+                        "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
+                        "0i",
+                        "", // discarded empty line
+                        "-0i",
+                        "9223372036854775807i",
+                        "NaN", // discarded bad value
+                        "null", // null value
+                        "-9223372036854775808i", // NaN
+                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
+                });
+    }
+
+    @Test
+    public void testInsertDateTableExists() throws Exception {
         assertType(ColumnType.DATE,
                 "value\ttimestamp\n" +
                         "2021-09-06T13:12:01.000Z\t1970-01-01T00:00:01.000000Z\n" +
                         "1970-01-01T00:00:00.000Z\t1970-01-01T00:00:04.000000Z\n" +
-                        "1970-01-01T00:00:00.000Z\t1970-01-01T00:00:06.000000Z\n" +
-                        "292278994-08-17T07:12:55.807Z\t1970-01-01T00:00:07.000000Z\n",
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "1970-01-01T00:00:00.000Z\t1970-01-01T00:00:07.000000Z\n" +
+                        "292278994-08-17T07:12:55.807Z\t1970-01-01T00:00:08.000000Z\n" +
+                        "\t1970-01-01T00:00:10.000000Z\n",
                 new CharSequence[]{
                         "1630933921000i",
                         "1630933921000",
                         "\"1970-01-01T00:00:05.000000Z\"",
                         "0i",
                         "",
+                        "-9223372036854775808i", // NaN
                         "-0i",
                         "9223372036854775807i",
                         "NaN",
+                        "null",
                         "1970-01-01T00:00:05.000000Z"
                 });
     }
 
     @Test
-    public void testInsertChar() throws Exception {
+    public void testInsertDateTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "1630933921000\t1970-01-01T00:00:01.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:03.000000Z\n" +
+                        "0\t1970-01-01T00:00:05.000000Z\n" +
+                        "0\t1970-01-01T00:00:07.000000Z\n" +
+                        "9223372036854775807\t1970-01-01T00:00:08.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:10.000000Z\n",
+                new CharSequence[]{
+                        "1630933921000i",
+                        "1630933921000",
+                        "-9223372036854775808i", // NaN
+                        "\"1970-01-01T00:00:05.000000Z\"",
+                        "0i",
+                        "",
+                        "-0i",
+                        "9223372036854775807i",
+                        "NaN",
+                        "null",
+                        "1970-01-01T00:00:05.000000Z"
+                });
+    }
+
+    @Test
+    public void testInsertCharTableExists() throws Exception {
         assertType(ColumnType.CHAR,
                 "value\ttimestamp\n" +
                         "1\t1970-01-01T00:00:01.000000Z\n" +
                         "1\t1970-01-01T00:00:02.000000Z\n" +
                         "N\t1970-01-01T00:00:05.000000Z\n" +
-                        "N\t1970-01-01T00:00:06.000000Z\n",
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "N\t1970-01-01T00:00:07.000000Z\n",
                 new CharSequence[]{
                         "\"1630933921000\"",
                         "\"1970-01-01T00:00:05.000000Z\"",
                         "",
                         "-0i",
                         "\"NaN\"",
+                        "null",
                         "\"N\"",
+                        "0",
                         "1970-01-01T00:00:05.000000Z"
                 });
     }
 
     @Test
-    public void testInsertInt() throws Exception {
+    public void testInsertCharTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "1630933921000\t1970-01-01T00:00:01.000000Z\n" +
+                        "1970-01-01T00:00:05.000000Z\t1970-01-01T00:00:02.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:05.000000Z\n" +
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "N\t1970-01-01T00:00:07.000000Z\n",
+                new CharSequence[]{
+                        "\"1630933921000\"",
+                        "\"1970-01-01T00:00:05.000000Z\"",
+                        "",
+                        "-0i",
+                        "\"NaN\"",
+                        "null",
+                        "\"N\"",
+                        "0",
+                        "1970-01-01T00:00:05.000000Z"
+                });
+    }
+
+    @Test
+    public void testInsertIntTableExists() throws Exception {
         assertType(ColumnType.INT,
                 "value\ttimestamp\n" +
                         "0\t1970-01-01T00:00:01.000000Z\n" +
@@ -133,7 +250,9 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "NaN\t1970-01-01T00:00:05.000000Z\n" +
                         "NaN\t1970-01-01T00:00:06.000000Z\n" +
                         "2147483647\t1970-01-01T00:00:07.000000Z\n" +
-                        "-2147483647\t1970-01-01T00:00:08.000000Z\n",
+                        "-2147483647\t1970-01-01T00:00:08.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:11.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:13.000000Z\n",
                 new CharSequence[]{
                         "0i",
                         "100i",
@@ -145,6 +264,9 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-2147483647i",
                         "0",
                         "100",
+                        "-2147483648i",
+                        "-2147483648",
+                        "null",
                         "-0",
                         "-100",
                         "2147483647",
@@ -155,7 +277,43 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertShort() throws Exception {
+    public void testInsertIntTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0\t1970-01-01T00:00:01.000000Z\n" +
+                        "100\t1970-01-01T00:00:02.000000Z\n" +
+                        "0\t1970-01-01T00:00:03.000000Z\n" +
+                        "-100\t1970-01-01T00:00:04.000000Z\n" +
+                        "9223372036854775807\t1970-01-01T00:00:05.000000Z\n" +
+                        "-9223372036854775807\t1970-01-01T00:00:06.000000Z\n" +
+                        "2147483647\t1970-01-01T00:00:07.000000Z\n" +
+                        "-2147483647\t1970-01-01T00:00:08.000000Z\n" +
+                        "-2147483648\t1970-01-01T00:00:11.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:13.000000Z\n",
+                new CharSequence[]{
+                        "0i",
+                        "100i",
+                        "-0i",
+                        "-100i",
+                        "9223372036854775807i",
+                        "-9223372036854775807i",
+                        "2147483647i",
+                        "-2147483647i",
+                        "0",
+                        "100",
+                        "-2147483648i",
+                        "-2147483648",
+                        "null",
+                        "-0",
+                        "-100",
+                        "2147483647",
+                        "-2147483647",
+                        "NaN",
+                        ""
+                });
+    }
+
+    @Test
+    public void testInsertShortTableExists() throws Exception {
         assertType(ColumnType.SHORT,
                 "value\ttimestamp\n" +
                         "0\t1970-01-01T00:00:01.000000Z\n" +
@@ -163,7 +321,10 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0\t1970-01-01T00:00:03.000000Z\n" +
                         "-100\t1970-01-01T00:00:04.000000Z\n" +
                         "32767\t1970-01-01T00:00:05.000000Z\n" +
-                        "-32767\t1970-01-01T00:00:06.000000Z\n",
+                        "-32767\t1970-01-01T00:00:06.000000Z\n" +
+                        "0\t1970-01-01T00:00:07.000000Z\n" +
+                        "0\t1970-01-01T00:00:08.000000Z\n" +
+                        "0\t1970-01-01T00:00:10.000000Z\n",
                 new CharSequence[]{
                         "0i",
                         "100i",
@@ -171,6 +332,10 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-100i",
                         "32767i",
                         "-32767i",
+                        "-2147483648i",
+                        "2147483648i",
+                        "2147483648",
+                        "null",
                         "0",
                         "100",
                         "-0",
@@ -180,7 +345,38 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertByte() throws Exception {
+    public void testInsertShortTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0\t1970-01-01T00:00:01.000000Z\n" +
+                        "100\t1970-01-01T00:00:02.000000Z\n" +
+                        "0\t1970-01-01T00:00:03.000000Z\n" +
+                        "-100\t1970-01-01T00:00:04.000000Z\n" +
+                        "32767\t1970-01-01T00:00:05.000000Z\n" +
+                        "-32767\t1970-01-01T00:00:06.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:07.000000Z\n" +
+                        "-2147483648\t1970-01-01T00:00:08.000000Z\n" +
+                        "2147483648\t1970-01-01T00:00:09.000000Z\n",
+                new CharSequence[]{
+                        "0i",
+                        "100i",
+                        "-0i",
+                        "-100i",
+                        "32767i",
+                        "-32767i",
+                        "null",
+                        "-2147483648i",
+                        "2147483648i",
+                        "2147483648",
+                        "0",
+                        "100",
+                        "-0",
+                        "NaN",
+                        ""
+                });
+    }
+
+    @Test
+    public void testInsertByteTableExists() throws Exception {
         assertType(ColumnType.BYTE,
                 "value\ttimestamp\n" +
                         "0\t1970-01-01T00:00:01.000000Z\n" +
@@ -188,7 +384,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0\t1970-01-01T00:00:03.000000Z\n" +
                         "-100\t1970-01-01T00:00:04.000000Z\n" +
                         "127\t1970-01-01T00:00:05.000000Z\n" +
-                        "-127\t1970-01-01T00:00:06.000000Z\n",
+                        "-127\t1970-01-01T00:00:06.000000Z\n" +
+                        "0\t1970-01-01T00:00:09.000000Z\n",
                 new CharSequence[]{
                         "0i",
                         "100i",
@@ -196,7 +393,9 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-100i",
                         "127i",
                         "-127i",
+                        "-2147483648i",
                         "0",
+                        "null",
                         "100",
                         "-0",
                         "NaN",
@@ -205,20 +404,97 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertLong256() throws Exception {
-        assertType(ColumnType.LONG256,
-                "value\ttimestamp\n" +
-                        "0x1234\t1970-01-01T00:00:01.000000Z\n" +
-                        "0x1234\t1970-01-01T00:00:02.000000Z\n",
+    public void testInsertByteTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0\t1970-01-01T00:00:01.000000Z\n" +
+                        "100\t1970-01-01T00:00:02.000000Z\n" +
+                        "0\t1970-01-01T00:00:03.000000Z\n" +
+                        "-100\t1970-01-01T00:00:04.000000Z\n" +
+                        "127\t1970-01-01T00:00:05.000000Z\n" +
+                        "-2147483648\t1970-01-01T00:00:06.000000Z\n" +
+                        "-127\t1970-01-01T00:00:07.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:09.000000Z\n",
                 new CharSequence[]{
-                        "0x1234i",
-                        "0x1234",
+                        "0i",
+                        "100i",
+                        "-0i",
+                        "-100i",
+                        "127i",
+                        "-2147483648i",
+                        "-127i",
+                        "0",
+                        "null",
+                        "100",
+                        "-0",
+                        "NaN",
                         ""
                 });
     }
 
     @Test
-    public void testInsertBoolean() throws Exception {
+    public void testInsertLong256TableExists() throws Exception {
+        assertType(ColumnType.LONG256,
+                "value\ttimestamp\n" +
+                        "\t1970-01-01T00:00:02.000000Z\n" +
+                        "0x1234\t1970-01-01T00:00:04.000000Z\n" +
+                        "0x1234\t1970-01-01T00:00:05.000000Z\n" +
+                        "0x00\t1970-01-01T00:00:06.000000Z\n",
+                new CharSequence[]{
+                        "\"\"", // discarded, bad type string
+                        "null", // actual null
+                        "\"null\"", // discarded, bad type string
+                        "0x1234i", // actual long256
+                        "0x1234", // actual long256
+                        "0x00", // actual long256 value 0
+                        "" // discarded, empty line
+                });
+    }
+
+    @Test
+    public void testInsertLong256TableDoesNotExist1() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0x1234\t1970-01-01T00:00:01.000000Z\n" +
+                        "\t1970-01-01T00:00:03.000000Z\n" +
+                        "0x00\t1970-01-01T00:00:04.000000Z\n" +
+                        "0x1234\t1970-01-01T00:00:07.000000Z\n",
+                new CharSequence[]{
+                        "0x1234i", // long256
+                        "", // discarded, empty line
+                        "null", // actual null
+                        "0x00", // actual long256 value 0
+                        "\"null\"", // discarded, bad type string
+                        "120i", // discarded, bad type long
+                        "0x1234", // actual long256
+                });
+    }
+
+    @Test
+    public void testInsertLong256TableDoesNotExist2() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "0x00\t1970-01-01T00:00:03.000000Z\n" +
+                        "0x1234\t1970-01-01T00:00:05.000000Z\n",
+                new CharSequence[]{
+                        "", // discarded, empty line
+                        "null", // discarded, no actual type clues to create col
+                        "0x00", //actual long256 value 0
+                        "\"null\"", // discarded, bad type string
+                        "0x1234", // actual long256
+                });
+    }
+
+    @Test
+    public void testInsertLong256TableDoesNotExist3() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "null\t1970-01-01T00:00:02.000000Z\n",
+                new CharSequence[]{
+                        "", // discarded, empty line
+                        "\"null\"", // actual string
+                        "0x1234", //  discarded, bad type long256
+                });
+    }
+
+    @Test
+    public void testInsertBooleanTableExists() throws Exception {
         assertType(ColumnType.BOOLEAN,
                 "value\ttimestamp\n" +
                         "true\t1970-01-01T00:00:01.000000Z\n" +
@@ -230,13 +506,15 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "false\t1970-01-01T00:00:07.000000Z\n" +
                         "false\t1970-01-01T00:00:08.000000Z\n" +
                         "false\t1970-01-01T00:00:09.000000Z\n" +
-                        "false\t1970-01-01T00:00:10.000000Z\n",
+                        "false\t1970-01-01T00:00:10.000000Z\n" +
+                        "false\t1970-01-01T00:00:11.000000Z\n",
                 new CharSequence[]{
                         "true",
                         "tRUe",
                         "TRUE",
                         "t",
                         "T",
+                        "null",
                         "false",
                         "fALSe",
                         "FALSE",
@@ -248,20 +526,53 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertSymbol() throws Exception {
+    public void testInsertBooleanTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "true\t1970-01-01T00:00:01.000000Z\n" +
+                        "true\t1970-01-01T00:00:02.000000Z\n" +
+                        "true\t1970-01-01T00:00:03.000000Z\n" +
+                        "true\t1970-01-01T00:00:04.000000Z\n" +
+                        "true\t1970-01-01T00:00:05.000000Z\n" +
+                        "false\t1970-01-01T00:00:06.000000Z\n" +
+                        "false\t1970-01-01T00:00:07.000000Z\n" +
+                        "false\t1970-01-01T00:00:08.000000Z\n" +
+                        "false\t1970-01-01T00:00:09.000000Z\n" +
+                        "false\t1970-01-01T00:00:10.000000Z\n" +
+                        "false\t1970-01-01T00:00:11.000000Z\n",
+                new CharSequence[]{
+                        "true",
+                        "tRUe",
+                        "TRUE",
+                        "t",
+                        "T",
+                        "null",
+                        "false",
+                        "fALSe",
+                        "FALSE",
+                        "f",
+                        "F",
+                        "",
+                        "e",
+                });
+    }
+
+    @Test
+    public void testInsertSymbolTableExists() throws Exception {
         assertType(ColumnType.SYMBOL,
                 "value\ttimestamp\n" +
                         "e\t1970-01-01T00:00:01.000000Z\n" +
                         "xxx\t1970-01-01T00:00:02.000000Z\n" +
                         "paff\t1970-01-01T00:00:03.000000Z\n" +
                         "yyy\t1970-01-01T00:00:04.000000Z\n" +
-                        "A\t1970-01-01T00:00:06.000000Z\n",
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "A\t1970-01-01T00:00:07.000000Z\n",
                 new CharSequence[]{
                         "e",
                         "xxx",
                         "paff",
                         "yyy",
                         "tt\"tt",
+                        "null",
                         "A",
                         "@plant2",
                         ""
@@ -269,19 +580,43 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertString() throws Exception {
+    public void testInsertSymbolTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "e\t1970-01-01T00:00:01.000000Z\n" +
+                        "xxx\t1970-01-01T00:00:02.000000Z\n" +
+                        "paff\t1970-01-01T00:00:03.000000Z\n" +
+                        "yyy\t1970-01-01T00:00:04.000000Z\n" +
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "A\t1970-01-01T00:00:07.000000Z\n",
+                new CharSequence[]{
+                        "e",
+                        "xxx",
+                        "paff",
+                        "yyy",
+                        "tt\"tt",
+                        "null",
+                        "A",
+                        "@plant2",
+                        ""
+                });
+    }
+
+    @Test
+    public void testInsertStringTableExists() throws Exception {
         assertType(ColumnType.STRING,
                 "value\ttimestamp\n" +
                         "e\t1970-01-01T00:00:01.000000Z\n" +
                         "xxx\t1970-01-01T00:00:02.000000Z\n" +
                         "paff\t1970-01-01T00:00:03.000000Z\n" +
-                        "tt\"tt\t1970-01-01T00:00:07.000000Z\n",
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "tt\"tt\t1970-01-01T00:00:08.000000Z\n",
                 new CharSequence[]{
                         "\"e\"",
                         "\"xxx\"",
                         "\"paff\"",
                         "\"paff",
                         "paff\"",
+                        "null",
                         "yyy",
                         "\"tt\\\"tt\"",
                         "A",
@@ -291,26 +626,62 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertDouble() throws Exception {
+    public void testInsertStringTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "e\t1970-01-01T00:00:01.000000Z\n" +
+                        "xxx\t1970-01-01T00:00:02.000000Z\n" +
+                        "paff\t1970-01-01T00:00:03.000000Z\n" +
+                        "\t1970-01-01T00:00:06.000000Z\n" +
+                        "tt\"tt\t1970-01-01T00:00:08.000000Z\n",
+                new CharSequence[]{
+                        "\"e\"",
+                        "\"xxx\"",
+                        "\"paff\"",
+                        "\"paff",
+                        "paff\"",
+                        "null",
+                        "yyy",
+                        "\"tt\\\"tt\"",
+                        "A",
+                        "@plant2",
+                        ""
+                });
+    }
+
+
+    @Test
+    public void testInsertDoubleTableExists() throws Exception {
         assertType(ColumnType.DOUBLE,
                 "value\ttimestamp\n" +
-                        "0.425667788123\t1970-01-01T00:00:02.000000Z\n" +
-                        "3.1415926535897936\t1970-01-01T00:00:03.000000Z\n" +
-                        "1.35E-12\t1970-01-01T00:00:04.000000Z\n" +
-                        "1.35E-12\t1970-01-01T00:00:05.000000Z\n" +
-                        "1.35E12\t1970-01-01T00:00:06.000000Z\n" +
-                        "1.35E12\t1970-01-01T00:00:07.000000Z\n" +
-                        "-3.5\t1970-01-01T00:00:08.000000Z\n" +
-                        "-3.01E-43\t1970-01-01T00:00:09.000000Z\n" +
-                        "123.0\t1970-01-01T00:00:10.000000Z\n" +
-                        "-123.0\t1970-01-01T00:00:11.000000Z\n",
+                        "1.7976931348623157E308\t1970-01-01T00:00:02.000000Z\n" +
+                        "0.425667788123\t1970-01-01T00:00:03.000000Z\n" +
+                        "3.1415926535897936\t1970-01-01T00:00:04.000000Z\n" +
+                        "1.7976931348623157E308\t1970-01-01T00:00:05.000000Z\n" +
+                        "1.7976931348623153E308\t1970-01-01T00:00:06.000000Z\n" +
+                        "Infinity\t1970-01-01T00:00:07.000000Z\n" +
+                        "-Infinity\t1970-01-01T00:00:08.000000Z\n" +
+                        "1.35E-12\t1970-01-01T00:00:09.000000Z\n" +
+                        "1.35E-12\t1970-01-01T00:00:10.000000Z\n" +
+                        "1.35E12\t1970-01-01T00:00:11.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:12.000000Z\n" +
+                        "1.35E12\t1970-01-01T00:00:13.000000Z\n" +
+                        "-3.5\t1970-01-01T00:00:14.000000Z\n" +
+                        "-3.01E-43\t1970-01-01T00:00:15.000000Z\n" +
+                        "123.0\t1970-01-01T00:00:16.000000Z\n" +
+                        "-123.0\t1970-01-01T00:00:17.000000Z\n",
                 new CharSequence[]{
                         "1.6x",
+                        "1.7976931348623157E308",
                         "0.425667788123",
                         "3.14159265358979323846",
+                        "1.7976931348623156E308",
+                        "1.7976931348623152E308",
+                        "1.7976931348623152E312",
+                        "-1.7976931348623152E312",
                         "1.35E-12",
                         "1.35e-12",
                         "1.35e12",
+                        "null",
                         "1.35E12",
                         "-0.0035e3",
                         "-3.01e-43",
@@ -322,7 +693,49 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     @Test
-    public void testInsertFloat() throws Exception {
+    public void testInsertDoubleTableDoesNotExist() throws Exception {
+        assertTypeNoTable("value\ttimestamp\n" +
+                        "1.7976931348623157E308\t1970-01-01T00:00:01.000000Z\n" +
+                        "0.425667788123\t1970-01-01T00:00:02.000000Z\n" +
+                        "3.1415926535897936\t1970-01-01T00:00:04.000000Z\n" +
+                        "1.35E-12\t1970-01-01T00:00:05.000000Z\n" +
+                        "1.35E-12\t1970-01-01T00:00:06.000000Z\n" +
+                        "1.35E12\t1970-01-01T00:00:07.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:08.000000Z\n" +
+                        "1.35E12\t1970-01-01T00:00:09.000000Z\n" +
+                        "-3.5\t1970-01-01T00:00:10.000000Z\n" +
+                        "3.1415926535897936\t1970-01-01T00:00:11.000000Z\n" +
+                        "1.7976931348623153E308\t1970-01-01T00:00:12.000000Z\n" +
+                        "Infinity\t1970-01-01T00:00:13.000000Z\n" +
+                        "-Infinity\t1970-01-01T00:00:14.000000Z\n" +
+                        "-3.01E-43\t1970-01-01T00:00:15.000000Z\n" +
+                        "123.0\t1970-01-01T00:00:16.000000Z\n" +
+                        "-123.0\t1970-01-01T00:00:17.000000Z\n",
+                new CharSequence[]{
+                        "1.7976931348623156E308",
+                        "0.425667788123",
+                        "1.6x",
+                        "3.14159265358979323846",
+                        "1.35E-12",
+                        "1.35e-12",
+                        "1.35e12",
+                        "null",
+                        "1.35E12",
+                        "-0.0035e3",
+                        "3.14159265358979323846",
+                        "1.7976931348623152E308",
+                        "1.7976931348623152E312",
+                        "-1.7976931348623152E312",
+                        "-3.01e-43",
+                        "123",
+                        "-123",
+                        "NaN",
+                        ""
+                });
+    }
+
+    @Test
+    public void testInsertFloatTableExists() throws Exception {
         assertType(ColumnType.FLOAT,
                 "value\ttimestamp\n" +
                         "0.4257\t1970-01-01T00:00:01.000000Z\n" +
@@ -331,10 +744,14 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0.0000\t1970-01-01T00:00:04.000000Z\n" +
                         "1.35000005E12\t1970-01-01T00:00:05.000000Z\n" +
                         "1.35000005E12\t1970-01-01T00:00:06.000000Z\n" +
-                        "-3.5000\t1970-01-01T00:00:07.000000Z\n" +
-                        "-0.0000\t1970-01-01T00:00:08.000000Z\n" +
-                        "123.0000\t1970-01-01T00:00:09.000000Z\n" +
-                        "-123.0000\t1970-01-01T00:00:10.000000Z\n",
+                        "NaN\t1970-01-01T00:00:07.000000Z\n" +
+                        "3.4028235E38\t1970-01-01T00:00:08.000000Z\n" +
+                        "Infinity\t1970-01-01T00:00:09.000000Z\n" +
+                        "-Infinity\t1970-01-01T00:00:10.000000Z\n" +
+                        "-3.5000\t1970-01-01T00:00:11.000000Z\n" +
+                        "-0.0000\t1970-01-01T00:00:12.000000Z\n" +
+                        "123.0000\t1970-01-01T00:00:13.000000Z\n" +
+                        "-123.0000\t1970-01-01T00:00:14.000000Z\n",
                 new CharSequence[]{
                         "0.425667788123",
                         "3.14159265358979323846",
@@ -342,6 +759,49 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "1.35e-12",
                         "1.35e12",
                         "1.35E12",
+                        "null",
+                        "3.4028235E38",
+                        "3.4028235E39",
+                        "-3.4028235E39",
+                        "-0.0035e3",
+                        "-3.01e-43",
+                        "123",
+                        "-123",
+                        "NaN",
+                        "",
+                        "1.6x"
+                });
+    }
+
+    @Test
+    public void testInsertFloatTableDoesnotExist() throws Exception {
+        assertType(ColumnType.FLOAT,
+                "value\ttimestamp\n" +
+                        "0.4257\t1970-01-01T00:00:01.000000Z\n" +
+                        "3.1416\t1970-01-01T00:00:02.000000Z\n" +
+                        "0.0000\t1970-01-01T00:00:03.000000Z\n" +
+                        "0.0000\t1970-01-01T00:00:04.000000Z\n" +
+                        "1.35000005E12\t1970-01-01T00:00:05.000000Z\n" +
+                        "3.4028235E38\t1970-01-01T00:00:06.000000Z\n" +
+                        "Infinity\t1970-01-01T00:00:07.000000Z\n" +
+                        "-Infinity\t1970-01-01T00:00:08.000000Z\n" +
+                        "1.35000005E12\t1970-01-01T00:00:09.000000Z\n" +
+                        "NaN\t1970-01-01T00:00:10.000000Z\n" +
+                        "-3.5000\t1970-01-01T00:00:11.000000Z\n" +
+                        "-0.0000\t1970-01-01T00:00:12.000000Z\n" +
+                        "123.0000\t1970-01-01T00:00:13.000000Z\n" +
+                        "-123.0000\t1970-01-01T00:00:14.000000Z\n",
+                new CharSequence[]{
+                        "0.425667788123",
+                        "3.14159265358979323846",
+                        "1.35E-12",
+                        "1.35e-12",
+                        "1.35e12",
+                        "3.4028235E38",
+                        "3.4028235E39",
+                        "-3.4028235E39",
+                        "1.35E12",
+                        "null",
                         "-0.0035e3",
                         "-3.01e-43",
                         "123",
@@ -353,14 +813,21 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
     protected static void assertType(int columnType, String expected, CharSequence[] values) throws Exception {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-            CairoTestUtils.create(model.col(targetColumnName, columnType).timestamp());
-        }
+        assertType(columnType, expected, values, true);
+    }
+
+    protected static void assertTypeNoTable(String expected, CharSequence[] values) throws Exception {
+        assertType(ColumnType.UNDEFINED, expected, values, false);
+    }
+
+    private static void assertType(int columnType, String expected, CharSequence[] values, boolean createTable) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (CairoEngine engine = new CairoEngine(configuration)) {
                 try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                        CairoTestUtils.create(model.col(targetColumnName, columnType).timestamp());
+                    if (createTable) {
+                        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
+                            CairoTestUtils.create(model.col(targetColumnName, columnType).timestamp());
+                        }
                     }
                     receiver.start();
                     long ts = 0L;

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -837,7 +837,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         }
                         sender.flush();
                     }
-                    assertReader(tableName, expected);
+                    assertReader(engine, tableName, expected);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -26,8 +26,8 @@ package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.*;
 import io.questdb.cutlass.line.LineProtoSender;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
+
 
 public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     static final String tableName = "other";
@@ -44,7 +44,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "\t1970-01-01T00:00:09.000000Z\n" +
                         "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:10.000000Z\n" +
                         "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:11.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "1630933921000i", // valid
                         "1630933921000", // discarded bad type double
                         "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
@@ -73,7 +73,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "\t1970-01-01T00:00:09.000000Z\n" +
                         "1970-01-01T00:00:00.000Z\t1970-01-01T00:00:10.000000Z\n" +
                         "292278994-08-17T07:12:55.807Z\t1970-01-01T00:00:11.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "1630933921000i", // valid
                         "1630933921000", // discarded bad type double
                         "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
@@ -103,7 +103,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-9223372036854775807\t1970-01-01T00:00:06.000000Z\n" +
                         "NaN\t1970-01-01T00:00:07.000000Z\n" +
                         "NaN\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -137,7 +137,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-9223372036854775807\t1970-01-01T00:00:06.000000Z\n" +
                         "NaN\t1970-01-01T00:00:07.000000Z\n" +
                         "NaN\t1970-01-01T00:00:20.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -175,7 +175,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-2147483647\t1970-01-01T00:00:08.000000Z\n" +
                         "NaN\t1970-01-01T00:00:11.000000Z\n" +
                         "NaN\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -211,7 +211,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-2147483647\t1970-01-01T00:00:08.000000Z\n" +
                         "-2147483648\t1970-01-01T00:00:11.000000Z\n" +
                         "NaN\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -251,7 +251,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0\t1970-01-01T00:00:11.000000Z\n" +
                         "0\t1970-01-01T00:00:12.000000Z\n" +
                         "0\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -286,7 +286,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-2147483648\t1970-01-01T00:00:08.000000Z\n" +
                         "2147483648\t1970-01-01T00:00:09.000000Z\n" +
                         "NaN\t1970-01-01T00:00:15.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid, taken as long, no way to make a short
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -316,7 +316,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "127\t1970-01-01T00:00:05.000000Z\n" +
                         "-128\t1970-01-01T00:00:06.000000Z\n" +
                         "0\t1970-01-01T00:00:14.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -345,7 +345,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-2147483648\t1970-01-01T00:00:06.000000Z\n" +
                         "-127\t1970-01-01T00:00:07.000000Z\n" +
                         "NaN\t1970-01-01T00:00:13.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0i", // valid, taken as long, no way to make a short
                         "100i", // valid
                         "-0i", // valid equals 0
@@ -371,7 +371,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "\t1970-01-01T00:00:03.000000Z\n" +
                         "N\t1970-01-01T00:00:05.000000Z\n" +
                         "N\t1970-01-01T00:00:07.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "\"1630933921000\"", // valid
                         "\"1970-01-01T00:00:05.000000Z\"", // valid
                         "", // valid null
@@ -391,7 +391,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "\t1970-01-01T00:00:01.000000Z\n" +
                         "0x1234\t1970-01-01T00:00:05.000000Z\n" +
                         "\t1970-01-01T00:00:08.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "", // valid null
                         "\"\"", // discarded bad type string
                         "null", // discarded bad type symbol
@@ -409,7 +409,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0x1234\t1970-01-01T00:00:01.000000Z\n" +
                         "\t1970-01-01T00:00:02.000000Z\n" +
                         "0x056789543288867543333668887654\t1970-01-01T00:00:05.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0x1234i", // valid long256
                         "", // valid null
                         "null", // discarded bad type symbol
@@ -436,7 +436,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "false\t1970-01-01T00:00:10.000000Z\n" +
                         "false\t1970-01-01T00:00:11.000000Z\n" +
                         "false\t1970-01-01T00:00:12.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "true", // valid
                         "tRUe", // valid
                         "TRUE", // valid
@@ -467,7 +467,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "false\t1970-01-01T00:00:10.000000Z\n" +
                         "false\t1970-01-01T00:00:11.000000Z\n" +
                         "false\t1970-01-01T00:00:12.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "true", // valid
                         "tRUe", // valid
                         "TRUE", // valid
@@ -498,7 +498,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "@plant2\t1970-01-01T00:00:08.000000Z\n" +
                         "@plant\t1970-01-01T00:00:09.000000Z\n" +
                         "\t1970-01-01T00:00:11.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "e", // valid
                         "xxx", // valid
                         "paff", // valid
@@ -526,7 +526,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "@plant2\t1970-01-01T00:00:08.000000Z\n" +
                         "@plant\t1970-01-01T00:00:09.000000Z\n" +
                         "\t1970-01-01T00:00:11.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "e", // valid
                         "xxx", // valid
                         "paff", // valid
@@ -553,7 +553,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "tt\\\"tt\\\" \\\n" +
                         " =, ,=\\\"\t1970-01-01T00:00:12.000000Z\n" +
                         "\t1970-01-01T00:00:15.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "\"e\"", // valid
                         "\"xxx\"", // valid
                         "\"paff\"", // valid
@@ -583,7 +583,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "tt\\\"tt\\\" \\\n" +
                         " =, ,=\\\"\t1970-01-01T00:00:12.000000Z\n" +
                         "\t1970-01-01T00:00:15.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "\"e\"", // valid
                         "\"xxx\"", // valid
                         "\"paff\"", // valid
@@ -623,7 +623,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-123.0\t1970-01-01T00:00:17.000000Z\n" +
                         "NaN\t1970-01-01T00:00:18.000000Z\n" +
                         "NaN\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "1.6x", // discarded bad type symbol
                         "1.7976931348623157E308", // valid
                         "0.425667788123", // valid
@@ -666,7 +666,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-123.0\t1970-01-01T00:00:17.000000Z\n" +
                         "NaN\t1970-01-01T00:00:18.000000Z\n" +
                         "NaN\t1970-01-01T00:00:19.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "1.7976931348623156E308", // valid
                         "0.425667788123", // valid
                         "1.6x", // discarded bad type symbol
@@ -709,7 +709,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "NaN\t1970-01-01T00:00:15.000000Z\n" +
                         "NaN\t1970-01-01T00:00:16.000000Z\n" +
                         "NaN\t1970-01-01T00:00:17.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0.425667788123", // valid
                         "3.14159265358979323846", // valid
                         "1.35E-12", // valid equals 0
@@ -749,7 +749,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-123.0\t1970-01-01T00:00:14.000000Z\n" +
                         "NaN\t1970-01-01T00:00:15.000000Z\n" +
                         "NaN\t1970-01-01T00:00:16.000000Z\n",
-                new CharSequence[]{
+                new String[]{
                         "0.425667788123", // valid, but interpreted as double, cannot make float columns
                         "3.14159265358979323846", // valid
                         "1.35E-12", // valid
@@ -771,33 +771,19 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
     }
 
 
-    protected static void assertTypeNoTable(String expected, CharSequence[] values) throws Exception {
+    private static void assertTypeNoTable(String expected, String[] values) throws Exception {
         assertType(ColumnType.UNDEFINED, expected, values);
     }
 
-    protected static void assertType(int columnType, String expected, CharSequence[] values) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoReceiver receiver = createLineProtoReceiver(engine)) {
-                    if (columnType != ColumnType.UNDEFINED) {
-                        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                            CairoTestUtils.create(model.col(targetColumnName, columnType).timestamp());
-                        }
-                    }
-                    receiver.start();
-                    long ts = 0L;
-                    try (LineProtoSender sender = createLineProtoSender()) {
-                        for (int i = 0; i < values.length; i++) {
-                            ((LineProtoSender) sender.metric(tableName).put(' ')
-                                    .encodeUtf8(targetColumnName)) // this method belongs to a super class that returns this
-                                    .put('=')
-                                    .put(values[i]) // field method decorates this token, I want full control
-                                    .$(ts += 1000000000);
-                        }
-                        sender.flush();
-                    }
-                    assertReader(engine, tableName, expected);
-                }
+    private static void assertType(int columnType, String expected, String[] values) throws Exception {
+        assertType(tableName, targetColumnName, columnType, expected, sender -> {
+            long ts = 0L;
+            for (int i = 0; i < values.length; i++) {
+                ((LineProtoSender) sender.metric(tableName).put(' ')
+                        .encodeUtf8(targetColumnName)) // this method belongs to a super class that returns this
+                        .put('=')
+                        .put(values[i]) // field method decorates this token, I want full control
+                        .$(ts += 1000000000);
             }
         });
     }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertShortGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertShortGeoHashTest.java
@@ -141,8 +141,10 @@ public class LineUdpInsertShortGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 15);
                     receiver.start();
                     sendGeoHashLine("");
+                    sendGeoHashLine("null");
                     assertReader(tableName,
                             "geohash\ttimestamp\n" +
+                                    "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
             }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertShortGeoHashTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertShortGeoHashTest.java
@@ -74,7 +74,7 @@ public class LineUdpInsertShortGeoHashTest extends LineUdpInsertGeoHashTest {
                         sender.metric(tableName).field("carrots", "j").$(3000000000L);
                         sender.flush();
                     }
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\tcarrots\n" +
                                     "\t1970-01-01T00:00:01.000000Z\t9\n" +
                                     "\t1970-01-01T00:00:02.000000Z\t4\n" +
@@ -93,7 +93,7 @@ public class LineUdpInsertShortGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 14);
                     receiver.start();
                     sendGeoHashLine("9v1s8hm7wpkssv1h");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "01001110110000\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -125,7 +125,7 @@ public class LineUdpInsertShortGeoHashTest extends LineUdpInsertGeoHashTest {
                     createTable(engine, 9);
                     receiver.start();
                     sendGeoHashLine("sp-");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");
                 }
@@ -142,7 +142,7 @@ public class LineUdpInsertShortGeoHashTest extends LineUdpInsertGeoHashTest {
                     receiver.start();
                     sendGeoHashLine("");
                     sendGeoHashLine("null");
-                    assertReader(tableName,
+                    assertReader(engine, tableName,
                             "geohash\ttimestamp\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n" +
                                     "\t1970-01-01T00:00:01.000000Z\n");

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
@@ -83,7 +83,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                 break;
             } catch (CairoException err) {
                 pendingRecoveryErr = err;
-                LockSupport.parkNanos(200);
+                LockSupport.parkNanos(1000000); // 1 milli
             }
         }
         if (pendingRecoveryErr != null) {


### PR DESCRIPTION
ILP (influx line protocol) messages can be sent through TCP and UDP, both paths should result in an equivalent parse of the content.

### Line surface

`<table_name>(,<sym>=<S>)* <field>=<V>(,<field>=<V>)* <timestamp_nano><eol>`

- table_name: name of the table to insert into, if it does not exist it will be created.
- sym/field: name of a symbol and a field respectively. 
- S: value of the symbol. It will look like a string, but without quotes around it. Strings are not tolerated, nor any other type.
- V: value of the field, which can be absent/empty, to signify null.
- timestamp_nano: a long, `not 'i'` terminated, representing the epoch UTC in nanosecond precision (unlike field value's whose precision is in millisecond and must end in 'i').
- eol: '\n'.

When **V**s arrive, we need to guess their type by analysing the token surface. The method is similar in both TCP and UDP, but there are slight differences as highlighted by tests `LineTcpInsertOtherTypesTest` and `LineUdpInsertOtherTypesTest`, and their counterparts `NewLineProtocolParserTest.testGetValueType` and `CairoLineProtoParserSupportTest.testGetValueType`.

### Token surface parsing TCP:

Numeric types end up being either long or double. If the column already exists, then the value is cast as appropriate, otherwise a column of type long, or double, will be created.

We examine the last byte of the token `NewLineProtoParser.parse`.

`NewLineProtoParser.parseMeasurement` parses strings eagerly. Strings are parsed when a field name is found followed by an opening `"`. Upon finding the opening quote `"` (single quote is not supported), a max of 150 bytes are examined to find the closing quote (the scape char `\` retains its meaning while parsing a string). Beyond 150 bytes it is too big a string, ILP is not meant to be used to ingest strings bigger than this (artificial limitation with performance in mind) and the line is discarded. 

### Token surface parsing UDP:

We examine the last byte of the token `CairoLineProtoParserSupport.getValueType`.

Numeric types and strings behave as above.

