### PR TITLE
chore(sql): improve strpos function

### DIFF
--- a/benchmarks/src/main/java/org/questdb/StrPosBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/StrPosBenchmark.java
@@ -71,7 +71,9 @@ public class StrPosBenchmark {
         for (int i = 0; i < N; i++) {
             builder.setLength(0);
             int startLen = rnd.nextInt(32);
-            builder.append("a".repeat(startLen));
+            for (int j = 0; j < startLen; j++) {
+                builder.append('a');
+            }
             builder.append(",b");
             strings[i] = builder.toString();
         }

--- a/benchmarks/src/main/java/org/questdb/StrPosBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/StrPosBenchmark.java
@@ -26,13 +26,12 @@ package org.questdb;
 
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.CharFunction;
 import io.questdb.griffin.engine.functions.StrFunction;
-import io.questdb.griffin.engine.functions.constants.CharConstant;
 import io.questdb.griffin.engine.functions.str.StrPosCharFunctionFactory;
 import io.questdb.griffin.engine.functions.str.StrPosFunctionFactory;
 import io.questdb.std.Rnd;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -49,14 +48,15 @@ public class StrPosBenchmark {
 
     private final Record[] records;
     private final String[] strings;
-    private final Function strposStrFunc;
-    private final Function strposCharFunc;
+    private final Function strFunc;
+    private final Function strConstFunc;
+    private final Function charFunc;
+    private final Function charConstFunc;
     private final Rnd rnd = new Rnd();
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .include(StrPosBenchmark.class.getSimpleName())
-                .addProfiler(GCProfiler.class)
                 .warmupIterations(2)
                 .measurementIterations(3)
                 .forks(1)
@@ -70,10 +70,8 @@ public class StrPosBenchmark {
         strings = new String[N];
         for (int i = 0; i < N; i++) {
             builder.setLength(0);
-            int startLen = rnd.nextInt(1000);
-            for (int j = 0; j < startLen; j++) {
-                builder.append('a');
-            }
+            int startLen = rnd.nextInt(32);
+            builder.append("a".repeat(startLen));
             builder.append(",b");
             strings[i] = builder.toString();
         }
@@ -89,7 +87,7 @@ public class StrPosBenchmark {
             };
         }
 
-        Function strFunc = new StrFunction() {
+        final Function strInputFunc = new StrFunction() {
             @Override
             public CharSequence getStr(Record rec) {
                 return rec.getStr(0);
@@ -100,9 +98,28 @@ public class StrPosBenchmark {
                 return rec.getStr(0);
             }
         };
-        Function substrFunc = new CharConstant(',');
-        strposStrFunc = new StrPosFunctionFactory.Func(strFunc, substrFunc);
-        strposCharFunc = new StrPosCharFunctionFactory.Func(strFunc, substrFunc);
+        final Function substrStrInputFunc = new StrFunction() {
+            @Override
+            public CharSequence getStr(Record rec) {
+                return ",";
+            }
+
+            @Override
+            public CharSequence getStrB(Record rec) {
+                return ",";
+            }
+        };
+        final Function substrCharInputFunc = new CharFunction() {
+            @Override
+            public char getChar(Record rec) {
+                return ',';
+            }
+        };
+
+        strFunc = new StrPosFunctionFactory.Func(strInputFunc, substrStrInputFunc);
+        strConstFunc = new StrPosFunctionFactory.ConstFunc(strInputFunc, ",");
+        charFunc = new StrPosCharFunctionFactory.Func(strInputFunc, substrCharInputFunc);
+        charConstFunc = new StrPosCharFunctionFactory.ConstFunc(strInputFunc, ',');
     }
 
     @Benchmark
@@ -113,12 +130,24 @@ public class StrPosBenchmark {
     @Benchmark
     public int testStrOverload() {
         int i = rnd.nextInt(N);
-        return strposStrFunc.getInt(records[i]);
+        return strFunc.getInt(records[i]);
+    }
+
+    @Benchmark
+    public int testStrConstOverload() {
+        int i = rnd.nextInt(N);
+        return strConstFunc.getInt(records[i]);
     }
 
     @Benchmark
     public int testCharOverload() {
         int i = rnd.nextInt(N);
-        return strposCharFunc.getInt(records[i]);
+        return charFunc.getInt(records[i]);
+    }
+
+    @Benchmark
+    public int testCharConstOverload() {
+        int i = rnd.nextInt(N);
+        return charConstFunc.getInt(records[i]);
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/str/StrPosFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/str/StrPosFunctionFactoryTest.java
@@ -30,29 +30,103 @@ import org.junit.Test;
 public class StrPosFunctionFactoryTest extends AbstractGriffinTest {
 
     @Test
-    public void testSimple() throws Exception {
+    public void testVarStr() throws Exception {
         assertQuery(
                 "substr\tstr\tstrpos\n" +
                         "XYZ\tABC XYZ XYZ\t5\n" +
-                        "C\tXYZ\t0\n" +
+                        "\tXYZ\tNaN\n" +
+                        "\tXYZ\tNaN\n" +
                         "C\tXYW\t0\n" +
                         "C\tXYW\t0\n" +
-                        "XYZ\tABC XYZ XYZ\t5\n" +
-                        "XYZ\tXYZ\t1\n" +
-                        "C\tXYZ\t0\n" +
+                        "\tABC XYZ XYZ\tNaN\n" +
+                        "C\tXYW\t0\n" +
                         "XYZ\tXYZ\t1\n" +
                         "C\tABC XYZ XYZ\t3\n" +
-                        "XYZ\tABC XYZ XYZ\t5\n" +
                         "C\tXYZ\t0\n" +
-                        "C\tABC XYZ XYZ\t3\n" +
-                        "XYZ\tABC XYZ XYZ\t5\n" +
-                        "XYZ\tXYW\t0\n" +
-                        "XYZ\tXYZ\t1\n",
+                        "XYZ\t\tNaN\n" +
+                        "\tABC XYZ XYZ\tNaN\n" +
+                        "C\t\tNaN\n" +
+                        "C\tXYW\t0\n" +
+                        "XYZ\t\tNaN\n",
                 "select substr,str,strpos(str,substr) from x",
                 "create table x as (" +
-                        "select rnd_str('ABC XYZ XYZ','XYZ','XYW') as str\n" +
-                        ", rnd_str('XYZ','C') as substr\n" +
+                        "select rnd_str('ABC XYZ XYZ','XYZ','XYW',NULL) as str\n" +
+                        ", rnd_str('XYZ','C',NULL) as substr\n" +
                         "from long_sequence(15)" +
+                        ")",
+                null,
+                true,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testVarStrConstSubstr() throws Exception {
+        assertQuery(
+                "str\tstrpos\n" +
+                        "ABC XYZ XYZ\t5\n" +
+                        "ABC XYZ XYZ\t5\n" +
+                        "XYZ\t1\n" +
+                        "XYW\t0\n" +
+                        "XYW\t0\n",
+                "select str,strpos(str,'XYZ') from x",
+                "create table x as (" +
+                        "select rnd_str('ABC XYZ XYZ','XYZ','XYW') as str\n" +
+                        "from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testVarChar() throws Exception {
+        assertQuery(
+                "substr\tstr\tstrpos\n" +
+                        "T\tTEST\t1\n" +
+                        "W\tA X X\t0\n" +
+                        "P\tA X X\t0\n" +
+                        "W\tCDE\t0\n" +
+                        "Y\tCDE\t0\n" +
+                        "X\tTEST\t0\n" +
+                        "E\tCDE\t3\n" +
+                        "N\tA X X\t0\n" +
+                        "X\tTEST\t0\n" +
+                        "Z\tA X X\t0\n" +
+                        "X\t\tNaN\n" +
+                        "X\tTEST\t0\n" +
+                        "B\t\tNaN\n" +
+                        "T\tCDE\t0\n" +
+                        "P\t\tNaN\n",
+                "select substr,str,strpos(str,substr) from x",
+                "create table x as (" +
+                        "select rnd_str('TEST','A X X','CDE',NULL) as str\n" +
+                        ", rnd_char() as substr\n" +
+                        "from long_sequence(15)" +
+                        ")",
+                null,
+                true,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testVarCharConstSubstr() throws Exception {
+        assertQuery(
+                "str\tstrpos\n" +
+                        "ABC XYZ XYZ\t3\n" +
+                        "ABC XYZ XYZ\t3\n" +
+                        "CBA\t1\n" +
+                        "XYZ\t0\n" +
+                        "XYZ\t0\n",
+                "select str,strpos(str,'C') from x",
+                "create table x as (" +
+                        "select rnd_str('ABC XYZ XYZ','CBA','XYZ') as str\n" +
+                        "from long_sequence(5)" +
                         ")",
                 null,
                 true,
@@ -64,9 +138,9 @@ public class StrPosFunctionFactoryTest extends AbstractGriffinTest {
     @Test
     public void testConstantNull() throws Exception {
         assertQuery(
-                "pos1\tpos2\n" +
-                        "NaN\tNaN\n",
-                "select strpos(null,'a') pos1, strpos('a',null) pos2",
+                "pos1\tpos2\tpos3\n" +
+                        "NaN\tNaN\tNaN\n",
+                "select strpos(null,'a') pos1, strpos(null,'abc') pos2, strpos('a',null) pos3",
                 null,
                 null,
                 true,


### PR DESCRIPTION
A follow-up for #1506

Includes the following:
* Introduces const variations for strpos functions since it's going to be a popular case for users
* Adds missing checks for zero char into `StrPosCharFunctionFactory`
* Adds tests to cover new code
* Updates the strpos benchmark

Results on my local (Ubuntu 20.04, OpenJDK 11.0.11):
```
Benchmark                              Mode  Cnt    Score     Error  Units
StrPosBenchmark.testBaseline           avgt    3   11.539 ±   0.596  ns/op
StrPosBenchmark.testCharConstOverload  avgt    3  504.146 ± 230.001  ns/op
StrPosBenchmark.testCharOverload       avgt    3  509.196 ±  62.726  ns/op
StrPosBenchmark.testStrConstOverload   avgt    3  567.364 ±  60.399  ns/op
StrPosBenchmark.testStrOverload        avgt    3  540.781 ±  75.134  ns/op
```

P.S. The results are more or less close to each other. What seems weird is the slightly higher error rate in `testCharConstOverload`, but not that it's something critical.