### PR TITLE
fix(cairo): fix crash o3 move uncommitted

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3057,7 +3057,7 @@ public class TableWriter implements Closeable {
                         srcVarOffset - dstVarOffset,
                         src,
                         0,
-                        transientRowsAdded - 1,
+                        transientRowsAdded - 1, // srcHi is inclusive in shiftCopyFixedSizeColumnData
                         dstAddr
                 );
                 long sourceEndOffset = srcDataMem.getAppendOffset();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3057,7 +3057,7 @@ public class TableWriter implements Closeable {
                         srcVarOffset - dstVarOffset,
                         src,
                         0,
-                        transientRowsAdded - 1, // srcHi is inclusive in shiftCopyFixedSizeColumnData
+                        transientRowsAdded - 1, // Hi is inclusive in shiftCopyFixedSizeColumnData
                         dstAddr
                 );
                 long sourceEndOffset = srcDataMem.getAppendOffset();

--- a/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
@@ -389,10 +389,8 @@ public class O3CommitLagTest extends AbstractO3Test {
                 o3.commit();
                 ordered.commit();
             }
-
-            engine.releaseAllWriters();
-            engine.releaseAllReaders();
             TestUtils.assertSqlCursors(compiler, sqlExecutionContext, "ordered", "o3", LOG);
+            engine.releaseAllReaders();
             try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "o3", "testing");
                  TableWriter ordered = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "ordered", "testing")) {
                 o3.truncate();

--- a/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
@@ -342,7 +342,7 @@ public class O3CommitLagTest extends AbstractO3Test {
         }
 
         long start = IntervalUtils.parseFloorPartialDate("2021-04-27T08:00:00");
-        long[] testCounts = new long[] {  2 * 1024 * 1024, 4 * 1024 * 1024, 16 * 8 * 1024 * 5  }; //2_000_000, 4_000_000,
+        long[] testCounts = new long[] {  2 * 1024 * 1024, 16 * 8 * 1024 * 5, 2_000_000 };
         for (int c = 0; c < testCounts.length; c++) {
             long idCount = testCounts[c];
 
@@ -390,6 +390,8 @@ public class O3CommitLagTest extends AbstractO3Test {
                 ordered.commit();
             }
 
+            engine.releaseAllWriters();
+            engine.releaseAllReaders();
             TestUtils.assertSqlCursors(compiler, sqlExecutionContext, "ordered", "o3", LOG);
             try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "o3", "testing");
                  TableWriter ordered = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "ordered", "testing")) {

--- a/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
@@ -342,13 +342,14 @@ public class O3CommitLagTest extends AbstractO3Test {
         }
 
         long start = IntervalUtils.parseFloorPartialDate("2021-04-27T08:00:00");
-        for (int mils = 2; mils < 6; mils += 2) {
-            long idCount = mils * 1_000_000L;
+        long[] testCounts = new long[] {  2 * 1024 * 1024, 4 * 1024 * 1024, 16 * 8 * 1024 * 5  }; //2_000_000, 4_000_000,
+        for (int c = 0; c < testCounts.length; c++) {
+            long idCount = testCounts[c];
 
             // Create big commit with has big part before OOO starts
             // which exceed default MAMemoryImpl size in one or all columns
             int iterations = 2;
-            String[] varCol = new String[]{"abc", "aldfjkasdlfkj", "as", "2021-04-27T12:00:00"};
+            String[] varCol = new String[]{"abc", "aldfjkasdlfkj", "as", "2021-04-27T12:00:00", "12345678901234578"};
 
             // Add 2 batches
             try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "o3", "testing");
@@ -390,7 +391,11 @@ public class O3CommitLagTest extends AbstractO3Test {
             }
 
             TestUtils.assertSqlCursors(compiler, sqlExecutionContext, "ordered", "o3", LOG);
-            start += idCount * iterations;
+            try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "o3", "testing");
+                 TableWriter ordered = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "ordered", "testing")) {
+                o3.truncate();
+                ordered.truncate();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1331. Calculates uncommitted move size correctly when data ends on exact mapped page boundary