### PR TITLE
fix(log): fix the way alert appender deals with template encoding

### DIFF
--- a/core/src/main/java/io/questdb/log/HttpLogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/HttpLogRecordSink.java
@@ -24,7 +24,9 @@
 
 package io.questdb.log;
 
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.Sinkable;
+import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.TestOnly;
 
 public class HttpLogRecordSink extends LogRecordSink {
@@ -147,6 +149,12 @@ public class HttpLogRecordSink extends LogRecordSink {
     @Override
     public HttpLogRecordSink put(CharSequence cs) {
         super.put(cs);
+        return this;
+    }
+
+    @Override
+    public HttpLogRecordSink encodeUtf8(CharSequence cs) {
+        super.encodeUtf8(cs);
         return this;
     }
 

--- a/core/src/main/java/io/questdb/log/HttpLogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/HttpLogRecordSink.java
@@ -68,7 +68,7 @@ public class HttpLogRecordSink extends LogRecordSink {
         if (hasContentLengthMarker) {
             // take the body length and format it into the ###### contentLength marker
             int bodyLen = (int) (_wptr - bodyStart);
-            long p = contentLengthEnd; // note, we replace # from lowest significant digit (right to left)
+            long p = contentLengthEnd; // note, we replace # from the lowest significant digit (right to left)
             if (bodyLen == 0) {
                 Unsafe.getUnsafe().putByte(p--, (byte) '0');
             } else {

--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -363,7 +363,7 @@ public class LogAlertSocket implements Closeable {
     private void setHostPort(int hostIdx, int portLimit, int hostLimit) {
         // host0:port0, host1 : port1 , ..., host9:port9
         //              ^     ^       ^
-        //              |     |       hostLimit
+        //              |     |       hostEnd
         //              |     portLimit
         //              hostIdx
 

--- a/core/src/main/java/io/questdb/log/LogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/LogRecordSink.java
@@ -29,11 +29,8 @@ import io.questdb.std.Sinkable;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.AbstractCharSink;
 import io.questdb.std.str.CharSink;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.TestOnly;
 
 public class LogRecordSink extends AbstractCharSink implements Sinkable {
-    private final CharSequenceOf charSeq = new CharSequenceOf();
     protected final long address;
     protected final long lim;
     protected long _wptr;
@@ -90,42 +87,5 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
     @Override
     public void toSink(CharSink sink) {
         Chars.utf8Decode(address, _wptr, sink);
-    }
-
-    public CharSink encodeUtf8(char [] chars, int lo, int hi) {
-        return super.encodeUtf8(charSeq.of(chars, lo, hi));
-    }
-
-    @TestOnly
-    static class CharSequenceOf implements CharSequence {
-        private char[] chars;
-        private int lo;
-        private int len;
-
-        CharSequenceOf of(char[] chars, int lo, int hi) {
-            this.chars = chars;
-            this.lo = lo;
-            this.len = hi - lo;
-            return this;
-        }
-
-        @Override
-        public int length() {
-            return len;
-        }
-
-        @Override
-        public char charAt(int index) {
-            if (index > -1 && index < len) {
-                return chars[lo + index];
-            }
-            throw new IndexOutOfBoundsException("Index out of range: " + index);
-        }
-
-        @NotNull
-        @Override
-        public CharSequence subSequence(int start, int end) {
-            throw new UnsupportedOperationException();
-        }
     }
 }

--- a/core/src/main/java/io/questdb/log/LogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/LogRecordSink.java
@@ -66,13 +66,21 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
 
     @Override
     public CharSink put(CharSequence cs) {
-        encodeUtf8(cs);
+        int rem = (int) (lim - _wptr);
+        int len = cs.length();
+        int n = Math.min(rem, len);
+        Chars.asciiStrCpy(cs, n, _wptr);
+        _wptr += n;
         return this;
     }
 
     @Override
     public CharSink put(CharSequence cs, int lo, int hi) {
-        encodeUtf8(cs, lo, hi);
+        int rem = (int) (lim - _wptr);
+        int len = hi - lo;
+        int n = Math.min(rem, len);
+        Chars.asciiStrCpy(cs, lo, n, _wptr);
+        _wptr += n;
         return this;
     }
 

--- a/core/src/main/java/io/questdb/log/LogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/LogRecordSink.java
@@ -66,12 +66,7 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
 
     @Override
     public CharSink put(CharSequence cs) {
-        int rem = (int) (lim - _wptr);
-        int len = cs.length();
-        int n = Math.min(rem, len);
-        Chars.asciiStrCpy(cs, n, _wptr);
-        _wptr += n;
-        return this;
+        return put(cs, 0, cs.length());
     }
 
     @Override
@@ -81,12 +76,6 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
         int n = Math.min(rem, len);
         Chars.asciiStrCpy(cs, lo, n, _wptr);
         _wptr += n;
-        return this;
-    }
-
-    @Override
-    public CharSink put(char[] chars, int lo, int hi) {
-        encodeUtf8(charSeq.of(chars, lo, hi));
         return this;
     }
 
@@ -101,6 +90,10 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
     @Override
     public void toSink(CharSink sink) {
         Chars.utf8Decode(address, _wptr, sink);
+    }
+
+    public CharSink encodeUtf8(char [] chars, int lo, int hi) {
+        return super.encodeUtf8(charSeq.of(chars, lo, hi));
     }
 
     @TestOnly

--- a/core/src/main/java/io/questdb/log/LogRecordSink.java
+++ b/core/src/main/java/io/questdb/log/LogRecordSink.java
@@ -63,7 +63,12 @@ public class LogRecordSink extends AbstractCharSink implements Sinkable {
 
     @Override
     public CharSink put(CharSequence cs) {
-        return put(cs, 0, cs.length());
+        int rem = (int) (lim - _wptr);
+        int len = cs.length();
+        int n = Math.min(rem, len);
+        Chars.asciiStrCpy(cs, n, _wptr);
+        _wptr += n;
+        return this;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/log/TemplateParser.java
+++ b/core/src/main/java/io/questdb/log/TemplateParser.java
@@ -199,7 +199,7 @@ public class TemplateParser implements Sinkable {
         templateNodes.add(new TemplateNode(TemplateNode.TYPE_ENV, envKey) {
             @Override
             public void toSink(CharSink sink) {
-                sink.put(envVal);
+                sink.encodeUtf8(envVal);
             }
         });
     }

--- a/core/src/test/java/io/questdb/log/HttpLogRecordSinkTest.java
+++ b/core/src/test/java/io/questdb/log/HttpLogRecordSinkTest.java
@@ -32,6 +32,68 @@ import java.util.function.Consumer;
 
 public class HttpLogRecordSinkTest {
 
+    private static final int bufferSize = 1024;
+
+    @Test
+    public void testContentLengthMarker() throws Exception {
+        withHttpLogRecordSink(alertBuilder -> {
+            alertBuilder.clear();
+            alertBuilder.putContentLengthMarker();
+            Assert.assertEquals(26, alertBuilder.$());
+            Assert.assertEquals("Content-Length:       26\r\n", alertBuilder.toString());
+
+            alertBuilder.clear();
+            alertBuilder.putContentLengthMarker();
+            Assert.assertEquals(38, alertBuilder.put("clairvoyance").$());
+            Assert.assertEquals("Content-Length:       38\r\nclairvoyance", alertBuilder.toString());
+
+            alertBuilder.clear();
+            alertBuilder.putContentLengthMarker();
+            String message = "$Sîne klâwen durh die wolken sint geslagen,sîn vil manegiu tugent michz leisten hiez.$\r\n\";";
+            Assert.assertEquals(119, alertBuilder.encodeUtf8(message).$());
+            Assert.assertEquals("Content-Length:      119\r\n" + message, alertBuilder.toString());
+
+            alertBuilder.clear();
+            alertBuilder.putContentLengthMarker();
+            message = "2021-11-26T19:22:47.8658077Z 2021-11-26T19:22:47.860908Z E i.q.c.BitmapIndexBwdReader cursor could not consistently read index header [corrupt?] [timeout=5000000μs]\n";
+            Assert.assertEquals(192, alertBuilder.encodeUtf8(message).$());
+            Assert.assertEquals("Content-Length:      192\r\n" + message, alertBuilder.toString());
+
+            alertBuilder.clear();
+            alertBuilder.putContentLengthMarker();
+            Assert.assertEquals("Content-Length:#########\r\n", alertBuilder.toString());
+            int limit = bufferSize - alertBuilder.length();
+            for (int i = 0; i < limit; i++) {
+                alertBuilder.put('Q');
+            }
+            alertBuilder.$();
+            Assert.assertEquals(bufferSize, alertBuilder.length());
+            Assert.assertTrue(alertBuilder
+                    .toString()
+                    .startsWith("Content-Length:     1024\r\nQQQQQQQQQQQQQQQQQQQQQQ"));
+            Assert.assertTrue(alertBuilder
+                    .toString()
+                    .endsWith("QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
+                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
+                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
+                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
+                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ"));
+        });
+    }
+
+    @Test
+    public void testContentLengthNoMarker() throws Exception {
+        withHttpLogRecordSink(alertBuilder -> {
+            alertBuilder.clear();
+            Assert.assertEquals(0, alertBuilder.$());
+            Assert.assertEquals("", alertBuilder.toString());
+
+            alertBuilder.clear();
+            Assert.assertEquals(12, alertBuilder.put("clairvoyance").$());
+            Assert.assertEquals("clairvoyance", alertBuilder.toString());
+        });
+    }
+
     @Test
     public void testEmptyMessage() throws Exception {
         withHttpLogRecordSink(alertBuilder -> {
@@ -58,49 +120,6 @@ public class HttpLogRecordSinkTest {
     }
 
     @Test
-    public void testSimpleMessage() throws Exception {
-        withHttpLogRecordSink(alertBuilder -> {
-            final String msg = "Hello, my name is Íñigo Montoya, you killed my father, prepare to ∑π¬µ∫√ç©!!";
-            final byte[] msgBytes = msg.getBytes(Files.UTF_8);
-            final int len = msgBytes.length;
-            final long msgPtr = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);
-            try {
-                LogRecordSink logRecord = new LogRecordSink(msgPtr, len);
-                logRecord.put(msg);
-                alertBuilder.put(logRecord).$();
-                Assert.assertEquals(
-                        "POST /api/v1/alerts HTTP/1.1\r\n" +
-                                "Host: localhost\r\n" +
-                                "User-Agent: QuestDB/LogAlert\r\n" +
-                                "Accept: */*\r\n" +
-                                "Content-Type: application/json\r\n" +
-                                "Content-Length:       89\r\n" +
-                                "\r\n" +
-                                "Hello, my name is Íñigo Montoya, you killed my father, prepare to ∑π¬µ∫√ç©!!",
-                        alertBuilder.toString()
-                );
-                Assert.assertEquals(239, alertBuilder.length());
-
-                String randomMsg = "Yup, this is a random message.";
-                alertBuilder.rewindToMark().put(randomMsg, 5, randomMsg.length()).$();
-                Assert.assertEquals(175, alertBuilder.length());
-                Assert.assertEquals("POST /api/v1/alerts HTTP/1.1\r\n" +
-                        "Host: localhost\r\n" +
-                        "User-Agent: QuestDB/LogAlert\r\n" +
-                        "Accept: */*\r\n" +
-                        "Content-Type: application/json\r\n" +
-                        "Content-Length:       25\r\n" +
-                        "\r\n" +
-                        "this is a random message.", alertBuilder.toString());
-            } finally {
-                if (msgPtr != 0) {
-                    Unsafe.free(msgPtr, len, MemoryTag.NATIVE_DEFAULT);
-                }
-            }
-        });
-    }
-
-    @Test
     public void testFilteringSimpleMessage() throws Exception {
         withHttpLogRecordSink(alertBuilder -> {
             final String msg = "\b\f\t$\"\\\r\n";
@@ -123,6 +142,50 @@ public class HttpLogRecordSinkTest {
                         alertBuilder.toString()
                 );
                 Assert.assertEquals(156, alertBuilder.length());
+            } finally {
+                if (msgPtr != 0) {
+                    Unsafe.free(msgPtr, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSimpleMessage() throws Exception {
+        withHttpLogRecordSink(alertBuilder -> {
+            final String msg = "Hello, my name is Íñigo Montoya, you killed my father, prepare to ∑π¬µ∫√ç©!!";
+            final byte[] msgBytes = msg.getBytes(Files.UTF_8);
+            final int len = msgBytes.length;
+            final long msgPtr = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);
+            try {
+                LogRecordSink logRecord = new LogRecordSink(msgPtr, len);
+                logRecord.encodeUtf8(msg);
+                alertBuilder.put(logRecord).$();
+                Assert.assertEquals(
+                        "POST /api/v1/alerts HTTP/1.1\r\n" +
+                                "Host: localhost\r\n" +
+                                "User-Agent: QuestDB/LogAlert\r\n" +
+                                "Accept: */*\r\n" +
+                                "Content-Type: application/json\r\n" +
+                                "Content-Length:       89\r\n" +
+                                "\r\n" +
+                                "Hello, my name is Íñigo Montoya, you killed my father, prepare to ∑π¬µ∫√ç©!!",
+                        alertBuilder.toString()
+                );
+                Assert.assertEquals(239, alertBuilder.length());
+
+                String randomMsg = "Yup, this is a random message.";
+                alertBuilder.rewindToMark().encodeUtf8(randomMsg, 5, randomMsg.length());
+                alertBuilder.$();
+                Assert.assertEquals(175, alertBuilder.length());
+                Assert.assertEquals("POST /api/v1/alerts HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "User-Agent: QuestDB/LogAlert\r\n" +
+                        "Accept: */*\r\n" +
+                        "Content-Type: application/json\r\n" +
+                        "Content-Length:       25\r\n" +
+                        "\r\n" +
+                        "this is a random message.", alertBuilder.toString());
             } finally {
                 if (msgPtr != 0) {
                     Unsafe.free(msgPtr, len, MemoryTag.NATIVE_DEFAULT);
@@ -162,74 +225,10 @@ public class HttpLogRecordSinkTest {
         });
     }
 
-    @Test
-    public void testContentLengthNoMarker() throws Exception {
-        withHttpLogRecordSink(alertBuilder -> {
-            alertBuilder.clear();
-            Assert.assertEquals(0, alertBuilder.$());
-            Assert.assertEquals("", alertBuilder.toString());
-
-            alertBuilder.clear();
-            Assert.assertEquals(12, alertBuilder.put("clairvoyance").$());
-            Assert.assertEquals("clairvoyance", alertBuilder.toString());
-        });
-    }
-
-    @Test
-    public void testContentLengthMarker() throws Exception {
-        withHttpLogRecordSink(alertBuilder -> {
-            alertBuilder.clear();
-            alertBuilder.putContentLengthMarker();
-            Assert.assertEquals(26, alertBuilder.$());
-            Assert.assertEquals("Content-Length:       26\r\n", alertBuilder.toString());
-
-            alertBuilder.clear();
-            alertBuilder.putContentLengthMarker();
-            Assert.assertEquals(38, alertBuilder.put("clairvoyance").$());
-            Assert.assertEquals("Content-Length:       38\r\nclairvoyance", alertBuilder.toString());
-
-            alertBuilder.clear();
-            alertBuilder.putContentLengthMarker();
-            String message = "$Sîne klâwen durh die wolken sint geslagen,sîn vil manegiu tugent michz leisten hiez.$\r\n\";";
-            Assert.assertEquals(119, alertBuilder.put(message).$());
-            Assert.assertEquals("Content-Length:      119\r\n" + message, alertBuilder.toString());
-
-            alertBuilder.clear();
-            alertBuilder.putContentLengthMarker();
-            message = "2021-11-26T19:22:47.8658077Z 2021-11-26T19:22:47.860908Z E i.q.c.BitmapIndexBwdReader cursor could not consistently read index header [corrupt?] [timeout=5000000μs]\n";
-            Assert.assertEquals(192, alertBuilder.put(message).$());
-            Assert.assertEquals("Content-Length:      192\r\n" + message, alertBuilder.toString());
-
-            alertBuilder.clear();
-            alertBuilder.putContentLengthMarker();
-            Assert.assertEquals("Content-Length:#########\r\n", alertBuilder.toString());
-            int limit = bufferSize - alertBuilder.length();
-            for (int i = 0; i < limit; i++) {
-                alertBuilder.put('Q');
-            }
-            alertBuilder.$();
-            Assert.assertEquals(bufferSize, alertBuilder.length());
-            Assert.assertTrue(alertBuilder
-                    .toString()
-                    .startsWith("Content-Length:     1024\r\nQQQQQQQQQQQQQQQQQQQQQQ"));
-            Assert.assertTrue(alertBuilder
-                    .toString()
-                    .endsWith("QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
-                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
-                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
-                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ" +
-                            "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ"));
-        });
-    }
-
-    private static final int bufferSize = 1024;
-
     private static void withHttpLogRecordSink(Consumer<HttpLogRecordSink> consumer) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-
             final long bufferPtr = Unsafe.malloc(bufferSize, MemoryTag.NATIVE_DEFAULT);
-            final long bufferLimit = bufferPtr + bufferSize;
-            final HttpLogRecordSink alertBuilder = new HttpLogRecordSink(bufferPtr, bufferLimit);
+            final HttpLogRecordSink alertBuilder = new HttpLogRecordSink(bufferPtr, bufferSize);
             alertBuilder.putHeader("localhost");
             alertBuilder.setMark();
             Assert.assertEquals(

--- a/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
+++ b/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
@@ -112,7 +112,7 @@ public class LogRecordSinkTest {
             final long buffPtr = Unsafe.malloc(buffSize, MemoryTag.NATIVE_DEFAULT);
             try {
                 LogRecordSink recordSink = new LogRecordSink(buffPtr, buffSize);
-                recordSink.put(expected.toCharArray(), 1, len - 1);
+                recordSink.encodeUtf8(expected.toCharArray(), 1, len - 1);
                 recordSink.toSink(sink);
                 Assert.assertEquals(expected.substring(1, len - 1), sink.toString());
             } finally {

--- a/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
+++ b/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
@@ -87,7 +87,7 @@ public class LogRecordSinkTest {
                 recordSink.setLevel(LogLevel.ERROR);
                 Assert.assertEquals(LogLevel.ERROR, recordSink.getLevel());
                 Assert.assertEquals(buffPtr, recordSink.getAddress());
-                recordSink.put(expected);
+                recordSink.encodeUtf8(expected);
                 recordSink.toSink(sink);
                 Assert.assertEquals(expected, sink.toString());
                 Assert.assertEquals(recordSink.length(), sink.length() * 2);
@@ -130,7 +130,7 @@ public class LogRecordSinkTest {
             final long buffPtr = Unsafe.malloc(buffSize, MemoryTag.NATIVE_DEFAULT);
             try {
                 LogRecordSink recordSink = new LogRecordSink(buffPtr, buffSize);
-                recordSink.put(expected, 2, len - 1);
+                recordSink.encodeUtf8(expected, 2, len - 1);
                 recordSink.toSink(sink);
                 Assert.assertEquals(expected.substring(2, len - 1), sink.toString());
             } finally {

--- a/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
+++ b/core/src/test/java/io/questdb/log/LogRecordSinkTest.java
@@ -40,41 +40,6 @@ public class LogRecordSinkTest {
         sink = new StringSink();
     }
 
-
-    @Test
-    public void testCharSequenceOf() {
-        char[] iCanEatGlass = "ᛖᚴ ᚷᛖᛏ ᛖᛏᛁ ᚧ ᚷᛚᛖᚱ ᛘᚾ ᚦᛖᛋᛋ ᚨᚧ ᚡᛖ ᚱᚧᚨ ᛋᚨᚱ".toCharArray();
-        LogRecordSink.CharSequenceOf charSeq = new LogRecordSink.CharSequenceOf();
-        charSeq.of(iCanEatGlass, 0, iCanEatGlass.length);
-        Assert.assertEquals(iCanEatGlass.length, charSeq.length());
-        for (int i = 0; i < iCanEatGlass.length; i++) {
-            Assert.assertEquals(iCanEatGlass[i], charSeq.charAt(i));
-        }
-    }
-
-    @Test
-    public void testOffsetCharSequenceOf() {
-        CharSequence sample = "Aš galiu valgyti stiklą ir jis manęs nežeidžia".subSequence(9, 18);
-        char[] iCanEatGlass = "Aš galiu valgyti stiklą ir jis manęs nežeidžia".toCharArray();
-        LogRecordSink.CharSequenceOf charSeq = new LogRecordSink.CharSequenceOf();
-        charSeq.of(iCanEatGlass, 9, 18);
-        Assert.assertEquals(sample.length(), charSeq.length());
-        for (int i = 0; i < sample.length(); i++) {
-            Assert.assertEquals(sample.charAt(i), charSeq.charAt(i));
-            Assert.assertEquals(iCanEatGlass[9 + i], charSeq.charAt(i));
-        }
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCharSequenceOfSubsequenceNotSupported() {
-        new LogRecordSink.CharSequenceOf().subSequence(0, 0);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void testCharSequenceOfOutOfBounds() {
-        new LogRecordSink.CharSequenceOf().charAt(1);
-    }
-
     @Test
     public void testConvoluted() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
@@ -112,9 +77,9 @@ public class LogRecordSinkTest {
             final long buffPtr = Unsafe.malloc(buffSize, MemoryTag.NATIVE_DEFAULT);
             try {
                 LogRecordSink recordSink = new LogRecordSink(buffPtr, buffSize);
-                recordSink.encodeUtf8(expected.toCharArray(), 1, len - 1);
+                recordSink.encodeUtf8(expected.substring(1, len - 1));
                 recordSink.toSink(sink);
-                Assert.assertEquals(expected.substring(1, len - 1), sink.toString());
+                TestUtils.assertEquals(expected.substring(1, len - 1), sink);
             } finally {
                 Unsafe.free(buffPtr, buffSize, MemoryTag.NATIVE_DEFAULT);
             }

--- a/core/src/test/java/io/questdb/log/TemplateParserTest.java
+++ b/core/src/test/java/io/questdb/log/TemplateParserTest.java
@@ -188,6 +188,7 @@ public class TemplateParserTest {
     public void testParseTemplate() throws IOException {
         try (InputStream is = LogAlertSocketWriter.class.getResourceAsStream("/alert-manager-tpt-international.json")) {
             byte[] buff = new byte[1024];
+            Assert.assertNotNull(is);
             int len = is.read(buff, 0, buff.length);
             String template = new String(buff, 0, len, Files.UTF_8);
             parser.parse(template, 0, LogAlertSocketWriter.ALERT_PROPS);

--- a/core/src/test/java/io/questdb/log/TemplateParserTest.java
+++ b/core/src/test/java/io/questdb/log/TemplateParserTest.java
@@ -191,7 +191,7 @@ public class TemplateParserTest {
             Assert.assertNotNull(is);
             int len = is.read(buff, 0, buff.length);
             String template = new String(buff, 0, len, Files.UTF_8);
-            parser.parse(template, 0, LogAlertSocketWriter.ALERT_PROPS);
+            parser.parseUtf8(template, 0, LogAlertSocketWriter.ALERT_PROPS);
             TestUtils.assertEquals(
                     "[\n" +
                             "  {\n" +

--- a/core/src/test/java/io/questdb/log/TemplateParserTest.java
+++ b/core/src/test/java/io/questdb/log/TemplateParserTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.log;
 
-import io.questdb.std.Files;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -160,7 +159,7 @@ public class TemplateParserTest {
     @Test
     public void testChangeFileTimestamp() {
         parser.parseEnv("${date:y}", 0);
-        parser.setDateValue(1637091363010000L); // time always in micros
+        parser.setDateValue(1637091363010000L); // time is always in micros
         TestUtils.assertEquals("2021", parser);
     }
 
@@ -179,7 +178,7 @@ public class TemplateParserTest {
     @Test
     public void testToString() {
         parser.parseEnv("calendar:${date:y}!", 0);
-        parser.setDateValue(1637091363010000L); // time always in micros
+        parser.setDateValue(1637091363010000L); // time is always in micros
         String str = parser.toString();
         TestUtils.assertEquals("calendar:2021!", str);
     }
@@ -190,7 +189,7 @@ public class TemplateParserTest {
             byte[] buff = new byte[1024];
             Assert.assertNotNull(is);
             int len = is.read(buff, 0, buff.length);
-            String template = new String(buff, 0, len, Files.UTF_8);
+            String template = new String(buff, 0, len);
             parser.parseUtf8(template, 0, LogAlertSocketWriter.ALERT_PROPS);
             TestUtils.assertEquals(
                     "[\n" +


### PR DESCRIPTION
Revisit sink so that by default the put method is ascii, and there are additional means of putting utf8 text.