### PR TITLE
chore(o3): make column memory size configurable

### DIFF
--- a/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
@@ -42,11 +42,16 @@ public class LineTCPSenderMain {
         try (LineProtoSender sender = new LineTCPProtoSender(Net.parseIPv4(hostIPv4), port, bufferCapacity)) {
             for (int i = 0; i < count; i++) {
                 // if ((i & 0x1) == 0) {
-                    sender.metric("weather1");
+                    sender.metric("weather" + rnd.nextLong(1000));
                     // } else {
                     // sender.metric("weather2");
                     // }
-                sender.tag("location", "l ondon").tag("by", "quest").field("temp", rnd.nextPositiveLong()).field("ok", rnd.nextPositiveInt()).$(Os.currentTimeMicros() * 1000);
+                sender
+                        .tag("location", "london")
+                        .tag("by", "quest")
+                        .field("temp", rnd.nextPositiveLong())
+                        .field("ok", rnd.nextPositiveInt())
+                        .$(rnd.nextLong(5000000000000L));
             }
             sender.flush();
         }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -200,6 +200,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int o3UpdPartitionSizeQueueCapacity;
     private final int o3PurgeDiscoveryQueueCapacity;
     private final int o3PurgeQueueCapacity;
+    private final int o3ColumnMemorySize;
     private final int maxUncommittedRows;
     private final long commitLag;
     private final long instanceHashLo;
@@ -661,6 +662,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.o3UpdPartitionSizeQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.upd.partition.size.queue.capacity", 128));
             this.o3PurgeDiscoveryQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.purge.discovery.queue.capacity", 128));
             this.o3PurgeQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.purge.queue.capacity", 128));
+            this.o3ColumnMemorySize = Numbers.ceilPow2(getIntSize(properties, env, "cairo.o3.column.memory.size", 16 * Numbers.SIZE_1MB));
             this.maxUncommittedRows = getInt(properties, env, "cairo.max.uncommitted.rows", 500_000);
             this.commitLag = getLong(properties, env, "cairo.commit.lag", 300_000) * 1_000;
             this.o3QuickSortEnabled = getBoolean(properties, env, "cairo.o3.quicksort.enabled", false);
@@ -1967,6 +1969,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getBinaryEncodingMaxLength() {
             return binaryEncodingMaxLength;
+        }
+
+        @Override
+        public int getO3ColumnMemorySize() {
+            return o3ColumnMemorySize;
         }
     }
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -143,6 +143,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final boolean lineUdpOwnThread;
     private final int sqlCopyBufferSize;
     private final long sqlAppendPageSize;
+    private final long sqlSmallFileAppendPageSize;
     private final int sqlAnalyticColumnPoolCapacity;
     private final int sqlCreateTableModelPoolCapacity;
     private final int sqlColumnCastModelPoolCapacity;
@@ -613,6 +614,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.sqlCopyModelPoolCapacity = getInt(properties, env, "cairo.sql.copy.model.pool.capacity", 32);
             this.sqlCopyBufferSize = getIntSize(properties, env, "cairo.sql.copy.buffer.size", 2 * 1024 * 1024);
             this.sqlAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, "cairo.sql.append.page.size", 16 * 1024 * 1024));
+            this.sqlSmallFileAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, "cairo.sql.small.append.page.size", FilesFacadeImpl.INSTANCE.getPageSize()));
             this.sampleByIndexSearchPageSize = getIntSize(properties, env, "cairo.sql.sampleby.page.size", 0);
             this.sqlDoubleToStrCastScale = getInt(properties, env, "cairo.sql.double.cast.scale", 12);
             this.sqlFloatToStrCastScale = getInt(properties, env, "cairo.sql.float.cast.scale", 4);
@@ -655,7 +657,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.o3UpdPartitionSizeQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.upd.partition.size.queue.capacity", 128));
             this.o3PurgeDiscoveryQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.purge.discovery.queue.capacity", 128));
             this.o3PurgeQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.o3.purge.queue.capacity", 128));
-            this.o3ColumnMemorySize = Numbers.ceilPow2(getIntSize(properties, env, "cairo.o3.column.memory.size", 16 * Numbers.SIZE_1MB));
+            this.o3ColumnMemorySize = (int) Files.ceilPageSize(getIntSize(properties, env, "cairo.o3.column.memory.size", 16 * Numbers.SIZE_1MB));
             this.maxUncommittedRows = getInt(properties, env, "cairo.max.uncommitted.rows", 500_000);
             this.commitLag = getLong(properties, env, "cairo.commit.lag", 300_000) * 1_000;
             this.o3QuickSortEnabled = getBoolean(properties, env, "cairo.o3.quicksort.enabled", false);
@@ -1877,6 +1879,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getAppendPageSize() {
             return sqlAppendPageSize;
+        }
+
+        @Override
+        public long getSmallFileAppendPageSize() {
+            return sqlSmallFileAppendPageSize;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -612,15 +612,8 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.sqlInsertModelPoolCapacity = getInt(properties, env, "cairo.sql.insert.model.pool.capacity", 64);
             this.sqlCopyModelPoolCapacity = getInt(properties, env, "cairo.sql.copy.model.pool.capacity", 32);
             this.sqlCopyBufferSize = getIntSize(properties, env, "cairo.sql.copy.buffer.size", 2 * 1024 * 1024);
-            long sqlAppendPageSize = getLongSize(properties, env, "cairo.sql.append.page.size", 16 * 1024 * 1024);
+            this.sqlAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, "cairo.sql.append.page.size", 16 * 1024 * 1024));
             this.sampleByIndexSearchPageSize = getIntSize(properties, env, "cairo.sql.sampleby.page.size", 0);
-            // round the append page size to the OS page size
-            final long osPageSize = FilesFacadeImpl.INSTANCE.getPageSize();
-            if ((sqlAppendPageSize % osPageSize) == 0) {
-                this.sqlAppendPageSize = sqlAppendPageSize;
-            } else {
-                this.sqlAppendPageSize = (sqlAppendPageSize / osPageSize + 1) * osPageSize;
-            }
             this.sqlDoubleToStrCastScale = getInt(properties, env, "cairo.sql.double.cast.scale", 12);
             this.sqlFloatToStrCastScale = getInt(properties, env, "cairo.sql.float.cast.scale", 4);
             this.sqlGroupByMapCapacity = getInt(properties, env, "cairo.sql.groupby.map.capacity", 1024);

--- a/core/src/main/java/io/questdb/cairo/AbstractIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractIndexReader.java
@@ -150,13 +150,7 @@ public abstract class AbstractIndexReader implements BitmapIndexReader {
             if (unIndexedNullCount > 0) {
                 this.keyCountIncludingNulls++;
             }
-            this.valueMem.partialFile(
-                    configuration.getFilesFacade(),
-                    BitmapIndexUtils.valueFileName(path.trimTo(plen), name),
-                    valueMemSize,
-                    valueMemSize,
-                    MemoryTag.MMAP_INDEX_READER
-            );
+            this.valueMem.of(configuration.getFilesFacade(), BitmapIndexUtils.valueFileName(path.trimTo(plen), name), valueMemSize, valueMemSize, MemoryTag.MMAP_INDEX_READER);
         } catch (Throwable e) {
             close();
             throw e;

--- a/core/src/main/java/io/questdb/cairo/AbstractIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractIndexReader.java
@@ -98,7 +98,7 @@ public abstract class AbstractIndexReader implements BitmapIndexReader {
         this.spinLockTimeoutUs = configuration.getSpinLockTimeoutUs();
 
         try {
-            this.keyMem.wholeFile(configuration.getFilesFacade(), BitmapIndexUtils.keyFileName(path, name), MemoryTag.MMAP_DEFAULT);
+            this.keyMem.wholeFile(configuration.getFilesFacade(), BitmapIndexUtils.keyFileName(path, name), MemoryTag.MMAP_INDEX_READER);
             this.clock = configuration.getMicrosecondClock();
 
             // key file should already be created at least with header
@@ -118,6 +118,7 @@ public abstract class AbstractIndexReader implements BitmapIndexReader {
             // read. Confirm start sequence hasn't changed after values read. If it has changed - retry the whole thing.
             int blockValueCountMod;
             int keyCount;
+            long valueMemSize;
             final long deadline = clock.getTicks() + spinLockTimeoutUs;
             while (true) {
                 long seq = this.keyMem.getLong(BitmapIndexUtils.KEY_RESERVED_OFFSET_SEQUENCE);
@@ -127,6 +128,7 @@ public abstract class AbstractIndexReader implements BitmapIndexReader {
 
                     blockValueCountMod = this.keyMem.getInt(BitmapIndexUtils.KEY_RESERVED_OFFSET_BLOCK_VALUE_COUNT) - 1;
                     keyCount = this.keyMem.getInt(BitmapIndexUtils.KEY_RESERVED_OFFSET_KEY_COUNT);
+                    valueMemSize = this.keyMem.getLong(BitmapIndexUtils.KEY_RESERVED_OFFSET_VALUE_MEM_SIZE);
 
                     Unsafe.getUnsafe().loadFence();
                     if (this.keyMem.getLong(BitmapIndexUtils.KEY_RESERVED_OFFSET_SEQUENCE) == seq) {
@@ -148,7 +150,13 @@ public abstract class AbstractIndexReader implements BitmapIndexReader {
             if (unIndexedNullCount > 0) {
                 this.keyCountIncludingNulls++;
             }
-            this.valueMem.wholeFile(configuration.getFilesFacade(), BitmapIndexUtils.valueFileName(path.trimTo(plen), name), MemoryTag.MMAP_DEFAULT);
+            this.valueMem.partialFile(
+                    configuration.getFilesFacade(),
+                    BitmapIndexUtils.valueFileName(path.trimTo(plen), name),
+                    valueMemSize,
+                    valueMemSize,
+                    MemoryTag.MMAP_INDEX_READER
+            );
         } catch (Throwable e) {
             close();
             throw e;

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -255,4 +255,6 @@ public interface CairoConfiguration {
     int getLatestByQueueCapacity();
 
     int getBinaryEncodingMaxLength();
+
+    int getO3ColumnMemorySize();
 }

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -37,212 +37,30 @@ import io.questdb.std.datetime.millitime.MillisecondClock;
 
 public interface CairoConfiguration {
 
-    int getBindVariablePoolSize();
+    boolean enableTestFactories();
 
-    int getO3PurgeDiscoveryQueueCapacity();
+    int getAnalyticColumnPoolCapacity();
 
-    int getO3PurgeQueueCapacity();
+    long getDataAppendPageSize();
 
-    int getSampleByIndexSearchPageSize();
+    DateFormat getBackupDirTimestampFormat();
 
-    int getSqlCopyBufferSize();
-
-    int getCopyPoolCapacity();
-
-    int getCreateAsSelectRetryCount();
-
-    CharSequence getDefaultMapType();
-
-    boolean getDefaultSymbolCacheFlag();
-
-    int getDefaultSymbolCapacity();
-
-    int getFileOperationRetryCount();
-
-    FilesFacade getFilesFacade();
-
-    long getIdleCheckInterval();
-
-    long getInactiveReaderTTL();
-
-    long getInactiveWriterTTL();
-
-    int getIndexValueBlockSize();
-
-    int getDoubleToStrCastScale();
-
-    int getFloatToStrCastScale();
-
-    int getMaxSwapFileCount();
-
-    MicrosecondClock getMicrosecondClock();
-
-    MillisecondClock getMillisecondClock();
-
-    default NanosecondClock getNanosecondClock() {
-        return NanosecondClockImpl.INSTANCE;
-    }
-
-    int getMkDirMode();
-
-    int getParallelIndexThreshold();
-
-    int getReaderPoolMaxSegments();
-
-    CharSequence getRoot(); // some folder with suffix env['cairo.root'] e.g. /.../db
-
-    CharSequence getDbDirectory(); // env['cairo.root'], defaults to db
-
-    CharSequence getConfRoot(); // same as root/../conf
-
-    // null input root disables "copy" sql
-    CharSequence getInputRoot();
+    int getBackupMkDirMode();
 
     // null disables backups
     CharSequence getBackupRoot();
 
-    DateFormat getBackupDirTimestampFormat();
-
     CharSequence getBackupTempDirName();
 
-    int getBackupMkDirMode();
+    int getBinaryEncodingMaxLength();
 
-    long getSpinLockTimeoutUs();
-
-    int getSqlCharacterStoreCapacity();
-
-    int getSqlCharacterStoreSequencePoolCapacity();
-
-    int getSqlColumnPoolCapacity();
-
-    double getSqlCompactMapLoadFactor();
-
-    int getSqlExpressionPoolCapacity();
-
-    double getSqlFastMapLoadFactor();
-
-    int getSqlJoinContextPoolCapacity();
-
-    int getSqlLexerPoolCapacity();
-
-    int getSqlMapKeyCapacity();
-
-    int getSqlMapPageSize();
-
-    int getSqlDistinctTimestampKeyCapacity();
-
-    double getSqlDistinctTimestampLoadFactor();
-
-    int getSqlMapMaxPages();
-
-    int getSqlMapMaxResizes();
-
-    int getSqlModelPoolCapacity();
-
-    long getSqlSortKeyPageSize();
-
-    int getSqlSortKeyMaxPages();
-
-    long getSqlSortLightValuePageSize();
-
-    int getSqlSortLightValueMaxPages();
-
-    int getSqlHashJoinValuePageSize();
-
-    int getSqlHashJoinValueMaxPages();
-
-    int getSqlAnalyticStorePageSize();
-
-    int getSqlAnalyticStoreMaxPages();
-
-    int getSqlAnalyticRowIdPageSize();
-
-    int getSqlAnalyticRowIdMaxPages();
-
-    int getSqlAnalyticTreeKeyPageSize();
-
-    int getSqlAnalyticTreeKeyMaxPages();
-
-    long getSqlLatestByRowCount();
-
-    int getSqlHashJoinLightValuePageSize();
-
-    int getSqlHashJoinLightValueMaxPages();
-
-    int getSqlSortValuePageSize();
-
-    int getSqlSortValueMaxPages();
-
-    TextConfiguration getTextConfiguration();
-
-    long getWorkStealTimeoutNanos();
-
-    boolean isParallelIndexingEnabled();
-
-    /**
-     * This holds table metadata, which is usually quite small. 16K page should be adequate.
-     *
-     * @return memory page size
-     */
-    int getSqlJoinMetadataPageSize();
-
-    int getSqlJoinMetadataMaxResizes();
-
-    int getAnalyticColumnPoolCapacity();
-
-    int getCreateTableModelPoolCapacity();
-
-    int getColumnCastModelPoolCapacity();
-
-    int getRenameTableModelPoolCapacity();
-
-    int getWithClauseModelPoolCapacity();
-
-    int getInsertPoolCapacity();
-
-    int getCommitMode();
-
-    DateLocale getDefaultDateLocale();
-
-    int getGroupByPoolCapacity();
-
-    int getMaxSymbolNotEqualsCount();
-
-    int getGroupByMapCapacity();
-
-    boolean enableTestFactories();
-
-    TelemetryConfiguration getTelemetryConfiguration();
-
-    long getAppendPageSize();
-
-    long getSmallFileAppendPageSize();
-
-    int getTableBlockWriterQueueCapacity();
-
-    int getColumnIndexerQueueCapacity();
-
-    int getVectorAggregateQueueCapacity();
-
-    int getO3CallbackQueueCapacity();
-
-    int getO3PartitionQueueCapacity();
-
-    int getO3OpenColumnQueueCapacity();
-
-    int getO3CopyQueueCapacity();
-
-    int getO3PartitionUpdateQueueCapacity();
+    int getBindVariablePoolSize();
 
     BuildInformation getBuildInformation();
 
-    long getDatabaseIdHi();
+    int getColumnCastModelPoolCapacity();
 
-    long getDatabaseIdLo();
-
-    int getTxnScoreboardEntryCount();
-
-    int getMaxUncommittedRows();
+    int getColumnIndexerQueueCapacity();
 
     /**
      * Default commit lag in microseconds for new tables. This value
@@ -252,11 +70,197 @@ public interface CairoConfiguration {
      */
     long getCommitLag();
 
-    boolean isO3QuickSortEnabled();
+    int getCommitMode();
+
+    CharSequence getConfRoot(); // same as root/../conf
+
+    int getCopyPoolCapacity();
+
+    int getCreateAsSelectRetryCount();
+
+    int getCreateTableModelPoolCapacity();
+
+    long getDataIndexKeyAppendPageSize();
+
+    long getDataIndexValueAppendPageSize();
+
+    long getDatabaseIdHi();
+
+    long getDatabaseIdLo();
+
+    CharSequence getDbDirectory(); // env['cairo.root'], defaults to db
+
+    DateLocale getDefaultDateLocale();
+
+    CharSequence getDefaultMapType();
+
+    boolean getDefaultSymbolCacheFlag();
+
+    int getDefaultSymbolCapacity();
+
+    int getDoubleToStrCastScale();
+
+    int getFileOperationRetryCount();
+
+    FilesFacade getFilesFacade();
+
+    int getFloatToStrCastScale();
+
+    int getGroupByMapCapacity();
+
+    int getGroupByPoolCapacity();
+
+    long getIdleCheckInterval();
+
+    long getInactiveReaderTTL();
+
+    long getInactiveWriterTTL();
+
+    int getIndexValueBlockSize();
+
+    // null input root disables "copy" sql
+    CharSequence getInputRoot();
+
+    int getInsertPoolCapacity();
 
     int getLatestByQueueCapacity();
 
-    int getBinaryEncodingMaxLength();
+    int getMaxSwapFileCount();
+
+    int getMaxSymbolNotEqualsCount();
+
+    int getMaxUncommittedRows();
+
+    MicrosecondClock getMicrosecondClock();
+
+    MillisecondClock getMillisecondClock();
+
+    int getMkDirMode();
+
+    default NanosecondClock getNanosecondClock() {
+        return NanosecondClockImpl.INSTANCE;
+    }
+
+    int getO3CallbackQueueCapacity();
 
     int getO3ColumnMemorySize();
+
+    int getO3CopyQueueCapacity();
+
+    int getO3OpenColumnQueueCapacity();
+
+    int getO3PartitionQueueCapacity();
+
+    int getO3PartitionUpdateQueueCapacity();
+
+    int getO3PurgeDiscoveryQueueCapacity();
+
+    int getO3PurgeQueueCapacity();
+
+    int getParallelIndexThreshold();
+
+    int getReaderPoolMaxSegments();
+
+    int getRenameTableModelPoolCapacity();
+
+    CharSequence getRoot(); // some folder with suffix env['cairo.root'] e.g. /.../db
+
+    int getSampleByIndexSearchPageSize();
+
+    long getMiscAppendPageSize();
+
+    long getSpinLockTimeoutUs();
+
+    int getSqlAnalyticRowIdMaxPages();
+
+    int getSqlAnalyticRowIdPageSize();
+
+    int getSqlAnalyticStoreMaxPages();
+
+    int getSqlAnalyticStorePageSize();
+
+    int getSqlAnalyticTreeKeyMaxPages();
+
+    int getSqlAnalyticTreeKeyPageSize();
+
+    int getSqlCharacterStoreCapacity();
+
+    int getSqlCharacterStoreSequencePoolCapacity();
+
+    int getSqlColumnPoolCapacity();
+
+    double getSqlCompactMapLoadFactor();
+
+    int getSqlCopyBufferSize();
+
+    int getSqlDistinctTimestampKeyCapacity();
+
+    double getSqlDistinctTimestampLoadFactor();
+
+    int getSqlExpressionPoolCapacity();
+
+    double getSqlFastMapLoadFactor();
+
+    int getSqlHashJoinLightValueMaxPages();
+
+    int getSqlHashJoinLightValuePageSize();
+
+    int getSqlHashJoinValueMaxPages();
+
+    int getSqlHashJoinValuePageSize();
+
+    int getSqlJoinContextPoolCapacity();
+
+    int getSqlJoinMetadataMaxResizes();
+
+    /**
+     * These holds table metadata, which is usually quite small. 16K page should be adequate.
+     *
+     * @return memory page size
+     */
+    int getSqlJoinMetadataPageSize();
+
+    long getSqlLatestByRowCount();
+
+    int getSqlLexerPoolCapacity();
+
+    int getSqlMapKeyCapacity();
+
+    int getSqlMapMaxPages();
+
+    int getSqlMapMaxResizes();
+
+    int getSqlMapPageSize();
+
+    int getSqlModelPoolCapacity();
+
+    int getSqlSortKeyMaxPages();
+
+    long getSqlSortKeyPageSize();
+
+    int getSqlSortLightValueMaxPages();
+
+    long getSqlSortLightValuePageSize();
+
+    int getSqlSortValueMaxPages();
+
+    int getSqlSortValuePageSize();
+
+    int getTableBlockWriterQueueCapacity();
+
+    TelemetryConfiguration getTelemetryConfiguration();
+
+    TextConfiguration getTextConfiguration();
+
+    int getTxnScoreboardEntryCount();
+
+    int getVectorAggregateQueueCapacity();
+
+    int getWithClauseModelPoolCapacity();
+
+    long getWorkStealTimeoutNanos();
+
+    boolean isO3QuickSortEnabled();
+
+    boolean isParallelIndexingEnabled();
 }

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -216,6 +216,8 @@ public interface CairoConfiguration {
 
     long getAppendPageSize();
 
+    long getSmallFileAppendPageSize();
+
     int getTableBlockWriterQueueCapacity();
 
     int getColumnIndexerQueueCapacity();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -59,6 +59,16 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public long getDataIndexKeyAppendPageSize() {
+        return Files.PAGE_SIZE;
+    }
+
+    @Override
+    public long getDataIndexValueAppendPageSize() {
+        return Files.ceilPageSize(1024*1024);
+    }
+
+    @Override
     public int getBindVariablePoolSize() {
         return 8;
     }
@@ -476,12 +486,12 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public long getAppendPageSize() {
+    public long getDataAppendPageSize() {
         return getFilesFacade().getMapPageSize();
     }
 
     @Override
-    public long getSmallFileAppendPageSize() {
+    public long getMiscAppendPageSize() {
         return getFilesFacade().getPageSize();
     }
 

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -481,6 +481,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public long getSmallFileAppendPageSize() {
+        return getFilesFacade().getPageSize();
+    }
+
+    @Override
     public int getTableBlockWriterQueueCapacity() {
         return 4;
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -564,4 +564,9 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     public int getBinaryEncodingMaxLength() {
         return 32768;
     }
+
+    @Override
+    public int getO3ColumnMemorySize() {
+        return 16 * Numbers.SIZE_1MB;
+    }
 }

--- a/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
@@ -102,8 +102,14 @@ class SymbolColumnIndexer implements ColumnIndexer, Closeable {
     ) {
         this.columnTop = columnTop;
         try {
-            this.writer.of(configuration, path, name);
-            this.sliderMem.of(columnMem, MemoryTag.MMAP_DEFAULT);
+            this.writer.of(
+                    configuration,
+                    path,
+                    name,
+                    configuration.getDataIndexKeyAppendPageSize(),
+                    configuration.getDataIndexValueAppendPageSize()
+            );
+            this.sliderMem.of(columnMem, MemoryTag.MMAP_INDEX_SLIDER);
         } catch (Throwable e) {
             this.close();
             throw e;
@@ -114,7 +120,13 @@ class SymbolColumnIndexer implements ColumnIndexer, Closeable {
     public void configureWriter(CairoConfiguration configuration, Path path, CharSequence name, long columnTop) {
         this.columnTop = columnTop;
         try {
-            this.writer.of(configuration, path, name);
+            this.writer.of(
+                    configuration,
+                    path,
+                    name,
+                    configuration.getDataIndexKeyAppendPageSize(),
+                    configuration.getDataIndexValueAppendPageSize()
+            );
         } catch (Throwable e) {
             this.close();
             throw e;

--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -117,13 +117,7 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             // open "offset" memory and make sure we start appending from where
             // we left off. Where we left off is stored externally to symbol map
             final long offsetMemSize = SymbolMapWriter.keyToOffset(symbolCount);
-            this.offsetMem.partialFile(
-                    ff,
-                    path,
-                    offsetMemSize,
-                    offsetMemSize,
-                    MemoryTag.MMAP_INDEX_READER
-            );
+            this.offsetMem.of(ff, path, offsetMemSize, offsetMemSize, MemoryTag.MMAP_INDEX_READER);
             symbolCapacity = offsetMem.getInt(SymbolMapWriter.HEADER_CAPACITY);
             this.cached = offsetMem.getBool(SymbolMapWriter.HEADER_CACHE_ENABLED);
             this.nullValue = offsetMem.getBool(SymbolMapWriter.HEADER_NULL_FLAG);

--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -116,7 +116,14 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
 
             // open "offset" memory and make sure we start appending from where
             // we left off. Where we left off is stored externally to symbol map
-            this.offsetMem.partialFile(ff, path, SymbolMapWriter.keyToOffset(symbolCount), MemoryTag.MMAP_DEFAULT);
+            final long offsetMemSize = SymbolMapWriter.keyToOffset(symbolCount);
+            this.offsetMem.partialFile(
+                    ff,
+                    path,
+                    offsetMemSize,
+                    offsetMemSize,
+                    MemoryTag.MMAP_INDEX_READER
+            );
             symbolCapacity = offsetMem.getInt(SymbolMapWriter.HEADER_CAPACITY);
             this.cached = offsetMem.getBool(SymbolMapWriter.HEADER_CACHE_ENABLED);
             this.nullValue = offsetMem.getBool(SymbolMapWriter.HEADER_NULL_FLAG);
@@ -125,7 +132,7 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             this.indexReader.of(configuration, path.trimTo(plen), name, 0, -1);
 
             // this is the place where symbol values are stored
-            this.charMem.wholeFile(ff, SymbolMapWriter.charFileName(path.trimTo(plen), name), MemoryTag.MMAP_DEFAULT);
+            this.charMem.wholeFile(ff, SymbolMapWriter.charFileName(path.trimTo(plen), name), MemoryTag.MMAP_INDEX_READER);
 
             // move append pointer for symbol values in the correct place
             growCharMemToSymbolCount(symbolCount);

--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -64,7 +64,7 @@ public class SymbolMapWriter implements Closeable {
         final int plen = path.length();
         try {
             final FilesFacade ff = configuration.getFilesFacade();
-            final long mapPageSize = ff.getMapPageSize();
+            final long mapPageSize = configuration.getSmallFileAppendPageSize();
 
             // this constructor does not create index. Index must exist
             // and we use "offset" file to store "header"

--- a/core/src/main/java/io/questdb/cairo/TableBlockWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableBlockWriter.java
@@ -136,7 +136,7 @@ public class TableBlockWriter implements Closeable {
         long alignedMapOffset = (mapOffset / ff.getPageSize()) * ff.getPageSize();
         long addressOffsetDueToAlignment = mapOffset - alignedMapOffset;
         long alignedMapSz = mapSz + addressOffsetDueToAlignment;
-        long address = TableUtils.mapRW(ff, fd, alignedMapSz, alignedMapOffset, MemoryTag.MMAP_DEFAULT);
+        long address = TableUtils.mapRW(ff, fd, alignedMapSz, alignedMapOffset, MemoryTag.MMAP_BLOCK_WRITER);
         assert (address / ff.getPageSize()) * ff.getPageSize() == address; // address MUST be page aligned
         return address + addressOffsetDueToAlignment;
     }
@@ -144,7 +144,7 @@ public class TableBlockWriter implements Closeable {
     private static void unmapFile(FilesFacade ff, final long address, final long mapSz) {
         long alignedAddress = (address / ff.getPageSize()) * ff.getPageSize();
         long alignedMapSz = mapSz + address - alignedAddress;
-        ff.munmap(alignedAddress, alignedMapSz, MemoryTag.MMAP_DEFAULT);
+        ff.munmap(alignedAddress, alignedMapSz, MemoryTag.MMAP_BLOCK_WRITER);
     }
 
     void clear() {

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -818,7 +818,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             long columnSize
     ) {
         if (mem != null && mem != NullColumn.INSTANCE) {
-            mem.partialFile(ff, path, columnSize, MemoryTag.MMAP_TABLE_READER);
+            mem.partialFile(ff, path, columnSize, columnSize, MemoryTag.MMAP_TABLE_READER);
         } else {
             mem = Vm.getMRInstance(ff, path, columnSize, MemoryTag.MMAP_TABLE_READER);
             columns.setQuick(primaryIndex, mem);

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -818,7 +818,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             long columnSize
     ) {
         if (mem != null && mem != NullColumn.INSTANCE) {
-            mem.partialFile(ff, path, columnSize, columnSize, MemoryTag.MMAP_TABLE_READER);
+            mem.of(ff, path, columnSize, columnSize, MemoryTag.MMAP_TABLE_READER);
         } else {
             mem = Vm.getMRInstance(ff, path, columnSize, MemoryTag.MMAP_TABLE_READER);
             columns.setQuick(primaryIndex, mem);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -63,7 +63,6 @@ public class TableWriter implements Closeable {
     public static final int O3_BLOCK_O3 = 1;
     public static final int O3_BLOCK_DATA = 2;
     public static final int O3_BLOCK_MERGE = 3;
-    private static final int MEM_PAGE_SIZE = 16 * Numbers.SIZE_1MB;
     private static final Log LOG = LogFactory.getLog(TableWriter.class);
     private static final CharSequenceHashSet IGNORED_FILES = new CharSequenceHashSet();
     private static final Runnable NOOP = () -> {
@@ -109,6 +108,7 @@ public class TableWriter implements Closeable {
     private final Timestamps.TimestampAddMethod timestampAddMethod;
     private final int defaultCommitMode;
     private final FindVisitor removePartitionDirectories = this::removePartitionDirectories0;
+    private final int o3ColumnMemorySize;
     private final ObjList<Runnable> nullSetters;
     private final ObjList<Runnable> o3NullSetters;
     private final ObjList<MemoryCARW> o3Columns;
@@ -207,7 +207,7 @@ public class TableWriter implements Closeable {
         this.o3PartitionUpdatePubSeq = new MPSequence(this.o3PartitionUpdateQueue.getCapacity());
         this.o3PartitionUpdateSubSeq = new SCSequence();
         o3PartitionUpdatePubSeq.then(o3PartitionUpdateSubSeq).then(o3PartitionUpdatePubSeq);
-
+        this.o3ColumnMemorySize = configuration.getO3ColumnMemorySize();
         this.path = new Path();
         this.path.of(root).concat(tableName);
         this.other = new Path().of(root).concat(tableName);
@@ -1737,16 +1737,16 @@ public class TableWriter implements Closeable {
     private void configureColumn(int type, boolean indexFlag) {
         final MemoryMAR primary = Vm.getMARInstance();
         final MemoryMAR secondary;
-        final MemoryCARW oooPrimary = Vm.getCARWInstance(MEM_PAGE_SIZE, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
+        final MemoryCARW oooPrimary = Vm.getCARWInstance(o3ColumnMemorySize, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
         final MemoryCARW oooSecondary;
-        final MemoryCARW oooPrimary2 = Vm.getCARWInstance(MEM_PAGE_SIZE, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
+        final MemoryCARW oooPrimary2 = Vm.getCARWInstance(o3ColumnMemorySize, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
         final MemoryCARW oooSecondary2;
         switch (ColumnType.tagOf(type)) {
             case ColumnType.BINARY:
             case ColumnType.STRING:
                 secondary = Vm.getMARInstance();
-                oooSecondary = Vm.getCARWInstance(MEM_PAGE_SIZE, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
-                oooSecondary2 = Vm.getCARWInstance(MEM_PAGE_SIZE, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
+                oooSecondary = Vm.getCARWInstance(o3ColumnMemorySize, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
+                oooSecondary2 = Vm.getCARWInstance(o3ColumnMemorySize, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
                 break;
             default:
                 secondary = null;
@@ -1792,7 +1792,7 @@ public class TableWriter implements Closeable {
         final int timestampIndex = metadata.getTimestampIndex();
         if (timestampIndex != -1) {
             o3TimestampMem = o3Columns.getQuick(getPrimaryColumnIndex(timestampIndex));
-            o3TimestampMemCpy = Vm.getCARWInstance(MEM_PAGE_SIZE, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
+            o3TimestampMemCpy = Vm.getCARWInstance(o3ColumnMemorySize, Integer.MAX_VALUE, MemoryTag.NATIVE_O3);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2213,13 +2213,7 @@ public class TableWriter implements Closeable {
                             if (partitionSize > columnTop) {
                                 TableUtils.dFile(path.trimTo(plen), columnName);
                                 final long columnSize = (partitionSize - columnTop) << ColumnType.pow2SizeOf(ColumnType.INT);
-                                roMem.partialFile(
-                                        ff,
-                                        path,
-                                        columnSize,
-                                        columnSize,
-                                        MemoryTag.MMAP_TABLE_WRITER
-                                );
+                                roMem.of(ff, path, columnSize, columnSize, MemoryTag.MMAP_TABLE_WRITER);
                                 indexer.configureWriter(configuration, path.trimTo(plen), columnName, columnTop);
                                 indexer.index(roMem, columnTop, partitionSize);
                             }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1096,6 +1096,9 @@ public class TableWriter implements Closeable {
     }
 
     public void transferLock(long lockFd) {
+        if (lockFd == -1) {
+            System.out.println("why?");
+        }
         assert lockFd != -1;
         this.lockFd = lockFd;
     }
@@ -2209,7 +2212,14 @@ public class TableWriter implements Closeable {
 
                             if (partitionSize > columnTop) {
                                 TableUtils.dFile(path.trimTo(plen), columnName);
-                                roMem.partialFile(ff, path, (partitionSize - columnTop) << ColumnType.pow2SizeOf(ColumnType.INT), MemoryTag.MMAP_TABLE_WRITER);
+                                final long columnSize = (partitionSize - columnTop) << ColumnType.pow2SizeOf(ColumnType.INT);
+                                roMem.partialFile(
+                                        ff,
+                                        path,
+                                        columnSize,
+                                        columnSize,
+                                        MemoryTag.MMAP_TABLE_WRITER
+                                );
                                 indexer.configureWriter(configuration, path.trimTo(plen), columnName, columnTop);
                                 indexer.index(roMem, columnTop, partitionSize);
                             }
@@ -3466,9 +3476,9 @@ public class TableWriter implements Closeable {
         MemoryMAR mem2 = getSecondaryColumn(i);
 
         try {
-            mem1.of(ff, dFile(path.trimTo(plen), name), configuration.getAppendPageSize(), -1, MemoryTag.MMAP_TABLE_WRITER);
+            mem1.of(ff, dFile(path.trimTo(plen), name), configuration.getDataAppendPageSize(), -1, MemoryTag.MMAP_TABLE_WRITER);
             if (mem2 != null) {
-                mem2.of(ff, iFile(path.trimTo(plen), name), configuration.getAppendPageSize(), -1, MemoryTag.MMAP_TABLE_WRITER);
+                mem2.of(ff, iFile(path.trimTo(plen), name), configuration.getDataAppendPageSize(), -1, MemoryTag.MMAP_TABLE_WRITER);
             }
         } finally {
             path.trimTo(plen);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1096,9 +1096,6 @@ public class TableWriter implements Closeable {
     }
 
     public void transferLock(long lockFd) {
-        if (lockFd == -1) {
-            System.out.println("why?");
-        }
         assert lockFd != -1;
         this.lockFd = lockFd;
     }

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
@@ -211,7 +211,7 @@ public class MemoryCMARWImpl extends AbstractMemoryCR implements MemoryCMARW, Me
     @Override
     public void of(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag) {
         this.extendSegmentMsb = Numbers.msb(extendSegmentSize);
-        this.minMappedMemorySize = ff.getMapPageSize();
+        this.minMappedMemorySize = extendSegmentSize;
         openFile(ff, name);
         map(ff, name, size, memoryTag);
     }

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
@@ -64,10 +64,6 @@ public interface MemoryM extends Closeable {
      */
     void of(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag);
 
-    default void partialFile(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag) {
-        of(ff, name, extendSegmentSize, size, memoryTag);
-    }
-
     default void wholeFile(FilesFacade ff, LPSZ name, int memoryTag) {
         of(ff, name, ff.getMapPageSize(), ff.length(name), memoryTag);
     }

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
@@ -64,8 +64,8 @@ public interface MemoryM extends Closeable {
      */
     void of(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag);
 
-    default void partialFile(FilesFacade ff, LPSZ name, long size, int memoryTag) {
-        of(ff, name, ff.getMapPageSize(), size, memoryTag);
+    default void partialFile(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag) {
+        of(ff, name, extendSegmentSize, size, memoryTag);
     }
 
     default void wholeFile(FilesFacade ff, LPSZ name, int memoryTag) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -77,10 +77,16 @@ class SymbolCache implements Closeable {
 
     void of(CairoConfiguration configuration, Path path, CharSequence name, int symIndex) {
         FilesFacade ff = configuration.getFilesFacade();
-        transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symIndex);
+        transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symIndex) + Integer.BYTES;
         final int plen = path.length();
-        txMem.partialFile(ff, path.concat(TableUtils.TXN_FILE_NAME).$(), transientSymCountOffset + Integer.BYTES, MemoryTag.MMAP_DEFAULT);
-        int symCount = txMem.getInt(transientSymCountOffset);
+        txMem.partialFile(
+                ff,
+                path.concat(TableUtils.TXN_FILE_NAME).$(),
+                transientSymCountOffset,
+                transientSymCountOffset,
+                MemoryTag.MMAP_INDEX_READER
+        );
+        int symCount = txMem.getInt(transientSymCountOffset - Integer.BYTES);
         path.trimTo(plen);
         symMapReader.of(configuration, path, name, symCount);
         indexBySym.clear(symCount);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -79,13 +79,7 @@ class SymbolCache implements Closeable {
         FilesFacade ff = configuration.getFilesFacade();
         transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symIndex) + Integer.BYTES;
         final int plen = path.length();
-        txMem.partialFile(
-                ff,
-                path.concat(TableUtils.TXN_FILE_NAME).$(),
-                transientSymCountOffset,
-                transientSymCountOffset,
-                MemoryTag.MMAP_INDEX_READER
-        );
+        txMem.of(ff, path.concat(TableUtils.TXN_FILE_NAME).$(), transientSymCountOffset, transientSymCountOffset, MemoryTag.MMAP_INDEX_READER);
         int symCount = txMem.getInt(transientSymCountOffset - Integer.BYTES);
         path.trimTo(plen);
         symMapReader.of(configuration, path, name, symCount);

--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -330,12 +330,7 @@ public final class Files {
     private static native boolean rename(long lpszOld, long lpszNew);
 
     public static long ceilPageSize(long size) {
-        long pageCount = size / PAGE_SIZE;
-        long sz = pageCount * PAGE_SIZE;
-        if (sz < size) {
-            return sz + PAGE_SIZE;
-        }
-        return sz;
+        return ((size + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
     }
 
     static {

--- a/core/src/main/java/io/questdb/std/MemoryTag.java
+++ b/core/src/main/java/io/questdb/std/MemoryTag.java
@@ -38,7 +38,6 @@ public final class MemoryTag {
     public static final int NATIVE_LONG_LIST = 10;
     public static final int NATIVE_HTTP_CONN = 11;
     public static final int NATIVE_PGW_CONN = 12;
-
     public static final int MMAP_INDEX_READER = 13;
     public static final int MMAP_INDEX_WRITER = 14;
     public static final int MMAP_INDEX_SLIDER = 15;
@@ -69,6 +68,5 @@ public final class MemoryTag {
         tagNameMap.extendAndSet(MMAP_INDEX_WRITER, "MMAP_INDEX_WRITER");
         tagNameMap.extendAndSet(MMAP_INDEX_SLIDER, "MMAP_INDEX_SLIDER");
         tagNameMap.extendAndSet(MMAP_BLOCK_WRITER, "MMAP_BLOCK_WRITER");
-
     }
 }

--- a/core/src/main/java/io/questdb/std/MemoryTag.java
+++ b/core/src/main/java/io/questdb/std/MemoryTag.java
@@ -38,31 +38,37 @@ public final class MemoryTag {
     public static final int NATIVE_LONG_LIST = 10;
     public static final int NATIVE_HTTP_CONN = 11;
     public static final int NATIVE_PGW_CONN = 12;
-    public static final int SIZE = NATIVE_PGW_CONN + 1;
 
-    private static final IntObjHashMap<String> tagNameMap = new IntObjHashMap<>();
+    public static final int MMAP_INDEX_READER = 13;
+    public static final int MMAP_INDEX_WRITER = 14;
+    public static final int MMAP_INDEX_SLIDER = 15;
+    public static final int MMAP_BLOCK_WRITER = 16;
+    public static final int SIZE = MMAP_BLOCK_WRITER + 1;
+
+    private static final ObjList<String> tagNameMap = new ObjList<>(SIZE);
 
     public static String nameOf(int tag) {
-        final int index = tagNameMap.keyIndex(tag);
-        if (index > -1) {
-            return "Unknown";
-        }
-        return tagNameMap.valueAtQuick(index);
+        return tagNameMap.getQuick(tag);
     }
 
     static {
-        tagNameMap.put(MMAP_DEFAULT, "MMAP_DEFAULT");
-        tagNameMap.put(NATIVE_DEFAULT, "NATIVE_DEFAULT");
-        tagNameMap.put(MMAP_O3, "MMAP_O3");
-        tagNameMap.put(NATIVE_O3, "NATIVE_O3");
-        tagNameMap.put(NATIVE_RECORD_CHAIN, "NATIVE_RECORD_CHAIN");
-        tagNameMap.put(MMAP_TABLE_WRITER, "MMAP_TABLE_WRITER");
-        tagNameMap.put(NATIVE_TREE_CHAIN, "NATIVE_TREE_CHAIN");
-        tagNameMap.put(MMAP_TABLE_READER, "MMAP_TABLE_READER");
-        tagNameMap.put(NATIVE_COMPACT_MAP, "NATIVE_COMPACT_MAP");
-        tagNameMap.put(NATIVE_FAST_MAP, "NATIVE_FAST_MAP");
-        tagNameMap.put(NATIVE_LONG_LIST, "NATIVE_LONG_LIST");
-        tagNameMap.put(NATIVE_HTTP_CONN, "NATIVE_HTTP_CONN");
-        tagNameMap.put(NATIVE_PGW_CONN, "NATIVE_PGW_CONN");
+        tagNameMap.extendAndSet(MMAP_DEFAULT, "MMAP_DEFAULT");
+        tagNameMap.extendAndSet(NATIVE_DEFAULT, "NATIVE_DEFAULT");
+        tagNameMap.extendAndSet(MMAP_O3, "MMAP_O3");
+        tagNameMap.extendAndSet(NATIVE_O3, "NATIVE_O3");
+        tagNameMap.extendAndSet(NATIVE_RECORD_CHAIN, "NATIVE_RECORD_CHAIN");
+        tagNameMap.extendAndSet(MMAP_TABLE_WRITER, "MMAP_TABLE_WRITER");
+        tagNameMap.extendAndSet(NATIVE_TREE_CHAIN, "NATIVE_TREE_CHAIN");
+        tagNameMap.extendAndSet(MMAP_TABLE_READER, "MMAP_TABLE_READER");
+        tagNameMap.extendAndSet(NATIVE_COMPACT_MAP, "NATIVE_COMPACT_MAP");
+        tagNameMap.extendAndSet(NATIVE_FAST_MAP, "NATIVE_FAST_MAP");
+        tagNameMap.extendAndSet(NATIVE_LONG_LIST, "NATIVE_LONG_LIST");
+        tagNameMap.extendAndSet(NATIVE_HTTP_CONN, "NATIVE_HTTP_CONN");
+        tagNameMap.extendAndSet(NATIVE_PGW_CONN, "NATIVE_PGW_CONN");
+        tagNameMap.extendAndSet(MMAP_INDEX_READER, "MMAP_INDEX_READER");
+        tagNameMap.extendAndSet(MMAP_INDEX_WRITER, "MMAP_INDEX_WRITER");
+        tagNameMap.extendAndSet(MMAP_INDEX_SLIDER, "MMAP_INDEX_SLIDER");
+        tagNameMap.extendAndSet(MMAP_BLOCK_WRITER, "MMAP_BLOCK_WRITER");
+
     }
 }

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -296,6 +296,23 @@
 # Maximum number of uncommitted rows in TCP ilp
 #cairo.o3.max.uncommitted.rows=1000
 
+# Memory page size per column for O3 operations. Please be aware O3 will use 2x of this RAM per column
+#cairo.o3.column.memory.size=16M
+
+# mmap sliding page size that TableWriter uses to append data for each column
+#cairo.writer.data.append.page.size=16M
+
+# mmap page size for mapping small files, such as _txn, _todo and _meta
+# the default value is OS page size (4k Linux, 64K windows, 16k OSX M1)
+# if you override this value it will be rounded to the nearest (greater) multiple of OS page size
+#cairo.writer.misc.append.page.size=4k
+
+# mmap page size for appending index key data; key data is number of distinct symbol values times 4 bytes
+#cairo.writer.data.index.key.append.page.size=512k
+
+# mmap page size for appending value data; value data are rowids, e.g. number of rows in partition times 8 bytes
+#cairo.writer.data.index.value.append.page.size=16M
+
 ################ LINE UDP settings ##################
 
 #line.udp.bind.to=0.0.0.0:9009

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -35,6 +35,7 @@ import io.questdb.network.EpollFacadeImpl;
 import io.questdb.network.IOOperation;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.network.SelectFacadeImpl;
+import io.questdb.std.Files;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.Misc;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
@@ -256,13 +257,19 @@ public class PropServerConfigurationTest {
 
         Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
         Assert.assertEquals("HTTP/1.1 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
-        Assert.assertEquals(16777216, configuration.getCairoConfiguration().getAppendPageSize());
+        Assert.assertEquals(16777216, configuration.getCairoConfiguration().getDataAppendPageSize());
 
         Assert.assertEquals("Unknown Version", configuration.getCairoConfiguration().getBuildInformation().getQuestDbVersion());
         Assert.assertEquals("Unknown Version", configuration.getCairoConfiguration().getBuildInformation().getJdkVersion());
         Assert.assertEquals("Unknown Version", configuration.getCairoConfiguration().getBuildInformation().getCommitHash());
 
         Assert.assertFalse(configuration.getMetricsConfiguration().isEnabled());
+
+        Assert.assertEquals(16777216, configuration.getCairoConfiguration().getDataAppendPageSize());
+        Assert.assertEquals(524288, configuration.getCairoConfiguration().getDataIndexKeyAppendPageSize());
+        Assert.assertEquals(16777216, configuration.getCairoConfiguration().getDataIndexValueAppendPageSize());
+        Assert.assertEquals(Files.PAGE_SIZE, configuration.getCairoConfiguration().getMiscAppendPageSize());
+        Assert.assertEquals(2.0, configuration.getHttpServerConfiguration().getWaitProcessorConfiguration().getExponentialWaitMultiplier(), 0.00001);
     }
 
     @Test
@@ -302,7 +309,7 @@ public class PropServerConfigurationTest {
 
         // long size
         properties.setProperty("cairo.sql.append.page.size", "3G");
-        env.put("QDB_CAIRO_SQL_APPEND_PAGE_SIZE", "9G");
+        env.put("QDB_CAIRO_WRITER_DATA_APPEND_PAGE_SIZE", "9G");
 
         PropServerConfiguration configuration = new PropServerConfiguration(root, properties, env, LOG, new BuildInformationHolder());
         Assert.assertEquals(1.5, configuration.getCairoConfiguration().getTextConfiguration().getMaxRequiredDelimiterStdDev(), 0.000001);
@@ -313,7 +320,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(12288, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getSendBufferSize());
         Assert.assertEquals(900, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMultipartIdleSpinCount());
         Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
-        Assert.assertEquals(9663676416L, configuration.getCairoConfiguration().getAppendPageSize());
+        Assert.assertEquals(9663676416L, configuration.getCairoConfiguration().getDataAppendPageSize());
     }
 
     @Test
@@ -590,7 +597,11 @@ public class PropServerConfigurationTest {
 
             Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
             Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
-            Assert.assertEquals(33554432L, configuration.getCairoConfiguration().getAppendPageSize());
+            Assert.assertEquals(1048576, configuration.getCairoConfiguration().getDataAppendPageSize());
+            Assert.assertEquals(65536, configuration.getCairoConfiguration().getDataIndexKeyAppendPageSize());
+            Assert.assertEquals(262144, configuration.getCairoConfiguration().getDataIndexValueAppendPageSize());
+            Assert.assertEquals(131072, configuration.getCairoConfiguration().getMiscAppendPageSize());
+            Assert.assertEquals(1.5, configuration.getHttpServerConfiguration().getWaitProcessorConfiguration().getExponentialWaitMultiplier(), 0.00001);
 
             Assert.assertTrue(configuration.getMetricsConfiguration().isEnabled());
 

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -598,7 +598,7 @@ public class PropServerConfigurationTest {
             Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
             Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
             Assert.assertEquals(1048576, configuration.getCairoConfiguration().getDataAppendPageSize());
-            Assert.assertEquals(65536, configuration.getCairoConfiguration().getDataIndexKeyAppendPageSize());
+            Assert.assertEquals(Files.PAGE_SIZE, configuration.getCairoConfiguration().getDataIndexKeyAppendPageSize());
             Assert.assertEquals(262144, configuration.getCairoConfiguration().getDataIndexValueAppendPageSize());
             Assert.assertEquals(131072, configuration.getCairoConfiguration().getMiscAppendPageSize());
             Assert.assertEquals(1.5, configuration.getHttpServerConfiguration().getWaitProcessorConfiguration().getExponentialWaitMultiplier(), 0.00001);

--- a/core/src/test/java/io/questdb/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/cairo/BitmapIndexTest.java
@@ -784,7 +784,13 @@ public class BitmapIndexTest extends AbstractCairoTest {
 
                     create(configuration, path.trimTo(plen), "x", N / MOD / 128);
                     try (BitmapIndexWriter writer = new BitmapIndexWriter()) {
-                        writer.of(configuration, path.trimTo(plen), "x");
+                        writer.of(
+                                configuration,
+                                path.trimTo(plen),
+                                "x",
+                                configuration.getDataIndexKeyAppendPageSize(),
+                                configuration.getDataIndexValueAppendPageSize()
+                        );
                         indexInts(rwin, writer, N);
                     }
                 }
@@ -1052,7 +1058,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
                 mem.skip(BitmapIndexUtils.KEY_FILE_RESERVED - mem.getAppendOffset());
 
             }
-            assertWriterConstructorFail("Incorrect file size");
+            assertWriterConstructorFail("corrupt file");
         });
     }
 
@@ -1070,7 +1076,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
             // Therefore, truncate file manually to below the expected file size
 
             final FilesFacade ff = FilesFacadeImpl.INSTANCE;
-            try (Path path  = new Path()) {
+            try (Path path = new Path()) {
                 path.of(configuration.getRoot()).concat("x").put(".k").$();
                 long fd = TableUtils.openFileRWOrFail(ff, path);
                 try {

--- a/core/src/test/java/io/questdb/cairo/CairoMemoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/CairoMemoryTest.java
@@ -413,7 +413,8 @@ public class CairoMemoryTest {
                 Assert.assertEquals(8L * N, mem.getAppendOffset());
             }
             try (MemoryCMARW mem = Vm.getSmallCMARWInstance(FF, path, MemoryTag.MMAP_DEFAULT)) {
-                for (int i = 0; i < N; i++) {
+                final int M = (int) (mem.size()/Long.BYTES);
+                for (int i = 0; i < M; i++) {
                     Assert.assertEquals(i, mem.getLong(i * 8));
                 }
             }

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -1104,11 +1104,6 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 private int mapCount = 0;
 
                 @Override
-                public long getMapPageSize() {
-                    return 65535;
-                }
-
-                @Override
                 public long mmap(long fd, long len, long offset, int flags, int memoryTag) {
                     // mess with the target FD
                     if (fd == this.fd) {
@@ -1145,6 +1140,16 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 @Override
                 public FilesFacade getFilesFacade() {
                     return ff;
+                }
+
+                @Override
+                public long getDataIndexKeyAppendPageSize() {
+                    return 65535;
+                }
+
+                @Override
+                public long getDataIndexValueAppendPageSize() {
+                    return 65535;
                 }
             };
 
@@ -1446,11 +1451,6 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 private int mapCount = 0;
 
                 @Override
-                public long getMapPageSize() {
-                    return 65535;
-                }
-
-                @Override
                 public long mmap(long fd, long len, long offset, int flags, int memoryTag) {
                     // mess with the target FD
                     if (fd == this.fd) {
@@ -1493,6 +1493,16 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 @Override
                 public int getParallelIndexThreshold() {
                     return 1;
+                }
+
+                @Override
+                public long getDataIndexKeyAppendPageSize() {
+                    return 65535;
+                }
+
+                @Override
+                public long getDataIndexValueAppendPageSize() {
+                    return 65535;
                 }
             };
 

--- a/core/src/test/java/io/questdb/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableWriterTest.java
@@ -2651,7 +2651,7 @@ public class TableWriterTest extends AbstractCairoTest {
             create(FF, PartitionBy.DAY, 10000);
             CairoConfiguration configuration = new DefaultCairoConfiguration(root) {
                 @Override
-                public long getAppendPageSize() {
+                public long getDataAppendPageSize() {
                     return getFilesFacade().getPageSize();
                 }
             };
@@ -2667,7 +2667,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 for (int i = 0, n = w.columns.size(); i < n; i++) {
                     MemoryMAR m = w.columns.getQuick(i);
                     if (m != null) {
-                        Assert.assertEquals(configuration.getAppendPageSize(), m.getExtendSegmentSize());
+                        Assert.assertEquals(configuration.getDataAppendPageSize(), m.getExtendSegmentSize());
                     }
                 }
             }

--- a/core/src/test/java/io/questdb/cairo/vm/ContinuousMemoryMTest.java
+++ b/core/src/test/java/io/questdb/cairo/vm/ContinuousMemoryMTest.java
@@ -565,7 +565,7 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
 
     @Test
     public void testPageCountAPI() throws Exception {
-        withMem(0, (rwMem, roMem) -> {
+        withMem(FilesFacadeImpl.INSTANCE.getMapPageSize(), 0, (rwMem, roMem) -> {
 
             Assert.assertEquals(0, roMem.getPageCount());
             // read-write memory will always have one page unless it is closed
@@ -591,12 +591,13 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
     @Test
     public void testPageCountIsZeroAfterClose() throws Exception {
         assertMemoryLeak(() -> {
+            final FilesFacade ff = FilesFacadeImpl.INSTANCE;
             try (final Path path = Path.getThreadLocal(root).concat("t.d").$()) {
                 rnd.reset();
                 MemoryMARW rwMem = Vm.getMARWInstance(
-                        FilesFacadeImpl.INSTANCE,
+                        ff,
                         path,
-                        0,
+                        ff.getMapPageSize(),
                         0,
                         MemoryTag.MMAP_DEFAULT);
                 rwMem.close();
@@ -914,6 +915,10 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
     }
 
     private void withMem(long sz, MemTestCode code) throws Exception {
+        withMem(sz, sz, code);
+    }
+
+    private void withMem(long appendSz, long sz, MemTestCode code) throws Exception {
         assertMemoryLeak(() -> {
             final Path path = Path.getThreadLocal(root).concat("t.d").$();
             rnd.reset();
@@ -921,7 +926,7 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
                     MemoryCMARW rwMem = Vm.getCMARWInstance(
                             FilesFacadeImpl.INSTANCE,
                             path,
-                            sz,
+                            appendSz,
                             -1,
                             MemoryTag.MMAP_DEFAULT
                     );

--- a/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
@@ -792,7 +792,7 @@ public class RetryIODispatcherTest {
 
                     writer.close();
                     Assert.assertTrue("Table rename did not complete within timeout after writer is released",
-                            countDownLatch.await(500, TimeUnit.MILLISECONDS));
+                            countDownLatch.await(5, TimeUnit.SECONDS));
                 });
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
@@ -31,8 +31,13 @@ public class SymbolCacheTest extends AbstractCairoTest {
                     long symCountOffset = TableUtils.getSymbolWriterIndexOffset(symColIndex2);
                     long transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symColIndex2);
                     path.of(configuration.getRoot()).concat(tableName);
-                    txMem.partialFile(configuration.getFilesFacade(), path.concat(TableUtils.TXN_FILE_NAME).$(),
-                            transientSymCountOffset + Integer.BYTES, MemoryTag.MMAP_DEFAULT);
+                    txMem.partialFile(
+                            configuration.getFilesFacade(),
+                            path.concat(TableUtils.TXN_FILE_NAME).$(),
+                            transientSymCountOffset + Integer.BYTES,
+                            transientSymCountOffset + Integer.BYTES,
+                            MemoryTag.MMAP_DEFAULT
+                    );
                     cache.of(configuration, path.of(configuration.getRoot()).concat(tableName), "symCol2", symColIndex2);
 
                     TableWriter.Row r = writer.newRow();
@@ -110,8 +115,13 @@ public class SymbolCacheTest extends AbstractCairoTest {
                     symCountOffset = TableUtils.getSymbolWriterIndexOffset(symColIndex2);
                     transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symColIndex2);
                     path.of(configuration.getRoot()).concat(tableName);
-                    txMem.partialFile(configuration.getFilesFacade(), path.concat(TableUtils.TXN_FILE_NAME).$(),
-                            transientSymCountOffset + Integer.BYTES, MemoryTag.MMAP_DEFAULT);
+                    txMem.partialFile(
+                            configuration.getFilesFacade(),
+                            path.concat(TableUtils.TXN_FILE_NAME).$(),
+                            transientSymCountOffset + Integer.BYTES,
+                            transientSymCountOffset + Integer.BYTES,
+                            MemoryTag.MMAP_DEFAULT
+                    );
                     cache.of(configuration, path.of(configuration.getRoot()).concat(tableName), "symCol2", symColIndex2);
 
                     Assert.assertEquals(5, txMem.getInt(symCountOffset));

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
@@ -31,13 +31,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                     long symCountOffset = TableUtils.getSymbolWriterIndexOffset(symColIndex2);
                     long transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symColIndex2);
                     path.of(configuration.getRoot()).concat(tableName);
-                    txMem.partialFile(
-                            configuration.getFilesFacade(),
-                            path.concat(TableUtils.TXN_FILE_NAME).$(),
-                            transientSymCountOffset + Integer.BYTES,
-                            transientSymCountOffset + Integer.BYTES,
-                            MemoryTag.MMAP_DEFAULT
-                    );
+                    txMem.of(configuration.getFilesFacade(), path.concat(TableUtils.TXN_FILE_NAME).$(), transientSymCountOffset + Integer.BYTES, transientSymCountOffset + Integer.BYTES, MemoryTag.MMAP_DEFAULT);
                     cache.of(configuration, path.of(configuration.getRoot()).concat(tableName), "symCol2", symColIndex2);
 
                     TableWriter.Row r = writer.newRow();
@@ -115,13 +109,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                     symCountOffset = TableUtils.getSymbolWriterIndexOffset(symColIndex2);
                     transientSymCountOffset = TableUtils.getSymbolWriterTransientIndexOffset(symColIndex2);
                     path.of(configuration.getRoot()).concat(tableName);
-                    txMem.partialFile(
-                            configuration.getFilesFacade(),
-                            path.concat(TableUtils.TXN_FILE_NAME).$(),
-                            transientSymCountOffset + Integer.BYTES,
-                            transientSymCountOffset + Integer.BYTES,
-                            MemoryTag.MMAP_DEFAULT
-                    );
+                    txMem.of(configuration.getFilesFacade(), path.concat(TableUtils.TXN_FILE_NAME).$(), transientSymCountOffset + Integer.BYTES, transientSymCountOffset + Integer.BYTES, MemoryTag.MMAP_DEFAULT);
                     cache.of(configuration, path.of(configuration.getRoot()).concat(tableName), "symCol2", symColIndex2);
 
                     Assert.assertEquals(5, txMem.getInt(symCountOffset));

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -107,9 +107,16 @@ cairo.sql.copy.model.pool.capacity=64
 cairo.commit.mode=async
 cairo.sql.double.cast.scale=8
 cairo.sql.float.cast.scale=3
-cairo.sql.append.page.size=32M
+cairo.writer.append.page.size=32M
 cairo.sql.bind.variable.pool.size=16
 cairo.sql.sampleby.page.size=2001
+
+cairo.o3.column.memory.size=256k
+cairo.writer.data.index.key.append.page.size=1k
+cairo.writer.data.index.value.append.page.size=256k
+cairo.writer.data.append.page.size=1m
+cairo.writer.misc.append.page.size=128k
+http.busy.retry.exponential.wait.multiplier=1.5
 
 cairo.sql.distinct.timestamp.key.capacity=256
 cairo.sql.distinct.timestamp.load.factor=0.4


### PR DESCRIPTION
This change introduces fine-grained controls for overallocation when ingesting data. These are configuration options:
- Memory page size per column for O3 operations. Please be aware O3 will use 2x of this RAM per column
```
cairo.o3.column.memory.size=16M
```

- mmap sliding page size that TableWriter uses to append data for each column
```
cairo.writer.data.append.page.size=16M
```
- mmap page size for mapping small files, such as _txn, _todo and _meta. The default value is OS page size (4k Linux, 64K windows, 16k OSX M1). If you override this value it will be rounded to the nearest (greater) multiple of OS page size
```
cairo.writer.misc.append.page.size=4k
```
- mmap page size for appending index key data; key data is number of distinct symbol values times 4 bytes
```
cairo.writer.data.index.key.append.page.size=512k
```
- mmap page size for appending value data; value data are rowids, e.g. number of rows in partition times 8 bytes
 ```
cairo.writer.data.index.value.append.page.size=16M
```


## Example config for large number of small tables

```
cairo.o3.column.memory.size=256k
cairo.writer.data.append.page.size=256k
cairo.writer.data.index.key.append.page.size=64k
cairo.writer.data.index.value.append.page.size=256k
```