### PR TITLE
chore(sql): improve error message for o3 insert on non-partitioned table

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -815,7 +815,7 @@ public class TableWriter implements Closeable {
                 }
 
                 if (timestamp < txWriter.getMaxTimestamp()) {
-                    throw CairoException.instance(ff.errno()).put("Cannot insert rows out of order. Table=").put(path);
+                    throw CairoException.instance(ff.errno()).put("Cannot insert rows out of order to non-partitioned table. Table=").put(path);
                 }
 
                 bumpMasterRef();

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -797,7 +797,7 @@ public class InsertTest extends AbstractGriffinTest {
             try {
                 executeInsert("insert into trades VALUES (1), (3), (2);");
             } catch (CairoException e) {
-                TestUtils.assertContains(e.getFlyweightMessage(), "Cannot insert rows out of order.");
+                TestUtils.assertContains(e.getFlyweightMessage(), "Cannot insert rows out of order to non-partitioned table.");
             }
         });
     }


### PR DESCRIPTION
Aims to make the error reason more obvious to the end user.