### PR TITLE
feat(ui): add column type to grid

### DIFF
--- a/ui/src/js/console/grid.js
+++ b/ui/src/js/console/grid.js
@@ -392,9 +392,22 @@ $.fn.grid = function (msgBus) {
     totalWidth = 0
     for (i = 0; i < columns.length; i++) {
       var c = columns[i]
-      var col = $('<div class="qg-header qg-w' + i + '">' + c.name + "</div>")
+      var col = $(
+        '<div class="qg-header qg-w' +
+          i +
+          '" data-column-name="' +
+          c.name +
+          '"><span class="qg-header-type">' +
+          c.type.toLowerCase() +
+          '</span><span class="qg-header-name">' +
+          c.name +
+          "</span></div>",
+      )
         .on("click", function (e) {
-          bus.trigger("editor.insert.column", e.target.innerHTML)
+          bus.trigger(
+            "editor.insert.column",
+            e.currentTarget.getAttribute("data-column-name"),
+          )
         })
         .appendTo(header)
       switch (c.type) {
@@ -405,7 +418,7 @@ $.fn.grid = function (msgBus) {
       }
       w = Math.max(
         defaults.minColumnWidth,
-        Math.ceil(c.name.length * 8 * 1.2 + 8),
+        Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 8),
       )
       colMax.push(w)
       totalWidth += w

--- a/ui/src/styles/_grid.scss
+++ b/ui/src/styles/_grid.scss
@@ -31,6 +31,7 @@
 }
 
 .qg-header-row {
+  display: flex;
   overflow: hidden;
   height: 33px;
 
@@ -70,14 +71,15 @@
 }
 
 .qg-header {
-  display: inline-block;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  flex-direction: row;
   padding: 5px 3px 7px;
-  font-weight: 700;
-  border-bottom: 1px solid #191a21;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: right;
   cursor: pointer;
+  border-bottom: 1px solid #191a21;
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Old versions of Firefox */
@@ -86,11 +88,26 @@
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
+
+}
+
+.qg-header-name {
+  font-weight: 700;
   color: #f1fa8c !important;
+}
+
+.qg-header-type {
+  font-weight: 700;
+  font-style: italic;
+  margin: 0 7px;
+  color: #6272a4;
+  white-space: nowrap;
 }
 
 .qg-header-l {
   text-align: left;
+  flex-direction: row-reverse;
+  white-space: nowrap;
 }
 
 .qg-viewport {


### PR DESCRIPTION
Adds a column type indication to results grid, aligned with the overall positioning (left/right) of header text.

This slightly changes the column width calculation, because we have to make sure the type is always visible even in a dense layout (a lot of columns).

<img width="1797" alt="CleanShot 2021-11-26 at 12 14 23@2x" src="https://user-images.githubusercontent.com/1871646/143573428-1eebdf1e-12e3-4436-bc22-01a138bbcdb5.png">

