### PR TITLE
chore(ilp): fuzz test to send space in symbol values

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -53,6 +53,7 @@ class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
     private static final int MAX_NUM_OF_SKIPPED_COLS = 2;
     private static final int NEW_COLUMN_RANDOMIZE_FACTOR = 2;
     private static final int UPPERCASE_TABLE_RANDOMIZE_FACTOR = 2;
+    private static final int SEND_SYMBOLS_WITH_SPACE_RANDOMIZE_FACTOR = 2;
 
     private final Rnd random = new Rnd(System.currentTimeMillis(), System.currentTimeMillis());
     private final AtomicLong timestampMillis = new AtomicLong(1465839830102300L);
@@ -92,6 +93,7 @@ class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
     private boolean diffCasesInColNames = false;
     private boolean exerciseTags = true;
     private boolean sendStringsAsSymbols = false;
+    private boolean sendSymbolsWithSpace = false;
 
     private volatile String errorMsg = null;
 
@@ -255,6 +257,10 @@ class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
                 return valueBase + postfix;
             case SYMBOL:
                 postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
+                if (sendSymbolsWithSpace && random.nextInt(SEND_SYMBOLS_WITH_SPACE_RANDOMIZE_FACTOR) == 0) {
+                    final int spaceIndex = random.nextInt(valueBase.length()-1);
+                    valueBase = valueBase.substring(0, spaceIndex) + "  " + valueBase.substring(spaceIndex);
+                }
                 return valueBase + postfix;
             case STRING:
                 postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
@@ -309,7 +315,7 @@ class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
     }
 
     void initFuzzParameters(int duplicatesFactor, int columnReorderingFactor, int columnSkipFactor, int newColumnFactor, int nonAsciiValueFactor,
-                            boolean diffCasesInColNames, boolean exerciseTags, boolean sendStringsAsSymbols) {
+                            boolean diffCasesInColNames, boolean exerciseTags, boolean sendStringsAsSymbols, boolean sendSymbolsWithSpace) {
         this.duplicatesFactor = duplicatesFactor;
         this.columnReorderingFactor = columnReorderingFactor;
         this.columnSkipFactor = columnSkipFactor;
@@ -318,6 +324,7 @@ class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
         this.diffCasesInColNames = diffCasesInColNames;
         this.exerciseTags = exerciseTags;
         this.sendStringsAsSymbols = sendStringsAsSymbols;
+        this.sendSymbolsWithSpace = sendSymbolsWithSpace;
     }
 
     void initLoadParameters(int numOfLines, int numOfIterations, int numOfThreads, int numOfTables, long waitBetweenIterationsMillis) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
@@ -35,7 +35,7 @@ public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
     @Test
     public void testAddColumnsNoTagsStringsAsSymbol() throws Exception {
         initLoadParameters(15, 2, 2, 5, 75);
-        initFuzzParameters(-1, -1, -1, 4, -1, false, false, true);
+        initFuzzParameters(-1, -1, -1, 4, -1, false, false, true, false);
         runTest();
     }
 
@@ -44,28 +44,42 @@ public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
     @Test
     public void testAddColumns() throws Exception {
         initLoadParameters(15, 2, 2, 5, 75);
-        initFuzzParameters(-1, -1, -1, 4, -1, false, true, false);
+        initFuzzParameters(-1, -1, -1, 4, -1, false, true, false, false);
         runTest();
     }
 
     @Test
     public void testDuplicatesReorderingColumnsNoTagsStringsAsSymbol() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(4, 4, -1, -1, -1, true, false, true);
+        initFuzzParameters(4, 4, -1, -1, -1, true, false, true, false);
         runTest();
     }
 
     @Test
     public void testDuplicatesReorderingColumns() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(4, 4, -1, -1, -1, true, true, false);
+        initFuzzParameters(4, 4, -1, -1, -1, true, true, false, false);
+        runTest();
+    }
+
+    @Test
+    public void testDuplicatesReorderingColumnsSendSymbolsWithSpace() throws Exception {
+        initLoadParameters(100, 5, 5, 5, 50);
+        initFuzzParameters(4, 4, -1, -1, -1, true, true, false, true);
         runTest();
     }
 
     @Test
     public void testLoadNoTagsStringsAsSymbol() throws Exception {
         initLoadParameters(100, 5, 7, 12, 20);
-        initFuzzParameters(-1, -1, -1, -1, -1, false, false, true);
+        initFuzzParameters(-1, -1, -1, -1, -1, false, false, true, false);
+        runTest();
+    }
+
+    @Test
+    public void testLoadSendSymbolsWithSpace() throws Exception {
+        initLoadParameters(100, 5, 4, 8, 20);
+        initFuzzParameters(-1, -1, -1, -1, -1, false, true, false, true);
         runTest();
     }
 
@@ -78,28 +92,28 @@ public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
     @Test
     public void testReorderingAddSkipDuplicateColumnsWithNonAsciiNoTagsStringsAsSymbol() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(4, 4, 4, -1, 4, true, false, true);
+        initFuzzParameters(4, 4, 4, -1, 4, true, false, true, false);
         runTest();
     }
 
     @Test
     public void testReorderingAddSkipDuplicateColumnsWithNonAscii() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(4, 4, 4, -1, 4, true, true, false);
+        initFuzzParameters(4, 4, 4, -1, 4, true, true, false, false);
         runTest();
     }
 
     @Test
     public void testReorderingColumnsNoTagsStringsAsSymbol() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(-1, 4, -1, -1, -1, false, false, true);
+        initFuzzParameters(-1, 4, -1, -1, -1, false, false, true, false);
         runTest();
     }
 
     @Test
     public void testReorderingColumns() throws Exception {
         initLoadParameters(100, 5, 5, 5, 50);
-        initFuzzParameters(-1, 4, -1, -1, -1, false, true, false);
+        initFuzzParameters(-1, 4, -1, -1, -1, false, true, false, false);
         runTest();
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
@@ -117,6 +117,15 @@ public class LineData {
         return original.toString().substring(1, original.length() - 1);
     }
 
+    boolean isValid() {
+        for (int i = 0, n = values.size(); i < n; i++) {
+            if (tagFlags.get(i) && values.get(i).toString().contains(" ")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public String toString() {
         return toString(new StringBuilder()).toString();

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
@@ -61,7 +61,13 @@ public class TableData {
     }
 
     public synchronized int size() {
-        return rows.size();
+        int count = 0;
+        for (int i = 0, n = rows.size(); i < n; i++) {
+            if (rows.get(i).isValid()) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public synchronized void addLine(LineData line) {
@@ -81,7 +87,10 @@ public class TableData {
             sb.append(column).append( i == n-1 ? "\n" : "\t");
         }
         for (int i = 0, n = rows.size(); i < n; i++) {
-            sb.append(rows.get(index.popIndex()).getRow(columns, defaults));
+            final LineData line = rows.get(index.popIndex());
+            if (line.isValid()) {
+                sb.append(line.getRow(columns, defaults));
+            }
             index.popValue();
         }
         return sb.toString();


### PR DESCRIPTION
Enhancing fuzz test to be able to send space in symbol values.
Spaces in symbol values are making the ILP message malformed and the line should be dropped on the server side.
The test validates that those lines are dropped and the valid lines are ingested.