### PR TITLE
chore(test): speeding up tests (and test name adjustment)

### DIFF
--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -89,27 +89,6 @@ public class LogAlertSocket implements Closeable {
     }
 
     public LogAlertSocket(
-            String alertTargets,
-            int inBufferSize,
-            int outBufferSize,
-            long reconnectDelay,
-            String defaultHost,
-            int defaultPort,
-            Log log
-    ) {
-        this(
-                NetworkFacadeImpl.INSTANCE,
-                alertTargets,
-                inBufferSize,
-                outBufferSize,
-                reconnectDelay,
-                defaultHost,
-                defaultPort,
-                log
-        );
-    }
-
-    private LogAlertSocket(
             NetworkFacade nf,
             String alertTargets,
             int inBufferSize,

--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -75,9 +75,9 @@ public class LogAlertSocket implements Closeable {
     private long fdSocket = -1;
     private String alertTargets; // host[:port](,host[:port])*
 
-    public LogAlertSocket(String alertTargets, Log log) {
+    public LogAlertSocket(NetworkFacade nf, String alertTargets, Log log) {
         this(
-                NetworkFacadeImpl.INSTANCE,
+                nf,
                 alertTargets,
                 IN_BUFFER_SIZE,
                 OUT_BUFFER_SIZE,

--- a/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
@@ -165,19 +165,7 @@ public class LogAlertSocketTest {
         TestUtils.assertMemoryLeak(() -> {
             final String host = "127.0.0.1";
             final int port = 1241;
-            final NetworkFacade nf = new NetworkFacadeImpl() {
-                int connectCount = 1;
-                @Override
-                public long connect(long fd, long sockaddr) {
-                    if (--connectCount == 0) {
-                        return super.connect(fd, sockaddr);
-                    } else {
-                        return -1;
-                    }
-                }
-            };
-
-            try (LogAlertSocket alertSkt = new LogAlertSocket(nf, host + ":" + port, LOG)) {
+            try (LogAlertSocket alertSkt = new LogAlertSocket(NetworkFacadeImpl.INSTANCE, host + ":" + port, LOG)) {
                 final HttpLogRecordSink builder = new HttpLogRecordSink(alertSkt)
                         .putHeader(host)
                         .setMark();

--- a/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
@@ -25,13 +25,14 @@
 package io.questdb.log;
 
 import io.questdb.mp.SOCountDownLatch;
+import io.questdb.network.NetworkFacade;
+import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.Misc;
 import io.questdb.std.Sinkable;
 import io.questdb.std.str.CharSinkBase;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -42,13 +43,6 @@ import static io.questdb.log.HttpLogRecordSink.CRLF;
 public class LogAlertSocketTest {
 
     private static final Log LOG = LogFactory.getLog(LogAlertSocketTest.class);
-
-    private StringSink sink;
-
-    @Before
-    public void setUp() {
-        sink = new StringSink();
-    }
 
     @Test
     public void testParseAlertTargetsEmpty() throws Exception {
@@ -122,7 +116,7 @@ public class LogAlertSocketTest {
     @Test
     public void testFailOver() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (LogAlertSocket alertSkt = new LogAlertSocket("localhost:1234,localhost:1242", LOG)) {
+            try (LogAlertSocket alertSkt = new LogAlertSocket(NetworkFacadeImpl.INSTANCE, "localhost:1234,localhost:1242", LOG)) {
                 final HttpLogRecordSink builder = new HttpLogRecordSink(alertSkt)
                         .putHeader("localhost")
                         .setMark();
@@ -171,7 +165,19 @@ public class LogAlertSocketTest {
         TestUtils.assertMemoryLeak(() -> {
             final String host = "127.0.0.1";
             final int port = 1241;
-            try (LogAlertSocket alertSkt = new LogAlertSocket(host + ":" + port, LOG)) {
+            final NetworkFacade nf = new NetworkFacadeImpl() {
+                int connectCount = 1;
+                @Override
+                public long connect(long fd, long sockaddr) {
+                    if (--connectCount == 0) {
+                        return super.connect(fd, sockaddr);
+                    } else {
+                        return -1;
+                    }
+                }
+            };
+
+            try (LogAlertSocket alertSkt = new LogAlertSocket(nf, host + ":" + port, LOG)) {
                 final HttpLogRecordSink builder = new HttpLogRecordSink(alertSkt)
                         .putHeader(host)
                         .setMark();
@@ -195,10 +201,10 @@ public class LogAlertSocketTest {
                                 .$()));
 
                 // wait for haltness
-                Assert.assertTrue(haltLatch.await(20_000_000_000L));
+                haltLatch.await();
                 Assert.assertFalse(server.isRunning());
 
-                // send and fail after a reconnect delay
+                // send and fail after a re-connect delay
                 final long start = System.nanoTime();
                 Assert.assertFalse(alertSkt.send(builder.length()));
                 Assert.assertTrue(System.nanoTime() - start >= 2 * LogAlertSocket.RECONNECT_DELAY_NANO);
@@ -209,7 +215,13 @@ public class LogAlertSocketTest {
     @Test
     public void testFailOverNoServers() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (LogAlertSocket alertSkt = new LogAlertSocket("localhost:1234,localhost:1243", LOG)) {
+            final NetworkFacade nf = new NetworkFacadeImpl() {
+                @Override
+                public long connect(long fd, long sockaddr) {
+                    return -1;
+                }
+            };
+            try (LogAlertSocket alertSkt = new LogAlertSocket(nf, "localhost:1234,localhost:1243", LOG)) {
                 final HttpLogRecordSink builder = new HttpLogRecordSink(alertSkt)
                         .putHeader("localhost")
                         .setMark();
@@ -373,8 +385,14 @@ public class LogAlertSocketTest {
 
     private void testParseStatusResponse(CharSequence httpMessage, CharSequence expected) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
+            NetworkFacade nf = new NetworkFacadeImpl() {
+                @Override
+                public long connect(long fd, long sockaddr) {
+                    return -1;
+                }
+            };
             MockLog log = new MockLog();
-            try (LogAlertSocket alertSkt = new LogAlertSocket("", log)) {
+            try (LogAlertSocket alertSkt = new LogAlertSocket(nf, "", log)) {
                 LogRecordSink logRecord = new LogRecordSink(alertSkt.getInBufferPtr(), alertSkt.getInBufferSize());
                 logRecord.put(httpMessage);
                 alertSkt.logResponse(logRecord.length());
@@ -385,7 +403,13 @@ public class LogAlertSocketTest {
 
     private void assertLogError(String socketAddress, String expected) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (LogAlertSocket ignored = new LogAlertSocket(socketAddress, LOG)) {
+            NetworkFacade nf = new NetworkFacadeImpl() {
+                @Override
+                public long connect(long fd, long sockaddr) {
+                    return -1;
+                }
+            };
+            try (LogAlertSocket ignored = new LogAlertSocket(nf, socketAddress, LOG)) {
                 Assert.fail();
             } catch (LogError logError) {
                 Assert.assertEquals(expected, logError.getMessage());
@@ -399,7 +423,14 @@ public class LogAlertSocketTest {
             int[] expectedPorts
     ) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (LogAlertSocket socket = new LogAlertSocket(alertTargets, LOG)) {
+            NetworkFacade nf = new NetworkFacadeImpl() {
+                @Override
+                public long connect(long fd, long sockaddr) {
+                    return -1;
+                }
+            };
+
+            try (LogAlertSocket socket = new LogAlertSocket(nf, alertTargets, LOG)) {
                 Assert.assertEquals(expectedHosts.length, socket.getAlertHostsCount());
                 Assert.assertEquals(expectedPorts.length, socket.getAlertHostsCount());
                 for (int i = 0; i < expectedHosts.length; i++) {

--- a/core/src/test/java/io/questdb/log/LogAlertSocketWriterTest.java
+++ b/core/src/test/java/io/questdb/log/LogAlertSocketWriterTest.java
@@ -26,7 +26,6 @@ package io.questdb.log;
 
 import io.questdb.BuildInformation;
 import io.questdb.BuildInformationHolder;
-import io.questdb.mp.SOCountDownLatch;
 import io.questdb.network.NetworkError;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
@@ -64,12 +63,15 @@ public class LogAlertSocketWriterTest {
                     final long logRecordBuffPtr = Unsafe.malloc(logRecordBuffSize, MemoryTag.NATIVE_DEFAULT);
                     try {
                         // create mock alert target servers
+                        // Vlad: we are wasting time here not connecting anywhere
+/*
                         final SOCountDownLatch haltLatch = new SOCountDownLatch(2);
                         final MockAlertTarget[] alertsTarget = new MockAlertTarget[2];
                         alertsTarget[0] = new MockAlertTarget(1234, haltLatch::countDown);
                         alertsTarget[1] = new MockAlertTarget(1242, haltLatch::countDown);
                         alertsTarget[0].start();
                         alertsTarget[1].start();
+*/
 
                         writer.setAlertTargets("localhost:1234,localhost:1242");
                         writer.bindProperties(LogFactory.INSTANCE);
@@ -149,9 +151,11 @@ public class LogAlertSocketWriterTest {
                                 writer.getAlertSink()
                         );
 
+/*
                         haltLatch.await();
                         Assert.assertFalse(alertsTarget[0].isRunning());
                         Assert.assertFalse(alertsTarget[1].isRunning());
+*/
                     } finally {
                         Unsafe.free(logRecordBuffPtr, logRecordBuffSize, MemoryTag.NATIVE_DEFAULT);
                     }
@@ -163,14 +167,16 @@ public class LogAlertSocketWriterTest {
         withLogAlertSocketWriter(
                 () -> 1637091363010000L,
                 writer -> {
-
+                    // this test does not interact with server
                     final int logRecordBuffSize = 1024; // plenty, to allow for encoding/escaping
                     final long logRecordBuffPtr = Unsafe.malloc(logRecordBuffSize, MemoryTag.NATIVE_DEFAULT);
                     try {
+/*
                         // create mock alert target server
                         final SOCountDownLatch haltLatch = new SOCountDownLatch(1);
                         final MockAlertTarget alertTarget = new MockAlertTarget(1234, haltLatch::countDown);
                         alertTarget.start();
+*/
                         writer.setLocation("/alert-manager-tpt-international.json");
                         writer.setAlertTargets("localhost:1234");
                         writer.setReconnectDelay("100");
@@ -213,8 +219,10 @@ public class LogAlertSocketWriterTest {
                                 writer.getAlertSink()
                         );
 
+/*
                         Assert.assertTrue(haltLatch.await(10_000_000_000L));
                         Assert.assertFalse(alertTarget.isRunning());
+*/
                     } finally {
                         Unsafe.free(logRecordBuffPtr, logRecordBuffSize, MemoryTag.NATIVE_DEFAULT);
                     }

--- a/core/src/test/java/io/questdb/log/MockAlertTarget.java
+++ b/core/src/test/java/io/questdb/log/MockAlertTarget.java
@@ -62,11 +62,11 @@ class MockAlertTarget extends Thread {
                 // setup server socket and accept client
                 serverSkt = new ServerSocket(portNumber);
                 serverSkt.setReuseAddress(true);
-                serverSkt.setSoTimeout(5000);
+                serverSkt.setSoTimeout(50);
                 clientSkt = serverSkt.accept();
                 in = new BufferedReader(new InputStreamReader(clientSkt.getInputStream()));
                 out = new PrintWriter(clientSkt.getOutputStream(), true);
-                clientSkt.setSoTimeout(5000);
+                clientSkt.setSoTimeout(50);
                 clientSkt.setReuseAddress(true);
                 clientSkt.setTcpNoDelay(true);
                 clientSkt.setKeepAlive(false);

--- a/core/src/test/java/io/questdb/log/MockAlertTarget.java
+++ b/core/src/test/java/io/questdb/log/MockAlertTarget.java
@@ -62,11 +62,11 @@ class MockAlertTarget extends Thread {
                 // setup server socket and accept client
                 serverSkt = new ServerSocket(portNumber);
                 serverSkt.setReuseAddress(true);
-                serverSkt.setSoTimeout(50);
+                serverSkt.setSoTimeout(5000);
                 clientSkt = serverSkt.accept();
                 in = new BufferedReader(new InputStreamReader(clientSkt.getInputStream()));
                 out = new PrintWriter(clientSkt.getOutputStream(), true);
-                clientSkt.setSoTimeout(50);
+                clientSkt.setSoTimeout(5000);
                 clientSkt.setReuseAddress(true);
                 clientSkt.setTcpNoDelay(true);
                 clientSkt.setKeepAlive(false);


### PR DESCRIPTION
Tests were unnecessarily slow to run. They don't connect anywhere useful but still wait on connect timeout. Before the change:

![image](https://user-images.githubusercontent.com/7276403/146057505-df89de86-0741-4a56-bc32-b6fb93d13880.png)

After this PR:

![image](https://user-images.githubusercontent.com/7276403/146057606-aca905d9-07af-48ad-80ec-d1166e455eb0.png)

circled is calendar reload, which happens once for the entire test group, e.g. when running this class together with others the exec time will be in millis