### PR TITLE
chore(sql): new latest by syntax

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -876,7 +876,7 @@ public final class SqlParser {
             parseSelectFrom(lexer, model, masterModel);
             tok = setModelAliasAndTimestamp(lexer, model);
 
-            // expect [latest by]
+            // expect [latest by] (deprecated syntax)
             if (tok != null && isLatestKeyword(tok)) {
                 parseLatestBy(lexer, model);
                 tok = optTok(lexer);
@@ -894,6 +894,9 @@ public final class SqlParser {
         // expect [where]
 
         if (tok != null && isWhereKeyword(tok)) {
+            if (model.getLatestByType() == QueryModel.LATEST_BY_NEW) {
+                throw SqlException.$((lexer.lastTokenPosition()), "unexpected where clause after 'latest on'");
+            }
             ExpressionNode expr = expr(lexer, model);
             if (expr != null) {
                 model.setWhereClause(expr);
@@ -901,6 +904,16 @@ public final class SqlParser {
             } else {
                 throw SqlException.$((lexer.lastTokenPosition()), "empty where clause");
             }
+        }
+
+        // expect [latest by] (new syntax)
+        if (tok != null && isLatestKeyword(tok)) {
+            if (model.getLatestByType() == QueryModel.LATEST_BY_DEPRECATED) {
+                throw SqlException.$((lexer.lastTokenPosition()), "mix of new and deprecated 'latest by' syntax");
+            }
+            expectTok(lexer, "on");
+            parseLatestByNew(lexer, model);
+            tok = optTok(lexer);
         }
 
         // expect [sample by]
@@ -971,7 +984,7 @@ public final class SqlParser {
             }
         }
 
-        //expect [group by]
+        // expect [group by]
 
         if (tok != null && isGroupKeyword(tok)) {
             expectBy(lexer);
@@ -1216,12 +1229,53 @@ public final class SqlParser {
     }
 
     private void parseLatestBy(GenericLexer lexer, QueryModel model) throws SqlException {
-        expectBy(lexer);
+        CharSequence tok = optTok(lexer);
+        if (tok != null) {
+            if (isByKeyword(tok)) {
+                parseLatestByDeprecated(lexer, model);
+                return;
+            }
+            if (isOnKeyword(tok)) {
+                parseLatestByNew(lexer, model);
+                return;
+            }
+        }
+        throw SqlException.$((lexer.lastTokenPosition()), "'on' or 'by' expected");
+    }
+
+    private void parseLatestByDeprecated(GenericLexer lexer, QueryModel model) throws SqlException {
+        // 'latest by' is already parsed at this point
+
         CharSequence tok;
         do {
             model.addLatestBy(expectLiteral(lexer));
             tok = SqlUtil.fetchNext(lexer);
         } while (Chars.equalsNc(tok, ','));
+
+        model.setLatestByType(QueryModel.LATEST_BY_DEPRECATED);
+
+        if (tok != null) {
+            lexer.unparse();
+        }
+    }
+
+    private void parseLatestByNew(GenericLexer lexer, QueryModel model) throws SqlException {
+        // 'latest on' is already parsed at this point
+
+        // <timestamp>
+        final ExpressionNode timestamp = expectLiteral(lexer);
+        model.setTimestamp(timestamp);
+        // 'partition by'
+        expectTok(lexer, "partition");
+        expectTok(lexer, "by");
+        // <columns>
+        CharSequence tok;
+        do {
+            model.addLatestBy(expectLiteral(lexer));
+            tok = SqlUtil.fetchNext(lexer);
+        } while (Chars.equalsNc(tok, ','));
+
+        model.setLatestByType(QueryModel.LATEST_BY_NEW);
 
         if (tok != null) {
             lexer.unparse();

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -2493,7 +2493,7 @@ public class IODispatcherTest {
             // check if we have one record
             sendAndReceive(
                     NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
+                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+on+timestamp+partition+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
                             "Host: localhost:9000\r\n" +
                             "Connection: keep-alive\r\n" +
                             "Accept: */*\r\n" +
@@ -2512,8 +2512,8 @@ public class IODispatcherTest {
                             "Content-Type: application/json; charset=utf-8\r\n" +
                             "Keep-Alive: timeout=5, max=10000\r\n" +
                             "\r\n" +
-                            "014c\r\n" +
-                            "{\"query\":\"\\n\\nselect * from balances_x latest by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\"]],\"count\":1}\r\n" +
+                            "0163\r\n" +
+                            "{\"query\":\"\\n\\nselect * from balances_x latest on timestamp partition by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\"]],\"count\":1}\r\n" +
                             "00\r\n" +
                             "\r\n",
                     1,
@@ -2552,7 +2552,7 @@ public class IODispatcherTest {
             // select again expecting only metadata
             sendAndReceive(
                     NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
+                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+on+timestamp+partition+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
                             "Host: localhost:9000\r\n" +
                             "Connection: keep-alive\r\n" +
                             "Accept: */*\r\n" +
@@ -2571,8 +2571,8 @@ public class IODispatcherTest {
                             "Content-Type: application/json; charset=utf-8\r\n" +
                             "Keep-Alive: timeout=5, max=10000\r\n" +
                             "\r\n" +
-                            "011c\r\n" +
-                            "{\"query\":\"\\n\\nselect * from balances_x latest by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[],\"count\":0}\r\n" +
+                            "0133\r\n" +
+                            "{\"query\":\"\\n\\nselect * from balances_x latest on timestamp partition by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[],\"count\":0}\r\n" +
                             "00\r\n" +
                             "\r\n",
                     1,
@@ -3572,7 +3572,7 @@ public class IODispatcherTest {
             // check if we have one record
             sendAndReceive(
                     NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
+                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+on+timestamp+partition+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
                             "Host: localhost:9000\r\n" +
                             "Connection: keep-alive\r\n" +
                             "Accept: */*\r\n" +
@@ -3591,8 +3591,8 @@ public class IODispatcherTest {
                             "Content-Type: application/json; charset=utf-8\r\n" +
                             "Keep-Alive: timeout=5, max=10000\r\n" +
                             "\r\n" +
-                            "014c\r\n" +
-                            "{\"query\":\"\\n\\nselect * from balances_x latest by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\"]],\"count\":1}\r\n" +
+                            "0163\r\n" +
+                            "{\"query\":\"\\n\\nselect * from balances_x latest on timestamp partition by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\"]],\"count\":1}\r\n" +
                             "00\r\n" +
                             "\r\n",
                     1,
@@ -3634,7 +3634,7 @@ public class IODispatcherTest {
             // select again expecting only metadata
             sendAndReceive(
                     NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
+                    "GET /query?query=%0A%0Aselect+*+from+balances_x+latest+on+timestamp+partition+by+cust_id%2C+balance_ccy&limit=0%2C1000&count=true HTTP/1.1\r\n" +
                             "Host: localhost:9000\r\n" +
                             "Connection: keep-alive\r\n" +
                             "Accept: */*\r\n" +
@@ -3653,8 +3653,8 @@ public class IODispatcherTest {
                             "Content-Type: application/json; charset=utf-8\r\n" +
                             "Keep-Alive: timeout=5, max=10000\r\n" +
                             "\r\n" +
-                            "016d\r\n" +
-                            "{\"query\":\"\\n\\nselect * from balances_x latest by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"},{\"name\":\"xyz\",\"type\":\"INT\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\",null]],\"count\":1}\r\n" +
+                            "0184\r\n" +
+                            "{\"query\":\"\\n\\nselect * from balances_x latest on timestamp partition by cust_id, balance_ccy\",\"columns\":[{\"name\":\"cust_id\",\"type\":\"INT\"},{\"name\":\"balance_ccy\",\"type\":\"SYMBOL\"},{\"name\":\"balance\",\"type\":\"DOUBLE\"},{\"name\":\"status\",\"type\":\"BYTE\"},{\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"},{\"name\":\"xyz\",\"type\":\"INT\"}],\"dataset\":[[1,\"USD\",1500.0,0,\"1970-01-01T01:40:00.000001Z\",null]],\"count\":1}\r\n" +
                             "00\r\n" +
                             "\r\n",
                     1,
@@ -4493,7 +4493,7 @@ public class IODispatcherTest {
             // check if we have one record
             sendAndReceive(
                     NetworkFacadeImpl.INSTANCE,
-                    "GET /query?query=select+*+from+xx+latest+by+value&count=true HTTP/1.1\r\n" +
+                    "GET /query?query=select+*+from+xx+latest+on+ts+partition+by+value&count=true HTTP/1.1\r\n" +
                             "Host: localhost:9000\r\n" +
                             "Connection: keep-alive\r\n" +
                             "Accept: */*\r\n" +
@@ -4512,8 +4512,8 @@ public class IODispatcherTest {
                             "Content-Type: application/json; charset=utf-8\r\n" +
                             "Keep-Alive: timeout=5, max=10000\r\n" +
                             "\r\n" +
-                            "b4\r\n" +
-                            "{\"query\":\"select * from xx latest by value\",\"columns\":[{\"name\":\"value\",\"type\":\"LONG256\"},{\"name\":\"ts\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[\"\",\"1970-01-01T00:00:00.000000Z\"]],\"count\":1}\r\n" +
+                            "c4\r\n" +
+                            "{\"query\":\"select * from xx latest on ts partition by value\",\"columns\":[{\"name\":\"value\",\"type\":\"LONG256\"},{\"name\":\"ts\",\"type\":\"TIMESTAMP\"}],\"dataset\":[[\"\",\"1970-01-01T00:00:00.000000Z\"]],\"count\":1}\r\n" +
                             "00\r\n" +
                             "\r\n",
                     1,

--- a/core/src/test/java/io/questdb/griffin/JoinTest.java
+++ b/core/src/test/java/io/questdb/griffin/JoinTest.java
@@ -3681,8 +3681,8 @@ public class JoinTest extends AbstractGriffinTest {
 
             assertQuery("id\n",
                     "with\n" +
-                            "eventlist as (select * from contact_events latest by _id order by timestamp)\n" +
-                            ",contactlist as (select * from contacts latest by _id order by timestamp)\n" +
+                            "eventlist as (select * from contact_events latest on timestamp partition by _id order by timestamp)\n" +
+                            ",contactlist as (select * from contacts latest on timestamp partition by _id order by timestamp)\n" +
                             ",c as (select distinct contactid from eventlist where groupId = 'ykom80aRN5AwUcuRp4LJ' except select distinct _id as contactId from contactlist where notRealType = 'bot')\n" +
                             "select\n" +
                             "c.contactId as id\n" +

--- a/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
+++ b/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
@@ -162,7 +162,7 @@ public class LatestByParallelTest {
                 " from long_sequence(20)" +
                 "), index(b) timestamp(k) partition by DAY";
 
-        final String query = "select a,k,b from x latest by b where a > 40";
+        final String query = "select a,k,b from x where a > 40 latest on k partition by b";
 
         assertQuery(compiler, sqlExecutionContext, expected, ddl, query);
     }
@@ -190,7 +190,7 @@ public class LatestByParallelTest {
                 " long_sequence(20)" +
                 "), index(b) timestamp(k) partition by DAY";
 
-        final String query = "select * from x latest by b";
+        final String query = "select * from x latest on k partition by b";
 
         assertQuery(compiler, sqlExecutionContext, expected, ddl, query);
     }
@@ -215,7 +215,7 @@ public class LatestByParallelTest {
                 " long_sequence(20)" +
                 "), index(b) timestamp(k) partition by DAY";
 
-        final String query = "select * from x latest by b where k < '1970-01-03'";
+        final String query = "select * from x where k < '1970-01-03' latest on k partition by b";
 
         assertQuery(compiler, sqlExecutionContext, expected, ddl, query);
     }

--- a/core/src/test/java/io/questdb/griffin/MemoryLeakTest.java
+++ b/core/src/test/java/io/questdb/griffin/MemoryLeakTest.java
@@ -63,7 +63,7 @@ public class MemoryLeakTest extends AbstractGriffinTest {
                     StringSink sink = new StringSink();
                     sink.clear();
                     sink.put("users");
-                    sink.put(" latest by id where sequence > :low and sequence < :high");
+                    sink.put(" where sequence > :low and sequence < :high latest on timestamp partition by id");
                     try (RecordCursorFactory rcf = compiler.compile(sink, executionContext).getRecordCursorFactory()) {
                         bindVariableService.setLong("low", 0);
                         bindVariableService.setLong("high", N + 1);

--- a/core/src/test/java/io/questdb/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/griffin/SecurityTest.java
@@ -511,7 +511,7 @@ public class SecurityTest extends AbstractGriffinTest {
                 assertQuery(
                         memoryRestrictedCompiler,
                         "TOO MUCH",
-                        "select ts, d from tb1 LATEST BY d",
+                        "select ts, d from tb1 LATEST ON ts PARTITION BY d",
                         "ts",
                         true, readOnlyExecutionContext);
                 Assert.fail();

--- a/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
+++ b/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
@@ -41,7 +41,7 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
             execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, inactive, timestamp) values (1, 'USD', true, 6000000006);", sqlExecutionContext).getInsertStatement());
 
             assertSql(
-                    "(select * from balances latest by balance_ccy where cust_id=1) where not inactive;",
+                    "(select * from balances where cust_id=1 latest on timestamp partition by balance_ccy) where not inactive;",
                     "cust_id\tbalance_ccy\tbalance\tinactive\ttimestamp\n" +
                             "1\tEUR\t650.5\tfalse\t1970-01-01T01:40:00.000002Z\n"
             );
@@ -60,7 +60,7 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
-                    "(select state from state_table latest by state limit -1) where state != 'ON';",
+                    "(select state from state_table latest on time partition by state limit -1) where state != 'ON';",
                     sink,
                     "state\n"
             );

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -1847,7 +1847,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "48.820511018586934\tVTJW\t1970-01-12T13:46:40.000000Z\n" +
                         "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b",
+                "select * from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -1881,7 +1881,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         assertQuery("a\tb\tk\n" +
                         "97.55263540567968\ttrue\t1970-01-20T16:13:20.000000Z\n" +
                         "37.62501709498378\tfalse\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b",
+                "select * from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select * from" +
@@ -1919,7 +1919,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                 "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b where 6 < 10",
+                "select * from x where 6 < 10 latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -1957,7 +1957,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                 "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b where a > 40",
+                "select * from x where a > 40 latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -1995,7 +1995,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                 "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b",
+                "select * from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2034,7 +2034,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                 "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b where 5 > 2",
+                "select * from x where 5 > 2 latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2071,7 +2071,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "50.25890936351257\t1970-01-20T16:13:20.000000Z\tRXGZ\n" +
                 "72.604681060764\t1970-01-22T23:46:40.000000Z\t\n";
         assertQuery(expected,
-                "select a,k,b from x latest by b where a > 40",
+                "select a,k,b from x where a > 40 latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2110,7 +2110,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         final String expected = "a\tb\tc\tk\n" +
                 "67.52509547112409\tCPSW\tSXUX\t1970-01-21T20:00:00.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b where c = 'SXUX'",
+                "select * from x where c = 'SXUX' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2142,7 +2142,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         final String expected = "b\tk\n" +
                 "RXGZ\t1970-01-12T13:46:40.000000Z\n";
         assertQuery(expected,
-                "select b,k from x latest by b where b = 'RXGZ' and k < '1970-01-22'",
+                "select b,k from x where b = 'RXGZ' and k < '1970-01-22' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2196,7 +2196,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     TestUtils.assertSql(
                             compiler,
                             sqlExecutionContext,
-                            "trips latest by vendor where id > 0 order by ts",
+                            "trips where id > 0 latest on ts partition by vendor order by ts",
                             sink,
                             "id\tvendor\tts\n" +
                                     "1878619626\tKK\t1970-01-01T00:01:39.200000Z\n" +
@@ -2216,7 +2216,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tv\n",
-                            "select * from pos latest by uuid where hash within(#f, #z, #v)",
+                            "select * from pos where hash within(#f, #z, #v) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2234,7 +2234,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf9\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tve\n",
-                            "select * from pos latest by uuid where hash within(#f9, #z3, #ve)",
+                            "select * from pos where hash within(#f9, #z3, #ve) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2252,7 +2252,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf9\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tve\n",
-                            "select * from pos latest by uuid where hash within(make_geohash(-62, 53.4, 10), #z3, #ve)",
+                            "select * from pos where hash within(make_geohash(-62, 53.4, 10), #z3, #ve) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2270,7 +2270,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf91t\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz31w\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tvepe\n",
-                            "select * from pos latest by uuid where hash within(#f91, #z31w, #vepe)",
+                            "select * from pos where hash within(#f91, #z31w, #vepe) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2288,7 +2288,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf91t48s7\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz31wzd5w\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tvepe7h62\n",
-                            "select * from pos latest by uuid where hash within(#f91, #z31w, #vepe7h)",
+                            "select * from pos where hash within(#f91, #z31w, #vepe7h) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2304,7 +2304,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where hash within(#f9, #z3, #vepe7h)",
+                                "select * from pos where hash within(#f9, #z3, #vepe7h) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2334,7 +2334,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     );
                     try {
                         assertQuery("time\tuuid\thash\n",
-                                "select * from x latest by s where geo8 within(make_geohash(lon, lat, 40), #z3, #vegg)",
+                                "select * from x where geo8 within(make_geohash(lon, lat, 40), #z3, #vegg) latest on ts partition by s",
                                 "ts",
                                 true,
                                 true,
@@ -2356,7 +2356,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                         "2021-05-10T23:59:59.150000Z\tXXX\tf9\n" +
                                         "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                         "2021-05-12T00:00:00.186000Z\tZZZ\tve\n",
-                                "select * from pos latest by uuid where hash within('z3', #z3, #ve)",
+                                "select * from pos where hash within('z3', #z3, #ve) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2378,7 +2378,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                         "2021-05-10T23:59:59.150000Z\tXXX\tf9\n" +
                                         "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                         "2021-05-12T00:00:00.186000Z\tZZZ\tve\n",
-                                "select * from pos latest by uuid where hash within(make_geohash(-620.0, 53.4, 10), #z3, #ve)",
+                                "select * from pos where hash within(make_geohash(-620.0, 53.4, 10), #z3, #ve) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2405,7 +2405,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "y\t1970-01-18T07:41:40.000000Z\n" +
                                     "y\t1970-01-18T08:18:20.000000Z\n" +
                                     "z\t1970-01-18T08:35:00.000000Z\n",
-                            "select geo1, ts from x latest by s where geo1 within(#x, #y, #z)",
+                            "select geo1, ts from x where geo1 within(#x, #y, #z) latest on ts partition by s",
                             "ts",
                             true,
                             true,
@@ -2432,7 +2432,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "yvh\t1970-01-18T06:55:00.000000Z\n" +
                                     "y1n\t1970-01-18T07:28:20.000000Z\n" +
                                     "zs4\t1970-01-18T08:03:20.000000Z\n",
-                            "select geo2, ts from x latest by s where geo2 within(#x, #y, #z)",
+                            "select geo2, ts from x where geo2 within(#x, #y, #z) latest on ts partition by s",
                             "ts",
                             true,
                             true,
@@ -2459,7 +2459,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "xxusm\t1970-01-18T07:55:00.000000Z\n" +
                                     "x1dse\t1970-01-18T08:18:20.000000Z\n" +
                                     "zmt6j\t1970-01-18T08:38:20.000000Z\n",
-                            "select geo4, ts from x latest by s where geo4 within(#x, #y, #z)",
+                            "select geo4, ts from x where geo4 within(#x, #y, #z) latest on ts partition by s",
                             "ts",
                             true,
                             true,
@@ -2482,7 +2482,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "1111110\t1970-01-18T07:10:00.000000Z\n" +
                                     "1111110\t1970-01-18T08:20:00.000000Z\n" +
                                     "1111111\t1970-01-18T08:28:20.000000Z\n",
-                            "select bits7, ts from x latest by s where bits7 within(##111111)",
+                            "select bits7, ts from x where bits7 within(##111111) latest on ts partition by s",
                             "ts",
                             true,
                             true,
@@ -2503,7 +2503,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "ybsge\t1970-01-18T06:45:00.000000Z\n" +
                                     "z4t7w\t1970-01-18T07:45:00.000000Z\n" +
                                     "xxusm\t1970-01-18T07:55:00.000000Z\n",
-                            "select geo4, ts from x latest by s where geo4 within(#xx, #y, #z4)",
+                            "select geo4, ts from x where geo4 within(#xx, #y, #z4) latest on ts partition by s",
                             "ts",
                             true,
                             true,
@@ -2520,7 +2520,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     assertQuery("i\ts\tts\tbits3\tbits7\tbits9\n" +
                                     "9384\tYFFD\t1970-01-17T15:31:40.000000Z\t101\t1110000\t101111011\n" +
                                     "9397\tMXUK\t1970-01-17T15:53:20.000000Z\t100\t1110001\t110001111\n",
-                            "select * from x latest by s where bits7 within(#wt/5)",//(##11100)",
+                            "select * from x where bits7 within(#wt/5) latest on ts partition by s",//(##11100)",
                             "ts",
                             true,
                             true,
@@ -2536,7 +2536,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createRndGeoHashBitsTable();
                     try {
                         assertQuery("",
-                                "select * from x latest by s where bits3 within(##111111)",
+                                "select * from x where bits3 within(##111111) latest on ts partition by s",
                                 "ts",
                                 true,
                                 true,
@@ -2558,7 +2558,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                                     "2021-05-10T23:59:59.150000Z\tXXX\tf9\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                     "2021-05-12T00:00:00.186000Z\tZZZ\tve\n",
-                            "select * from pos latest by uuid where hash within(cast('f9' as geohash(2c)), #z3, #ve)",
+                            "select * from pos where hash within(cast('f9' as geohash(2c)), #z3, #ve) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2576,7 +2576,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "time\tuuid\thash\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz\n" +
                                     "2021-05-11T00:00:00.111000Z\tddd\tb\n",
-                            "select * from pos latest by uuid where time in '2021-05-11' and hash within (#z, #b)",
+                            "select * from pos where time in '2021-05-11' and hash within (#z, #b) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2594,7 +2594,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "time\tuuid\thash\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz3\n" +
                                     "2021-05-11T00:00:00.111000Z\tddd\tbc\n",
-                            "select * from pos latest by uuid where time in '2021-05-11' and hash within (#z, #b)",
+                            "select * from pos where time in '2021-05-11' and hash within (#z, #b) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2612,7 +2612,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "time\tuuid\thash\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz31w\n" +
                                     "2021-05-11T00:00:00.111000Z\tddd\tbcnk\n",
-                            "select * from pos latest by uuid where time in '2021-05-11' and hash within (#z, #b)",
+                            "select * from pos where time in '2021-05-11' and hash within (#z, #b) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2629,7 +2629,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     assertQuery(
                             "time\tuuid\thash\n" +
                                     "2021-05-11T00:00:00.083000Z\tYYY\tz31wzd5w\n",
-                            "select * from pos latest by uuid where time in '2021-05-11' and hash within (#z31, #bbx)",
+                            "select * from pos where time in '2021-05-11' and hash within (#z31, #bbx) latest on time partition by uuid",
                             "time",
                             true,
                             true,
@@ -2645,7 +2645,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where 'hash' within(#f9)",
+                                "select * from pos where 'hash' within(#f9) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2664,7 +2664,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where uuid within(#f9)",
+                                "select * from pos where uuid within(#f9) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2683,7 +2683,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where hash within()",
+                                "select * from pos where hash within() latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2702,7 +2702,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where hash within(#f9, #z3, null)",
+                                "select * from pos where hash within(#f9, #z3, null) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2721,7 +2721,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where hash within(#f9) or hash within(#z3)",
+                                "select * from pos where hash within(#f9) or hash within(#z3) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2740,7 +2740,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     createGeoHashTable(2);
                     try {
                         assertQuery("",
-                                "select * from pos latest by uuid where hash within(cast('f91t' as geohash(4c)), #z3, null)",
+                                "select * from pos where hash within(cast('f91t' as geohash(4c)), #z3, null) latest on time partition by uuid",
                                 "time",
                                 true,
                                 true,
@@ -2789,7 +2789,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     TestUtils.assertSql(
                             compiler,
                             sqlExecutionContext,
-                            "trips latest by vendor where vendor in ('KK', 'ZZ', 'TT', 'DD', 'PP', 'QQ', 'CC') order by ts",
+                            "trips where vendor in ('KK', 'ZZ', 'TT', 'DD', 'PP', 'QQ', 'CC') latest on ts partition by vendor order by ts",
                             sink,
                             "id\tvendor\tts\n" +
                                     "-1243990650\tZZ\t1970-01-01T00:01:39.900000Z\n" +
@@ -2814,7 +2814,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "50.25890936351257\t1970-01-20T16:13:20.000000Z\tRXGZ\n" +
                 "72.604681060764\t1970-01-22T23:46:40.000000Z\t\n";
         assertQuery(expected,
-                "select a,k,b from x latest by b",
+                "select a,k,b from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2860,7 +2860,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "1970-01-18T08:40:00.000000Z\t49.00510449885239\n" +
                 "1970-01-22T23:46:40.000000Z\t40.455469747939254\n";
         assertQuery(expected,
-                "select k,a from x latest by b",
+                "select k,a from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -2927,7 +2927,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     TestUtils.assertSql(
                             compiler,
                             sqlExecutionContext,
-                            "trips latest by vendor order by ts",
+                            "trips latest on ts partition by vendor order by ts",
                             sink,
                             "id\tvendor\tts\n" +
                                     "1878619626\tKK\t1970-01-01T00:01:39.200000Z\n" +
@@ -2951,7 +2951,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "CPSW\t1970-01-19T12:26:40.000000Z\t51.85631921367574\n" +
                         "RXGZ\t1970-01-20T16:13:20.000000Z\t50.25890936351257\n" +
                         "\t1970-01-22T23:46:40.000000Z\t72.604681060764\n",
-                "select b,k,a from x latest by b",
+                "select b,k,a from x latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3024,7 +3024,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     TestUtils.assertSql(
                             compiler,
                             sqlExecutionContext,
-                            "trips latest by vendor order by ts",
+                            "trips latest on ts partition by vendor order by ts",
                             sink,
                             "id\tvendor\tts\n" +
                                     "1878619626\tKK\t1970-01-01T00:01:39.200000Z\n" +
@@ -3047,7 +3047,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 "49.00510449885239\tPEHN\t1970-01-18T08:40:00.000000Z\n" +
                 "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n";
         assertQuery(expected,
-                "select * from x latest by b where a > 40",
+                "select * from x where a > 40 latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3096,8 +3096,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
-                    "SELECT * FROM balances LATEST BY cust_id, balance_ccy \n" +
-                            "WHERE cust_id = 'c1' and balance_ccy='EUR'",
+                    "SELECT * FROM balances \n" +
+                            "WHERE cust_id = 'c1' and balance_ccy='EUR' \n" +
+                            "LATEST ON timestamp PARTITION BY cust_id, balance_ccy",
                     sink,
                     "cust_id\tbalance_ccy\tbalance\ttimestamp\n" +
                             "c1\tEUR\t782.0\t2021-09-14T17:35:04.000000Z\n"
@@ -3176,7 +3177,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             sqlExecutionContext);
 
                     try (final RecordCursorFactory factory = compiler.compile(
-                            "select * from x latest by b where b = 'PEHN' and a < 22",
+                            "select * from x where b = 'PEHN' and a < 22 latest on k partition by b",
                             sqlExecutionContext
                     ).getRecordCursorFactory()) {
                         try {
@@ -3217,7 +3218,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             executeInsert("insert into tab values ('d1', 'c1', 101.1, '2021-10-15T11:31:35.878Z', '2021-10-05T11:31:35.878Z')");
             executeInsert("insert into tab values ('d2', 'c1', 111.7, '2021-10-16T17:31:35.878Z', '2021-10-06T15:31:35.878Z')");
             assertSql(
-                    "(tab latest by id where name in (select distinct name from tab where name != 'c2')) timestamp(other_ts)",
+                    "tab where name in (select distinct name from tab where name != 'c2') latest on other_ts partition by id",
                     "id\tname\tvalue\tother_ts\tts\n" +
                             "d1\tc1\t101.4\t2021-10-15 14:31:35.878\t2021-10-05 14:31:35.878\n" +
                             "d2\tc1\t111.7\t2021-10-16 17:31:35.878\t2021-10-06 15:31:35.878\n");
@@ -3229,7 +3230,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         // no index
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n",
-                "select * from x latest by b where b = 'RXGZ'",
+                "select * from x where b = 'RXGZ' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select " +
@@ -3256,7 +3257,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         // no index
         assertQuery("k\ta\tb\n" +
                         "1970-01-03T07:33:20.000000Z\t23.90529010846525\tRXGZ\n",
-                "select k,a,b from x latest by b where b = 'RXGZ'",
+                "select k,a,b from x where b = 'RXGZ' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select " +
@@ -3283,7 +3284,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         TestMatchFunctionFactory.clear();
         assertQuery("a\tb\tk\n" +
                         "5.942010834028011\tPEHN\t1970-08-03T02:53:20.000000Z\n",
-                "select * from x latest by b where b = 'PEHN' and a < 22 and test_match()",
+                "select * from x where b = 'PEHN' and a < 22 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3311,7 +3312,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByKeyValueFilteredEmpty() throws Exception {
         TestMatchFunctionFactory.clear();
         assertQuery("a\tb\tk\n",
-                "select * from x latest by b where b = 'PEHN' and a < 22 and 1 = 2 and test_match()",
+                "select * from x where b = 'PEHN' and a < 22 and 1 = 2 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3334,7 +3335,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByKeyValueIndexed() throws Exception {
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n",
-                "select * from x latest by b where b = 'RXGZ'",
+                "select * from x where b = 'RXGZ' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3360,7 +3361,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         TestMatchFunctionFactory.clear();
         assertQuery("a\tb\tk\n" +
                         "5.942010834028011\tPEHN\t1970-08-03T02:53:20.000000Z\n",
-                "select * from x latest by b where b = 'PEHN' and a < 22 and test_match()",
+                "select * from x where b = 'PEHN' and a < 22 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3387,7 +3388,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByKeyValueInterval() throws Exception {
         assertQuery("a\tb\tk\n" +
                         "84.45258177211063\tPEHN\t1970-01-16T01:06:40.000000Z\n",
-                "select * from x latest by b where b = 'PEHN' and k IN '1970-01-06T18:53:20;11d'",
+                "select * from x where b = 'PEHN' and k IN '1970-01-06T18:53:20;11d' latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3406,7 +3407,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n",
-                "select * from x latest by b where b in ('RXGZ','HYRX')",
+                "select * from x where b in ('RXGZ','HYRX') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3441,7 +3442,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in ('RXGZ','HYRX', null) and a > 12 and a < 50 and test_match()",
+                "select * from x where b in ('RXGZ','HYRX', null) and a > 12 and a < 50 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3476,7 +3477,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n",
-                "select * from x latest by b where b in ('RXGZ','HYRX')",
+                "select * from x where b in ('RXGZ','HYRX') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3509,7 +3510,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "97.71103146051203\tHYRX\t1970-01-07T22:40:00.000000Z\n",
-                "select * from x latest by b where b in ('RXGZ','HYRX') and a > 20 and test_match()",
+                "select * from x where b in ('RXGZ','HYRX') and a > 20 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3542,7 +3543,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByMissingKeyValue() throws Exception {
         assertQuery(null,
-                "select * from x latest by b where b in ('XYZ')",
+                "select * from x where b in ('XYZ') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3568,7 +3569,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByMissingKeyValueFiltered() throws Exception {
         TestMatchFunctionFactory.clear();
         assertQuery(null,
-                "select * from x latest by b where b in ('XYZ') and a < 60 and test_match()",
+                "select * from x where b in ('XYZ') and a < 60 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3596,7 +3597,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByMissingKeyValueIndexed() throws Exception {
         assertQuery(null,
-                "select * from x latest by b where b in ('XYZ')",
+                "select * from x where b in ('XYZ') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3621,7 +3622,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByMissingKeyValueIndexedColumnDereference() throws Exception {
         assertQuery(null,
-                "select b,k,a from x latest by b where b in ('XYZ')",
+                "select b,k,a from x where b in ('XYZ') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3647,7 +3648,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByMissingKeyValueIndexedFiltered() throws Exception {
         TestMatchFunctionFactory.clear();
         assertQuery(null,
-                "select * from x latest by b where b in ('XYZ') and a < 60 and test_match()",
+                "select * from x where b in ('XYZ') and a < 60 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3676,7 +3677,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         // no index
         assertQuery("a\tb\tk\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n",
-                "select * from x latest by b where b in ('XYZ','HYRX')",
+                "select * from x where b in ('XYZ','HYRX') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3708,7 +3709,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         TestMatchFunctionFactory.clear();
         assertQuery("a\tb\tk\n" +
                         "97.71103146051203\tHYRX\t1970-01-07T22:40:00.000000Z\n",
-                "select * from x latest by b where b in ('XYZ', 'HYRX') and a > 30 and test_match()",
+                "select * from x where b in ('XYZ', 'HYRX') and a > 30 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3742,7 +3743,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestByMissingKeyValuesIndexed() throws Exception {
         assertQuery("a\tb\tk\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n",
-                "select * from x latest by b where b in ('XYZ', 'HYRX')",
+                "select * from x where b in ('XYZ', 'HYRX') latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3774,7 +3775,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         TestMatchFunctionFactory.clear();
         assertQuery("a\tb\tk\n" +
                         "54.55175324785665\tHYRX\t1970-02-02T07:00:00.000000Z\n",
-                "select * from x latest by b where b in ('XYZ', 'HYRX') and a > 30 and test_match()",
+                "select * from x where b in ('XYZ', 'HYRX') and a > 30 and test_match() latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3893,7 +3894,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByMultipleColumns() throws Exception {
         assertQuery("cust_id\tbalance_ccy\tbalance\tstatus\ttimestamp\n",
-                "select * from balances latest by cust_id, balance_ccy",
+                "select * from balances latest on timestamp partition by cust_id, balance_ccy",
                 "create table balances (\n" +
                         "\tcust_id int, \n" +
                         "\tbalance_ccy symbol, \n" +
@@ -3933,7 +3934,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByNonExistingColumn() throws Exception {
         assertFailure(
-                "select * from x latest by y",
+                "select * from x latest on k partition by y",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -3943,7 +3944,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         " from" +
                         " long_sequence(20)" +
                         "), index(b) timestamp(k) partition by DAY",
-                26,
+                41,
                 "Invalid column");
     }
 
@@ -3994,7 +3995,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select list('RXGZ', 'HYRX', null) a from long_sequence(10))",
+                "select * from x where b in (select list('RXGZ', 'HYRX', null) a from long_sequence(10)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4029,7 +4030,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select list('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))",
+                "select * from x where b in (select list('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4066,8 +4067,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select rnd_symbol('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))" +
-                        " and a > 12 and a < 50 and test_match()",
+                "select * from x where b in (select rnd_symbol('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))" +
+                        " and a > 12 and a < 50 and test_match()" +
+                        " latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4105,7 +4107,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select list('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))",
+                "select * from x where b in (select list('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4141,8 +4143,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select rnd_symbol('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))" +
-                        " and a > 12 and a < 50 and test_match()",
+                "select * from x where b in (select rnd_symbol('RXGZ', 'HYRX', null, 'UCLA') a from long_sequence(10))" +
+                        " and a > 12 and a < 50 and test_match()" +
+                        " latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4181,8 +4184,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select rnd_symbol('RXGZ', 'HYRX', null) a from long_sequence(10))" +
-                        " and a > 12 and a < 50 and test_match()",
+                "select * from x where b in (select rnd_symbol('RXGZ', 'HYRX', null) a from long_sequence(10))" +
+                        " and a > 12 and a < 50 and test_match()" +
+                        " latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4218,7 +4222,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select list('RXGZ', 'HYRX', null) a from long_sequence(10))",
+                "select * from x where b in (select list('RXGZ', 'HYRX', null) a from long_sequence(10)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4253,8 +4257,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
                         "12.026122412833129\tHYRX\t1970-01-11T10:00:00.000000Z\n" +
                         "40.455469747939254\t\t1970-01-22T23:46:40.000000Z\n",
-                "select * from x latest by b where b in (select rnd_symbol('RXGZ', 'HYRX', null) a from long_sequence(10))" +
-                        " and a > 12 and a < 50 and test_match()",
+                "select * from x where b in (select rnd_symbol('RXGZ', 'HYRX', null) a from long_sequence(10))" +
+                        " and a > 12 and a < 50 and test_match()" +
+                        " latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4287,7 +4292,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestBySubQueryIndexedIntColumn() throws Exception {
         assertFailure(
-                "select * from x latest by b where b in (select 1 a from long_sequence(4))",
+                "select * from x where b in (select 1 a from long_sequence(4)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4297,7 +4302,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         " from" +
                         " long_sequence(20)" +
                         "), index(b) timestamp(k) partition by DAY",
-                47,
+                35,
                 "unsupported column type");
     }
 
@@ -4305,7 +4310,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLatestBySubQueryIndexedStrColumn() throws Exception {
         assertQuery("a\tb\tk\n" +
                         "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n",
-                "select * from x latest by b where b in (select 'RXGZ' from long_sequence(4))",
+                "select * from x where b in (select 'RXGZ' from long_sequence(4)) latest on k partition by b",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -4345,7 +4350,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "    symbol symbol, " +
                         "    ts timestamp" +
                         ")",
-                null);
+                "ts");
     }
 
     @Test
@@ -4379,7 +4384,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         "    symbol symbol index, " +
                         "    ts timestamp" +
                         ")",
-                null);
+                "ts");
     }
 
     @Test
@@ -4404,7 +4409,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
         assertQuery("ts\tmarket_type\tavg\n" +
                         "1970-01-01T00:00:09.999996Z\taaa\t0.02110922811597793\n" +
                         "1970-01-01T00:00:09.999996Z\tbbb\t0.344021345830156\n",
-                "select ts, market_type, avg(bid_price) FROM market_updates LATEST BY market_type SAMPLE BY 1s",
+                "select ts, market_type, avg(bid_price) FROM market_updates LATEST ON ts PARTITION BY market_type SAMPLE BY 1s",
                 "create table market_updates as (" +
                         "select " +
                         "rnd_symbol('aaa','bbb') market_type, " +
@@ -4446,7 +4451,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             executeInsert("insert into tab values ('d2', 'c1', 401.2, '2021-10-16T11:31:35.878Z', '2021-10-06T12:31:35.878Z')");
             executeInsert("insert into tab values ('d2', 'c1', 111.7, '2021-10-16T17:31:35.878Z', '2021-10-26T15:31:35.878Z')");
             assertSql(
-                    "(tab latest by id where name in ('c2')) timestamp(other_ts)",
+                    "tab where name in ('c2') latest on other_ts partition by id",
                     "id\tname\tvalue\tother_ts\tts\n" +
                             "d1\tc2\t102.5\t2021-10-15T12:31:35.878000Z\t2021-01-05T15:31:35.878000Z\n" +
                             "d2\tc2\t401.1\t2021-10-16T17:31:35.878000Z\t2021-10-26T11:31:35.878000Z\n");
@@ -4487,7 +4492,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             executeInsert("insert into tab values ('d2', 'c1', 401.2, '2021-10-16T11:31:35.878Z', '2021-10-06T12:31:35.878Z')");
             executeInsert("insert into tab values ('d2', 'c1', 111.7, '2021-10-16T17:31:35.878Z', '2021-10-26T15:31:35.878Z')");
             assertSql(
-                    "(tab latest by id where name in ('c2')) timestamp(ts)",
+                    "tab where name in ('c2') latest on ts partition by id",
                     "id\tname\tvalue\tother_ts\tts\n" +
                             "d1\tc2\t102.10000000000001\t2021-10-15T17:31:35.878000Z\t2021-10-04T11:31:35.878000Z\n" +
                             "d2\tc2\t401.1\t2021-10-16T17:31:35.878000Z\t2021-10-26T11:31:35.878000Z\n");
@@ -4514,9 +4519,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 ") timestamp(ts) partition by DAY";
         CharSequence expectedTail = "invalid type, only [BOOLEAN, SHORT, INT, LONG, LONG256, CHAR, STRING, SYMBOL] are supported in LATEST BY";
         assertFailure(
-                "comprehensive latest by byte",
+                "comprehensive latest on ts partition by byte",
                 createTableDDL,
-                24,
+                40,
                 "byte (BYTE): " + expectedTail);
         for (String[] nameType : new String[][]{
                 {"date", "DATE"},
@@ -4530,9 +4535,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 {"binary", "BINARY"},
                 {"ts", "TIMESTAMP"}}) {
             assertFailure(
-                    "comprehensive latest by " + nameType[0],
+                    "comprehensive latest on ts partition by " + nameType[0],
                     null,
-                    24,
+                    40,
                     String.format("%s (%s): %s", nameType[0], nameType[1], expectedTail));
         }
     }
@@ -4540,6 +4545,68 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     @Test
     public void testLatestByValue() throws Exception {
         // no index
+        assertQuery("a\tb\tk\n" +
+                        "65.08594025855301\tHNR\t1970-01-02T03:46:40.000000Z\n",
+                "select * from x where b = 'HNR' latest on k partition by b",
+                "create table x as " +
+                        "(" +
+                        "select " +
+                        " rnd_double(0)*100 a," +
+                        " rnd_str(2,4,4) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from" +
+                        " long_sequence(20)" +
+                        ") timestamp(k) partition by DAY",
+                "k",
+                "insert into x select * from (" +
+                        "select" +
+                        " rnd_double(0)*100," +
+                        " 'HNR'," +
+                        " to_timestamp('1971', 'yyyy') t" +
+                        " from long_sequence(1)" +
+                        ") timestamp(t)",
+                "a\tb\tk\n" +
+                        "34.56897991538844\tHNR\t1971-01-01T00:00:00.000000Z\n",
+                true,
+                true,
+                false,
+                true);
+    }
+
+    @Test
+    public void testLatestByDeprecated() throws Exception {
+        assertQuery("a\tb\tk\n" +
+                        "28.45577791213847\tHNR\t1970-01-02T03:46:40.000000Z\n" +
+                        "88.99286912289664\tABC\t1970-01-05T15:06:40.000000Z\n",
+                "select * from x latest by b",
+                "create table x as " +
+                        "(" +
+                        "select " +
+                        " rnd_double(0)*100 a," +
+                        " rnd_str('ABC','HNR') b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from" +
+                        " long_sequence(5)" +
+                        ") timestamp(k) partition by DAY",
+                "k",
+                "insert into x select * from (" +
+                        "select" +
+                        " rnd_double(0)*100," +
+                        " 'HNR'," +
+                        " to_timestamp('1971', 'yyyy') t" +
+                        " from long_sequence(1)" +
+                        ") timestamp(t)",
+                "a\tb\tk\n" +
+                        "88.99286912289664\tABC\t1970-01-05T15:06:40.000000Z\n" +
+                        "11.427984775756228\tHNR\t1971-01-01T00:00:00.000000Z\n",
+                true,
+                true,
+                false,
+                true);
+    }
+
+    @Test
+    public void testLatestByDeprecatedFiltered() throws Exception {
         assertQuery("a\tb\tk\n" +
                         "65.08594025855301\tHNR\t1970-01-02T03:46:40.000000Z\n",
                 "select * from x latest by b where b = 'HNR'",
@@ -6994,8 +7061,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
-                    "select metric, sum(value) from x latest by node \n" +
-                            "where node in ('node1', 'node2') and metric in ('cpu')",
+                    "select metric, sum(value) from x \n" +
+                            "where node in ('node1', 'node2') and metric in ('cpu') \n" +
+                            "latest on ts partition by node",
                     sink,
                     "metric\tsum\n" +
                             "cpu\t175\n"
@@ -7023,44 +7091,44 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             executeInsert("insert into tab values ('d2', 'c1', 401.2, '2021-10-06T12:31:35.878Z')");
             executeInsert("insert into tab values ('d2', 'c1', 111.7, '2021-10-06T15:31:35.878Z')");
             assertSql(
-                    "tab latest by id, name where id = 'd1'",
+                    "tab where id = 'd1' latest on ts partition by id, name",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc1\t101.4\t2021-10-05T14:31:35.878000Z\n" +
                             "d1\tc2\t102.5\t2021-10-05T15:31:35.878000Z\n");
             assertSql(
-                    "tab latest by id, name where id != 'd2' and value < 102.5",
+                    "tab where id != 'd2' and value < 102.5 latest on ts partition by id, name",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc1\t101.4\t2021-10-05T14:31:35.878000Z\n" +
                             "d1\tc2\t102.4\t2021-10-05T14:31:35.878000Z\n");
             assertSql(
-                    "tab latest by id, name where name = 'c1'",
+                    "tab where name = 'c1' latest on ts partition by id, name",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc1\t101.4\t2021-10-05T14:31:35.878000Z\n" +
                             "d2\tc1\t111.7\t2021-10-06T15:31:35.878000Z\n");
             assertSql(
-                    "tab latest by id, name where name != 'c2' and value <= 111.7",
+                    "tab where name != 'c2' and value <= 111.7 latest on ts partition by id, name",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc1\t101.4\t2021-10-05T14:31:35.878000Z\n" +
                             "d2\tc1\t111.7\t2021-10-06T15:31:35.878000Z\n");
             // TODO: broken 2,4,5,7
             assertSql(
-                    "tab latest by id where name = 'c2'",
+                    "tab where name = 'c2' latest on ts partition by id",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc2\t102.5\t2021-10-05T15:31:35.878000Z\n" +
                             "d2\tc2\t401.1\t2021-10-06T11:31:35.878000Z\n");
             // TODO: broken 3,4,5,6
             assertSql(
-                    "tab latest by name where id = 'd1'",
+                    "tab where id = 'd1' latest on ts partition by name",
                     "id\tname\tvalue\tts\n" +
                             "d1\tc1\t101.4\t2021-10-05T14:31:35.878000Z\n" +
                             "d1\tc2\t102.5\t2021-10-05T15:31:35.878000Z\n");
             assertSql(
-                    "tab latest by name where id = 'd2'",
+                    "tab where id = 'd2' latest on ts partition by name",
                     "id\tname\tvalue\tts\n" +
                             "d2\tc2\t401.1\t2021-10-06T11:31:35.878000Z\n" +
                             "d2\tc1\t111.7\t2021-10-06T15:31:35.878000Z\n");
             assertSql(
-                    "tab latest by name where id != 'd1'",
+                    "tab where id != 'd1' latest on ts partition by name",
                     "id\tname\tvalue\tts\n" +
                             "d2\tc2\t401.1\t2021-10-06T11:31:35.878000Z\n" +
                             "d2\tc1\t111.7\t2021-10-06T15:31:35.878000Z\n");
@@ -7093,8 +7161,9 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
-                    "select * from x latest by node, metric \n" +
-                            "where node in ('node2') and metric in ('cpu', 'memory')",
+                    "select * from x \n" +
+                            "where node in ('node2') and metric in ('cpu', 'memory') \n" +
+                            "latest on ts partition by node, metric",
                     sink,
                     "ts\tnode\tmetric\tvalue\n" +
                             "2021-11-17T17:35:03.000000Z\tnode2\tcpu\t75\n" +
@@ -7122,21 +7191,21 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
                             "true\t24814\t24814\t7759636733976435003\t0x386129f34be87b5e3990fb6012dac1d3495a30aaa8bf53224e89d27e7ee5104e\tJ\tORANGE\t123\t1970-01-01T00:00:09.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by boolean", ts);
+                    "tab latest on ts partition by boolean", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
                             "false\t14333\t14333\t8260188555232587029\t0x7ee65ec7b6e3bc3a422a8855e9d7bfd29199af5c2aa91ba39c022fa261bdede7\tJ\tCOCO\t123\t1970-01-01T00:00:07.000000Z\n" +
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab timestamp(ts) latest by short", "ts");
+                    "tab latest on ts partition by short", "ts");
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
                             "false\t14333\t14333\t8260188555232587029\t0x7ee65ec7b6e3bc3a422a8855e9d7bfd29199af5c2aa91ba39c022fa261bdede7\tJ\tCOCO\t123\t1970-01-01T00:00:07.000000Z\n" +
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by int", ts);
+                    "tab latest on ts partition by int", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
@@ -7144,7 +7213,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "true\t24814\t24814\t7759636733976435003\t0x386129f34be87b5e3990fb6012dac1d3495a30aaa8bf53224e89d27e7ee5104e\tJ\tORANGE\t123\t1970-01-01T00:00:09.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by long", ts);
+                    "tab latest on ts partition by long", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
@@ -7152,7 +7221,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "true\t24814\t24814\t7759636733976435003\t0x386129f34be87b5e3990fb6012dac1d3495a30aaa8bf53224e89d27e7ee5104e\tJ\tORANGE\t123\t1970-01-01T00:00:09.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by long256", ts);
+                    "tab latest on ts partition by long256", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
@@ -7162,7 +7231,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "true\t24814\t24814\t7759636733976435003\t0x386129f34be87b5e3990fb6012dac1d3495a30aaa8bf53224e89d27e7ee5104e\tJ\tORANGE\t123\t1970-01-01T00:00:09.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by char", ts);
+                    "tab latest on ts partition by char", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
@@ -7170,14 +7239,14 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             "false\t14333\t14333\t8260188555232587029\t0x7ee65ec7b6e3bc3a422a8855e9d7bfd29199af5c2aa91ba39c022fa261bdede7\tJ\tCOCO\t123\t1970-01-01T00:00:07.000000Z\n" +
                             "true\t24814\t24814\t7759636733976435003\t0x386129f34be87b5e3990fb6012dac1d3495a30aaa8bf53224e89d27e7ee5104e\tJ\tORANGE\t123\t1970-01-01T00:00:09.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by string", ts);
+                    "tab latest on ts partition by string", ts);
 
             expectSqlResult(
                     "boolean\tshort\tint\tlong\tlong256\tchar\tstring\tsymbol\tts\n" +
                             "true\t24814\t24814\t3614738589890112276\t0x7ee65ec7b6e3bc3a422a8855e9d7bfd29199af5c2aa91ba39c022fa261bdede7\tJ\t\tXoXoX\t1970-01-01T00:00:04.000000Z\n" +
                             "false\t14817\t14817\t8260188555232587029\t0x4e1c798ce76392e690c6042566c5a1cda5b9a155686af43ac109ac68336ea0c9\tZ\tBANANA\t_(*y*)_\t1970-01-01T00:00:08.000000Z\n" +
                             "false\t24814\t24814\t6404066507400987550\t0x8b04de5aad1f110fdda84f010e21add4b83e6733ca158dd091627fc790e28086\tW\tBANANA\t123\t1970-01-02T00:00:01.000000Z\n",
-                    "tab latest by symbol", ts);
+                    "tab latest on ts partition by symbol", ts);
         });
     }
 }

--- a/core/src/test/java/io/questdb/griffin/TruncateTest.java
+++ b/core/src/test/java/io/questdb/griffin/TruncateTest.java
@@ -409,7 +409,7 @@ public class TruncateTest extends AbstractGriffinTest {
 
     @Test
     public void testDropTableWithCachedPlanLatestBy() throws Exception {
-        testDropTableWithCachedPlan("select * from y latest by symbol1");
+        testDropTableWithCachedPlan("select * from y latest on timestamp partition by symbol1");
     }
 
     private void testDropTableWithCachedPlan(String query) throws Exception {

--- a/core/src/test/java/io/questdb/griffin/WithClauseTest.java
+++ b/core/src/test/java/io/questdb/griffin/WithClauseTest.java
@@ -42,12 +42,12 @@ public class WithClauseTest extends AbstractGriffinTest {
 
             // this is deliberately shuffled column in select to check that correct metadata is used on filtering
             // latest by queries
-            String expected = select("select groupId, _id, contactid, timestamp, _id from contact_events2 latest by _id where groupId = 'g1' order by timestamp");
+            String expected = select("select groupId, _id, contactid, timestamp, _id from contact_events2 where groupId = 'g1' latest on timestamp partition by _id order by timestamp");
             Assert.assertTrue(expected.length() > 100);
 
             assertQuery(expected,
                     "with eventlist as (\n" +
-                            "    select * from contact_events2 latest by _id where groupId = 'g1' order by timestamp\n" +
+                            "    select * from contact_events2 where groupId = 'g1' latest on timestamp partition by _id order by timestamp\n" +
                             ")\n" +
                             "select groupId, _id, contactid, timestamp, _id from eventlist where groupId = 'g1' \n",
                     "timestamp", true, false, true);

--- a/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
@@ -427,11 +427,11 @@ public class SampleByTest extends AbstractGriffinTest {
                         "XY\t1\n" +
                         "ZP\t1\n" +
                         "\t1\n",
-                "select c, count() from (x latest by c)",
+                "select c, count() from (x latest on ts partition by c)",
                 "create table x as " +
                         "(" +
                         "select" +
-                        " x," +
+                        " cast(x as timestamp) ts," +
                         " rnd_symbol('XY','ZP', null, 'UU') c" +
                         " from" +
                         " long_sequence(20)" +
@@ -439,7 +439,7 @@ public class SampleByTest extends AbstractGriffinTest {
                 null,
                 "insert into x select * from (" +
                         "select" +
-                        " x," +
+                        " cast(x+20 as timestamp) ts," +
                         " rnd_symbol('KK', 'PL') c" +
                         " from" +
                         " long_sequence(5)" +
@@ -3030,7 +3030,7 @@ public class SampleByTest extends AbstractGriffinTest {
                         "PEHN\tNaN\t1970-01-03T08:24:00.000000Z\n" +
                         "HYRX\tNaN\t1970-01-03T08:24:00.000000Z\n",
 
-                "select b, count(), k from (x latest by b) sample by 3h fill(linear)",
+                "select b, count(), k from (x latest on k partition by b) sample by 3h fill(linear)",
                 "create table x as " +
                         "(" +
                         "select" +
@@ -8051,8 +8051,7 @@ public class SampleByTest extends AbstractGriffinTest {
                         "VTJW\t20.56\t1970-01-03T17:00:00.000000Z\n" +
                         "PEHN\t20.56\t1970-01-03T17:00:00.000000Z\n" +
                         "\t40.455469747939254\t1970-01-03T17:00:00.000000Z\n",
-                "select b, sum(a), k from (x latest by b) sample by 3h fill(20.56)",
-//                "(x latest by b)",
+                "select b, sum(a), k from (x latest on k partition by b) sample by 3h fill(20.56)",
                 "create table x as " +
                         "(" +
                         "select" +


### PR DESCRIPTION
Refs #1553 - the next step would be to fix all of the ignored tests for latest by that we have in `SqlCodeGeneratorTest`

Adds support for new latest by syntax:
```
select * from tab where x > 0 latest on timestamp partition by y
```

Note that support for the `start at`/`end at` clauses is not included. As suggested in the original GH issue, users should define the timestamp filter in where clause.

Support for the old latest by syntax is kept for backward-compatibility purposes, yet it should be marked as deprecated.