### PR TITLE
feat(build): have docker image use jdk17 to build questdb

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.7-jdk
+FROM openjdk:17.0.1-jdk-buster
 
 RUN apt-get update \
   && apt-get install git curl -y

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17.0.1-jdk-buster
+FROM openjdk:17.0.1-jdk-bullseye
 
 RUN apt-get update \
   && apt-get install git curl -y

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -L "https://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.
 
 WORKDIR /build/questdb
 
-RUN ../apache-maven-3.6.3/bin/mvn clean package -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
+RUN ../apache-maven-3.6.3/bin/mvn clean package -Djdk.lang.Process.launchMechanism=vfork -DskipTests -P build-web-console,build-binaries,use-built-in-nodejs
 
 WORKDIR /build/questdb/core/target
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -187,13 +187,6 @@
                     <doCheck>false</doCheck>
                     <doUpdate>false</doUpdate>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-jgit</artifactId>
-                        <version>1.9.5</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -187,6 +187,13 @@
                     <doCheck>false</doCheck>
                     <doUpdate>false</doUpdate>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-jgit</artifactId>
+                        <version>1.9.5</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Next official QuestDB docker image release will use JDK17