### PR TITLE
refactor(core): cleaner algo to resolve race condition between pool return and close

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -34,7 +34,6 @@ import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.ConcurrentHashMap;
-import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 import java.util.Arrays;

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -37,7 +37,6 @@ import io.questdb.std.ConcurrentHashMap;
 import io.questdb.std.Unsafe;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 
 public class ReaderPool extends AbstractPool implements ResourcePool<TableReader> {
@@ -234,10 +233,7 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
         int casFailures = 0;
         int closeReason = deadline < Long.MAX_VALUE ? PoolConstants.CR_IDLE : PoolConstants.CR_POOL_CLOSE;
 
-        Iterator<Entry> iterator = entries.values().iterator();
-        while (iterator.hasNext()) {
-            Entry e = iterator.next();
-
+        for (Entry e : entries.values()) {
             do {
                 for (int i = 0; i < ENTRY_SIZE; i++) {
                     R r;
@@ -318,14 +314,20 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
             return false;
         }
 
-        if (Unsafe.arrayGetVolatile(e.allocations, index) != UNALLOCATED) {
+        final long owner = Unsafe.arrayGetVolatile(e.allocations, index);
+        if (owner != UNALLOCATED) {
 
             LOG.debug().$('\'').$(name).$("' is back [at=").$(e.index).$(':').$(index).$(", thread=").$(thread).$(']').$();
             notifyListener(thread, name, PoolListener.EV_RETURN, e.index, index);
 
+            // release the entry for anyone to pick up
             e.releaseTimes[index] = clock.getTicks();
             Unsafe.arrayPutOrdered(e.allocations, index, UNALLOCATED);
-            return !isClosed();
+            final boolean closed = isClosed();
+
+            // When pool is closed we will race against release thread
+            // to release our entry. No need to bother releasing map entry, pool is going down.
+            return !closed || !Unsafe.cas(e.allocations, index, UNALLOCATED, owner);
         }
 
         LOG.error().$('\'').$(name).$("' is available [at=").$(e.index).$(':').$(index).$(']').$();
@@ -369,10 +371,7 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
                 if (pool != null && entry != null && pool.returnToPool(this)) {
                     return;
                 }
-                final Entry e = this.entry;
-                if (e == null || Unsafe.cas(e.allocations, index, UNALLOCATED, Thread.currentThread().getId())) {
-                    super.close();
-                }
+                super.close();
             }
         }
 

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -34,6 +34,7 @@ import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.ConcurrentHashMap;
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 import java.util.Arrays;
@@ -368,8 +369,11 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
         public void close() {
             if (isOpen()) {
                 goPassive();
-                if (pool != null && entry != null && pool.returnToPool(this)) {
-                    return;
+                final ReaderPool pool = this.pool;
+                if (pool != null && entry != null) {
+                    if (pool.returnToPool(this)) {
+                        return;
+                    }
                 }
                 super.close();
             }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -24,8 +24,8 @@
 
 package io.questdb.test.tools;
 
-import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.*;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.CompiledQuery;
 import io.questdb.griffin.SqlCompiler;
@@ -69,18 +69,6 @@ public final class TestUtils {
             if (a.byteAt(i) != b.byteAt(i)) return false;
         }
         return true;
-    }
-
-    public static long connect(long fd, long sockAddr) {
-        Assert.assertTrue(fd > -1);
-        return Net.connect(fd, sockAddr);
-    }
-
-    public static void await(CyclicBarrier barrier) {
-        try {
-            barrier.await();
-        } catch (Throwable ignore) {
-        }
     }
 
     public static void assertConnect(long fd, long sockAddr) {
@@ -423,13 +411,16 @@ public final class TestUtils {
         }
 
         // Checks that the same tag used for allocation and freeing native memory
-        for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {
-            long actualMemByTag = Unsafe.getMemUsedByTag(i);
-            if (memoryUsageByTag[i] != actualMemByTag) {
-                Assert.assertEquals("Memory usage by tag: " + MemoryTag.nameOf(i), memoryUsageByTag[i], actualMemByTag);
+        long memAfter = Unsafe.getMemUsed();
+        if (mem != memAfter) {
+            for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {
+                long actualMemByTag = Unsafe.getMemUsedByTag(i);
+                if (memoryUsageByTag[i] != actualMemByTag) {
+                    Assert.assertEquals("Memory usage by tag: " + MemoryTag.nameOf(i), memoryUsageByTag[i], actualMemByTag);
+                }
             }
+            Assert.assertEquals(mem, memAfter);
         }
-        Assert.assertEquals(mem, Unsafe.getMemUsed());
     }
 
     public static void assertReader(CharSequence expected, TableReader reader, MutableCharSink sink) {
@@ -507,6 +498,18 @@ public final class TestUtils {
         assertEquals(expected, sink);
     }
 
+    public static void await(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (Throwable ignore) {
+        }
+    }
+
+    public static long connect(long fd, long sockAddr) {
+        Assert.assertTrue(fd > -1);
+        return Net.connect(fd, sockAddr);
+    }
+
     public static void copyMimeTypes(String targetDir) throws IOException {
         try (InputStream stream = TestUtils.class.getResourceAsStream("/site/conf/mime.types")) {
             Assert.assertNotNull(stream);
@@ -520,15 +523,6 @@ public final class TestUtils {
                 }
             }
         }
-    }
-
-    public static boolean drainEngineCmdQueue(CairoEngine engine) {
-        boolean useful = false;
-        while (engine.tick()) {
-            useful = true;
-            // drain the engine queue
-        }
-        return useful;
     }
 
     public static void createPopulateTable(
@@ -632,6 +626,15 @@ public final class TestUtils {
             }
             Files.mkdirs(path.of(root).slash$(), 509);
         }
+    }
+
+    public static boolean drainEngineCmdQueue(CairoEngine engine) {
+        boolean useful = false;
+        while (engine.tick()) {
+            useful = true;
+            // drain the engine queue
+        }
+        return useful;
     }
 
     public static int getJavaVersion() {

--- a/core/src/test/resources/log-file.conf
+++ b/core/src/test/resources/log-file.conf
@@ -2,7 +2,6 @@
 writers=file
 
 # stdout
-w.file.class=io.questdb.log.LogRollingFileWriter
+w.file.class=io.questdb.log.LogFileWriter
 w.file.level=ERROR,INFO
 w.file.location=out.log
-w.file.rollSize=100m


### PR DESCRIPTION
Closes #1813

Full disclosure: the error I was able to reproduce was different. It was related to my local logger setup. This setup was rotating log files, interfering with closed file counter in the test.

On my M1 test ran 30 min without failure.

#### Extras

Reduced effort in each test to assert memory leak. Memory tags only evaluated when total usage before and after does not match. I feel instances where exact memory exchange between tags are non-existent.