### PR TITLE
fix(core): fixed numerous flapping tests

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -471,8 +471,8 @@ public class WriterPool extends AbstractPool {
             e.ownershipReason = OWNERSHIP_REASON_NONE;
             e.lastReleaseTime = configuration.getMicrosecondClock().getTicks();
             Unsafe.getUnsafe().storeFence();
-            e.owner = UNALLOCATED;
-            Unsafe.getUnsafe().storeFence();
+            Unsafe.getUnsafe().putOrderedLong(e, ENTRY_OWNER, UNALLOCATED);
+            Unsafe.getUnsafe().fullFence();
             notifyListener(thread, name, PoolListener.EV_RETURN);
         } else {
             LOG.error().$("orphaned [table=`").utf8(name).$("`]").$();

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -467,23 +467,18 @@ public class WriterPool extends AbstractPool {
 
         if (e.owner != UNALLOCATED) {
             LOG.info().$("<< [table=`").utf8(name).$("`, thread=").$(thread).$(']').$();
-            if (isClosed()) {
-                e.writer = null;
-                LOG.info().$("allowing '").utf8(name).$("' to close [thread=").$(e.owner).$(']').$();
-                notifyListener(thread, name, PoolListener.EV_OUT_OF_POOL_CLOSE);
-                return false;
-            }
 
             e.ownershipReason = OWNERSHIP_REASON_NONE;
             e.lastReleaseTime = configuration.getMicrosecondClock().getTicks();
             Unsafe.getUnsafe().storeFence();
-            Unsafe.getUnsafe().putOrderedLong(e, ENTRY_OWNER, UNALLOCATED);
-            Unsafe.getUnsafe().fullFence();
+
             if (isClosed()) {
                 e.writer = null;
                 notifyListener(thread, name, PoolListener.EV_OUT_OF_POOL_CLOSE);
                 return false;
             }
+
+            Unsafe.getUnsafe().putOrderedLong(e, ENTRY_OWNER, UNALLOCATED);
             notifyListener(thread, name, PoolListener.EV_RETURN);
         } else {
             LOG.error().$("orphaned [table=`").utf8(name).$("`]").$();

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -58,7 +58,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private final CairoConfiguration configuration;
     private final LongList columnNameType = new LongList();
     private final LongList columnIndexAndType = new LongList();
-    private final IntList geohashBitsSizeByColIdx = new IntList(); // 0 if not a geohash, else bits precision
+    private final IntList geoHashBitsSizeByColIdx = new IntList(); // 0 if not a GeoHash, else bits precision
     private final LongList columnValues = new LongList();
     private final MemoryMARW ddlMem = Vm.getMARWInstance();
     private final MicrosecondClock clock;
@@ -156,7 +156,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                 break;
             case EVT_TIMESTAMP:
                 columnValues.add(token.getCacheAddress());
-                geohashBitsSizeByColIdx.add(0);
+                geoHashBitsSizeByColIdx.add(0);
                 break;
             default:
                 break;
@@ -191,7 +191,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                 LineUdpParserSupport.putValue(
                         row,
                         (int) columnNameType.getQuick(i * 2 + 1),
-                        geohashBitsSizeByColIdx.getQuick(i),
+                        geoHashBitsSizeByColIdx.getQuick(i),
                         i,
                         cache.get(columnValues.getQuick(i))
                 );
@@ -215,7 +215,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                 LineUdpParserSupport.putValue(
                         row,
                         Numbers.decodeHighInt(value),
-                        geohashBitsSizeByColIdx.getQuick(i),
+                        geoHashBitsSizeByColIdx.getQuick(i),
                         Numbers.decodeLowInt(value),
                         cache.get(columnValues.getQuick(i))
                 );
@@ -241,7 +241,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private void clearState() {
         columnNameType.clear();
         columnIndexAndType.clear();
-        geohashBitsSizeByColIdx.clear();
+        geoHashBitsSizeByColIdx.clear();
         columnValues.clear();
     }
 
@@ -397,7 +397,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
             if (valid) {
                 columnIndexAndType.add(Numbers.encodeLowHighInts(columnIndex, columnType));
                 columnValues.add(value.getCacheAddress());
-                geohashBitsSizeByColIdx.add(geoHashBits);
+                geoHashBitsSizeByColIdx.add(geoHashBits);
             } else {
                 LOG.error().$("mismatched column and value types [table=").$(writer.getTableName())
                         .$(", column=").$(metadata.getColumnName(columnIndex))
@@ -412,7 +412,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                 writer.addColumn(colNameAsChars, valueType);
                 columnIndexAndType.add(Numbers.encodeLowHighInts(columnCount++, valueType));
                 columnValues.add(value.getCacheAddress());
-                geohashBitsSizeByColIdx.add(0);
+                geoHashBitsSizeByColIdx.add(0);
             } else {
                 LOG.error().$("invalid column name [table=").$(writer.getTableName())
                         .$(", columnName=").$(colNameAsChars)
@@ -425,7 +425,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private void parseValueNewTable(CachedCharSequence value, int valueType) {
         columnNameType.add(valueType);
         columnValues.add(value.getCacheAddress());
-        geohashBitsSizeByColIdx.add(0); // not a geohash, no constant literal
+        geoHashBitsSizeByColIdx.add(0); // not a GeoHash, no constant literal
         // that can be recognised yet
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -155,12 +155,18 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
     }
 
     protected void runInContext(LineTcpReceiverTest.LineTcpServerAwareContext r) throws Exception {
+        runInContext(r, false);
+    }
+
+    protected void runInContext(LineTcpReceiverTest.LineTcpServerAwareContext r, boolean needMaintenanceJob) throws Exception {
         minIdleMsBeforeWriterRelease = 250;
         assertMemoryLeak(() -> {
             final Path path = new Path(4096);
             try (LineTcpReceiver receiver = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine)) {
                 sharedWorkerPool.assignCleaner(Path.CLEANER);
-                sharedWorkerPool.assign(engine.getEngineMaintenanceJob());
+                if (needMaintenanceJob) {
+                    sharedWorkerPool.assign(engine.getEngineMaintenanceJob());
+                }
                 sharedWorkerPool.start(LOG);
                 try {
                     r.run(receiver);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
@@ -48,38 +48,77 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
 public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
-    private final static Log LOG = LogFactory.getLog(AlterTableLineTcpReceiverTest.class);
-    private SqlException sqlException;
     public static final int WAIT_NO_WAIT = 0x0;
     public static final int WAIT_ENGINE_TABLE_RELEASE = 0x1;
     public static final int WAIT_ILP_TABLE_RELEASE = 0x2;
     public static final int WAIT_ALTER_TABLE_RELEASE = 0x4;
+    private final static Log LOG = LogFactory.getLog(AlterTableLineTcpReceiverTest.class);
+    private final SCSequence scSequence = new SCSequence();
+    private SqlException sqlException;
     private volatile QueryFuture alterCommandQueryFuture;
-    private final SCSequence scSequence  = new SCSequence();
 
     @Test
-    public void testAlterTableAddIndex() throws Exception {
+    public void testAlterCommandAddColumn() throws Exception {
         runInContext((server) -> {
-            String lineData = "plug,label=Power,room=6A watts=\"1\" 2631819999000\n" +
-                    "plug,label=Power,room=6B watts=\"22\" 1631817902842\n" +
-                    "plug,label=Line,room=6C watts=\"333\" 1531817902842\n";
-            SqlException ex = sendWithAlterStatement(server, lineData, "plug", WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE, false,
-                    "ALTER TABLE plug ALTER COLUMN label ADD INDEX");
-            Assert.assertNull(ex);
+            String lineData = "plug,room=6A watts=\"1\" 2631819999000\n" +
+                    "plug,room=6B watts=\"22\" 1631817902842\n" +
+                    "plug,room=6C watts=\"333\" 1531817902842\n";
 
-            String expected = "label\troom\twatts\ttimestamp\n" +
-                    "Line\t6C\t333\t1970-01-01T00:25:31.817902Z\n" +
-                    "Power\t6B\t22\t1970-01-01T00:27:11.817902Z\n" +
-                    "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n";
-            assertTable(expected, "plug");
-            try(TableReader rdr = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "plug")) {
-                TableReaderMetadata metadata = rdr.getMetadata();
-                Assert.assertTrue("Alter makes column indexed",
-                        metadata.isColumnIndexed(
-                                metadata.getColumnIndex("label")
-                        ));
-            }
+            SqlException exception = sendWithAlterStatement(
+                    server,
+                    lineData,
+                    WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
+                    false,
+                    "ALTER TABLE plug Add COLUMN label2 INT");
+
+            Assert.assertNull(exception);
+
+            lineData = "plug,label=Power,room=6A watts=\"4\" 2631819999000\n" +
+                    "plug,label=Power,room=6B watts=\"55\" 1631817902842\n" +
+                    "plug,label=Line,room=6C watts=\"666\" 1531817902842\n";
+
+            send(
+                    server,
+                    lineData
+            );
+
+            String expected = "room\twatts\ttimestamp\tlabel2\tlabel\n" +
+                    "6C\t666\t1970-01-01T00:25:31.817902Z\tNaN\tLine\n" +
+                    "6C\t333\t1970-01-01T00:25:31.817902Z\tNaN\t\n" +
+                    "6B\t55\t1970-01-01T00:27:11.817902Z\tNaN\tPower\n" +
+                    "6B\t22\t1970-01-01T00:27:11.817902Z\tNaN\t\n" +
+                    "6A\t4\t1970-01-01T00:43:51.819999Z\tNaN\tPower\n" +
+                    "6A\t1\t1970-01-01T00:43:51.819999Z\tNaN\t\n";
+            assertTable(expected);
         });
+    }
+
+    @Test
+    public void testAlterCommandDropPartition() throws Exception {
+        long day1 = 0;
+        long day2 = IntervalUtils.parseFloorPartialDate("1970-02-02") * 1000;
+        long day3 = IntervalUtils.parseFloorPartialDate("1970-03-03") * 1000;
+        runInContext((server) -> {
+                    String lineData = "plug,room=6A watts=\"1\" " + day1 + "\n";
+                    send(server, lineData);
+                    lineData = "plug,room=6B watts=\"22\" " + day2 + "\n" +
+                            "plug,room=6C watts=\"333\" " + day3 + "\n";
+
+                    SqlException exception = sendWithAlterStatement(
+                            server,
+                            lineData,
+                            WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
+                            false,
+                            "ALTER TABLE plug DROP PARTITION LIST '1970-01-01'");
+
+                    Assert.assertNull(exception);
+                    String expected = "room\twatts\ttimestamp\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\n" +
+                            "6C\t333\t1970-03-03T00:00:00.000000Z\n";
+                    assertTable(expected);
+                },
+                true
+        );
     }
 
     @Test
@@ -90,7 +129,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     "plug,label=Line,room=6C watts=\"333\" 1531817902842\n";
 
             SqlException exception = sendWithAlterStatement(server, lineData,
-                    "plug",
                     WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
                     false,
                     "ALTER TABLE plug DROP COLUMN label");
@@ -100,7 +138,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             exception = sendWithAlterStatement(
                     server,
                     lineData,
-                    "plug",
                     WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
                     false,
                     "ALTER TABLE plug RENAME COLUMN label TO label2"
@@ -116,7 +153,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     "plug,label=Line,room=6C watts=\"666\" 1531817902843\n";
 
             // re-send, this should re-add column label
-            send(server, lineData, "plug");
+            send(server, lineData);
 
             String expected = "label\troom\twatts\ttimestamp\n" +
                     "Line\t6C\t666\t1970-01-01T00:25:31.817902Z\n" +
@@ -128,72 +165,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     "Power\t6A\t4\t1970-01-01T00:43:51.819999Z\n" +
                     "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n" +
                     "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n";
-            assertTable(expected, "plug");
-        });
-    }
-
-    @Test
-    public void testAlterCommandAddColumn() throws Exception {
-        runInContext((server) -> {
-            String lineData = "plug,room=6A watts=\"1\" 2631819999000\n" +
-                    "plug,room=6B watts=\"22\" 1631817902842\n" +
-                    "plug,room=6C watts=\"333\" 1531817902842\n";
-
-            SqlException exception = sendWithAlterStatement(
-                    server,
-                    lineData,
-                    "plug",
-                    WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
-                    false,
-                    "ALTER TABLE plug Add COLUMN label2 INT");
-
-            Assert.assertNull(exception);
-
-            lineData = "plug,label=Power,room=6A watts=\"4\" 2631819999000\n" +
-                    "plug,label=Power,room=6B watts=\"55\" 1631817902842\n" +
-                    "plug,label=Line,room=6C watts=\"666\" 1531817902842\n";
-
-            send(
-                    server,
-                    lineData,
-                    "plug"
-            );
-
-            String expected = "room\twatts\ttimestamp\tlabel2\tlabel\n" +
-                    "6C\t666\t1970-01-01T00:25:31.817902Z\tNaN\tLine\n" +
-                    "6C\t333\t1970-01-01T00:25:31.817902Z\tNaN\t\n" +
-                    "6B\t55\t1970-01-01T00:27:11.817902Z\tNaN\tPower\n" +
-                    "6B\t22\t1970-01-01T00:27:11.817902Z\tNaN\t\n" +
-                    "6A\t4\t1970-01-01T00:43:51.819999Z\tNaN\tPower\n" +
-                    "6A\t1\t1970-01-01T00:43:51.819999Z\tNaN\t\n";
-            assertTable(expected, "plug");
-        });
-    }
-
-    @Test
-    public void testAlterCommandDropPartition() throws Exception {
-        long day1 = 0;
-        long day2 = IntervalUtils.parseFloorPartialDate("1970-02-02") * 1000;
-        long day3 = IntervalUtils.parseFloorPartialDate("1970-03-03") * 1000;
-        runInContext((server) -> {
-            String lineData = "plug,room=6A watts=\"1\" " + day1 + "\n";
-            send(server, lineData, "plug");
-            lineData = "plug,room=6B watts=\"22\" " + day2 + "\n" +
-                    "plug,room=6C watts=\"333\" " + day3 + "\n";
-
-            SqlException exception = sendWithAlterStatement(
-                    server,
-                    lineData,
-                    "plug",
-                    WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
-                    false,
-                    "ALTER TABLE plug DROP PARTITION LIST '1970-01-01'");
-
-            Assert.assertNull(exception);
-            String expected = "room\twatts\ttimestamp\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\n" +
-                    "6C\t333\t1970-03-03T00:00:00.000000Z\n";
-            assertTable(expected, "plug");
+            assertTable(expected);
         });
     }
 
@@ -202,34 +174,35 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         long day1 = 0;
         long day2 = IntervalUtils.parseFloorPartialDate("1970-02-02") * 1000;
         runInContext((server) -> {
-            String lineData = "plug,room=6A watts=\"1\" " + day1 + "\n";
-            send(server, lineData, "plug");
-            lineData = "plug,room=6B watts=\"22\" " + day2 + "\n";
+                    String lineData = "plug,room=6A watts=\"1\" " + day1 + "\n";
+                    send(server, lineData);
+                    lineData = "plug,room=6B watts=\"22\" " + day2 + "\n";
 
-            for(int i = 0; i < 10; i++) {
-                SqlException exception = sendWithAlterStatement(
-                        server,
-                        lineData,
-                        "plug",
-                        WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
-                        false,
-                        "ALTER TABLE plug add column col" + i + " int");
-                Assert.assertNull(exception);
-            }
-            String expected = "room\twatts\ttimestamp\tcol0\tcol1\tcol2\tcol3\tcol4\tcol5\tcol6\tcol7\tcol8\tcol9\n" +
-                    "6A\t1\t1970-01-01T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
-                    "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n";
-            assertTable(expected, "plug");
-        });
+                    for (int i = 0; i < 10; i++) {
+                        SqlException exception = sendWithAlterStatement(
+                                server,
+                                lineData,
+                                WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
+                                false,
+                                "ALTER TABLE plug add column col" + i + " int");
+                        Assert.assertNull(exception);
+                    }
+                    String expected = "room\twatts\ttimestamp\tcol0\tcol1\tcol2\tcol3\tcol4\tcol5\tcol6\tcol7\tcol8\tcol9\n" +
+                            "6A\t1\t1970-01-01T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n" +
+                            "6B\t22\t1970-02-02T00:00:00.000000Z\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\tNaN\n";
+                    assertTable(expected);
+                },
+                true
+        );
     }
 
     @Test
@@ -242,7 +215,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             SqlException exception = sendWithAlterStatement(
                     server,
                     lineData,
-                    "plug",
                     WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
                     false,
                     "ALTER TABLE plug SET PARAM commitLag = 20s;");
@@ -251,7 +223,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             exception = sendWithAlterStatement(
                     server,
                     lineData,
-                    "plug",
                     WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
                     false,
                     "ALTER TABLE plug SET PARAM maxUncommittedRows = 1;");
@@ -260,7 +231,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             SqlException exception3 = sendWithAlterStatement(
                     server,
                     lineData,
-                    "plug",
                     WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE,
                     false,
                     "alter table plug alter column label nocache;");
@@ -275,8 +245,8 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                             "Power\t6B\t22\t1970-01-01T00:27:11.817902Z\n" +
                             "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n" +
                             "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n" +
-                            "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n",
-                    "plug");
+                            "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n"
+            );
 
             engine.releaseAllReaders();
             try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "plug")) {
@@ -288,18 +258,66 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         });
     }
 
-    private void assertTable(CharSequence expected, CharSequence tableName) {
-        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+    @Test
+    public void testAlterTableAddIndex() throws Exception {
+        runInContext((server) -> {
+            String lineData = "plug,label=Power,room=6A watts=\"1\" 2631819999000\n" +
+                    "plug,label=Power,room=6B watts=\"22\" 1631817902842\n" +
+                    "plug,label=Line,room=6C watts=\"333\" 1531817902842\n";
+            SqlException ex = sendWithAlterStatement(server, lineData, WAIT_ALTER_TABLE_RELEASE | WAIT_ENGINE_TABLE_RELEASE, false,
+                    "ALTER TABLE plug ALTER COLUMN label ADD INDEX");
+            Assert.assertNull(ex);
+
+            String expected = "label\troom\twatts\ttimestamp\n" +
+                    "Line\t6C\t333\t1970-01-01T00:25:31.817902Z\n" +
+                    "Power\t6B\t22\t1970-01-01T00:27:11.817902Z\n" +
+                    "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n";
+            assertTable(expected);
+            try (TableReader rdr = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "plug")) {
+                TableReaderMetadata metadata = rdr.getMetadata();
+                Assert.assertTrue("Alter makes column indexed",
+                        metadata.isColumnIndexed(
+                                metadata.getColumnIndex("label")
+                        ));
+            }
+        });
+    }
+
+    private void assertTable(CharSequence expected) {
+        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "plug")) {
             assertCursorTwoPass(expected, reader.getCursor(), reader.getMetadata());
         }
     }
 
-    @FunctionalInterface
-    public interface LineTcpServerAwareContext {
-        void run(LineTcpReceiver receiver);
+    private QueryFuture executeAlterSql(String sql) throws SqlException {
+        // Subscribe local writer even queue to the global engine writer response queue
+        LOG.info().$("Started waiting for writer ASYNC event").$();
+        try (SqlCompiler compiler = new SqlCompiler(engine);
+             SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
+                     .with(
+                             AllowAllCairoSecurityContext.INSTANCE,
+                             new BindVariableServiceImpl(configuration),
+                             null,
+                             -1,
+                             null
+                     )
+        ) {
+            CompiledQuery cc = compiler.compile(sql, sqlExecutionContext);
+            AlterStatement alterStatement = cc.getAlterStatement();
+            assert alterStatement != null;
+
+            return cc.execute(scSequence);
+        }
     }
 
-    private SqlException sendWithAlterStatement(LineTcpReceiver server, String lineData, String tableName, int wait, boolean noLinger, String alterTableCommand) {
+    private void send(LineTcpReceiver receiver, String lineData) throws Exception {
+        SqlException ex = sendWithAlterStatement(receiver, lineData, WAIT_ENGINE_TABLE_RELEASE, true, null);
+        if (ex != null) {
+            throw ex;
+        }
+    }
+
+    private SqlException sendWithAlterStatement(LineTcpReceiver server, String lineData, int wait, boolean noLinger, String alterTableCommand) {
         sqlException = null;
         int countDownCount = 1;
         if ((wait & WAIT_ENGINE_TABLE_RELEASE) != 0 && (wait & WAIT_ALTER_TABLE_RELEASE) != 0) {
@@ -310,7 +328,6 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         if (alterTableCommand != null && (wait & WAIT_ALTER_TABLE_RELEASE) != 0) {
             new Thread(() -> {
-                boolean waited = false;
                 // Wait in parallel thead
                 try {
                     startBarrier.await();
@@ -332,7 +349,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         if (wait != WAIT_NO_WAIT) {
             engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
-                if (Chars.equalsNc(tableName, name)) {
+                if (Chars.equalsNc("plug", name)) {
                     if ((wait & WAIT_ENGINE_TABLE_RELEASE) != 0 || (wait & WAIT_ALTER_TABLE_RELEASE) != 0) {
                         if (factoryType == PoolListener.SRC_WRITER) {
                             switch (event) {
@@ -405,31 +422,8 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         return null;
     }
 
-    private QueryFuture executeAlterSql(String sql) throws SqlException {
-        // Subscribe local writer even queue to the global engine writer response queue
-        LOG.info().$("Started waiting for writer ASYNC event").$();
-        try (SqlCompiler compiler = new SqlCompiler(engine);
-             SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
-                     .with(
-                             AllowAllCairoSecurityContext.INSTANCE,
-                             new BindVariableServiceImpl(configuration),
-                             null,
-                             -1,
-                             null
-                     )
-        ) {
-            CompiledQuery cc = compiler.compile(sql, sqlExecutionContext);
-            AlterStatement alterStatement = cc.getAlterStatement();
-            assert alterStatement != null;
-
-            return cc.execute(scSequence);
-        }
-    }
-
-    private void send(LineTcpReceiver receiver, String lineData, String tableName) throws Exception {
-        SqlException ex = sendWithAlterStatement(receiver, lineData, tableName, WAIT_ENGINE_TABLE_RELEASE, true, null);
-        if (ex != null) {
-            throw ex;
-        }
+    @FunctionalInterface
+    public interface LineTcpServerAwareContext {
+        void run(LineTcpReceiver receiver);
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -247,7 +247,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                         } catch (AssertionError e) {
                             int releasedCount = -tableIndex.get(tableName).getCount();
                             // Wait one more writer release before re-trying to compare
-                            wait(tableIndex.get(tableName), releasedCount + 1, minIdleMsBeforeWriterRelease);
+                            wait(tableIndex.get(tableName), releasedCount + 3, minIdleMsBeforeWriterRelease);
                             assertTable(expectedSB, tableName);
                         }
                     } catch (Throwable err) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -974,11 +974,12 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
     private void send(LineTcpReceiver receiver, String tableName, int wait, Runnable sendToSocket) {
         SOCountDownLatch releaseLatch = new SOCountDownLatch(1);
+        final String t = tableName;
         switch (wait) {
             case WAIT_ENGINE_TABLE_RELEASE:
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                     if (Chars.equals(tableName, name)) {
-                        if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                        if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN && Chars.equals(tableName, t) ) {
                             releaseLatch.countDown();
                         }
                     }


### PR DESCRIPTION
another attempt to fix test, same as https://github.com/questdb/questdb/pull/1670

The rationale for this PR was that all of our existing PRs were failing for reasons unrelated to the PR. We have a lot of flapping tests.

Following the async alter table PR the writer maintenance job was introduced in the TcpILP tests:

- testWriterRelease* tests were intermittently disrupted by maintenance job expiring writers (10s idle timeout)
- removal of maintenance job from thread pool upset some of the `alter table` tests
- both tests use the same test code, so I made using writer maintenance job optional per test
- tests were failing with message "cannot lock table, reason `unlocking`". This made no sense. I refactored use of lock reason
- refactoring lock reason perhaps saved us some yet unreported grief: we do not lock and update reason atomically, yet lock reason is used as the indicator if table is locked or not. So it was entirely possible to get "table unlocked" from the `lock()` call while table was actually locked. Code acting on "unlocked" table was prone to failure
- fixed flapping test `WriterPoolTest.testGetAndCloseRace()` https://github.com/questdb/questdb/pull/1671/commits/bb65a22a9d6e788049ae60e30def7212e601ebf3