### PR TITLE
fix(cairo): fix o3 partition purge jobs

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PurgeDiscoveryJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PurgeDiscoveryJob.java
@@ -102,56 +102,74 @@ public class O3PurgeDiscoveryJob extends AbstractQueueConsumerJob<O3PurgeDiscove
         if (txnList.size() > 1) {
             txnList.sort();
 
-            for (int i = 0, n = txnList.size() - 1; i < n; i++) {
+            // Find highest version strictly below last commited txn number
+            // This will be the highest partition name number we will try to delete
+            int removeBefore = txnList.binarySearch(mostRecentTxn - 1, BinarySearch.SCAN_UP);
+            if (removeBefore < 0) {
+                removeBefore = -removeBefore - 1;
+            }
+
+            removeBefore = Math.min(removeBefore, txnList.size() - 2);
+            for (int i = 0; i <= removeBefore; i++) {
+                // All readers should be strictly higher than minTxnToExpect
+                // in order to delete partition with nameTxnToRemove suffix
                 final long nameTxnToRemove = txnList.getQuick(i);
-                if (nameTxnToRemove <= mostRecentTxn) {
-                    final long minTxnToExpect = txnList.getQuick(i + 1);
-                    int errno;
-                    if ((errno = O3PurgeJob.purgePartitionDir(
-                            ff,
-                            path.of(root).concat(tableName),
-                            partitionBy,
-                            partitionTimestamp,
-                            txnScoreboard,
-                            nameTxnToRemove,
-                            minTxnToExpect
-                    )) != 0) {
-                        // queue the job
-                        if (purgePubSeq != null) {
-                            long cursor = purgePubSeq.next();
-                            if (cursor > -1) {
+                final long minTxnToExpect = txnList.getQuick(i + 1);
+
+
+                int errno;
+                if ((errno = O3PurgeJob.purgePartitionDir(
+                        ff,
+                        path.of(root).concat(tableName),
+                        partitionBy,
+                        partitionTimestamp,
+                        txnScoreboard,
+                        nameTxnToRemove,
+                        minTxnToExpect
+                )) != 0) {
+                    // queue the job
+                    if (purgePubSeq != null) {
+                        long cursor = purgePubSeq.next();
+                        if (cursor > -1) {
+                            if (errno > 0) {
                                 LOG.error()
                                         .$("queuing [table=").$(tableName)
                                         .$(", ts=").$ts(partitionTimestamp)
                                         .$(", txn=").$(nameTxnToRemove)
                                         .$(", errno=").$(errno)
                                         .$(']').$();
-                                O3PurgeTask task = purgeQueue.get(cursor);
-                                task.of(
-                                        tableName,
-                                        partitionBy,
-                                        txnScoreboard,
-                                        partitionTimestamp,
-                                        nameTxnToRemove,
-                                        minTxnToExpect
-                                );
-                                purgePubSeq.done(cursor);
                             } else {
-                                LOG.error()
-                                        .$("purge queue is full [table=").$(tableName)
+                                LOG.info()
+                                        .$("queuing [table=").$(tableName)
                                         .$(", ts=").$ts(partitionTimestamp)
                                         .$(", txn=").$(nameTxnToRemove)
-                                        .$(", errno=").$(errno)
                                         .$(']').$();
                             }
+                            O3PurgeTask task = purgeQueue.get(cursor);
+                            task.of(
+                                    tableName,
+                                    partitionBy,
+                                    txnScoreboard,
+                                    partitionTimestamp,
+                                    nameTxnToRemove,
+                                    minTxnToExpect
+                            );
+                            purgePubSeq.done(cursor);
                         } else {
                             LOG.error()
-                                    .$("could not purge [table=").$(tableName)
+                                    .$("purge queue is full [table=").$(tableName)
                                     .$(", ts=").$ts(partitionTimestamp)
                                     .$(", txn=").$(nameTxnToRemove)
                                     .$(", errno=").$(errno)
                                     .$(']').$();
                         }
+                    } else {
+                        LOG.error()
+                                .$("could not purge [table=").$(tableName)
+                                .$(", ts=").$ts(partitionTimestamp)
+                                .$(", txn=").$(nameTxnToRemove)
+                                .$(", errno=").$(errno)
+                                .$(']').$();
                     }
                 }
             }

--- a/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableWriter;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
+import io.questdb.std.Os;
 import io.questdb.std.str.Path;
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,6 +76,10 @@ public class O3PartitionPurgeTest extends AbstractGriffinTest {
                 rdr.openPartition(0);
             }
 
+            if (Os.type == Os.WINDOWS) {
+                engine.releaseInactive();
+            }
+
             runPartitionPurgeJobs();
 
             try (Path path = new Path()) {
@@ -107,6 +112,10 @@ public class O3PartitionPurgeTest extends AbstractGriffinTest {
 
                 // This should not fail
                 rdr.openPartition(0);
+            }
+
+            if(Os.type == Os.WINDOWS) {
+                engine.releaseInactive();
             }
 
             runPartitionPurgeJobs();
@@ -153,6 +162,9 @@ public class O3PartitionPurgeTest extends AbstractGriffinTest {
                 reader.openPartition(0);
                 reader.close();
 
+                if (Os.type == Os.WINDOWS) {
+                    engine.releaseInactive();
+                }
                 runPartitionPurgeJobs();
             }
 
@@ -198,11 +210,22 @@ public class O3PartitionPurgeTest extends AbstractGriffinTest {
                 reader.openPartition(0);
                 reader.close();
 
+                // when reader is returned to pool it remains in open state
+                // holding files such that purge fails with access violation
+                if (Os.type == Os.WINDOWS) {
+                    engine.releaseInactive();
+                }
+
                 runPartitionPurgeJobs();
 
                 reader = readers[2 * i + 1];
                 reader.openPartition(0);
                 reader.close();
+                // when reader is returned to pool it remains in open state
+                // holding files such that purge fails with access violation
+                if (Os.type == Os.WINDOWS) {
+                    engine.releaseInactive();
+                }
 
                 runPartitionPurgeJobs();
             }

--- a/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin;
+
+import io.questdb.cairo.TableReader;
+import org.junit.Test;
+
+public class O3PartitionPurgeTest extends AbstractGriffinTest {
+    @Test
+    public void testReaderUsesPartition() throws SqlException {
+        compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
+
+        // OOO insert
+        compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+        // This should lock partition 1970-01-10.1 from being deleted from disk
+        try (TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl")) {
+
+            // in order insert
+            compiler.compile("insert into tbl select 2, '1970-01-10T11'", sqlExecutionContext);
+
+            // OOO insert
+            compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+            // This should not fail
+            rdr.openPartition(0);
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3PartitionPurgeTest.java
@@ -24,28 +24,200 @@
 
 package io.questdb.griffin;
 
+import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
+import io.questdb.std.Chars;
+import io.questdb.std.Files;
+import io.questdb.std.str.Path;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class O3PartitionPurgeTest extends AbstractGriffinTest {
     @Test
-    public void testReaderUsesPartition() throws SqlException {
-        compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
+    public void testManyReadersOpenClosedAscDense() throws Exception {
+        testManyReadersOpenClosedDense(0, 1, 5);
+    }
 
-        // OOO insert
-        compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+    @Test
+    public void testManyReadersOpenClosedAscSparse() throws Exception {
+        testManyReadersOpenClosedSparse(0, 1, 4);
+    }
 
-        // This should lock partition 1970-01-10.1 from being deleted from disk
-        try (TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl")) {
+    @Test
+    public void testManyReadersOpenClosedDescDense() throws Exception {
+        testManyReadersOpenClosedDense(3, -1, 4);
+    }
 
-            // in order insert
-            compiler.compile("insert into tbl select 2, '1970-01-10T11'", sqlExecutionContext);
+    @Test
+    public void testManyReadersOpenClosedDescSparse() throws Exception {
+        testManyReadersOpenClosedSparse(4, -1, 5);
+    }
+
+    @Test
+    public void testReaderUsesPartition() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
 
             // OOO insert
             compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
 
-            // This should not fail
-            rdr.openPartition(0);
+            // This should lock partition 1970-01-10.1 from being deleted from disk
+            try (TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl")) {
+
+                // in order insert
+                compiler.compile("insert into tbl select 2, '1970-01-10T11'", sqlExecutionContext);
+
+                // OOO insert
+                compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+                // This should not fail
+                rdr.openPartition(0);
+            }
+
+            runPartitionPurgeJobs();
+
+            try (Path path = new Path()) {
+                path.concat(engine.getConfiguration().getRoot()).concat("tbl").concat("1970-01-10");
+                int len = path.length();
+                for (int i = 0; i < 3; i++) {
+                    path.trimTo(len).put(".").put(Integer.toString(i)).concat("x.d").$();
+                    Assert.assertFalse(Chars.toString(path), Files.exists(path));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReaderUsesPartitionOfNonO3Commit() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
+
+            // OOO insert
+            compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+            // in order insert
+            compiler.compile("insert into tbl select 2, '1970-01-10T11'", sqlExecutionContext);
+
+            // This should lock partition 1970-01-10.1 from being deleted from disk
+            try (TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl")) {
+
+                // OOO insert
+                compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+                // This should not fail
+                rdr.openPartition(0);
+            }
+
+            runPartitionPurgeJobs();
+
+            try (Path path = new Path()) {
+                path.concat(engine.getConfiguration().getRoot()).concat("tbl").concat("1970-01-10");
+                int len = path.length();
+                for (int i = 0; i < 3; i++) {
+                    path.trimTo(len).put(".").put(Integer.toString(i)).concat("x.d").$();
+                    Assert.assertFalse(Chars.toString(path), Files.exists(path));
+                }
+            }
+        });
+    }
+
+    private void runPartitionPurgeJobs() {
+        try (TableWriter writer = engine.getWriter(sqlExecutionContext.getCairoSecurityContext(), "tbl", "purge tasks")) {
+            PartitionBy.PartitionFloorMethod partitionFloorMethod = PartitionBy.getPartitionFloorMethod(PartitionBy.DAY);
+            assert partitionFloorMethod != null;
+            long lastPartition = partitionFloorMethod.floor(writer.getMaxTimestamp());
+            writer.o3QueuePartitionForPurge(lastPartition, writer.getTxn());
+            writer.consumeO3PartitionRemoveTasks();
         }
+    }
+
+    private void testManyReadersOpenClosedDense(int start, int increment, int iterations) throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
+
+            TableReader[] readers = new TableReader[iterations];
+            for (int i = 0; i < iterations; i++) {
+                TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl");
+                readers[i] = rdr;
+
+                // OOO insert
+                compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+                runPartitionPurgeJobs();
+            }
+
+            // Unwind readers one by one old to new
+            for (int i = start; i >= 0 && i < iterations; i += increment) {
+                TableReader reader = readers[i];
+                reader.openPartition(0);
+                reader.close();
+
+                runPartitionPurgeJobs();
+            }
+
+            try (Path path = new Path()) {
+                path.concat(engine.getConfiguration().getRoot()).concat("tbl").concat("1970-01-10");
+                int len = path.length();
+                for (int i = 0; i < iterations; i++) {
+                    path.trimTo(len).put(".").put(Integer.toString(i)).concat("x.d").$();
+                    Assert.assertFalse(Chars.toString(path), Files.exists(path));
+                }
+
+                path.trimTo(len).put(".").put(Integer.toString(iterations)).concat("x.d").$();
+                Assert.assertTrue(Files.exists(path));
+            }
+        });
+    }
+
+    private void testManyReadersOpenClosedSparse(int start, int increment, int iterations) throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY", sqlExecutionContext);
+            TableReader[] readers = new TableReader[2 * iterations];
+
+            for (int i = 0; i < iterations; i++) {
+                TableReader rdr = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl");
+                readers[2 * i] = rdr;
+
+                // in order insert
+                compiler.compile("insert into tbl select 2, '1970-01-10T11'", sqlExecutionContext);
+
+                runPartitionPurgeJobs();
+
+                TableReader rdr2 = engine.getReader(sqlExecutionContext.getCairoSecurityContext(), "tbl");
+                readers[2 * i + 1] = rdr2;
+                // OOO insert
+                compiler.compile("insert into tbl select 4, '1970-01-10T09'", sqlExecutionContext);
+
+                runPartitionPurgeJobs();
+            }
+
+            // Unwind readers one by in set order
+            for (int i = start; i >= 0 && i < iterations; i += increment) {
+                TableReader reader = readers[2 * i];
+                reader.openPartition(0);
+                reader.close();
+
+                runPartitionPurgeJobs();
+
+                reader = readers[2 * i + 1];
+                reader.openPartition(0);
+                reader.close();
+
+                runPartitionPurgeJobs();
+            }
+
+            try (Path path = new Path()) {
+                path.concat(engine.getConfiguration().getRoot()).concat("tbl").concat("1970-01-10");
+                int len = path.length();
+                for (int i = 0; i < 2 * iterations; i++) {
+                    path.trimTo(len).put(".").put(Integer.toString(i)).concat("x.d").$();
+                    Assert.assertFalse(Chars.toString(path), Files.exists(path));
+                }
+
+                path.trimTo(len).put(".").put(Integer.toString(2 * iterations)).concat("x.d").$();
+                Assert.assertTrue(Files.exists(path));
+            }
+        });
     }
 }


### PR DESCRIPTION
Partition purge jobs did not work properly for cases where not every commit is out of order commit. 

This change will only remove a partition if there are no readers with transaction number below next available partition version. 

It also addresses inconsistency that when reader reads transaction 10 it will look at partition folders .9 and not .10