### PR TITLE
chore(ilp): support tags in fuzz test

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -471,7 +471,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         // this is a silly exercise in walking the index
         for (int i = 0; i < columnCount; i++) {
 
-            // prevent writing same entry more times
+            // prevent writing same entry more than once
             if (Unsafe.getUnsafe().getByte(stateAddress + i) == -1) {
                 continue;
             }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -458,8 +458,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         }
     }
 
-    public void reshuffleSymbolMapReaders(long pTransitionIndex) {
-        final int columnCount = Unsafe.getUnsafe().getInt(pTransitionIndex + 4);
+    private void reshuffleSymbolMapReaders(long pTransitionIndex, int columnCount) {
         final long index = pTransitionIndex + 8;
         final long stateAddress = index + columnCount * 8L;
 
@@ -472,7 +471,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         // this is a silly exercise in walking the index
         for (int i = 0; i < columnCount; i++) {
 
-            // prevent writing same entry once
+            // prevent writing same entry more times
             if (Unsafe.getUnsafe().getByte(stateAddress + i) == -1) {
                 continue;
             }
@@ -1151,7 +1150,7 @@ public class TableReader implements Closeable, SymbolTableSource {
                 reshuffleColumns(columnCount, pTransitionIndex);
             }
             // rearrange symbol map reader list
-            reshuffleSymbolMapReaders(pTransitionIndex);
+            reshuffleSymbolMapReaders(pTransitionIndex, columnCount);
             this.columnCount = columnCount;
         } finally {
             TableUtils.freeTransitionIndex(pTransitionIndex);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
@@ -32,9 +32,6 @@ import org.junit.Test;
 // this is ready we will make this test part of the CI
 public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
 
-    // there seem to be an issue with the transactionality of adding new columns
-    // when the issue is fixed 'newColumnFactor' can be used and this test should be enabled
-    @Ignore
     @Test
     public void testAddColumns() throws Exception {
         initLoadParameters(15, 2, 2, 5, 100);
@@ -58,7 +55,7 @@ public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
     @Test
     public void testReorderingAddSkipDuplicateColumnsWithNonAscii() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(4, 4, 4, -1, 4, true);
+        initFuzzParameters(4, 4, 4, 4, 4, true);
         runTest();
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.line.tcp.load;
 
+import io.questdb.std.BoolList;
 import io.questdb.std.LowerCaseCharSequenceIntHashMap;
 import io.questdb.std.ObjList;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
@@ -32,43 +33,69 @@ import io.questdb.std.str.StringSink;
 public class LineData {
     private final long timestampNanos;
 
-    // colName/value pairs for each line
-    // colName can be different to real colName (dupes, uppercase...)
-    private final ObjList<CharSequence> colNames = new ObjList<>();
-    private final ObjList<CharSequence> colValues = new ObjList<>();
+    // column/tag name and value pairs for each line
+    // column/tag name can be different to real name (dupes, uppercase...)
+    private final ObjList<CharSequence> names = new ObjList<>();
+    private final ObjList<CharSequence> values = new ObjList<>();
+    private final BoolList tagFlags = new BoolList();
 
-    private final LowerCaseCharSequenceIntHashMap colNameToIndex = new LowerCaseCharSequenceIntHashMap();
+    private final LowerCaseCharSequenceIntHashMap nameToIndex = new LowerCaseCharSequenceIntHashMap();
 
     public LineData(long timestampMicros) {
         timestampNanos = timestampMicros * 1000;
         final StringSink timestampSink = new StringSink();
         TimestampFormatUtils.appendDateTimeUSec(timestampSink, timestampMicros);
-        add("timestamp", timestampSink);
+        addColumn("timestamp", timestampSink);
     }
 
     public long getTimestamp() {
         return timestampNanos;
     }
 
-    public void add(CharSequence colName, CharSequence colValue) {
-        colNames.add(colName);
-        colValues.add(colValue);
-        colNameToIndex.putIfAbsent(colName, colNames.size() -1);
+    public void addTag(CharSequence tagName, CharSequence tagValue) {
+        add(tagName, tagValue, true);
+    }
+
+    public void addColumn(CharSequence colName, CharSequence colValue) {
+        add(colName, colValue, false);
+    }
+
+    private void add(CharSequence name, CharSequence value, boolean isTag) {
+        names.add(name);
+        values.add(value);
+        tagFlags.add(isTag);
+        nameToIndex.putIfAbsent(name, names.size() -1);
     }
 
     public String toLine(final CharSequence tableName) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(tableName).append(" ");
+        sb.append(tableName);
         return toString(sb).append("\n").toString();
     }
 
     StringBuilder toString(final StringBuilder sb) {
-        for (int i = 0, n = colNames.size(); i < n; i++) {
-            final CharSequence colName = colNames.get(i);
-            if (colName.equals("timestamp")) {
-                continue;
+        for (int i = 0, n = names.size(); i < n; i++) {
+            if (tagFlags.get(i)) {
+                sb.append(",").append(names.get(i)).append("=").append(values.get(i));
             }
-            sb.append(colName).append("=").append(colValues.get(i)).append(i == n - 1 ? "" : ",");
+        }
+
+        boolean firstColumn = true;
+        for (int i = 0, n = names.size(); i < n; i++) {
+            if (!tagFlags.get(i)) {
+                final CharSequence colName = names.get(i);
+                if (colName.equals("timestamp")) {
+                    continue;
+                }
+                if (firstColumn) {
+                    sb.append(" ");
+                    firstColumn = false;
+                }
+                sb.append(colName).append("=").append(values.get(i)).append(",");
+            }
+        }
+        if (!firstColumn) {
+            sb.setLength(sb.length() - 1);
         }
         return sb.append(" ").append(timestampNanos);
     }
@@ -77,10 +104,17 @@ public class LineData {
         final StringBuilder sb = new StringBuilder();
         for (int i = 0, n = columns.size(); i < n; i++) {
             final CharSequence colName = columns.get(i);
-            final int index = colNameToIndex.get(colName);
-            sb.append(index < 0 ? defaults.get(i) : colValues.get(index)).append(i == n - 1 ? "\n" : "\t");
+            final int index = nameToIndex.get(colName);
+            sb.append(index < 0 ? defaults.get(i) : getValue(values.get(index))).append(i == n - 1 ? "\n" : "\t");
         }
         return sb.toString();
+    }
+
+    private CharSequence getValue(CharSequence original) {
+        if (original.charAt(0) != '"') {
+            return original;
+        }
+        return original.toString().substring(1, original.length() - 1);
     }
 
     @Override


### PR DESCRIPTION
This change includes ILP tags in fuzz testing.
Currently the fuzz test sends only columns to QuestDB.
It also adds quotes around string values.
Previously they were treated as symbols because of the missing quotes.

Current message format used by the test:
```
weather0 location=us-midwestC,terület=europeY,temperature=80.0,humidity=25.0,hőmérséklet=13.0,notes=noteU,ветер=63.0 1465839830102302000
```

New format exercising tags and uses proper string fields:
```
weather0,location=us-midwestC,city=LondonU terület="europeY",temperature=80.0,humidity=25.0,hőmérséklet=13.0,notes="noteU",ветер=63.0 1465839830102302000
```

