### PR TITLE
chore: removing "prettier" from "core"

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,2 +1,4 @@
 src/index.hbs
-../core/src/test/
+../core/
+../benchmarks/
+../.*


### PR DESCRIPTION
It is really getting on my nerves:
- slows down commits
- fails unrelated commits
- fails on third-party libraries in `cmake-`
- rewrites test resources
- fails on auto-generated doc in `core/target`

I'm disabling it for `core` entirely