### PR TITLE
fix(ilp): reject `null` fields when table does not exist

### DIFF
--- a/benchmarks/src/main/java/org/questdb/RawTCPILPSenderMain.java
+++ b/benchmarks/src/main/java/org/questdb/RawTCPILPSenderMain.java
@@ -32,7 +32,7 @@ import io.questdb.std.Unsafe;
 
 public class RawTCPILPSenderMain {
     public static void main(String[] args) {
-        final String ilp = "vbw water_speed_longitudinal=0.07,water_speed_transveral=1,water_speed_status=\"A\",ground_speed_longitudinal=0,ground_speed_transveral=0,ground_speed_status=\"A\",water_speed_stern_transversal=1.2,water_speed_stern_transversal_status=\"V\",ground_speed_stern_transversal=0,ground_speed_stern_transversal_status=\"V\" 1627046637414969856\n";
+        final String ilp = "vbw water_speed_longitudinal=0.07,water_speed_transveral=,water_speed_status=\"A\",ground_speed_longitudinal=0,ground_speed_transveral=0,ground_speed_status=\"A\",water_speed_stern_transversal=,water_speed_stern_transversal_status=\"V\",ground_speed_stern_transversal=0,ground_speed_stern_transversal_status=\"V\" 1627046637414969856\n";
         final int len = ilp.length();
 
         long mem = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -139,7 +139,7 @@ class LineTcpMeasurementEvent implements Closeable {
                         row.cancel();
                         row = null;
                         int colType = DefaultColumnTypes.DEFAULT_COLUMN_TYPES[entityType];
-                        if (colType != ENTITY_TYPE_NULL && TableUtils.isValidInfluxColumnName(charSink)) {
+                        if (TableUtils.isValidInfluxColumnName(charSink)) {
                             writer.addColumn(charSink, colType);
                         } else {
                             throw CairoException.instance(0)

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -37,6 +37,8 @@ import io.questdb.std.str.StringSink;
 
 import java.io.Closeable;
 
+import static io.questdb.cutlass.line.tcp.LineTcpParser.ENTITY_TYPE_NULL;
+
 class LineTcpMeasurementEvent implements Closeable {
     private static final Log LOG = LogFactory.getLog(LineTcpMeasurementEvent.class);
     private final MicrosecondClock clock;
@@ -137,7 +139,7 @@ class LineTcpMeasurementEvent implements Closeable {
                         row.cancel();
                         row = null;
                         int colType = DefaultColumnTypes.DEFAULT_COLUMN_TYPES[entityType];
-                        if (TableUtils.isValidInfluxColumnName(charSink)) {
+                        if (colType != ENTITY_TYPE_NULL && TableUtils.isValidInfluxColumnName(charSink)) {
                             writer.addColumn(charSink, colType);
                         } else {
                             throw CairoException.instance(0)
@@ -397,7 +399,7 @@ class LineTcpMeasurementEvent implements Closeable {
                         break;
                     }
 
-                    case LineTcpParser.ENTITY_TYPE_NULL: {
+                    case ENTITY_TYPE_NULL: {
                         // ignored, default nulls is used
                         break;
                     }
@@ -603,7 +605,7 @@ class LineTcpMeasurementEvent implements Closeable {
                         bufPos += Byte.BYTES;
                         break;
                     }
-                    case LineTcpParser.ENTITY_TYPE_NULL: {
+                    case ENTITY_TYPE_NULL: {
                         Unsafe.getUnsafe().putByte(bufPos, entity.getType());
                         bufPos += Byte.BYTES;
                         break;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableStructureAdapter.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableStructureAdapter.java
@@ -125,13 +125,12 @@ class TableStructureAdapter implements TableStructure {
         return cairoConfiguration.getCommitLag();
     }
 
-    TableStructureAdapter of(CharSequence tableName, LineTcpParser protoParser) {
+    TableStructureAdapter of(CharSequence tableName, LineTcpParser parser) {
         this.tableName = tableName;
-
         entityNames.clear();
         entities.clear();
-        for (int i = 0; i < protoParser.getEntityCount(); i++) {
-            final LineTcpParser.ProtoEntity entity = protoParser.getEntity(i);
+        for (int i = 0; i < parser.getEntityCount(); i++) {
+            final LineTcpParser.ProtoEntity entity = parser.getEntity(i);
             final CharSequence name = entity.getName();
             if (entityNames.add(name)) {
                 if (Chars.equals(name, DEFAULT_TIMESTAMP_FIELD)) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -49,6 +49,34 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     private int rebalanceNRebalances = 0;
 
     @Test
+    public void testAddCastFieldColumnNoTable() throws Exception {
+        String tableName = "addCastColumn";
+        runInContext(() -> {
+            recvBuffer =
+                    tableName + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            tableName + ",location=us-eastcoast cast=cast,temperature=81,humidity=23 1465839830101400200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\tcast\thumidity\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\tNaN\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tcast\t23.0\n";
+            try (TableReader reader = new TableReader(configuration, tableName)) {
+                TableReaderMetadata meta = reader.getMetadata();
+                assertCursorTwoPass(expected, reader.getCursor(), meta);
+                Assert.assertEquals(5, meta.getColumnCount());
+                Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("location"));
+                Assert.assertEquals(ColumnType.DOUBLE, meta.getColumnType("temperature"));
+                Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("cast"));
+                Assert.assertEquals(ColumnType.TIMESTAMP, meta.getColumnType("timestamp"));
+                Assert.assertEquals(ColumnType.DOUBLE, meta.getColumnType("humidity"));
+            }
+        });
+    }
+
+    @Test
     public void testAddFieldColumn() throws Exception {
         String table = "addField";
         runInContext(() -> {
@@ -74,34 +102,6 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
                     "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\n";
             assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testAddCastFieldColumnNoTable() throws Exception {
-        String tableName = "addCastColumn";
-        runInContext(() -> {
-            recvBuffer =
-                    tableName + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            tableName + ",location=us-eastcoast cast=cast,temperature=81,humidity=23 1465839830101400200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\tcast\thumidity\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\tNaN\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tcast\t23.0\n";
-            try (TableReader reader = new TableReader(configuration, tableName)) {
-                TableReaderMetadata meta = reader.getMetadata();
-                assertCursorTwoPass(expected, reader.getCursor(), meta);
-                Assert.assertEquals(5, meta.getColumnCount());
-                Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("location"));
-                Assert.assertEquals(ColumnType.DOUBLE, meta.getColumnType("temperature"));
-                Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("cast"));
-                Assert.assertEquals(ColumnType.TIMESTAMP, meta.getColumnType("timestamp"));
-                Assert.assertEquals(ColumnType.DOUBLE, meta.getColumnType("humidity"));
-            }
         });
     }
 
@@ -600,31 +600,426 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     }
 
     @Test
-    public void testNewTableNullType() throws Exception {
+    public void testDesignatedTimestampAsField() throws Exception {
+        String table = "duplicateTimestamp";
         runInContext(() -> {
             recvBuffer =
-                    "vbw water_speed_longitudinal=0.07,water_speed_transveral=,water_speed_status=\"A\",ground_speed_longitudinal=0,ground_speed_transveral=0,ground_speed_status=\"A\",water_speed_stern_transversal=,water_speed_stern_transversal_status=\"V\",ground_speed_stern_transversal=0,ground_speed_stern_transversal_status=\"V\" 1627046637414969856\n";
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,timestamp=1465839830101600200t\n" +
+                            table + ",location=us-midwest temperature=85,Timestamp=1465839830102300200t\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
             do {
                 handleContextIO();
                 Assert.assertFalse(disconnected);
             } while (recvBuffer.length() > 0);
             closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
 
-            try(SqlCompiler compiler = new SqlCompiler(engine)) {
-                try {
-                    // must not create table
-                    TestUtils.assertSql(
-                            compiler,
-                            new SqlExecutionContextImpl(engine, 1),
-                            "tables()",
-                            sink,
-                            "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\tcommitLag\n"
-                    );
-                } catch (SqlException e) {
-                    Assert.fail();
-                }
+    @Test
+    public void testDesignatedTimestampAsFieldInAllRows() throws Exception {
+        String table = "duplicateTimestamp";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest timestamp=1465839830100400200t,temperature=82\n" +
+                            table + ",location=us-midwest timestamp=1465839830100500200t,temperature=83\n" +
+                            table + ",location=us-eastcoast timestamp=1465839830101600200t,temperature=81\n" +
+                            table + ",location=us-midwest timestamp=1465839830102300200t,temperature=85\n" +
+                            table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=89\n" +
+                            table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=80\n" +
+                            table + ",location=us-westcost timestamp=1465839830102500200t,temperature=82\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttimestamp\ttemperature\n" +
+                    "us-midwest\t2016-06-13T17:43:50.100400Z\t82.0\n" +
+                    "us-midwest\t2016-06-13T17:43:50.100500Z\t83.0\n" +
+                    "us-eastcoast\t2016-06-13T17:43:50.101600Z\t81.0\n" +
+                    "us-midwest\t2016-06-13T17:43:50.102300Z\t85.0\n" +
+                    "us-eastcoast\t2016-06-13T17:43:50.102400Z\t89.0\n" +
+                    "us-eastcoast\t2016-06-13T17:43:50.102400Z\t80.0\n" +
+                    "us-westcost\t2016-06-13T17:43:50.102500Z\t82.0\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDesignatedTimestampAsFieldInFirstRow() throws Exception {
+        String table = "duplicateTimestamp";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,timestamp=1465839830100200200t\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81 1465839830101600200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100200Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDesignatedTimestampNotCalledTimestampWhenTableExistAlready() throws Exception {
+        String table = "tableExistAlready";
+        runInContext(() -> {
+            try (
+                    SqlCompiler compiler = new SqlCompiler(engine);
+                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)) {
+                compiler.compile(
+                        "create table " + table + " (location SYMBOL, temperature DOUBLE, time TIMESTAMP) timestamp(time);",
+                        sqlExecutionContext);
+            } catch (SqlException ex) {
+                throw new RuntimeException(ex);
             }
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,time=1465839830100300200t 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast,city=york temperature=81 1465839830101400200\n" +
+                            table + ",location=us-midwest,city=london temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80,time=1465839830102500200t\n" +
+                            table + ",location=us-westcost temperature=82,time=1465839830102600200t 1465839830102700200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttime\tcity\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100300Z\t\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\t\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tyork\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\tlondon\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102500Z\t\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102600Z\t\n";
+            assertTable(expected, table);
+        });
+    }
 
+    @Test
+    public void testDuplicateField() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,temperature=23 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateFieldInFirstRow() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,temperature=77 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateFieldInFirstRowCaseInsensitivity() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,TEMPERATURE=77,TemPerAture=76 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateFieldNonASCII() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",terület=us-midwest hőmérséklet=82,ветер=2.0 1465839830100400200\n" +
+                            table + ",terület=us-midwest hőmérséklet=83,ветер=3.0,hőmérséklet=43 1465839830100500200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=81,HŐMÉRSÉKLET=23,ветер=2.0 1465839830101400200\n" +
+                            table + ",terület=us-midwest ветер=2.1,hőmérséklet=85,ветер=2.4 1465839830102300200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
+                            table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
+                    "us-midwest\t82.0\t2.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t3.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2.0\t2016-06-13T17:43:50.101400Z\n" +
+                    "us-midwest\t85.0\t2.1\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2.2\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateFieldNonASCIIFirstRow() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",terület=us-midwest hőmérséklet=82,ветер=2.5,ветер=2.4 1465839830100400200\n" +
+                            table + ",terület=us-midwest hőmérséklet=83,ветер=3.0 1465839830100500200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=81,HŐMÉRSÉKLET=23,ветер=2.0 1465839830101400200\n" +
+                            table + ",terület=us-midwest ветер=2.1,hőmérséklet=85 1465839830102300200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
+                            table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
+                            table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
+                    "us-midwest\t82.0\t2.5\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t3.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2.0\t2016-06-13T17:43:50.101400Z\n" +
+                    "us-midwest\t85.0\t2.1\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2.2\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateFieldWhenTableExistsAlready() throws Exception {
+        String table = "tableExistAlready";
+        runInContext(() -> {
+            try (
+                    SqlCompiler compiler = new SqlCompiler(engine);
+                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)) {
+                compiler.compile(
+                        "create table " + table + " (location SYMBOL, temperature DOUBLE, timestamp TIMESTAMP) timestamp(timestamp);",
+                        sqlExecutionContext);
+            } catch (SqlException ex) {
+                throw new RuntimeException(ex);
+            }
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,timestamp=1465839830100400200t 1465839830100300200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast,city=york,city=london temperature=81 1465839830101400200\n" +
+                            table + ",location=us-midwest,city=london temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82,timestamp=1465839830102500200t\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\tcity\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\t\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tyork\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\tlondon\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\t\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\t\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateNewField() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,humidity=24,humidity=26,humidity=25 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85,humidity=27 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\thumidity\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateNewFieldCaseInsensitivity() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,humidity=24,HUMIDITY=26,HuMiditY=25 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85,humidity=27 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89,HuMiditY=28,humidity=29 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\thumidity\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t28.0\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateTimestamp() throws Exception {
+        String table = "duplicateTimestamp";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,timestamp=1465839830101500200t 1465839830101600200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101500Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testDuplicateTimestampInFirstRow() throws Exception {
+        String table = "duplicateTimestamp";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82,timestamp=1465839830100400200t,TimeStamp=1465839830100400200t 1465839830100700200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81 1465839830101600200\n" +
+                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
         });
     }
 
@@ -809,6 +1204,35 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     }
 
     @Test
+    public void testMoreDuplicateNewFields() throws Exception {
+        String table = "dupField";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast temperature=81,humidity=24,humidity=26,humidity=25,pollution=2,pollution=3 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85,humidity=27,pollution=3,pollution=4 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89,pollution=5 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\thumidity\tpollution\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\n" +
+                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\tNaN\n" +
+                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\t2.0\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\t3.0\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\t5.0\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\tNaN\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\tNaN\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
     public void testMultiplTablesWithMultipleWriterThreads() throws Exception {
         nWriterThreads = 5;
         int nTables = 12;
@@ -932,6 +1356,73 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     "89.0\t101\t2016-06-13T17:43:50.102400Z\n" +
                     "80.0\t100\t2016-06-13T17:43:50.102400Z\n" +
                     "82.0\t100\t2016-06-13T17:43:50.102500Z\n";
+            assertTable(expected, table);
+        });
+    }
+
+    @Test
+    public void testNewTableNullType() throws Exception {
+        runInContext(() -> {
+            recvBuffer =
+                    "vbw water_speed_longitudinal=0.07,water_speed_transveral=,water_speed_status=\"A\",ground_speed_longitudinal=0,ground_speed_transveral=0,ground_speed_status=\"A\",water_speed_stern_transversal=,water_speed_stern_transversal_status=\"V\",ground_speed_stern_transversal=0,ground_speed_stern_transversal_status=\"V\" 1627046637414969856\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+
+
+            try (
+                    final SqlExecutionContext context = new SqlExecutionContextImpl(engine, 1);
+                    SqlCompiler compiler = new SqlCompiler(engine)
+            ) {
+                try {
+                    // must not create table
+                    TestUtils.assertSql(
+                            compiler,
+                            context,
+                            "tables()",
+                            sink,
+                            "id\tname\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\tcommitLag\n"
+                    );
+                    // should be able to create table after this (e.g. no debris left by ILP)
+                    compiler.compile("create table vbw(a int)", context);
+
+                } catch (SqlException e) {
+                    Assert.fail();
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testNonPrintableChars() throws Exception {
+        char nonPrintable = 0x3000;
+        char nonPrintable1 = 0x3080;
+        char nonPrintable2 = 0x3a55;
+        String table = "nonPrintable" + nonPrintable + "Chars";
+        runInContext(() -> {
+            recvBuffer =
+                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
+                            table + ",location=us-mid" + nonPrintable1 + "west temperature=83 1465839830100500200\n" +
+                            table + ",location=us-eastcoast" + nonPrintable2 + " temperature=81 1465839830101400200\n" +
+                            table + ",location=us-midwest temperature=85,hőmérséklet" + nonPrintable1 + "=24 1465839830102300200\n" +
+                            table + ",location=us-eastcoast temperature=89,hőmérséklet" + nonPrintable2 + "=26 1465839830102400200\n" +
+                            table + ",location=us-eastcoast temperature=80,hőmérséklet" + nonPrintable + "=25,hőmérséklet" + nonPrintable2 + "=23 1465839830102400200\n" +
+                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+            closeContext();
+            String expected = "location\ttemperature\ttimestamp\thőmérséklet" + nonPrintable1 + "\thőmérséklet" + nonPrintable2 + "\thőmérséklet" + nonPrintable + "\n" +
+                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\tNaN\n" +
+                    "us-mid" + nonPrintable1 + "west\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\tNaN\tNaN\n" +
+                    "us-eastcoast" + nonPrintable2 + "\t81.0\t2016-06-13T17:43:50.101400Z\tNaN\tNaN\tNaN\n" +
+                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t24.0\tNaN\tNaN\n" +
+                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\t26.0\tNaN\n" +
+                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\t23.0\t25.0\n" +
+                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\tNaN\tNaN\n";
             assertTable(expected, table);
         });
     }
@@ -1148,491 +1639,6 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     "us-eastcoast\t89.0\t1970-01-01T00:00:00.000000Z\n" +
                     "us-eastcoast\t80.0\t1970-01-01T00:00:00.000000Z\n" +
                     "us-westcost\t82.0\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testNonPrintableChars() throws Exception {
-        char nonPrintable = 0x3000;
-        char nonPrintable1 = 0x3080;
-        char nonPrintable2 = 0x3a55;
-        String table = "nonPrintable" + nonPrintable + "Chars";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-mid" + nonPrintable1 + "west temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast" + nonPrintable2 + " temperature=81 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85,hőmérséklet" + nonPrintable1 + "=24 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89,hőmérséklet" + nonPrintable2 + "=26 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80,hőmérséklet" + nonPrintable + "=25,hőmérséklet" + nonPrintable2 + "=23 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\thőmérséklet" + nonPrintable1 + "\thőmérséklet" + nonPrintable2 + "\thőmérséklet" + nonPrintable + "\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\tNaN\n" +
-                    "us-mid" + nonPrintable1 + "west\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\tNaN\tNaN\n" +
-                    "us-eastcoast" + nonPrintable2 + "\t81.0\t2016-06-13T17:43:50.101400Z\tNaN\tNaN\tNaN\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t24.0\tNaN\tNaN\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\t26.0\tNaN\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\t23.0\t25.0\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\tNaN\tNaN\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateField() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,temperature=23 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateFieldNonASCII() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",terület=us-midwest hőmérséklet=82,ветер=2.0 1465839830100400200\n" +
-                            table + ",terület=us-midwest hőmérséklet=83,ветер=3.0,hőmérséklet=43 1465839830100500200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=81,HŐMÉRSÉKLET=23,ветер=2.0 1465839830101400200\n" +
-                            table + ",terület=us-midwest ветер=2.1,hőmérséklet=85,ветер=2.4 1465839830102300200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
-                            table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
-                    "us-midwest\t82.0\t2.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t3.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2.0\t2016-06-13T17:43:50.101400Z\n" +
-                    "us-midwest\t85.0\t2.1\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2.2\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateFieldNonASCIIFirstRow() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",terület=us-midwest hőmérséklet=82,ветер=2.5,ветер=2.4 1465839830100400200\n" +
-                            table + ",terület=us-midwest hőmérséklet=83,ветер=3.0 1465839830100500200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=81,HŐMÉRSÉKLET=23,ветер=2.0 1465839830101400200\n" +
-                            table + ",terület=us-midwest ветер=2.1,hőmérséklet=85 1465839830102300200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
-                            table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
-                            table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
-                    "us-midwest\t82.0\t2.5\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t3.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2.0\t2016-06-13T17:43:50.101400Z\n" +
-                    "us-midwest\t85.0\t2.1\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\tNaN\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2.2\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateFieldInFirstRow() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,temperature=77 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateFieldInFirstRowCaseInsensitivity() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,TEMPERATURE=77,TemPerAture=76 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateNewField() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,humidity=24,humidity=26,humidity=25 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85,humidity=27 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\thumidity\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testMoreDuplicateNewFields() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,humidity=24,humidity=26,humidity=25,pollution=2,pollution=3 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85,humidity=27,pollution=3,pollution=4 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89,pollution=5 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\thumidity\tpollution\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\tNaN\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\t2.0\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\t3.0\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\tNaN\t5.0\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\tNaN\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\tNaN\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateNewFieldCaseInsensitivity() throws Exception {
-        String table = "dupField";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,humidity=24,HUMIDITY=26,HuMiditY=25 1465839830101400200\n" +
-                            table + ",location=us-midwest temperature=85,humidity=27 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89,HuMiditY=28,humidity=29 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\thumidity\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\tNaN\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\t24.0\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\t27.0\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t28.0\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\tNaN\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\tNaN\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateTimestamp() throws Exception {
-        String table = "duplicateTimestamp";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,timestamp=1465839830101500200t 1465839830101600200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101500Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateTimestampInFirstRow() throws Exception {
-        String table = "duplicateTimestamp";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,timestamp=1465839830100400200t,TimeStamp=1465839830100400200t 1465839830100700200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81 1465839830101600200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDesignatedTimestampAsField() throws Exception {
-        String table = "duplicateTimestamp";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81,timestamp=1465839830101600200t\n" +
-                            table + ",location=us-midwest temperature=85,Timestamp=1465839830102300200t\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDesignatedTimestampAsFieldInFirstRow() throws Exception {
-        String table = "duplicateTimestamp";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,timestamp=1465839830100200200t\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast temperature=81 1465839830101600200\n" +
-                            table + ",location=us-midwest temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100200Z\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101600Z\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDesignatedTimestampAsFieldInAllRows() throws Exception {
-        String table = "duplicateTimestamp";
-        runInContext(() -> {
-            recvBuffer =
-                    table + ",location=us-midwest timestamp=1465839830100400200t,temperature=82\n" +
-                            table + ",location=us-midwest timestamp=1465839830100500200t,temperature=83\n" +
-                            table + ",location=us-eastcoast timestamp=1465839830101600200t,temperature=81\n" +
-                            table + ",location=us-midwest timestamp=1465839830102300200t,temperature=85\n" +
-                            table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=89\n" +
-                            table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=80\n" +
-                            table + ",location=us-westcost timestamp=1465839830102500200t,temperature=82\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttimestamp\ttemperature\n" +
-                    "us-midwest\t2016-06-13T17:43:50.100400Z\t82.0\n" +
-                    "us-midwest\t2016-06-13T17:43:50.100500Z\t83.0\n" +
-                    "us-eastcoast\t2016-06-13T17:43:50.101600Z\t81.0\n" +
-                    "us-midwest\t2016-06-13T17:43:50.102300Z\t85.0\n" +
-                    "us-eastcoast\t2016-06-13T17:43:50.102400Z\t89.0\n" +
-                    "us-eastcoast\t2016-06-13T17:43:50.102400Z\t80.0\n" +
-                    "us-westcost\t2016-06-13T17:43:50.102500Z\t82.0\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDuplicateFieldWhenTableExistsAlready() throws Exception {
-        String table = "tableExistAlready";
-        runInContext(() -> {
-            try (
-                    SqlCompiler compiler = new SqlCompiler(engine);
-                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)) {
-                compiler.compile(
-                        "create table " + table + " (location SYMBOL, temperature DOUBLE, timestamp TIMESTAMP) timestamp(timestamp);",
-                        sqlExecutionContext);
-            } catch (SqlException ex) {
-                throw new RuntimeException(ex);
-            }
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,timestamp=1465839830100400200t 1465839830100300200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast,city=york,city=london temperature=81 1465839830101400200\n" +
-                            table + ",location=us-midwest,city=london temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
-                            table + ",location=us-westcost temperature=82,timestamp=1465839830102500200t\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttimestamp\tcity\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\t\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tyork\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\tlondon\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102400Z\t\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102500Z\t\n";
-            assertTable(expected, table);
-        });
-    }
-
-    @Test
-    public void testDesignatedTimestampNotCalledTimestampWhenTableExistAlready() throws Exception {
-        String table = "tableExistAlready";
-        runInContext(() -> {
-            try (
-                    SqlCompiler compiler = new SqlCompiler(engine);
-                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)) {
-                compiler.compile(
-                        "create table " + table + " (location SYMBOL, temperature DOUBLE, time TIMESTAMP) timestamp(time);",
-                        sqlExecutionContext);
-            } catch (SqlException ex) {
-                throw new RuntimeException(ex);
-            }
-            recvBuffer =
-                    table + ",location=us-midwest temperature=82,time=1465839830100300200t 1465839830100400200\n" +
-                            table + ",location=us-midwest temperature=83 1465839830100500200\n" +
-                            table + ",location=us-eastcoast,city=york temperature=81 1465839830101400200\n" +
-                            table + ",location=us-midwest,city=london temperature=85 1465839830102300200\n" +
-                            table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
-                            table + ",location=us-eastcoast temperature=80,time=1465839830102500200t\n" +
-                            table + ",location=us-westcost temperature=82,time=1465839830102600200t 1465839830102700200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
-            closeContext();
-            String expected = "location\ttemperature\ttime\tcity\n" +
-                    "us-midwest\t82.0\t2016-06-13T17:43:50.100300Z\t\n" +
-                    "us-midwest\t83.0\t2016-06-13T17:43:50.100500Z\t\n" +
-                    "us-eastcoast\t81.0\t2016-06-13T17:43:50.101400Z\tyork\n" +
-                    "us-midwest\t85.0\t2016-06-13T17:43:50.102300Z\tlondon\n" +
-                    "us-eastcoast\t89.0\t2016-06-13T17:43:50.102400Z\t\n" +
-                    "us-eastcoast\t80.0\t2016-06-13T17:43:50.102500Z\t\n" +
-                    "us-westcost\t82.0\t2016-06-13T17:43:50.102600Z\t\n";
             assertTable(expected, table);
         });
     }


### PR DESCRIPTION
Fixes #1661


Apologies, IntelliJ reformatted test file. The only change there is added test `testNewTableNullType`