### PR TITLE
chore(ci): check windows binaries for cpp runtime dependency

### DIFF
--- a/ci/cbinary-pipeline.yml
+++ b/ci/cbinary-pipeline.yml
@@ -110,6 +110,12 @@ stages:
             displayName: "Build source-code $(Agent.OS) for Windows"
             condition: eq(variables['Agent.OS'], 'Linux')
 
+          - bash: |
+              x86_64-w64-mingw32-objdump -p core/src/main/resources/io/questdb/bin/windows/libquestdb.dll | grep libstdc++
+              if [ $? -eq 0 ]; then echo "Failure: C++ runtime dependency detected"; exit 1; fi
+            condition: eq(variables['Agent.OS'], 'Linux')
+            displayName: "Check C++ runtime dependency"
+
           - task: S3Upload@1
             inputs:
               awsCredentials: "ondemand-dev"


### PR DESCRIPTION
Windows binary builds with the MinGW tool. 
 It introduces additional runtime dependencies we don't want to deploy.
```
libstdc++-6.dll
libgcc_s_seh-1.dll
libwinpthread-1.dll
```
Currently, `libwinpthread` is unlinked, `libgcc` linked statically. The `libstdc++` cannot be linked statically as it blows up symbols tables. We try to avoid c++ runtime dependency in the source code.  If dependency was accidentally introduced we want to be notified by build pipeline.

This PR introduces a simple check with `objdump` and `grep` tools.