### PR TITLE
fix(ui): remove devtools warning from web console

### DIFF
--- a/ui/monaco.config.js
+++ b/ui/monaco.config.js
@@ -23,7 +23,7 @@
  ******************************************************************************/
 
 module.exports = {
-  monacoPatterns: [
+  assetCopyPatterns: [
     {
       from: "node_modules/monaco-editor/min/vs/loader.js",
       to: "assets/vs/loader.js",
@@ -43,7 +43,7 @@ module.exports = {
     { from: "node_modules/monaco-editor/min/vs/base", to: "assets/vs/base" },
   ],
 
-  monacoMapPatterns: [
+  sourceMapCopyPatterns: [
     { from: "node_modules/monaco-editor/min-maps/vs/", to: "min-maps/vs" },
   ],
 }

--- a/ui/monaco.config.js
+++ b/ui/monaco.config.js
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+module.exports = {
+  monacoPatterns: [
+    {
+      from: "node_modules/monaco-editor/min/vs/loader.js",
+      to: "assets/vs/loader.js",
+    },
+    {
+      from: "node_modules/monaco-editor/min/vs/editor/editor.main.js",
+      to: "assets/vs/editor/editor.main.js",
+    },
+    {
+      from: "node_modules/monaco-editor/min/vs/editor/editor.main.nls.js",
+      to: "assets/vs/editor/editor.main.nls.js",
+    },
+    {
+      from: "node_modules/monaco-editor/min/vs/editor/editor.main.css",
+      to: "assets/vs/editor/editor.main.css",
+    },
+    { from: "node_modules/monaco-editor/min/vs/base", to: "assets/vs/base" },
+  ],
+
+  monacoMapPatterns: [
+    { from: "node_modules/monaco-editor/min-maps/vs/", to: "min-maps/vs" },
+  ],
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "build": "cross-env NODE_ENV=production webpack",
+    "postbuild": "node post-build.js",
     "start": "webpack-dev-server --progress",
     "start:prod": "cross-env NODE_ENV=production webpack-dev-server --progress",
     "analyze-bundle": "cross-env ANALYZE=true NODE_ENV=production webpack-cli --display-reasons",

--- a/ui/post-build.js
+++ b/ui/post-build.js
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+const fs = require("fs")
+const path = require("path")
+const { monacoPatterns } = require("./monaco.config")
+
+const distPath = path.join(__dirname, "dist")
+
+const removeLine = (filePath) => {
+  const content = fs.readFileSync(filePath, "utf8").split("\n")
+  const contentWithoutSourceMap = content
+    .filter((line) => !line.includes("sourceMappingURL"))
+    .join("\n")
+  fs.writeFileSync(filePath, contentWithoutSourceMap, "utf8")
+}
+
+monacoPatterns.forEach(({ to }) => {
+  if (Boolean(path.extname(to))) {
+    removeLine(path.join(distPath, to))
+  } else {
+    // `monaco.config` might include paths pointing to folders.
+    // In those cases, inspect every file in the folder
+
+    const queue = [
+      ...fs
+        .readdirSync(path.join(distPath, to))
+        .map((p) => path.join(distPath, to, p)),
+    ]
+    while (queue.length) {
+      const item = queue.shift()
+      if (Boolean(path.extname(item))) {
+        removeLine(item)
+      } else {
+        const files = fs.readdirSync(item).map((p) => path.join(item, p))
+        queue.push(...files)
+      }
+    }
+  }
+})

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -31,7 +31,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const Webpack = require("webpack")
 const AnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin
 
-const { monacoPatterns, monacoMapPatterns } = require("./monaco.config")
+const monacoConfig = require("./monaco.config")
 require("dotenv").config()
 
 const PORT = 9999
@@ -79,15 +79,18 @@ const devPlugins = [
   new CopyWebpackPlugin({
     patterns: [
       { from: "./assets/", to: "assets/" },
-      ...monacoPatterns,
-      ...monacoMapPatterns,
+      ...monacoConfig.assetCopyPatterns,
+      ...monacoConfig.sourceMapCopyPatterns,
     ],
   }),
 ]
 
 const prodPlugins = [
   new CopyWebpackPlugin({
-    patterns: [{ from: "./assets/", to: "assets/" }, ...monacoPatterns],
+    patterns: [
+      { from: "./assets/", to: "assets/" },
+      ...monacoConfig.assetCopyPatterns,
+    ],
   }),
 ]
 

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -31,6 +31,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const Webpack = require("webpack")
 const AnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin
 
+const { monacoPatterns, monacoMapPatterns } = require("./monaco.config")
 require("dotenv").config()
 
 const PORT = 9999
@@ -42,30 +43,6 @@ const ASSET_PATH = process.env.ASSET_PATH || "/"
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = "development"
 }
-
-const monacoPatterns = [
-  {
-    from: "node_modules/monaco-editor/min/vs/loader.js",
-    to: "assets/vs/loader.js",
-  },
-  {
-    from: "node_modules/monaco-editor/min/vs/editor/editor.main.js",
-    to: "assets/vs/editor/editor.main.js",
-  },
-  {
-    from: "node_modules/monaco-editor/min/vs/editor/editor.main.nls.js",
-    to: "assets/vs/editor/editor.main.nls.js",
-  },
-  {
-    from: "node_modules/monaco-editor/min/vs/editor/editor.main.css",
-    to: "assets/vs/editor/editor.main.css",
-  },
-  { from: "node_modules/monaco-editor/min/vs/base", to: "assets/vs/base" },
-]
-
-const monacoMapPatterns = [
-  { from: "node_modules/monaco-editor/min-maps/vs/", to: "min-maps/vs" },
-]
 
 const basePlugins = [
   new CleanWebpackPlugin(),


### PR DESCRIPTION
Currently, opening web console in a browser and opening its dev tools
might welcome you with some warnings:

[screenshot]

They are shown, because some JS dependencies used in console have a line
like this at the end of the file:

```
//# sourceMappingURL=../../min-maps/vs/loader.js.map
```

This line indicates to dev tools, that a file has an associated source
map file. Source map file helps with debugging: dev tools are able to
map minified `.js` file to a non-minified representation, and
development experience is like working with source code and not
transpilled version.

At least chrome dev tools have source maps enabled by default, thus, if
`.js` file has that `sourceMappingURL`, then dev tools tries to download that file.

Unfortunately in our case those files don't exist, so trying to fetch
them results in 404 and a warning.

An easy solution would be to just include source map files in the
`.jar`. However, they weigh around 11MB and I don't think they should be
shipped with production `.jar` version.

Thus, another approach is taken here - removing that `sourceMappingURL`
from the source code during the build of web console. As a result, dev
tools no longer look for source maps, there is no more warning and such
solution doesn't bloat the `.jar`.
