### PR TITLE
feat(griffin): limit max page frame size

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -151,13 +151,14 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlGroupByMapCapacity;
     private final int sqlMaxSymbolNotEqualsCount;
     private final int sqlBindVariablePoolSize;
+    private final int sqlPageFrameMaxSize;
     private final int sqlJitMode;
-    private final long sqlJitIRMemoryPageSize;
+    private final int sqlJitIRMemoryPageSize;
     private final int sqlJitIRMemoryMaxPages;
-    private final long sqlJitBindVarsMemoryPageSize;
+    private final int sqlJitBindVarsMemoryPageSize;
     private final int sqlJitBindVarsMemoryMaxPages;
-    private final long sqlJitRowsThreshold;
-    private final long sqlJitPageAddressCacheThreshold;
+    private final int sqlJitRowsThreshold;
+    private final int sqlJitPageAddressCacheThreshold;
     private final boolean sqlJitDebugEnabled;
     private final DateLocale locale;
     private final String backupRoot;
@@ -649,14 +650,15 @@ public class PropServerConfiguration implements ServerConfiguration {
             }
             this.sqlDistinctTimestampKeyCapacity = getInt(properties, env, "cairo.sql.distinct.timestamp.key.capacity", 512);
             this.sqlDistinctTimestampLoadFactor = getDouble(properties, env, "cairo.sql.distinct.timestamp.load.factor", 0.5);
+            this.sqlPageFrameMaxSize = Numbers.ceilPow2(getIntSize(properties, env, "cairo.sql.page.frame.max.size", 8 * 1024 * 1024));
 
             this.sqlJitMode = getSqlJitMode(properties, env);
-            this.sqlJitIRMemoryPageSize = getLongSize(properties, env, "cairo.sql.jit.ir.memory.page.size", 8 * 1024);
+            this.sqlJitIRMemoryPageSize = getIntSize(properties, env, "cairo.sql.jit.ir.memory.page.size", 8 * 1024);
             this.sqlJitIRMemoryMaxPages = getInt(properties, env, "cairo.sql.jit.ir.memory.max.pages", 8);
-            this.sqlJitBindVarsMemoryPageSize = getLongSize(properties, env, "cairo.sql.jit.bind.vars.memory.page.size", 4 * 1024);
+            this.sqlJitBindVarsMemoryPageSize = getIntSize(properties, env, "cairo.sql.jit.bind.vars.memory.page.size", 4 * 1024);
             this.sqlJitBindVarsMemoryMaxPages = getInt(properties, env, "cairo.sql.jit.bind.vars.memory.max.pages", 8);
-            this.sqlJitRowsThreshold = getLongSize(properties, env, "cairo.sql.jit.rows.threshold", 1024 * 1024);
-            this.sqlJitPageAddressCacheThreshold = getLongSize(properties, env, "cairo.sql.jit.page.address.cache.threshold", 1024 * 1024);
+            this.sqlJitRowsThreshold = getIntSize(properties, env, "cairo.sql.jit.rows.threshold", 1024 * 1024);
+            this.sqlJitPageAddressCacheThreshold = getIntSize(properties, env, "cairo.sql.jit.page.address.cache.threshold", 1024 * 1024);
             this.sqlJitDebugEnabled = getBoolean(properties, env, "cairo.sql.jit.debug.enabled", false);
 
             this.inputFormatConfiguration = new InputFormatConfiguration(
@@ -2031,12 +2033,17 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public int getSqlPageFrameMaxSize() {
+            return sqlPageFrameMaxSize;
+        }
+
+        @Override
         public int getSqlJitMode() {
             return sqlJitMode;
         }
 
         @Override
-        public long getSqlJitIRMemoryPageSize() {
+        public int getSqlJitIRMemoryPageSize() {
             return sqlJitIRMemoryPageSize;
         }
 
@@ -2046,7 +2053,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public long getSqlJitBindVarsMemoryPageSize() {
+        public int getSqlJitBindVarsMemoryPageSize() {
             return sqlJitBindVarsMemoryPageSize;
         }
 
@@ -2056,12 +2063,12 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public long getSqlJitRowsThreshold() {
+        public int getSqlJitRowsThreshold() {
             return sqlJitRowsThreshold;
         }
 
         @Override
-        public long getSqlJitPageAddressCacheThreshold() {
+        public int getSqlJitPageAddressCacheThreshold() {
             return sqlJitPageAddressCacheThreshold;
         }
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -260,19 +260,21 @@ public interface CairoConfiguration {
 
     int getSqlSortValuePageSize();
 
+    int getSqlPageFrameMaxSize();
+
     int getSqlJitMode();
 
-    long getSqlJitIRMemoryPageSize();
+    int getSqlJitIRMemoryPageSize();
 
     int getSqlJitIRMemoryMaxPages();
 
-    long getSqlJitBindVarsMemoryPageSize();
+    int getSqlJitBindVarsMemoryPageSize();
 
     int getSqlJitBindVarsMemoryMaxPages();
 
-    long getSqlJitRowsThreshold();
+    int getSqlJitRowsThreshold();
 
-    long getSqlJitPageAddressCacheThreshold();
+    int getSqlJitPageAddressCacheThreshold();
 
     boolean isSqlJitDebugEnabled();
 

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -606,12 +606,17 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getSqlPageFrameMaxSize() {
+        return 8 * Numbers.SIZE_1MB;
+    }
+
+    @Override
     public int getSqlJitMode() {
         return SqlJitMode.JIT_MODE_DISABLED;
     }
 
     @Override
-    public long getSqlJitIRMemoryPageSize() {
+    public int getSqlJitIRMemoryPageSize() {
         return 8192;
     }
 
@@ -621,7 +626,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public long getSqlJitBindVarsMemoryPageSize() {
+    public int getSqlJitBindVarsMemoryPageSize() {
         return 4096;
     }
 
@@ -631,12 +636,12 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public long getSqlJitRowsThreshold() {
+    public int getSqlJitRowsThreshold() {
         return Numbers.SIZE_1MB;
     }
 
     @Override
-    public long getSqlJitPageAddressCacheThreshold() {
+    public int getSqlJitPageAddressCacheThreshold() {
         return Numbers.SIZE_1MB;
     }
 

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -1086,6 +1086,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             );
                         }
                         return new DataFrameRecordCursorFactory(
+                                configuration,
                                 metadata,
                                 dataFrameCursorFactory,
                                 rcf,
@@ -2746,6 +2747,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 // This special case factory can later be disassembled to framing and index
                                 // cursors in Sample By processing
                                 return new DeferredSingleSymbolFilterDataFrameRecordCursorFactory(
+                                        configuration,
                                         keyColumnIndex,
                                         symbol,
                                         rcf,
@@ -2757,6 +2759,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 );
                             }
                             return new DataFrameRecordCursorFactory(
+                                    configuration,
                                     myMeta,
                                     dfcFactory,
                                     rcf,
@@ -2866,6 +2869,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 model.setWhereClause(intrinsicModel.filter);
                 return new DataFrameRecordCursorFactory(
+                        configuration,
                         myMeta,
                         dfcFactory,
                         new DataFrameRowCursorFactory(),
@@ -2884,6 +2888,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 // in the interest of isolating problems we will only affect this factory
 
                 return new DataFrameRecordCursorFactory(
+                        configuration,
                         myMeta,
                         new FullFwdDataFrameCursorFactory(engine, tableName, model.getTableId(), model.getTableVersion()),
                         new DataFrameRowCursorFactory(),

--- a/core/src/main/java/io/questdb/griffin/engine/table/CompiledFilterRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CompiledFilterRecordCursor.java
@@ -53,7 +53,7 @@ class CompiledFilterRecordCursor implements RecordCursor {
     // JIT compiled filter; used for dense page frames (no column tops)
     private CompiledFilter compiledFilter;
 
-    private final long rowsCapacityThreshold;
+    private final int rowsCapacityThreshold;
     private DirectLongList rows;
     private DirectLongList columns;
     private MemoryCARW bindVarMemory;
@@ -683,7 +683,7 @@ class CompiledFilterRecordCursor implements RecordCursor {
 
     private static class PageAddressCache implements Mutable {
 
-        private final long cacheSizeThreshold;
+        private final int cacheSizeThreshold;
         private int columnCount;
         private int varLenColumnCount;
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactory.java
@@ -24,10 +24,7 @@
 
 package io.questdb.griffin.engine.table;
 
-import io.questdb.cairo.BitmapIndexReader;
-import io.questdb.cairo.NullColumn;
-import io.questdb.cairo.SymbolMapReader;
-import io.questdb.cairo.TableReader;
+import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.api.MemoryR;
 import io.questdb.griffin.SqlException;
@@ -47,9 +44,11 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
     private final boolean framingSupported;
     private final IntList columnIndexes;
     private final IntList columnSizes;
+    protected final int pageFrameMaxSize;
     private TableReaderPageFrameCursor pageFrameCursor;
 
     public DataFrameRecordCursorFactory(
+            @NotNull CairoConfiguration configuration,
             RecordMetadata metadata,
             DataFrameCursorFactory dataFrameCursorFactory,
             RowCursorFactory rowCursorFactory,
@@ -68,6 +67,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
         this.framingSupported = framingSupported;
         this.columnIndexes = columnIndexes;
         this.columnSizes = columnSizes;
+        this.pageFrameMaxSize = configuration.getSqlPageFrameMaxSize();
     }
 
     @Override
@@ -87,7 +87,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
         if (pageFrameCursor != null) {
             return pageFrameCursor.of(dataFrameCursor);
         } else if (framingSupported) {
-            pageFrameCursor = new TableReaderPageFrameCursor(columnIndexes, columnSizes);
+            pageFrameCursor = new TableReaderPageFrameCursor(columnIndexes, columnSizes, pageFrameMaxSize);
             return pageFrameCursor.of(dataFrameCursor);
         } else {
             return null;
@@ -134,6 +134,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
         private final IntList columnSizes;
         private final LongList pageRowsRemaining = new LongList();
         private final LongList pageSizes = new LongList();
+        private final int pageFrameMaxSize;
         private TableReader reader;
         private int reenterPartitionIndex;
         private DataFrameCursor dataFrameCursor;
@@ -141,10 +142,11 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
         private long reenterPartitionHi;
         private boolean reenterDataFrame = false;
 
-        public TableReaderPageFrameCursor(IntList columnIndexes, IntList columnSizes) {
+        public TableReaderPageFrameCursor(IntList columnIndexes, IntList columnSizes, int pageFrameMaxSize) {
             this.columnIndexes = columnIndexes;
             this.columnSizes = columnSizes;
             this.columnCount = columnIndexes.size();
+            this.pageFrameMaxSize = pageFrameMaxSize;
         }
 
         @Override
@@ -154,7 +156,6 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
 
         @Override
         public @Nullable PageFrame next() {
-
             if (this.reenterDataFrame) {
                 return computeFrame(reenterPartitionLo, reenterPartitionHi);
             }
@@ -198,14 +199,14 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
         private TableReaderPageFrame computeFrame(final long partitionLo, final long partitionHi) {
             final int base = reader.getColumnBase(reenterPartitionIndex);
 
-            // we may need to split this data frame along "top" lines
-            // to do this, we calculate min top value from given position
-            long minTop = partitionHi;
+            // we may need to split this data frame either along "top" lines, or along
+            // max page frame sizes; to do this, we calculate min top value from given position
+            long adjustedHi = Math.min(partitionHi, partitionLo + pageFrameMaxSize);
             for (int i = 0; i < columnCount; i++) {
                 final int columnIndex = columnIndexes.getQuick(i);
                 long top = reader.getColumnTop(base, columnIndex);
-                if (top > partitionLo && top < minTop) {
-                    minTop = top;
+                if (top > partitionLo && top < adjustedHi) {
+                    adjustedHi = top;
                 }
             }
 
@@ -214,9 +215,9 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
                 final int readerColIndex = TableReader.getPrimaryColumnIndex(base, columnIndex);
                 final MemoryR col = reader.getColumn(readerColIndex);
                 // when the entire column is NULL we make it skip the whole of the data frame
-                final long top = col instanceof NullColumn ? minTop : reader.getColumnTop(base, columnIndex);
+                final long top = col instanceof NullColumn ? adjustedHi : reader.getColumnTop(base, columnIndex);
                 final long partitionLoAdjusted = partitionLo - top;
-                final long partitionHiAdjusted = minTop - top;
+                final long partitionHiAdjusted = adjustedHi - top;
                 final int sh = columnSizes.getQuick(i);
 
                 if (partitionHiAdjusted > 0) {
@@ -251,10 +252,10 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
                 }
             }
 
-            // it is possible that all columns in data frame are empty, but it doesn't mean the data frame size is 0
-            // sometimes we may want to imply nulls
-            if (minTop < partitionHi) {
-                this.reenterPartitionLo = minTop;
+            // it is possible that all columns in data frame are empty, but it doesn't mean
+            // the data frame size is 0; sometimes we may want to imply nulls
+            if (adjustedHi < partitionHi) {
+                this.reenterPartitionLo = adjustedHi;
                 this.reenterPartitionHi = partitionHi;
                 this.reenterDataFrame = true;
             } else {
@@ -262,7 +263,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
             }
 
             frame.partitionLo = partitionLo;
-            frame.partitionHi = minTop;
+            frame.partitionHi = adjustedHi;
             frame.partitionIndex = reenterPartitionIndex;
             return frame;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/table/DeferredSingleSymbolFilterDataFrameRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/DeferredSingleSymbolFilterDataFrameRecordCursorFactory.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin.engine.table;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.SymbolMapReader;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.*;
@@ -44,6 +45,7 @@ public class DeferredSingleSymbolFilterDataFrameRecordCursorFactory extends Data
     private TableReaderPageFrameCursor pageFrameCursor;
 
     public DeferredSingleSymbolFilterDataFrameRecordCursorFactory(
+            @NotNull CairoConfiguration configuration,
             int tableSymColIndex,
             CharSequence symbolValue,
             RowCursorFactory rowCursorFactory,
@@ -54,6 +56,7 @@ public class DeferredSingleSymbolFilterDataFrameRecordCursorFactory extends Data
             @Nullable IntList columnSizes
     ) {
         super(
+                configuration,
                 metadata,
                 dataFrameCursorFactory,
                 rowCursorFactory,
@@ -107,7 +110,7 @@ public class DeferredSingleSymbolFilterDataFrameRecordCursorFactory extends Data
         assert this.convertedToFrame;
         DataFrameCursor dataFrameCursor = dataFrameCursorFactory.getCursor(executionContext);
         if (pageFrameCursor == null) {
-            pageFrameCursor = new TableReaderPageFrameCursor(columnIndexes, columnSizes);
+            pageFrameCursor = new TableReaderPageFrameCursor(columnIndexes, columnSizes, pageFrameMaxSize);
         }
 
         pageFrameCursor.of(dataFrameCursor);

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -219,7 +219,7 @@ query.timeout.sec=60
 # max number of pages for storing keys in LongTreeChain before a resource limit exception is thrown
 # cairo.sql.sort.key.max.pages=2^31
 
-# sets the  memory page size and max pages for storing values in LongTreeChain
+# sets the memory page size and max pages for storing values in LongTreeChain
 #cairo.sql.sort.light.value.page.size=1048576
 #cairo.sql.sort.light.value.max.pages=2^31
 
@@ -227,8 +227,7 @@ query.timeout.sec=60
 #cairo.sql.hash.join.value.page.size=16777216
 #cairo.sql.hash.join.value.max.pages=2^31
 
-
-# sets the number of rows for latest By  ###
+# sets the number of rows for latest By
 #cairo.sql.latest.by.row.count=1000
 
 # sets the memory page size and max pages of the slave chain in light hash joins
@@ -300,18 +299,31 @@ query.timeout.sec=60
 # 0 means to use symbol block capacity
 # cairo.sql.sampleby.page.size=0
 
+# sets the maximum size of the page frames used in SQL queries
+#cairo.sql.page.frame.max.size=8M
+
 # SQL JIT compiler mode. Options:
 # 1. on (enable JIT and use vector instructions when possible)
 # 2. scalar (enable JIT and use scalar instructions only)
 # 3. off (disable JIT; default value)
 # Note: SQL JIT compiler is a beta feature.
 #cairo.sql.jit.mode=off
+
+# sets the memory page size and max pages for storing IR for JIT compilation
 #cairo.sql.jit.ir.memory.page.size=8K
 #cairo.sql.jit.ir.memory.max.pages=8
+
+# sets the memory page size and max pages for storing bind variable values for JIT compiled filter
 #cairo.sql.jit.bind.vars.memory.page.size=4K
 #cairo.sql.jit.bind.vars.memory.max.pages=8
+
+# sets minimum number of rows to shrink filtered rows memory after query execution
 #cairo.sql.jit.rows.threshold=1M
+
+# sets minimum cache size to shrink page address cache after query execution
 #cairo.sql.jit.page.address.cache.threshold=1M
+
+# sets debug flag for JIT compilation; when enabled, assembly will be printed into stdout
 #cairo.sql.jit.debug.enabled=false
 
 #cairo.date.locale=en

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -202,6 +202,8 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(-1, configuration.getLineUdpReceiverConfiguration().ownThreadAffinity());
         Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().ownThread());
 
+        Assert.assertEquals(8 * 1024 * 1024, configuration.getCairoConfiguration().getSqlPageFrameMaxSize());
+
         Assert.assertEquals(SqlJitMode.JIT_MODE_DISABLED, configuration.getCairoConfiguration().getSqlJitMode());
         Assert.assertEquals(8192, configuration.getCairoConfiguration().getSqlJitIRMemoryPageSize());
         Assert.assertEquals(8, configuration.getCairoConfiguration().getSqlJitIRMemoryMaxPages());
@@ -575,6 +577,8 @@ public class PropServerConfigurationTest {
             Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().isEnabled());
             Assert.assertEquals(2, configuration.getLineUdpReceiverConfiguration().ownThreadAffinity());
             Assert.assertTrue(configuration.getLineUdpReceiverConfiguration().ownThread());
+
+            Assert.assertEquals(1024, configuration.getCairoConfiguration().getSqlPageFrameMaxSize());
 
             Assert.assertEquals(SqlJitMode.JIT_MODE_FORCE_SCALAR, configuration.getCairoConfiguration().getSqlJitMode());
             Assert.assertEquals(2048, configuration.getCairoConfiguration().getSqlJitIRMemoryPageSize());

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -68,6 +68,7 @@ public class AbstractCairoTest {
     protected static int sampleByIndexSearchPageSize;
     protected static int binaryEncodingMaxLength = -1;
     protected static CharSequence defaultMapType;
+    protected static int pageFrameMaxSize = -1;
 
     @Rule
     public TestName testName = new TestName();
@@ -156,6 +157,11 @@ public class AbstractCairoTest {
                 // but we want to have it enabled in tests.
                 return SqlJitMode.JIT_MODE_ENABLED;
             }
+
+            @Override
+            public int getSqlPageFrameMaxSize() {
+                return pageFrameMaxSize < 0 ? super.getSqlPageFrameMaxSize() : pageFrameMaxSize;
+            }
         };
         engine = new CairoEngine(configuration);
         messageBus = engine.getMessageBus();
@@ -189,6 +195,7 @@ public class AbstractCairoTest {
         defaultMapType = null;
         writerAsyncCommandBusyWaitTimeout = -1;
         writerAsyncCommandMaxTimeout = -1;
+        pageFrameMaxSize = -1;
     }
 
     protected static void assertMemoryLeak(TestUtils.LeakProneCode code) throws Exception {

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -110,6 +110,7 @@ cairo.sql.float.cast.scale=3
 cairo.writer.append.page.size=32M
 cairo.sql.bind.variable.pool.size=16
 cairo.sql.sampleby.page.size=2001
+cairo.sql.page.frame.max.size=1K
 cairo.sql.jit.mode=scalar
 cairo.sql.jit.ir.memory.page.size=2K
 cairo.sql.jit.ir.memory.max.pages=2

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -209,7 +209,7 @@ http.enabled=true
 # max number of pages for storing keys in LongTreeChain before a resource limit exception is thrown
 # cairo.sql.sort.key.max.pages=2^31
 
-# sets the  memory page size and max pages for storing values in LongTreeChain
+# sets the memory page size and max pages for storing values in LongTreeChain
 #cairo.sql.sort.light.value.page.size=1048576
 #cairo.sql.sort.light.value.max.pages=2^31
 
@@ -217,8 +217,7 @@ http.enabled=true
 #cairo.sql.hash.join.value.page.size=16777216
 #cairo.sql.hash.join.value.max.pages=2^31
 
-
-# sets the number of rows for latest By  ###
+# sets the number of rows for latest By
 #cairo.sql.latest.by.row.count=1000
 
 # sets the memory page size and max pages of the slave chain in light hash joins
@@ -296,18 +295,31 @@ http.enabled=true
 # Maximum number of uncommitted rows in TCP ILP
 #cairo.max.uncommitted.rows=500000
 
+# sets the maximum size of the page frames used in SQL queries
+#cairo.sql.page.frame.max.size=8M
+
 # SQL JIT compiler mode. Options:
 # 1. on (enable JIT and use vector instructions when possible)
 # 2. scalar (enable JIT and use scalar instructions only)
 # 3. off (disable JIT; default value)
 # Note: SQL JIT compiler is a beta feature.
 #cairo.sql.jit.mode=off
+
+# sets the memory page size and max pages for storing IR for JIT compilation
 #cairo.sql.jit.ir.memory.page.size=8K
 #cairo.sql.jit.ir.memory.max.pages=8
+
+# sets the memory page size and max pages for storing bind variable values for JIT compiled filter
 #cairo.sql.jit.bind.vars.memory.page.size=4K
 #cairo.sql.jit.bind.vars.memory.max.pages=8
+
+# sets minimum number of rows to shrink filtered rows memory after query execution
 #cairo.sql.jit.rows.threshold=1M
+
+# sets minimum cache size to shrink page address cache after query execution
 #cairo.sql.jit.page.address.cache.threshold=1M
+
+# sets debug flag for JIT compilation; when enabled, assembly will be printed into stdout
 #cairo.sql.jit.debug.enabled=false
 
 ################ LINE UDP settings ##################


### PR DESCRIPTION
A follow-up to #1592

Limits max size of page frames used in SQL queries. The max page frame size is set to 8M by default. This leads to a maximum of 64MB of RAM allocated for the row id array used in JIT compiled filters.

I also run `SqlJitCompilerBenchmark` on my machine and didn't spot a noticeable difference in the benchmark results with this change.

Also updates descriptions and types for SQL JIT settings.