### PR TITLE
fix(cairo): handle OS process crash on opening txn file

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -50,7 +50,10 @@ public final class TxWriter extends TxReader implements Closeable {
         try {
             readUnchecked();
         } catch (Throwable e) {
-            close();
+            // Do not truncate in case the file cannot be read
+            txMem.close(false);
+            txMem = null;
+            super.close();
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
@@ -271,7 +271,7 @@ public class MemoryCMARWImpl extends AbstractMemoryCR implements MemoryCMARW, Me
                     memoryTag);
         } catch (Throwable e) {
             appendAddress = pageAddress + previousSize;
-            close();
+            close(false);
             throw e;
         }
         size = newSize;
@@ -305,7 +305,7 @@ public class MemoryCMARWImpl extends AbstractMemoryCR implements MemoryCMARW, Me
             this.pageAddress = TableUtils.mapRW(ff, fd, size, memoryTag);
             this.lim = pageAddress + size;
         } catch (Throwable e) {
-            close();
+            close(false);
             throw e;
         }
     }

--- a/core/src/test/java/io/questdb/cairo/TxnTest.java
+++ b/core/src/test/java/io/questdb/cairo/TxnTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cairo;
+
+import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.vm.api.MemoryMARW;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.Path;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TxnTest extends AbstractCairoTest {
+    @Test
+    public void testFailedTxWriterDoesNotCorruptTable() throws Exception {
+
+        TestUtils.assertMemoryLeak(() -> {
+            FilesFacade errorFf = new FilesFacadeImpl() {
+                @Override
+                public long mremap(long fd, long addr, long previousSize, long newSize, long offset, int mode, int memoryTag) {
+                    return -1;
+                }
+            };
+
+            FilesFacadeImpl cleanFf = new FilesFacadeImpl();
+            assertMemoryLeak(() -> {
+
+                String tableName = "txntest";
+                try (Path path = new Path()) {
+                    try (
+                            MemoryMARW mem = Vm.getCMARWInstance();
+                            TableModel ts = new TableModel(configuration, tableName, PartitionBy.DAY)
+                    ) {
+                        ts.timestamp();
+                        TableUtils.createTable(cleanFf, mem, path, configuration.getRoot(), ts, configuration.getMkDirMode(), 1);
+                    }
+                }
+
+
+                try (Path path = new Path()) {
+                    path.of(configuration.getRoot()).concat(tableName);
+                    int testPartitionCount = 3000;
+                    try (TxWriter txWriter = new TxWriter(cleanFf, path, PartitionBy.DAY)) {
+                        // Add lots of partitions
+                        for (int i = 0; i < testPartitionCount; i++) {
+                            txWriter.updatePartitionSizeByTimestamp(i * Timestamps.DAY_MICROS, i + 1);
+                        }
+                        txWriter.updateMaxTimestamp(testPartitionCount * Timestamps.DAY_MICROS + 1);
+                        txWriter.commit(CommitMode.SYNC, new ObjList<>());
+                    }
+
+                    // Reopen without OS errors
+                    try (TxWriter txWriter = new TxWriter(cleanFf, path, PartitionBy.DAY)) {
+                        // Read lots of partitions
+                        Assert.assertEquals(testPartitionCount, txWriter.getPartitionCount());
+                        for (int i = 0; i < testPartitionCount - 1; i++) {
+                            Assert.assertEquals(i + 1, txWriter.getPartitionSize(i));
+                        }
+                    }
+
+                    // Open with OS error to file extend
+                    try (TxWriter ignored = new TxWriter(errorFf, path, PartitionBy.DAY)) {
+                        Assert.fail("Should not be able to extend on opening");
+                    } catch (CairoException ex) {
+                        // expected
+                    }
+
+                    // Reopen without OS errors
+                    try (TxWriter txWriter = new TxWriter(cleanFf, path, PartitionBy.DAY)) {
+                        // Read lots of partitions
+                        Assert.assertEquals(testPartitionCount, txWriter.getPartitionCount());
+                        for (int i = 0; i < testPartitionCount - 1; i++) {
+                            Assert.assertEquals(i + 1, txWriter.getPartitionSize(i));
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+}


### PR DESCRIPTION
Closes #1427

When TxWriter fails to extend memory buffer to read whole file on opening, before reading Attached Partition section it closes file with truncate and wipes out all the partition data.

The fix will prevent truncation of the file if reading hasn't finished.