### PR TITLE
chore(sql): fix geohash flapping test

### DIFF
--- a/core/src/main/java/io/questdb/cairo/GeoHashes.java
+++ b/core/src/main/java/io/questdb/cairo/GeoHashes.java
@@ -193,7 +193,7 @@ public class GeoHashes {
         }
         final int chars = Math.min((int) (hi - lo), MAX_STRING_LENGTH);
         int actualBits = 5 * chars;
-        if (actualBits < bits) {
+        if (actualBits < bits || bits == 0) {
             throw NumericException.INSTANCE;
         }
         long geohash = 0;

--- a/core/src/test/java/io/questdb/cairo/GeoHashesTest.java
+++ b/core/src/test/java/io/questdb/cairo/GeoHashesTest.java
@@ -336,11 +336,9 @@ public class GeoHashesTest {
     public void testFromStringTruncatingNlShorterThanRequiredLength2() {
         testUnsafeFromStringTruncatingNl("123", (lo, hi) -> {
             try {
-                GeoHashes.fromStringTruncatingNl(lo, lo + 7, 0);
-                Assert.fail();
-            } catch (StringIndexOutOfBoundsException fail) {
-                Assert.fail();
-            } catch (NumericException ignored) {
+                Assert.assertEquals(0, GeoHashes.fromStringTruncatingNl(lo, hi + 7, 1));
+            } catch (NumericException expected) {
+                // beyond hi we will find whatever, very unlikely that it parses as a geohash char
             }
             return null;
         });
@@ -425,8 +423,8 @@ public class GeoHashesTest {
             testUnsafeFromStringTruncatingNl("123456789bcdezz", (lo1, hi1) -> {
                 try {
                     Assert.assertEquals(
-                            GeoHashes.fromStringTruncatingNl(lo0, lo0 + 12, 0),
-                            GeoHashes.fromStringTruncatingNl(lo1 + 1, lo1 + 13, 0));
+                            GeoHashes.fromStringTruncatingNl(lo0, lo0 + 12, 4),
+                            GeoHashes.fromStringTruncatingNl(lo1 + 1, lo1 + 13, 4));
 
                     Assert.assertNotEquals(
                             GeoHashes.fromStringTruncatingNl(lo0, lo0 + 12, 20),


### PR DESCRIPTION
We create a buffer to hold "123" and then attempt to parse a geohash
7 chars in len. We have control over the first 3 chars, which parse
well, then the next 4 are random bytes which are unlikely to parse as
valid geohash chars in base 32.