### PR TITLE
fix(core): sleep bug

### DIFF
--- a/core/src/main/java/io/questdb/std/Os.java
+++ b/core/src/main/java/io/questdb/std/Os.java
@@ -134,14 +134,16 @@ public final class Os {
     }
 
     public static void sleep(long millis) {
-        final long t = System.currentTimeMillis();
+        long t = System.currentTimeMillis();
         long deadline = millis;
         while (deadline > 0) {
             try {
                 Thread.sleep(deadline);
                 break;
             } catch (InterruptedException e) {
-                deadline = System.currentTimeMillis() - t;
+                long t2 = System.currentTimeMillis();
+                deadline -= t2 - t;
+                t = t2;
             }
         }
     }

--- a/core/src/test/java/io/questdb/std/OsTest.java
+++ b/core/src/test/java/io/questdb/std/OsTest.java
@@ -24,14 +24,13 @@
 
 package io.questdb.std;
 
-import io.questdb.log.Log;
-import io.questdb.log.LogFactory;
+import io.questdb.mp.SOCountDownLatch;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -71,5 +70,24 @@ public class OsTest {
         Assert.assertTrue(actual > 0);
         long delta = actual / 1_000_000 - reference;
         Assert.assertTrue(delta < 200);
+    }
+
+    @Test
+    public void testSleepEnds() {
+        SOCountDownLatch doneLatch = new SOCountDownLatch(1);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        Thread t = new Thread(() -> {
+            TestUtils.await(barrier);
+            Os.sleep(1000);
+            doneLatch.countDown();
+        });
+
+        long time = System.currentTimeMillis();
+        t.start();
+
+        TestUtils.await(barrier);
+        t.interrupt();
+        Assert.assertTrue(doneLatch.await(10_000_000_000L));
+        Assert.assertTrue(System.currentTimeMillis() - time > 1000);
     }
 }


### PR DESCRIPTION
While looking at newly flapped test `testAlterTableAddIndexContinuesAfterStartTimeoutExpiredAndTimeout` I released that `Os.sleep(millis)` implementation is buggy.

If this implementation was to be spuriously interrupted, it could finish prematurely (e.g. before specified interval elapses).\

Therefore this fixes the test I mentioned above as well as some other tests perhaps.