### PR TITLE
Issue #1213 - TCP and UDP parts of the Influx protocol were fixed.

### DIFF
--- a/core/src/main/java/io/questdb/std/LowerCaseCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/LowerCaseCharSequenceIntHashMap.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import io.questdb.std.str.IntIntFunction;
+
 import java.util.Arrays;
 
 public class LowerCaseCharSequenceIntHashMap extends AbstractLowerCaseCharSequenceHashSet {
@@ -107,6 +109,38 @@ public class LowerCaseCharSequenceIntHashMap extends AbstractLowerCaseCharSequen
             return true;
         }
         return false;
+    }
+
+    public int compute(final CharSequence key, final IntIntFunction function) {
+        final int result;
+        final int index = keyIndex(key);
+        if (index < 0) {
+            final int valueIndex = -index - 1;
+            result = function.apply(values[valueIndex]);
+
+            if (result != noEntryValue) {
+                values[valueIndex] = result;
+            } else {
+                removeAt(index);
+            }
+
+            return result;
+        } else {
+            result = function.apply(noEntryValue);
+            if (result != noEntryValue) {
+                putAt0(index, key, result);
+            }
+        }
+
+        return result;
+    }
+
+    public void updateAllValues(final int value) {
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != noEntryValue) {
+                values[i] = value;
+            }
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/str/IntIntFunction.java
+++ b/core/src/main/java/io/questdb/std/str/IntIntFunction.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std.str;
+
+@FunctionalInterface
+public interface IntIntFunction {
+    int apply(int value);
+}

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
@@ -670,6 +670,101 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDuplicatedFields() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:00:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:03:00.000000Z\n";
+        String lines = "weather g=1i,a=0.1,windspeed=1.0 0\n" +
+                "weather g=2i,windspeed=2.0,windspeed=3.0 60000000000\n" +
+                "weather g=3i,a=0.4,a=0.5 120000000000\n" +
+                "weather g=4i,a=0.71,windspeed=67.72 180000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsInFirstLine() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:01:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:03:00.000000Z\n";
+        String lines = "weather g=2i,windspeed=2.0,windspeed=3.0 0\n" +
+                "weather g=1i,a=0.1,windspeed=1.0 60000000000\n" +
+                "weather g=3i,a=0.4,a=0.5 120000000000\n" +
+                "weather g=4i,a=0.71,windspeed=67.72 180000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsInFirstLines() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:02:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:03:00.000000Z\n";
+        String lines = "weather g=2i,windspeed=2.0,windspeed=3.0 0\n" +
+                "weather g=3i,a=0.4,a=0.5 60000000000\n" +
+                "weather g=1i,a=0.1,windspeed=1.0 120000000000\n" +
+                "weather g=4i,a=0.71,windspeed=67.72 180000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsFirstAndLastLine() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:01:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:02:00.000000Z\n";
+        String lines = "weather g=2i,windspeed=2.0,windspeed=3.0 0\n" +
+                "weather g=1i,a=0.1,windspeed=1.0 60000000000\n" +
+                "weather g=4i,a=0.71,windspeed=67.72 120000000000\n" +
+                "weather g=3i,a=0.4,a=0.5 180000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsTwoTables() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:01:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:04:00.000000Z\n";
+        String lines =
+                "table val1=1,val2=2 0\n" +
+                        "weather g=1i,a=0.1,windspeed=1.0 60000000000\n" +
+                        "weather g=2i,windspeed=2.0,windspeed=3.0 120000000000\n" +
+                        "weather g=3i,a=0.4,a=0.5 180000000000\n" +
+                        "weather g=4i,a=0.71,windspeed=67.72 240000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsInTwoTables() throws Exception {
+        String expected = "g\ta\twindspeed\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:01:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:04:00.000000Z\n";
+        String lines =
+                "table val1=1,val2=2,val1=1 0\n" +
+                        "weather g=1i,a=0.1,windspeed=1.0 60000000000\n" +
+                        "weather g=2i,windspeed=2.0,windspeed=3.0 120000000000\n" +
+                        "weather g=3i,a=0.4,a=0.5 180000000000\n" +
+                        "weather g=4i,a=0.71,windspeed=67.72 240000000000\n";
+
+        assertThat(expected, lines, "weather");
+    }
+
+    @Test
+    public void testDuplicatedFieldsInternational() throws Exception {
+        String expected = "г\tа\tветер\ttimestamp\n" +
+                "1\t0.1\t1.0\t1970-01-01T00:00:00.000000Z\n" +
+                "4\t0.71\t67.72\t1970-01-01T00:03:00.000000Z\n";
+        String lines = "погода г=1i,а=0.1,ветер=1.0 0\n" +
+                "погода г=2i,ветер=2.0,ветер=3.0 60000000000\n" +
+                "погода г=3i,а=0.4,а=0.5 120000000000\n" +
+                "погода г=4i,а=0.71,ветер=67.72 180000000000\n";
+
+        assertThat(expected, lines, "погода");
+    }
+
+    @Test
     public void testColumnConversion1() throws Exception {
         try (
                 @SuppressWarnings("resource")

--- a/core/src/test/java/io/questdb/std/LowerCaseCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/LowerCaseCharSequenceIntHashMapTest.java
@@ -29,8 +29,7 @@ import io.questdb.std.str.StringSink;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class LowerCaseCharSequenceIntHashMapTest {
 
@@ -51,7 +50,7 @@ public class LowerCaseCharSequenceIntHashMapTest {
         Assert.assertEquals(1, lowerCaseMap.get("A"));
         Assert.assertEquals(2, lowerCaseMap.get("bb"));
 
-        ObjList<CharSequence>  keys =  lowerCaseMap.keys();
+        ObjList<CharSequence> keys = lowerCaseMap.keys();
         Assert.assertEquals(2, keys.size());
         Assert.assertEquals("a", keys.get(0));
         Assert.assertEquals("Bb", keys.get(1));
@@ -125,5 +124,193 @@ public class LowerCaseCharSequenceIntHashMapTest {
             }
         }
 
+    }
+
+    @Test
+    public void testUpdateAll() {
+        final Rnd rnd = new Rnd();
+        final LowerCaseCharSequenceIntHashMap lowerCaseMap = new LowerCaseCharSequenceIntHashMap();
+        final int N = 10_000;
+
+        lowerCaseMap.updateAllValues(42);
+
+        Assert.assertEquals(-1, lowerCaseMap.get("arREd"));
+
+        final HashMap<String, Integer> referenceMap = new HashMap<>();
+        for (int i = 0; i < N; i++) {
+            final String str = rnd.nextString(4);
+
+            int value = rnd.nextInt();
+            if (value == -1) {
+                value = 0;
+            }
+
+            referenceMap.put(str.toLowerCase(Locale.ROOT), value);
+            lowerCaseMap.put(str, value);
+        }
+
+
+        lowerCaseMap.updateAllValues(42);
+
+        for (final String key : referenceMap.keySet()) {
+            final int value = lowerCaseMap.get(key);
+            Assert.assertEquals(42, value);
+        }
+
+
+        for (int i = 0; i < N; i++) {
+            final String str = rnd.nextString(4);
+            if (referenceMap.containsKey(str.toLowerCase(Locale.ROOT))) {
+                Assert.assertEquals(42, lowerCaseMap.get(str));
+            } else {
+                Assert.assertEquals(-1, lowerCaseMap.get(str));
+            }
+        }
+
+        lowerCaseMap.updateAllValues(24);
+
+        for (final String key : referenceMap.keySet()) {
+            final int value = lowerCaseMap.get(key);
+            Assert.assertEquals(24, value);
+        }
+
+
+        for (int i = 0; i < N; i++) {
+            final String str = rnd.nextString(4);
+            if (referenceMap.containsKey(str.toLowerCase(Locale.ROOT))) {
+                Assert.assertEquals(24, lowerCaseMap.get(str));
+            } else {
+                Assert.assertEquals(-1, lowerCaseMap.get(str));
+            }
+        }
+        lowerCaseMap.clear();
+
+        lowerCaseMap.updateAllValues(666);
+
+        for (final String key : referenceMap.keySet()) {
+            final int value = lowerCaseMap.get(key);
+            Assert.assertEquals(-1, value);
+        }
+
+        for (int i = 0; i < N; i++) {
+            final String str = rnd.nextString(4);
+            Assert.assertEquals(-1, lowerCaseMap.get(str));
+        }
+    }
+
+    @Test
+    public void testCompute() {
+        final Rnd rnd = new Rnd();
+
+        final LowerCaseCharSequenceIntHashMap lowerCaseMap = new LowerCaseCharSequenceIntHashMap();
+        final int N = 10_000;
+
+        lowerCaseMap.compute("aresR", value -> {
+            Assert.assertEquals(-1, value);
+            return 23;
+        });
+
+        Assert.assertEquals(23, lowerCaseMap.get("aresr"));
+
+        final HashMap<String, Integer> referenceMap = new HashMap<>();
+        for (int i = 0; i < N; i++) {
+            final String str = rnd.nextString(4);
+
+            int value = rnd.nextInt();
+            if (value == -1) {
+                value = 0;
+            }
+
+            referenceMap.put(str.toLowerCase(Locale.ROOT), value);
+            lowerCaseMap.put(str, value);
+        }
+
+        Iterator<String> keyIterator = referenceMap.keySet().iterator();
+
+        final HashSet<String> addedKeys = new HashSet<>();
+        while (keyIterator.hasNext()) {
+            if (rnd.nextBoolean()) {
+                final String currentKey = keyIterator.next();
+                final int value = referenceMap.get(currentKey);
+                final int newValue = lowerCaseMap.compute(randomUpperCase(currentKey, rnd), val -> {
+                    final int newVal = val + 42;
+                    if (newVal == -1) {
+                        return 0;
+                    }
+                    return newVal;
+                });
+
+                final int expectedValue;
+                if (value + 42 == -1) {
+                    expectedValue = 0;
+                } else {
+                    expectedValue = value + 42;
+                }
+                Assert.assertEquals(expectedValue, newValue);
+                referenceMap.compute(currentKey, (k, v) -> newValue);
+            } else {
+                final String currentKey = rnd.nextString(5);
+                if (!addedKeys.contains(currentKey)) {
+                    final int newValue = lowerCaseMap.compute(currentKey, val -> {
+                        Assert.assertEquals(-1, val);
+                        return 42;
+                    });
+                    Assert.assertEquals(42, newValue);
+                    addedKeys.add(currentKey);
+                }
+            }
+        }
+
+        for (final String key : addedKeys) {
+            referenceMap.put(key, 42);
+        }
+
+        HashSet<String> removedKeys = new HashSet<>();
+        for (final String key : referenceMap.keySet()) {
+
+            if (rnd.nextInt(4) == 3) {
+
+                final int value = referenceMap.get(key);
+                final int newValue = lowerCaseMap.compute(randomUpperCase(key, rnd), v -> {
+                    Assert.assertEquals(value, v);
+                    return -1;
+                });
+
+                removedKeys.add(key);
+                Assert.assertEquals(-1, newValue);
+            }
+
+            final String noKey = rnd.nextString(6);
+            final int newValue = lowerCaseMap.compute(noKey, value -> {
+                Assert.assertEquals(-1, value);
+                return -1;
+            });
+
+            Assert.assertEquals(-1, newValue);
+        }
+
+        for (String key : removedKeys) {
+            referenceMap.remove(key);
+        }
+
+        for (String key : referenceMap.keySet()) {
+            final int expVal = referenceMap.get(key);
+            final int refVal = lowerCaseMap.get(randomUpperCase(key, rnd));
+
+            Assert.assertEquals(expVal, refVal);
+        }
+    }
+
+    private String randomUpperCase(final String value, final Rnd rnd) {
+        final StringSink sink = new StringSink();
+        for (int i = 0; i < value.length(); i++) {
+            if (rnd.nextBoolean()) {
+                sink.put(Character.toUpperCase(value.charAt(i)));
+            } else {
+                sink.put(value.charAt(i));
+            }
+        }
+
+        return sink.toString();
     }
 }


### PR DESCRIPTION
Fix of issue #1213 that keeps counters of duplicated fields that are indexed in a list according to column indexes for the hot path and uses hash maps enhanced with `compute` method for the slow path when metadata are initially fetched.

Two methods were added into LowerCaseCharSequenceIntHashMap - `updateAll` and `compute`. The first could be replaced by a simple call to the `clear` method if that is more desirable. 
 