### PR TITLE
fix(ilp): sanitize table name to avoid FS corruption

### DIFF
--- a/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/LineTCPSenderMain.java
@@ -30,27 +30,22 @@ import io.questdb.std.Rnd;
 
 public class LineTCPSenderMain {
     public static void main(String[] args) {
-        final long count = 10_000_000;
+        final long count = 30_000_000;
         String hostIPv4 = "127.0.0.1";
         int port = 9009; // 8089 influx
-        int bufferCapacity = 256 * 1024;
+        int bufferCapacity = 4 * 1024;
 
         final Rnd rnd = new Rnd();
         long start = System.nanoTime();
         try (LineTcpSender sender = new LineTcpSender(Net.parseIPv4(hostIPv4), port, bufferCapacity)) {
             for (int i = 0; i < count; i++) {
-                // if ((i & 0x1) == 0) {
                 sender.metric("weather");
-                // } else {
-                // sender.metric("weather2");
-                // }
                 sender
                         .tag("location", "london")
-                        .tag("by", rnd.nextString(5))
+                        .tag("by", "blah")
                         .field("temp", rnd.nextPositiveLong())
-                        .field("ok", rnd.nextPositiveInt())
-                        .$(rnd.nextLong(5000000000000L));
-//                sender.$();
+                        .field("ok", rnd.nextPositiveInt());
+                sender.$();
             }
             sender.flush();
         }

--- a/benchmarks/src/main/java/org/questdb/RawTCPILPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/RawTCPILPSenderMain.java
@@ -32,7 +32,7 @@ import io.questdb.std.Unsafe;
 
 public class RawTCPILPSenderMain {
     public static void main(String[] args) {
-        final String ilp = "dhl_plug,building=ba1aa618-4de4-40be-a4f7-72e341274b91,floor=a3979437-5d95-4f4d-8ef2-ace635cffce4,label=144c8537-db16-11e9-a374-0e9c62fb84fe,room=d534235d-d253-4aaa-8e40-eb8dc07c0d2b,socket_id=affbe16e-6a9e-4a06-85fe-e24430a1d8ba,address_id=8ca1d63a-d119-45aa-9747-351eb40bedf9 mac_address=\"xxxx\",milliamps=4,millijoules=151200,millivolts=120609,milliwatts=2520,duration=60587 1635189276608000\n";
+        final String ilp = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0gs,building=ba1aa618-4de4-40be-a4f7-72e341274b91,floor=a3979437-5d95-4f4d-8ef2-ace635cffce4,label=144c8537-db16-11e9-a374-0e9c62fb84fe,room=d534235d-d253-4aaa-8e40-eb8dc07c0d2b,socket_id=affbe16e-6a9e-4a06-85fe-e24430a1d8ba,address_id=8ca1d63a-d119-45aa-9747-351eb40bedf9 mac_address=\"xxxx\",milliamps=4,millijoules=151200,millivolts=120609,milliwatts=2520,duration=60587 1635189276608000\n";
         final int len = ilp.length();
 
         long mem = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -564,7 +564,7 @@ class LineTcpMeasurementScheduler implements Closeable {
                         case LineTcpParser.ENTITY_TYPE_INTEGER:
                             Unsafe.getUnsafe().putByte(bufPos, entity.getType());
                             bufPos += Byte.BYTES;
-                            Unsafe.getUnsafe().putLong(bufPos, entity.getIntegerValue());
+                            Unsafe.getUnsafe().putLong(bufPos, entity.getLongValue());
                             bufPos += Long.BYTES;
                             break;
                         case LineTcpParser.ENTITY_TYPE_FLOAT:
@@ -646,7 +646,7 @@ class LineTcpMeasurementScheduler implements Closeable {
                         case LineTcpParser.ENTITY_TYPE_TIMESTAMP: {
                             Unsafe.getUnsafe().putByte(bufPos, entity.getType());
                             bufPos += Byte.BYTES;
-                            Unsafe.getUnsafe().putLong(bufPos, entity.getTimestampValue());
+                            Unsafe.getUnsafe().putLong(bufPos, entity.getLongValue());
                             bufPos += Long.BYTES;
                             break;
                         }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -237,8 +237,8 @@ public class LineTcpParser implements Closeable {
                     LOG.info().$("could not parse [byte=\\0]").$();
                     return getError();
                 case '/':
-                case '.':
                     if (entityHandler != entityValueHandler) {
+                        LOG.info().$("could not parse [byte=/]").$();
                         return getError();
                     }
                     appendByte = true;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -675,10 +675,4 @@ public class LineTcpParser implements Closeable {
             return true;
         }
     }
-
-
-
-
-
-
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -65,18 +65,20 @@ public class LineTcpParser implements Closeable {
     private ErrorCode errorCode;
     private EntityHandler entityHandler;
     private long timestamp;
-    private final EntityHandler entityTimestampHandler = this::expectTimestamp;    private final EntityHandler entityTableHandler = this::expectTableName;
+    private final EntityHandler entityTimestampHandler = this::expectTimestamp;
+    private final EntityHandler entityTableHandler = this::expectTableName;
+    private final EntityHandler entityValueHandler = this::expectEntityValue;
+    private final EntityHandler entityNameHandler = this::expectEntityName;
     private int nQuoteCharacters;
     private boolean scape;
     private boolean nextValueCanBeOpenQuote;
-    private boolean hasNonAscii;    private final EntityHandler entityValueHandler = this::expectEntityValue;
+    private boolean hasNonAscii;
 
     public static long sanitizeEnd(long lo, long hi) {
         long p = hi - 1;
         OUT:
         while (p >= lo) {
             switch (Unsafe.getUnsafe().getByte(p)) {
-                case ' ':
                 case '\0':
                 case '\t':
                 case '\\':
@@ -95,7 +97,6 @@ public class LineTcpParser implements Closeable {
         OUT:
         while (p < hi) {
             switch (Unsafe.getUnsafe().getByte(p)) {
-                case ' ':
                 case '\0':
                 case '\t':
                 case '\\':
@@ -108,7 +109,7 @@ public class LineTcpParser implements Closeable {
             }
         }
         return p;
-    }    private final EntityHandler entityNameHandler = this::expectEntityName;
+    }
 
     @Override
     public void close() {

--- a/core/src/main/java/io/questdb/std/str/DirectByteCharSequence.java
+++ b/core/src/main/java/io/questdb/std/str/DirectByteCharSequence.java
@@ -35,7 +35,6 @@ public class DirectByteCharSequence extends AbstractCharSequence implements Muta
     private long lo;
     private long hi;
 
-
     @Override
     public byte byteAt(int index) {
         return Unsafe.getUnsafe().getByte(lo + index);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -491,6 +491,52 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     }
 
     @Test
+    public void testMangledStartOfTableName() throws Exception {
+        runInContext(() -> {
+            try (
+                    @SuppressWarnings("resource")
+                    TableModel model = new TableModel(configuration, "t_ilp21",
+                            PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT).col("int1", ColumnType.INT)
+                            .col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp()) {
+                CairoTestUtils.create(model);
+            }
+            microSecondTicks = 1465839830102800L;
+            recvBuffer = "\0\0/\\\tt_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
+                    "\0\0/\\\tt_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
+            handleContextIO();
+            Assert.assertFalse(disconnected);
+            closeContext();
+            String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
+                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1.2000\t23\t2016-06-13T17:43:50.102Z\t-7\t2016-06-13T17:43:50.102800Z\n" +
+                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1000.0000\t-500000\t2016-06-13T17:43:50.102Z\t3\t2016-06-13T17:43:50.102800Z\n";
+            assertTable(expected, "t_ilp21");
+        });
+    }
+
+    @Test
+    public void testMangledEndOfTableName() throws Exception {
+        runInContext(() -> {
+            try (
+                    @SuppressWarnings("resource")
+                    TableModel model = new TableModel(configuration, "t_ilp21",
+                            PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT).col("int1", ColumnType.INT)
+                            .col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp()) {
+                CairoTestUtils.create(model);
+            }
+            microSecondTicks = 1465839830102800L;
+            recvBuffer = "t_ilp21\0\0/\\\t event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
+                    "\0\0/\\\tt_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
+            handleContextIO();
+            Assert.assertFalse(disconnected);
+            closeContext();
+            String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
+                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1.2000\t23\t2016-06-13T17:43:50.102Z\t-7\t2016-06-13T17:43:50.102800Z\n" +
+                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1000.0000\t-500000\t2016-06-13T17:43:50.102Z\t3\t2016-06-13T17:43:50.102800Z\n";
+            assertTable(expected, "t_ilp21");
+        });
+    }
+
+    @Test
     public void testColumnConversion2() throws Exception {
         runInContext(() -> {
             try (

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -491,52 +491,6 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     }
 
     @Test
-    public void testMangledStartOfTableName() throws Exception {
-        runInContext(() -> {
-            try (
-                    @SuppressWarnings("resource")
-                    TableModel model = new TableModel(configuration, "t_ilp21",
-                            PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT).col("int1", ColumnType.INT)
-                            .col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp()) {
-                CairoTestUtils.create(model);
-            }
-            microSecondTicks = 1465839830102800L;
-            recvBuffer = "\0\0/\\\tt_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
-                    "\0\0/\\\tt_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
-            closeContext();
-            String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
-                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1.2000\t23\t2016-06-13T17:43:50.102Z\t-7\t2016-06-13T17:43:50.102800Z\n" +
-                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1000.0000\t-500000\t2016-06-13T17:43:50.102Z\t3\t2016-06-13T17:43:50.102800Z\n";
-            assertTable(expected, "t_ilp21");
-        });
-    }
-
-    @Test
-    public void testMangledEndOfTableName() throws Exception {
-        runInContext(() -> {
-            try (
-                    @SuppressWarnings("resource")
-                    TableModel model = new TableModel(configuration, "t_ilp21",
-                            PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT).col("int1", ColumnType.INT)
-                            .col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp()) {
-                CairoTestUtils.create(model);
-            }
-            microSecondTicks = 1465839830102800L;
-            recvBuffer = "t_ilp21\0\0/\\\t event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
-                    "\0\0/\\\tt_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
-            closeContext();
-            String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
-                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1.2000\t23\t2016-06-13T17:43:50.102Z\t-7\t2016-06-13T17:43:50.102800Z\n" +
-                    "12\t0x5a9796963abad00001e5f6bbdb38\t2016-06-13T17:43:50.102400Z\t1000.0000\t-500000\t2016-06-13T17:43:50.102Z\t3\t2016-06-13T17:43:50.102800Z\n";
-            assertTable(expected, "t_ilp21");
-        });
-    }
-
-    @Test
     public void testColumnConversion2() throws Exception {
         runInContext(() -> {
             try (

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
@@ -250,6 +250,14 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
+    public void testMangledMeasurementNameFromBothEnds() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "\0\0\0,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
     public void testWithQuotedStringsWithSpaces() {
         assertThat(
                 "measurement,tag=value,tag2=value field=10000i,field2=\"longstring\",fld3=\"short string\" 100000\n",
@@ -281,7 +289,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testSpaceInMesurmentName() {
+    public void testSpaceInMeasurementName() {
         assertThat(
                 "tab ble,tag= 1 field=2 123\n",
                 "tab\\ ble,tag=\\ 1 field=2 123\n"

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
@@ -250,6 +250,126 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
+    public void testInvalidMeasurementNamePrefix1() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "../measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid1() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "mea..surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid2() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "mea/surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid3() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "mea\0surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid4() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "mea\\\\surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd1() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "measurement\\\\,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd2() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "measurement..,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd3() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "measurement/,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd4() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "measurement\0,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix4() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "..measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameDot1() {
+        assertThat(
+                ".measurement,tag=value,tag2=value field=10000i\n",
+                ".measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameDot2() {
+        assertThat(
+                "meas.urement,tag=value,tag2=value field=10000i\n",
+                "meas.urement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameDot3() {
+        assertThat(
+                "measurement.,tag=value,tag2=value field=10000i\n",
+                "measurement.,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix2() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "\0measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix3() {
+        assertThat(
+                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "\\\\measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
     public void testMangledMeasurementNameFromBothEnds() {
         assertThat(
                 "--ERROR=INVALID_MEASUREMENT_NAME--",

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
@@ -258,9 +258,9 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testInvalidMeasurementNameMid1() {
+    public void testValidMeasurementNameMid1() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                "mea..surement,tag=value,tag2=value field=10000i\n",
                 "mea..surement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -298,9 +298,9 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testInvalidMeasurementNameEnd2() {
+    public void testValidMeasurementNameEnd2() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                "measurement..,tag=value,tag2=value field=10000i\n",
                 "measurement..,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -322,9 +322,9 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testInvalidMeasurementNamePrefix4() {
+    public void testValidMeasurementNamePrefix4() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                "..measurement,tag=value,tag2=value field=10000i\n",
                 "..measurement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -332,23 +332,23 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameDot1() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                ".measurement,tag=value,tag2=value field=10000i\n",
                 ".measurement,tag=value,tag2=value field=10000i\n"
         );
     }
 
     @Test
-    public void testInvalidMeasurementNameDot2() {
+    public void testValidMeasurementNameDot2() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                "meas.urement,tag=value,tag2=value field=10000i\n",
                 "meas.urement,tag=value,tag2=value field=10000i\n"
         );
     }
 
     @Test
-    public void testInvalidMeasurementNameDot3() {
+    public void testValidMeasurementNameDot3() {
         assertThat(
-                "--ERROR=INVALID_TABLE_NAME--",
+                "measurement.,tag=value,tag2=value field=10000i\n",
                 "measurement.,tag=value,tag2=value field=10000i\n"
         );
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
@@ -252,7 +252,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNamePrefix1() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "../measurement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -260,7 +260,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameMid1() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "mea..surement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -268,7 +268,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameMid2() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "mea/surement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -276,7 +276,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameMid3() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "mea\0surement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -284,7 +284,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameMid4() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "mea\\\\surement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -292,7 +292,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameEnd1() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "measurement\\\\,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -300,7 +300,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameEnd2() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "measurement..,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -308,7 +308,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameEnd3() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "measurement/,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -316,7 +316,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNameEnd4() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "measurement\0,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -324,31 +324,31 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNamePrefix4() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "..measurement,tag=value,tag2=value field=10000i\n"
         );
     }
 
     @Test
-    public void testValidMeasurementNameDot1() {
+    public void testInvalidMeasurementNameDot1() {
         assertThat(
-                ".measurement,tag=value,tag2=value field=10000i\n",
+                "--ERROR=INVALID_TABLE_NAME--",
                 ".measurement,tag=value,tag2=value field=10000i\n"
         );
     }
 
     @Test
-    public void testValidMeasurementNameDot2() {
+    public void testInvalidMeasurementNameDot2() {
         assertThat(
-                "meas.urement,tag=value,tag2=value field=10000i\n",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "meas.urement,tag=value,tag2=value field=10000i\n"
         );
     }
 
     @Test
-    public void testValidMeasurementNameDot3() {
+    public void testInvalidMeasurementNameDot3() {
         assertThat(
-                "measurement.,tag=value,tag2=value field=10000i\n",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "measurement.,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -356,7 +356,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNamePrefix2() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "\0measurement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -364,7 +364,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testInvalidMeasurementNamePrefix3() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "\\\\measurement,tag=value,tag2=value field=10000i\n"
         );
     }
@@ -372,7 +372,7 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     @Test
     public void testMangledMeasurementNameFromBothEnds() {
         assertThat(
-                "--ERROR=INVALID_MEASUREMENT_NAME--",
+                "--ERROR=INVALID_TABLE_NAME--",
                 "\0\0\0,tag=value,tag2=value field=10000i\n"
         );
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParserTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParserTest.java
@@ -67,10 +67,10 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
         assertType(LineTcpParser.ENTITY_TYPE_STRING, "\"0x123a4\"");
         assertType(LineTcpParser.ENTITY_TYPE_STRING, "\"0x123a4 looks \\\" like=long256,\\\n but tis not!\"", "\"0x123a4 looks \" like=long256,\n but tis not!\"", LineTcpParser.ParseResult.MEASUREMENT_COMPLETE);
         assertType(LineTcpParser.ENTITY_TYPE_STRING, "\"0x123a4 looks like=long256, but tis not!\"");
-        assertType(LineTcpParser.ENTITY_TYPE_NONE, "\"0x123a4 looks \\\" like=long256,\\\n but tis not!",
-                LineTcpParser.ParseResult.ERROR); // missing closing '"'
-        assertType(LineTcpParser.ENTITY_TYPE_TAG, "0x123a4 looks \\\" like=long256,\\\n but tis not!\"",
-                LineTcpParser.ParseResult.ERROR); // wanted to be a string, missing opening '"'
+        assertError(LineTcpParser.ENTITY_TYPE_NONE, "\"0x123a4 looks \\\" like=long256,\\\n but tis not!"
+        ); // missing closing '"'
+        assertError(LineTcpParser.ENTITY_TYPE_TAG, "0x123a4 looks \\\" like=long256,\\\n but tis not!\""
+        ); // wanted to be a string, missing opening '"'
 
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x123i");
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x1i");
@@ -84,7 +84,7 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
         assertType(LineTcpParser.ENTITY_TYPE_FLOAT, "1");
 
         assertType(LineTcpParser.ENTITY_TYPE_SYMBOL, "aaa\"");
-        assertType(LineTcpParser.ENTITY_TYPE_NONE, "\"aaa", LineTcpParser.ParseResult.ERROR);
+        assertError(LineTcpParser.ENTITY_TYPE_NONE, "\"aaa");
 
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "123a4i");
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "oxi");
@@ -105,8 +105,8 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
         assertType(type, value, value, LineTcpParser.ParseResult.MEASUREMENT_COMPLETE);
     }
 
-    private static void assertType(int type, String value, LineTcpParser.ParseResult expectedParseResult) throws Exception {
-        assertType(type, value, value, expectedParseResult);
+    private static void assertError(int type, String value) throws Exception {
+        assertType(type, value, value, LineTcpParser.ParseResult.ERROR);
     }
 
     private static void assertType(int type,


### PR DESCRIPTION
Fixes #1595

We do not sanitize table name, which originates from ILP. The following is not disallowed:

```
../../tab,tag=val
```

```
\0\0\0tab,tag=val
```

```
\0\0\0,tag=val
```

etc...

Additionally disallowing the following characters in table names and columns: `\`,`/`,`.` and `\0`