### PR TITLE
fix(cairo): fix mmap offset page alignment in o3

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -476,6 +476,7 @@ public final class TableUtils {
      * Important note. Linux requires the offset to be page aligned.
      */
     public static long mapRO(FilesFacade ff, long fd, long size, long offset, int memoryTag) {
+        assert offset % ff.getPageSize() == 0;
         final long address = ff.mmap(fd, size, offset, Files.MAP_RO, memoryTag);
         if (address == FilesFacade.MAP_FAILED) {
             throw CairoException.instance(ff.errno())
@@ -500,6 +501,7 @@ public final class TableUtils {
      * Important note. Linux requires the offset to be page aligned.
      */
     public static long mapRW(FilesFacade ff, long fd, long size, long offset, int memoryTag) {
+        assert offset % ff.getPageSize() == 0;
         allocateDiskSpace(ff, fd, size + offset);
         long addr = ff.mmap(fd, size, offset, Files.MAP_RW, memoryTag);
         if (addr > -1) {

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -470,12 +470,18 @@ public final class TableUtils {
         return mapRO(ff, fd, size, 0, memoryTag);
     }
 
+    /**
+     * Maps a file in read-only mode.
+     *
+     * Important note. Linux requires the offset to be page aligned.
+     */
     public static long mapRO(FilesFacade ff, long fd, long size, long offset, int memoryTag) {
         final long address = ff.mmap(fd, size, offset, Files.MAP_RO, memoryTag);
         if (address == FilesFacade.MAP_FAILED) {
             throw CairoException.instance(ff.errno())
                     .put("could not mmap ")
                     .put(" [size=").put(size)
+                    .put(", offset=").put(offset)
                     .put(", fd=").put(fd)
                     .put(", memUsed=").put(Unsafe.getMemUsed())
                     .put(", fileLen=").put(ff.length(fd))
@@ -488,6 +494,11 @@ public final class TableUtils {
         return mapRW(ff, fd, size, 0, memoryTag);
     }
 
+    /**
+     * Maps a file in read-write mode.
+     *
+     * Important note. Linux requires the offset to be page aligned.
+     */
     public static long mapRW(FilesFacade ff, long fd, long size, long offset, int memoryTag) {
         allocateDiskSpace(ff, fd, size + offset);
         long addr = ff.mmap(fd, size, offset, Files.MAP_RW, memoryTag);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3125,7 +3125,7 @@ public class TableWriter implements Closeable {
                     srcAddress = srcFixMem.addressOf(sourceOffset);
                 } else {
                     // Linux requires the mmap offset to be page aligned
-                    long alignedOffset = ff.alignedOffset(sourceOffset);
+                    long alignedOffset = Files.floorPageSize(sourceOffset);
                     alignedExtraLen = sourceOffset - alignedOffset;
                     srcAddress = mapRO(ff, srcFixMem.getFd(), sourceLen + alignedExtraLen, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
                 }
@@ -3158,11 +3158,11 @@ public class TableWriter implements Closeable {
                 Vect.memcpy(appendAddress, sourceAddress, extendedSize);
             } else {
                 // Linux requires the mmap offset to be page aligned
-                long alignedOffset = ff.alignedOffset(srcFixOffset);
-                long alignedExtraSize = srcFixOffset - alignedOffset;
-                long sourceAddress = mapRO(ff, srcDataMem.getFd(), extendedSize + alignedExtraSize, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
-                Vect.memcpy(appendAddress, sourceAddress + alignedExtraSize, extendedSize);
-                ff.munmap(sourceAddress, extendedSize + alignedExtraSize, MemoryTag.MMAP_TABLE_WRITER);
+                long alignedOffset = Files.floorPageSize(srcFixOffset);
+                long alignedExtraLen = srcFixOffset - alignedOffset;
+                long sourceAddress = mapRO(ff, srcDataMem.getFd(), extendedSize + alignedExtraLen, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
+                Vect.memcpy(appendAddress, sourceAddress + alignedExtraLen, extendedSize);
+                ff.munmap(sourceAddress, extendedSize + alignedExtraLen, MemoryTag.MMAP_TABLE_WRITER);
             }
             srcDataMem.jumpTo(srcFixOffset);
         } else {
@@ -3182,7 +3182,7 @@ public class TableWriter implements Closeable {
                 address = srcDataMem.addressOf(srcFixOffset);
             } else {
                 // Linux requires the mmap offset to be page aligned
-                long alignedOffset = ff.alignedOffset(srcFixOffset);
+                long alignedOffset = Files.floorPageSize(srcFixOffset);
                 alignedExtraLen = srcFixOffset - alignedOffset;
                 address = mapRO(ff, srcDataMem.getFd(), srcFixLen + alignedExtraLen, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
             }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3116,19 +3116,24 @@ public class TableWriter implements Closeable {
 
                 // ensure memory is available
                 o3IndexMem.jumpTo(dstAppendOffset + (transientRowsAdded << indexShl));
+                long alignedExtraLen;
                 long srcAddress;
                 boolean isMapped = srcFixMem.isMapped(sourceOffset, sourceLen);
 
                 if (isMapped) {
+                    alignedExtraLen = 0;
                     srcAddress = srcFixMem.addressOf(sourceOffset);
                 } else {
-                    srcAddress = mapRO(ff, srcFixMem.getFd(), sourceLen, sourceOffset, MemoryTag.MMAP_TABLE_WRITER);
+                    // Linux requires the mmap offset to be page aligned
+                    long alignedOffset = ff.alignedOffset(sourceOffset);
+                    alignedExtraLen = sourceOffset - alignedOffset;
+                    srcAddress = mapRO(ff, srcFixMem.getFd(), sourceLen + alignedExtraLen, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
                 }
 
                 long srcVarOffset = Unsafe.getUnsafe().getLong(srcAddress);
                 O3Utils.shiftCopyFixedSizeColumnData(
                         srcVarOffset - dstVarOffset,
-                        srcAddress + Long.BYTES,
+                        srcAddress + alignedExtraLen + Long.BYTES,
                         0,
                         transientRowsAdded - 1,
                         // copy uncommitted index over the trailing LONG
@@ -3137,7 +3142,7 @@ public class TableWriter implements Closeable {
 
                 if (!isMapped) {
                     // If memory mapping was mapped specially for this move, close it
-                    ff.munmap(srcAddress, sourceLen, MemoryTag.MMAP_TABLE_WRITER);
+                    ff.munmap(srcAddress, sourceLen + alignedExtraLen, MemoryTag.MMAP_TABLE_WRITER);
                 }
 
                 long sourceEndOffset = srcDataMem.getAppendOffset();
@@ -3152,9 +3157,12 @@ public class TableWriter implements Closeable {
                 long sourceAddress = srcDataMem.addressOf(srcFixOffset);
                 Vect.memcpy(appendAddress, sourceAddress, extendedSize);
             } else {
-                long sourceAddress = mapRO(ff, srcDataMem.getFd(), extendedSize, srcFixOffset, MemoryTag.MMAP_TABLE_WRITER);
-                Vect.memcpy(appendAddress, sourceAddress, extendedSize);
-                ff.munmap(sourceAddress, extendedSize, MemoryTag.MMAP_TABLE_WRITER);
+                // Linux requires the mmap offset to be page aligned
+                long alignedOffset = ff.alignedOffset(srcFixOffset);
+                long alignedExtraSize = srcFixOffset - alignedOffset;
+                long sourceAddress = mapRO(ff, srcDataMem.getFd(), extendedSize + alignedExtraSize, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
+                Vect.memcpy(appendAddress, sourceAddress + alignedExtraSize, extendedSize);
+                ff.munmap(sourceAddress, extendedSize + alignedExtraSize, MemoryTag.MMAP_TABLE_WRITER);
             }
             srcDataMem.jumpTo(srcFixOffset);
         } else {
@@ -3166,21 +3174,26 @@ public class TableWriter implements Closeable {
             long srcFixOffset = committedTransientRowCount << shl;
             long srcFixLen = transientRowsAdded << shl;
             boolean isMapped = srcDataMem.isMapped(srcFixOffset, srcFixLen);
+            long alignedExtraLen;
             long address;
 
             if (isMapped) {
+                alignedExtraLen = 0;
                 address = srcDataMem.addressOf(srcFixOffset);
             } else {
-                address = mapRO(ff, srcDataMem.getFd(), srcFixLen, srcFixOffset, MemoryTag.MMAP_TABLE_WRITER);
+                // Linux requires the mmap offset to be page aligned
+                long alignedOffset = ff.alignedOffset(srcFixOffset);
+                alignedExtraLen = srcFixOffset - alignedOffset;
+                address = mapRO(ff, srcDataMem.getFd(), srcFixLen + alignedExtraLen, alignedOffset, MemoryTag.MMAP_TABLE_WRITER);
             }
 
             for (long n = 0; n < transientRowsAdded; n++) {
-                long ts = Unsafe.getUnsafe().getLong(address + (n << shl));
+                long ts = Unsafe.getUnsafe().getLong(address + alignedExtraLen + (n << shl));
                 o3TimestampMem.putLong128(ts, o3RowCount + n);
             }
 
             if (!isMapped) {
-                ff.munmap(address, srcFixLen, MemoryTag.MMAP_TABLE_WRITER);
+                ff.munmap(address, srcFixLen + alignedExtraLen, MemoryTag.MMAP_TABLE_WRITER);
             }
 
             srcDataMem.jumpTo(srcFixOffset);

--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -333,6 +333,10 @@ public final class Files {
         return ((size + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
     }
 
+    public static long floorPageSize(long size) {
+        return size - size % PAGE_SIZE;
+    }
+
     static {
         Os.init();
         UTF_8 = StandardCharsets.UTF_8;

--- a/core/src/main/java/io/questdb/std/FilesFacade.java
+++ b/core/src/main/java/io/questdb/std/FilesFacade.java
@@ -64,10 +64,6 @@ public interface FilesFacade {
 
     long getPageSize();
 
-    default long alignedOffset(long offset) {
-        return offset - offset % getPageSize();
-    }
-
     boolean isRestrictedFileSystem();
 
     void iterateDir(LPSZ path, FindVisitor func);

--- a/core/src/main/java/io/questdb/std/FilesFacade.java
+++ b/core/src/main/java/io/questdb/std/FilesFacade.java
@@ -64,6 +64,10 @@ public interface FilesFacade {
 
     long getPageSize();
 
+    default long alignedOffset(long offset) {
+        return offset - offset % getPageSize();
+    }
+
     boolean isRestrictedFileSystem();
 
     void iterateDir(LPSZ path, FindVisitor func);

--- a/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3CommitLagTest.java
@@ -367,7 +367,7 @@ public class O3CommitLagTest extends AbstractO3Test {
         );
 
         int longColIndex = -1;
-        int flotColIndex = -1;
+        int floatColIndex = -1;
         int strColIndex = -1;
         for (int i = 0; i < tableModel.getColumnCount(); i++) {
             switch (ColumnType.tagOf(tableModel.getColumnType(i))) {
@@ -375,7 +375,7 @@ public class O3CommitLagTest extends AbstractO3Test {
                     longColIndex = i;
                     break;
                 case ColumnType.FLOAT:
-                    flotColIndex = i;
+                    floatColIndex = i;
                     break;
                 case ColumnType.STRING:
                     strColIndex = i;
@@ -388,8 +388,8 @@ public class O3CommitLagTest extends AbstractO3Test {
         for (int c = 0; c < testCounts.length; c++) {
             long idCount = testCounts[c];
 
-            // Create big commit with has big part before OOO starts
-            // which exceed default MAMemoryImpl size in one or all columns
+            // Create big commit with a big part before OOO starts
+            // which exceeds default MAMemoryImpl size in one or all columns
             int iterations = 2;
             String[] varCol = new String[]{"abc", "aldfjkasdlfkj", "as", "2021-04-27T12:00:00", "12345678901234578"};
 
@@ -405,8 +405,8 @@ public class O3CommitLagTest extends AbstractO3Test {
                         if (longColIndex > -1) {
                             row.putLong(longColIndex, timestamp);
                         }
-                        if (flotColIndex > -1) {
-                            row.putFloat(flotColIndex, rnd.nextFloat());
+                        if (floatColIndex > -1) {
+                            row.putFloat(floatColIndex, rnd.nextFloat());
                         }
                         if (strColIndex > -1) {
                             row.putStr(strColIndex, varCol[id % varCol.length]);
@@ -418,8 +418,8 @@ public class O3CommitLagTest extends AbstractO3Test {
                         if (longColIndex > -1) {
                             row.putLong(longColIndex, timestamp);
                         }
-                        if (flotColIndex > -1) {
-                            row.putFloat(flotColIndex, rnd.nextFloat());
+                        if (floatColIndex > -1) {
+                            row.putFloat(floatColIndex, rnd.nextFloat());
                         }
                         if (strColIndex > -1) {
                             row.putStr(strColIndex, varCol[id % varCol.length]);

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -6902,7 +6902,7 @@ public class O3Test extends AbstractO3Test {
             long mappedPageSize = configuration.getDataAppendPageSize();
             Assert.assertTrue("Batch size must be greater than mapped page size", batchOnDiskSize > mappedPageSize);
             long pageSize = configuration.getMiscAppendPageSize();
-            Assert.assertTrue("Batch size must be unaligned with page size", batchOnDiskSize % pageSize != 0);
+            Assert.assertNotEquals("Batch size must be unaligned with page size", 0, batchOnDiskSize % pageSize);
 
             long start = IntervalUtils.parseFloorPartialDate("2021-10-09T10:00:00");
             String[] varCol = new String[]{"aldfjkasdlfkj", "2021-10-10T12:00:00", "12345678901234578"};

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.Job;
@@ -789,6 +790,11 @@ public class O3Test extends AbstractO3Test {
     @Test
     public void testWriterOpensCorrectTxnPartitionOnRestart() throws Exception {
         executeWithPool(0, O3Test::testWriterOpensCorrectTxnPartitionOnRestart0);
+    }
+
+    @Test
+    public void testWriterOpensUnmappedPage() throws Exception {
+        executeWithPool(0, O3Test::testWriterOpensUnmappedPage);
     }
 
     private static void testWriterOpensCorrectTxnPartitionOnRestart0(
@@ -6850,5 +6856,95 @@ public class O3Test extends AbstractO3Test {
                 "x"
         );
         assertXCountY(compiler, sqlExecutionContext);
+    }
+
+    private static void testWriterOpensUnmappedPage(
+            CairoEngine engine,
+            SqlCompiler compiler,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException, NumericException {
+        CairoConfiguration configuration = engine.getConfiguration();
+        try (TableModel tableModel = new TableModel(configuration, "x", PartitionBy.DAY)) {
+            tableModel
+                    .col("id", ColumnType.LONG)
+                    .col("str", ColumnType.STRING)
+                    .col("sym", ColumnType.SYMBOL).indexed(true, 2)
+                    .timestamp("ts");
+
+            TestUtils.createPopulateTable("x",
+                    compiler,
+                    sqlExecutionContext,
+                    tableModel,
+                    0,
+                    "2021-10-09",
+                    0
+            );
+
+            int longColIndex = -1;
+            int symColIndex = -1;
+            int strColIndex = -1;
+            for (int i = 0; i < tableModel.getColumnCount(); i++) {
+                switch (ColumnType.tagOf(tableModel.getColumnType(i))) {
+                    case ColumnType.LONG:
+                        longColIndex = i;
+                        break;
+                    case ColumnType.SYMBOL:
+                        symColIndex = i;
+                        break;
+                    case ColumnType.STRING:
+                        strColIndex = i;
+                        break;
+                }
+            }
+
+            int idBatchSize = 3 * 1024 * 1024 + 1;
+            long batchOnDiskSize = (long) ColumnType.sizeOf(ColumnType.LONG) * idBatchSize;
+            long mappedPageSize = configuration.getDataAppendPageSize();
+            Assert.assertTrue("Batch size must be greater than mapped page size", batchOnDiskSize > mappedPageSize);
+            long pageSize = configuration.getMiscAppendPageSize();
+            Assert.assertTrue("Batch size must be unaligned with page size", batchOnDiskSize % pageSize != 0);
+
+            long start = IntervalUtils.parseFloorPartialDate("2021-10-09T10:00:00");
+            String[] varCol = new String[]{"aldfjkasdlfkj", "2021-10-10T12:00:00", "12345678901234578"};
+
+            // Add 2 batches
+            int iterations = 2;
+            try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "x", "testing")) {
+                for (int i = 0; i < iterations; i++) {
+                    for (int id = 0; id < idBatchSize; id++) {
+                        // We leave start + idBatchSize out to insert it O3 later
+                        long timestamp = start + i * idBatchSize + id + i;
+                        TableWriter.Row row = o3.newRow(timestamp);
+                        row.putLong(longColIndex, timestamp);
+                        row.putSym(symColIndex, "test");
+                        row.putStr(strColIndex, varCol[id % varCol.length]);
+                        row.append();
+                    }
+
+                    // Commit only the first batch
+                    if (i == 0) {
+                        o3.commit();
+                    }
+                }
+
+                // Append one more row out of order
+                long timestamp = start + idBatchSize;
+                TableWriter.Row row = o3.newRow(timestamp);
+                row.putLong(longColIndex, timestamp);
+                row.putSym(symColIndex, "test");
+                row.putStr(strColIndex, varCol[0]);
+                row.append();
+
+                o3.commit();
+            }
+
+            TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
+                    "count\n" + (2 * idBatchSize + 1) + "\n"
+            );
+            engine.releaseAllReaders();
+            try (TableWriter o3 = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, "x", "testing")) {
+                o3.truncate();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1521

Linux (and probably other POSIX-compliant systems) requires mmap's offset to be page size aligned. Under certain conditions O3 writes led to unmapped pages being open with unaligned offset value.