### PR TITLE
fix(sql): support timestamp formats used by python drivers

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimestampFunctionFactory.java
@@ -31,11 +31,11 @@ import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.TimestampFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.std.IntList;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
 import io.questdb.std.ObjList;
-import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 
 public class ToTimestampFunctionFactory implements FunctionFactory {
     @Override
@@ -67,7 +67,7 @@ public class ToTimestampFunctionFactory implements FunctionFactory {
             final CharSequence value = arg.getStr(rec);
             try {
                 if (value != null) {
-                    return TimestampFormatUtils.PG_TIMESTAMPZ_FORMAT.parse(value, TimestampFormatUtils.enLocale);
+                    return IntervalUtils.parseFloorPartialDate(value);
                 }
             } catch (NumericException ignore) {
             }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
@@ -42,7 +42,6 @@ public class TimestampFormatUtils {
     public static final DateFormat GREEDY_MILLIS2_UTC_FORMAT;
     public static final DateFormat USEC_UTC_FORMAT;
     public static final DateFormat PG_TIMESTAMP_FORMAT;
-    public static final DateFormat PG_TIMESTAMPZ_FORMAT;
     public static final DateFormat PG_TIMESTAMP_MILLI_TIME_Z_FORMAT;
     public static final DateFormat PG_TIMESTAMP_TIME_Z_FORMAT;
     public static final DateFormat NANOS_UTC_FORMAT;
@@ -368,7 +367,6 @@ public class TimestampFormatUtils {
         TimestampFormatCompiler compiler = new TimestampFormatCompiler();
         HTTP_FORMAT = compiler.compile("E, d MMM yyyy HH:mm:ss Z");
         PG_TIMESTAMP_FORMAT = compiler.compile("y-MM-dd HH:mm:ss.SSSUUU");
-        PG_TIMESTAMPZ_FORMAT = compiler.compile("y-MM-ddTHH:mm:ss.SSSUUU");
         PG_TIMESTAMP_TIME_Z_FORMAT = compiler.compile("y-MM-dd HH:mm:ssz");
         NANOS_UTC_FORMAT = compiler.compile("yyyy-MM-ddTHH:mm:ss.SSSUUUNNNz");
 

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -1288,6 +1288,33 @@ nodejs code:
     }
 
     @Test
+    public void testInsertTimestampWithTypeSuffix() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    final PGWireServer ignored = createPGServer(1);
+                    final Connection connection = getConnection(true, false)
+            ) {
+                final PreparedStatement statement = connection.prepareStatement("create table x (ts timestamp) timestamp(ts)");
+                statement.execute();
+
+                // the below timestamp formats are used by Python drivers
+                final PreparedStatement insert = connection.prepareStatement("insert into x values " +
+                        "('2020-06-01T00:00:02'::timestamp)," +
+                        "('2020-06-01T00:00:02.000009'::timestamp)");
+                insert.execute();
+
+                final String expected = "ts[TIMESTAMP]\n" +
+                        "2020-06-01 00:00:02.0\n" +
+                        "2020-06-01 00:00:02.000009\n";
+                try (ResultSet resultSet = connection.prepareStatement("select * from x").executeQuery()) {
+                    sink.clear();
+                    assertResultSet(expected, sink, resultSet);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testIntAndLongParametersWithFormatCountGreaterThanValueCount() throws Exception {
         String script = ">0000006e00030000757365720078797a0064617461626173650071646200636c69656e745f656e636f64696e67005554463800446174655374796c650049534f0054696d655a6f6e65004575726f70652f4c6f6e646f6e0065787472615f666c6f61745f64696769747300320000\n" +
                 "<520000000800000003\n" +


### PR DESCRIPTION
Fixes #1808