### PR TITLE
feat(sql): dump thread stacks function + changes output of dump memory usage function + added more logging

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4303,7 +4303,10 @@ public class TableWriter implements Closeable {
         final Sequence indexPubSequence = this.messageBus.getIndexerPubSequence();
         final RingQueue<ColumnIndexerTask> indexerQueue = this.messageBus.getIndexerQueue();
 
-        LOG.info().$("parallel indexing [indexCount=").$(indexCount).$(']').$();
+        LOG.info().$("parallel indexing [table=").$(tableName)
+                .$(", indexCount=").$(indexCount)
+                .$(", rowCount=").$(hi - lo)
+                .I$();
         int serialIndexCount = 0;
 
         // we are going to index last column in this thread while other columns are on the queue
@@ -4378,7 +4381,10 @@ public class TableWriter implements Closeable {
     }
 
     private void updateIndexesSerially(long lo, long hi) {
-        LOG.info().$("serial indexing [indexCount=").$(indexCount).$(']').$();
+        LOG.info().$("serial indexing [table=").$(tableName)
+                .$(", indexCount=").$(indexCount)
+                .$(", rowCount=").$(hi - lo)
+                .I$();
         for (int i = 0, n = denseIndexers.size(); i < n; i++) {
             try {
                 denseIndexers.getQuick(i).refreshSourceAndIndex(lo, hi);
@@ -4388,7 +4394,7 @@ public class TableWriter implements Closeable {
                 throwDistressException(e);
             }
         }
-        LOG.info().$("serial indexing done [indexCount=").$(indexCount).$(']').$();
+        LOG.info().$("serial indexing done [table=").$(tableName).I$();
     }
 
     private void updateIndexesSlow() {

--- a/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
+++ b/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
@@ -130,12 +130,12 @@ public class EngineMigration {
             for (int i = 1; ff.exists(toTemp.$()); i++) {
                 // if backup file already exists
                 // add .<num> at the end until file name is unique
-                LOG.info().$("back up file exists, [path=").$(toTemp).I$();
+                LOG.info().$("backup dest exists [to=").$(toTemp).I$();
                 toTemp.trimTo(copyPathLen);
                 toTemp.concat(backupName).put(".v").put(version).put(".").put(i);
             }
 
-            LOG.info().$("back up coping file [from=").$(src).$(",to=").$(toTemp).I$();
+            LOG.info().$("backing up [file=").$(src).$(",to=").$(toTemp).I$();
             if (ff.copy(src.$(), toTemp.$()) < 0) {
                 throw CairoException.instance(ff.errno()).put("Cannot backup transaction file [to=").put(toTemp).put(']');
             }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -216,10 +216,10 @@ class LineTcpConnectionContext implements IOContext, Mutable {
                     }
                 }
             } catch (CairoException ex) {
-                LOG.error().$('[').$(fd).$("] could not process line data [msg=").$(ex.getFlyweightMessage()).I$();
+                LOG.error().$('[').$(fd).$("] could not process line data [table=").$(protoParser.getMeasurementName()).$(", msg=").$(ex.getFlyweightMessage()).I$();
                 return IOContextResult.NEEDS_DISCONNECT;
             } catch (Throwable ex) {
-                LOG.error().$('[').$(fd).$("] could not process line data [ex=").$(ex).I$();
+                LOG.error().$('[').$(fd).$("] could not process line data [table=").$(protoParser.getMeasurementName()).$(", ex=").$(ex).I$();
                 return IOContextResult.NEEDS_DISCONNECT;
             }
         }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1440,7 +1440,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
         if (Chars.utf8Decode(lo, hi, e)) {
             queryText = characterStore.toImmutable();
 
-            LOG.info().$("parse [q=").utf8(queryText).$(']').$();
+            LOG.info().$("parse [fd=").$(fd).$(", q=").utf8(queryText).I$();
             compileQuery(compiler);
             return;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageFunctionFactory.java
@@ -60,7 +60,7 @@ public class DumpMemoryUsageFunctionFactory implements FunctionFactory {
     private static class DumpMemoryUsageFunction extends BooleanFunction {
         @Override
         public boolean getBool(Record rec) {
-            final LogRecord record = LOG.info();
+            final LogRecord record = LOG.advisory();
 
             record.$("\n\tTOTAL: ").$(Unsafe.getMemUsed());
             for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpThreadStacksFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpThreadStacksFunctionFactory.java
@@ -34,17 +34,19 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.log.LogRecord;
 import io.questdb.std.IntList;
-import io.questdb.std.MemoryTag;
 import io.questdb.std.ObjList;
-import io.questdb.std.Unsafe;
 
-public class DumpMemoryUsageFunctionFactory implements FunctionFactory {
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 
-    private static final Log LOG = LogFactory.getLog("dump-memory-usage");
+public class DumpThreadStacksFunctionFactory implements FunctionFactory {
+
+    private static final Log LOG = LogFactory.getLog("dump-thread-stacks");
 
     @Override
     public String getSignature() {
-        return "dump_memory_usage()";
+        return "dump_thread_stacks()";
     }
 
     @Override
@@ -54,20 +56,29 @@ public class DumpMemoryUsageFunctionFactory implements FunctionFactory {
                                 CairoConfiguration configuration,
                                 SqlExecutionContext sqlExecutionContext
     ) {
-        return new DumpMemoryUsageFunction();
+        return new DumpThreadStacksFunction();
     }
 
-    private static class DumpMemoryUsageFunction extends BooleanFunction {
+    private static class DumpThreadStacksFunction extends BooleanFunction {
         @Override
         public boolean getBool(Record rec) {
-            final LogRecord record = LOG.info();
-
-            record.$("\n\tTOTAL: ").$(Unsafe.getMemUsed());
-            for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {
-                record.$('\n').$('\t').$(MemoryTag.nameOf(i)).$(": ").$(Unsafe.getMemUsedByTag(i));
+            final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+            final ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 20);
+            // Each thread stack on its own LOG message to avoid overrunning log buffer
+            // Generally overrun will truncate the log message. We are likely to overrun considering how
+            // many threads we could be running
+            for (ThreadInfo threadInfo : threadInfos) {
+                final LogRecord record = LOG.advisory();
+                final Thread.State state = threadInfo.getThreadState();
+                record.$('\n');
+                record.$('\'').$(threadInfo.getThreadName()).$("': ").$(state);
+                final StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+                for (final StackTraceElement stackTraceElement : stackTraceElements) {
+                    record.$("\n\t\tat ").$(stackTraceElement);
+                }
+                record.$("\n\n");
+                record.$();
             }
-            record.$('\n');
-            record.$();
             return true;
         }
     }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -29,6 +29,7 @@ open module io.questdb {
     requires transitive jdk.unsupported;
     requires static org.jetbrains.annotations;
     requires static java.sql;
+    requires static java.management;
 
     uses io.questdb.griffin.FunctionFactory;
 
@@ -542,6 +543,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.TableMetadataCursorFactory,
             io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,
 //                  concat()
             io.questdb.griffin.engine.functions.str.ConcatFunctionFactory,
             // replace()

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -495,6 +495,7 @@ io.questdb.griffin.engine.functions.catalogue.RangeCatalogueFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.TableMetadataCursorFactory
 io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory
 
 # concat()
 io.questdb.griffin.engine.functions.str.ConcatFunctionFactory

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -395,47 +395,6 @@ public class PGJobContextTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testBlobOverLimit2() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (
-                    final Connection connection = getConnection(false, true)
-            ) {
-                Statement statement = connection.createStatement();
-                ResultSet rs = statement.executeQuery(
-                        "SELECT\n" +
-                                "    id,\n" +
-                                "    delivery_start_utc_symbol as y_utc_h,\n" +
-                                "    case\n" +
-                                "            --when (seller='sf' AND sell_area='10YHU-MAVIR----U') then -1.0*volume_mw\n" +
-                                "            --when (buyer='sf' AND buy_area='10YHU-MAVIR----U') then 1.0*volume_mw\n" +
-                                "            when seller='sf' then -1.0*volume_mw\n" +
-                                "            when buyer='sf' then 1.0*volume_mw\n" +
-                                "            else 0.0\n" +
-                                "        end\n" +
-                                "        as y_sf_position_mw_h\n" +
-                                "FROM (\n" +
-                                "    SELECT\n" +
-                                "        id,\n" +
-                                "        delivery_start_utc_symbol,\n" +
-                                "        seller,\n" +
-                                "        buyer,\n" +
-                                "        volume_mw\n" +
-                                "    FROM trades\n" +
-                                "    WHERE\n" +
-                                "        country = 'hu'\n" +
-                                "        AND delivery_start_utc >= '2021-09-24T18:00:44.699976+00:00'\n" +
-                                "        AND timestamp >= '2021-09-23T09:00:00.699976+00:00'\n" +
-                                "        AND product = 'hours_1'\n" +
-                                "        AND (seller = 'sf' OR buyer = 'sf'))");
-
-                assertResultSet("", sink, rs);
-            } catch (PSQLException e) {
-                TestUtils.assertContains(e.getServerErrorMessage().getMessage(), "blob is too large");
-            }
-        });
-    }
-
-    @Test
     public void testBrokenUtf8QueryInParseMessage() throws Exception {
         assertHexScript(
                 NetworkFacadeImpl.INSTANCE,

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -386,7 +386,49 @@ public class PGJobContextTest extends AbstractGriffinTest {
                                 "rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2)," +
                                 "rnd_bin(1024,2048,2) " +
                                 "from long_sequence(50)");
+
                 Assert.fail();
+            } catch (PSQLException e) {
+                TestUtils.assertContains(e.getServerErrorMessage().getMessage(), "blob is too large");
+            }
+        });
+    }
+
+    @Test
+    public void testBlobOverLimit2() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (
+                    final Connection connection = getConnection(false, true)
+            ) {
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(
+                        "SELECT\n" +
+                                "    id,\n" +
+                                "    delivery_start_utc_symbol as y_utc_h,\n" +
+                                "    case\n" +
+                                "            --when (seller='sf' AND sell_area='10YHU-MAVIR----U') then -1.0*volume_mw\n" +
+                                "            --when (buyer='sf' AND buy_area='10YHU-MAVIR----U') then 1.0*volume_mw\n" +
+                                "            when seller='sf' then -1.0*volume_mw\n" +
+                                "            when buyer='sf' then 1.0*volume_mw\n" +
+                                "            else 0.0\n" +
+                                "        end\n" +
+                                "        as y_sf_position_mw_h\n" +
+                                "FROM (\n" +
+                                "    SELECT\n" +
+                                "        id,\n" +
+                                "        delivery_start_utc_symbol,\n" +
+                                "        seller,\n" +
+                                "        buyer,\n" +
+                                "        volume_mw\n" +
+                                "    FROM trades\n" +
+                                "    WHERE\n" +
+                                "        country = 'hu'\n" +
+                                "        AND delivery_start_utc >= '2021-09-24T18:00:44.699976+00:00'\n" +
+                                "        AND timestamp >= '2021-09-23T09:00:00.699976+00:00'\n" +
+                                "        AND product = 'hours_1'\n" +
+                                "        AND (seller = 'sf' OR buyer = 'sf'))");
+
+                assertResultSet("", sink, rs);
             } catch (PSQLException e) {
                 TestUtils.assertContains(e.getServerErrorMessage().getMessage(), "blob is too large");
             }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+public class DumpMemoryUsageTest extends AbstractGriffinTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                "select dump_memory_usage",
+                sink,
+                "dump_memory_usage\n" +
+                        "true\n"
+        ));
+        // this sleep to allow async logger to print out the values,
+        // although we don't assert them it is less awkward than calling
+        // the dump and see no output in the logs
+        Thread.sleep(500);
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/DumpThreadStacksTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/DumpThreadStacksTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+public class DumpThreadStacksTest extends AbstractGriffinTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                "select dump_thread_stacks",
+                sink,
+                "dump_thread_stacks\n" +
+                        "true\n"
+        ));
+        // this sleep to allow async logger to print out the values,
+        // although we don't assert them it is less awkward than calling
+        // the dump and see no output in the logs
+        Thread.sleep(500);
+    }
+}


### PR DESCRIPTION
Added function to help user-side diagnostics. When HTTP server is responsive but we suspect high CPU utilization from one or more of our threads use the following to dump thread stacks to log:

```sql
select dump_thread_stacks
```

Sample output is:

```
2021-10-06T12:03:01.216001Z A dump-thread-stacks 
'main': RUNNABLE
		at java.management@11.0.8/sun.management.ThreadImpl.getThreadInfo1(Native Method)
		at java.management@11.0.8/sun.management.ThreadImpl.getThreadInfo(ThreadImpl.java:190)
		at app/io.questdb/io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory$DumpThreadStacksFunction.getBool(DumpThreadStacksFunctionFactory.java:66)
		at app/io.questdb/io.questdb.cairo.sql.VirtualRecord.getBool(VirtualRecord.java:59)
		at app/io.questdb/io.questdb.cairo.RecordCursorPrinter.printColumn(RecordCursorPrinter.java:174)
		at app/io.questdb/io.questdb.cairo.RecordCursorPrinter.printRecordNoNl(RecordCursorPrinter.java:110)
		at app/io.questdb/io.questdb.cairo.RecordCursorPrinter.print(RecordCursorPrinter.java:74)
		at app/io.questdb/io.questdb.cairo.RecordCursorPrinter.print(RecordCursorPrinter.java:53)
		at app/io.questdb/io.questdb.test.tools.TestUtils.printCursor(TestUtils.java:617)
		at app/io.questdb/io.questdb.test.tools.TestUtils.printSql(TestUtils.java:628)
		at app/io.questdb/io.questdb.test.tools.TestUtils.assertSql(TestUtils.java:418)
		at app/io.questdb/io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksTest.lambda$testSimple$0(DumpThreadStacksTest.java:35)
		at app/io.questdb/io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksTest$$Lambda$308/0x00000007c0280c40.run(Unknown Source)
		at app/io.questdb/io.questdb.cairo.AbstractCairoTest.lambda$assertMemoryLeak$1(AbstractCairoTest.java:176)
		at app/io.questdb/io.questdb.cairo.AbstractCairoTest$$Lambda$309/0x00000007c0287840.run(Unknown Source)
		at app/io.questdb/io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:387)
		at app/io.questdb/io.questdb.cairo.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:173)
		at app/io.questdb/io.questdb.cairo.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:168)
		at app/io.questdb/io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksTest.testSimple(DumpThreadStacksTest.java:35)
		at java.base@11.0.8/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)


2021-10-06T12:03:01.216286Z A dump-thread-stacks 
'Reference Handler': RUNNABLE
		at java.base@11.0.8/java.lang.ref.Reference.waitForReferencePendingList(Native Method)
		at java.base@11.0.8/java.lang.ref.Reference.processPendingReferences(Reference.java:241)
		at java.base@11.0.8/java.lang.ref.Reference$ReferenceHandler.run(Reference.java:213)


2021-10-06T12:03:01.216341Z A dump-thread-stacks 
'Finalizer': WAITING
		at java.base@11.0.8/java.lang.Object.wait(Native Method)
		at java.base@11.0.8/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
		at java.base@11.0.8/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:176)
		at java.base@11.0.8/java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:170)


```

I also changed output of memory diagnostic function, added by Eugene:

```sql
select dump_memory_usage
```

New sample output in log is:

```
2021-10-06T12:05:49.125414Z I dump-memory-usage 
	TOTAL: 9497088
	MMAP_DEFAULT: 65536
	NATIVE_DEFAULT: 9431552
	MMAP_O3: 0
	NATIVE_O3: 0
	NATIVE_RECORD_CHAIN: 0
	MMAP_TABLE_WRITER: 0
	NATIVE_TREE_CHAIN: 0
	MMAP_TABLE_READER: 0
	NATIVE_COMPACT_MAP: 0
	NATIVE_FAST_MAP: 0
	NATIVE_LONG_LIST: 0
	NATIVE_HTTP_CONN: 0
	NATIVE_PGW_CONN: 0
	MMAP_INDEX_READER: 0
	MMAP_INDEX_WRITER: 0
	MMAP_INDEX_SLIDER: 0
	MMAP_BLOCK_WRITER: 0

```