### PR TITLE
chore(ui): fix keyboard shortcuts

### DIFF
--- a/ui/src/scenes/Editor/Ace/index.tsx
+++ b/ui/src/scenes/Editor/Ace/index.tsx
@@ -242,7 +242,7 @@ const Ace = () => {
     editor.commands.addCommand({
       bindKey: "F9",
       name: Command.EXECUTE,
-      exec: () => toggleRunning,
+      exec: () => toggleRunning(),
     })
 
     editor.commands.addCommand({
@@ -250,7 +250,7 @@ const Ace = () => {
         mac: "Command-Enter",
         win: "Ctrl-Enter",
       },
-      exec: () => toggleRunning,
+      exec: () => toggleRunning(),
       name: Command.EXECUTE_AT,
     })
 


### PR DESCRIPTION
Fix `F9` and `CMD`+`Enter` shortcuts that are broken due to typos.