### PR TITLE
feat(sql): New syntax 'drop table if exists table-name' to not fail when the table does not exist

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -2167,8 +2167,8 @@ public class SqlCompiler implements Closeable {
                     final int valueCount = values.size();
                     if (columnCount != valueCount) {
                         throw SqlException.$(
-                                        model.getEndOfRowTupleValuesPosition(t),
-                                        "row value count does not match column count [expected=").put(columnCount).put(", actual=").put(values.size())
+                                model.getEndOfRowTupleValuesPosition(t),
+                                "row value count does not match column count [expected=").put(columnCount).put(", actual=").put(values.size())
                                 .put(", tuple=").put(t + 1).put(']');
                     }
                     valueFunctions = new ObjList<>(columnCount);
@@ -2359,8 +2359,8 @@ public class SqlCompiler implements Closeable {
         for (int i = 0, n = model.getRowTupleCount(); i < n; i++) {
             if (columnSetSize > 0 && columnSetSize != model.getRowTupleValues(i).size()) {
                 throw SqlException.$(
-                                model.getEndOfRowTupleValuesPosition(i),
-                                "row value count does not match column count [expected=").put(columnSetSize).put(", actual=").put(model.getRowTupleValues(i).size())
+                        model.getEndOfRowTupleValuesPosition(i),
+                        "row value count does not match column count [expected=").put(columnSetSize).put(", actual=").put(model.getRowTupleValues(i).size())
                         .put(", tuple=").put(i + 1).put(']');
             }
         }

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -465,7 +465,7 @@ public class PGJobContextTest extends AbstractGriffinTest {
 
                 connection.prepareStatement("create table xyz(a int)").execute();
                 try (TableWriter ignored1 = engine.getWriter(sqlExecutionContext.getCairoSecurityContext(), "xyz", "testing")) {
-                    connection.prepareStatement("drop table if exists xyz").execute();
+                    connection.prepareStatement("drop table xyz").execute();
                     Assert.fail();
                 } catch (SQLException e) {
                     TestUtils.assertContains(e.getMessage(), "Could not lock 'xyz'");
@@ -1435,7 +1435,7 @@ nodejs code:
 
 
                     compiler.compile("create table spot1 as (select * from test_batch)", sqlExecutionContext);
-                    compiler.compile("drop table if exists test_batch", sqlExecutionContext);
+                    compiler.compile("drop table test_batch", sqlExecutionContext);
                     compiler.compile("rename table spot1 to test_batch", sqlExecutionContext);
 
                     batchInsert.setLong(1, 0L);
@@ -2363,7 +2363,7 @@ nodejs code:
                             "null,1970-01-01 00:11:22.334455,null\n";
                     assertResultSet(expected, sink, rs);
                 }
-                statement.execute("drop table if exists tab");
+                statement.execute("drop table tab");
             }
         });
     }
@@ -2387,7 +2387,7 @@ nodejs code:
                             "null,null,null\n";
                     assertResultSet(expected, sink, rs);
                 }
-                statement.execute("drop table if exists tab");
+                statement.execute("drop table tab");
             }
         });
     }
@@ -2640,7 +2640,7 @@ nodejs code:
 
                 try (final Connection connection = getConnection(false, false)) {
                     queryTimestampsInRange(connection);
-                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                         statement.execute();
                     }
                 }
@@ -2674,7 +2674,7 @@ nodejs code:
                 }
 
                 try (final Connection connection = getConnection(false, false);
-                     PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                     PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                     statement.execute();
                 }
                 Assert.assertTrue("Exception is not thrown", caught);
@@ -2695,7 +2695,7 @@ nodejs code:
 
                 queryTimestampsInRange(connection);
 
-                try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                     statement.execute();
                 }
             }
@@ -2720,7 +2720,7 @@ nodejs code:
 
                     queryTimestampsInRange(connection);
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                         statement.execute();
                     }
                 } finally {
@@ -3801,7 +3801,7 @@ create table tab as (
                         }
                     }
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                         statement.execute();
                     }
                 }
@@ -3928,7 +3928,7 @@ create table tab as (
                         }
                     }
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                         statement.execute();
                     }
                 }
@@ -5456,7 +5456,7 @@ create table tab as (
         // we are going to:
         // 1. create a table
         // 2. insert a record
-        // 3. drop table if exists
+        // 3. drop table
         // 4. attempt to insert a record (should fail)
         assertMemoryLeak(() -> {
             try (
@@ -5474,7 +5474,7 @@ create table tab as (
                 insert.setInt(1, 1);
                 insert.execute();
 
-                PreparedStatement drop = connection.prepareStatement("drop table if exists x");
+                PreparedStatement drop = connection.prepareStatement("drop table x");
                 drop.execute();
 
                 try {
@@ -5616,7 +5616,7 @@ create table tab as (
                     ResultSet rs0 = select.executeQuery();
                     rs0.close();
 
-                    connection.prepareStatement("drop table if exists y").execute();
+                    connection.prepareStatement("drop table y").execute();
                     connection.prepareStatement("create table y as ( " +
                             " select " +
                             " timestamp_sequence('1970-01-01T02:30:00.000000Z', 1000000000L) timestamp " +

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -77,6 +77,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static io.questdb.std.Numbers.hexDigits;
+import static io.questdb.test.tools.TestUtils.assertContains;
 import static io.questdb.test.tools.TestUtils.drainEngineCmdQueue;
 import static org.junit.Assert.*;
 
@@ -464,7 +465,7 @@ public class PGJobContextTest extends AbstractGriffinTest {
 
                 connection.prepareStatement("create table xyz(a int)").execute();
                 try (TableWriter ignored1 = engine.getWriter(sqlExecutionContext.getCairoSecurityContext(), "xyz", "testing")) {
-                    connection.prepareStatement("drop table xyz").execute();
+                    connection.prepareStatement("drop table if exists xyz").execute();
                     Assert.fail();
                 } catch (SQLException e) {
                     TestUtils.assertContains(e.getMessage(), "Could not lock 'xyz'");
@@ -1434,7 +1435,7 @@ nodejs code:
 
 
                     compiler.compile("create table spot1 as (select * from test_batch)", sqlExecutionContext);
-                    compiler.compile("drop table test_batch", sqlExecutionContext);
+                    compiler.compile("drop table if exists test_batch", sqlExecutionContext);
                     compiler.compile("rename table spot1 to test_batch", sqlExecutionContext);
 
                     batchInsert.setLong(1, 0L);
@@ -2362,7 +2363,7 @@ nodejs code:
                             "null,1970-01-01 00:11:22.334455,null\n";
                     assertResultSet(expected, sink, rs);
                 }
-                statement.execute("drop table tab");
+                statement.execute("drop table if exists tab");
             }
         });
     }
@@ -2386,7 +2387,7 @@ nodejs code:
                             "null,null,null\n";
                     assertResultSet(expected, sink, rs);
                 }
-                statement.execute("drop table tab");
+                statement.execute("drop table if exists tab");
             }
         });
     }
@@ -2639,7 +2640,7 @@ nodejs code:
 
                 try (final Connection connection = getConnection(false, false)) {
                     queryTimestampsInRange(connection);
-                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
                         statement.execute();
                     }
                 }
@@ -2673,7 +2674,7 @@ nodejs code:
                 }
 
                 try (final Connection connection = getConnection(false, false);
-                     PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                     PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
                     statement.execute();
                 }
                 Assert.assertTrue("Exception is not thrown", caught);
@@ -2694,7 +2695,7 @@ nodejs code:
 
                 queryTimestampsInRange(connection);
 
-                try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
                     statement.execute();
                 }
             }
@@ -2719,7 +2720,7 @@ nodejs code:
 
                     queryTimestampsInRange(connection);
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
                         statement.execute();
                     }
                 } finally {
@@ -3800,7 +3801,48 @@ create table tab as (
                         }
                     }
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
+                        statement.execute();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDropTable() throws Exception {
+        String [][] sqlExpectedErrMsg = {
+                {"drop table doesnt", "ERROR: table 'doesnt' does not exist"},
+                {"drop table", "ERROR: expected [if exists] table-name"},
+                {"drop doesnt", "ERROR: 'table' expected"},
+                {"drop", "ERROR: 'table' expected"},
+                {"drop table if doesnt", "ERROR: expected exists"},
+                {"drop table exists doesnt", "ERROR: unexpected token [doesnt]"},
+                {"drop table if exists", "ERROR: table name expected"},
+                {"drop table if exists;", "ERROR: table name expected"},
+        };
+        TestUtils.assertMemoryLeak(() -> {
+            try (final PGWireServer ignored = createPGServer(1);
+                 final Connection connection = getConnection(false, false)) {
+                for (int i=0 , n=sqlExpectedErrMsg.length; i < n; i++) {
+                    String []testData = sqlExpectedErrMsg[i];
+                    try (PreparedStatement statement = connection.prepareStatement(testData[0])) {
+                        statement.execute();
+                        Assert.fail();
+                    } catch (PSQLException e) {
+                        assertContains(e.getMessage(), testData[1]);
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDropTableIfExistsDoesNotFailWhenTableDoesNotExist() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (final PGWireServer ignored = createPGServer(1)) {
+                try (final Connection connection = getConnection(false, false)) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists doesnt")) {
                         statement.execute();
                     }
                 }
@@ -3886,7 +3928,7 @@ create table tab as (
                         }
                     }
 
-                    try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
+                    try (PreparedStatement statement = connection.prepareStatement("drop table if exists xts")) {
                         statement.execute();
                     }
                 }
@@ -5414,7 +5456,7 @@ create table tab as (
         // we are going to:
         // 1. create a table
         // 2. insert a record
-        // 3. drop table
+        // 3. drop table if exists
         // 4. attempt to insert a record (should fail)
         assertMemoryLeak(() -> {
             try (
@@ -5432,7 +5474,7 @@ create table tab as (
                 insert.setInt(1, 1);
                 insert.execute();
 
-                PreparedStatement drop = connection.prepareStatement("drop table x");
+                PreparedStatement drop = connection.prepareStatement("drop table if exists x");
                 drop.execute();
 
                 try {
@@ -5574,7 +5616,7 @@ create table tab as (
                     ResultSet rs0 = select.executeQuery();
                     rs0.close();
 
-                    connection.prepareStatement("drop table y").execute();
+                    connection.prepareStatement("drop table if exists y").execute();
                     connection.prepareStatement("create table y as ( " +
                             " select " +
                             " timestamp_sequence('1970-01-01T02:30:00.000000Z', 1000000000L) timestamp " +

--- a/core/src/test/java/io/questdb/griffin/DropTableTest.java
+++ b/core/src/test/java/io/questdb/griffin/DropTableTest.java
@@ -138,4 +138,12 @@ public class DropTableTest extends AbstractGriffinTest {
             Assert.assertEquals(CompiledQuery.DROP, cc.getType());
         });
     }
+
+    @Test
+    public void testDropIfExists() throws Exception {
+        assertMemoryLeak(() -> {
+            CompiledQuery cc = compiler.compile("drop table if exists 'una tabla de queso';", sqlExecutionContext);
+            Assert.assertEquals(CompiledQuery.DROP, cc.getType());
+        });
+    }
 }


### PR DESCRIPTION

Before this change, the statement:

```
drop table mytable
```
would fail, which meant having to do a try/catch in client code.

After this change, we support in addition the statement:

```
drop table if exists mytable
```
which will drop the table if exists, and do nothing when not.
