### PR TITLE
chore(ilp): load test

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -36,6 +36,7 @@ import io.questdb.std.str.FloatingDirectCharSink;
 import io.questdb.std.str.StringSink;
 
 import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.questdb.cutlass.line.tcp.LineTcpParser.ENTITY_TYPE_NULL;
 
@@ -51,6 +52,9 @@ class LineTcpMeasurementEvent implements Closeable {
     private int reshuffleTargetWorkerId;
     private volatile boolean reshuffleComplete;
     private boolean commitOnWriterClose;
+
+    private static final AtomicInteger readCount = new AtomicInteger();
+    private static final AtomicInteger writeCount = new AtomicInteger();
 
     LineTcpMeasurementEvent(
             long bufLo,
@@ -100,6 +104,7 @@ class LineTcpMeasurementEvent implements Closeable {
     }
 
     void append(StringSink charSink, FloatingDirectCharSink floatingCharSink) {
+        LOG.info().$(writeCount.incrementAndGet()).$();
         TableWriter.Row row = null;
         try {
             TableWriter writer = tableUpdateDetails.getWriter();
@@ -428,6 +433,7 @@ class LineTcpMeasurementEvent implements Closeable {
             FloatingDirectCharSink floatingCharSink,
             int workerId
     ) {
+        //LOG.info().$("read: ").$(readCount.incrementAndGet()).$();
         writerWorkerId = LineTcpMeasurementEventType.ALL_WRITERS_INCOMPLETE_EVENT;
         final TableUpdateDetails.ThreadLocalDetails localDetails = tableUpdateDetails.getThreadLocalDetails(workerId);
         final BoolList processedCols = localDetails.getProcessedCols();

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
@@ -48,11 +48,8 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
 public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
-    public static final int WAIT_NO_WAIT = 0x0;
-    public static final int WAIT_ENGINE_TABLE_RELEASE = 0x1;
-    public static final int WAIT_ILP_TABLE_RELEASE = 0x2;
-    public static final int WAIT_ALTER_TABLE_RELEASE = 0x4;
     private final static Log LOG = LogFactory.getLog(AlterTableLineTcpReceiverTest.class);
+
     private final SCSequence scSequence = new SCSequence();
     private SqlException sqlException;
     private volatile QueryFuture alterCommandQueryFuture;
@@ -284,9 +281,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     private void assertTable(CharSequence expected) {
-        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "plug")) {
-            assertCursorTwoPass(expected, reader.getCursor(), reader.getMetadata());
-        }
+        assertTable(expected, "plug");
     }
 
     private QueryFuture executeAlterSql(String sql) throws SqlException {
@@ -328,7 +323,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         if (alterTableCommand != null && (wait & WAIT_ALTER_TABLE_RELEASE) != 0) {
             new Thread(() -> {
-                // Wait in parallel thead
+                // Wait in parallel thread
                 try {
                     startBarrier.await();
                     LOG.info().$("Busy waiting for writer ASYNC event ").$(alterCommandQueryFuture).$();
@@ -420,10 +415,5 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             }
         }
         return null;
-    }
-
-    @FunctionalInterface
-    public interface LineTcpServerAwareContext {
-        void run(LineTcpReceiver receiver);
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverLoadTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverLoadTest.java
@@ -99,7 +99,6 @@ public class LineTcpReceiverLoadTest extends AbstractLineTcpReceiverTest {
                         }
                     }).start();
                 }
-                LOG.info().$("sds").$();
                 threadPushFinished.await();
 
                 for (int i = 0; i < numOfTables; i++) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverLoadTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverLoadTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line.tcp;
+
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableReaderMetadata;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.pool.PoolListener;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cutlass.line.tcp.fuzzer.LineData;
+import io.questdb.cutlass.line.tcp.fuzzer.TableData;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.mp.SOCountDownLatch;
+import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.std.*;
+import org.junit.*;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class LineTcpReceiverLoadTest extends AbstractLineTcpReceiverTest {
+    private static final Log LOG = LogFactory.getLog(LineTcpReceiverLoadTest.class);
+    private static final Rnd random = new Rnd();
+
+    private final AtomicLong timestampMillis = new AtomicLong(1465839830102300L);
+
+    private final int numOfLines = 10000;
+    private final int numOfIterations = 10;
+    private final int numOfThreads = 10;
+    private final int numOfTables = 10;
+
+    private final SOCountDownLatch threadPushFinished = new SOCountDownLatch(numOfThreads - 1);
+
+    private final String[] colNameBases = new String[] {"location", "temperature"};
+    private final String[] colValueBases = new String[] {"us-midwest", "8"};
+    private final CharSequenceObjHashMap<TableData> tables = new CharSequenceObjHashMap<>();
+
+    @Test
+    public void testLoad() throws Exception {
+        runInContext(receiver -> {
+            for (int i = 0; i < numOfTables; i++) {
+                final CharSequence tableName = getTableName(i);
+                tables.put(tableName, new TableData(tableName));
+            }
+
+            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                    final TableData table  = tables.get(name);
+                    if (!table.isChecked()) {
+                        checkTableReady(table);
+                    } else {
+                        table.setChecked(false);
+                    }
+                }
+            });
+
+            try {
+                for (int i = 0; i < numOfThreads; i++) {
+                    new Thread(() -> {
+                        final StringBuilder sb = new StringBuilder();
+                        try {
+                            for (int n = 0; n < numOfIterations; n++) {
+                                sb.setLength(0);
+                                for (int j = 0; j < numOfLines; j++) {
+                                    final TableData table = pickTable();
+                                    final CharSequence tableName = table.getName();
+                                    final LineData line = generateLine();
+                                    table.addLine(line);
+                                    sb.append(line.toLine(tableName));
+                                }
+                                send(receiver, sb.toString());
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            threadPushFinished.countDown();
+                        }
+                    }).start();
+                }
+                LOG.info().$("sds").$();
+                threadPushFinished.await();
+
+                for (int i = 0; i < numOfTables; i++) {
+                    final CharSequence tableName = getTableName(i);
+                    final TableData table = tables.get(tableName);
+                    table.await();
+                    assertTable(table);
+                }
+            } finally {
+                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {});
+            }
+        });
+    }
+
+    protected void checkTableReady(TableData table) {
+        if (threadPushFinished.getCount() > 0) {
+            // we are still sending, no point to check the table yet
+            return;
+        }
+        try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, table.getName(), "checkTableReady")) {
+            LOG.info().$("table.getName(): ").$(table.getName()).$(", table.size(): ").$(table.size()).$(", writer.size(): ").$(writer.size()).$();
+            table.setReady(writer);
+            table.setChecked(true);
+        }
+    }
+
+    protected void assertTable(TableData table) {
+        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, table.getName())) {
+            final TableReaderMetadata metadata = reader.getMetadata();
+            assertCursorTwoPass(table.generateRows(metadata), reader.getCursor(), metadata);
+        }
+    }
+
+    private TableData pickTable() {
+        return tables.get(getTableName(random.nextInt(numOfTables)));
+    }
+
+    private CharSequence getTableName(int tableIndex) {
+        return "weather" + tableIndex;
+    }
+
+    private LineData generateLine() {
+        final LineData line = new LineData(timestampMillis.incrementAndGet());
+        for (int j = 0; j < colNameBases.length; j++) {
+            final CharSequence colName = colNameBases[j];
+            final CharSequence colValue = colValueBases[j] + (j == 1 ? random.nextInt(9) + ".0" : "");
+            line.add(colName, colValue);
+        }
+        return line;
+    }
+
+    private void send(LineTcpReceiver receiver, String lineData) {
+        LOG.info().$("ilp:\n").$(lineData).$();
+        send(receiver, null, WAIT_NO_WAIT, () -> sendToSocket(lineData, false));
+    }
+
+    @Override
+    protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
+        return new WorkerPoolConfiguration() {
+            private final int[] affinity = {-1, -1, -1, -1};
+
+            @Override
+            public int[] getWorkerAffinity() {
+                return affinity;
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+
+            @Override
+            public boolean haltOnError() {
+                return true;
+            }
+        };
+    }
+}

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/fuzzer/LineData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/fuzzer/LineData.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line.tcp.fuzzer;
+
+import io.questdb.std.CharSequenceObjHashMap;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.str.StringSink;
+
+public class LineData {
+    // colName/value pairs for each line
+    // colName can be different to real colName (dupes, uppercase, etc...)
+    private final long timestampNanos;
+    private final ObjList<CharSequence> colNames = new ObjList<>();
+    private final CharSequenceObjHashMap<CharSequence> colValues = new CharSequenceObjHashMap<>();
+
+    public LineData(long timestampMicros) {
+        timestampNanos = timestampMicros * 1000;
+        final StringSink timestampSink = new StringSink();
+        TimestampFormatUtils.appendDateTimeUSec(timestampSink, timestampMicros);
+        add("timestamp", timestampSink);
+    }
+
+    public long getTimestamp() {
+        return timestampNanos;
+    }
+
+    public void add(CharSequence colName, CharSequence colValue) {
+        colNames.add(colName);
+        colValues.put(colName, colValue);
+    }
+
+    public String toLine(final CharSequence tableName) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(tableName).append(" ");
+        return toString(sb).append("\n").toString();
+    }
+
+    StringBuilder toString(final StringBuilder sb) {
+        for (int i = 0, n = colNames.size(); i < n; i++) {
+            final CharSequence colName = colNames.get(i);
+            if (colName.equals("timestamp")) {
+                continue;
+            }
+            sb.append(colName).append("=").append(colValues.get(colName)).append(i == n - 1 ? "" : ",");
+        }
+        return sb.append(" ").append(timestampNanos);
+    }
+
+    CharSequence getRow(ObjList<CharSequence> columns) {
+        // work out duplicated/missing/extra columns while building the row
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0, n = columns.size(); i < n; i++) {
+            final CharSequence colName = columns.get(i);
+            sb.append(colValues.get(colName)).append(i == n - 1 ? "\n" : "\t");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toString(new StringBuilder()).toString();
+    }
+}

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/fuzzer/TableData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/fuzzer/TableData.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line.tcp.fuzzer;
+
+import io.questdb.cairo.TableReaderMetadata;
+import io.questdb.cairo.TableWriter;
+import io.questdb.std.IntLongPriorityQueue;
+import io.questdb.std.ObjList;
+
+import java.util.concurrent.locks.LockSupport;
+
+public class TableData {
+    private final CharSequence tableName;
+    private final ObjList<LineData> rows = new ObjList<>();
+    private final IntLongPriorityQueue index = new IntLongPriorityQueue();
+
+    private volatile boolean ready = false;
+    private volatile boolean checked = false;
+
+    public TableData(CharSequence tableName) {
+        this.tableName = tableName;
+    }
+
+    public CharSequence getName() {
+        return tableName;
+    }
+
+    public void setReady(TableWriter writer) {
+        ready = size() <= writer.size();
+    }
+
+    public void await() {
+        while (!ready) {
+            LockSupport.parkNanos(10);
+        }
+    }
+
+    public boolean isChecked() {
+        return checked;
+    }
+
+    public void setChecked(boolean checked) {
+        this.checked = checked;
+    }
+
+    public synchronized int size() {
+        return rows.size();
+    }
+
+    public synchronized void addLine(LineData line) {
+        rows.add(line);
+        index.add(rows.size() - 1, line.getTimestamp());
+    }
+
+    public synchronized CharSequence generateRows(TableReaderMetadata metadata) {
+        final StringBuilder sb = new StringBuilder();
+        final ObjList<CharSequence> columns = new ObjList<>();
+        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
+            CharSequence column = metadata.getColumnQuick(i).getName();
+            columns.add(column);
+            sb.append(column).append( i == n-1 ? "\n" : "\t");
+        }
+        for (int i = 0, n = rows.size(); i < n; i++) {
+            sb.append(rows.get(index.popIndex()).getRow(columns));
+            index.popValue();
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public synchronized String toString() {
+        return "[" + tableName + ":" + rows + "]";
+    }
+}


### PR DESCRIPTION
Load test for ILP.
The test generates an arbitrary number of lines and ingests them in batches.
Ingestion uses multiple threads to simulate different clients ingesting parallel.
Tables are randomly picked for each line.
Each line has a unique timestamp.

Parameters are in LineTcpReceiverLoadTest:
```
    private final int numOfLines = 10000;
    private final int numOfIterations = 10;
    private final int numOfThreads = 10;
    private final int numOfTables = 10;
```
Observed a number of different issues while testing, hence PR is in draft mode.
Also left some debug lines in LineTcpMeasurementEvent which should not be merged at the end.
Those lines were left in the PR intentionally, wanted to push the exact same code I used to test.
Just in case if the extra logging does anything to do with observing the crashes, exceptions.

**Issue 1: Handling of index during O3 commit**
```
2022-01-04T16:37:32.368745Z I i.q.c.TableWriter sorting o3 [table=weather5]
2022-01-04T16:37:32.368755Z I i.q.c.TableWriter sorted [table=weather5]
2022-01-04T16:37:32.368975Z E i.q.c.TableWriter 
java.lang.AssertionError
	at io.questdb.cairo.O3PartitionJob.createMergeIndex(O3PartitionJob.java:603)
	at io.questdb.cairo.O3PartitionJob.publishOpenColumnTasks(O3PartitionJob.java:743)
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:498)
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:568)
	at io.questdb.cairo.TableWriter.o3ProcessPartitionSafe(TableWriter.java:3391)
	at io.questdb.cairo.TableWriter.o3ConsumePartitionUpdates(TableWriter.java:2955)
	at io.questdb.cairo.TableWriter.o3Commit(TableWriter.java:2782)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:1855)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:688)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:684)
	at io.questdb.cutlass.line.tcp.TableUpdateDetails.handleWriterThreadMaintenance(TableUpdateDetails.java:228)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.doMaintenance(LineTcpWriterJob.java:104)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:90)
	at io.questdb.mp.Worker.run(Worker.java:111)
```
[Issue1.log](https://github.com/questdb/questdb/files/7809538/Issue1.log)

**Issue 2: O3 merge failure followed by a crash**
```
2022-01-04T16:36:32.644862Z I i.q.c.TableWriter sorted [table=weather2]
2022-01-04T16:36:32.644938Z E i.q.c.O3PartitionJob process existing partition error [table=weather2, e=
java.lang.AssertionError
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:295)
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:568)
	at io.questdb.cairo.TableWriter.o3ProcessPartitionSafe(TableWriter.java:3391)
	at io.questdb.cairo.TableWriter.o3ConsumePartitionUpdates(TableWriter.java:2955)
	at io.questdb.cairo.TableWriter.o3Commit(TableWriter.java:2782)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:1855)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:688)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:684)
	at io.questdb.cutlass.line.tcp.TableUpdateDetails.handleWriterThreadMaintenance(TableUpdateDetails.java:228)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.doMaintenance(LineTcpWriterJob.java:104)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:90)
	at io.questdb.mp.Worker.run(Worker.java:111)
]
...
2022-01-04T16:36:32.656526Z I i.q.c.O3PurgeDiscoveryJob processing [table=weather2, ts=2016-06-13T00:00:00.000000Z]
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000011595a49c, pid=42323, tid=33283
```
[Issue2.log](https://github.com/questdb/questdb/files/7809541/Issue2.log)
[Issue2_hs_err_pid42323.log](https://github.com/questdb/questdb/files/7809542/Issue2_hs_err_pid42323.log)

**Issue 3: O3 merge fix column error**
```
2022-01-04T15:17:47.674877Z I i.q.c.TableWriter sorting o3 [table=weather2]
2022-01-04T15:17:47.674882Z I i.q.c.TableWriter sorted [table=weather2]
2022-01-04T15:17:47.675075Z I i.q.c.TableWriter sorting o3 [table=weather3]
2022-01-04T15:17:47.675081Z I i.q.c.TableWriter sorted [table=weather3]
2022-01-04T15:17:47.675212Z I i.q.c.TableWriter closing last partition [table=weather2]
2022-01-04T15:17:47.675366Z I i.q.c.TableWriter merged partition [table=`weather2`, ts=2016-06-13T00:00:00.000000Z, txn=357]
2022-01-04T15:17:47.676282Z E i.q.c.O3OpenColumnJob merge fix error [table=weather2, e=
io.questdb.cairo.CairoException: [9] No space left [size=294896, fd=1]
]
2022-01-04T15:17:47.676392Z E i.q.c.O3OpenColumnJob merge fix error [table=weather2, e=
io.questdb.cairo.CairoException: [9] No space left [size=589792, fd=1]
]
2022-01-04T15:17:47.676682Z E i.q.c.O3OpenColumnJob merge fix error [table=weather2, e=
io.questdb.cairo.CairoException: [9] No space left [size=589792, fd=1]
]
2022-01-04T15:17:47.677239Z I i.q.c.TableWriter closing last partition [table=weather3]
2022-01-04T15:17:47.677339Z I i.q.c.TableWriter merged partition [table=`weather3`, ts=2016-06-13T00:00:00.000000Z, txn=374]
2022-01-04T15:17:47.677454Z I i.q.c.TableWriter switched partition [path='/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit14426361183120481984/dbRoot/weather3/2016-06-13.374']
2022-01-04T15:17:47.678935Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit14426361183120481984/dbRoot/weather3/2016-06-13.373/, readerTxn=0, readerTxnCount=0]
2022-01-04T15:17:47.679670Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit14426361183120481984/dbRoot/weather2/2016-06-13.355/, readerTxn=0, readerTxnCount=0]
2022-01-04T15:17:47.682047Z E i.q.c.TableWriter 
java.lang.IllegalStateException: fd 1 is already closed!
	at io.questdb.std.Files.auditClose(Files.java:61)
	at io.questdb.std.Files.close(Files.java:94)
	at io.questdb.std.FilesFacadeImpl.close(FilesFacadeImpl.java:44)
	at io.questdb.cairo.O3Utils.close(O3Utils.java:104)
	at io.questdb.cairo.O3Utils.unmapAndClose(O3Utils.java:92)
	at io.questdb.cairo.O3OpenColumnJob.mergeFixColumn(O3OpenColumnJob.java:1847)
	at io.questdb.cairo.O3OpenColumnJob.mergeLastPartition(O3OpenColumnJob.java:1451)
	at io.questdb.cairo.O3OpenColumnJob.openColumn(O3OpenColumnJob.java:371)
	at io.questdb.cairo.O3OpenColumnJob.openColumn(O3OpenColumnJob.java:208)
	at io.questdb.cairo.TableWriter.o3OpenColumnSafe(TableWriter.java:3231)
	at io.questdb.cairo.TableWriter.o3ConsumePartitionUpdates(TableWriter.java:2974)
	at io.questdb.cairo.TableWriter.o3Commit(TableWriter.java:2782)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:1855)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:688)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:684)
	at io.questdb.cutlass.line.tcp.TableUpdateDetails.handleWriterThreadMaintenance(TableUpdateDetails.java:228)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.doMaintenance(LineTcpWriterJob.java:104)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:90)
	at io.questdb.mp.Worker.run(Worker.java:111)
```
[Issue3.log](https://github.com/questdb/questdb/files/7809543/Issue3.log)

**Issue 4: O3 is trying to close a file which has already been closed**
```
2022-01-04T14:46:14.908706Z I i.q.c.TableWriter sorting o3 [table=weather5]
2022-01-04T14:46:14.908708Z I i.q.c.TableWriter sorted [table=weather5]
2022-01-04T14:46:14.908930Z I i.q.c.TableWriter closing last partition [table=weather5]
2022-01-04T14:46:14.909044Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather4/2016-06-13.308/, readerTxn=0, readerTxnCount=0]
2022-01-04T14:46:14.909068Z I i.q.c.TableWriter sorting o3 [table=weather2]
2022-01-04T14:46:14.909070Z I i.q.c.TableWriter sorted [table=weather2]
2022-01-04T14:46:14.909101Z I i.q.c.TableWriter merged partition [table=`weather5`, ts=2016-06-13T00:00:00.000000Z, txn=316]
2022-01-04T14:46:14.911792Z I i.q.c.TableWriter closing last partition [table=weather9]
2022-01-04T14:46:14.911908Z E i.q.c.O3PartitionJob process existing partition error [table=weather5, e=
io.questdb.cairo.CairoException: [9] No space left [size=508296, fd=-1]
]
2022-01-04T14:46:14.912053Z I i.q.c.TableWriter merged partition [table=`weather9`, ts=2016-06-13T00:00:00.000000Z, txn=309]
2022-01-04T14:46:14.912202Z I i.q.c.TableWriter switched partition [path='/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather5/2016-06-13.316']
2022-01-04T14:46:14.912244Z I i.q.c.TableWriter switched partition [path='/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather9/2016-06-13.309']
2022-01-04T14:46:14.912354Z I i.q.c.TableWriter closing last partition [table=weather2]
2022-01-04T14:46:14.912638Z I i.q.c.TableWriter merged partition [table=`weather2`, ts=2016-06-13T00:00:00.000000Z, txn=311]
2022-01-04T14:46:14.912748Z I i.q.c.TableWriter switched partition [path='/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather2/2016-06-13.311']
2022-01-04T14:46:14.912777Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather5/2016-06-13.315/, readerTxn=0, readerTxnCount=0]
2022-01-04T14:46:14.912800Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather9/2016-06-13.308/, readerTxn=0, readerTxnCount=0]
2022-01-04T14:46:14.913068Z I i.q.c.TableWriter purged [path=/var/folders/ds/mflhl4j12vvccsw9n4y2m_vw0000gn/T/junit6987653982164158006/dbRoot/weather2/2016-06-13.310/, readerTxn=0, readerTxnCount=0]
2022-01-04T14:46:14.915444Z E i.q.c.TableWriter 
java.lang.IllegalStateException: fd 1 is already closed!
	at io.questdb.std.Files.auditClose(Files.java:61)
	at io.questdb.std.Files.close(Files.java:94)
	at io.questdb.std.FilesFacadeImpl.close(FilesFacadeImpl.java:44)
	at io.questdb.cairo.O3Utils.close(O3Utils.java:104)
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:486)
	at io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:568)
	at io.questdb.cairo.TableWriter.o3ProcessPartitionSafe(TableWriter.java:3391)
	at io.questdb.cairo.TableWriter.o3ConsumePartitionUpdates(TableWriter.java:2955)
	at io.questdb.cairo.TableWriter.o3Commit(TableWriter.java:2782)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:1855)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:688)
	at io.questdb.cairo.TableWriter.commit(TableWriter.java:684)
	at io.questdb.cutlass.line.tcp.TableUpdateDetails.handleWriterThreadMaintenance(TableUpdateDetails.java:228)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.doMaintenance(LineTcpWriterJob.java:104)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:90)
	at io.questdb.mp.Worker.run(Worker.java:111)
```
[Issue4.log](https://github.com/questdb/questdb/files/7809544/Issue4.log)

**Issue 5: TableWriter is trying to close already closed file**
```
2022-01-04T14:41:54.488998Z I i.q.c.TableWriter switched to o3 [table=weather5]
2022-01-04T14:41:54.489046Z I i.q.c.TableWriter sorting o3 [table=weather5]
2022-01-04T14:41:54.489050Z I i.q.c.TableWriter sorted [table=weather5]
2022-01-04T14:41:54.490938Z E i.q.c.l.t.AbstractLineTcpReceiverTest unhandled error [job=io.questdb.cutlass.line.tcp.LineTcpWriterJob@5c7810e4, ex=
java.lang.IllegalStateException: fd 61 is already closed!
	at io.questdb.std.Files.auditClose(Files.java:61)
	at io.questdb.std.Files.close(Files.java:94)
	at io.questdb.std.FilesFacadeImpl.close(FilesFacadeImpl.java:44)
	at io.questdb.cairo.vm.Vm.bestEffortClose(Vm.java:45)
	at io.questdb.cairo.vm.MemoryCMARWImpl.close(MemoryCMARWImpl.java:164)
	at io.questdb.cairo.vm.MemoryCMARWImpl.close(MemoryCMARWImpl.java:196)
	at io.questdb.std.Misc.free(Misc.java:45)
	at io.questdb.cairo.BitmapIndexWriter.close(BitmapIndexWriter.java:143)
	at io.questdb.std.Misc.free(Misc.java:45)
	at io.questdb.cairo.SymbolMapWriter.close(SymbolMapWriter.java:186)
	at io.questdb.std.Misc.free(Misc.java:45)
	at io.questdb.cairo.TableWriter.freeSymbolMapWriters(TableWriter.java:2257)
	at io.questdb.cairo.TableWriter.doClose(TableWriter.java:2173)
	at io.questdb.cairo.TableWriter.close(TableWriter.java:679)
	at io.questdb.cairo.pool.WriterPool.closeWriter(WriterPool.java:391)
	at io.questdb.cairo.pool.WriterPool.returnToPool(WriterPool.java:477)
	at io.questdb.cairo.pool.WriterPool$Entry.close(WriterPool.java:524)
	at io.questdb.cairo.TableWriter.close(TableWriter.java:678)
	at io.questdb.std.Misc.free(Misc.java:45)
	at io.questdb.cutlass.line.tcp.TableUpdateDetails.handleWriterThreadMaintenance(TableUpdateDetails.java:231)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.doMaintenance(LineTcpWriterJob.java:104)
	at io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:90)
	at io.questdb.mp.Worker.run(Worker.java:111)
]
```
[Issue5.log](https://github.com/questdb/questdb/files/7809546/Issue5.log)
