### PR TITLE
fix(cairo): fix scoreboard race for new table readers

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
@@ -675,7 +675,6 @@ public class RetryIODispatcherTest {
                     // check if we have parallelCount x insertCount  records
                     int waitCount = 1000 / 50 * parallelCount;
                     for (int i = 0; i < waitCount; i++) {
-
                         try {
                             new SendAndReceiveRequestBuilder().executeWithStandardHeaders(
                                     "GET /query?query=select+count()+from+balances_x&count=true HTTP/1.1\r\n",
@@ -691,7 +690,6 @@ public class RetryIODispatcherTest {
                             } else {
                                 throw e;
                             }
-
                         }
                     }
                 });


### PR DESCRIPTION
Refs: #1559

Fresh table reader instances were using 0 transaction numbers in scoreboard acquire/release calls which led to races in the scoreboard's min value initialization. The init() method in scoreboard was swapping 0 min value with L_MIN and a later table reader was swapping this L_MIN value with its current transaction number. This could have led to min being set to a value greater than 0 while there are some fresh reader instances that haven't released their txn 0 yet. As the result of this race, the assertion in releaseTxn() was failing.

To fix this race, the TxnScoreboard Java class now adds 1 to all received txn values before calling the C++ implementation.