### PR TITLE
Make refresh button execute correct query

### DIFF
--- a/ui/src/scenes/Editor/Ace/index.tsx
+++ b/ui/src/scenes/Editor/Ace/index.tsx
@@ -128,8 +128,6 @@ const Ace = () => {
         : getQueryRequestFromEditor(editor)
 
       if (request?.query) {
-        setLastExecutedQuery(request.query)
-
         void quest
           .queryRaw(request.query, { limit: "0,1000" })
           .then((result) => {
@@ -155,6 +153,7 @@ const Ace = () => {
             }
 
             if (result.type === QuestDB.Type.DQL) {
+              setLastExecutedQuery(request.query)
               dispatch(
                 actions.query.addNotification({
                   content: (
@@ -216,7 +215,7 @@ const Ace = () => {
         dispatch(actions.query.stopRunning())
       }
     }
-  }, [quest, dispatch, running, lastExecutedQuery])
+  }, [quest, dispatch, running])
 
   useEffect(() => {
     if (!aceEditor.current) {

--- a/ui/src/scenes/Editor/Ace/utils.ts
+++ b/ui/src/scenes/Editor/Ace/utils.ts
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 import * as ace from "ace-builds"
+import { IAceEditor } from "react-ace/lib/types"
 
 type Position = Readonly<{
   column: number
@@ -168,6 +169,25 @@ export const getQueryFromSelection = (
       row: start.row,
       column: start.column,
     }
+  }
+}
+
+export const getQueryRequestFromEditor = (
+  e: IAceEditor,
+): Request | undefined => {
+  if (e.getSelectedText().length === 0) {
+    return getQueryFromCursor(e)
+  }
+  return getQueryFromSelection(e)
+}
+
+export const getQueryRequestFromLastExecutedQuery = (
+  query: string,
+): Request | undefined => {
+  return {
+    query,
+    row: 0,
+    column: 0,
   }
 }
 

--- a/ui/src/scenes/Editor/Menu/index.tsx
+++ b/ui/src/scenes/Editor/Menu/index.tsx
@@ -157,14 +157,14 @@ const Menu = () => {
 
   return (
     <Wrapper _display={sm ? "none" : "inline"}>
-      {running && (
+      {running.value && (
         <ErrorButton onClick={handleClick}>
           <Stop size="18px" />
           <span>Cancel</span>
         </ErrorButton>
       )}
 
-      {!running && (
+      {!running.value && (
         <SuccessButton onClick={handleClick} title="Ctrl+Enter">
           <Play size="18px" />
           <span>Run</span>

--- a/ui/src/store/Query/actions.ts
+++ b/ui/src/store/Query/actions.ts
@@ -62,8 +62,11 @@ const stopRunning = (): QueryAction => ({
   type: QueryAT.STOP_RUNNING,
 })
 
-const toggleRunning = (): QueryAction => ({
+const toggleRunning = (isRefresh = false): QueryAction => ({
   type: QueryAT.TOGGLE_RUNNING,
+  payload: {
+    isRefresh,
+  },
 })
 
 export default {

--- a/ui/src/store/Query/reducers.ts
+++ b/ui/src/store/Query/reducers.ts
@@ -26,7 +26,10 @@ import { QueryAction, QueryAT, QueryStateShape } from "types"
 
 export const initialState: QueryStateShape = {
   notifications: [],
-  running: false,
+  running: {
+    value: false,
+    isRefresh: false,
+  },
   maxNotifications: 20,
 }
 
@@ -71,14 +74,20 @@ const query = (state = initialState, action: QueryAction): QueryStateShape => {
     case QueryAT.STOP_RUNNING: {
       return {
         ...state,
-        running: false,
+        running: {
+          value: false,
+          isRefresh: false,
+        },
       }
     }
 
     case QueryAT.TOGGLE_RUNNING: {
       return {
         ...state,
-        running: !state.running,
+        running: {
+          value: !state.running.value,
+          isRefresh: action.payload.isRefresh,
+        },
       }
     }
 

--- a/ui/src/store/Query/selectors.ts
+++ b/ui/src/store/Query/selectors.ts
@@ -22,7 +22,7 @@
  *
  ******************************************************************************/
 
-import { NotificationShape, StoreShape } from "types"
+import { NotificationShape, RunningShape, StoreShape } from "types"
 import type { QueryRawResult } from "utils/questdb"
 
 const getNotifications: (store: StoreShape) => NotificationShape[] = (store) =>
@@ -31,7 +31,7 @@ const getNotifications: (store: StoreShape) => NotificationShape[] = (store) =>
 const getResult: (store: StoreShape) => undefined | QueryRawResult = (store) =>
   store.query.result
 
-const getRunning: (store: StoreShape) => boolean = (store) =>
+const getRunning: (store: StoreShape) => RunningShape = (store) =>
   store.query.running
 
 export default {

--- a/ui/src/store/Query/types.ts
+++ b/ui/src/store/Query/types.ts
@@ -40,10 +40,15 @@ export type NotificationShape = Readonly<{
   type: NotificationType
 }>
 
+export type RunningShape = Readonly<{
+  value: boolean
+  isRefresh: boolean
+}>
+
 export type QueryStateShape = Readonly<{
   notifications: NotificationShape[]
   result?: QueryRawResult
-  running: boolean
+  running: RunningShape
   maxNotifications: number
 }>
 
@@ -81,6 +86,9 @@ type StopRunningAction = Readonly<{
 
 type ToggleRunningAction = Readonly<{
   type: QueryAT.TOGGLE_RUNNING
+  payload: Readonly<{
+    isRefresh: boolean
+  }>
 }>
 
 export type QueryAction =


### PR DESCRIPTION
I'm new to the project, so any suggestion would be appreciated. In case of complex discussions, I guess it would be better to chat on Slack.

This PR is a first approach to https://github.com/questdb/questdb/issues/1482. Looking at the code I found two approaches:
- `grid.js` having the responsibility of the last executed query (DISCARDED)
 The idea was to include a `lastQuery` parameter similar to the current `query` variable, which stores the last executed query.  However, this is discarded because the process of running the actual query happens in the editor.

- Editor storing the last executed query (IMPLEMENTED)
 In this approach, `grid.js` simply executes whatever query is passed and the responsibility is only on the editor side.
  
   Both running a new query and refreshing the current one depend on the `running` state, so I have included a new flag `isRefresh`.   It is also possible to keep this parameter in a different state action (even within the component, avoiding using Redux), but we would have to set the `running` and `isRefresh` parameters separately… I wonder if it would create any race condition in the future. Something like: 
```
 setIsRefresh(true); 
toggleRunning(); 
```
In order to retrieve the last executed query, my first idea was to use the notifications log, but we are storing React components, so it would more difficult to get the query string. Therefore, I have created a new variable `lastExecutedQuery`. 