### PR TITLE
chore(core): java 17 support

### DIFF
--- a/ci/new-pull-request.yml
+++ b/ci/new-pull-request.yml
@@ -33,9 +33,9 @@ stages:
               imageName: "ubuntu-latest"
               os: Linux
               jdk: "1.8"
-            linux-jdk17:
-              imageName: "ubuntu-latest"
-              os: Linux
+            mac-jdk17:
+              imageName: "mac-latest"
+              os: macOS
               jdk: "1.17"
         pool:
           vmImage: $(imageName)

--- a/ci/new-pull-request.yml
+++ b/ci/new-pull-request.yml
@@ -33,6 +33,10 @@ stages:
               imageName: "ubuntu-latest"
               os: Linux
               jdk: "1.8"
+            linux-jdk17:
+              imageName: "ubuntu-latest"
+              os: Linux
+              jdk: "1.17"
         pool:
           vmImage: $(imageName)
         timeoutInMinutes: 30

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -23,10 +23,10 @@ jobs:
         poolName: "Azure Pipelines"
         os: Linux
         jdk: "1.8"
-      linux-jdk17:
-        imageName: "ubuntu-latest"
+      mac-jdk17:
+        imageName: "macos-latest"
         poolName: "Azure Pipelines"
-        os: Linux
+        os: macOS
         jdk: "1.17"
   pool:
     vmImage: $(imageName)

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -23,6 +23,11 @@ jobs:
         poolName: "Azure Pipelines"
         os: Linux
         jdk: "1.8"
+      linux-jdk17:
+        imageName: "ubuntu-latest"
+        poolName: "Azure Pipelines"
+        os: Linux
+        jdk: "1.17"
   pool:
     vmImage: $(imageName)
     name: $(poolName) 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.pool.WriterSource;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cutlass.text.TextLoader;
 import io.questdb.cutlass.text.types.TypeManager;
 import io.questdb.griffin.*;

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.map.RecordValueSink;
 import io.questdb.cairo.map.RecordValueSinkFactory;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.EmptyTableRecordCursorFactory;
 import io.questdb.griffin.engine.LimitRecordCursorFactory;
 import io.questdb.griffin.engine.RecordComparator;

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -29,6 +29,7 @@ import io.questdb.PropServerConfiguration;
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.WriterPool;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.text.Atomicity;

--- a/core/src/main/java/io/questdb/griffin/engine/AbstractVirtualFunctionRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/AbstractVirtualFunctionRecordCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine;
 
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.groupby.GroupByUtils;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;

--- a/core/src/main/java/io/questdb/griffin/engine/LimitRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/LimitRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import org.jetbrains.annotations.Nullable;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/SymbolFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/SymbolFunction.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions;
 
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Long256;
 import io.questdb.std.str.CharSink;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.analytic.AnalyticContext;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/IndexedParameterLinkFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/IndexedParameterLinkFunction.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.bind;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.BinarySequence;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/NamedParameterLinkFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/NamedParameterLinkFunction.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.bind;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.BinarySequence;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.bool;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AbstractClassCatalogueFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AbstractClassCatalogueFunctionFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.catalogue;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cutlass.pgwire.PGOids;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AttrDefCatalogueFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AttrDefCatalogueFunctionFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.catalogue;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.CursorFunction;
@@ -33,7 +34,6 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.*;
 import io.questdb.std.str.Path;
-import io.questdb.std.str.StringSink;
 
 public class AttrDefCatalogueFunctionFactory implements FunctionFactory {
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AttributeCatalogueFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AttributeCatalogueFunctionFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.catalogue;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMR;
 import io.questdb.cutlass.pgwire.PGOids;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TableMetadataCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.catalogue;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.CursorFunction;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/columns/SymbolColumn.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/columns/SymbolColumn.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.functions.columns;
 
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import org.jetbrains.annotations.Nullable;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymStrFunctionFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.functions.eq;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/TouchTableFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/TouchTableFunctionFactory.java
@@ -28,6 +28,7 @@ import io.questdb.TelemetryJob;
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/CountRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/CountRecordCursorFactory.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctRecordCursorFactory.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctSymbolRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctSymbolRecordCursorFactory.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.SymbolMapReader;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctTimeSeriesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/DistinctTimeSeriesRecordCursorFactory.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.map.FastMap;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlKeywords;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionParser;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByNotKeyedVectorRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByNotKeyedVectorRecordCursorFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.groupby.vect;
 import io.questdb.MessageBus;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.log.Log;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.log.Log;

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinLightRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinNoKeyRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinNoKeyRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.map.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;

--- a/core/src/main/java/io/questdb/griffin/engine/join/CrossJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/CrossJoinRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.EmptyTableRecordCursor;

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashJoinLightRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinLightRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;

--- a/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/griffin/engine/join/LtJoinNoKeyRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LtJoinNoKeyRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/griffin/engine/join/LtJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LtJoinRecordCursorFactory.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.map.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;

--- a/core/src/main/java/io/questdb/griffin/engine/join/RecordAsAFieldRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/RecordAsAFieldRecordCursorFactory.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Chars;

--- a/core/src/main/java/io/questdb/griffin/engine/join/SpliceJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SpliceJoinLightRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.EmptyTableRandomRecordCursor;

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestBySubQueryRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestBySubQueryRecordCursorFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.table;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntHashSet;

--- a/core/src/main/java/io/questdb/griffin/engine/union/UnionAllRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/UnionAllRecordCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.union;
 
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.std.Misc;
 
 class UnionAllRecordCursor implements NoRandomAccessRecordCursor {

--- a/core/src/main/java/io/questdb/griffin/engine/union/UnionRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/UnionRecordCursor.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;
 import io.questdb.std.Misc;

--- a/core/src/main/java/io/questdb/std/BytecodeAssembler.java
+++ b/core/src/main/java/io/questdb/std/BytecodeAssembler.java
@@ -29,6 +29,7 @@ import io.questdb.log.LogFactory;
 import io.questdb.std.ex.BytecodeException;
 import io.questdb.std.str.AbstractCharSink;
 import io.questdb.std.str.CharSink;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
@@ -410,10 +411,11 @@ public class BytecodeAssembler {
     }
 
     @SuppressWarnings("unchecked")
+    @Nullable
     public <T> Class<T> loadClass(Class<?> host) {
         byte[] b = new byte[position()];
         System.arraycopy(buf.array(), 0, b, 0, b.length);
-        return (Class<T>) Unsafe.getUnsafe().defineAnonymousClass(host, b, null);
+        return (Class<T>) Unsafe.defineAnonymousClass(host, b);
     }
 
     public void lreturn() {
@@ -430,6 +432,7 @@ public class BytecodeAssembler {
 
     public <T> T newInstance() {
         Class<T> x = loadClass(host);
+        assert x != null;
         try {
             return x.getDeclaredConstructor().newInstance();
         } catch (Exception e) {

--- a/core/src/test/java/io/questdb/cairo/RecordChainTest.java
+++ b/core/src/test/java/io/questdb/cairo/RecordChainTest.java
@@ -25,6 +25,7 @@
 package io.questdb.cairo;
 
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.IntFunction;
 import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.std.*;

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -28,6 +28,7 @@ import io.questdb.Metrics;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.mp.SCSequence;
 import io.questdb.std.*;

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -27,6 +27,7 @@ package io.questdb.griffin;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.TestBinarySequence;
 import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.std.BinarySequence;

--- a/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
@@ -610,15 +610,15 @@ public class TimestampFormatCompilerTest {
 
     @Test
     public void testNegativeYear() throws Exception {
-        assertThat("yyyy MMM dd", "-2010-09-01T00:00:00.000Z", "-2010 Sep 01");
+        assertThat("yyyy MMM dd", "-2010-08-01T00:00:00.000Z", "-2010 Aug 01");
 
         DateFormat fmt1 = compiler.compile("G yyyy MMM", true);
         DateFormat fmt2 = compiler.compile("yyyy MMM dd", true);
 
-        long millis = fmt2.parse("-2010 Sep 01", defaultLocale);
+        long millis = fmt2.parse("-2010 Aug 01", defaultLocale);
         sink.clear();
         fmt1.format(millis, defaultLocale, "Z", sink);
-        TestUtils.assertEquals("BC -2010 Sep", sink);
+        TestUtils.assertEquals("BC -2010 Aug", sink);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/std/datetime/microtime/TimestampLocaleTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/microtime/TimestampLocaleTest.java
@@ -69,10 +69,10 @@ public class TimestampLocaleTest {
 
     @Test
     public void testShortMonth() throws Exception {
-        String date = "23 Sep 2010";
+        String date = "23 Aug 2010";
         long result = DateLocaleFactory.INSTANCE.getLocale("en-GB").matchMonth(date, 3, date.length());
         Assert.assertEquals(3, Numbers.decodeHighInt(result));
-        Assert.assertEquals(8, Numbers.decodeLowInt(result));
+        Assert.assertEquals(7, Numbers.decodeLowInt(result));
     }
 
     @Test(expected = NumericException.class)

--- a/core/src/test/java/io/questdb/std/datetime/millitime/DateFormatCompilerTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/millitime/DateFormatCompilerTest.java
@@ -43,7 +43,7 @@ public class DateFormatCompilerTest {
 
     private static final DateFormatCompiler compiler = new DateFormatCompiler();
     private static final DateLocale defaultLocale = DateLocaleFactory.INSTANCE.getLocale("en-GB");
-    private final static StringSink sink = new StringSink();
+    private static final StringSink sink = new StringSink();
 
     @BeforeClass
     public static void setUp() {
@@ -579,15 +579,15 @@ public class DateFormatCompilerTest {
 
     @Test
     public void testNegativeYear() throws Exception {
-        assertThat("yyyy MMM dd", "-2010-09-01T00:00:00.000Z", "-2010 Sep 01");
+        assertThat("yyyy MMM dd", "-2010-08-01T00:00:00.000Z", "-2010 Aug 01");
 
         DateFormat fmt1 = compiler.compile("G yyyy MMM", true);
         DateFormat fmt2 = compiler.compile("yyyy MMM dd", true);
 
-        long millis = fmt2.parse("-2010 Sep 01", defaultLocale);
+        long millis = fmt2.parse("-2010 Aug 01", defaultLocale);
         sink.clear();
         fmt1.format(millis, defaultLocale, "Z", sink);
-        TestUtils.assertEquals("BC -2010 Sep", sink);
+        TestUtils.assertEquals("BC -2010 Aug", sink);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/std/datetime/millitime/DateLocaleTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/millitime/DateLocaleTest.java
@@ -69,10 +69,10 @@ public class DateLocaleTest {
 
     @Test
     public void testShortMonth() throws Exception {
-        String date = "23 Sep 2010";
+        String date = "23 Aug 2010";
         long result = DateLocaleFactory.INSTANCE.getLocale("en-GB").matchMonth(date, 3, date.length());
         Assert.assertEquals(3, Numbers.decodeHighInt(result));
-        Assert.assertEquals(8, Numbers.decodeLowInt(result));
+        Assert.assertEquals(7, Numbers.decodeLowInt(result));
     }
 
     @Test(expected = NumericException.class)

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -26,6 +26,7 @@ package io.questdb.test.tools;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.CompiledQuery;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;


### PR DESCRIPTION
Closes: #1503

Includes the following:
* Add explicit imports for `*.sql.Record` to avoid naming clashes with `java.lang.Record`
  - Alternatively we could rename the class to something like `SqlRecord`, but that would mean a breaking API change
* Use `MethodHandles.Lookup#defineHiddenClass` when deprecated `Unsafe#defineAnonymousClass` is not available
  - The detection is reflection based and done in the runtime, so we don't need to add another artifact profile
* Fix `en_GB` date locale dependent tests. The reason is that the short name for September was changed from `Sep` to `Sept` in Common Locale Data Repository (CLDR). OpenJDK [updated](https://github.com/openjdk/jdk/pull/1279/files) their CLDR snapshot in Java 17.
  - **Open question**. We could make users aware of this change, but on the other hand locales are a subject to change in any JDK version. Should we somehow inform users?

To get Java 17 and IntelliJ to work together, uncheck this (the problem is described [here](https://bugs.openjdk.java.net/browse/JDK-8178152)):

![image](https://user-images.githubusercontent.com/7276403/146025103-6dbbe607-ffae-4edc-891e-6633e26a005f.png)

Ubuntu 20.04 has openjdk 17 in the standard repository:
```bash
$ sudo apt-cache search openjdk | grep 17
openjdk-17-dbg - Java runtime based on OpenJDK (debugging symbols)
openjdk-17-demo - Java runtime based on OpenJDK (demos and examples)
openjdk-17-doc - OpenJDK Development Kit (JDK) documentation
openjdk-17-jdk - OpenJDK Development Kit (JDK)
openjdk-17-jdk-headless - OpenJDK Development Kit (JDK) (headless)
openjdk-17-jre - OpenJDK Java runtime, using Hotspot JIT
openjdk-17-jre-headless - OpenJDK Java runtime, using Hotspot JIT (headless)
openjdk-17-jre-zero - Alternative JVM for OpenJDK, using Zero
openjdk-17-source - OpenJDK Development Kit (JDK) source files
```

Builds for manual installation are also available on https://jdk.java.net/17/