### PR TITLE
fix(cairo): fix reader and txn scoreboard leak

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -1167,11 +1167,16 @@ public class TableReader implements Closeable, SymbolTableSource {
 
         // reload tx file, this will update the versions
         if (this.readTxnSlow()) {
-            reloadStruct(prevStructVersion);
-            // partition reload will apply truncate if necessary
-            // applyTruncate for non-partitioned tables only
-            reconcileOpenPartitions(prevPartitionVersion);
-            return true;
+            try {
+                reloadStruct(prevStructVersion);
+                // partition reload will apply truncate if necessary
+                // applyTruncate for non-partitioned tables only
+                reconcileOpenPartitions(prevPartitionVersion);
+                return true;
+            } catch (Throwable e) {
+                txnScoreboard.releaseTxn(txn);
+                throw e;
+            }
         }
 
         return false;

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -91,7 +91,12 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
                         e.readers[i] = r;
                         notifyListener(thread, name, PoolListener.EV_CREATE, e.index, i);
                     } else {
-                        r.goActive();
+                        try {
+                            r.goActive();
+                        } catch (Throwable ex) {
+                            r.close();
+                            throw ex;
+                        }
                         notifyListener(thread, name, PoolListener.EV_GET, e.index, i);
                     }
 


### PR DESCRIPTION
Fix `txn_scoreboard` leak which eventually leads to all SELECT queries being locked with `max txn-inflight limit reached` error.

Problem happens when `TableReader` is taken from the pool, it re-reads transaction and fails to reload partitions. If failure happens at this point scoreboard is not released and reader is kept locked out of the pool.

Failure to release partition structure is quite likely on busy read/write system because of flaw in O3 purge partition logic which to be fixed separately.
