### PR TITLE
refactor(ilp): refactored UDP and TCP senders

### DIFF
--- a/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
@@ -24,7 +24,6 @@
 
 package org.questdb;
 
-import io.questdb.cutlass.line.LineUdpSender;
 import io.questdb.cutlass.line.LineTcpSender;
 import io.questdb.network.Net;
 import io.questdb.std.Rnd;
@@ -38,19 +37,20 @@ public class LineTCPSenderMain {
 
         final Rnd rnd = new Rnd();
         long start = System.nanoTime();
-        try (LineUdpSender sender = new LineTcpSender(Net.parseIPv4(hostIPv4), port, bufferCapacity)) {
+        try (LineTcpSender sender = new LineTcpSender(Net.parseIPv4(hostIPv4), port, bufferCapacity)) {
             for (int i = 0; i < count; i++) {
                 // if ((i & 0x1) == 0) {
-                    sender.metric("weather");
-                    // } else {
-                    // sender.metric("weather2");
-                    // }
+                sender.metric("weather");
+                // } else {
+                // sender.metric("weather2");
+                // }
                 sender
                         .tag("location", "london")
                         .tag("by", rnd.nextString(5))
                         .field("temp", rnd.nextPositiveLong())
                         .field("ok", rnd.nextPositiveInt())
                         .$(rnd.nextLong(5000000000000L));
+//                sender.$();
             }
             sender.flush();
         }

--- a/benchmarks/src/main/java/org/questdb/LineUDPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/LineUDPSenderMain.java
@@ -24,6 +24,7 @@
 
 package org.questdb;
 
+import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.cutlass.line.LineUdpSender;
 import io.questdb.network.Net;
 import io.questdb.std.Os;

--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2020 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line;
+
+import io.questdb.cairo.CairoException;
+import io.questdb.log.Log;
+import io.questdb.network.NetworkError;
+import io.questdb.network.NetworkFacade;
+import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.Chars;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
+import io.questdb.std.str.AbstractCharSink;
+import io.questdb.std.str.CharSink;
+
+import java.io.Closeable;
+
+public abstract class AbstractLineSender extends AbstractCharSink implements Closeable {
+    protected final int capacity;
+    protected final long fd;
+    protected final NetworkFacade nf;
+    private final long bufA;
+    private final long bufB;
+    private final long sockaddr;
+    private boolean quoted = false;
+
+    private long lo;
+    private long hi;
+    private long ptr;
+    private long lineStart;
+    private boolean hasMetric = false;
+    private boolean noFields = true;
+    private final Log log;
+
+    public AbstractLineSender(
+            int interfaceIPv4Address,
+            int sendToIPv4Address,
+            int sendToPort,
+            int bufferCapacity,
+            int ttl,
+            Log log
+    ) {
+        this(NetworkFacadeImpl.INSTANCE, interfaceIPv4Address, sendToIPv4Address, sendToPort, bufferCapacity, ttl, log);
+    }
+
+    public AbstractLineSender(
+            NetworkFacade nf,
+            int interfaceIPv4Address,
+            int sendToIPv4Address,
+            int sendToPort,
+            int capacity,
+            int ttl,
+            Log log
+    ) {
+        this.nf = nf;
+        this.capacity = capacity;
+        this.log = log;
+        sockaddr = nf.sockaddr(sendToIPv4Address, sendToPort);
+        fd = createSocket(interfaceIPv4Address, ttl, sockaddr);
+
+        bufA = Unsafe.malloc(capacity, MemoryTag.NATIVE_DEFAULT);
+        bufB = Unsafe.malloc(capacity, MemoryTag.NATIVE_DEFAULT);
+
+        lo = bufA;
+        hi = lo + capacity;
+        ptr = lo;
+        lineStart = lo;
+    }
+
+    public void $(long timestamp) {
+        put(' ').put(timestamp);
+        $();
+    }
+
+    public void $() {
+        put('\n');
+        lineStart = ptr;
+        hasMetric = false;
+        noFields = true;
+    }
+
+    @Override
+    public void close() {
+        if (nf.close(fd) != 0) {
+            log.error().$("could not close UDP socket [fd=").$(fd).$(", errno=").$(nf.errno()).$(']').$();
+        }
+        nf.freeSockAddr(sockaddr);
+        Unsafe.free(bufA, capacity, MemoryTag.NATIVE_DEFAULT);
+        Unsafe.free(bufB, capacity, MemoryTag.NATIVE_DEFAULT);
+    }
+
+    public AbstractLineSender field(CharSequence name, long value) {
+        field(name).put(value).put('i');
+        return this;
+    }
+
+    public AbstractLineSender field(CharSequence name, CharSequence value) {
+        field(name).put('"');
+        quoted = true;
+        encodeUtf8(value);
+        quoted = false;
+        put('"');
+        return this;
+    }
+
+    public AbstractLineSender field(CharSequence name, double value) {
+        field(name).put(value);
+        return this;
+    }
+
+    public AbstractLineSender field(CharSequence name, boolean value) {
+        field(name).put(value ? 't' : 'f');
+        return this;
+    }
+
+    @Override
+    public void flush() {
+        send();
+        ptr = lineStart = lo;
+    }
+
+    @Override
+    public AbstractLineSender put(CharSequence cs) {
+        int l = cs.length();
+        if (ptr + l < hi) {
+            Chars.asciiStrCpy(cs, l, ptr);
+        } else {
+            send00();
+            if (ptr + l < hi) {
+                Chars.asciiStrCpy(cs, l, ptr);
+            } else {
+                throw CairoException.instance(0).put("value too long");
+            }
+        }
+        ptr += l;
+        return this;
+    }
+
+    @Override
+    public AbstractLineSender put(char c) {
+        if (ptr >= hi) {
+            send00();
+        }
+        Unsafe.getUnsafe().putByte(ptr++, (byte) c);
+        return this;
+    }
+
+    @Override
+    public CharSink put(char[] chars, int start, int len) {
+        if (ptr + len < hi) {
+            Chars.asciiCopyTo(chars, start, len, ptr);
+        } else {
+            send00();
+            if (ptr + len < hi) {
+                Chars.asciiCopyTo(chars, start, len, ptr);
+            } else {
+                throw CairoException.instance(0).put("value too long");
+            }
+        }
+        ptr += len;
+        return this;
+    }
+
+    public AbstractLineSender metric(CharSequence metric) {
+        if (hasMetric) {
+            throw CairoException.instance(0).put("duplicate metric");
+        }
+        quoted = false;
+        hasMetric = true;
+        return put(metric);
+    }
+
+    public AbstractLineSender tag(CharSequence tag, CharSequence value) {
+        if (hasMetric) {
+            put(',').encodeUtf8(tag).put('=').encodeUtf8(value);
+            return this;
+        }
+        throw CairoException.instance(0).put("metric expected");
+    }
+
+    protected abstract long createSocket(int interfaceIPv4Address, int ttl, long sockaddr);
+
+    private CharSink field(CharSequence name) {
+        if (hasMetric) {
+            if (noFields) {
+                put(' ');
+                noFields = false;
+            } else {
+                put(',');
+            }
+
+            return encodeUtf8(name).put('=');
+        }
+        throw CairoException.instance(0).put("metric expected");
+    }
+
+    @Override
+    protected void putUtf8Special(char c) {
+        switch (c) {
+            case ' ':
+            case ',':
+            case '=':
+                if (!quoted) {
+                    put('\\');
+                }
+            default:
+                put(c);
+                break;
+            case '"':
+                if (quoted) {
+                    put('\\');
+                }
+                put('\"');
+                break;
+            case '\\':
+                put('\\').put('\\');
+                break;
+        }
+    }
+
+    private void send() {
+        if (lo < lineStart) {
+            int len = (int) (lineStart - lo);
+            sendToSocket(fd, lo, sockaddr, len);
+        }
+    }
+
+    private void send00() {
+        int len = (int) (ptr - lineStart);
+        if (len == 0) {
+            send();
+            ptr = lineStart = lo;
+        } else if (len < capacity) {
+            long target = lo == bufA ? bufB : bufA;
+            Vect.memcpy(lineStart, target, len);
+            send();
+            lineStart = lo = target;
+            ptr = target + len;
+            hi = lo + capacity;
+        } else {
+            throw NetworkError.instance(0).put("line too long");
+        }
+    }
+
+    protected abstract void sendToSocket(long fd, long lo, long sockaddr, int len);
+}

--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
@@ -28,11 +28,11 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.network.NetworkError;
 
-public class LineTcpSender extends LineUdpSender {
-    private static final Log LOG = LogFactory.getLog(LineUdpSender.class);
+public class LineTcpSender extends AbstractLineSender {
+    private static final Log LOG = LogFactory.getLog(LineTcpSender.class);
 
     public LineTcpSender(int sendToIPv4Address, int sendToPort, int bufferCapacity) {
-        super(0, sendToIPv4Address, sendToPort, bufferCapacity, 0);
+        super(0, sendToIPv4Address, sendToPort, bufferCapacity, 0, LOG);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
@@ -24,71 +24,24 @@
 
 package io.questdb.cutlass.line;
 
-import io.questdb.cairo.CairoException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.network.NetworkError;
 import io.questdb.network.NetworkFacade;
-import io.questdb.network.NetworkFacadeImpl;
-import io.questdb.std.Chars;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.Unsafe;
-import io.questdb.std.Vect;
-import io.questdb.std.str.AbstractCharSink;
-import io.questdb.std.str.CharSink;
 
-import java.io.Closeable;
+public class LineUdpSender extends AbstractLineSender {
 
-public class LineUdpSender extends AbstractCharSink implements Closeable {
     private static final Log LOG = LogFactory.getLog(LineUdpSender.class);
 
-    protected final int capacity;
-    private final long bufA;
-    private final long bufB;
-    private final long sockaddr;
-    protected final long fd;
-    protected final NetworkFacade nf;
-    private boolean quoted = false;
-
-    private long lo;
-    private long hi;
-    private long ptr;
-    private long lineStart;
-    private boolean hasMetric = false;
-    private boolean noFields = true;
-
-    public LineUdpSender(
-            int interfaceIPv4Address,
-            int sendToIPv4Address,
-            int sendToPort,
-            int bufferCapacity,
-            int ttl
-    ) {
-        this(NetworkFacadeImpl.INSTANCE, interfaceIPv4Address, sendToIPv4Address, sendToPort, bufferCapacity, ttl);
+    public LineUdpSender(int interfaceIPv4Address, int sendToIPv4Address, int sendToPort, int bufferCapacity, int ttl) {
+        super(interfaceIPv4Address, sendToIPv4Address, sendToPort, bufferCapacity, ttl, LOG);
     }
 
-    public LineUdpSender(
-            NetworkFacade nf,
-            int interfaceIPv4Address,
-            int sendToIPv4Address,
-            int sendToPort,
-            int capacity,
-            int ttl
-    ) {
-        this.nf = nf;
-        this.capacity = capacity;
-        sockaddr = nf.sockaddr(sendToIPv4Address, sendToPort);
-        fd = createSocket(interfaceIPv4Address, ttl, sockaddr);
-
-        bufA = Unsafe.malloc(capacity, MemoryTag.NATIVE_DEFAULT);
-        bufB = Unsafe.malloc(capacity, MemoryTag.NATIVE_DEFAULT);
-
-        lo = bufA;
-        hi = lo + capacity;
-        ptr = lo;
-        lineStart = lo;
+    public LineUdpSender(NetworkFacade nf, int interfaceIPv4Address, int sendToIPv4Address, int sendToPort, int capacity, int ttl) {
+        super(nf, interfaceIPv4Address, sendToIPv4Address, sendToPort, capacity, ttl, LOG);
     }
 
+    @Override
     protected long createSocket(int interfaceIPv4Address, int ttl, long sockaddr) throws NetworkError {
         long fd = nf.socketUdp();
 
@@ -107,186 +60,13 @@ public class LineUdpSender extends AbstractCharSink implements Closeable {
             nf.close(fd, LOG);
             throw NetworkError.instance(errno).put("could not set ttl [fd=").put(fd).put(", ttl=").put(ttl).put(']');
         }
-
         return fd;
     }
 
-    public void $(long timestamp) {
-        put(' ').put(timestamp);
-        $();
-    }
-
-    public void $() {
-        put('\n');
-        lineStart = ptr;
-        hasMetric = false;
-        noFields = true;
-    }
-
     @Override
-    public void close() {
-        if (nf.close(fd) != 0) {
-            LOG.error().$("could not close UDP socket [fd=").$(fd).$(", errno=").$(nf.errno()).$(']').$();
-        }
-        nf.freeSockAddr(sockaddr);
-        Unsafe.free(bufA, capacity, MemoryTag.NATIVE_DEFAULT);
-        Unsafe.free(bufB, capacity, MemoryTag.NATIVE_DEFAULT);
-    }
-
-    public LineUdpSender field(CharSequence name, long value) {
-        field(name).put(value).put('i');
-        return this;
-    }
-
-    public LineUdpSender field(CharSequence name, CharSequence value) {
-        field(name).put('"');
-        quoted = true;
-        encodeUtf8(value);
-        quoted = false;
-        put('"');
-        return this;
-    }
-
-    public LineUdpSender field(CharSequence name, double value) {
-        field(name).put(value);
-        return this;
-    }
-
-    public LineUdpSender field(CharSequence name, boolean value) {
-        field(name).put(value ? 't' : 'f');
-        return this;
-    }
-
-    @Override
-    public void flush() {
-        send();
-        ptr = lineStart = lo;
-    }
-
-    @Override
-    public LineUdpSender put(CharSequence cs) {
-        int l = cs.length();
-        if (ptr + l < hi) {
-            Chars.asciiStrCpy(cs, l, ptr);
-        } else {
-            send00();
-            if (ptr + l < hi) {
-                Chars.asciiStrCpy(cs, l, ptr);
-            } else {
-                throw CairoException.instance(0).put("value too long");
-            }
-        }
-        ptr += l;
-        return this;
-    }
-
-    @Override
-    public CharSink put(char[] chars, int start, int len) {
-        if (ptr + len < hi) {
-            Chars.asciiCopyTo(chars, start, len, ptr);
-        } else {
-            send00();
-            if (ptr + len < hi) {
-                Chars.asciiCopyTo(chars, start, len, ptr);
-            } else {
-                throw CairoException.instance(0).put("value too long");
-            }
-        }
-        ptr += len;
-        return this;
-    }
-
-    public LineUdpSender metric(CharSequence metric) {
-        if (hasMetric) {
-            throw CairoException.instance(0).put("duplicate metric");
-        }
-        quoted = false;
-        hasMetric = true;
-        return put(metric);
-    }
-
-    @Override
-    public LineUdpSender put(char c) {
-        if (ptr >= hi) {
-            send00();
-        }
-        Unsafe.getUnsafe().putByte(ptr++, (byte) c);
-        return this;
-    }
-
-    public LineUdpSender tag(CharSequence tag, CharSequence value) {
-        if (hasMetric) {
-            put(',').encodeUtf8(tag).put('=').encodeUtf8(value);
-            return this;
-        }
-        throw CairoException.instance(0).put("metric expected");
-    }
-
-    private CharSink field(CharSequence name) {
-        if (hasMetric) {
-            if (noFields) {
-                put(' ');
-                noFields = false;
-            } else {
-                put(',');
-            }
-
-            return encodeUtf8(name).put('=');
-        }
-        throw CairoException.instance(0).put("metric expected");
-    }
-
-    @Override
-    protected void putUtf8Special(char c) {
-        switch (c) {
-            case ' ':
-            case ',':
-            case '=':
-                if (!quoted) {
-                    put('\\');
-                }
-            default:
-                put(c);
-                break;
-            case '"':
-                if (quoted) {
-                    put('\\');
-                }
-                put('\"');
-                break;
-            case '\\':
-                put('\\').put('\\');
-                break;
-        }
-    }
-
-    private void send() {
-        if (lo < lineStart) {
-            int len = (int) (lineStart - lo);
-            sendToSocket(fd, lo, sockaddr, len);
-        }
-    }
-
     protected void sendToSocket(long fd, long lo, long sockaddr, int len) throws NetworkError {
         if (nf.sendTo(fd, lo, len, sockaddr) != len) {
             throw NetworkError.instance(nf.errno()).put("send error");
-        }
-    }
-
-    private void send00() {
-        int len = (int) (ptr - lineStart);
-        if (len == 0) {
-            send();
-            ptr = lineStart = lo;
-        } else if (len < capacity) {
-            long target = lo == bufA ? bufB : bufA;
-            Vect.memcpy(lineStart, target, len);
-            send();
-            lineStart = lo = target;
-            ptr = target + len;
-            hi = lo + capacity;
-        } else {
-            throw NetworkError.instance(0).put("line too long");
         }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserSupport.java
@@ -187,7 +187,7 @@ public class LineUdpParserSupport {
         int valueLen = value.length();
         if (valueLen > 0) {
             char first = value.charAt(0);
-            char last = value.charAt(valueLen - 1); // see LineUdpSender.field methods
+            char last = value.charAt(valueLen - 1); // see AbstractLineSender.field methods
             switch (last) {
                 case 'i':
                     if (valueLen > 3 && value.charAt(0) == '0' && value.charAt(1) == 'x') {

--- a/core/src/test/java/io/questdb/cutlass/line/AuthenticatedLineTcpSender.java
+++ b/core/src/test/java/io/questdb/cutlass/line/AuthenticatedLineTcpSender.java
@@ -36,7 +36,7 @@ import java.security.*;
 import java.util.Base64;
 
 public class AuthenticatedLineTcpSender extends LineTcpSender {
-    private static final Log LOG = LogFactory.getLog(LineUdpSender.class);
+    private static final Log LOG = LogFactory.getLog(AbstractLineSender.class);
     private static final long BUF_SZ = 1024;
     private final byte[] keyIdBytes;
     private final PrivateKey privateKey;
@@ -115,11 +115,6 @@ public class AuthenticatedLineTcpSender extends LineTcpSender {
             throw NetworkError.instance(nf.errno()).put("send error");
         }
         LOG.info().$("authenticated").$();
-    }
-
-    @Override
-    protected void sendToSocket(long fd, long lo, long sockaddr, int len) throws NetworkError {
-        super.sendToSocket(fd, lo, sockaddr, len);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -31,8 +31,8 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.ReaderOutOfDateException;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.cutlass.line.AuthenticatedLineTcpSender;
-import io.questdb.cutlass.line.LineUdpSender;
 import io.questdb.cutlass.line.LineTcpSender;
 import io.questdb.griffin.CompiledQuery;
 import io.questdb.griffin.SqlCompiler;
@@ -63,7 +63,6 @@ import org.junit.Test;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
-import java.sql.Time;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
@@ -192,7 +191,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                         "weather windspeed=4.0 631170000000000000\n";
 
         runInContext((receiver) -> {
-            send(receiver, lineData, "weather", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "weather");
 
             String expected =
                     "windspeed\ttimestamp\ttimetocycle\n" +
@@ -212,7 +211,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                         "weather windspeed=4.0 631170000000000000\n";
 
         runInContext((receiver) -> {
-            send(receiver, lineData, "weather", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "weather");
 
             String expected =
                     "windspeed\ttimestamp\ttimetocycle\n" +
@@ -233,7 +232,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                         "weather dir=\"SSW\",windspeed=4.0 631170000000000000\n";
 
         runInContext((receiver) -> {
-            send(receiver, lineData, "weather", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "weather");
 
             String expected =
                     "dir\twindspeed\ttimestamp\ttimetocycle\n" +
@@ -369,7 +368,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                     "plug,room=6A watts=\"3188\" 1631817599910\n" +
                     "plug,room=6A watts=\"3180\" 1631817902842\n" +
                     "plug,label=Power,room=6A watts=\"475\" 1631817478737\n";
-            send(receiver, lineData, "plug", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "plug");
 
             String expected = "room\twatts\ttimestamp\tlabel\n" +
                     "6A\t3195\t1970-01-01T00:27:11.817296Z\t\n" +
@@ -387,7 +386,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
         runInContext((receiver) -> {
             String lineData = "plug,room=6A watts=\"1\" 2631819999000\n" +
                     "plug,label=Power,room=6B watts=\"22\" 1631817902842\n";
-            send(receiver, lineData, "plug", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "plug");
 
             String expected = "room\twatts\ttimestamp\tlabel\n" +
                     "6B\t22\t1970-01-01T00:27:11.817902Z\tPower\n" +
@@ -403,7 +402,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
             String lineData = "plug,room=6A watts=\"1\" 2631819999000\n" +
                     "plug,label=Power,room=6B watts=\"22\" 1631817902842\n" +
                     "plug,label=Line,room=6C watts=\"333\" 1531817902842\n";
-            send(receiver, lineData, "plug", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "plug");
 
             String expected = "room\twatts\ttimestamp\tlabel\n" +
                     "6C\t333\t1970-01-01T00:25:31.817902Z\tLine\n" +
@@ -447,7 +446,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                                     "weather windspeed=2.0 631152000000000000\n" +
                                     "weather timetocycle=0.0,windspeed=3.0 631160000000000000\n" +
                                     "weather windspeed=4.0 631170000000000000\n";
-                    send(receiver, lineData, "weather", WAIT_ENGINE_TABLE_RELEASE, false);
+                    sendLinger(receiver, lineData, "weather");
                 });
 
                 try (RecordCursor cursor = cursorFactory.getCursor(sqlExecutionContext)) {
@@ -484,7 +483,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
         String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
 
         runInContext((receiver) -> {
-            send(receiver, lineData, "table_a", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "table_a");
 
             String expected = "ReceiveTime\tSequenceNumber\tMessageType\tLength\ttest\n" +
                     "2016-06-13T17:43:50.100400Z\t1\tB\t92\t1.5\n";
@@ -516,7 +515,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                                 "up in=2.0 631152000000000000\n" +
                                 "up in=3.0 631160000000000000\n" +
                                 "up in=4.0 631170000000000000\n";
-                send(receiver, lineData, "up", WAIT_ENGINE_TABLE_RELEASE, false);
+                sendLinger(receiver, lineData, "up");
             });
 
             TestUtils.assertSql(compiler, sqlExecutionContext, "up", sink, expected);
@@ -530,7 +529,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                 "tag_n_7=7,tag_n_8=8,tag_n_9=9,tag_n_10=10,tag_n_11=11,tag_n_12=12,tag_n_13=13," +
                 "tag_n_14=14,tag_n_15=15,tag_n_16=16,tag_n_17=17 value=42.4 1619509249714000000\n";
         runInContext((receiver) -> {
-            send(receiver, lineData, "tableCRASH", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "tableCRASH");
 
             String expected = "tag_n_1\ttag_n_2\ttag_n_3\ttag_n_4\ttag_n_5\ttag_n_6\ttag_n_7\ttag_n_8\ttag_n_9\ttag_n_10\ttag_n_11\ttag_n_12\ttag_n_13\ttag_n_14\ttag_n_15\ttag_n_16\ttag_n_17\tvalue\ttimestamp\n" +
                     "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14\t15\t16\t17\t42.400000000000006\t2021-04-27T07:40:49.714000Z\n";
@@ -549,7 +548,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                 + "tab ts_nsec=5555555555555555555i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
                 + "tab ts_nsec=6666666666666666666i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n";
         runInContext((receiver) -> {
-            send(receiver, lineData, "tab", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "tab");
 
             String expected = "ts_nsec\traw_msg\ttimestamp\n" +
                     "1111111111111111111\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
@@ -565,8 +564,8 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
     @Test
     public void testFieldWithUnquotedString() throws Exception {
         runInContext((receiver) -> {
-            send(receiver,  "tab raw_msg=____ 1619509249714000000\n", "tab", WAIT_ENGINE_TABLE_RELEASE, false);
-            send(receiver,  "tab raw_msg=__\"_ 1619509249714000000\n", "tab", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver,  "tab raw_msg=____ 1619509249714000000\n", "tab");
+            sendLinger(receiver,  "tab raw_msg=__\"_ 1619509249714000000\n", "tab");
 
             String expected = "raw_msg\ttimestamp\n" +
                     "____\t2021-04-27T07:40:49.714000Z\n" +
@@ -589,10 +588,10 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
 
         runInContext((receiver) -> {
             String lineData = "लаблअца поле=\"значение\" 1619509249714000000\n";
-            send(receiver, lineData, "लаблअца", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "लаблअца");
 
             String lineData2 = "लаблअца,символ=значение2 поле=\"значение3\" 1619509249714000000\n";
-            send(receiver, lineData2, "लаблअца", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData2, "लаблअца");
 
             assertTable("символ\tполе\tвремя\n" +
                     "\tзначение\t2021-04-27T07:40:49.714000Z\n" +
@@ -604,10 +603,10 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
     public void testUnicodeTableNameExistingTable() throws Exception {
         runInContext((receiver) -> {
             String lineData = "लаблअца поле=значение 1619509249714000000\n";
-            send(receiver, lineData, "लаблअца", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "लаблअца");
 
             String lineData2 = "लаблअца,символ=значение2  1619509249714000000\n";
-            send(receiver, lineData2, "लаблअца", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData2, "लаблअца");
 
             String expected = "поле\ttimestamp\tсимвол\n" +
                     "значение\t2021-04-27T07:40:49.714000Z\t\n" +
@@ -775,7 +774,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
             };
 
             String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
-            send(receiver, lineData, "table_a", WAIT_ENGINE_TABLE_RELEASE, false);
+            sendLinger(receiver, lineData, "table_a");
 
             String expected = "ReceiveTime\tSequenceNumber\tMessageType\tLength\n";
             assertTable(expected, "table_a");
@@ -938,15 +937,11 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
     }
 
     private void send(LineTcpReceiver receiver, String lineData, String tableName, int wait) {
-        send(receiver, tableName, wait, () -> {
-            sendToSocket(lineData, true);
-        });
+        send(receiver, tableName, wait, () -> sendToSocket(lineData, true));
     }
 
-    private void send(LineTcpReceiver receiver, String lineData, String tableName, int wait, boolean nolinger) {
-        send(receiver, tableName, wait, () -> {
-            sendToSocket(lineData, nolinger);
-        });
+    private void sendLinger(LineTcpReceiver receiver, String lineData, String tableName) {
+        send(receiver, tableName, LineTcpReceiverTest.WAIT_ENGINE_TABLE_RELEASE, () -> sendToSocket(lineData, false));
     }
 
     public static final int WAIT_NO_WAIT = 0;
@@ -1070,7 +1065,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                 sharedWorkerPool.start(LOG);
 
                 try {
-                    final LineUdpSender[] senders = new LineUdpSender[tables.size()];
+                    final AbstractLineSender[] senders = new AbstractLineSender[tables.size()];
                     for (int n = 0; n < senders.length; n++) {
                         if (null != authKeyId) {
                             AuthenticatedLineTcpSender sender = new AuthenticatedLineTcpSender(
@@ -1094,7 +1089,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                     StringSink tsSink = new StringSink();
                     for (int nRow = 0; nRow < nRows; nRow++) {
                         int nTable = nRow < tables.size() ? nRow : rand.nextInt(tables.size());
-                        LineUdpSender sender = senders[nTable];
+                        AbstractLineSender sender = senders[nTable];
                         StringBuilder sb = expectedSbs[nTable];
                         CharSequence tableName = tables.get(nTable);
                         sender.metric(tableName);
@@ -1120,7 +1115,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                     }
 
                     for (int n = 0; n < senders.length; n++) {
-                        LineUdpSender sender = senders[n];
+                        AbstractLineSender sender = senders[n];
                         sender.close();
                     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertOtherTypesTest.java
@@ -25,7 +25,7 @@
 package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.*;
-import io.questdb.cutlass.line.LineUdpSender;
+import io.questdb.cutlass.line.AbstractLineSender;
 import org.junit.Test;
 
 
@@ -798,7 +798,7 @@ public class LineUdpInsertOtherTypesTest extends LineUdpInsertTest {
         assertType(tableName, targetColumnName, columnType, expected, sender -> {
             long ts = 0L;
             for (int i = 0; i < values.length; i++) {
-                ((LineUdpSender) sender.metric(tableName).put(' ')
+                ((AbstractLineSender) sender.metric(tableName).put(' ')
                         .encodeUtf8(targetColumnName)) // this method belongs to a super class that returns this
                         .put('=')
                         .put(values[i]) // field method decorates this token, I want full control

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.PoolListener;
+import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.cutlass.line.LineUdpSender;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.network.Net;
@@ -54,7 +55,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
         return lpr;
     }
 
-    protected static LineUdpSender createLineProtoSender() {
+    protected static AbstractLineSender createLineProtoSender() {
         return new LineUdpSender(NetworkFacadeImpl.INSTANCE, 0, LOCALHOST, PORT, 1024, 1);
     }
 
@@ -79,7 +80,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                                      String targetColumnName,
                                      int columnType,
                                      String expected,
-                                     Consumer<LineUdpSender> senderConsumer,
+                                     Consumer<AbstractLineSender> senderConsumer,
                                      String... expectedExtraStringColumns) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (CairoEngine engine = new CairoEngine(configuration)) {
@@ -96,7 +97,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                         }
                     }
                     receiver.start();
-                    try (LineUdpSender sender = createLineProtoSender()) {
+                    try (AbstractLineSender sender = createLineProtoSender()) {
                         senderConsumer.accept(sender);
                         sender.flush();
                     }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserSupportTest.java
@@ -26,7 +26,7 @@ package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.PoolListener;
-import io.questdb.cutlass.line.LineUdpSender;
+import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.Chars;
 import io.questdb.std.Os;
@@ -256,7 +256,7 @@ public class LineUdpParserSupportTest extends LineUdpInsertTest {
     private void testColumnType(int columnType,
                                 int geoHashColumnBits,
                                 String expected,
-                                Consumer<LineUdpSender> senderConsumer) throws Exception {
+                                Consumer<AbstractLineSender> senderConsumer) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (CairoEngine engine = new CairoEngine(configuration)) {
                 final SOCountDownLatch waitForData = new SOCountDownLatch(1);
@@ -273,7 +273,7 @@ public class LineUdpParserSupportTest extends LineUdpInsertTest {
                                 .timestamp());
                     }
                     receiver.start();
-                    try (LineUdpSender sender = createLineProtoSender()) {
+                    try (AbstractLineSender sender = createLineProtoSender()) {
                         senderConsumer.accept(sender);
                         sender.flush();
                     }


### PR DESCRIPTION
to avoid confusing inheritance, TCP inherited UPD. It wasn't clear at all in what way these are siblings. They now inherit common sender, which is Sink.

This refactoring was triggered by this code line:

```
LineUdpSender sender = new LineTcpSender(..)
```