### PR TITLE
chore: added command line utils project with TxSerializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,5 +47,6 @@
     <modules>
         <module>core</module>
         <module>benchmarks</module>
+        <module>utils</module>
     </modules>
 </project>

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,14 @@
+# QuestDB command line utils
+
+### TxSerializer
+
+Serializes binary `_txn` file to / from readable JSON format. Primary usage to investigate storage issues
+
+Usage 
+
+```
+io.questdb.cliutil.TxSerializer -d <json_path> | -s <json_path> <txn_path> 
+```
+
+- `-d` option prints contents of `_txn` file to std output in JSON format
+- `-s` option transforms existing JSON file into binary _txn format

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -57,49 +57,50 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-      <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+  <profiles>
+    <profile>
+      <id>java8</id>
+      <properties>
+        <jdk.version>8</jdk.version>
+        <java.enforce.version>1.8.0_242</java.enforce.version>
+        <questdb.artifactid>questdb-jdk8</questdb.artifactid>
+        <javac.compile.source>1.8</javac.compile.source>
+        <javac.compile.target>1.8</javac.compile.target>
+      </properties>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+              <fork>true</fork>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.jetbrains</groupId>
+          <artifactId>annotations</artifactId>
+          <version>16.0.2</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>java11+</id>
+      <properties>
+        <questdb.artifactid>questdb</questdb.artifactid>
+      </properties>
+      <activation>
+        <jdk>(1.8,)</jdk>
+      </activation>
+    </profile>
+  </profiles>
 </project>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,0 +1,105 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~     ___                  _   ____  ____
+  ~    / _ \ _   _  ___  ___| |_|  _ \| __ )
+  ~   | | | | | | |/ _ \/ __| __| | | |  _ \
+  ~   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+  ~    \__\_\\__,_|\___||___/\__|____/|____/
+  ~
+  ~  Copyright (c) 2014-2019 Appsicle
+  ~  Copyright (c) 2019-2020 QuestDB
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>utils</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Command line utils for QuestDB</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.questdb</groupId>
+      <artifactId>questdb</artifactId>
+      <version>6.0.8-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/utils/src/main/java/io/questdb/cliutil/TxFileStruct.java
+++ b/utils/src/main/java/io/questdb/cliutil/TxFileStruct.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cliutil;
+
+import java.util.ArrayList;
+
+import static io.questdb.cairo.TableUtils.getPartitionTableIndexOffset;
+
+public class TxFileStruct {
+    public long TX_OFFSET_TXN;
+    public long TX_OFFSET_TRANSIENT_ROW_COUNT;
+    public long TX_OFFSET_FIXED_ROW_COUNT;
+    public long TX_OFFSET_MIN_TIMESTAMP;
+    public long TX_OFFSET_MAX_TIMESTAMP;
+    public long TX_OFFSET_DATA_VERSION;
+    public long TX_OFFSET_STRUCT_VERSION;
+    public long TX_OFFSET_TXN_CHECK;
+    public long TX_OFFSET_PARTITION_TABLE_VERSION;
+    public int TX_OFFSET_MAP_WRITER_COUNT;
+    public ArrayList<SymbolInfo> SYMBOLS;
+    public int ATTACHED_PARTITION_SIZE;
+    public ArrayList<AttachedPartition> ATTACHED_PARTITIONS;
+
+    public long calculateFileSize() {
+        return getPartitionTableIndexOffset(TX_OFFSET_MAP_WRITER_COUNT, ATTACHED_PARTITION_SIZE * 4);
+    }
+
+    static class AttachedPartition {
+        long TS;
+        long SIZE;
+        long NAME_TX;
+        long DATA_TX;
+    }
+
+    static class SymbolInfo {
+        int COUNT;
+        int UNCOMMITTED_COUNT;
+    }
+}

--- a/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
+++ b/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cliutil;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.vm.api.MemoryCMARW;
+import io.questdb.cairo.vm.api.MemoryMR;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Vect;
+import io.questdb.std.str.Path;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+
+import static io.questdb.cairo.TableUtils.*;
+import static io.questdb.cairo.TableUtils.getPartitionTableIndexOffset;
+
+public class TxSerializer
+{
+    static long TX_OFFSET_TXN = 0;
+    static long TX_OFFSET_DATA_VERSION = 48;
+    static long TX_OFFSET_PARTITION_TABLE_VERSION = 56;
+    static long TX_OFFSET_MAP_WRITER_COUNT = 72;
+    static long TX_OFFSET_TRANSIENT_ROW_COUNT = 8;
+    static long TX_OFFSET_FIXED_ROW_COUNT = 16;
+    static long TX_OFFSET_STRUCT_VERSION = 40;
+    static long TX_OFFSET_TXN_CHECK = 64;
+    static long TX_OFFSET_MIN_TIMESTAMP = 24;
+    static long TX_OFFSET_MAX_TIMESTAMP = 32;
+    static FilesFacade ff = new FilesFacadeImpl();
+
+    static {
+        try {
+            initializeOffsets();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Read _txn file and prints to std output JSON translation.
+     * Reads json file and saves it to binary _txn format.
+     *
+     *  Command line arguments: -s <json_path> <txn_path> | -d <json_path>
+     */
+    public static void main(String[] args) throws IOException {
+        if (args.length < 2 || args.length > 3) {
+            printUsage();
+            return;
+        }
+
+
+        TxSerializer serializer = new TxSerializer();
+        if ("-s".equals(args[0])) {
+            if (args.length != 3) {
+                printUsage();
+                return;
+            }
+            serializer.serializeFile(args[1], args[2]);
+        }
+
+        if ("-d".equals(args[0])) {
+            String json = serializer.toJson(args[1]);
+            if (json != null) {
+                System.out.println(json);
+            }
+        }
+    }
+
+    private static void initializeOffsets() throws NoSuchFieldException, IllegalAccessException {
+        TX_OFFSET_TXN = getField("TX_OFFSET_TXN");
+        TX_OFFSET_TRANSIENT_ROW_COUNT = getField("TX_OFFSET_TRANSIENT_ROW_COUNT");
+        TX_OFFSET_DATA_VERSION = getField("TX_OFFSET_DATA_VERSION");
+        TX_OFFSET_PARTITION_TABLE_VERSION = getField("TX_OFFSET_PARTITION_TABLE_VERSION");
+        TX_OFFSET_FIXED_ROW_COUNT = getField("TX_OFFSET_FIXED_ROW_COUNT");
+        TX_OFFSET_STRUCT_VERSION = getField("TX_OFFSET_STRUCT_VERSION");
+        TX_OFFSET_MAP_WRITER_COUNT = getField("TX_OFFSET_MAP_WRITER_COUNT");
+        TX_OFFSET_TXN_CHECK = getField("TX_OFFSET_TXN_CHECK");
+        TX_OFFSET_MIN_TIMESTAMP = getField("TX_OFFSET_MIN_TIMESTAMP");
+        TX_OFFSET_MAX_TIMESTAMP = getField("TX_OFFSET_MAX_TIMESTAMP");
+    }
+
+    private static long getField(String name) throws NoSuchFieldException, IllegalAccessException {
+        Field f = TableUtils.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.getLong(null);
+    }
+
+    public String toJson(String txPath) {
+        TxFileStruct tx = new TxFileStruct();
+
+        try (Path path = new Path()) {
+            path.put(txPath).$();
+            if (!ff.exists(path)) {
+                System.out.println("error: " + txPath + " does not exist");
+            }
+            try (MemoryMR roTxMem = Vm.getMRInstance(ff, path, ff.length(path), MemoryTag.MMAP_DEFAULT)) {
+                roTxMem.growToFileSize();
+                tx.TX_OFFSET_TXN = roTxMem.getLong(TX_OFFSET_TXN);
+                tx.TX_OFFSET_TRANSIENT_ROW_COUNT = roTxMem.getLong(TX_OFFSET_TRANSIENT_ROW_COUNT);
+                tx.TX_OFFSET_FIXED_ROW_COUNT = roTxMem.getLong(TX_OFFSET_FIXED_ROW_COUNT);
+                tx.TX_OFFSET_MIN_TIMESTAMP = roTxMem.getLong(TX_OFFSET_MIN_TIMESTAMP);
+                tx.TX_OFFSET_MAX_TIMESTAMP = roTxMem.getLong(TX_OFFSET_MAX_TIMESTAMP);
+                tx.TX_OFFSET_DATA_VERSION = roTxMem.getLong(TX_OFFSET_DATA_VERSION);
+                tx.TX_OFFSET_STRUCT_VERSION = roTxMem.getLong(TX_OFFSET_STRUCT_VERSION);
+                tx.TX_OFFSET_TXN_CHECK = roTxMem.getLong(TX_OFFSET_TXN_CHECK);
+                tx.TX_OFFSET_MAP_WRITER_COUNT = roTxMem.getInt(TX_OFFSET_MAP_WRITER_COUNT);
+                tx.TX_OFFSET_PARTITION_TABLE_VERSION = roTxMem.getLong(TX_OFFSET_PARTITION_TABLE_VERSION);
+
+                int symbolsCount = tx.TX_OFFSET_MAP_WRITER_COUNT;
+                tx.SYMBOLS = new ArrayList<>();
+                long offset = getSymbolWriterIndexOffset(0);
+                while(offset + 3 < Math.min(roTxMem.size(), getSymbolWriterIndexOffset(symbolsCount))) {
+                    TxFileStruct.SymbolInfo symbol = new TxFileStruct.SymbolInfo();
+                    tx.SYMBOLS.add(symbol);
+                    symbol.COUNT = roTxMem.getInt(offset);
+                    offset += 4;
+                    if (offset + 3 < roTxMem.size()) {
+                        symbol.UNCOMMITTED_COUNT = roTxMem.getInt(offset);
+                        offset += 4;
+                    }
+                }
+
+                int txAttachedPartitionsSize = roTxMem.getInt(getPartitionTableSizeOffset(symbolsCount)) / Long.BYTES / 4;
+                tx.ATTACHED_PARTITION_SIZE = txAttachedPartitionsSize;
+                tx.ATTACHED_PARTITIONS = new ArrayList<>();
+                offset = getPartitionTableIndexOffset(symbolsCount, 0);
+
+                while(offset + 7 < Math.min(roTxMem.size(), getPartitionTableIndexOffset(symbolsCount, txAttachedPartitionsSize * 4))) {
+                    TxFileStruct.AttachedPartition partition = new TxFileStruct.AttachedPartition();
+                    tx.ATTACHED_PARTITIONS.add(partition);
+                    partition.TS = roTxMem.getLong(offset);
+                    offset += 8;
+                    if (offset + 7 < roTxMem.size()) {
+                        partition.SIZE = roTxMem.getLong(offset);
+                        offset += 8;
+                    }
+                    if (offset + 7 < roTxMem.size()) {
+                        partition.NAME_TX = roTxMem.getLong(offset);
+                        offset += 8;
+                    }
+                    if (offset + 7 < roTxMem.size()) {
+                        partition.DATA_TX = roTxMem.getLong(offset);
+                        offset += 8;
+                    }
+                }
+            }
+        }
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(tx);
+    }
+
+    private static void printUsage() {
+        System.out.println("usage: " + TxSerializer.class.getName() + " -s <json_path> <txn_path> | -d <json_path>");
+    }
+
+    private void serializeFile(String jsonFile, String target) throws IOException {
+        String json = Files.readString(Paths.get(jsonFile), StandardCharsets.UTF_8);
+        serializeJson(json, target);
+    }
+
+
+    public void serializeJson(String json, String target) {
+        Gson des = new Gson();
+        TxFileStruct tx = des.fromJson(json, TxFileStruct.class);
+
+        if (tx.ATTACHED_PARTITION_SIZE != 0 && (tx.ATTACHED_PARTITIONS == null || tx.ATTACHED_PARTITION_SIZE != tx.ATTACHED_PARTITIONS.size())) {
+            String arraySize = tx.ATTACHED_PARTITIONS == null ? "null" : Integer.toString(tx.ATTACHED_PARTITIONS.size());
+            throw new IllegalArgumentException("ATTACHED_PARTITIONS array size of " + arraySize + " is different from ATTACHED_PARTITION_SIZE of " + tx.ATTACHED_PARTITION_SIZE );
+        }
+
+        if (tx.TX_OFFSET_MAP_WRITER_COUNT != 0 && (tx.SYMBOLS == null || tx.TX_OFFSET_MAP_WRITER_COUNT != tx.SYMBOLS.size())) {
+            String arraySize = tx.SYMBOLS == null ? "null" : Integer.toString(tx.SYMBOLS.size());
+            throw new IllegalArgumentException("SYMBOLS array size if " + arraySize + "is different from MAP_WRITER_COUNT of " + tx.TX_OFFSET_MAP_WRITER_COUNT);
+        }
+
+        long fileSize = tx.calculateFileSize();
+        try (Path path = new Path()) {
+            path.put(target).$();
+            try (MemoryCMARW rwTxMem = Vm.getSmallCMARWInstance(ff, path, MemoryTag.MMAP_DEFAULT)) {
+                Vect.memset(rwTxMem.addressOf(0), fileSize, 0);
+
+                rwTxMem.setTruncateSize(fileSize);
+                rwTxMem.putLong(TX_OFFSET_TXN, tx.TX_OFFSET_TXN);
+                rwTxMem.putLong(TX_OFFSET_TRANSIENT_ROW_COUNT, tx.TX_OFFSET_TRANSIENT_ROW_COUNT);
+                rwTxMem.putLong(TX_OFFSET_FIXED_ROW_COUNT, tx.TX_OFFSET_FIXED_ROW_COUNT);
+                rwTxMem.putLong(TX_OFFSET_MIN_TIMESTAMP, tx.TX_OFFSET_MIN_TIMESTAMP);
+                rwTxMem.putLong(TX_OFFSET_MAX_TIMESTAMP, tx.TX_OFFSET_MAX_TIMESTAMP);
+                rwTxMem.putLong(TX_OFFSET_DATA_VERSION, tx.TX_OFFSET_DATA_VERSION);
+                rwTxMem.putLong(TX_OFFSET_STRUCT_VERSION, tx.TX_OFFSET_STRUCT_VERSION);
+                rwTxMem.putLong(TX_OFFSET_TXN_CHECK, tx.TX_OFFSET_TXN_CHECK);
+                rwTxMem.putInt(TX_OFFSET_MAP_WRITER_COUNT, tx.TX_OFFSET_MAP_WRITER_COUNT);
+                rwTxMem.putLong(TX_OFFSET_PARTITION_TABLE_VERSION, tx.TX_OFFSET_PARTITION_TABLE_VERSION);
+
+                if (tx.TX_OFFSET_MAP_WRITER_COUNT != 0) {
+                    int isym = 0;
+                    for (TxFileStruct.SymbolInfo si: tx.SYMBOLS) {
+                        long offset = getSymbolWriterIndexOffset(isym++);
+                        rwTxMem.putInt(offset, si.COUNT);
+                        offset += 4;
+                        rwTxMem.putInt(offset, si.UNCOMMITTED_COUNT);
+                    }
+                }
+
+                rwTxMem.putInt(getPartitionTableSizeOffset(tx.TX_OFFSET_MAP_WRITER_COUNT), tx.ATTACHED_PARTITION_SIZE * 8 * 4);
+                if (tx.ATTACHED_PARTITION_SIZE != 0) {
+                    int ipart = 0;
+                    for (TxFileStruct.AttachedPartition part: tx.ATTACHED_PARTITIONS) {
+                        long offset = getPartitionTableIndexOffset(tx.TX_OFFSET_MAP_WRITER_COUNT, 4 * ipart++);
+                        rwTxMem.putLong(offset, part.TS);
+                        offset += 8;
+                        rwTxMem.putLong(offset, part.SIZE);
+                        offset += 8;
+                        rwTxMem.putLong(offset, part.NAME_TX);
+                        offset += 8;
+                        rwTxMem.putLong(offset, part.DATA_TX);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
+++ b/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
@@ -188,7 +188,7 @@ public class TxSerializer
     }
 
     private void serializeFile(String jsonFile, String target) throws IOException {
-        String json = Files.readString(Paths.get(jsonFile), StandardCharsets.UTF_8);
+        String json = new String(Files.readAllBytes(Paths.get(jsonFile)), StandardCharsets.UTF_8);
         serializeJson(json, target);
     }
 

--- a/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
+++ b/utils/src/main/java/io/questdb/cliutil/TxSerializer.java
@@ -26,7 +26,6 @@ package io.questdb.cliutil;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCMARW;
@@ -45,7 +44,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import static io.questdb.cairo.TableUtils.*;
-import static io.questdb.cairo.TableUtils.getPartitionTableIndexOffset;
 
 public class TxSerializer
 {
@@ -187,6 +185,7 @@ public class TxSerializer
         System.out.println("usage: " + TxSerializer.class.getName() + " -s <json_path> <txn_path> | -d <json_path>");
     }
 
+    @SuppressWarnings("ReadWriteStringCanBeUsed")
     private void serializeFile(String jsonFile, String target) throws IOException {
         String json = new String(Files.readAllBytes(Paths.get(jsonFile)), StandardCharsets.UTF_8);
         serializeJson(json, target);

--- a/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
+++ b/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cliutil;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
+import io.questdb.std.Files;
+import io.questdb.std.str.Path;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+public class TxSerializerTest {
+    @ClassRule
+    public static TemporaryFolder temp = new TemporaryFolder();
+    protected static CharSequence root;
+    private static DefaultCairoConfiguration configuration;
+    private static CairoEngine engine;
+    private static SqlCompiler compiler;
+    private static SqlExecutionContextImpl sqlExecutionContext;
+
+    @BeforeClass
+    public static void setUpStatic() {
+        seCairoStatic();
+        compiler = new SqlCompiler(engine);
+        BindVariableServiceImpl bindVariableService = new BindVariableServiceImpl(configuration);
+        sqlExecutionContext = new SqlExecutionContextImpl(
+                engine, 1, engine.getMessageBus())
+                .with(
+                        AllowAllCairoSecurityContext.INSTANCE,
+                        bindVariableService,
+                        null,
+                        -1,
+                        null);
+        bindVariableService.clear();
+    }
+
+    public static void seCairoStatic() {
+        // it is necessary to initialise logger before tests start
+        // logger doesn't relinquish memory until JVM stops
+        // which causes memory leak detector to fail should logger be
+        // created mid-test
+        try {
+            root = temp.newFolder("dbRoot").getAbsolutePath();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError();
+        }
+        configuration = new DefaultCairoConfiguration(root);
+        engine = new CairoEngine(configuration);
+    }
+
+    @AfterClass
+    public static void tearDownStatic() {
+        engine.close();
+        compiler.close();
+    }
+
+    public static void createTestPath(CharSequence root) {
+        try (Path path = new Path().of(root).$()) {
+            if (Files.exists(path)) {
+                return;
+            }
+            Files.mkdirs(path.of(root).slash$(), 509);
+        }
+    }
+
+    public static void removeTestPath(CharSequence root) {
+        Path path = Path.getThreadLocal(root);
+        Files.rmdir(path.slash$());
+    }
+
+    @Before
+    public void setUp() {
+        createTestPath(root);
+        engine.openTableId();
+        engine.resetTableId();
+    }
+
+    @After
+    public void tearDown() {
+        engine.freeTableId();
+        engine.clear();
+        removeTestPath(root);
+    }
+
+    @Test
+    public void testPartitionedDaily() throws SqlException {
+        String createTableSql = "create table xxx as (" +
+                "select " +
+                "rnd_symbol('A', 'B', 'C') as sym1," +
+                "rnd_symbol(4,4,4,2) as sym2," +
+                "x," +
+                "timestamp_sequence(0, 1000000000000) ts " +
+                "from long_sequence(10)" +
+                ") timestamp(ts) PARTITION BY DAY";
+
+        testRoundTxnSerialization(createTableSql, true);
+    }
+
+    @Test
+    public void testPartitionedNoneNoTimestamp() throws SqlException {
+        String createTableSql = "create table xxx as (" +
+                "select " +
+                "rnd_symbol('A', 'B', 'C') as sym1," +
+                "rnd_symbol(4,4,4,2) as sym2," +
+                "x," +
+                "timestamp_sequence(0, 1000000000000) ts " +
+                "from long_sequence(10)" +
+                ")";
+
+        testRoundTxnSerialization(createTableSql, true);
+    }
+
+
+    @Test
+    public void testPartitionedNoneWithTimestamp() throws SqlException {
+        String createTableSql = "create table xxx as (" +
+                "select " +
+                "rnd_symbol('A', 'B', 'C') as sym1," +
+                "rnd_symbol(4,4,4,2) as sym2," +
+                "x," +
+                "timestamp_sequence(0, 1000000000000) ts " +
+                "from long_sequence(10)" +
+                ") timestamp(ts)";
+
+        testRoundTxnSerialization(createTableSql, false);
+    }
+
+    private void testRoundTxnSerialization(String createTableSql, boolean oooSupports) throws SqlException {
+        compiler.compile(createTableSql, sqlExecutionContext);
+        assertFirstColumnValueLong("select count() from xxx", 10);
+        long symCount = getColumnValueLong("select count_distinct(sym1) from xxx");
+        long symCount2 = getColumnValueLong("select count_distinct(sym2) from xxx");
+
+        engine.releaseAllWriters();
+        engine.releaseAllReaders();
+
+        TxSerializer serializer = new TxSerializer();
+        String txPath = root + "/" + "xxx/_txn";
+        String json = serializer.toJson(txPath);
+        serializer.serializeJson(json, txPath);
+
+        // Repeat
+        String json2 = serializer.toJson(txPath);
+        Assert.assertEquals(json, json2);
+        serializer.serializeJson(json, txPath);
+
+        assertFirstColumnValueLong("select count() from xxx", 10);
+        assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
+        assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
+        assertFirstColumnValueLong("select x from xxx limit 1", 1);
+        assertFirstColumnValueLong("select x from xxx limit 5, 6", 6);
+
+        if (oooSupports) {
+            // Insert same records
+            compiler.compile("insert into xxx select * from xxx",
+                    sqlExecutionContext);
+            assertFirstColumnValueLong("select count() from xxx", 20);
+            assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
+            assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
+            assertFirstColumnValueLong("select x from xxx limit 1", 1);
+        } else {
+            compiler.compile("insert into xxx select sym1, sym2, x, dateadd('y', 1, ts) from xxx",
+                    sqlExecutionContext);
+            assertFirstColumnValueLong("select count() from xxx", 20);
+            assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
+            assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
+            assertFirstColumnValueLong("select x from xxx limit 1", 1);
+        }
+    }
+
+    private void assertFirstColumnValueLong(String sql, long expected) throws SqlException {
+        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(expected, cursor.getRecord().getLong(0));
+            }
+        }
+    }
+
+    private long getColumnValueLong(String sql) throws SqlException {
+        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Assert.assertTrue(cursor.hasNext());
+                return cursor.getRecord().getLong(0);
+            }
+        }
+    }
+}

--- a/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
+++ b/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
@@ -51,7 +51,7 @@ public class TxSerializerTest {
 
     @BeforeClass
     public static void setUpStatic() {
-        seCairoStatic();
+        setCairoStatic();
         compiler = new SqlCompiler(engine);
         BindVariableServiceImpl bindVariableService = new BindVariableServiceImpl(configuration);
         sqlExecutionContext = new SqlExecutionContextImpl(
@@ -65,7 +65,7 @@ public class TxSerializerTest {
         bindVariableService.clear();
     }
 
-    public static void seCairoStatic() {
+    public static void setCairoStatic() {
         // it is necessary to initialise logger before tests start
         // logger doesn't relinquish memory until JVM stops
         // which causes memory leak detector to fail should logger be
@@ -185,18 +185,14 @@ public class TxSerializerTest {
             // Insert same records
             compiler.compile("insert into xxx select * from xxx",
                     sqlExecutionContext);
-            assertFirstColumnValueLong("select count() from xxx", 20);
-            assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
-            assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
-            assertFirstColumnValueLong("select x from xxx limit 1", 1);
         } else {
             compiler.compile("insert into xxx select sym1, sym2, x, dateadd('y', 1, ts) from xxx",
                     sqlExecutionContext);
-            assertFirstColumnValueLong("select count() from xxx", 20);
-            assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
-            assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
-            assertFirstColumnValueLong("select x from xxx limit 1", 1);
         }
+        assertFirstColumnValueLong("select count() from xxx", 20);
+        assertFirstColumnValueLong("select count_distinct(sym1) from xxx", symCount);
+        assertFirstColumnValueLong("select count_distinct(sym2) from xxx", symCount2);
+        assertFirstColumnValueLong("select x from xxx limit 1", 1);
     }
 
     private void assertFirstColumnValueLong(String sql, long expected) throws SqlException {


### PR DESCRIPTION
# QuestDB command line utils

### TxSerializer

Serializes binary `_txn` file to / from readable JSON format. Primary usage to investigate storage issues

Usage 

```
io.questdb.cliutil.TxSerializer -d <json_path> | -s <json_path> <txn_path> 
```

- `-d` option prints contents of `_txn` file to std output in JSON format
- `-s` option transforms existing JSON file into binary _txn format