### PR TITLE
feat(cairo): wait for writer if it's about to be released by maintanance from the pool

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -509,12 +509,10 @@ public class CairoEngine implements Closeable, WriterSource {
     private class EngineMaintenanceJob extends SynchronizedJob {
 
         private final MicrosecondClock clock;
-        private final long checkInterval;
         private long last = 0;
 
         public EngineMaintenanceJob(CairoConfiguration configuration) {
             this.clock = configuration.getMicrosecondClock();
-            this.checkInterval = configuration.getIdleCheckInterval() * 1000;
         }
 
         @Override
@@ -525,7 +523,7 @@ public class CairoEngine implements Closeable, WriterSource {
                 // process and drain cmd queue
                 useful = true;
             }
-            if (last + checkInterval < t) {
+            if (last + configuration.getIdleCheckInterval() < t) {
                 last = t;
                 return useful | releaseInactive();
             }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -509,10 +509,12 @@ public class CairoEngine implements Closeable, WriterSource {
     private class EngineMaintenanceJob extends SynchronizedJob {
 
         private final MicrosecondClock clock;
+        private final long checkInterval;
         private long last = 0;
 
         public EngineMaintenanceJob(CairoConfiguration configuration) {
             this.clock = configuration.getMicrosecondClock();
+            this.checkInterval = configuration.getIdleCheckInterval() * 1000;
         }
 
         @Override
@@ -523,7 +525,7 @@ public class CairoEngine implements Closeable, WriterSource {
                 // process and drain cmd queue
                 useful = true;
             }
-            if (last + configuration.getIdleCheckInterval() < t) {
+            if (last + checkInterval < t) {
                 last = t;
                 return useful | releaseInactive();
             }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3797,7 +3797,7 @@ public class TableWriter implements Closeable {
                 }
             }
             populateDenseIndexerList();
-            LOG.info().$("switched partition [path='").$(path).I$();
+            LOG.info().$("switched partition [path='").$(path).$('\'').I$();
         } catch (Throwable e) {
             distressed = true;
             throw e;

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -362,7 +362,7 @@ public class WriterPool extends AbstractPool {
                 // looks like this one can be released
                 // try to lock it
                 // Lock with negative owner to indicate it's about to be released
-                if (Unsafe.cas(e, ENTRY_OWNER, UNALLOCATED, -thread)) {
+                if (Unsafe.cas(e, ENTRY_OWNER, UNALLOCATED, UNALLOCATED - thread)) {
                     // lock successful
                     closeWriter(thread, e, PoolListener.EV_EXPIRE, reason);
                     iterator.remove();

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -136,8 +136,8 @@ public class WriterPool extends AbstractPool {
                 }
                 return checkClosedAndGetWriter(tableName, e, lockReason);
             } else {
-                if (owner < -1L) {
-                    // writer is about to be released from the pool by releaseAll method.
+                if (e.owner < 0) {
+                    // writer is about to be released from the pool by release method.
                     // try again, it should become available soon.
                     LockSupport.parkNanos(1);
                     continue;

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -136,8 +136,8 @@ public class WriterPool extends AbstractPool {
                 }
                 return checkClosedAndGetWriter(tableName, e, lockReason);
             } else {
-                if (owner < 0) {
-                    // writer is about to be released from the pool by relaseAll method.
+                if (owner < -1L) {
+                    // writer is about to be released from the pool by releaseAll method.
                     // try again, it should become available soon.
                     LockSupport.parkNanos(1);
                     continue;
@@ -368,7 +368,7 @@ public class WriterPool extends AbstractPool {
                     iterator.remove();
                     removed = true;
                 }
-            } else if (e.lockFd != -1L) {
+            } else if (e.lockFd != -1L && deadline == Long.MAX_VALUE) {
                 if (ff.close(e.lockFd)) {
                     e.lockFd = -1L;
                     iterator.remove();

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -145,7 +145,7 @@ public class WriterPool extends AbstractPool {
                     throw e.ex;
                 }
             }
-            LOG.info().$("busy [table=`").utf8(tableName).$("`, owner=").$(owner).$(']').$();
+            LOG.info().$("busy [table=`").utf8(tableName).$("`, owner=").$(owner).$(", thread=").$(thread).I$();
             throw EntryUnavailableException.instance(e.ownershipReason);
         }
     }
@@ -297,7 +297,7 @@ public class WriterPool extends AbstractPool {
                 Unsafe.getUnsafe().putOrderedLong(e, ENTRY_OWNER, UNALLOCATED);
             }
             notifyListener(thread, name, PoolListener.EV_UNLOCKED);
-            LOG.debug().$("unlocked [table=`").utf8(name).$("`]").$();
+            LOG.debug().$("unlocked [table=`").utf8(name).$("`, thread=").$(thread).I$();
         } else {
             notifyListener(thread, name, PoolListener.EV_NOT_LOCK_OWNER);
             throw CairoException.instance(0).put("Not lock owner of ").put(name);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -70,7 +70,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             int workerCount,
             Metrics metrics
     ) {
-        this(configuration, engine, workerCount, (FunctionFactoryCache) null, metrics);
+        this(configuration, engine, workerCount, null, metrics);
     }
 
     public JsonQueryProcessor(
@@ -80,7 +80,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             @Nullable FunctionFactoryCache functionFactoryCache,
             Metrics metrics
     ) {
-        this(configuration, engine, workerCount, new SqlCompiler(engine, functionFactoryCache), metrics);
+        this(configuration, engine, workerCount, new SqlCompiler(engine, functionFactoryCache), metrics, new SqlExecutionContextImpl(engine, workerCount));
     }
 
     public JsonQueryProcessor(
@@ -88,7 +88,8 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             CairoEngine engine,
             int workerCount,
             SqlCompiler sqlCompiler,
-            Metrics metrics
+            Metrics metrics,
+            SqlExecutionContextImpl sqlExecutionContext
     ) {
         this.configuration = configuration;
         this.compiler = sqlCompiler;
@@ -106,7 +107,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         this.queryExecutors.extendAndSet(CompiledQuery.INSERT_AS_SELECT, sendConfirmation);
         this.queryExecutors.extendAndSet(CompiledQuery.COPY_REMOTE, JsonQueryProcessor::cannotCopyRemote);
         this.queryExecutors.extendAndSet(CompiledQuery.BACKUP_TABLE, sendConfirmation);
-        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount);
+        this.sqlExecutionContext = sqlExecutionContext;
         this.nanosecondClock = engine.getConfiguration().getNanosecondClock();
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(configuration.getCircuitBreakerConfiguration());
         this.metrics = metrics;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -169,7 +169,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     private final PGResumeProcessor resumeCursorQueryRef = this::resumeCursorQuery;
     private final SCSequence tempSequence = new SCSequence();
 
-    public PGConnectionContext(CairoEngine engine, PGWireConfiguration configuration, int workerCount) {
+    public PGConnectionContext(CairoEngine engine, PGWireConfiguration configuration, SqlExecutionContextImpl sqlExecutionContext) {
         this.engine = engine;
         this.utf8Sink = new DirectCharSink(engine.getConfiguration().getTextConfiguration().getUtf8SinkSize());
         this.typeManager = new TypeManager(engine.getConfiguration().getTextConfiguration(), utf8Sink);
@@ -192,7 +192,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
         this.serverVersion = configuration.getServerVersion();
         this.authenticator = new PGBasicAuthenticator(configuration.getDefaultUsername(), configuration.getDefaultPassword());
         this.locale = configuration.getDefaultDateLocale();
-        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount);
+        this.sqlExecutionContext = sqlExecutionContext;
         this.sqlExecutionContext.setRandom(this.rnd = configuration.getRandom());
         this.namedStatementWrapperPool = new WeakObjectPool<>(NamedStatementWrapper::new, configuration.getNamesStatementPoolCapacity()); // 16
         this.namedPortalPool = new WeakObjectPool<>(Portal::new, configuration.getNamesStatementPoolCapacity()); // 16

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -38,7 +38,6 @@ import io.questdb.network.*;
 import io.questdb.std.Misc;
 import io.questdb.std.ThreadLocal;
 import io.questdb.std.WeakObjectPool;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;

--- a/core/src/main/java/io/questdb/griffin/CompiledQueryImpl.java
+++ b/core/src/main/java/io/questdb/griffin/CompiledQueryImpl.java
@@ -104,7 +104,7 @@ public class CompiledQueryImpl implements CompiledQuery {
                 if (eventSubSeq == null) {
                     throw busyException;
                 }
-                alterFuture.of(eventSubSeq);
+                alterFuture.of(defaultSqlExecutionContext, eventSubSeq);
                 return alterFuture;
             } catch (TableStructureChangesException e) {
                 assert false : "This must never happen when parameter acceptChange=true";
@@ -206,6 +206,7 @@ public class CompiledQueryImpl implements CompiledQuery {
         private SCSequence eventSubSeq;
         private int status;
         private long commandId;
+        private QueryFutureUpdateListener queryFutureUpdateListener;
 
         @Override
         public void await() throws SqlException {
@@ -245,9 +246,10 @@ public class CompiledQueryImpl implements CompiledQuery {
          * Initializes instance of AlterTableQueryFuture with the parameters to wait for the new command
          * @param eventSubSeq - event sequence used to wait for the command execution to be signaled as complete
          */
-        public void of(SCSequence eventSubSeq) {
+        public void of(SqlExecutionContext executionContext, SCSequence eventSubSeq) {
             assert eventSubSeq != null : "event subscriber sequence must be provided";
 
+            this.queryFutureUpdateListener = executionContext.getQueryFutureUpdateListener();
             // Set up execution wait sequence to listen to the Engine async writer events
             final FanOut writerEventFanOut = engine.getMessageBus().getTableWriterEventFanOut();
             writerEventFanOut.and(eventSubSeq);
@@ -256,6 +258,7 @@ public class CompiledQueryImpl implements CompiledQuery {
             try {
                 // Publish new command and get published Command Id
                 commandId = engine.publishTableWriterCommand(alterStatement);
+                queryFutureUpdateListener.reportStart(alterStatement.getTableName(), commandId);
                 status = QUERY_NO_RESPONSE;
             } catch (Throwable ex) {
                 close();
@@ -304,9 +307,11 @@ public class CompiledQueryImpl implements CompiledQuery {
                         if (strLen > -1) {
                             throw SqlException.$(queryTableNamePosition, event.getData() + 4L, event.getData() + 4L + 2L * strLen);
                         }
+                        queryFutureUpdateListener.reportProgress(commandId, QUERY_COMPLETE);
                         return QUERY_COMPLETE;
                     } else {
                         status = QUERY_STARTED;
+                        queryFutureUpdateListener.reportProgress(commandId, QUERY_STARTED);
                         LOG.info().$("writer command QUERY_STARTED response received [instance=").$(commandId).I$();
                     }
                 } finally {

--- a/core/src/main/java/io/questdb/griffin/QueryFutureUpdateListener.java
+++ b/core/src/main/java/io/questdb/griffin/QueryFutureUpdateListener.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin;
+
+public interface QueryFutureUpdateListener {
+    QueryFutureUpdateListener EMPTY = new QueryFutureUpdateListener() {
+        @Override
+        public void reportProgress(long commandId, int status) {
+        }
+
+        @Override
+        public void reportStart(CharSequence tableName, long commandId) {
+        }
+    };
+
+    void reportProgress(long commandId, int status);
+
+    void reportStart(CharSequence tableName, long commandId);
+}

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
@@ -41,6 +41,8 @@ import java.io.Closeable;
 
 public interface SqlExecutionContext extends Closeable {
 
+    QueryFutureUpdateListener getQueryFutureUpdateListener();
+
     BindVariableService getBindVariableService();
 
     CairoSecurityContext getCairoSecurityContext();

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContextImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContextImpl.java
@@ -74,6 +74,11 @@ public class SqlExecutionContextImpl implements SqlExecutionContext {
     }
 
     @Override
+    public QueryFutureUpdateListener getQueryFutureUpdateListener() {
+        return QueryFutureUpdateListener.EMPTY;
+    }
+
+    @Override
     public BindVariableService getBindVariableService() {
         return bindVariableService;
     }

--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -408,24 +408,28 @@ public class LogAlertSocket implements Closeable {
                 .$("Added alert manager [")
                 .$(alertHostsCount)
                 .$("]: ");
-        if (!hostResolved) {
-            String host = alertTargets.substring(hostIdx, hostEnd).trim();
-            try {
-                alertHosts[alertHostsCount] = InetAddress.getByName(host).getHostAddress();
-                logRecord.$(host).$(" (").$(alertHosts[alertHostsCount]).$(')');
-            } catch (UnknownHostException e) {
-                throw new LogError(String.format(
-                        "Invalid host value [%s] at position %d for alertTargets: %s",
-                        host,
-                        hostIdx,
-                        alertTargets
-                ));
+        try {
+            if (!hostResolved) {
+                String host = alertTargets.substring(hostIdx, hostEnd).trim();
+                try {
+                    alertHosts[alertHostsCount] = InetAddress.getByName(host).getHostAddress();
+                    logRecord.$(host).$(" (").$(alertHosts[alertHostsCount]).$(')');
+                } catch (UnknownHostException e) {
+                    throw new LogError(String.format(
+                            "Invalid host value [%s] at position %d for alertTargets: %s",
+                            host,
+                            hostIdx,
+                            alertTargets
+                    ));
+                }
+            } else {
+                logRecord.$(alertHosts[alertHostsCount]);
             }
-        } else {
-            logRecord.$(alertHosts[alertHostsCount]);
+            logRecord.$(':').$(alertPorts[alertHostsCount]);
+            alertHostsCount++;
+        } finally {
+            logRecord.$();
         }
-        logRecord.$(':').$(alertPorts[alertHostsCount]).$();
-        alertHostsCount++;
     }
 
     private static boolean isContentLength(CharSequence tok, int lo, int hi) {

--- a/core/src/test/java/io/questdb/FilesTest.java
+++ b/core/src/test/java/io/questdb/FilesTest.java
@@ -25,6 +25,7 @@
 package io.questdb;
 
 import io.questdb.std.*;
+import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.millitime.DateFormatUtils;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
@@ -41,283 +42,321 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class FilesTest {
+import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
 
+public class FilesTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    // Kick static LOG inits to not mess with assertMemoryLeak measurments inside the tests
+    private final DateFormat IGNORED = DateFormatUtils.PG_DATE_FORMAT;
+
     @Test
     public void testAllocate() throws Exception {
-        File temp = temporaryFolder.newFile();
-        TestUtils.writeStringToFile(temp, "abcde");
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertEquals(5, Files.length(path));
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            TestUtils.writeStringToFile(temp, "abcde");
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertEquals(5, Files.length(path));
 
-            long fd = Files.openRW(path);
-            try {
-                Files.allocate(fd, 10);
-                Assert.assertEquals(10, Files.length(path));
-                Files.allocate(fd, 120);
-                Assert.assertEquals(120, Files.length(path));
-            } finally {
-                Files.close(fd);
+                long fd = Files.openRW(path);
+                try {
+                    Files.allocate(fd, 10);
+                    Assert.assertEquals(10, Files.length(path));
+                    Files.allocate(fd, 120);
+                    Assert.assertEquals(120, Files.length(path));
+                } finally {
+                    Files.close(fd);
+                }
             }
-        }
+        });
     }
 
     @Test
     public void testAllocateLoop() throws Exception {
-        File temp = temporaryFolder.newFile();
-        TestUtils.writeStringToFile(temp, "abcde");
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertEquals(5, Files.length(path));
-            long fd = Files.openRW(path);
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            TestUtils.writeStringToFile(temp, "abcde");
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertEquals(5, Files.length(path));
+                long fd = Files.openRW(path);
 
-            long M50 = 100 * 1024L * 1024L;
-            try {
-                // If allocate tries to allocate by the given size
-                // instead of to the size this will allocate 2TB and suppose to fail
-                for (int i = 0; i < 20000; i++) {
-                    Files.allocate(fd, M50 + i);
-                    Assert.assertEquals(M50 + i, Files.length(path));
+                long M50 = 100 * 1024L * 1024L;
+                try {
+                    // If allocate tries to allocate by the given size
+                    // instead of to the size this will allocate 2TB and suppose to fail
+                    for (int i = 0; i < 20000; i++) {
+                        Files.allocate(fd, M50 + i);
+                        Assert.assertEquals(M50 + i, Files.length(path));
+                    }
+                } finally {
+                    Files.close(fd);
                 }
-            } finally {
-                Files.close(fd);
             }
-        }
+        });
     }
 
     @Test
     public void testCopy() throws Exception {
-        File temp = temporaryFolder.newFile();
-        TestUtils.writeStringToFile(temp, "abcde");
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            try (Path copyPath = new Path().of(temp.getAbsolutePath()).put("-copy").$()) {
-                Files.copy(path, copyPath);
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            TestUtils.writeStringToFile(temp, "abcde");
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                try (Path copyPath = new Path().of(temp.getAbsolutePath()).put("-copy").$()) {
+                    Files.copy(path, copyPath);
 
-                Assert.assertEquals(5, Files.length(copyPath));
-                TestUtils.assertFileContentsEquals(path, copyPath);
+                    Assert.assertEquals(5, Files.length(copyPath));
+                    TestUtils.assertFileContentsEquals(path, copyPath);
+                }
             }
-        }
+        });
     }
 
     @Test
     public void testCopyBigFile() throws Exception {
-        File temp = temporaryFolder.newFile();
-        int fileSize = 2 * 1024 * 1024; // in MB
-        byte[] page = new byte[1024 * 64];
-        Rnd rnd = new Rnd();
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            int fileSize = 2 * 1024 * 1024; // in MB
+            byte[] page = new byte[1024 * 64];
+            Rnd rnd = new Rnd();
 
-        for (int i = 0; i < page.length; i++) {
-            page[i] = rnd.nextByte();
-        }
-
-        try (FileOutputStream fos = new FileOutputStream(temp)) {
-            for (int i = 0; i < fileSize / page.length; i++) {
-                fos.write(page);
+            for (int i = 0; i < page.length; i++) {
+                page[i] = rnd.nextByte();
             }
-        }
 
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            try (Path copyPath = new Path().of(temp.getAbsolutePath()).put("-copy").$()) {
-                Files.copy(path, copyPath);
-
-                Assert.assertEquals(fileSize, Files.length(copyPath));
-                TestUtils.assertFileContentsEquals(path, copyPath);
+            try (FileOutputStream fos = new FileOutputStream(temp)) {
+                for (int i = 0; i < fileSize / page.length; i++) {
+                    fos.write(page);
+                }
             }
-        }
+
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                try (Path copyPath = new Path().of(temp.getAbsolutePath()).put("-copy").$()) {
+                    Files.copy(path, copyPath);
+
+                    Assert.assertEquals(fileSize, Files.length(copyPath));
+                    TestUtils.assertFileContentsEquals(path, copyPath);
+                }
+            }
+        });
     }
 
     @Test
     public void testDeleteDir2() throws Exception {
-        File r = temporaryFolder.newFolder("to_delete");
-        Assert.assertTrue(new File(r, "a/b/c").mkdirs());
-        Assert.assertTrue(new File(r, "d/e/f").mkdirs());
-        touch(new File(r, "d/1.txt"));
-        touch(new File(r, "a/b/2.txt"));
-        try (Path path = new Path().of(r.getAbsolutePath()).$()) {
-            Assert.assertEquals(0, Files.rmdir(path));
-            Assert.assertFalse(r.exists());
-        }
+        assertMemoryLeak(() -> {
+            File r = temporaryFolder.newFolder("to_delete");
+            Assert.assertTrue(new File(r, "a/b/c").mkdirs());
+            Assert.assertTrue(new File(r, "d/e/f").mkdirs());
+            touch(new File(r, "d/1.txt"));
+            touch(new File(r, "a/b/2.txt"));
+            try (Path path = new Path().of(r.getAbsolutePath()).$()) {
+                Assert.assertEquals(0, Files.rmdir(path));
+                Assert.assertFalse(r.exists());
+            }
+        });
     }
 
     @Test
     public void testDeleteOpenFile() throws Exception {
-        try (Path path = new Path()) {
-            File f = temporaryFolder.newFile();
-            long fd = Files.openRW(path.of(f.getAbsolutePath()).$());
-            Assert.assertTrue(Files.exists(fd));
-            Assert.assertTrue(Files.remove(path));
-            Assert.assertFalse(Files.exists(fd));
-            Files.close(fd);
-        }
+        assertMemoryLeak(() -> {
+            try (Path path = new Path()) {
+                File f = temporaryFolder.newFile();
+                long fd = Files.openRW(path.of(f.getAbsolutePath()).$());
+                Assert.assertTrue(Files.exists(fd));
+                Assert.assertTrue(Files.remove(path));
+                Assert.assertFalse(Files.exists(fd));
+                Files.close(fd);
+            }
+        });
     }
 
     @Test
     public void testFailsToAllocateWhenNotEnoughSpace() throws Exception {
-        File temp = temporaryFolder.newFile();
-        TestUtils.writeStringToFile(temp, "abcde");
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            long fd = Files.openRW(path);
-            Assert.assertEquals(5, Files.length(path));
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            TestUtils.writeStringToFile(temp, "abcde");
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                long fd = Files.openRW(path);
+                Assert.assertEquals(5, Files.length(path));
 
-            try {
-                long tb10 = 1024L * 1024L * 1024L * 1024L * 10; // 10TB
-                boolean success = Files.allocate(fd, tb10);
-                Assert.assertFalse("Allocation should fail on reasonable hard disk size", success);
-            } finally {
-                Files.close(fd);
-            }
-        }
-    }
-
-    @Test
-    public void testLastModified() throws IOException, NumericException {
-        try (Path path = new Path()) {
-            assertLastModified(path, DateFormatUtils.parseUTCDate("2015-10-17T10:00:00.000Z"));
-            assertLastModified(path, 122222212222L);
-        }
-    }
-
-    @Test
-    public void testListDir() {
-        String temp = temporaryFolder.getRoot().getAbsolutePath();
-        ObjList<String> names = new ObjList<>();
-        try (Path path = new Path().of(temp).$()) {
-            try (Path cp = new Path()) {
-                Assert.assertTrue(Files.touch(cp.of(temp).concat("a.txt").$()));
-                StringSink nameSink = new StringSink();
-                long pFind = Files.findFirst(path);
-                Assert.assertTrue(pFind != 0);
                 try {
-                    do {
-                        nameSink.clear();
-                        Chars.utf8DecodeZ(Files.findName(pFind), nameSink);
-                        names.add(nameSink.toString());
-                    } while (Files.findNext(pFind) > 0);
+                    long tb10 = 1024L * 1024L * 1024L * 1024L * 10; // 10TB
+                    boolean success = Files.allocate(fd, tb10);
+                    Assert.assertFalse("Allocation should fail on reasonable hard disk size", success);
                 } finally {
-                    Files.findClose(pFind);
+                    Files.close(fd);
                 }
             }
-        }
-
-        names.sort(Chars::compare);
-
-        Assert.assertEquals("[.,..,a.txt]", names.toString());
+        });
     }
 
     @Test
-    public void testListNonExistingDir() {
-        String temp = temporaryFolder.getRoot().getAbsolutePath();
-        try (Path path = new Path().of(temp).concat("xyz").$()) {
-            long pFind = Files.findFirst(path);
-            Assert.assertEquals("failed os=" + Os.errno(), 0, pFind);
-        }
+    public void testLastModified() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path()) {
+                assertLastModified(path, DateFormatUtils.parseUTCDate("2015-10-17T10:00:00.000Z"));
+                assertLastModified(path, 122222212222L);
+            }
+        });
+    }
+
+    @Test
+    public void testListDir() throws Exception {
+        assertMemoryLeak(() -> {
+            String temp = temporaryFolder.getRoot().getAbsolutePath();
+            ObjList<String> names = new ObjList<>();
+            try (Path path = new Path().of(temp).$()) {
+                try (Path cp = new Path()) {
+                    Assert.assertTrue(Files.touch(cp.of(temp).concat("a.txt").$()));
+                    StringSink nameSink = new StringSink();
+                    long pFind = Files.findFirst(path);
+                    Assert.assertTrue(pFind != 0);
+                    try {
+                        do {
+                            nameSink.clear();
+                            Chars.utf8DecodeZ(Files.findName(pFind), nameSink);
+                            names.add(nameSink.toString());
+                        } while (Files.findNext(pFind) > 0);
+                    } finally {
+                        Files.findClose(pFind);
+                    }
+                }
+            }
+
+            names.sort(Chars::compare);
+
+            Assert.assertEquals("[.,..,a.txt]", names.toString());
+        });
+    }
+
+    @Test
+    public void testListNonExistingDir() throws Exception {
+        assertMemoryLeak(() -> {
+            String temp = temporaryFolder.getRoot().getAbsolutePath();
+            try (Path path = new Path().of(temp).concat("xyz").$()) {
+                long pFind = Files.findFirst(path);
+                Assert.assertEquals("failed os=" + Os.errno(), 0, pFind);
+            }
+        });
     }
 
     @Test
     public void testMkdirs() throws Exception {
-        File r = temporaryFolder.newFolder("to_delete");
-        try (Path path = new Path().of(r.getAbsolutePath())) {
-            path.concat("a").concat("b").concat("c").concat("f.text").$();
-            Assert.assertEquals(0, Files.mkdirs(path, 509));
-        }
+        assertMemoryLeak(() -> {
+            File r = temporaryFolder.newFolder("to_delete");
+            try (Path path = new Path().of(r.getAbsolutePath())) {
+                path.concat("a").concat("b").concat("c").concat("f.text").$();
+                Assert.assertEquals(0, Files.mkdirs(path, 509));
+            }
 
-        try (Path path = new Path().of(r.getAbsolutePath())) {
-            path.concat("a").concat("b").concat("c").$();
-            Assert.assertTrue(Files.exists(path));
-        }
+            try (Path path = new Path().of(r.getAbsolutePath())) {
+                path.concat("a").concat("b").concat("c").$();
+                Assert.assertTrue(Files.exists(path));
+            }
+        });
     }
 
     @Test
-    public void testOpenCleanRWAllocatesToSize() {
-        File temp = temporaryFolder.getRoot();
-        try (Path path = new Path().of(temp.getAbsolutePath()).concat("openCleanRWParallel").$()) {
-            long fd = Files.openCleanRW(path, 1024);
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertEquals(1024, Files.length(path));
+    public void testOpenCleanRWAllocatesToSize() throws Exception {
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.getRoot();
+            try (Path path = new Path().of(temp.getAbsolutePath()).concat("openCleanRWParallel").$()) {
+                long fd = Files.openCleanRW(path, 1024);
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertEquals(1024, Files.length(path));
 
-            long fd2 = Files.openCleanRW(path, 2048);
-            Assert.assertEquals(2048, Files.length(path));
+                long fd2 = Files.openCleanRW(path, 2048);
+                Assert.assertEquals(2048, Files.length(path));
 
-            Files.close(fd);
-            Files.close(fd2);
-        }
+                Files.close(fd);
+                Files.close(fd2);
+            }
+        });
     }
 
     @Test
     public void testOpenCleanRWParallel() throws Exception {
-        File temp = temporaryFolder.getRoot();
-        int threadCount = 15;
-        int iteration = 10;
-        int fileSize = 1024;
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.getRoot();
+            int threadCount = 15;
+            int iteration = 10;
+            int fileSize = 1024;
 
-        try (Path path = new Path().of(temp.getAbsolutePath()).concat("openCleanRWParallel").$()) {
-            Assert.assertFalse(Files.exists(path));
+            try (Path path = new Path().of(temp.getAbsolutePath()).concat("openCleanRWParallel").$()) {
+                Assert.assertFalse(Files.exists(path));
 
-            final CyclicBarrier barrier = new CyclicBarrier(threadCount);
-            final CountDownLatch halt = new CountDownLatch(threadCount);
-            final AtomicInteger errors = new AtomicInteger();
+                final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+                final CountDownLatch halt = new CountDownLatch(threadCount);
+                final AtomicInteger errors = new AtomicInteger();
 
-            for (int k = 0; k < threadCount; k++) {
-                new Thread(() -> {
-                    try {
-                        barrier.await();
-                        for (int i = 0; i < iteration; i++) {
-                            long fd = Files.openCleanRW(path, fileSize);
-                            if (fd < 0) {
-                                errors.incrementAndGet();
+                for (int k = 0; k < threadCount; k++) {
+                    new Thread(() -> {
+                        try {
+                            barrier.await();
+                            for (int i = 0; i < iteration; i++) {
+                                long fd = Files.openCleanRW(path, fileSize);
+                                if (fd < 0) {
+                                    errors.incrementAndGet();
+                                }
+                                int error = Files.close(fd);
+                                if (error != 0) {
+                                    errors.incrementAndGet();
+                                }
                             }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                            errors.incrementAndGet();
+                        } finally {
+                            halt.countDown();
                         }
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        errors.incrementAndGet();
-                    } finally {
-                        halt.countDown();
-                    }
-                }).start();
-            }
+                    }).start();
+                }
 
-            halt.await();
-            Assert.assertEquals(0, errors.get());
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertEquals(fileSize, Files.length(path));
-        }
+                halt.await();
+                Assert.assertEquals(0, errors.get());
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertEquals(fileSize, Files.length(path));
+            }
+        });
     }
 
     @Test
     public void testRemove() throws Exception {
-        try (Path path = new Path().of(temporaryFolder.newFile().getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.touch(path));
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertTrue(Files.remove(path));
-            Assert.assertFalse(Files.exists(path));
-        }
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(temporaryFolder.newFile().getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.touch(path));
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertTrue(Files.remove(path));
+                Assert.assertFalse(Files.exists(path));
+            }
+        });
     }
 
     @Test
     public void testTruncate() throws Exception {
-        File temp = temporaryFolder.newFile();
-        TestUtils.writeStringToFile(temp, "abcde");
-        try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
-            Assert.assertTrue(Files.exists(path));
-            Assert.assertEquals(5, Files.length(path));
+        assertMemoryLeak(() -> {
+            File temp = temporaryFolder.newFile();
+            TestUtils.writeStringToFile(temp, "abcde");
+            try (Path path = new Path().of(temp.getAbsolutePath()).$()) {
+                Assert.assertTrue(Files.exists(path));
+                Assert.assertEquals(5, Files.length(path));
 
-            long fd = Files.openRW(path);
-            try {
-                Files.truncate(fd, 3);
-                Assert.assertEquals(3, Files.length(path));
-                Files.truncate(fd, 0);
-                Assert.assertEquals(0, Files.length(path));
-            } finally {
-                Files.close(fd);
+                long fd = Files.openRW(path);
+                try {
+                    Files.truncate(fd, 3);
+                    Assert.assertEquals(3, Files.length(path));
+                    Files.truncate(fd, 0);
+                    Assert.assertEquals(0, Files.length(path));
+                } finally {
+                    Files.close(fd);
+                }
             }
-        }
+        });
     }
 
     private static void touch(File file) throws IOException {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -198,7 +198,7 @@ public class AbstractCairoTest {
             AbstractCairoTest.ff = ff2;
             try {
                 code.run();
-                engine.releaseInactive();
+                engine.releaseAllWriters();
                 Assert.assertEquals(0, engine.getBusyWriterCount());
                 Assert.assertEquals(0, engine.getBusyReaderCount());
             } finally {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -68,7 +68,6 @@ public class AbstractCairoTest {
     protected static int sampleByIndexSearchPageSize;
     protected static int binaryEncodingMaxLength = -1;
     protected static CharSequence defaultMapType;
-    protected static long inactiveWriterTTL = -10000;
 
     @Rule
     public TestName testName = new TestName();
@@ -147,11 +146,6 @@ public class AbstractCairoTest {
             public long getWriterAsyncCommandMaxTimeout() {
                 return writerAsyncCommandMaxTimeout < 0 ? super.getWriterAsyncCommandMaxTimeout() : writerAsyncCommandMaxTimeout;
             }
-
-            @Override
-            public long getInactiveWriterTTL() {
-                return inactiveWriterTTL;
-            }
         };
         engine = new CairoEngine(configuration);
         messageBus = engine.getMessageBus();
@@ -185,7 +179,6 @@ public class AbstractCairoTest {
         defaultMapType = null;
         writerAsyncCommandBusyWaitTimeout = -1;
         writerAsyncCommandMaxTimeout = -1;
-        inactiveWriterTTL = -10000;
     }
 
     protected static void assertMemoryLeak(TestUtils.LeakProneCode code) throws Exception {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -68,6 +68,7 @@ public class AbstractCairoTest {
     protected static int sampleByIndexSearchPageSize;
     protected static int binaryEncodingMaxLength = -1;
     protected static CharSequence defaultMapType;
+    protected static long inactiveWriterTTL = -10000;
 
     @Rule
     public TestName testName = new TestName();
@@ -146,6 +147,11 @@ public class AbstractCairoTest {
             public long getWriterAsyncCommandMaxTimeout() {
                 return writerAsyncCommandMaxTimeout < 0 ? super.getWriterAsyncCommandMaxTimeout() : writerAsyncCommandMaxTimeout;
             }
+
+            @Override
+            public long getInactiveWriterTTL() {
+                return inactiveWriterTTL;
+            }
         };
         engine = new CairoEngine(configuration);
         messageBus = engine.getMessageBus();
@@ -179,6 +185,7 @@ public class AbstractCairoTest {
         defaultMapType = null;
         writerAsyncCommandBusyWaitTimeout = -1;
         writerAsyncCommandMaxTimeout = -1;
+        inactiveWriterTTL = -10000;
     }
 
     protected static void assertMemoryLeak(TestUtils.LeakProneCode code) throws Exception {

--- a/core/src/test/java/io/questdb/cairo/AllowAllSqlSecurityContext.java
+++ b/core/src/test/java/io/questdb/cairo/AllowAllSqlSecurityContext.java
@@ -27,6 +27,7 @@ package io.questdb.cairo;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.BindVariableService;
 import io.questdb.cairo.sql.VirtualRecord;
+import io.questdb.griffin.QueryFutureUpdateListener;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.engine.analytic.AnalyticContext;
@@ -35,6 +36,11 @@ import org.jetbrains.annotations.Nullable;
 
 public final class AllowAllSqlSecurityContext {
     public static final SqlExecutionContext INSTANCE = new SqlExecutionContext() {
+        @Override
+        public QueryFutureUpdateListener getQueryFutureUpdateListener() {
+            return QueryFutureUpdateListener.EMPTY;
+        }
+
         @Override
         public BindVariableService getBindVariableService() {
             return null;

--- a/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
@@ -288,7 +288,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                 new Thread(() -> {
                     try {
                         barrier.await();
-                        pool.releaseAll();
+                        pool.releaseInactive();
                     } catch (Exception e) {
                         exceptionCount.incrementAndGet();
                         e.printStackTrace();
@@ -305,6 +305,57 @@ public class WriterPoolTest extends AbstractCairoTest {
                             Assert.assertNotNull(writer);
                         } catch (PoolClosedException ex) {
                             // this can also happen when this thread is delayed enough for pool close to complete
+                        }
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        stopLatch.countDown();
+                    }
+                }).start();
+
+                Assert.assertTrue(stopLatch.await(2, TimeUnit.SECONDS));
+                Assert.assertEquals(0, exceptionCount.get());
+            });
+        }
+    }
+
+    @Test
+    public void testLockUnlockAndReleaseRace() throws Exception {
+
+        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
+            CairoTestUtils.create(model);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            assertWithPool(pool -> {
+                AtomicInteger exceptionCount = new AtomicInteger();
+                CyclicBarrier barrier = new CyclicBarrier(2);
+                CountDownLatch stopLatch = new CountDownLatch(2);
+
+                // make sure writer exists in pool
+                try (TableWriter writer = pool.get("xyz", "testing")) {
+                    Assert.assertNotNull(writer);
+                }
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        pool.releaseInactive();
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        stopLatch.countDown();
+                    }
+                }).start();
+
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        if (pool.lock("xyz", "testing") == WriterPool.OWNERSHIP_REASON_NONE) {
+                            pool.unlock("xyz");
                         }
                     } catch (Exception e) {
                         exceptionCount.incrementAndGet();

--- a/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
@@ -267,6 +267,59 @@ public class WriterPoolTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGetAndReleaseRace() throws Exception {
+
+        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
+            CairoTestUtils.create(model);
+        }
+
+        for (int i = 0; i < 100; i++) {
+            assertWithPool(pool -> {
+                AtomicInteger exceptionCount = new AtomicInteger();
+                CyclicBarrier barrier = new CyclicBarrier(2);
+                CountDownLatch stopLatch = new CountDownLatch(2);
+
+                // make sure writer exists in pool
+                try (TableWriter writer = pool.get("xyz", "testing")) {
+                    Assert.assertNotNull(writer);
+                }
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        pool.releaseAll();
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        stopLatch.countDown();
+                    }
+                }).start();
+
+
+                new Thread(() -> {
+                    try {
+                        barrier.await();
+                        try (TableWriter writer = pool.get("xyz", "testing")) {
+                            Assert.assertNotNull(writer);
+                        } catch (PoolClosedException ex) {
+                            // this can also happen when this thread is delayed enough for pool close to complete
+                        }
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        stopLatch.countDown();
+                    }
+                }).start();
+
+                Assert.assertTrue(stopLatch.await(2, TimeUnit.SECONDS));
+                Assert.assertEquals(0, exceptionCount.get());
+            });
+        }
+    }
+
+    @Test
     public void testGetAndCloseRace() throws Exception {
 
         try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {

--- a/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
@@ -97,6 +97,7 @@ public class DispatcherWriterQueueTest {
     @Test
     public void testAlterTableAddDisconnect() throws Exception {
         SOCountDownLatch alterAckReceived = new SOCountDownLatch(1);
+        SOCountDownLatch disconnectLatch = new SOCountDownLatch(1);
 
         HttpQueryTestBuilder queryTestBuilder = new HttpQueryTestBuilder()
                 .withTempFolder(temp)
@@ -112,6 +113,7 @@ public class DispatcherWriterQueueTest {
                     public long openRW(LPSZ name) {
                         if (Chars.endsWith(name, "default/s.v") || Chars.endsWith(name, "default\\s.v")) {
                             alterAckReceived.await();
+                            disconnectLatch.countDown();
                         }
                         return super.openRW(name);
                     }
@@ -130,7 +132,7 @@ public class DispatcherWriterQueueTest {
                 2,
                 0,
                 queryTestBuilder,
-                alterAckReceived,
+                disconnectLatch,
                 "alter+table+<x>+alter+column+s+add+index");
     }
 

--- a/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
@@ -48,6 +48,8 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
+import static io.questdb.test.tools.TestUtils.drainEngineCmdQueue;
+
 public class DispatcherWriterQueueTest {
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
@@ -384,6 +386,7 @@ public class DispatcherWriterQueueTest {
                     alterVerifyAction.run(writer, rdr);
                 }
             } finally {
+                drainEngineCmdQueue(engine);
                 if (writer != null) {
                     writer.close();
                 }

--- a/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/DispatcherWriterQueueTest.java
@@ -37,6 +37,7 @@ import io.questdb.network.Net;
 import io.questdb.std.Chars;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.Os;
+import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.str.LPSZ;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -363,7 +364,10 @@ public class DispatcherWriterQueueTest {
                     }
                 }
 
-                for (int i = 0; i < 100 && finished.getCount() > 0 && errors.get() <= errorsExpected; i++) {
+                MicrosecondClock microsecondClock = engine.getConfiguration().getMicrosecondClock();
+                long startTimeMicro = microsecondClock.getTicks();
+                // Wait 1 min max for completion
+                while (microsecondClock.getTicks() - startTimeMicro < 60_000_000 && finished.getCount() > 0 && errors.get() <= errorsExpected) {
                     writer.tick(true);
                     finished.await(1_000_000);
                 }

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -30,7 +30,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cutlass.http.processors.*;
-import io.questdb.griffin.SqlException;
+import io.questdb.griffin.*;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.WorkerPool;
@@ -56,6 +56,7 @@ public class HttpQueryTestBuilder {
     private long startWriterWaitTimeout = 500_000;
     private long maxWriterWaitTimeout = 30_000_000L;
     private FilesFacade filesFacade = new FilesFacadeImpl();
+    private QueryFutureUpdateListener queryFutureUpdateListener;
 
     public int getWorkerCount() {
         return this.workerCount;
@@ -149,6 +150,13 @@ public class HttpQueryTestBuilder {
                     }
                 });
 
+                SqlExecutionContextImpl sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount) {
+                    @Override
+                    public QueryFutureUpdateListener getQueryFutureUpdateListener() {
+                        return queryFutureUpdateListener != null ? queryFutureUpdateListener : QueryFutureUpdateListener.EMPTY;
+                    }
+                };
+
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
@@ -156,7 +164,9 @@ public class HttpQueryTestBuilder {
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
                                 workerPool.getWorkerCount(),
-                                Metrics.enabled()
+                                new SqlCompiler(engine, null),
+                                Metrics.enabled(),
+                                sqlExecutionContext
                         );
                     }
 
@@ -266,6 +276,11 @@ public class HttpQueryTestBuilder {
 
     public HttpQueryTestBuilder withWorkerCount(int workerCount) {
         this.workerCount = workerCount;
+        return this;
+    }
+
+    public HttpQueryTestBuilder withQueryFutureUpdateListener(QueryFutureUpdateListener queryFutureUpdateListener) {
+        this.queryFutureUpdateListener = queryFutureUpdateListener;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -4390,7 +4390,6 @@ nodejs code:
         };
 
         WorkerPool pool = new WorkerPool(conf);
-        inactiveWriterTTL = 1000000;
         pool.assign(engine.getEngineMaintenanceJob());
         try (
                 final PGWireServer ignored = PGWireServer.create(

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -73,7 +73,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -4391,6 +4390,7 @@ nodejs code:
         };
 
         WorkerPool pool = new WorkerPool(conf);
+        inactiveWriterTTL = 1000000;
         pool.assign(engine.getEngineMaintenanceJob());
         try (
                 final PGWireServer ignored = PGWireServer.create(
@@ -4445,7 +4445,7 @@ nodejs code:
                     }).start();
 
                     start.await();
-                    LockSupport.parkNanos(1);
+                    Os.sleep(100);
                     connection1.commit();
                     finished.await();
 

--- a/core/src/test/java/io/questdb/griffin/TableBackupTest.java
+++ b/core/src/test/java/io/questdb/griffin/TableBackupTest.java
@@ -144,6 +144,9 @@ public class TableBackupTest {
     public void tearDown() {
         finalBackupPath.close();
         path.close();
+        mainSqlExecutionContext.close();
+        mainCompiler.close();
+        mainEngine.close();
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -518,6 +518,15 @@ public final class TestUtils {
         }
     }
 
+    public static boolean drainEngineCmdQueue(CairoEngine engine) {
+        boolean useful = false;
+        while (engine.tick()) {
+            useful = true;
+            // drain the engine queue
+        }
+        return useful;
+    }
+
     public static void createPopulateTable(
             SqlCompiler compiler,
             SqlExecutionContext sqlExecutionContext,


### PR DESCRIPTION
Few issues with Engine maintanance and Writer pool fixed:

- When CairoEngine examines WriterPool periodically to evict and close old unused entries it blocks writer for a period of time needed to close the instance. If an Insert statement is processed at the same time it will get writer busy error with empty reason. To prevent it WriterPool will lock the entries about to be evicted with negative thread id and if such a lock found in get method another attempt to re-acquire the writer will be performed.
- When Writer Pool is examined by CairoEngine it will unconditionally unlock all locked table entries. If a table is being created at the time where maintanance the creation fails
Make busy writer Alter table test more stable in PgWire and Http Json integration tests.