### PR TITLE
fix(sql): fix not equals filter on indexed symbol column

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -131,9 +131,9 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
             }
         }
 
-        // We need to include null values to the result set to follow
-        // the behavior of the NOT IN() SQL function.
         if (!excludeNull && symbolMapReader.containsNullValue() && !includedKeys.contains(SymbolTable.VALUE_IS_NULL)) {
+            // If the table contains null values and they're not excluded, we need to include
+            // them to the result set to match the behavior of the NOT IN() SQL function.
             includedKeys.add(SymbolTable.VALUE_IS_NULL);
             addRowCursorFactory(SymbolTable.VALUE_IS_NULL);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -112,15 +112,10 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
 
         final SymbolMapReaderImpl symbolMapReader = (SymbolMapReaderImpl) tableReader.getSymbolMapReader(columnIndex);
 
-        boolean excludeNull = false;
         // Generate excluded key set.
         for (int i = 0, n = keyExcludedValueFunctions.size(); i < n; i++) {
             final CharSequence value = keyExcludedValueFunctions.getQuick(i).getStr(null);
-            if (value != null) {
-                excludedKeys.add(symbolMapReader.keyOf(value));
-            } else {
-                excludeNull = true;
-            }
+            excludedKeys.add(symbolMapReader.keyOf(value));
         }
 
         // Append new keys to the included set filtering out the excluded ones.
@@ -131,7 +126,8 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
             }
         }
 
-        if (!excludeNull && symbolMapReader.containsNullValue() && !includedKeys.contains(SymbolTable.VALUE_IS_NULL)) {
+        if (symbolMapReader.containsNullValue()
+                && !excludedKeys.contains(SymbolTable.VALUE_IS_NULL) && !includedKeys.contains(SymbolTable.VALUE_IS_NULL)) {
             // If the table contains null values and they're not excluded, we need to include
             // them to the result set to match the behavior of the NOT IN() SQL function.
             includedKeys.add(SymbolTable.VALUE_IS_NULL);

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -120,17 +120,15 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
 
         // Append new keys to the included set filtering out the excluded ones.
         for (int k = 0, n = symbolMapReader.getSymbolCount(); k < n; k++) {
-            if (!excludedKeys.contains(k) && !includedKeys.contains(k)) {
-                includedKeys.add(k);
+            if (!excludedKeys.contains(k) && includedKeys.add(k)) {
                 addRowCursorFactory(k);
             }
         }
 
         if (symbolMapReader.containsNullValue()
-                && !excludedKeys.contains(SymbolTable.VALUE_IS_NULL) && !includedKeys.contains(SymbolTable.VALUE_IS_NULL)) {
+                && !excludedKeys.contains(SymbolTable.VALUE_IS_NULL) && includedKeys.add(SymbolTable.VALUE_IS_NULL)) {
             // If the table contains null values and they're not excluded, we need to include
             // them to the result set to match the behavior of the NOT IN() SQL function.
-            includedKeys.add(SymbolTable.VALUE_IS_NULL);
             addRowCursorFactory(SymbolTable.VALUE_IS_NULL);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/table/SymbolFunctionRowCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SymbolFunctionRowCursorFactory.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table;
+
+public interface SymbolFunctionRowCursorFactory extends FunctionBasedRowCursorFactory {
+
+    void of(int symbolKey);
+
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/SymbolIndexFilteredRowCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SymbolIndexFilteredRowCursorFactory.java
@@ -31,7 +31,7 @@ import io.questdb.cairo.sql.RowCursor;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 
-public class SymbolIndexFilteredRowCursorFactory implements FunctionBasedRowCursorFactory {
+public class SymbolIndexFilteredRowCursorFactory implements SymbolFunctionRowCursorFactory {
     private final SymbolIndexFilteredRowCursor cursor;
     private final Function symbolFunction;
 
@@ -53,6 +53,11 @@ public class SymbolIndexFilteredRowCursorFactory implements FunctionBasedRowCurs
                 columnIndexes
         );
         this.symbolFunction = symbolFunction;
+    }
+
+    @Override
+    public void of(int symbolKey) {
+        cursor.of(symbolKey);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/SymbolIndexRowCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SymbolIndexRowCursorFactory.java
@@ -29,9 +29,9 @@ import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RowCursor;
 
-public class SymbolIndexRowCursorFactory implements FunctionBasedRowCursorFactory {
+public class SymbolIndexRowCursorFactory implements SymbolFunctionRowCursorFactory {
     private final int columnIndex;
-    private final int symbolKey;
+    private int symbolKey;
     private final boolean cachedIndexReaderCursor;
     private final int indexDirection;
     private final Function symbolFunction;
@@ -48,6 +48,11 @@ public class SymbolIndexRowCursorFactory implements FunctionBasedRowCursorFactor
         this.cachedIndexReaderCursor = cachedIndexReaderCursor;
         this.indexDirection = indexDirection;
         this.symbolFunction = symbolFunction;
+    }
+
+    @Override
+    public void of(int symbolKey) {
+        this.symbolKey = TableUtils.toIndexKey(symbolKey);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -4163,6 +4163,74 @@ create table tab as (
         );
     }
 
+    @Test
+    public void testIndexedSymbolBindVariableNotEqualsMultipleExecutions() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    final PGWireServer ignored = createPGServer(1);
+                    final Connection connection = getConnection(false, true)
+            ) {
+                connection.prepareStatement("create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,3) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from" +
+                        " long_sequence(4)" +
+                        "), index(b) timestamp(k) partition by DAY").execute();
+
+                sink.clear();
+                try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ?")) {
+                    ps.setString(1, "VTJW");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertResultSet(
+                                "a[DOUBLE],b[VARCHAR],k[TIMESTAMP]\n" +
+                                        "11.427984775756228,null,1970-01-01 00:00:00.0\n" +
+                                        "23.90529010846525,RXGZ,1970-01-03 07:33:20.0\n" +
+                                        "70.94360487171201,PEHN,1970-01-04 11:20:00.0\n",
+                                sink,
+                                rs
+                        );
+                    }
+                }
+
+                // verify that the underlying factory correctly re-calculates
+                // the excluded set when the bind variable value changes
+                sink.clear();
+                try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ?")) {
+                    ps.setString(1, "RXGZ");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertResultSet(
+                                "a[DOUBLE],b[VARCHAR],k[TIMESTAMP]\n" +
+                                        "11.427984775756228,null,1970-01-01 00:00:00.0\n" +
+                                        "42.17768841969397,VTJW,1970-01-02 03:46:40.0\n" +
+                                        "70.94360487171201,PEHN,1970-01-04 11:20:00.0\n",
+                                sink,
+                                rs
+                        );
+                    }
+                }
+
+                // the factory should correctly recognize NULL as the excluded value
+                sink.clear();
+                try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ?")) {
+                    ps.setString(1, null);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertResultSet(
+                                "a[DOUBLE],b[VARCHAR],k[TIMESTAMP]\n" +
+                                        "42.17768841969397,VTJW,1970-01-02 03:46:40.0\n" +
+                                        "23.90529010846525,RXGZ,1970-01-03 07:33:20.0\n" +
+                                        "70.94360487171201,PEHN,1970-01-04 11:20:00.0\n",
+                                sink,
+                                rs
+                        );
+                    }
+                }
+            }
+        });
+    }
+
     private static void toSink(InputStream is, CharSink sink) throws IOException {
         // limit what we print
         byte[] bb = new byte[1];

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -4164,7 +4164,7 @@ create table tab as (
     }
 
     @Test
-    public void testIndexedSymbolBindVariableNotEqualsMultipleExecutions() throws Exception {
+    public void testIndexedSymbolBindVariableNotEqualsSingleValueMultipleExecutions() throws Exception {
         assertMemoryLeak(() -> {
             try (
                     final PGWireServer ignored = createPGServer(1);
@@ -4195,8 +4195,8 @@ create table tab as (
                     }
                 }
 
-                // verify that the underlying factory correctly re-calculates
-                // the excluded set when the bind variable value changes
+                // Verify that the underlying factory correctly re-calculates
+                // the excluded set when the bind variable value changes.
                 sink.clear();
                 try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ?")) {
                     ps.setString(1, "RXGZ");
@@ -4212,7 +4212,7 @@ create table tab as (
                     }
                 }
 
-                // the factory should correctly recognize NULL as the excluded value
+                // The factory should correctly recognize NULL as the excluded value.
                 sink.clear();
                 try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ?")) {
                     ps.setString(1, null);
@@ -4222,6 +4222,66 @@ create table tab as (
                                         "42.17768841969397,VTJW,1970-01-02 03:46:40.0\n" +
                                         "23.90529010846525,RXGZ,1970-01-03 07:33:20.0\n" +
                                         "70.94360487171201,PEHN,1970-01-04 11:20:00.0\n",
+                                sink,
+                                rs
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testIndexedSymbolBindVariableNotMultipleValuesMultipleExecutions() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    final PGWireServer ignored = createPGServer(1);
+                    final Connection connection = getConnection(false, true)
+            ) {
+                connection.prepareStatement("create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,0) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from" +
+                        " long_sequence(1)" +
+                        "), index(b) timestamp(k) partition by DAY").execute();
+
+                // First we try to filter out not yet existing keys.
+                sink.clear();
+                try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ? and b != ?")) {
+                    ps.setString(1, "EHBH");
+                    ps.setString(2, "BBTG");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertResultSet(
+                                "a[DOUBLE],b[VARCHAR],k[TIMESTAMP]\n" +
+                                        "11.427984775756228,HYRX,1970-01-01 00:00:00.0\n",
+                                sink,
+                                rs
+                        );
+                    }
+                }
+
+                // Insert new rows including the keys of interest.
+                connection.prepareStatement("insert into x " +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,0) b," +
+                        " timestamp_sequence(100000000000, 100000000000) k" +
+                        " from" +
+                        " long_sequence(3)").execute();
+
+                // The query should filter the keys out.
+                sink.clear();
+                try (PreparedStatement ps = connection.prepareStatement("select * from x where b != ? and b != ?")) {
+                    ps.setString(1, "EHBH");
+                    ps.setString(2, "BBTG");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertResultSet(
+                                "a[DOUBLE],b[VARCHAR],k[TIMESTAMP]\n" +
+                                        "11.427984775756228,HYRX,1970-01-01 00:00:00.0\n" +
+                                        "40.22810626779558,EYYQ,1970-01-04 11:20:00.0\n",
                                 sink,
                                 rs
                         );

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -1594,9 +1594,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     " long_sequence(20)" +
                     ")" + (indexed ? ", index(b) " : " ") + "timestamp(k) partition by DAY", sqlExecutionContext);
 
-            try (
-                    RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()
-            ) {
+            try (RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(
                         "a\tb\tk\n" +
                                 "97.71103146051203\tHYRX\t1970-01-07T22:40:00.000000Z\n" +
@@ -1644,21 +1642,20 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                     "(" +
                     "select" +
                     " rnd_double(0)*100 a," +
-                    " rnd_symbol(5,4,4,0) b," +
+                    " rnd_symbol(5,4,4,1) b," +
                     " timestamp_sequence(0, 100000000000) k" +
                     " from" +
                     " long_sequence(5)" +
                     ")" + (indexed ? ", index(b) " : " ") + "timestamp(k) partition by DAY", sqlExecutionContext);
 
-            try (
-                    RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()
-            ) {
+            try (RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(
                         "a\tb\tk\n" +
-                                "55.99161804800813\tRXGZ\t1970-01-02T03:46:40.000000Z\n" +
-                                "62.76954028373309\tPEHN\t1970-01-03T07:33:20.000000Z\n" +
-                                "31.00545983862456\tPEHN\t1970-01-04T11:20:00.000000Z\n" +
-                                "0.35983672154330515\tCPSW\t1970-01-05T15:06:40.000000Z\n",
+                                "11.427984775756228\t\t1970-01-01T00:00:00.000000Z\n" +
+                                "42.17768841969397\tVTJW\t1970-01-02T03:46:40.000000Z\n" +
+                                "23.90529010846525\tRXGZ\t1970-01-03T07:33:20.000000Z\n" +
+                                "70.94360487171201\tPEHN\t1970-01-04T11:20:00.000000Z\n" +
+                                "87.99634725391621\t\t1970-01-05T15:06:40.000000Z\n",
                         factory,
                         true,
                         true,


### PR DESCRIPTION
Fixes the following problems for queries with a not equals filter over an indexed symbol column (e.g. `select * from tab where sym != 42`):
* The underlying record cursor factory was filtering out NULL values leading to different behavior than the same filter non-indexed column
* In case of a filter with bind variables, the factory didn't recalculate the included set properly on bind variable values change
* Each query execution led to `ObjList::indexOf` (array scan, O(N) operation) done on each key. Moreover, `CharSequence::toString` done for each symbol value led to some litter. To fix that `ObjList`s containing symbol values were replaced with `IntHashSet`s with symbol keys.