### PR TITLE
fix(sql): tweak hash function to speed up FastMap

### DIFF
--- a/core/src/main/java/io/questdb/cairo/vm/MemoryPARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryPARWImpl.java
@@ -705,25 +705,6 @@ public class MemoryPARWImpl implements MemoryARW {
         return view.of(offset + STRING_LENGTH_BYTES, len);
     }
 
-    public long hash(long offset, long size) {
-        if (roOffsetLo < offset && offset < roOffsetHi - size) {
-            long n = size - (size % 8);
-            long address = absolutePointer + offset;
-
-            long h = 179426491L;
-            for (long i = 0; i < n; i += 8) {
-                h = (h << 5) - h + Unsafe.getUnsafe().getLong(address + i);
-            }
-
-            for (; n < size; n++) {
-                h = (h << 5) - h + Unsafe.getUnsafe().getByte(address + n);
-            }
-            return h;
-        }
-
-        return hash0(offset, size);
-    }
-
     public boolean isMapped(long offset, long len) {
         int pageIndex = pageIndex(offset);
         int pageEndIndex = pageIndex(offset + len - 1);

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryR.java
@@ -98,8 +98,8 @@ public interface MemoryR extends Closeable {
     default long hash0(long offset, long size) {
         long n = size - (size & 7);
         long h = 179426491L;
-        for (long i = 0; i < n; i += 8) {
-            h = (h << 5) - h + getLong(offset + i);
+        for (long i = 0; i < n; i += 4) {
+            h = (h << 5) - h + getInt(offset + i);
         }
 
         for (; n < size; n++) {

--- a/core/src/main/java/io/questdb/std/DirectLongList.java
+++ b/core/src/main/java/io/questdb/std/DirectLongList.java
@@ -153,11 +153,15 @@ public class DirectLongList implements Mutable, Closeable {
     public String toString() {
         CharSink sb = Misc.getThreadLocalBuilder();
         sb.put('{');
-        for (int i = 0; i < size(); i++) {
+        final int maxElementsToPrint = 1000; // Do not try to print too much, it can hang IntelliJ debugger.
+        for (int i = 0, n = (int) Math.min(maxElementsToPrint, size()); i < n; i++) {
             if (i > 0) {
                 sb.put(',').put(' ');
             }
             sb.put(get(i));
+        }
+        if (size() > maxElementsToPrint) {
+            sb.put(", .. ");
         }
         sb.put('}');
         return sb.toString();

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -42,13 +42,35 @@ public final class Hash {
     }
 
     /**
-     * Calculates positive integer hash of memory pointer using Java hashcode() algorithm.
+     * Calculates positive integer hash of memory pointer using Java hashcode() algorithm using Ints
      *
      * @param p   memory pointer
      * @param len memory length in bytes
      * @return hash code
      */
     public static int hashMem(long p, int len) {
+        long hash = 0;
+        final long hi = p + len;
+        while (hi - p > 3) {
+            hash = (hash << 5) - hash + Unsafe.getUnsafe().getInt(p);
+            p += Integer.BYTES;
+        }
+
+        while (p < hi) {
+            hash = (hash << 5) - hash + Unsafe.getUnsafe().getByte(p++);
+        }
+
+        return spread((int) hash);
+    }
+
+    /**
+     * Calculates positive integer hash of memory pointer using Java hashcode() algorithm using Longs
+     *
+     * @param p   memory pointer
+     * @param len memory length in bytes
+     * @return hash code
+     */
+    public static int hashMemAlternative(long p, int len) {
         long hash = 0;
         final long hi = p + len;
         while (hi - p > 7) {

--- a/core/src/test/java/io/questdb/HashTest.java
+++ b/core/src/test/java/io/questdb/HashTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb;
 
+import io.questdb.cairo.map.FastMap;
 import io.questdb.std.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,6 +33,17 @@ public class HashTest {
 
     @Test
     public void testStringHash() {
+        FastMap.HashFunction hashFunction = Hash::hashMem;
+        testHash(hashFunction);
+    }
+
+    @Test
+    public void testStringHashAlternative() {
+        FastMap.HashFunction hashFunction = Hash::hashMemAlternative;
+        testHash(hashFunction);
+    }
+
+    private void testHash(FastMap.HashFunction hashFunction) {
         Rnd rnd = new Rnd();
         IntHashSet hashes = new IntHashSet(100000);
         final int LEN = 64;
@@ -40,7 +52,7 @@ public class HashTest {
 
         for (int i = 0; i < 100000; i++) {
             rnd.nextChars(address, LEN / 2);
-            hashes.add(Hash.hashMem(address, LEN));
+            hashes.add(hashFunction.hash(address, LEN));
         }
         Assert.assertTrue("Hash function distribution dropped", hashes.size() > 99990);
     }

--- a/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
+++ b/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
@@ -142,58 +142,6 @@ public class FastMapTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testLong256AndCharAsKey() {
-        Rnd rnd = new Rnd();
-
-        ArrayColumnTypes keyTypes = new ArrayColumnTypes();
-        ArrayColumnTypes valueTypes = new ArrayColumnTypes();
-
-        keyTypes.add(ColumnType.LONG256);
-        keyTypes.add(ColumnType.CHAR);
-
-        valueTypes.add(ColumnType.DOUBLE);
-
-        Long256Impl long256 = new Long256Impl();
-
-        try (FastMap map = new FastMap(64, keyTypes, valueTypes, 64, 0.8, 24)) {
-            final int N = 100000;
-            for (int i = 0; i < N; i++) {
-                MapKey key = map.withKey();
-                long256.fromRnd(rnd);
-                key.putLong256(long256);
-                key.putChar(rnd.nextChar());
-
-                MapValue value = key.createValue();
-                Assert.assertTrue(value.isNew());
-                value.putDouble(0, rnd.nextDouble());
-            }
-
-            rnd.reset();
-
-            // assert that all values are good
-            for (int i = 0; i < N; i++) {
-                MapKey key = map.withKey();
-                long256.fromRnd(rnd);
-                key.putLong256(long256);
-                key.putChar(rnd.nextChar());
-
-                MapValue value = key.createValue();
-                Assert.assertFalse(value.isNew());
-                Assert.assertEquals(rnd.nextDouble(), value.getDouble(0), 0.000000001d);
-            }
-
-            try (RecordCursor cursor = map.getCursor()) {
-                rnd.reset();
-                assertCursorLong256(rnd, cursor, long256);
-
-                rnd.reset();
-                cursor.toTop();
-                assertCursorLong256(rnd, cursor, long256);
-            }
-        }
-    }
-
-    @Test
     public void testAppendExisting() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             Rnd rnd = new Rnd();
@@ -235,45 +183,56 @@ public class FastMapTest extends AbstractCairoTest {
         testAppendUnique(3);
     }
 
-    @Test(expected = LimitOverflowException.class)
-    public void testMaxResizes() throws Exception {
-        testAppendUnique(1);
+    @Test
+    public void testCollisionPerformance() {
+        ArrayColumnTypes keyTypes = new ArrayColumnTypes();
+        ArrayColumnTypes valueTypes = new ArrayColumnTypes();
+
+        keyTypes.add(ColumnType.STRING);
+        keyTypes.add(ColumnType.STRING);
+
+        valueTypes.add(ColumnType.LONG);
+
+        // These are default FastMap configuration for a join
+        try (FastMap map = new FastMap(4194304, keyTypes, valueTypes, 2097152, 0.5, 2147483647)) {
+            for (int i = 0; i < 40_000_000; i++) {
+                MapKey key = map.withKey();
+                key.putStr(Integer.toString(i / 151));
+                key.putStr(Integer.toString((i + 3) / 151));
+
+                MapValue value = key.createValue();
+                value.putLong(0, i);
+            }
+        }
     }
 
-    private void testAppendUnique(int maxResizes) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            Rnd rnd = new Rnd();
-            int N = 100000;
-            int M = 25;
-            try (FastMap map = new FastMap(
-                    Numbers.SIZE_1MB,
-                    new SingleColumnType(ColumnType.STRING),
-                    new SingleColumnType(ColumnType.LONG),
-                    N / 4, 0.5f, maxResizes)) {
-                for (int i = 0; i < N; i++) {
-                    CharSequence s = rnd.nextChars(M);
-                    MapKey key = map.withKey();
-                    key.putStr(s);
-                    MapValue value = key.createValue();
-                    value.putLong(0, i + 1);
-                }
-                Assert.assertEquals(N, map.size());
+    @Test
+    public void testCollisionPerformanceLongKeys() {
+        ArrayColumnTypes keyTypes = new ArrayColumnTypes();
+        ArrayColumnTypes valueTypes = new ArrayColumnTypes();
 
-                long expectedAppendOffset = map.getAppendOffset();
+        keyTypes.add(ColumnType.LONG);
+        keyTypes.add(ColumnType.LONG);
+        keyTypes.add(ColumnType.LONG);
+        keyTypes.add(ColumnType.INT);
+        keyTypes.add(ColumnType.LONG);
 
-                rnd.reset();
-                for (int i = 0; i < N; i++) {
-                    CharSequence s = rnd.nextChars(M);
-                    MapKey key = map.withKey();
-                    key.putStr(s);
-                    MapValue value = key.findValue();
-                    Assert.assertNotNull(value);
-                    Assert.assertEquals(i + 1, value.getLong(0));
-                }
-                Assert.assertEquals(N, map.size());
-                Assert.assertEquals(expectedAppendOffset, map.getAppendOffset());
+        valueTypes.add(ColumnType.LONG);
+
+        // These are default FastMap configuration for a join
+        try (FastMap map = new FastMap(4194304, keyTypes, valueTypes, 2097152, 0.5, Hash::hashMemAlternative, 10000)) {
+            for (int i = 0; i < 40_000_000; i++) {
+                MapKey key = map.withKey();
+                key.putLong(i / 151);
+                key.putLong((i + 3) / 151);
+                key.putLong((i + 15) / 151);
+                key.putInt((i + 15) % 269);
+                key.putLong((i + 85) / 151);
+
+                MapValue value = key.createValue();
+                value.putLong(0, i);
             }
-        });
+        }
     }
 
     @Test
@@ -312,6 +271,82 @@ public class FastMapTest extends AbstractCairoTest {
                 assertDupes(map, rnd, N);
                 map.clear();
                 assertDupes(map, rnd, N);
+            }
+        });
+    }
+
+    @Test
+    public void testGeohashRecordAsKey() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int N = 5000;
+            final Rnd rnd = new Rnd();
+            int precisionBits = 10;
+            int geohashType = ColumnType.getGeoHashTypeWithBits(precisionBits);
+
+            BytecodeAssembler asm = new BytecodeAssembler();
+            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
+                model.col("a", ColumnType.LONG).col("b", geohashType);
+                CairoTestUtils.create(model);
+            }
+
+            try (TableWriter writer = new TableWriter(configuration, "x")) {
+                for (int i = 0; i < N; i++) {
+                    TableWriter.Row row = writer.newRow();
+                    long rndGeohash = GeoHashes.fromCoordinatesDeg(rnd.nextDouble() * 180 - 90, rnd.nextDouble() * 360 - 180, precisionBits);
+                    row.putLong(0, i);
+                    row.putGeoHash(1, rndGeohash);
+                    row.append();
+                }
+                writer.commit();
+            }
+
+            try (TableReader reader = new TableReader(configuration, "x")) {
+                EntityColumnFilter entityColumnFilter = new EntityColumnFilter();
+                entityColumnFilter.of(reader.getMetadata().getColumnCount());
+
+                try (FastMap map = new FastMap(
+                        Numbers.SIZE_1MB,
+                        new SymbolAsStrTypes(reader.getMetadata()),
+                        new ArrayColumnTypes()
+                                .add(ColumnType.LONG)
+                                .add(ColumnType.INT)
+                                .add(ColumnType.SHORT)
+                                .add(ColumnType.BYTE)
+                                .add(ColumnType.FLOAT)
+                                .add(ColumnType.DOUBLE)
+                                .add(ColumnType.DATE)
+                                .add(ColumnType.TIMESTAMP)
+                                .add(ColumnType.BOOLEAN)
+                        ,
+                        N,
+                        0.9f, 1)) {
+
+                    RecordSink sink = RecordSinkFactory.getInstance(asm, reader.getMetadata(), entityColumnFilter, true);
+                    // this random will be populating values
+                    Rnd rnd2 = new Rnd();
+
+                    RecordCursor cursor = reader.getCursor();
+                    populateMap(map, rnd2, cursor, sink);
+
+                    try (RecordCursor mapCursor = map.getCursor()) {
+                        long c = 0;
+                        rnd.reset();
+                        rnd2.reset();
+                        final Record record = mapCursor.getRecord();
+                        while (mapCursor.hasNext()) {
+                            // value
+                            Assert.assertEquals(++c, record.getLong(0));
+                            Assert.assertEquals(rnd2.nextInt(), record.getInt(1));
+                            Assert.assertEquals(rnd2.nextShort(), record.getShort(2));
+                            Assert.assertEquals(rnd2.nextByte(), record.getByte(3));
+                            Assert.assertEquals(rnd2.nextFloat(), record.getFloat(4), 0.000001f);
+                            Assert.assertEquals(rnd2.nextDouble(), record.getDouble(5), 0.000000001);
+                            Assert.assertEquals(rnd2.nextLong(), record.getDate(6));
+                            Assert.assertEquals(rnd2.nextLong(), record.getTimestamp(7));
+                            Assert.assertEquals(rnd2.nextBoolean(), record.getBool(8));
+                        }
+                    }
+                }
             }
         });
     }
@@ -367,6 +402,63 @@ public class FastMapTest extends AbstractCairoTest {
                 Assert.assertEquals(rnd.nextInt(), key.findValue().getInt(0));
             }
         });
+    }
+
+    @Test
+    public void testLong256AndCharAsKey() {
+        Rnd rnd = new Rnd();
+
+        ArrayColumnTypes keyTypes = new ArrayColumnTypes();
+        ArrayColumnTypes valueTypes = new ArrayColumnTypes();
+
+        keyTypes.add(ColumnType.LONG256);
+        keyTypes.add(ColumnType.CHAR);
+
+        valueTypes.add(ColumnType.DOUBLE);
+
+        Long256Impl long256 = new Long256Impl();
+
+        try (FastMap map = new FastMap(64, keyTypes, valueTypes, 64, 0.8, 24)) {
+            final int N = 100000;
+            for (int i = 0; i < N; i++) {
+                MapKey key = map.withKey();
+                long256.fromRnd(rnd);
+                key.putLong256(long256);
+                key.putChar(rnd.nextChar());
+
+                MapValue value = key.createValue();
+                Assert.assertTrue(value.isNew());
+                value.putDouble(0, rnd.nextDouble());
+            }
+
+            rnd.reset();
+
+            // assert that all values are good
+            for (int i = 0; i < N; i++) {
+                MapKey key = map.withKey();
+                long256.fromRnd(rnd);
+                key.putLong256(long256);
+                key.putChar(rnd.nextChar());
+
+                MapValue value = key.createValue();
+                Assert.assertFalse(value.isNew());
+                Assert.assertEquals(rnd.nextDouble(), value.getDouble(0), 0.000000001d);
+            }
+
+            try (RecordCursor cursor = map.getCursor()) {
+                rnd.reset();
+                assertCursorLong256(rnd, cursor, long256);
+
+                rnd.reset();
+                cursor.toTop();
+                assertCursorLong256(rnd, cursor, long256);
+            }
+        }
+    }
+
+    @Test(expected = LimitOverflowException.class)
+    public void testMaxResizes() throws Exception {
+        testAppendUnique(1);
     }
 
     @Test
@@ -472,82 +564,6 @@ public class FastMapTest extends AbstractCairoTest {
                         assertCursor2(rnd, binarySequence, keyColumnOffset, rnd2, mapCursor);
                         mapCursor.toTop();
                         assertCursor2(rnd, binarySequence, keyColumnOffset, rnd2, mapCursor);
-                    }
-                }
-            }
-        });
-    }
-
-    @Test
-    public void testGeohashRecordAsKey() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            final int N = 5000;
-            final Rnd rnd = new Rnd();
-            int precisionBits = 10;
-            int geohashType = ColumnType.getGeoHashTypeWithBits(precisionBits);
-
-            BytecodeAssembler asm = new BytecodeAssembler();
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-                model.col("a", ColumnType.LONG).col("b", geohashType);
-                CairoTestUtils.create(model);
-            }
-
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
-                for (int i = 0; i < N; i++) {
-                    TableWriter.Row row = writer.newRow();
-                    long rndGeohash = GeoHashes.fromCoordinatesDeg(rnd.nextDouble() * 180 - 90, rnd.nextDouble() * 360 - 180, precisionBits);
-                    row.putLong(0, i);
-                    row.putGeoHash(1, rndGeohash);
-                    row.append();
-                }
-                writer.commit();
-            }
-
-            try (TableReader reader = new TableReader(configuration, "x")) {
-                EntityColumnFilter entityColumnFilter = new EntityColumnFilter();
-                entityColumnFilter.of(reader.getMetadata().getColumnCount());
-
-                try (FastMap map = new FastMap(
-                        Numbers.SIZE_1MB,
-                        new SymbolAsStrTypes(reader.getMetadata()),
-                        new ArrayColumnTypes()
-                                .add(ColumnType.LONG)
-                                .add(ColumnType.INT)
-                                .add(ColumnType.SHORT)
-                                .add(ColumnType.BYTE)
-                                .add(ColumnType.FLOAT)
-                                .add(ColumnType.DOUBLE)
-                                .add(ColumnType.DATE)
-                                .add(ColumnType.TIMESTAMP)
-                                .add(ColumnType.BOOLEAN)
-                        ,
-                        N,
-                        0.9f, 1)) {
-
-                    RecordSink sink = RecordSinkFactory.getInstance(asm, reader.getMetadata(), entityColumnFilter, true);
-                    // this random will be populating values
-                    Rnd rnd2 = new Rnd();
-
-                    RecordCursor cursor = reader.getCursor();
-                    populateMap(map, rnd2, cursor, sink);
-
-                    try (RecordCursor mapCursor = map.getCursor()) {
-                        long c = 0;
-                        rnd.reset();
-                        rnd2.reset();
-                        final Record record = mapCursor.getRecord();
-                        while (mapCursor.hasNext()) {
-                            // value
-                            Assert.assertEquals(++c, record.getLong(0));
-                            Assert.assertEquals(rnd2.nextInt(), record.getInt(1));
-                            Assert.assertEquals(rnd2.nextShort(), record.getShort(2));
-                            Assert.assertEquals(rnd2.nextByte(), record.getByte(3));
-                            Assert.assertEquals(rnd2.nextFloat(), record.getFloat(4), 0.000001f);
-                            Assert.assertEquals(rnd2.nextDouble(), record.getDouble(5), 0.000000001);
-                            Assert.assertEquals(rnd2.nextLong(), record.getDate(6));
-                            Assert.assertEquals(rnd2.nextLong(), record.getTimestamp(7));
-                            Assert.assertEquals(rnd2.nextBoolean(), record.getBool(8));
-                        }
                     }
                 }
             }
@@ -665,8 +681,8 @@ public class FastMapTest extends AbstractCairoTest {
                         Assert.assertEquals(rnd2.nextLong(), value.getDate(6));
                         Assert.assertEquals(rnd2.nextLong(), value.getTimestamp(7));
                         Assert.assertEquals(rnd2.nextBoolean(), value.getBool(8));
-                        Assert.assertEquals((byte)Math.abs(rnd2.nextByte()), value.getGeoByte(9));
-                        Assert.assertEquals((short)Math.abs(rnd2.nextShort()), value.getGeoShort(10));
+                        Assert.assertEquals((byte) Math.abs(rnd2.nextByte()), value.getGeoByte(9));
+                        Assert.assertEquals((short) Math.abs(rnd2.nextShort()), value.getGeoShort(10));
                         Assert.assertEquals(Math.abs(rnd2.nextInt()), value.getGeoInt(11));
                         Assert.assertEquals(Math.abs(rnd2.nextLong()), value.getGeoLong(12));
                     }
@@ -690,7 +706,7 @@ public class FastMapTest extends AbstractCairoTest {
             try (TableReader reader = new TableReader(configuration, "x")) {
                 ListColumnFilter listColumnFilter = new ListColumnFilter();
                 for (int i = 0, n = reader.getMetadata().getColumnCount(); i < n; i++) {
-                    listColumnFilter.add(i+1);
+                    listColumnFilter.add(i + 1);
                 }
 
                 try (FastMap map = new FastMap(
@@ -1070,6 +1086,42 @@ public class FastMapTest extends AbstractCairoTest {
             value.putInt(11, Math.abs(rnd2.nextInt()));
             value.putLong(12, Math.abs(rnd2.nextLong()));
         }
+    }
+
+    private void testAppendUnique(int maxResizes) throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            Rnd rnd = new Rnd();
+            int N = 100000;
+            int M = 25;
+            try (FastMap map = new FastMap(
+                    Numbers.SIZE_1MB,
+                    new SingleColumnType(ColumnType.STRING),
+                    new SingleColumnType(ColumnType.LONG),
+                    N / 4, 0.5f, maxResizes)) {
+                for (int i = 0; i < N; i++) {
+                    CharSequence s = rnd.nextChars(M);
+                    MapKey key = map.withKey();
+                    key.putStr(s);
+                    MapValue value = key.createValue();
+                    value.putLong(0, i + 1);
+                }
+                Assert.assertEquals(N, map.size());
+
+                long expectedAppendOffset = map.getAppendOffset();
+
+                rnd.reset();
+                for (int i = 0; i < N; i++) {
+                    CharSequence s = rnd.nextChars(M);
+                    MapKey key = map.withKey();
+                    key.putStr(s);
+                    MapValue value = key.findValue();
+                    Assert.assertNotNull(value);
+                    Assert.assertEquals(i + 1, value.getLong(0));
+                }
+                Assert.assertEquals(N, map.size());
+                Assert.assertEquals(expectedAppendOffset, map.getAppendOffset());
+            }
+        });
     }
 
     private void testUnsupportedValueType() throws Exception {

--- a/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
+++ b/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
@@ -212,22 +212,16 @@ public class FastMapTest extends AbstractCairoTest {
         ArrayColumnTypes valueTypes = new ArrayColumnTypes();
 
         keyTypes.add(ColumnType.LONG);
-        keyTypes.add(ColumnType.LONG);
-        keyTypes.add(ColumnType.LONG);
         keyTypes.add(ColumnType.INT);
-        keyTypes.add(ColumnType.LONG);
 
         valueTypes.add(ColumnType.LONG);
 
         // These are default FastMap configuration for a join
-        try (FastMap map = new FastMap(4194304, keyTypes, valueTypes, 2097152, 0.5, Hash::hashMemAlternative, 10000)) {
+        try (FastMap map = new FastMap(4194304, keyTypes, valueTypes, 2097152, 0.5, 10000)) {
             for (int i = 0; i < 40_000_000; i++) {
                 MapKey key = map.withKey();
                 key.putLong(i / 151);
-                key.putLong((i + 3) / 151);
-                key.putLong((i + 15) / 151);
                 key.putInt((i + 15) % 269);
-                key.putLong((i + 85) / 151);
 
                 MapValue value = key.createValue();
                 value.putLong(0, i);

--- a/core/src/test/java/io/questdb/std/DirectLongListTest.java
+++ b/core/src/test/java/io/questdb/std/DirectLongListTest.java
@@ -115,6 +115,7 @@ public class DirectLongListTest {
         list.close();
         list2.close();
     }
+
     @Test
     public void testSearch() {
         DirectLongList list = new DirectLongList(256);
@@ -122,8 +123,22 @@ public class DirectLongListTest {
         for (int i = 0; i < N; ++i) {
             list.add(i);
         }
-        Assert.assertEquals(N/2, list.scanSearch(N/2, 0, list.size()));
-        Assert.assertEquals(N/2, list.binarySearch(N/2));
+        Assert.assertEquals(N / 2, list.scanSearch(N / 2, 0, list.size()));
+        Assert.assertEquals(N / 2, list.binarySearch(N / 2));
         list.close();
+    }
+
+    @Test
+    public void testToString() {
+        DirectLongList list = new DirectLongList(1001);
+        final int N = 1000;
+        for (int i = 0; i < N; ++i) {
+            list.add(i);
+        }
+        String str1 = list.toString();
+        list.add(1001);
+        String str2 = list.toString();
+
+        Assert.assertEquals(str1.substring(0, str1.length() - 1) + ", .. }", str2);
     }
 }


### PR DESCRIPTION
Fixes #1635

Run time of new `testCollisionPerformanceStringKeys` before the change - 7mins, after 2 secs