### PR TITLE
fix: fix ALTER TABLE ADD COLUMN parse error #1612

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1062,7 +1062,8 @@ public class SqlCompiler implements Closeable {
             int symbolCapacity;
             final boolean indexed;
 
-            if (ColumnType.isSymbol(type) && tok != null && !Chars.equals(tok, ',')) {
+            if (ColumnType.isSymbol(type) && tok != null &&
+                    !Chars.equals(tok, ',') && !Chars.equals(tok, ';')) {
 
                 if (isCapacityKeyword(tok)) {
                     tok = expectToken(lexer, "symbol capacity");
@@ -1123,7 +1124,7 @@ public class SqlCompiler implements Closeable {
                 } else {
                     indexValueBlockCapacity = configuration.getIndexValueBlockSize();
                 }
-            } else {
+            } else { //set defaults 
 
                 //ignoring `NULL` and `NOT NULL`
                 if (tok != null && SqlKeywords.isNotKeyword(tok)) {
@@ -1161,7 +1162,7 @@ public class SqlCompiler implements Closeable {
                         .put(']');
             }
 
-            if (tok == null) {
+            if (tok == null || Chars.equals(tok, ';')) {
                 break;
             }
 


### PR DESCRIPTION
Should fix #1612 . 
I think this type of error can happen for other types of statements due to how sql is parsed and because sql is usually tested without ';' at end of statement . 