### PR TITLE
feat(ui): basic syntax highlighting for geohashes in web console

### DIFF
--- a/ui/src/scenes/Editor/Ace/questdbMode.ts
+++ b/ui/src/scenes/Editor/Ace/questdbMode.ts
@@ -69,6 +69,10 @@ const QuestDBHighlightRules = function (this: HighlightRules) {
         regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b",
       },
       {
+        token: "entity.name.function", // geohash literal
+        regex: "\#{1,2}([a-zA-Z_$]|[a-zA-Z0-9_$])*\\b",
+      },
+      {
         token: keywordMapper,
         regex: "[a-zA-Z_$][a-zA-Z0-9_$]*\\b",
       },


### PR DESCRIPTION
This PR adds support for syntax highlighting of geohash literals:


* `#ezzn5kxb`
* `##11011101010111001010010001010`