### PR TITLE
chore(sql): fixed cast with index parse error

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -585,14 +585,14 @@ public final class SqlParser {
         columnCastModel.setType(type, columnName.position, columnType.position);
 
         if (ColumnType.isSymbol(type)) {
-            CharSequence tok = tok(lexer, "'capacity', 'nocache', 'cache', 'index' or ')'");
+            CharSequence tok = tok(lexer, "'capacity', 'nocache', 'cache' or ')'");
 
             int symbolCapacity;
             int capacityPosition;
             if (isCapacityKeyword(tok)) {
                 capacityPosition = lexer.getPosition();
                 columnCastModel.setSymbolCapacity(symbolCapacity = parseSymbolCapacity(lexer));
-                tok = tok(lexer, "'nocache', 'cache', 'index' or ')'");
+                tok = tok(lexer, "'nocache', 'cache' or ')'");
             } else {
                 columnCastModel.setSymbolCapacity(configuration.getDefaultSymbolCapacity());
                 symbolCapacity = -1;
@@ -616,27 +616,7 @@ public final class SqlParser {
                 TableUtils.validateSymbolCapacityCached(true, symbolCapacity, capacityPosition);
             }
 
-            // parse index clause
-
-            tok = tok(lexer, "')', or 'index'");
-
-            if (isIndexKeyword(tok)) {
-                columnCastModel.setIndexed(true);
-                tok = tok(lexer, "')', or 'capacity'");
-
-                if (isCapacityKeyword(tok)) {
-                    int errorPosition = lexer.getPosition();
-                    int indexValueBlockSize = expectInt(lexer);
-                    TableUtils.validateIndexValueBlockSize(errorPosition, indexValueBlockSize);
-                    columnCastModel.setIndexValueBlockSize(Numbers.ceilPow2(indexValueBlockSize));
-                } else {
-                    columnCastModel.setIndexValueBlockSize(configuration.getIndexValueBlockSize());
-                    lexer.unparse();
-                }
-            } else {
-                columnCastModel.setIndexed(false);
-                lexer.unparse();
-            }
+            columnCastModel.setIndexed(false);
         }
 
         expectTok(lexer, ')');

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -631,6 +631,7 @@ public final class SqlParser {
                     columnCastModel.setIndexValueBlockSize(Numbers.ceilPow2(indexValueBlockSize));
                 } else {
                     columnCastModel.setIndexValueBlockSize(configuration.getIndexValueBlockSize());
+                    lexer.unparse();
                 }
             } else {
                 columnCastModel.setIndexed(false);

--- a/core/src/test/java/io/questdb/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/cairo/CreateTableTest.java
@@ -166,10 +166,7 @@ public class CreateTableTest extends AbstractGriffinTest {
             try (TableReader r = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
                 TableReaderMetadata metadata = r.getMetadata();
                 IntList indexed = new IntList();
-
-                for (int i = 0, cols = metadata.getColumnCount(); i < cols; i++) {
-                    indexed.add(0);
-                }
+                indexed.setPos(metadata.getColumnCount());
 
                 for (String columnName : columnNames) {
                     int i = metadata.getColumnIndex(columnName);

--- a/core/src/test/java/io/questdb/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/cairo/CreateTableTest.java
@@ -1,0 +1,135 @@
+package io.questdb.cairo;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.SqlException;
+import org.junit.Test;
+
+/**
+ * Test interactions between cast and index clauses in CREATE TABLE and CREATE TABLE AS SELECT statements .
+ */
+public class CreateTableTest extends AbstractGriffinTest {
+
+    @Test
+    public void testCreateTableWithNoIndex() throws Exception {
+        assertQuery("s\n", "select * from tab", "create table tab (s symbol) ", null);
+    }
+
+    @Test
+    public void testCreateTableWithIndex() throws Exception {
+        assertQuery("s\n", "select * from tab", "create table tab (s symbol), index(s)", null);
+    }
+
+    @Test
+    public void testCreateTableWithMultipleIndexes() throws Exception {
+        assertQuery("s1\ts2\ts3\n", "select * from tab", "create table tab (s1 symbol, s2 symbol, s3 symbol), index(s1), index(s2), index(s3)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithNoIndex() throws Exception {
+        assertCompile("create table old(s1 symbol)");
+        assertQuery("s1\n", "select * from new", "create table new as (select * from old)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithOneIndex() throws Exception {
+        assertCompile("create table old(s1 symbol,s2 symbol, s3 symbol)");
+        assertQuery("s1\ts2\ts3\n", "select * from new", "create table new as (select * from old), index(s1)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithMultipleIndexs() throws Exception {
+        assertCompile("create table old(s1 symbol,s2 symbol, s3 symbol)");
+        assertQuery("s1\ts2\ts3\n", "select * from new", "create table new as (select * from old), index(s1), index(s2), index(s3)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithOneCast() throws Exception {
+        assertCompile("create table old(s1 symbol,s2 symbol, s3 symbol)");
+        assertQuery("s1\ts2\ts3\n", "select * from new", "create table new as (select * from old), cast(s1 as string)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithMultipleCasts() throws Exception {
+        assertCompile("create table old(s symbol,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as string), cast(l as long), cast(ts as date)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithCastAndSeparateIndex() throws Exception {
+        assertCompile("create table old(s symbol,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(l as int), index(s)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithCastAndIndex_v2() throws Exception {
+        assertCompile("create table old(s symbol,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), index(s), cast(l as int)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithCastAndIndexOnTheSameColumn() throws Exception {
+        assertCompile("create table old(s string,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol), index(s)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithCastAndIndexOnTheSameColumnV2() throws Exception {
+        assertCompile("create table old(s string,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), index(s), cast(s as symbol)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithCastAndIndexOnTheSameColumnV3() throws Exception {
+        assertCompile("create table old(s string,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol index)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithMultipleCastWithIndexes() throws Exception {
+        assertCompile("create table old(s string, sym symbol, ts timestamp)");
+        assertQuery("s\tsym\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol index), cast(sym as symbol index)", null);
+    }
+
+    @Test(expected = SqlException.class)
+    public void testCreateTableAsSelectWithCastSymbolToStringAndIndexOnIt() throws Exception {
+        assertCompile("create table old(s symbol,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), index(s), cast(s as string)", null);
+    }
+
+    @Test(expected = SqlException.class)
+    public void testCreateTableAsSelectWithIndexOnSymbolCastedToString() throws Exception {
+        assertCompile("create table old(s symbol,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as string), index(s)", null);
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexes() throws Exception {
+        assertCompile("create table old(s string,sym symbol, ts timestamp)");
+        assertQuery("s\tsym\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol)", null);
+    }
+
+    @Test//this should be fixed!!!
+    public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV2() throws Exception {
+        assertCompile("create table old(s string,sym symbol, ts timestamp)");
+        assertQuery("s\tsym\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol index)", null);
+    }
+
+    @Test//this should be fixed!!!
+    public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV3() throws Exception {
+        assertCompile("create table old(s string,sym symbol, ts timestamp)");
+        assertQuery("s\tsym\tts\n", "select * from new",
+                "create table new as (select * from old), index(s), cast(s as symbol index), cast(ts as date), index(sym), cast(sym as symbol index)", null);
+    }
+}
+

--- a/core/src/test/java/io/questdb/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/cairo/CreateTableTest.java
@@ -1,7 +1,10 @@
 package io.questdb.cairo;
 
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.griffin.AbstractGriffinTest;
 import io.questdb.griffin.SqlException;
+import io.questdb.std.IntList;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -17,11 +20,15 @@ public class CreateTableTest extends AbstractGriffinTest {
     @Test
     public void testCreateTableWithIndex() throws Exception {
         assertQuery("s\n", "select * from tab", "create table tab (s symbol), index(s)", null);
+
+        assertColumnsIndexed("tab", "s");
     }
 
     @Test
     public void testCreateTableWithMultipleIndexes() throws Exception {
         assertQuery("s1\ts2\ts3\n", "select * from tab", "create table tab (s1 symbol, s2 symbol, s3 symbol), index(s1), index(s2), index(s3)", null);
+
+        assertColumnsIndexed("tab", "s1", "s2", "s3");
     }
 
     @Test
@@ -34,12 +41,16 @@ public class CreateTableTest extends AbstractGriffinTest {
     public void testCreateTableAsSelectWithOneIndex() throws Exception {
         assertCompile("create table old(s1 symbol,s2 symbol, s3 symbol)");
         assertQuery("s1\ts2\ts3\n", "select * from new", "create table new as (select * from old), index(s1)", null);
+
+        assertColumnsIndexed("new", "s1");
     }
 
     @Test
     public void testCreateTableAsSelectWithMultipleIndexs() throws Exception {
         assertCompile("create table old(s1 symbol,s2 symbol, s3 symbol)");
         assertQuery("s1\ts2\ts3\n", "select * from new", "create table new as (select * from old), index(s1), index(s2), index(s3)", null);
+
+        assertColumnsIndexed("new", "s1", "s2", "s3");
     }
 
     @Test
@@ -60,6 +71,8 @@ public class CreateTableTest extends AbstractGriffinTest {
         assertCompile("create table old(s symbol,l long, ts timestamp)");
         assertQuery("s\tl\tts\n", "select * from new",
                 "create table new as (select * from old), cast(l as int), index(s)", null);
+
+        assertColumnsIndexed("new", "s");
     }
 
     @Test
@@ -67,6 +80,8 @@ public class CreateTableTest extends AbstractGriffinTest {
         assertCompile("create table old(s symbol,l long, ts timestamp)");
         assertQuery("s\tl\tts\n", "select * from new",
                 "create table new as (select * from old), index(s), cast(l as int)", null);
+
+        assertColumnsIndexed("new", "s");
     }
 
     @Test
@@ -74,6 +89,8 @@ public class CreateTableTest extends AbstractGriffinTest {
         assertCompile("create table old(s string,l long, ts timestamp)");
         assertQuery("s\tl\tts\n", "select * from new",
                 "create table new as (select * from old), cast(s as symbol), index(s)", null);
+
+        assertColumnsIndexed("new", "s");
     }
 
     @Test
@@ -81,27 +98,17 @@ public class CreateTableTest extends AbstractGriffinTest {
         assertCompile("create table old(s string,l long, ts timestamp)");
         assertQuery("s\tl\tts\n", "select * from new",
                 "create table new as (select * from old), index(s), cast(s as symbol)", null);
+
+        assertColumnsIndexed("new", "s");
     }
 
     @Test
     public void testCreateTableAsSelectWithCastAndIndexOnTheSameColumnV3() throws Exception {
         assertCompile("create table old(s string,l long, ts timestamp)");
         assertQuery("s\tl\tts\n", "select * from new",
-                "create table new as (select * from old), cast(s as symbol index)", null);
-    }
+                "create table new as (select * from old), cast(s as symbol), index(s)", null);
 
-    @Test
-    public void testCreateTableAsSelectWithCastAndIndexCapacityOnTheSameColumn() throws Exception {
-        assertCompile("create table old(s string,l long, ts timestamp)");
-        assertQuery("s\tl\tts\n", "select * from new",
-                "create table new as (select * from old), cast(s as symbol index capacity 10)", null);
-    }
-
-    @Test
-    public void testCreateTableAsSelectWithMultipleCastWithIndexes() throws Exception {
-        assertCompile("create table old(s string, sym symbol, ts timestamp)");
-        assertQuery("s\tsym\tts\n", "select * from new",
-                "create table new as (select * from old), cast(s as symbol index), cast(sym as symbol index)", null);
+        assertColumnsIndexed("new", "s");
     }
 
     @Test(expected = SqlException.class)
@@ -123,20 +130,62 @@ public class CreateTableTest extends AbstractGriffinTest {
         assertCompile("create table old(s string,sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",
                 "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol)", null);
+
+        assertColumnsIndexed("new", "s", "sym");
     }
 
     @Test
     public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV2() throws Exception {
         assertCompile("create table old(s string,sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",
-                "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol index)", null);
+                "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol)", null);
+
+        assertColumnsIndexed("new", "s", "sym");
     }
 
     @Test
     public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV3() throws Exception {
         assertCompile("create table old(s string,sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",
-                "create table new as (select * from old), index(s), cast(s as symbol index), cast(ts as date), index(sym), cast(sym as symbol index)", null);
+                "create table new as (select * from old), index(s), cast(s as symbol), cast(ts as date), index(sym), cast(sym as symbol)", null);
+
+        assertColumnsIndexed("new", "s", "sym");
+    }
+
+    @Test
+    public void testCreateTableAsSelectInheritsColumnIndex() throws Exception {
+        assertCompile("create table old(s string,sym symbol index, ts timestamp)");
+        assertQuery("s\tsym\tts\n", "select * from new",
+                "create table new as (select * from old), index(s), cast(s as symbol), cast(ts as date)", null);
+
+        assertColumnsIndexed("new", "s");
+    }
+
+    private void assertColumnsIndexed(String tableName, String... columnNames) throws Exception {
+        assertMemoryLeak(() -> {
+            try (TableReader r = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+                TableReaderMetadata metadata = r.getMetadata();
+                IntList indexed = new IntList();
+
+                for (int i = 0, cols = metadata.getColumnCount(); i < cols; i++) {
+                    indexed.add(0);
+                }
+
+                for (String columnName : columnNames) {
+                    int i = metadata.getColumnIndex(columnName);
+                    indexed.setQuick(i, 1);
+
+                    Assert.assertTrue("Column " + columnName + " should be indexed!", metadata.isColumnIndexed(i));
+                }
+
+                for (int i = 0, len = indexed.size(); i < len; i++) {
+                    if (indexed.getQuick(i) == 0) {
+                        String columnName = metadata.getColumnName(i);
+                        Assert.assertFalse("Column " + columnName + " shouldn't be indexed!", metadata.isColumnIndexed(i));
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/core/src/test/java/io/questdb/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/cairo/CreateTableTest.java
@@ -91,6 +91,13 @@ public class CreateTableTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testCreateTableAsSelectWithCastAndIndexCapacityOnTheSameColumn() throws Exception {
+        assertCompile("create table old(s string,l long, ts timestamp)");
+        assertQuery("s\tl\tts\n", "select * from new",
+                "create table new as (select * from old), cast(s as symbol index capacity 10)", null);
+    }
+
+    @Test
     public void testCreateTableAsSelectWithMultipleCastWithIndexes() throws Exception {
         assertCompile("create table old(s string, sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",
@@ -118,14 +125,14 @@ public class CreateTableTest extends AbstractGriffinTest {
                 "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol)", null);
     }
 
-    @Test//this should be fixed!!!
+    @Test
     public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV2() throws Exception {
         assertCompile("create table old(s string,sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",
                 "create table new as (select * from old), cast(s as symbol), index(s), cast(ts as date), index(sym), cast(sym as symbol index)", null);
     }
 
-    @Test//this should be fixed!!!
+    @Test
     public void testCreateTableAsSelectWithMultipleInterleavedCastAndIndexesV3() throws Exception {
         assertCompile("create table old(s string,sym symbol, ts timestamp)");
         assertQuery("s\tsym\tts\n", "select * from new",

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -1175,6 +1175,10 @@ public class AbstractGriffinTest extends AbstractCairoTest {
         }
     }
 
+    protected static void assertCompile(CharSequence query) throws Exception {
+        assertMemoryLeak(() -> compile(query));
+    }
+
     @NotNull
     protected static CompiledQuery compile(CharSequence query) throws SqlException {
         return compile(query, sqlExecutionContext);

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -887,8 +887,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCreateTableCastIndexCapacityHigh() throws Exception {
         assertSyntaxError(
-                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache index capacity 100000000)",
-                96,
+                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache), index(c capacity 100000000)",
+                100,
                 "max index block capacity is",
                 modelOf("tab")
                         .col("a", ColumnType.INT)
@@ -901,8 +901,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCreateTableCastIndexCapacityLow() throws Exception {
         assertSyntaxError(
-                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache index capacity 1)",
-                96,
+                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache), index(c capacity 1)",
+                100,
                 "min index block capacity is",
                 modelOf("tab")
                         .col("a", ColumnType.INT)
@@ -915,8 +915,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCreateTableCastIndexDef() throws SqlException {
         assertCreateTable(
-                "create table x as (select-choose a, b, c from (select [a, b, c] from tab)), cast(a as DOUBLE:35), cast(c as SYMBOL:54 capacity 32 nocache index capacity 512)",
-                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache index capacity 300)",
+                "create table x as (select-choose a, b, c from (select [a, b, c] from tab)), index(c capacity 512), cast(a as DOUBLE:35), cast(c as SYMBOL:54 capacity 32 nocache)",
+                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache), index(c capacity 300)",
                 modelOf("tab")
                         .col("a", ColumnType.INT)
                         .col("b", ColumnType.LONG)
@@ -928,8 +928,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCreateTableCastIndexInvalidCapacity() throws Exception {
         assertSyntaxError(
-                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache index capacity -)",
-                97,
+                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache), index(c capacity -)",
+                101,
                 "bad integer",
                 modelOf("tab")
                         .col("a", ColumnType.INT)
@@ -942,8 +942,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCreateTableCastIndexNegativeCapacity() throws Exception {
         assertSyntaxError(
-                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache index capacity -3)",
-                96,
+                "create table x as (tab), cast(a as double), cast(c as symbol capacity 20 nocache), index(c capacity -3)",
+                100,
                 "min index block capacity is",
                 modelOf("tab")
                         .col("a", ColumnType.INT)


### PR DESCRIPTION
Fixes "cast(s as symbol index)" by removing index handling from this element so separate index(column_name) should be used.  
Cast with index doesn't create index in master anyway .
