### PR TITLE
fix(core): fixed flapping test 'testWriterRelease4'

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -48,6 +48,8 @@ import org.jetbrains.annotations.Nullable;
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.questdb.cairo.pool.WriterPool.OWNERSHIP_REASON_NONE;
+
 public class CairoEngine implements Closeable, WriterSource {
     public static final String BUSY_READER = "busyReader";
     private static final Log LOG = LogFactory.getLog(CairoEngine.class);
@@ -288,7 +290,7 @@ public class CairoEngine implements Closeable, WriterSource {
         securityContext.checkWritePermission();
 
         CharSequence lockedReason = writerPool.lock(tableName, lockReason);
-        if (null == lockedReason) {
+        if (lockedReason == OWNERSHIP_REASON_NONE) {
             boolean locked = readerPool.lock(tableName);
             if (locked) {
                 LOG.info().$("locked [table=`").utf8(tableName).$("`, thread=").$(Thread.currentThread().getId()).$(']').$();

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -63,7 +63,7 @@ import java.util.Iterator;
 public class WriterPool extends AbstractPool {
     private static final Log LOG = LogFactory.getLog(WriterPool.class);
     static final String OWNERSHIP_REASON_MISSING = "missing or owned by other process";
-    static final String OWNERSHIP_REASON_NONE = "not owned by anyone";
+    public static final String OWNERSHIP_REASON_NONE = null;
     static final String OWNERSHIP_REASON_WRITER_ERROR = "writer error";
     private final static long ENTRY_OWNER = Unsafe.getFieldOffset(Entry.class, "owner");
     private final ConcurrentHashMap<Entry> entries = new ConcurrentHashMap<>();

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -27,6 +27,7 @@ package io.questdb.griffin;
 import io.questdb.MessageBus;
 import io.questdb.PropServerConfiguration;
 import io.questdb.cairo.*;
+import io.questdb.cairo.pool.WriterPool;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
@@ -964,7 +965,7 @@ public class SqlCompiler implements Closeable {
         tableExistsOrFail(tableNamePosition, tok, executionContext);
         try {
             CharSequence lockedReason = engine.lockWriter(tok, "alterSystem");
-            if (null != lockedReason) {
+            if (lockedReason != WriterPool.OWNERSHIP_REASON_NONE) {
                 throw SqlException.$(tableNamePosition, "could not lock, busy [table=`").put(tok).put(", lockedReason=").put(lockedReason).put("`]");
             }
             return compiledQuery.ofLock();
@@ -1470,7 +1471,7 @@ public class SqlCompiler implements Closeable {
             Function function,
             TableReader reader,
             AlterStatementBuilder changePartitionStatement
-    ) throws SqlException {
+    ) {
         // Iterate partitions in descending order so if folders are missing on disk
         // removePartition does not fail to determine next minTimestamp
         // Last partition cannot be dropped, exclude it from the list

--- a/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
@@ -133,6 +133,21 @@ public class WriterPoolTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLockWorkflow() throws Exception {
+        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
+            CairoTestUtils.create(model);
+        }
+
+        assertWithPool(pool -> {
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
+            pool.unlock("x");
+            pool.get("x", "testing").close();
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
+            pool.unlock("x");
+        });
+    }
+
+    @Test
     public void testCannotLockWriter() throws Exception {
 
         final TestFilesFacade ff = new TestFilesFacade() {
@@ -171,7 +186,7 @@ public class WriterPoolTest extends AbstractCairoTest {
             writer.close();
 
 
-            Assert.assertNull(pool.lock("z", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("z", "testing"));
 
             // check that we can't get writer from pool
             try {
@@ -307,7 +322,7 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testLockNonExisting() throws Exception {
         assertWithPool(pool -> {
-            Assert.assertNull(pool.lock("z", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("z", "testing"));
 
             try {
                 pool.get("z", "testing");
@@ -341,7 +356,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                 Assert.assertTrue(wy.isOpen());
 
                 // check that lock is successful
-                Assert.assertNull(pool.lock("x", "testing"));
+                Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
 
                 // check that writer x is closed and writer y is open (lock must not spill out to other writers)
                 Assert.assertTrue(wy.isOpen());
@@ -399,7 +414,7 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testNewLock() throws Exception {
         assertWithPool(pool -> {
-            Assert.assertNull(pool.lock("z", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("z", "testing"));
             try {
                 pool.get("z", "testing");
                 Assert.fail();
@@ -448,7 +463,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            Assert.assertNull(pool.lock("x", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
 
             TableWriter writer = new TableWriter(configuration, "x", messageBus, false, DefaultLifecycleManager.INSTANCE);
             for (int i = 0; i < 100; i++) {
@@ -546,7 +561,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                             }
 
                             // lock frees up writer, make sure on next iteration threads have something to compete for
-                            if (null == pool.lock("z", "testing")) {
+                            if (pool.lock("z", "testing") == WriterPool.OWNERSHIP_REASON_NONE) {
                                 pool.unlock("z");
                             }
                         } catch (Exception e) {
@@ -586,7 +601,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                     new Thread(() -> {
                         try {
                             barrier.await();
-                            if (null == pool.lock("z", "testing")) {
+                            if (pool.lock("z", "testing") == WriterPool.OWNERSHIP_REASON_NONE) {
                                 LockSupport.parkNanos(1);
                                 pool.unlock("z");
                             } else {
@@ -619,7 +634,7 @@ public class WriterPoolTest extends AbstractCairoTest {
     public void testUnlockInAnotherThread() throws Exception {
         assertWithPool(pool -> {
 
-            Assert.assertNull(pool.lock("x", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
             AtomicInteger errors = new AtomicInteger();
 
             CountDownLatch latch = new CountDownLatch(1);
@@ -672,7 +687,7 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testUnlockWriterWhenPoolIsClosed() throws Exception {
         assertWithPool(pool -> {
-            Assert.assertNull(pool.lock("z", "testing"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("z", "testing"));
 
             pool.close();
 

--- a/core/src/test/java/io/questdb/griffin/AlterSystemLockUnlockWriterTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterSystemLockUnlockWriterTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin;
 
+import io.questdb.cairo.pool.WriterPool;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -124,7 +125,7 @@ public class AlterSystemLockUnlockWriterTest extends AbstractGriffinTest {
             createX();
             compile("alter system lock writer x", sqlExecutionContext);
             compile("alter system unlock writer x", sqlExecutionContext);
-            Assert.assertNull(engine.lockWriter("x", "new lock 2"));
+            Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, engine.lockWriter("x", "new lock 2"));
         });
     }
 


### PR DESCRIPTION
We seems to set incorrect reason when writer is otherwise not locked

```
2021-12-11T13:49:48.3931700Z testWriterRelease4(io.questdb.cutlass.line.tcp.LineTcpReceiverTest)  Time elapsed: 0.284 sec  <<< ERROR!
2021-12-11T13:49:48.4033190Z io.questdb.cairo.CairoException: [2] Could not lock 'weather' [reason='not owned by anyone']
2021-12-11T13:49:48.4133950Z 
```