### PR TITLE
fix(sql) Column alias 'time' does not work

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1011,21 +1011,27 @@ class ExpressionParser {
                         }
                     } else {
                         ExpressionNode last;
+                        // Handle `timestamp with time zone`
                         if ((last = this.opStack.peek()) != null && SqlKeywords.isTimestampKeyword(last.token) && SqlKeywords.isWithKeyword(tok)) {
                             CharSequence withTok = GenericLexer.immutableOf(tok);
                             int withTokPosition = lexer.getPosition();
-
-                            CharSequence timeTok = SqlUtil.fetchNext(lexer);
-                            if (SqlKeywords.isTimeKeyword(timeTok)) {
-                                CharSequence zoneTok = SqlUtil.fetchNext(lexer);
-                                if (SqlKeywords.isZoneKeyword(zoneTok)) {
-                                    // Skip "with time zone" part of "timestamp with time zone" for Postgres compatibility #740, #980
-                                    continue;
+                            tok = SqlUtil.fetchNext(lexer);
+                            if (tok != null && SqlKeywords.isTimeKeyword(tok)) {
+                                tok = SqlUtil.fetchNext(lexer);
+                                if (tok != null && SqlKeywords.isZoneKeyword(tok)) {
+                                    CharSequence zoneTok = GenericLexer.immutableOf(tok);
+                                    int zoneTokPosition = lexer.getTokenHi();
+                                    tok = SqlUtil.fetchNext(lexer);
+                                    // Next token is string literal, or we are in 'as' part of cast function
+                                    boolean isInActiveCastAs = (castBraceCountStack.size() > 0 && (castBraceCountStack.size() == castAsCount));
+                                    if (tok != null && (isInActiveCastAs|| tok.charAt(0) == '\'')) {
+                                        lexer.backTo(zoneTokPosition, zoneTok);
+                                        continue;
+                                    }
+                                    throw SqlException.$(zoneTokPosition, "String literal expected after 'timestamp with time zone'");
                                 }
                             }
-
                             lexer.backTo(withTokPosition, withTok);
-                            tok = withTok;
                         }
                         // literal can be at start of input, after a bracket or part of an operator
                         // all other cases are illegal and will be considered end-of-input

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -735,15 +735,29 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testTimestampWithTimeZone() throws Exception {
+    public void testInsertTimestampWithTimeZone() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table t (timestamp timestamp) timestamp(timestamp);", sqlExecutionContext);
             executeInsert("insert into t values (timestamp with time zone '2020-12-31 15:15:51.663+00:00')");
 
-            String expected2 = "timestamp\n" +
-                               "2020-12-31T15:15:51.663000Z\n";
+            String expected1 = "timestamp\n" +
+                    "2020-12-31T15:15:51.663000Z\n";
+
+            assertReader(expected1, "t");
+
+            executeInsert("insert into t values (cast('2021-12-31 15:15:51.663+00:00' as timestamp with time zone))");
+
+            String expected2 = expected1 +
+                    "2021-12-31T15:15:51.663000Z\n";
 
             assertReader(expected2, "t");
+
+            try {
+                compiler.compile("insert into t values  (timestamp with time zone)", sqlExecutionContext);
+            } catch (SqlException e) {
+                Assert.assertEquals(47, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "String literal expected after 'timestamp with time zone'");
+            }
         });
     }
 

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -734,6 +734,19 @@ public class InsertTest extends AbstractGriffinTest {
         });
     }
 
+    @Test
+    public void testTimestampWithTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table t (timestamp timestamp) timestamp(timestamp);", sqlExecutionContext);
+            executeInsert("insert into t values (timestamp with time zone '2020-12-31 15:15:51.663+00:00')");
+
+            String expected2 = "timestamp\n" +
+                               "2020-12-31T15:15:51.663000Z\n";
+
+            assertReader(expected2, "t");
+        });
+    }
+
     private void assertInsertTimestamp(String expected, String ddl2, String exceptionType, boolean commitInsert) throws Exception {
         if (commitInsert) {
             compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts)", sqlExecutionContext);

--- a/core/src/test/java/io/questdb/griffin/SimpleTableTest.java
+++ b/core/src/test/java/io/questdb/griffin/SimpleTableTest.java
@@ -41,4 +41,22 @@ public class SimpleTableTest extends AbstractGriffinTest {
         assertSql("select ts from tab1 where id > 1", "ts\n" +
                 "2020-01-01T00:00:00.000000Z\n");
     }
+
+    @Test
+    public void testTimeStampWithTimezone() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table t (timestamp timestamp) timestamp(timestamp);", sqlExecutionContext);
+            executeInsert("insert into t values (1);");
+
+            String expected1 = "time\n" +
+                                "1970-01-01T00:00:00.000001Z\n";
+
+            assertSql("select timestamp time from t;", expected1);
+            
+            String expected2 = "timestamp\n" +
+                               "1970-01-01T00:00:00.000001Z\n";
+
+            assertSql("select timestamp with time zone from t;", expected2);
+        });
+    }
 }

--- a/core/src/test/java/io/questdb/griffin/SimpleTableTest.java
+++ b/core/src/test/java/io/questdb/griffin/SimpleTableTest.java
@@ -28,6 +28,8 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableModel;
 import io.questdb.std.NumericException;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SimpleTableTest extends AbstractGriffinTest {
@@ -49,14 +51,28 @@ public class SimpleTableTest extends AbstractGriffinTest {
             executeInsert("insert into t values (1);");
 
             String expected1 = "time\n" +
-                                "1970-01-01T00:00:00.000001Z\n";
+                    "1970-01-01T00:00:00.000001Z\n";
 
             assertSql("select timestamp time from t;", expected1);
-            
-            String expected2 = "timestamp\n" +
-                               "1970-01-01T00:00:00.000001Z\n";
 
-            assertSql("select timestamp with time zone from t;", expected2);
+            try {
+                compiler.compile("select timestamp with time zone from t;", sqlExecutionContext);
+            } catch (SqlException e) {
+                Assert.assertEquals(31, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "String literal expected after 'timestamp with time zone'");
+            }
+
+            String expected2 = "with\n" +
+                    "1970-01-01T00:00:00.000001Z\n";
+
+            assertSql("select timestamp with from t;", expected2);
+
+            String expected3 = "time\ttimestamp\n" +
+                    "2020-12-31T15:15:51.663000Z\t1970-01-01T00:00:00.000001Z\n";
+
+            assertSql("select timestamp with time zone '2020-12-31 15:15:51.663+00:00' time, timestamp from t;", expected3);
+
+            assertSql("select cast('2020-12-31 15:15:51.663+00:00' as timestamp with time zone) time, timestamp from t;", expected3);
         });
     }
 }


### PR DESCRIPTION
When statement is parsed it is expected that complete part `with time zone` should be
skipped.