### PR TITLE
feat: Enhance type compatibility check to extend numeric conversions …

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -92,9 +92,6 @@ public class SqlCompiler implements Closeable {
     private final TextLoader textLoader;
     private final FilesFacade ff;
 
-    static final double MAX_FLOAT_VALUE = Float.MAX_VALUE;
-    static final double MIN_FLOAT_VALUE = Float.MIN_VALUE;
-
     public SqlCompiler(CairoEngine engine) {
         this(engine, null);
     }
@@ -310,13 +307,13 @@ public class SqlCompiler implements Closeable {
                             asm.invokeInterface(wPutTimestamp, 3);
                             break;
                         case ColumnType.SHORT:
-                            addCheckIntBoundsCall(asm, checkLongBounds, minLongShort, maxLongShort, i, fromColumnType, toColumnTypeTag);
+                            addCheckIntBoundsCall(asm, checkLongBounds, minLongShort, maxLongShort, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.i2s();
                             asm.invokeInterface(wPutShort, 2);
                             break;
                         case ColumnType.BYTE:
-                            addCheckIntBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, i, fromColumnType, toColumnTypeTag);
+                            addCheckIntBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.i2b();
                             asm.invokeInterface(wPutByte, 2);
@@ -338,7 +335,7 @@ public class SqlCompiler implements Closeable {
                     asm.invokeInterface(rGetLong);
                     switch (toColumnTypeTag) {
                         case ColumnType.INT:
-                            addCheckLongBoundsCall(asm, checkLongBounds, minLongInt, maxLongInt, i, fromColumnType, toColumnTypeTag);
+                            addCheckLongBoundsCall(asm, checkLongBounds, minLongInt, maxLongInt, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.l2i();
                             asm.invokeInterface(wPutInt, 2);
@@ -350,14 +347,14 @@ public class SqlCompiler implements Closeable {
                             asm.invokeInterface(wPutTimestamp, 3);
                             break;
                         case ColumnType.SHORT:
-                            addCheckLongBoundsCall(asm, checkLongBounds, minLongShort, maxLongShort, i, fromColumnType, toColumnTypeTag);
+                            addCheckLongBoundsCall(asm, checkLongBounds, minLongShort, maxLongShort, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.l2i();
                             asm.i2s();
                             asm.invokeInterface(wPutShort, 2);
                             break;
                         case ColumnType.BYTE:
-                            addCheckLongBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, i, fromColumnType, toColumnTypeTag);
+                            addCheckLongBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.l2i();
                             asm.i2b();
@@ -502,7 +499,7 @@ public class SqlCompiler implements Closeable {
                             asm.invokeInterface(wPutTimestamp, 3);
                             break;
                         case ColumnType.BYTE:
-                            addCheckIntBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, i, fromColumnType, toColumnTypeTag);
+                            addCheckIntBoundsCall(asm, checkLongBounds, minLongByte, maxLongByte, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.i2b();
                             asm.invokeInterface(wPutByte, 2);
@@ -528,38 +525,38 @@ public class SqlCompiler implements Closeable {
                     asm.invokeInterface(rGetFloat);
                     switch (toColumnTypeTag) {
                         case ColumnType.INT:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleInt, maxDoubleInt, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleInt, maxDoubleInt, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2i();
                             asm.invokeInterface(wPutInt, 2);
                             break;
                         case ColumnType.LONG:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2l();
                             asm.invokeInterface(wPutLong, 3);
                             break;
                         case ColumnType.DATE:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2l();
                             asm.invokeInterface(wPutDate, 3);
                             break;
                         case ColumnType.TIMESTAMP:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2l();
                             asm.invokeInterface(wPutTimestamp, 3);
                             break;
                         case ColumnType.SHORT:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleShort, maxDoubleShort, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleShort, maxDoubleShort, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2i();
                             asm.i2s();
                             asm.invokeInterface(wPutShort, 2);
                             break;
                         case ColumnType.BYTE:
-                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleByte, maxDoubleByte, i, fromColumnType, toColumnTypeTag);
+                            addCheckFloatBoundsCall(asm, checkDoubleBounds, minDoubleByte, maxDoubleByte, fromColumnType, toColumnTypeTag, toColumnIndex);
                             
                             asm.f2i();
                             asm.i2b();
@@ -578,45 +575,45 @@ public class SqlCompiler implements Closeable {
                     asm.invokeInterface(rGetDouble);
                     switch (toColumnTypeTag) {
                         case ColumnType.INT:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleInt, maxDoubleInt, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleInt, maxDoubleInt, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2i();
                             asm.invokeInterface(wPutInt,2);
                             break;
                         case ColumnType.LONG:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2l();
                             asm.invokeInterface(wPutLong, 3);
                             break;
                         case ColumnType.DATE:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2l();
                             asm.invokeInterface(wPutDate, 3);
                             break;
                         case ColumnType.TIMESTAMP:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleLong, maxDoubleLong, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2l();
                             asm.invokeInterface(wPutTimestamp, 3);
                             break;
                         case ColumnType.SHORT:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleShort, maxDoubleShort, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleShort, maxDoubleShort, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2i();
                             asm.i2s();
                             asm.invokeInterface(wPutShort, 2);
                             break;
                         case ColumnType.BYTE:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleByte, maxDoubleByte, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleByte, maxDoubleByte, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2i();
                             asm.i2b();
                             asm.invokeInterface(wPutByte, 2);
                             break;
                         case ColumnType.FLOAT:
-                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleFloat, maxDoubleFloat, i, fromColumnType, toColumnTypeTag);
+                            addCheckDoubleBoundsCall(asm, checkDoubleBounds, minDoubleFloat, maxDoubleFloat, fromColumnType, toColumnTypeTag, toColumnIndex);
 
                             asm.d2f();
                             asm.invokeInterface(wPutFloat, 2);
@@ -817,62 +814,40 @@ public class SqlCompiler implements Closeable {
         return asm.newInstance();
     }
 
-    private static void addCheckDoubleBoundsCall(BytecodeAssembler asm, int checkDoubleBounds, int min, int max, int i, int fromColumnType, int toColumnType) {
+    private static void addCheckDoubleBoundsCall(BytecodeAssembler asm, int checkDoubleBounds, int min, int max, int fromColumnType, int toColumnType, int toColumnIndex) {
         asm.dup2();
-        
-        asm.ldc2_w(min);
-        asm.ldc2_w(max);
-        asm.iconst(i);
-        asm.iconst(fromColumnType);
-        asm.iconst(toColumnType);
-        asm.invokeStatic(checkDoubleBounds);
+
+        invokeCheckMethod(asm, checkDoubleBounds, min, max, fromColumnType, toColumnType, toColumnIndex);
     }
 
-    private static void addCheckFloatBoundsCall(BytecodeAssembler asm, int checkDoubleBounds, int min, int max, int i, int fromColumnType, int toColumnType) {
+    private static void addCheckFloatBoundsCall(BytecodeAssembler asm, int checkDoubleBounds, int min, int max, int fromColumnType, int toColumnType, int toColumnIndex) {
         asm.dup();
         asm.f2d();
 
-        asm.ldc2_w(min);
-        asm.ldc2_w(max);
-        asm.iconst(i);
-        asm.iconst(fromColumnType);
-        asm.iconst(toColumnType);
-        asm.invokeStatic(checkDoubleBounds);
+        invokeCheckMethod(asm, checkDoubleBounds, min, max, fromColumnType, toColumnType, toColumnIndex);
     }
 
-    private static void addCheckLongBoundsCall(BytecodeAssembler asm, int checkLongBounds, int min, int max, int i, int fromColumnType, int toColumnType) {
+    private static void addCheckLongBoundsCall(BytecodeAssembler asm, int checkLongBounds, int min, int max, int fromColumnType, int toColumnType, int toColumnIndex) {
         asm.dup2();
-        
-        asm.ldc2_w(min);
-        asm.ldc2_w(max);
-        asm.iconst(i);
-        asm.iconst(fromColumnType);
-        asm.iconst(toColumnType);
-        asm.invokeStatic(checkLongBounds);
+
+        invokeCheckMethod(asm, checkLongBounds, min, max, fromColumnType, toColumnType, toColumnIndex);
     }
 
-    private static void addCheckIntBoundsCall(BytecodeAssembler asm, int checkLongBounds, int min, int max, int i, int fromColumnType, int toColumnType) {
+    private static void addCheckIntBoundsCall(BytecodeAssembler asm, int checkLongBounds, int min, int max, int fromColumnType, int toColumnType, int toColumnIndex) {
         asm.dup();
         asm.i2l();
 
-        asm.ldc2_w(min);
-        asm.ldc2_w(max);
-        asm.iconst(i);
-        asm.iconst(fromColumnType);
-        asm.iconst(toColumnType);
-        asm.invokeStatic(checkLongBounds);
+        invokeCheckMethod(asm, checkLongBounds, min, max, fromColumnType, toColumnType, toColumnIndex);
     }
 
-    /*
-    private static void addCheckFloatBoundsCall(BytecodeAssembler asm, int checkFloatBounds, int min, int max, int i, int fromColumnType, int toColumnType) {
-        asm.dup();
-        asm.ldc_w(min);
-        asm.ldc_w(max);
-        asm.iconst(i);
+    private static void invokeCheckMethod(BytecodeAssembler asm, int checkBounds, int min, int max, int fromColumnType, int toColumnType, int toColumnIndex) {
+        asm.ldc2_w(min);
+        asm.ldc2_w(max);
         asm.iconst(fromColumnType);
         asm.iconst(toColumnType);
-        asm.invokeStatic(checkFloatBounds);
-    }*/
+        asm.iconst(toColumnIndex);
+        asm.invokeStatic(checkBounds);
+    }
 
     public static void configureLexer(GenericLexer lexer) {
         for (int i = 0, k = sqlControlSymbols.size(); i < k; i++) {
@@ -2503,15 +2478,15 @@ public class SqlCompiler implements Closeable {
     public static class RecordToRowCopierUtils {
         private RecordToRowCopierUtils(){}
         //used by copier
-        static void checkDoubleBounds( double value, double min, double max, int position, int fromType, int toType) throws SqlException {
+        static void checkDoubleBounds( double value, double min, double max, int fromType, int toType, int toColumnIndex) throws SqlException {
             if ( value < min || value > max ){
-                throw SqlException.inconvertibleValue( position, value, fromType, toType );
+                throw SqlException.inconvertibleValue( toColumnIndex, value, fromType, toType );
             }
         }
         //used by copier
-        static void checkLongBounds( long value, long min, long max, int position, int fromType, int toType) throws SqlException {
+        static void checkLongBounds( long value, long min, long max, int fromType, int toType, int toColumnIndex) throws SqlException {
             if ( value < min || value > max ){
-                throw SqlException.inconvertibleValue( position, value, fromType, toType );
+                throw SqlException.inconvertibleValue( toColumnIndex, value, fromType, toType );
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/SqlException.java
+++ b/core/src/main/java/io/questdb/griffin/SqlException.java
@@ -56,24 +56,28 @@ public class SqlException extends Exception implements Sinkable, FlyweightMessag
                 .put(", to=").put(toName).put(']');
     }
 
-    public static SqlException inconvertibleValue(int position, double value, int fromType, int toType) { 
-        return $(position, "inconvertible value: ")
+    public static SqlException inconvertibleValue(int columnNumber, double value, int fromType, int toType) { 
+        return $(-1, "inconvertible value: ")
                 .put(value)
                 .put(" [")
                 .put(ColumnType.nameOf(fromType))
                 .put(" -> ")
                 .put(ColumnType.nameOf(toType))
-                .put(']');
+                .put(']')
+                .put(" in target column number: ")
+                .put(columnNumber);
     }
 
-    public static SqlException inconvertibleValue(int position, long value, int fromType, int toType) {
-        return $(position, "inconvertible value: ")
+    public static SqlException inconvertibleValue(int columnNumber, long value, int fromType, int toType) {
+        return $(-1, "inconvertible value: ")
                 .put(value)
                 .put(" [")
                 .put(ColumnType.nameOf(fromType))
                 .put(" -> ")
                 .put(ColumnType.nameOf(toType))
-                .put(']');
+                .put(']')
+                .put(" in target column number: ")
+                .put(columnNumber);
     }
 
     public static SqlException invalidColumn(int position, CharSequence column) {

--- a/core/src/main/java/io/questdb/griffin/SqlException.java
+++ b/core/src/main/java/io/questdb/griffin/SqlException.java
@@ -56,6 +56,13 @@ public class SqlException extends Exception implements Sinkable, FlyweightMessag
                 .put(", to=").put(toName).put(']');
     }
 
+    public static SqlException inconvertibleValue(int position, int fromType, int toType) { //TODO: add value and column names
+        return $(position, "inconvertible value: ")
+                .put(ColumnType.nameOf(fromType))
+                .put(" -> ")
+                .put(ColumnType.nameOf(toType));
+    }
+
     public static SqlException invalidColumn(int position, CharSequence column) {
         return position(position).put("Invalid column: ").put(column);
     }

--- a/core/src/main/java/io/questdb/griffin/SqlException.java
+++ b/core/src/main/java/io/questdb/griffin/SqlException.java
@@ -56,11 +56,24 @@ public class SqlException extends Exception implements Sinkable, FlyweightMessag
                 .put(", to=").put(toName).put(']');
     }
 
-    public static SqlException inconvertibleValue(int position, int fromType, int toType) { //TODO: add value and column names
+    public static SqlException inconvertibleValue(int position, double value, int fromType, int toType) { 
         return $(position, "inconvertible value: ")
+                .put(value)
+                .put(" [")
                 .put(ColumnType.nameOf(fromType))
                 .put(" -> ")
-                .put(ColumnType.nameOf(toType));
+                .put(ColumnType.nameOf(toType))
+                .put(']');
+    }
+
+    public static SqlException inconvertibleValue(int position, long value, int fromType, int toType) {
+        return $(position, "inconvertible value: ")
+                .put(value)
+                .put(" [")
+                .put(ColumnType.nameOf(fromType))
+                .put(" -> ")
+                .put(ColumnType.nameOf(toType))
+                .put(']');
     }
 
     public static SqlException invalidColumn(int position, CharSequence column) {
@@ -112,6 +125,11 @@ public class SqlException extends Exception implements Sinkable, FlyweightMessag
     }
 
     public SqlException put(long value) {
+        message.put(value);
+        return this;
+    }
+
+    public SqlException put(double value) {
         message.put(value);
         return this;
     }

--- a/core/src/main/java/io/questdb/std/BytecodeAssembler.java
+++ b/core/src/main/java/io/questdb/std/BytecodeAssembler.java
@@ -396,6 +396,11 @@ public class BytecodeAssembler {
         putShort(index);
     }
 
+    public void ldc_w(int index) {
+        putByte(0x13);
+        putShort(index);
+    }
+
     public void lload(int value) {
         optimisedIO(lload_0, lload_1, lload_2, lload_3, lload, value);
     }

--- a/core/src/main/java/io/questdb/std/BytecodeAssembler.java
+++ b/core/src/main/java/io/questdb/std/BytecodeAssembler.java
@@ -100,9 +100,13 @@ public class BytecodeAssembler {
         putShort(offset);
     }
 
+    public void athrow() {
+        putByte(0xbf);
+    }
+
     public void d2f() {
         putShort(0x90);
-    }
+    } //why not putByte? is the nop intentional ? 
 
     public void d2i() {
         putShort(0x8E);
@@ -110,6 +114,10 @@ public class BytecodeAssembler {
 
     public void d2l() {
         putShort(0x8F);
+    }
+
+    public void dcmpg() {
+        putByte(0x98);
     }
 
     public void defineClass(int thisClassIndex) {
@@ -164,6 +172,14 @@ public class BytecodeAssembler {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public void dup() {
+        putByte(0x59);
+    }
+
+    public void dup2() {
+        putByte(0x5c);
     }
 
     public void endMethod() {
@@ -268,6 +284,14 @@ public class BytecodeAssembler {
 
     public int if_icmpne() {
         return genericGoto(0xa0);
+    }
+
+    public int ifle() {
+        return genericGoto(0x9e);
+    }
+
+    public int iflt() {
+        return genericGoto(0x9b);
     }
 
     public int ifne() {
@@ -449,6 +473,14 @@ public class BytecodeAssembler {
         return poolInterfaceMethod(classIndex, poolNameAndType(poolUtf8(name), poolUtf8(sig)));
     }
 
+    public int poolDoubleConst(double value) {
+        putByte(0x06);
+        putDouble(value);
+        int index = poolCount;
+        poolCount += 2;
+        return index;
+    }
+
     public int poolLongConst(long value) {
         putByte(0x05);
         putLong(value);
@@ -551,6 +583,13 @@ public class BytecodeAssembler {
         putByte(0);
     }
 
+    public void putDouble(double value) {
+        if (buf.remaining() < 4) {
+            resize();
+        }
+        buf.putDouble(value);
+    }
+    
     public void putLong(long value) {
         if (buf.remaining() < 4) {
             resize();

--- a/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
+++ b/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
@@ -1,0 +1,64 @@
+package io.questdb.griffin;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+/**
+ *
+ */
+public class ImplicitTypeConversionsTest extends AbstractGriffinTest {
+
+    @Test(expected = SqlException.class)
+    public void testInsertDoubleAsFloat_CausesUnderflow_And_ReturnsException() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(f float);", sqlExecutionContext);
+            executeInsert("insert into tab values (-34028235000000000000000000000000000000.0);");
+
+            String expected = "f\n" +
+                    "-3.4028235E38\n";
+
+            assertReader(expected, "tab");
+        });
+    }
+
+    @Test(expected = SqlException.class)
+    public void testInsertDoubleAsFloat_CausesOverflow_And_ReturnsException() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(f float);", sqlExecutionContext);
+            executeInsert("insert into tab values (34028235700000000000000000000000000000.0);");
+
+            String expected = "f\n" +
+                    "3.4028235E38\n";
+
+            assertReader(expected, "tab");
+        });
+    }
+    
+    @Test
+    public void testInsertDoubleAsFloat_ReturnsExactValue() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(f float);", sqlExecutionContext);
+            executeInsert("insert into tab values (123.4567);");
+
+            String expected = "f\n" +
+                    "123.4567\n";
+
+            assertReader(expected, "tab");
+        });
+    }
+
+    @Test
+    public void testInsertDoubleAsFloat_ReturnsApproximateValue() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(f float);", sqlExecutionContext);
+            executeInsert("insert into tab values (123.45678);");
+
+            String expected = "f\n" +
+                    "123.4568\n";
+
+            assertReader(expected, "tab");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
+++ b/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
@@ -1,64 +1,532 @@
 package io.questdb.griffin;
 
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.SQLException;
-
 /**
- *
+ * Test implicit narrowing conversions : 
+ * double -> float, long, int, short, byte
+ * float -> long, int, short, byte
+ * long -> int, short, byte
+ * int -> short, byte
+ * short -> byte 
  */
 public class ImplicitTypeConversionsTest extends AbstractGriffinTest {
 
-    @Test(expected = SqlException.class)
+    //double->float
+    @Test
     public void testInsertDoubleAsFloat_CausesUnderflow_And_ReturnsException() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table tab(f float);", sqlExecutionContext);
-            executeInsert("insert into tab values (-34028235000000000000000000000000000000.0);");
-
-            String expected = "f\n" +
-                    "-3.4028235E38\n";
-
-            assertReader(expected, "tab");
-        });
+        testInsertCausesException("double","-34028235000000000000000000000000000000.0","float");
     }
 
-    @Test(expected = SqlException.class)
+    @Test
     public void testInsertDoubleAsFloat_CausesOverflow_And_ReturnsException() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table tab(f float);", sqlExecutionContext);
-            executeInsert("insert into tab values (34028235700000000000000000000000000000.0);");
-
-            String expected = "f\n" +
-                    "3.4028235E38\n";
-
-            assertReader(expected, "tab");
-        });
+        testInsertCausesException("double","34028235700000000000000000000000000000.0","float");
     }
     
     @Test
     public void testInsertDoubleAsFloat_ReturnsExactValue() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table tab(f float);", sqlExecutionContext);
-            executeInsert("insert into tab values (123.4567);");
-
-            String expected = "f\n" +
-                    "123.4567\n";
-
-            assertReader(expected, "tab");
-        });
+        testInsert("double", "123.4567", "float", "123.4567");
     }
 
     @Test
     public void testInsertDoubleAsFloat_ReturnsApproximateValue() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table tab(f float);", sqlExecutionContext);
-            executeInsert("insert into tab values (123.45678);");
+        testInsert("double", "12345.6789", "float", "12345.6784");
+    }
 
-            String expected = "f\n" +
-                    "123.4568\n";
+    @Test
+    public void testInsertZeroDoubleAsFloat_ReturnsExactValue() throws Exception {
+        testInsert("double", "0.0", "float", "0.0000");
+    }
+
+    @Test
+    public void testInsertNonZeroDoubleAsFloat_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("double","2.34567","float", "2.3457");//formatting issue, number is stored properly
+    }
+
+    @Test
+    public void testInsertDoubleAsFloat_ReturnsMinValue() throws Exception {
+        testInsert("double", "3.4028234E38", "float", "3.4028235E38");
+    }
+
+    @Test
+    public void testInsertDoubleAsFloat_ReturnsMaxValue() throws Exception {
+        testInsert("double", "-3.4028234E38", "float", "-3.4028235E38");
+    }
+
+    @Test
+    public void testInsertDoubleAsFloat_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","3.4028235E38","float");
+    }
+
+    @Test
+    public void testInsertDoubleAsFloat_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","-3.4028236E38","float");
+    }
+    
+    //double->long
+    @Test
+    public void testInsertZeroDoubleAsLong_ReturnsExactValue() throws Exception {
+        testInsert("double", "0.0", "long", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonDoubleDoubleAsLong_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("double","2.34567","short", "2");
+    }
+
+    //input can't be -9223372036854775808 due to  #1615
+    @Test
+    public void testInsertDoubleAsLong_ReturnsActualMinValue() throws Exception {
+        testInsert("double", "-9223372036854775250.0", "long", "-9223372036854774784");
+    }
+
+    //input can't be -9223372036854775808 due to  #1615
+    @Test
+    public void testInsertDoubleAsLong_ReturnsMinValue() throws Exception {
+        testInsert("double", "-9223372036854775300.0", "long", "NaN");//-9223372036854775808L is interpreted as NaN
+    }
+
+    @Test
+    public void testInsertDoubleAsLong_ReturnsMaxValue() throws Exception {
+        testInsert("double", "9223372036854775807.0", "long", "9223372036854775807");
+    }
+
+    @Test
+    public void testInsertDoubleAsLong_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","9223372036854775908.0","long");
+    }
+
+    @Test
+    public void testInsertDoubleAsLong_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","-9223372036855775809.0","long");
+    }
+    
+    //double->int
+    @Test
+    public void testInsertZeroDoubleAsInt_ReturnsExactValue() throws Exception {
+        testInsert("double", "0.0", "int", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonDoubleDoubleAsInt_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("double","2.34567","int", "2");
+    }
+
+    @Test
+    public void testInsertDoubleAsInt_ReturnsActualMinValue() throws Exception {
+        testInsert("double", "-2147483647.0", "int", "-2147483647");//see Numbers.append:127
+    }
+
+    @Test
+    public void testInsertDoubleAsInt_ReturnsMinValue() throws Exception {
+        testInsert("double", "-2147483648.0", "int", "NaN");//see Numbers.append:127
+    }
+
+    @Test
+    public void testInsertDoubleAsInt_ReturnsMaxValue() throws Exception {
+        testInsert("double", "2147483647.0", "int", "2147483647");
+    }
+
+    @Test
+    public void testInsertDoubleAsInt_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","2147483648.0","int");
+    }
+
+    @Test
+    public void testInsertDoubleAsInt_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","-2147483649.0","int");
+    }
+    
+    //double->short
+    @Test
+    public void testInsertZeroDoubleAsShort_ReturnsExactValue() throws Exception {
+        testInsert("double", "0.0", "short", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonIntegerDoubleAsShort_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("double","5.678","short", "5");
+    }
+
+    @Test
+    public void testInsertDoubleAsShort_ReturnsMinValue() throws Exception {
+        testInsert("double", "-32768.0", "short", "-32768");
+    }
+
+    @Test
+    public void testInsertDoubleAsShort_ReturnsMaxValue() throws Exception {
+        testInsert("double", "32767.0", "short", "32767");
+    }
+
+    @Test
+    public void testInsertDoubleAsShort_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","32768","short");
+    }
+
+    @Test
+    public void testInsertDoubleAsShort_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double","-32769","short");
+    }
+    
+    //double->byte
+    @Test
+    public void testInsertZeroIntegerDoubleAsByte_ReturnsExactValue() throws Exception {
+        testInsert("double","0.0","byte", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonIntegerDoubleAsByte_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("double","1.1234","byte", "1");
+    }
+
+    @Test
+    public void testInsertDoubleAsByte_ReturnsMinValue() throws Exception {
+        testInsert("double","-128.0","byte", "-128");
+    }
+
+    @Test
+    public void testInsertDoublesByte_ReturnsMaxValue() throws Exception {
+        testInsert("double","127.0","byte", "127");
+    }
+
+    @Test
+    public void testInsertDoubleAsByte_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double", "128", "byte");
+    }
+
+    @Test
+    public void testInsertDoubleAsByte_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("double", "-129", "byte");
+    }
+    
+
+    //float->long
+    @Test
+    public void testInsertZeroFloatAsLong_ReturnsExactValue() throws Exception {
+        testInsert("float", "0.0", "long", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonFloatFloatAsLong_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("float","7.891","long", "7");
+    }
+
+    @Test
+    public void testInsertFloatAsLong_ReturnsActualMinValue() throws Exception {
+        testInsert("float", "-9223371036854775807.0", "long", "-9223370937343148032");
+    }
+    
+    //input can't be -9223372036854775808 due to  #1615
+    @Test
+    public void testInsertFloatAsLong_ReturnsMinValue() throws Exception {
+        testInsert("float", "-9223372036854775807.0", "long", "NaN");//-9223372036854775808 is interpreted as NaN
+    }
+
+    @Test
+    public void testInsertFloatAsLong_ReturnsMaxValue() throws Exception {
+        testInsert("float", "9223372036854775807.0", "long", "9223372036854775807");
+    }
+                                
+    @Test
+    public void testInsertFloatAsLong_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","9223373036854775808.0","long");
+    }
+
+    @Test
+    public void testInsertFloatAsLong_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","-9223373036854775808.0","long");
+    }
+    
+    //float->int
+    @Test
+    public void testInsertZeroFloatAsInt_ReturnsExactValue() throws Exception {
+        testInsert("float", "0.0", "int", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonFloatFloatAsInt_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("float","2.34567","int", "2");
+    }
+
+    @Test
+    public void testInsertFloatAsInt_ReturnsActualMinValue() throws Exception {
+        testInsert("float", "-2147483520.0", "int", "-2147483520");//see Numbers.append:127
+    }
+    
+    @Test
+    public void testInsertFloatAsInt_ReturnsMinValue() throws Exception {
+        testInsert("float", "-2147483648.0", "int", "NaN");//see Numbers.append:127
+    }
+
+    @Test
+    public void testInsertFloatAsInt_ReturnsMaxValue() throws Exception {
+        testInsert("float", "2147483520.0", "int", "2147483520");
+    }
+
+    @Test
+    public void testInsertFloatAsInt_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","2147483648.0","int");
+    }
+
+    @Test
+    public void testInsertFloatAsInt_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","-2147483848.0","int");
+    }
+    
+    //float->short
+    @Test
+    public void testInsertZeroFloatAsShort_ReturnsExactValue() throws Exception {
+        testInsert("float", "0.0", "short", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonIntegerFloatAsShort_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("float","5.678","short", "5");
+    }
+
+    @Test
+    public void testInsertFloatAsShort_ReturnsMinValue() throws Exception {
+        testInsert("float", "-32768.0", "short", "-32768");
+    }
+
+    @Test
+    public void testInsertFloatAsShort_ReturnsMaxValue() throws Exception {
+        testInsert("float", "32767.0", "short", "32767");
+    }
+
+    @Test
+    public void testInsertFloatAsShort_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","32768","short");
+    }
+
+    @Test
+    public void testInsertFloatAsShort_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float","-32769","short");
+    }
+    
+    //float->byte
+    @Test
+    public void testInsertZeroIntegerFloatAsByte_ReturnsExactValue() throws Exception {
+        testInsert("float","0.0","byte", "0");
+    }
+
+    @Test
+    public void testInsertZeroNonIntegerFloatAsByte_ReturnsValueWithoutFraction() throws Exception {
+        testInsert("float","1.1234","byte", "1");
+    }
+
+    @Test
+    public void testInsertFloatAsByte_ReturnsMinValue() throws Exception {
+        testInsert("float","-128.0","byte", "-128");
+    }
+
+    @Test
+    public void testInsertFloatsByte_ReturnsMaxValue() throws Exception {
+        testInsert("float","127.0","byte", "127");
+    }
+
+    @Test
+    public void testInsertFloatAsByte_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float", "128", "byte");
+    }
+
+    @Test
+    public void testInsertFloatAsByte_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("float", "-129", "byte");
+    }
+    
+    //long->int
+    @Test
+    public void testInsertZeroLongAsInt_ReturnsExactValue() throws Exception {
+        testInsert("long", "0", "int");
+    }
+
+    @Test
+    public void testInsertLongAsInt_ReturnsActualMinValue() throws Exception {
+        testInsert("long", "-2147483647", "int", "-2147483647"); //see Numbers.append:127
+    }
+    
+    @Test
+    public void testInsertLongAsInt_ReturnsMinValue() throws Exception {
+        testInsert("long", "-2147483648", "int", "NaN"); //see Numbers.append:127
+    }
+
+    @Test
+    public void testInsertLongAsInt_ReturnsMaxValue() throws Exception {
+        testInsert("long", "2147483647", "int");
+    }
+
+    @Test
+    public void testInsertLongAsInt_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long","2147483648","int");
+    }
+
+    @Test
+    public void testInsertLongAsInt_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long","-2147483649","int");
+    }
+    
+    //long->short
+    @Test
+    public void testInsertZeroLongAsShort_ReturnsExactValue() throws Exception {
+        testInsert("long", "0", "short");
+    }
+
+    @Test
+    public void testInsertLongAsShort_ReturnsMinValue() throws Exception {
+        testInsert("long", "-32768", "short");
+    }
+
+    @Test
+    public void testInsertLongAsShort_ReturnsMaxValue() throws Exception {
+        testInsert("long", "32767", "short");
+    }
+
+    @Test
+    public void testInsertLongAsShort_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long","32768","short");
+    }
+
+    @Test
+    public void testInsertLongAsShort_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long","-32769","short");
+    }
+    
+    //long->byte
+    @Test
+    public void testInsertZeroLongAsByte_ReturnsExactValue() throws Exception {
+        testInsert("long","0","byte");
+    }
+
+    @Test
+    public void testInsertLongAsByte_ReturnsMinValue() throws Exception {
+        testInsert("long","-128","byte");
+    }
+
+    @Test
+    public void testInsertLongsByte_ReturnsMaxValue() throws Exception {
+        testInsert("long","127","byte");
+    }
+
+    @Test
+    public void testInsertLongAsByte_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long", "128", "byte");
+    }
+
+    @Test
+    public void testInsertLongAsByte_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("long", "-129", "byte");
+    }
+    
+    
+    //int->short
+    @Test
+    public void testInsertZeroIntAsShort_ReturnsExactValue() throws Exception {
+        testInsert("int", "0", "short");
+    }
+
+    @Test
+    public void testInsertIntAsShort_ReturnsMinValue() throws Exception {
+        testInsert("int", "-32768", "short");
+    }
+
+    @Test
+    public void testInsertIntAsShort_ReturnsMaxValue() throws Exception {
+        testInsert("int", "32767", "short");
+    }
+
+    @Test
+    public void testInsertIntAsShort_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("int","32768","short");
+    }
+
+    @Test
+    public void testInsertIntAsShort_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("int","-32769","short");
+    }
+
+
+    //int->byte
+    @Test
+    public void testInsertZeroIntAsByte_ReturnsExactValue() throws Exception {
+        testInsert("int","0","byte");
+    }
+
+    @Test
+    public void testInsertIntAsByte_ReturnsMinValue() throws Exception {
+        testInsert("int","-128","byte");
+    }
+
+    @Test
+    public void testInsertIntsByte_ReturnsMaxValue() throws Exception {
+        testInsert("int","127","byte");
+    }
+
+    @Test
+    public void testInsertIntAsByte_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException("int", "128", "byte");
+    }
+
+    @Test
+    public void testInsertIntAsByte_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException("int", "-129", "byte");
+    }
+
+    
+    //short->byte
+    @Test
+    public void testInsertZeroShortAsByte_ReturnsExactValue() throws Exception {
+        testInsert( "short", "0", "byte" );
+    }
+
+    @Test
+    public void testInsertShortAsByte_ReturnsMinValue() throws Exception {
+        testInsert( "short", "-128", "byte" );
+    }
+
+    @Test
+    public void testInsertShortAsByte_ReturnsMaxValue() throws Exception {
+        testInsert( "short", "127", "byte" );
+    }
+
+    @Test
+    public void testInsertShortAsByte_Causes_Overflow_and_throws_exception() throws Exception {
+        testInsertCausesException( "short", "128", "byte" );
+    }
+
+    @Test
+    public void testInsertShortAsByte_Causes_Underflow_and_throws_exception() throws Exception {
+        testInsertCausesException( "short", "-129", "byte" );
+    }
+    
+    private void testInsert(String valueType, String value, String targetColumnType, String expectedValue) throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tab(x " + targetColumnType + " );", sqlExecutionContext);
+            executeInsert("insert into tab values (cast(" + value + " as " + valueType + " ));");
+
+            String expected = "x\n" + expectedValue + "\n";
 
             assertReader(expected, "tab");
         });
     }
+
+    private void testInsert(String valueType, String value, String targetColumnType) throws Exception {
+        testInsert( valueType, value, targetColumnType, value );
+    }
+    
+    private void testInsertCausesException(String valueType, String value, String targetColumnType) throws Exception {
+        try {
+            assertMemoryLeak(() -> {
+                compiler.compile("create table tab(x " + targetColumnType + " );", sqlExecutionContext);
+                executeInsert("insert into tab values (cast(" + value + " as " + valueType + " ));");
+            });
+
+            Assert.fail("SqlException should be thrown!");
+        }
+        catch (SqlException sqlE){
+            //maybe add some message check
+        }
+    }
+
 }

--- a/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
+++ b/core/src/test/java/io/questdb/griffin/ImplicitTypeConversionsTest.java
@@ -1,5 +1,6 @@
 package io.questdb.griffin;
 
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -525,7 +526,7 @@ public class ImplicitTypeConversionsTest extends AbstractGriffinTest {
             Assert.fail("SqlException should be thrown!");
         }
         catch (SqlException sqlE){
-            //maybe add some message check
+            TestUtils.assertContains(sqlE.getFlyweightMessage(), "inconvertible value");
         }
     }
 

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -831,25 +831,25 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     public void testCastIntByte() throws SqlException {
         assertCastInt("a\n" +
                 "1\n" +
-                "0\n" +
-                "22\n" +
-                "22\n" +
-                "0\n" +
+                "19\n" +
+                "30\n" +
+                "16\n" +
                 "7\n" +
                 "26\n" +
                 "26\n" +
+                "15\n" +
+                "14\n" +
                 "0\n" +
-                "13\n" +
-                "0\n" +
-                "0\n" +
-                "0\n" +
-                "25\n" +
                 "21\n" +
-                "23\n" +
-                "0\n" +
+                "15\n" +
+                "3\n" +
+                "4\n" +
                 "6\n" +
                 "19\n" +
-                "7\n", ColumnType.BYTE);
+                "7\n" +
+                "13\n" +
+                "17\n" +
+                "25\n", ColumnType.BYTE, 0);
     }
 
     @Test
@@ -959,26 +959,26 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     public void testCastIntShort() throws SqlException {
         assertCastInt("a\n" +
                         "1\n" +
-                        "0\n" +
-                        "22\n" +
-                        "22\n" +
-                        "0\n" +
+                        "19\n" +
+                        "30\n" +
+                        "16\n" +
                         "7\n" +
                         "26\n" +
                         "26\n" +
+                        "15\n" +
+                        "14\n" +
                         "0\n" +
-                        "13\n" +
-                        "0\n" +
-                        "0\n" +
-                        "0\n" +
-                        "25\n" +
                         "21\n" +
-                        "23\n" +
-                        "0\n" +
+                        "15\n" +
+                        "3\n" +
+                        "4\n" +
                         "6\n" +
                         "19\n" +
-                        "7\n",
-                ColumnType.SHORT);
+                        "7\n" +
+                        "13\n" +
+                        "17\n" +
+                        "25\n",
+                ColumnType.SHORT, 0);
     }
 
     @Test
@@ -1011,26 +1011,26 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     public void testCastLongByte() throws SqlException {
         assertCastLong("a\n" +
                         "22\n" +
-                        "0\n" +
-                        "17\n" +
-                        "2\n" +
-                        "0\n" +
+                        "11\n" +
+                        "6\n" +
+                        "26\n" +
                         "21\n" +
                         "1\n" +
                         "20\n" +
-                        "0\n" +
-                        "14\n" +
-                        "0\n" +
+                        "15\n" +
+                        "9\n" +
                         "26\n" +
+                        "30\n" +
+                        "8\n" +
                         "0\n" +
-                        "23\n" +
-                        "2\n" +
-                        "24\n" +
-                        "0\n" +
+                        "4\n" +
                         "16\n" +
                         "10\n" +
-                        "6\n",
-                ColumnType.BYTE);
+                        "6\n" +
+                        "3\n" +
+                        "8\n" +
+                        "12\n",
+                ColumnType.BYTE, 0);
     }
 
     @Test
@@ -1115,52 +1115,52 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     public void testCastLongInt() throws SqlException {
         assertCastLong("a\n" +
                         "22\n" +
-                        "0\n" +
-                        "17\n" +
-                        "2\n" +
-                        "0\n" +
+                        "11\n" +
+                        "6\n" +
+                        "26\n" +
                         "21\n" +
                         "1\n" +
                         "20\n" +
-                        "0\n" +
-                        "14\n" +
-                        "0\n" +
+                        "15\n" +
+                        "9\n" +
                         "26\n" +
+                        "30\n" +
+                        "8\n" +
                         "0\n" +
-                        "23\n" +
-                        "2\n" +
-                        "24\n" +
-                        "0\n" +
+                        "4\n" +
                         "16\n" +
                         "10\n" +
-                        "6\n",
-                ColumnType.INT);
+                        "6\n" +
+                        "3\n" +
+                        "8\n" +
+                        "12\n",
+                ColumnType.INT, 0);
     }
 
     @Test
     public void testCastLongShort() throws SqlException {
         assertCastLong("a\n" +
                         "22\n" +
-                        "0\n" +
-                        "17\n" +
-                        "2\n" +
-                        "0\n" +
+                        "11\n" +
+                        "6\n" +
+                        "26\n" +
                         "21\n" +
                         "1\n" +
                         "20\n" +
-                        "0\n" +
-                        "14\n" +
-                        "0\n" +
+                        "15\n" +
+                        "9\n" +
                         "26\n" +
+                        "30\n" +
+                        "8\n" +
                         "0\n" +
-                        "23\n" +
-                        "2\n" +
-                        "24\n" +
-                        "0\n" +
+                        "4\n" +
                         "16\n" +
                         "10\n" +
-                        "6\n",
-                ColumnType.SHORT);
+                        "6\n" +
+                        "3\n" +
+                        "8\n" +
+                        "12\n",
+                ColumnType.SHORT, 0);
     }
 
     @Test
@@ -1241,27 +1241,27 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     @Test
     public void testCastShortByte() throws SqlException {
         assertCastShort("a\n" +
-                        "-106\n" +
-                        "-42\n" +
+                        "48\n" +
+                        "110\n" +
+                        "63\n" +
+                        "99\n" +
+                        "107\n" +
+                        "43\n" +
+                        "-10\n" +
+                        "-105\n" +
+                        "122\n" +
+                        "-88\n" +
                         "-76\n" +
-                        "-41\n" +
-                        "-41\n" +
-                        "-107\n" +
-                        "117\n" +
-                        "3\n" +
-                        "-35\n" +
-                        "21\n" +
-                        "38\n" +
-                        "-25\n" +
-                        "46\n" +
+                        "108\n" +
+                        "-78\n" +
+                        "-113\n" +
+                        "39\n" +
                         "-8\n" +
-                        "-120\n" +
-                        "101\n" +
-                        "30\n" +
-                        "-122\n" +
-                        "52\n" +
-                        "91\n",
-                ColumnType.BYTE);
+                        "-68\n" +
+                        "17\n" +
+                        "-69\n" +
+                        "-14\n",
+                ColumnType.BYTE, -128, 127);
     }
 
     @Test
@@ -3138,7 +3138,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "insert into x " +
                         "select" +
                         " rnd_int()," +
-                        " rnd_long()" +
+                        " rnd_date( to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 0)" +
                         " from long_sequence(30)", 32, "inconvertible types");
     }
 
@@ -3148,7 +3148,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "insert into x " +
                         "select" +
                         " rnd_int()," +
-                        " rnd_long()" +
+                        " rnd_char()" +
                         " from long_sequence(30)", 32, "inconvertible types");
     }
 
@@ -3158,7 +3158,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "insert into x (b,a)" +
                         "select" +
                         " rnd_int()," +
-                        " rnd_long()" +
+                        " rnd_date( to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 0)" +
                         " from long_sequence(30)", 17, "inconvertible types");
     }
 
@@ -3168,7 +3168,7 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "insert into x (b,a)" +
                         "select" +
                         " rnd_int()," +
-                        " rnd_long()" +
+                        " rnd_char()" +
                         " from long_sequence(30)", 17, "inconvertible types");
     }
 
@@ -3178,13 +3178,13 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                 "insert into x (b,a)" +
                         "select" +
                         " rnd_int()," +
-                        " rnd_long()" +
+                        " rnd_char()" +
                         " from long_sequence(30)", 17, "inconvertible types");
     }
 
     @Test
     public void testInsertAsSelectInconvertibleList4() throws Exception {
-        testInsertAsSelectError("create table x (a FLOAT, b INT, n TIMESTAMP)",
+        testInsertAsSelectError("create table x (a DATE, b INT, n TIMESTAMP)",
                 "insert into x (b,a)" +
                         "select" +
                         " rnd_int()," +
@@ -3832,10 +3832,14 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     private void assertCastInt(String expectedData, int castTo) throws SqlException {
+        assertCastInt( expectedData, castTo, 2);
+    }
+
+    private void assertCastInt(String expectedData, int castTo, int nanRate) throws SqlException {
         String expectedMeta = "{\"columnCount\":1,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"" + ColumnType.nameOf(castTo) + "\"}],\"timestampIndex\":-1}";
 
         String sql = "create table y as (" +
-                "select * from (select rnd_int(0, 30, 2) a from long_sequence(20))" +
+                "select * from (select rnd_int(0, 30, " + nanRate + ") a from long_sequence(20))" +
                 "), cast(a as " + ColumnType.nameOf(castTo) + ")";
 
         assertCast(expectedData, expectedMeta, sql);
@@ -3857,10 +3861,14 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     private void assertCastLong(String expectedData, int castTo) throws SqlException {
+        assertCastLong(expectedData, castTo, 2);
+    }
+
+    private void assertCastLong(String expectedData, int castTo, int nanRate) throws SqlException {
         String expectedMeta = "{\"columnCount\":1,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"" + ColumnType.nameOf(castTo) + "\"}],\"timestampIndex\":-1}";
 
         String sql = "create table y as (" +
-                "select * from (select rnd_long(0, 30, 2) a from long_sequence(20))" +
+                "select * from (select rnd_long(0, 30, " + nanRate + ") a from long_sequence(20))" +
                 "), cast(a as " + ColumnType.nameOf(castTo) + ")";
 
         assertCast(expectedData, expectedMeta, sql);
@@ -3882,10 +3890,14 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     private void assertCastShort(String expectedData, int castTo) throws SqlException {
+        assertCastShort(expectedData, castTo, 1024, 2048 );
+    }
+
+    private void assertCastShort(String expectedData, int castTo, int min, int max) throws SqlException {
         String expectedMeta = "{\"columnCount\":1,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"" + ColumnType.nameOf(castTo) + "\"}],\"timestampIndex\":-1}";
 
         String sql = "create table y as (" +
-                "select * from (select rnd_short(1024, 2048) a from long_sequence(20))), cast(a as " + ColumnType.nameOf(castTo) + ")";
+                "select * from (select rnd_short(" + min + ", " + max + ") a from long_sequence(20))), cast(a as " + ColumnType.nameOf(castTo) + ")";
 
         assertCast(expectedData, expectedMeta, sql);
     }


### PR DESCRIPTION
__Open questions:__
- [ ] Should implicit cast allow narrowing conversion between types with different interpretation (char->byte, timestamp->date) ? 
- [ ] Should Float/Double NaN to int/long Nan conversion be implemented in this PR ? 


__Description:__

This is a draft meant to start discussion on https://github.com/questdb/questdb/issues/1207.
Instead of making sure conversion maintains full precision I reckon it'd be more convenient to allow reasonable conversions between byte, short, ..., double types but prevent under- and over-flows like in PostgreSQL.

Preventing any loss of precision when converting from double to float could be a pain for the user ('can my double be represented as float' guessing game). 

It seems the most natural place for this validation is `RecordToRowCopier.copy` because doesn't know about the value unless it's a constant function. Handling constant function which might be an interesting special case (verification done once and removed from `RecordToRowCopier.copy`) but with limited utility.

__Notes:__

* In current implementation long can be 'widended' to double implicitly but it causes unexpected rounding to nearest representable value when close to `Long.MAX_VALUE`

* bytecode doesn't have stackmap yet so it works only when verification is disabled