### PR TITLE
fix(cairo): call msync on page release

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4612,8 +4612,7 @@ public class TableWriter implements Closeable {
 
     private void syncColumns() {
         for (int i = 0; i < columnCount; i++) {
-            final MemoryMAR m1 = columns.getQuick(i * 2);
-            m1.sync();
+            columns.getQuick(i * 2).sync();
             final MemoryMAR m2 = columns.getQuick(i * 2 + 1);
             if (m2 != null) {
                 m2.sync();

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryPMARImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryPMARImpl.java
@@ -111,8 +111,10 @@ public class MemoryPMARImpl extends MemoryPARWImpl implements MemoryMAR {
 
     @Override
     protected void release(long address) {
-        if (ff.msync(address, getPageSize(), false) != 0) {
-            throw CairoException.instance(ff.errno()).put("Cannot msync released page fd=").put(fd);
+        if (commitMode != CommitMode.NOSYNC) {
+            if (ff.msync(address, getPageSize(), false) != 0) {
+                LOG.error().$("could not msync released page [fd=").$(fd).$(", errno=").$(ff.errno()).$(']').$();
+            }
         }
         ff.munmap(address, getPageSize(), memoryTag);
     }

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryMA.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryMA.java
@@ -35,7 +35,9 @@ public interface MemoryMA extends MemoryM, MemoryA {
 
     long getAppendAddressSize();
 
-    void sync(boolean async);
+    void sync();
+
+    void setCommitMode(int commitMode);
 
     void of(FilesFacade ff, LPSZ name, long extendSegmentSize, int memoryTag);
 

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryMW.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryMW.java
@@ -26,5 +26,5 @@ package io.questdb.cairo.vm.api;
 
 public interface MemoryMW extends MemoryM, MemoryW {
     void setTruncateSize(long size);
-    void sync(boolean async);
+    void sync();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -137,7 +137,6 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
             transientState.textLoader.configureDestination(
                     name,
                     Chars.equalsNc("true", rh.getUrlParam("overwrite")),
-                    Chars.equalsNc("true", rh.getUrlParam("durable")),
                     getAtomicity(rh.getUrlParam("atomicity")),
                     partitionBy,
                     timestampIndexCol

--- a/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoUdpReceiver.java
@@ -50,7 +50,6 @@ public abstract class AbstractLineProtoUdpReceiver extends SynchronizedJob imple
     protected long fd;
     protected int commitRate;
     protected long totalCount = 0;
-    protected final int commitMode;
 
     public AbstractLineProtoUdpReceiver(
             LineUdpReceiverConfiguration configuration,
@@ -58,7 +57,6 @@ public abstract class AbstractLineProtoUdpReceiver extends SynchronizedJob imple
             WorkerPool workerPool
     ) {
         this.configuration = configuration;
-        this.commitMode = configuration.getCommitMode();
         nf = configuration.getNetworkFacade();
         fd = nf.socketUdp();
         if (fd < 0) {
@@ -104,7 +102,7 @@ public abstract class AbstractLineProtoUdpReceiver extends SynchronizedJob imple
                 LOG.info().$("closed [fd=").$(fd).$(']').$();
             }
             if (parser != null) {
-                parser.commitAll(commitMode);
+                parser.commitAll();
                 parser.close();
             }
             Misc.free(lexer);

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -110,12 +110,12 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
         }
     }
 
-    public void commitAll(int commitMode) {
+    public void commitAll() {
         if (writer != null) {
-            writer.commit(commitMode);
+            writer.commit();
         }
         for (int i = 0, n = commitList.size(); i < n; i++) {
-            commitList.valueQuick(i).commit(commitMode);
+            commitList.valueQuick(i).commit();
         }
         commitList.clear();
     }

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpReceiver.java
@@ -64,7 +64,7 @@ public class LineUdpReceiver extends AbstractLineProtoUdpReceiver {
 
             if (totalCount > commitRate) {
                 totalCount = 0;
-                parser.commitAll(commitMode);
+                parser.commitAll();
             }
 
             if (ran) {
@@ -73,7 +73,7 @@ public class LineUdpReceiver extends AbstractLineProtoUdpReceiver {
 
             ran = true;
         }
-        parser.commitAll(commitMode);
+        parser.commitAll();
         return ran;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LinuxMMLineUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LinuxMMLineUdpReceiver.java
@@ -69,7 +69,7 @@ public class LinuxMMLineUdpReceiver extends AbstractLineProtoUdpReceiver {
 
             if (totalCount > commitRate) {
                 totalCount = 0;
-                parser.commitAll(commitMode);
+                parser.commitAll();
             }
 
             if (ran) {
@@ -78,7 +78,7 @@ public class LinuxMMLineUdpReceiver extends AbstractLineProtoUdpReceiver {
 
             ran = true;
         }
-        parser.commitAll(commitMode);
+        parser.commitAll();
         return ran;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -54,7 +54,6 @@ public class CairoTextWriter implements Closeable, Mutable {
     private TableWriter writer;
     private long _size;
     private boolean overwrite;
-    private boolean durable;
     private int atomicity;
     private int partitionBy;
     private long commitLag = -1;
@@ -107,7 +106,7 @@ public class CairoTextWriter implements Closeable, Mutable {
 
     public void commit() {
         if (writer != null) {
-            writer.commit(durable ? CommitMode.SYNC : CommitMode.NOSYNC);
+            writer.commit();
         }
     }
 
@@ -151,10 +150,9 @@ public class CairoTextWriter implements Closeable, Mutable {
         return writer == null ? 0 : writer.size() - _size;
     }
 
-    public void of(CharSequence name, boolean overwrite, boolean durable, int atomicity, int partitionBy, CharSequence timestampIndexCol) {
+    public void of(CharSequence name, boolean overwrite, int atomicity, int partitionBy, CharSequence timestampIndexCol) {
         this.tableName = name;
         this.overwrite = overwrite;
-        this.durable = durable;
         this.atomicity = atomicity;
         this.partitionBy = partitionBy;
         this.importedTimestampColumnName = timestampIndexCol;
@@ -193,7 +191,7 @@ public class CairoTextWriter implements Closeable, Mutable {
 
     private void checkMaxAndCommitLag() {
         if (writer != null && maxUncommittedRows > 0 && writer.getO3RowCount() >= maxUncommittedRows) {
-            writer.commitWithLag(durable ? CommitMode.SYNC : CommitMode.NOSYNC);
+            writer.commitWithLag();
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
@@ -111,8 +111,8 @@ public class TextLoader implements Closeable, Mutable {
         assert this.columnDelimiter > 0;
     }
 
-    public void configureDestination(CharSequence tableName, boolean overwrite, boolean durable, int atomicity, int partitionBy, CharSequence timestampIndexCol) {
-        textWriter.of(tableName, overwrite, durable, atomicity, partitionBy, timestampIndexCol);
+    public void configureDestination(CharSequence tableName, boolean overwrite, int atomicity, int partitionBy, CharSequence timestampIndexCol) {
+        textWriter.of(tableName, overwrite, atomicity, partitionBy, timestampIndexCol);
         textDelimiterScanner.setTableName(tableName);
         textMetadataParser.setTableName(tableName);
         textLexer.setTableName(tableName);
@@ -120,7 +120,6 @@ public class TextLoader implements Closeable, Mutable {
         LOG.info()
                 .$("configured [table=`").$(tableName)
                 .$("`, overwrite=").$(overwrite)
-                .$(", durable=").$(durable)
                 .$(", atomicity=").$(atomicity)
                 .$(", partitionBy=").$(PartitionBy.toString(partitionBy))
                 .$(", timestamp=").$(timestampIndexCol)

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -2573,7 +2573,7 @@ public class SqlCompiler implements Closeable {
         // todo: configure the following
         //   - what happens when data row errors out, max errors may be?
         //   - we should be able to skip X rows from top, dodgy headers etc.
-        textLoader.configureDestination(model.getTableName().token, false, false, Atomicity.SKIP_ROW, PartitionBy.NONE, null);
+        textLoader.configureDestination(model.getTableName().token, false, Atomicity.SKIP_ROW, PartitionBy.NONE, null);
     }
 
     private CompiledQuery sqlShow(SqlExecutionContext executionContext) throws SqlException {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -62,6 +62,7 @@ public class AbstractCairoTest {
     protected static String inputRoot = null;
     protected static FilesFacade ff;
     protected static long configOverrideCommitLag = -1;
+    protected static int configOverrideCommitMode = -1;
     protected static int configOverrideMaxUncommittedRows = -1;
     protected static Metrics metrics = Metrics.enabled();
     protected static int capacity = -1;
@@ -116,6 +117,12 @@ public class AbstractCairoTest {
             public long getCommitLag() {
                 if (configOverrideCommitLag >= 0) return configOverrideCommitLag;
                 return super.getCommitLag();
+            }
+
+            @Override
+            public int getCommitMode() {
+                if (configOverrideCommitMode >= 0) return configOverrideCommitMode;
+                return super.getCommitMode();
             }
 
             @Override
@@ -211,6 +218,7 @@ public class AbstractCairoTest {
         TestUtils.removeTestPath(root);
         configOverrideMaxUncommittedRows = -1;
         configOverrideCommitLag = -1;
+        configOverrideCommitMode = -1;
         currentMicros = -1;
         sampleByIndexSearchPageSize = -1;
         defaultMapType = null;

--- a/core/src/test/java/io/questdb/cairo/CairoMemoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/CairoMemoryTest.java
@@ -298,7 +298,6 @@ public class CairoMemoryTest {
                     } finally {
                         FF.munmap(addr, fileSize, MemoryTag.MMAP_DEFAULT);
                     }
-
                 }
             }
         });

--- a/core/src/test/java/io/questdb/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableWriterTest.java
@@ -2726,6 +2726,8 @@ public class TableWriterTest extends AbstractCairoTest {
 
     @Test
     public void testTwoByteUtf8() {
+        configOverrideCommitMode = CommitMode.ASYNC;
+
         String name = "соотечественник";
         try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
                 .col("секьюрити", ColumnType.STRING)
@@ -2740,7 +2742,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 r.putStr(0, rnd.nextChars(5));
                 r.append();
             }
-            writer.commit(CommitMode.ASYNC);
+            writer.commit();
             writer.addColumn("митинг", ColumnType.INT);
             Assert.assertEquals(0, writer.getColumnIndex("секьюрити"));
             Assert.assertEquals(2, writer.getColumnIndex("митинг"));
@@ -2930,10 +2932,11 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     private void appendAndAssert10K(long ts, Rnd rnd) {
+        configOverrideCommitMode = CommitMode.SYNC;
         try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
             Assert.assertEquals(20, writer.columns.size());
             populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
-            writer.commit(CommitMode.SYNC);
+            writer.commit();
             Assert.assertEquals(30000, writer.size());
         }
     }
@@ -3035,7 +3038,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long interval = 60000L * 1000L;
         try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
             ts = populateProducts(writer, rnd, ts, n, interval);
-            writer.commit(CommitMode.NOSYNC);
+            writer.commit();
 
             Assert.assertEquals(n, writer.size());
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -6420,6 +6420,11 @@ public class IODispatcherTest {
                     }
                 };
             }
+
+            @Override
+            public int getCommitMode() {
+                return durable ? CommitMode.SYNC : CommitMode.NOSYNC;
+            }
         };
 
         String tableName = "test_table";
@@ -6431,7 +6436,6 @@ public class IODispatcherTest {
 
         String command = "POST /upload?fmt=json&" +
                 String.format("overwrite=%b&", overwrite) +
-                String.format("durable=%b&", durable) +
                 "forceHeader=true&" +
                 "timestamp=ts&" +
                 String.format("partitionBy=%s&", PartitionBy.toString(partitionBy)) +

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
@@ -731,7 +731,7 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
                             lexer.withParser(parser);
                             lexer.parse(mem, mem + len);
                             lexer.parseLast();
-                            parser.commitAll(CommitMode.NOSYNC);
+                            parser.commitAll();
                         }
                     } finally {
                         Unsafe.free(mem, len, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -3105,7 +3105,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
         textLoader.configureColumnDelimiter((byte) 44);
     }
 
-    private void configureLoaderDefaults0(TextLoader textLoader) {
+    private void configureLoaderDefaultsForImport(TextLoader textLoader) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
         textLoader.configureDestination("test", false, Atomicity.SKIP_COL, PartitionBy.DAY, "ts");
         textLoader.configureColumnDelimiter((byte) 44);
@@ -3223,7 +3223,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
             assertNoLeak(
                     engine,
                     textLoader -> {
-                        configureLoaderDefaults(textLoader);
+                        configureLoaderDefaultsForImport(textLoader);
                         textLoader.setForceHeaders(true);
                         textLoader.setCommitLag(commitLag);
                         textLoader.setMaxUncommittedRows(maxUncommittedRows);

--- a/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/TextLoaderTest.java
@@ -3093,7 +3093,7 @@ public class TextLoaderTest extends AbstractGriffinTest {
 
     private void configureLoaderDefaults(TextLoader textLoader, byte columnSeparator, int atomicity, boolean overwrite) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        textLoader.configureDestination("test", overwrite, false, atomicity, PartitionBy.NONE, null);
+        textLoader.configureDestination("test", overwrite, atomicity, PartitionBy.NONE, null);
         if (columnSeparator > 0) {
             textLoader.configureColumnDelimiter(columnSeparator);
         }
@@ -3101,13 +3101,13 @@ public class TextLoaderTest extends AbstractGriffinTest {
 
     private void configureLoaderDefaults(TextLoader textLoader, int atomicity, boolean overwrite, int partitionBy) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        textLoader.configureDestination("test", overwrite, false, atomicity, partitionBy, "ts");
+        textLoader.configureDestination("test", overwrite, atomicity, partitionBy, "ts");
         textLoader.configureColumnDelimiter((byte) 44);
     }
 
-    private void configureLoaderDefaults(TextLoader textLoader, boolean durable) {
+    private void configureLoaderDefaults0(TextLoader textLoader) {
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        textLoader.configureDestination("test", false, durable, Atomicity.SKIP_COL, PartitionBy.DAY, "ts");
+        textLoader.configureDestination("test", false, Atomicity.SKIP_COL, PartitionBy.DAY, "ts");
         textLoader.configureColumnDelimiter((byte) 44);
     }
 
@@ -3213,15 +3213,17 @@ public class TextLoaderTest extends AbstractGriffinTest {
             public long getCommitLag() {
                 return commitLag;
             }
+
+            @Override
+            public int getCommitMode() {
+                return durable ? CommitMode.SYNC : CommitMode.NOSYNC;
+            }
         };
         try (CairoEngine engine = new CairoEngine(configuration)) {
             assertNoLeak(
                     engine,
                     textLoader -> {
-                        configureLoaderDefaults(
-                                textLoader,
-                                durable
-                        );
+                        configureLoaderDefaults(textLoader);
                         textLoader.setForceHeaders(true);
                         textLoader.setCommitLag(commitLag);
                         textLoader.setMaxUncommittedRows(maxUncommittedRows);


### PR DESCRIPTION
Also removes durable parameter from /imp REST endpoint. That's because commit shouldn't be changed in runtime, on demand of REST API user. Otherwise reasoning about durability guarantees would be very hard.