### PR TITLE
feat(ilp): support timestamp fields

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -162,6 +162,10 @@ public final class ColumnType {
         return columnType == ColumnType.INT;
     }
 
+    public static boolean isLong(int columnType) {
+        return columnType == ColumnType.LONG;
+    }
+
     public static boolean isNull(int columnType) {
         return columnType == NULL;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -186,6 +186,7 @@ public class CairoLineProtoParserSupport {
         // and then it will be parsed accordingly by 'putValue'.
         int valueLen = value.length();
         if (valueLen > 0) {
+            char first = value.charAt(0);
             char last = value.charAt(valueLen - 1); // see LineProtoSender.field methods
             switch (last) {
                 case 'i':
@@ -194,7 +195,7 @@ public class CairoLineProtoParserSupport {
                     }
                     return valueLen == 1 ? ColumnType.SYMBOL : ColumnType.LONG;
                 case 't':
-                    if (valueLen > 1) {
+                    if (valueLen > 1 && ((first >= '0' && first <= '9') || first == '-')) {
                         return ColumnType.TIMESTAMP;
                     }
                     // fall through
@@ -221,7 +222,6 @@ public class CairoLineProtoParserSupport {
                     }
                     return ColumnType.STRING;
                 default:
-                    char first = value.charAt(0);
                     if (last >= '0' && last <= '9' && ((first >= '0' && first <= '9') || first == '-' || first == '.')) {
                         return ColumnType.DOUBLE;
                     }

--- a/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/CairoLineProtoParserSupport.java
@@ -193,14 +193,18 @@ public class CairoLineProtoParserSupport {
                         return ColumnType.LONG256;
                     }
                     return valueLen == 1 ? ColumnType.SYMBOL : ColumnType.LONG;
-                case 'e':
-                case 'E':
-                    // tru(e)
-                    //  fals(e)
                 case 't':
+                    if (valueLen > 1) {
+                        return ColumnType.TIMESTAMP;
+                    }
+                    // fall through
                 case 'T':
                     // t
                     // T
+                case 'e':
+                case 'E':
+                    // tru(e)
+                    // fals(e)
                 case 'f':
                 case 'F':
                     // f

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -603,6 +603,13 @@ class LineTcpMeasurementScheduler implements Closeable {
                             bufPos += Byte.BYTES;
                             break;
                         }
+                        case NewLineProtoParser.ENTITY_TYPE_TIMESTAMP: {
+                            Unsafe.getUnsafe().putByte(bufPos, entity.getType());
+                            bufPos += Byte.BYTES;
+                            Unsafe.getUnsafe().putLong(bufPos, entity.getTimestampValue());
+                            bufPos += Long.BYTES;
+                            break;
+                        }
                         default:
                             // unsupported types are ignored
                             break;
@@ -875,6 +882,13 @@ class LineTcpMeasurementScheduler implements Closeable {
                             byte geohash = Unsafe.getUnsafe().getByte(bufPos);
                             bufPos += Byte.BYTES;
                             row.putByte(colIndex, geohash);
+                            break;
+                        }
+
+                        case NewLineProtoParser.ENTITY_TYPE_TIMESTAMP: {
+                            long ts = Unsafe.getUnsafe().getLong(bufPos);
+                            bufPos += Long.BYTES;
+                            row.putTimestamp(colIndex, ts);
                             break;
                         }
 
@@ -1555,5 +1569,6 @@ class LineTcpMeasurementScheduler implements Closeable {
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_GEOSHORT] = ColumnType.getGeoHashTypeWithBits(16);
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_GEOINT] = ColumnType.getGeoHashTypeWithBits(32);
         DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_GEOLONG] = ColumnType.getGeoHashTypeWithBits(60);
+        DEFAULT_COLUMN_TYPES[NewLineProtoParser.ENTITY_TYPE_TIMESTAMP] = ColumnType.TIMESTAMP;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -798,7 +798,7 @@ class LineTcpMeasurementScheduler implements Closeable {
                             byte b = Unsafe.getUnsafe().getByte(bufPos);
                             bufPos += Byte.BYTES;
                             final int colType = writer.getMetadata().getColumnType(colIndex);
-                            if (ColumnType.isBoolean(colType)) {
+                            if (ColumnType.isBoolean(colType) || ColumnType.isLong(colType)) {
                                 row.putBool(colIndex, b == 1);
                             } else {
                                 throw CairoException.instance(0)

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -797,7 +797,15 @@ class LineTcpMeasurementScheduler implements Closeable {
                         case NewLineProtoParser.ENTITY_TYPE_BOOLEAN: {
                             byte b = Unsafe.getUnsafe().getByte(bufPos);
                             bufPos += Byte.BYTES;
-                            row.putBool(colIndex, b == 1);
+                            final int colType = writer.getMetadata().getColumnType(colIndex);
+                            if (ColumnType.isBoolean(colType)) {
+                                row.putBool(colIndex, b == 1);
+                            } else {
+                                throw CairoException.instance(0)
+                                        .put("cast error for line protocol boolean [columnIndex=").put(colIndex)
+                                        .put(", columnType=").put(ColumnType.nameOf(colType))
+                                        .put(']');
+                            }
                             break;
                         }
 
@@ -888,7 +896,15 @@ class LineTcpMeasurementScheduler implements Closeable {
                         case NewLineProtoParser.ENTITY_TYPE_TIMESTAMP: {
                             long ts = Unsafe.getUnsafe().getLong(bufPos);
                             bufPos += Long.BYTES;
-                            row.putTimestamp(colIndex, ts);
+                            final int colType = writer.getMetadata().getColumnType(colIndex);
+                            if (ColumnType.isTimestamp(colType)) {
+                                row.putTimestamp(colIndex, ts);
+                            } else {
+                                throw CairoException.instance(0)
+                                        .put("cast error for line protocol timestamp [columnIndex=").put(colIndex)
+                                        .put(", columnType=").put(ColumnType.nameOf(colType))
+                                        .put(']');
+                            }
                             break;
                         }
 

--- a/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/CairoLineProtoParser.java
@@ -385,6 +385,9 @@ public class CairoLineProtoParser implements LineProtoParser, Closeable {
                     case ColumnType.LONG256:
                         valid = columnTypeTag == ColumnType.LONG256;
                         break;
+                    case ColumnType.TIMESTAMP:
+                        valid = columnTypeTag == ColumnType.TIMESTAMP;
+                        break;
                     default:
                         valid = false;
                 }

--- a/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/CairoLineProtoParserSupportTest.java
@@ -233,6 +233,7 @@ public class CairoLineProtoParserSupportTest extends LineUdpInsertTest {
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1e-13"));
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1.0"));
         Assert.assertEquals(ColumnType.DOUBLE, CairoLineProtoParserSupport.getValueType("1"));
+        Assert.assertEquals(ColumnType.TIMESTAMP, CairoLineProtoParserSupport.getValueType("123t"));
 
         Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("aaa\""));
         Assert.assertEquals(ColumnType.UNDEFINED, CairoLineProtoParserSupport.getValueType("\"aaa"));

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
@@ -35,30 +35,36 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
 
     @Test
     public void testInsertTimestampTableExists() throws Exception {
-        // no literal representation for timestamp, only longs can be inserted
         assertType(ColumnType.TIMESTAMP,
                 "value\ttimestamp\n" +
                         "1970-01-19T21:02:13.921000Z\t1970-01-01T00:00:01.000000Z\n" +
-                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:07.000000Z\n" +
-                        "\t1970-01-01T00:00:08.000000Z\n" +
-                        "\t1970-01-01T00:00:09.000000Z\n" +
-                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:10.000000Z\n" +
-                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:11.000000Z\n",
+                        "1970-01-19T21:02:13.921000Z\t1970-01-01T00:00:02.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:08.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:09.000000Z\n" +
+                        "\t1970-01-01T00:00:10.000000Z\n" +
+                        "\t1970-01-01T00:00:11.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:12.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:13.000000Z\n" +
+                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:14.000000Z\n",
                 new CharSequence[]{
                         "1630933921000i", // valid
+                        "1630933921000t", // valid
                         "1630933921000", // discarded bad type double
                         "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
                         "1970-01-01T00:\"00:05.00\"0000Z", // discarded bad type symbol
                         "\"1970-01-01T00:00:05.000000Z", // discarded bad string value
                         "1970-01-01T00:00:05.000000Z\"", // discarded bad string value
                         "0i", // valid
+                        "0t", // valid
                         "-9223372036854775808i", // valid NaN, same as null
                         "", // valid null
                         "-0i", // valid
+                        "-0t", // valid
                         "9223372036854775807i", // valid
                         "NaN", // discarded bad type symbol
                         "null", // discarded bad type symbol
-                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
+                        "1970-01-01T00:00:05.000000Z", // discarded bad type symbol
+                        "t", // discarded bad type boolean
                 });
     }
 
@@ -87,7 +93,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "9223372036854775807i", // valid
                         "NaN", // discarded bad type symbol
                         "null", // discarded bad type symbol
-                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
+                        "1970-01-01T00:00:05.000000Z", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -125,6 +132,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "-100", // discarded bad type double
                         "null", // discarded bad type symbol
                         "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -162,6 +170,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "-100", // discarded bad type double
                         "null", // discarded bad type symbol
                         "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -197,7 +206,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "2147483647", // discarded bad type double
                         "-2147483647", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -233,7 +243,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "2147483647", // discarded bad type double
                         "-2147483647", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -268,7 +279,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -299,7 +311,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -328,7 +341,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -356,7 +370,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -378,6 +393,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "null", // discarded bad type symbol
                         "\"N\"", // valid
                         "0", // discarded bad type double
+                        "0t", // discarded bad type timestamp
                         "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
                 });
     }
@@ -397,7 +413,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "0x1234i", // actual long256
                         "0x1234", // discarded bad type double
                         "0x00", // discarded bad type double
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -416,6 +433,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "\"null\"", // discarded bad type string
                         "120i", // discarded bad type long
                         "0x1234", // discarded bad type double
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -448,6 +466,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "F", // valid
                         "", // valid null, equals false
                         "e", // valid
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -479,6 +498,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "F", // valid
                         "", // valid null, equals false
                         "e", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -640,7 +660,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "123", // valid
                         "-123", // valid
                         "NaN", // valid null
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -683,7 +704,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "123", // valid
                         "-123", // valid
                         "NaN", // valid null
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -725,7 +747,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "NaN", // valid null
                         "", // valid null
                         "NaN", // valid null
-                        "1.6x" // discarded bad type symbol
+                        "1.6x", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -764,7 +787,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
                         "-123", // valid
                         "NaN", // valid null
                         "", // valid null
-                        "1.6x" // discarded bad type symbol
+                        "1.6x", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
@@ -534,6 +534,19 @@ public class LineTcpServerTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testWriterTimestampField() throws Exception {
+        String lineData = "tab,tag=123t atimestamp=1000000t 1500000000000\n" +
+                "tab,tag=321t atimestamp=2000000t 1700000000000\n";
+        runInContext((server) -> {
+            send(server, lineData, "tab");
+            String expected = "tag\tatimestamp\ttimestamp\n" +
+                    "123t\t1970-01-01T00:00:01.000000Z\t1970-01-01T00:25:00.000000Z\n" +
+                    "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n";
+            assertTable(expected, "tab");
+        });
+    }
+
+    @Test
     public void testWriterAllLongs() throws Exception {
         currentMicros = 1;
         try (TableModel m = new TableModel(configuration, "messages", PartitionBy.MONTH)) {
@@ -674,7 +687,7 @@ public class LineTcpServerTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testWrterCommitFails() throws Exception {
+    public void testWriterCommitFails() throws Exception {
         try (TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY)) {
             m.timestamp("ReceiveTime")
                     .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpServerTest.java
@@ -534,42 +534,6 @@ public class LineTcpServerTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testWriterTimestampField() throws Exception {
-        String lineData = "tab,tag=123t atimestamp=1000000t 1500000000000\n" +
-                "tab,tag=321t atimestamp=2000000t 1700000000000\n" +
-                "tab,tag=123t atimestamp=3000000i 1900000000000\n" +
-                "tab,tag=321t atimestamp=t 2100000000000\n"; // <-- error here
-        runInContext((server) -> {
-            send(server, lineData, "tab");
-            String expected = "tag\tatimestamp\ttimestamp\n" +
-                    "123t\t1970-01-01T00:00:01.000000Z\t1970-01-01T00:25:00.000000Z\n" +
-                    "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n" +
-                    "123t\t1970-01-01T00:00:03.000000Z\t1970-01-01T00:31:40.000000Z\n";
-            assertTable(expected, "tab");
-        });
-    }
-
-    @Test
-    public void testWriterTimestampInNonTimestampFields() throws Exception {
-        try (TableModel m = new TableModel(configuration, "tab", PartitionBy.NONE)) {
-            m.col("int", ColumnType.INT)
-                    .col("str", ColumnType.STRING)
-                    .timestamp();
-            CairoTestUtils.createTableWithVersion(m, ColumnType.VERSION);
-        }
-
-        String lineData = "tab int=1000000i,str=\"string1\" 1500000000000\n" +
-                "tab int=2000000t,str=\"string2\" 1700000000000\n" + // <-- error here
-                "tab int=3000000i,str=4000000t 1900000000000\n"; // <-- error here
-        runInContext((server) -> {
-            send(server, lineData, "tab");
-            String expected = "int\tstr\ttimestamp\n" +
-                    "1000000\tstring1\t1970-01-01T00:25:00.000000Z\n";
-            assertTable(expected, "tab");
-        });
-    }
-
-    @Test
     public void testWriterAllLongs() throws Exception {
         currentMicros = 1;
         try (TableModel m = new TableModel(configuration, "messages", PartitionBy.MONTH)) {

--- a/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
@@ -346,6 +346,18 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTimestampField() throws Exception {
+        final String expected = "tag\tatimestamp\ttimestamp\n" +
+                "123t\t1970-01-01T00:00:01.000000Z\t1970-01-01T00:25:00.000000Z\n" +
+                "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n";
+
+        String lines = "tab,tag=123t atimestamp=1000000t 1500000000000\n" +
+                "tab,tag=321t atimestamp=2000000t 1700000000000\n";
+
+        assertThat(expected, lines, "tab");
+    }
+
+    @Test
     public void testBadTimestamp1() throws Exception {
         final String expected1 = "sym2\tdouble\tint\tbool\tstr\ttimestamp\tsym1\n" +
                 "\t1.3\t11\tfalse\tstring2\t1970-01-01T00:25:00.000000Z\tabc\n" +

--- a/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
@@ -346,40 +346,6 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testTimestampField() throws Exception {
-        final String expected = "tag\tatimestamp\ttimestamp\n" +
-                "123t\t1970-01-01T00:00:01.000000Z\t1970-01-01T00:25:00.000000Z\n" +
-                "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n" +
-                "123t\t1970-01-01T00:00:03.000000Z\t1970-01-01T00:31:40.000000Z\n";
-
-        String lines = "tab,tag=123t atimestamp=1000000t 1500000000000\n" +
-                "tab,tag=321t atimestamp=2000000t 1700000000000\n" +
-                "tab,tag=123t atimestamp=3000000i 1900000000000\n" +
-                "tab,tag=321t atimestamp=t 2100000000000\n"; // <-- error here
-
-        assertThat(expected, lines, "tab");
-    }
-
-    @Test
-    public void testTimestampInNonTimestampFields() throws Exception {
-        try (TableModel model = new TableModel(configuration, "tab", PartitionBy.NONE)
-                .col("int", ColumnType.INT)
-                .col("str", ColumnType.STRING)
-                .timestamp()) {
-            CairoTestUtils.create(model);
-        }
-
-        final String expected = "int\tstr\ttimestamp\n" +
-                "1000000\tstring1\t1970-01-01T00:25:00.000000Z\n";
-
-        String lines = "tab int=1000000i,str=\"string1\" 1500000000000\n" +
-                "tab int=2000000t,str=\"string2\" 1700000000000\n" + // <-- error here
-                "tab int=3000000i,str=4000000t 1900000000000\n"; // <-- error here
-
-        assertThat(expected, lines, "tab");
-    }
-
-    @Test
     public void testBadTimestamp1() throws Exception {
         final String expected1 = "sym2\tdouble\tint\tbool\tstr\ttimestamp\tsym1\n" +
                 "\t1.3\t11\tfalse\tstring2\t1970-01-01T00:25:00.000000Z\tabc\n" +

--- a/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/CairoLineProtoParserTest.java
@@ -349,10 +349,32 @@ public class CairoLineProtoParserTest extends AbstractCairoTest {
     public void testTimestampField() throws Exception {
         final String expected = "tag\tatimestamp\ttimestamp\n" +
                 "123t\t1970-01-01T00:00:01.000000Z\t1970-01-01T00:25:00.000000Z\n" +
-                "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n";
+                "321t\t1970-01-01T00:00:02.000000Z\t1970-01-01T00:28:20.000000Z\n" +
+                "123t\t1970-01-01T00:00:03.000000Z\t1970-01-01T00:31:40.000000Z\n";
 
         String lines = "tab,tag=123t atimestamp=1000000t 1500000000000\n" +
-                "tab,tag=321t atimestamp=2000000t 1700000000000\n";
+                "tab,tag=321t atimestamp=2000000t 1700000000000\n" +
+                "tab,tag=123t atimestamp=3000000i 1900000000000\n" +
+                "tab,tag=321t atimestamp=t 2100000000000\n"; // <-- error here
+
+        assertThat(expected, lines, "tab");
+    }
+
+    @Test
+    public void testTimestampInNonTimestampFields() throws Exception {
+        try (TableModel model = new TableModel(configuration, "tab", PartitionBy.NONE)
+                .col("int", ColumnType.INT)
+                .col("str", ColumnType.STRING)
+                .timestamp()) {
+            CairoTestUtils.create(model);
+        }
+
+        final String expected = "int\tstr\ttimestamp\n" +
+                "1000000\tstring1\t1970-01-01T00:25:00.000000Z\n";
+
+        String lines = "tab int=1000000i,str=\"string1\" 1500000000000\n" +
+                "tab int=2000000t,str=\"string2\" 1700000000000\n" + // <-- error here
+                "tab int=3000000i,str=4000000t 1900000000000\n"; // <-- error here
 
         assertThat(expected, lines, "tab");
     }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -35,30 +35,36 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
 
     @Test
     public void testInsertTimestampTableExists() throws Exception {
-        // no literal representation for timestamp, only longs can be inserted
         assertType(ColumnType.TIMESTAMP,
                 "value\ttimestamp\n" +
                         "1970-01-19T21:02:13.921000Z\t1970-01-01T00:00:01.000000Z\n" +
-                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:07.000000Z\n" +
-                        "\t1970-01-01T00:00:08.000000Z\n" +
-                        "\t1970-01-01T00:00:09.000000Z\n" +
-                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:10.000000Z\n" +
-                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:11.000000Z\n",
+                        "1970-01-19T21:02:13.921000Z\t1970-01-01T00:00:02.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:08.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:09.000000Z\n" +
+                        "\t1970-01-01T00:00:10.000000Z\n" +
+                        "\t1970-01-01T00:00:11.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:12.000000Z\n" +
+                        "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:13.000000Z\n" +
+                        "294247-01-10T04:00:54.775807Z\t1970-01-01T00:00:14.000000Z\n",
                 new String[]{
                         "1630933921000i", // valid
+                        "1630933921000t", // valid
                         "1630933921000", // discarded bad type double
                         "\"1970-01-01T00:00:05.000000Z\"", // discarded bad type string
                         "1970-01-01T00:\"00:05.00\"0000Z", // discarded bad type symbol
                         "\"1970-01-01T00:00:05.000000Z", // discarded bad string value
                         "1970-01-01T00:00:05.000000Z\"", // discarded bad string value
                         "0i", // valid
+                        "0t", // valid
                         "-9223372036854775808i", // valid NaN, same as null
                         "", // valid null
                         "-0i", // valid
+                        "-0t", // valid
                         "9223372036854775807i", // valid
                         "NaN", // discarded bad type symbol
                         "null", // discarded bad type symbol
-                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
+                        "1970-01-01T00:00:05.000000Z", // discarded bad type symbol
+                        "t", // discarded bad type boolean
                 });
     }
 
@@ -87,7 +93,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "9223372036854775807i", // valid
                         "NaN", // discarded bad type symbol
                         "null", // discarded bad type symbol
-                        "1970-01-01T00:00:05.000000Z" // discarded bad type symbol
+                        "1970-01-01T00:00:05.000000Z", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -123,6 +130,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-100", // discarded bad type double
                         "null", // discarded bad type symbol
                         "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -158,6 +166,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "-100", // discarded bad type double
                         "null", // discarded bad type symbol
                         "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -194,7 +203,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "2147483647", // discarded bad type double
                         "-2147483647", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -230,7 +240,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "2147483647", // discarded bad type double
                         "-2147483647", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -270,7 +281,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -301,7 +313,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -330,7 +343,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -358,7 +372,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "100", // discarded bad type double
                         "-0", // discarded bad type double
                         "NaN", // discarded bad type symbol
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -399,7 +414,8 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "0x1234i", // actual long256
                         "0x1234", // discarded bad type double
                         "0x00", // discarded bad type double
-                        "" // valid null
+                        "", // valid null
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -418,6 +434,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "\"null\"", // discarded bad type string
                         "120i", // discarded bad type long
                         "0x1234", // discarded bad type double
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -450,6 +467,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "F", // valid
                         "", // valid null, equals false
                         "e", // valid
+                        "0t", // discarded bad type timestamp
                 });
     }
 
@@ -481,6 +499,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
                         "F", // valid
                         "", // valid null, equals false
                         "e", // discarded bad type symbol
+                        "0t", // discarded bad type timestamp
                 });
     }
 


### PR DESCRIPTION
Refs: #1257
Documentation PR: https://github.com/questdb/questdb.io/pull/554

Extends ILP to support timestamp field type. Timestamp field values are determined based on the `t` suffix similar to how it's done with `i` suffix for long values.

The previous (undocumented) behavior was to interpret values like `1465839830100399000t` of symbol type in case of UDP and of boolean type (true) in TCP. Hence, this change should not be considered as a breaking change (although, marking it as a breaking change won't hurt).