### PR TITLE
chore: allow column names with spaces

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -347,7 +347,6 @@ public final class TableUtils {
         for (int i = 0, l = seq.length(); i < l; i++) {
             char c = seq.charAt(i);
             switch (c) {
-                case ' ':
                 case '?':
                 case '.':
                 case ',':
@@ -378,7 +377,6 @@ public final class TableUtils {
             switch (seq.charAt(i)) {
                 default:
                     break;
-                case ' ':
                 case '?':
                 case '.':
                 case ',':

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -562,10 +562,10 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
     @Test
     public void testFieldWithUnquotedString() throws Exception {
         runInContext((receiver) -> {
-            sendLinger(receiver,  "tab raw_msg=____ 1619509249714000000\n", "tab");
-            sendLinger(receiver,  "tab raw_msg=__\"_ 1619509249714000000\n", "tab");
+            sendLinger(receiver,  "tab raw\\ msg=____ 1619509249714000000\n", "tab");
+            sendLinger(receiver,  "tab raw\\ msg=__\"_ 1619509249714000000\n", "tab");
 
-            String expected = "raw_msg\ttimestamp\n" +
+            String expected = "raw msg\ttimestamp\n" +
                     "____\t2021-04-27T07:40:49.714000Z\n" +
                     "__\"_\t2021-04-27T07:40:49.714000Z\n";
             assertTable(expected, "tab");

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -796,7 +796,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                             .$(0);
                     lineTcpSender
                             .metric("table")
-                            .tag("tag 2", "value=\2") // Invalid column name, last line is not saved
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
                             .$(Timestamps.DAY_MICROS * 1000L);
                     lineTcpSender.flush();
                 }
@@ -948,12 +948,12 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                             .$(0);
                     lineTcpSender
                             .metric("table")
-                            .tag("tag 2", "value=\2") // Invalid column name, last line is not saved
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
                             .$(Timestamps.DAY_MICROS * 1000L);
                     // Repeat
                     lineTcpSender
                             .metric("table")
-                            .tag("tag 2", "value=\2") // Invalid column name, last line is not saved
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
                             .$(Timestamps.DAY_MICROS * 1000L);
                     lineTcpSender.flush();
                 }
@@ -992,7 +992,7 @@ public class LineTcpReceiverTest extends AbstractCairoTest {
                 try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
                     lineTcpSender
                             .metric("table")
-                            .tag("tag 2", "value=\2") // Invalid column name, line is not saved
+                            .tag("tag/2", "value=\2") // Invalid column name, line is not saved
                             .$(0);
                     lineTcpSender
                             .metric("table")

--- a/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableAddColumnTest.java
@@ -129,6 +129,32 @@ public class AlterTableAddColumnTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testAddColumnWithSpaceInName() throws Exception {
+        assertMemoryLeak(
+                () -> {
+                    createX();
+
+                    Assert.assertEquals(ALTER, compiler.compile("alter table x add \"spa ce\" string", sqlExecutionContext).getType());
+
+                    assertQueryPlain(
+                            "c\tspa ce\n" +
+                                    "XYZ\t\n" +
+                                    "ABC\t\n" +
+                                    "ABC\t\n" +
+                                    "XYZ\t\n" +
+                                    "\t\n" +
+                                    "CDE\t\n" +
+                                    "CDE\t\n" +
+                                    "ABC\t\n" +
+                                    "\t\n" +
+                                    "XYZ\t\n",
+                            "select c, \"spa ce\" from x"
+                    );
+                }
+        );
+    }
+
+    @Test
     public void testAddColumnWithoutUsingColumnKeyword() throws Exception {
         assertMemoryLeak(
                 () -> {


### PR DESCRIPTION
- space should be escaped in field / tag name in ILP
- column name should be double quoted in SQL