### PR TITLE
fix: escape table names while adding to editor

### DIFF
--- a/ui/src/scenes/Schema/Row/index.tsx
+++ b/ui/src/scenes/Schema/Row/index.tsx
@@ -115,12 +115,15 @@ const Row = ({
   tooltip,
   type,
 }: Props) => {
-  const handleClick = useCallback(
+  const handlePlusButtonClick = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation()
-      window.bus.trigger("editor.insert.column", name)
+      window.bus.trigger(
+        "editor.insert.column",
+        kind === "table" ? `'${name}'` : name,
+      )
     },
-    [name],
+    [name, kind],
   )
 
   return (
@@ -160,7 +163,7 @@ const Row = ({
           </Type>
         )}
 
-        <PlusButton onClick={handleClick} size="sm" tooltip={tooltip}>
+        <PlusButton onClick={handlePlusButtonClick} size="sm" tooltip={tooltip}>
           <CodeSSlash size="16px" />
           <span>Add</span>
         </PlusButton>


### PR DESCRIPTION
Fixes: https://github.com/questdb/questdb/issues/707

Enquote table names when clicking `</> Add` to ensure they work properly in SQL editor.

<img width="994" alt="CleanShot 2021-10-07 at 15 18 56@2x" src="https://user-images.githubusercontent.com/1871646/136420474-6fa071f3-6141-4a54-8bd2-d1bc59792878.png">
 