### PR TITLE
feat(http): consider unhandled errors in health check endpoint

### DIFF
--- a/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
@@ -24,6 +24,7 @@
 
 package org.questdb;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
@@ -84,7 +85,7 @@ public class TableReaderReloadBenchmark {
 
     @Setup(Level.Iteration)
     public void setup() throws NumericException {
-        writer = new TableWriter(configuration, "test");
+        writer = new TableWriter(configuration, "test", Metrics.disabled());
         writer.truncate();
         // create 10 partitions
         appendRow(TimestampFormatUtils.parseTimestamp("2012-03-01T00:00:00.000000Z"));

--- a/benchmarks/src/main/java/org/questdb/TableWriteBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableWriteBenchmark.java
@@ -24,6 +24,7 @@
 
 package org.questdb;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.griffin.SqlCompiler;
@@ -103,9 +104,9 @@ public class TableWriteBenchmark {
 
     @Setup(Level.Iteration)
     public void reset() {
-        writer = new TableWriter(configuration, "test1");
-        writer2 = new TableWriter(configuration, "test2");
-        writer3 = new TableWriter(configuration, "test3");
+        writer = new TableWriter(configuration, "test1", Metrics.disabled());
+        writer2 = new TableWriter(configuration, "test2", Metrics.disabled());
+        writer3 = new TableWriter(configuration, "test3", Metrics.disabled());
         rnd.reset();
     }
 

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -24,6 +24,7 @@
 
 package io.questdb;
 
+import io.questdb.cutlass.http.processors.HealthCheckMetrics;
 import io.questdb.cutlass.http.processors.JsonQueryMetrics;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.metrics.MetricsRegistryImpl;
@@ -36,11 +37,13 @@ import io.questdb.std.str.CharSink;
 public class Metrics implements Scrapable {
     private final boolean enabled;
     private final JsonQueryMetrics jsonQuery;
+    private final HealthCheckMetrics healthCheck;
     private final MetricsRegistry metricsRegistry;
 
     Metrics(boolean enabled, MetricsRegistry metricsRegistry) {
         this.enabled = enabled;
         this.jsonQuery = new JsonQueryMetrics(metricsRegistry);
+        this.healthCheck = new HealthCheckMetrics(metricsRegistry);
         createMemoryGauges(metricsRegistry);
         this.metricsRegistry = metricsRegistry;
     }
@@ -69,6 +72,10 @@ public class Metrics implements Scrapable {
 
     public JsonQueryMetrics jsonQuery() {
         return jsonQuery;
+    }
+
+    public HealthCheckMetrics healthCheck() {
+        return healthCheck;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -24,6 +24,7 @@
 
 package io.questdb;
 
+import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cutlass.http.processors.HealthCheckMetrics;
 import io.questdb.cutlass.http.processors.JsonQueryMetrics;
 import io.questdb.metrics.MetricsRegistry;
@@ -38,12 +39,14 @@ public class Metrics implements Scrapable {
     private final boolean enabled;
     private final JsonQueryMetrics jsonQuery;
     private final HealthCheckMetrics healthCheck;
+    private final TableWriterMetrics tableWriter;
     private final MetricsRegistry metricsRegistry;
 
     Metrics(boolean enabled, MetricsRegistry metricsRegistry) {
         this.enabled = enabled;
         this.jsonQuery = new JsonQueryMetrics(metricsRegistry);
         this.healthCheck = new HealthCheckMetrics(metricsRegistry);
+        this.tableWriter = new TableWriterMetrics(metricsRegistry);
         createMemoryGauges(metricsRegistry);
         this.metricsRegistry = metricsRegistry;
     }
@@ -76,6 +79,10 @@ public class Metrics implements Scrapable {
 
     public HealthCheckMetrics healthCheck() {
         return healthCheck;
+    }
+
+    public TableWriterMetrics tableWriter() {
+        return tableWriter;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -170,7 +170,7 @@ public class ServerMain {
         final ObjList<Closeable> instancesToClean = new ObjList<>();
 
         LogFactory.configureFromSystemProperties(workerPool);
-        final CairoEngine cairoEngine = new CairoEngine(configuration.getCairoConfiguration());
+        final CairoEngine cairoEngine = new CairoEngine(configuration.getCairoConfiguration(), metrics);
         workerPool.assign(cairoEngine.getEngineMaintenanceJob());
         instancesToClean.add(cairoEngine);
 

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -24,7 +24,9 @@
 
 package io.questdb;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.O3Utils;
+import io.questdb.cairo.SqlJitMode;
 import io.questdb.cutlass.http.HttpServer;
 import io.questdb.cutlass.json.JsonException;
 import io.questdb.cutlass.line.tcp.LineTcpReceiver;
@@ -153,7 +155,14 @@ public class ServerMain {
             }
         }
 
-        final WorkerPool workerPool = new WorkerPool(configuration.getWorkerPoolConfiguration());
+        Metrics metrics;
+        if (configuration.getMetricsConfiguration().isEnabled()) {
+            metrics = Metrics.enabled();
+        } else {
+            metrics = Metrics.disabled();
+        }
+
+        final WorkerPool workerPool = new WorkerPool(configuration.getWorkerPoolConfiguration(), metrics);
         final FunctionFactoryCache functionFactoryCache = new FunctionFactoryCache(
                 configuration.getCairoConfiguration(),
                 ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader())
@@ -176,13 +185,6 @@ public class ServerMain {
 
         workerPool.assignCleaner(Path.CLEANER);
         O3Utils.setupWorkerPool(workerPool, cairoEngine.getMessageBus());
-
-        Metrics metrics;
-        if (configuration.getMetricsConfiguration().isEnabled()) {
-            metrics = Metrics.enabled();
-        } else {
-            metrics = Metrics.disabled();
-        }
 
         try {
             initQuestDb(workerPool, cairoEngine, log);
@@ -221,7 +223,8 @@ public class ServerMain {
                     configuration.getLineTcpReceiverConfiguration(),
                     workerPool,
                     log,
-                    cairoEngine
+                    cairoEngine,
+                    metrics
             ));
 
             startQuestDb(workerPool, cairoEngine, log);
@@ -488,6 +491,9 @@ public class ServerMain {
             final CairoEngine cairoEngine,
             FunctionFactoryCache functionFactoryCache,
             Metrics metrics) {
+        if (!metrics.isEnabled()) {
+            log.advisory().$("Min health server is starting. Health check endpoint will not consider unhandled errors when metrics are disabled.").$();
+        }
         return HttpServer.createMin(
                 configuration.getHttpMinServerConfiguration(),
                 workerPool,
@@ -498,6 +504,7 @@ public class ServerMain {
         );
     }
 
+    @SuppressWarnings("unused")
     protected void initQuestDb(
             final WorkerPool workerPool,
             final CairoEngine cairoEngine,

--- a/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
+++ b/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
@@ -55,14 +55,14 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
         public boolean isEnabled() {
             return true;
         }
-
     };
 
     static WorkerPool configureWorkerPool(
             WorkerPoolAwareConfiguration configuration,
-            WorkerPool sharedPool
+            WorkerPool sharedPool,
+            Metrics metrics
     ) {
-        return configuration.getWorkerCount() > 0 ? new WorkerPool(configuration) : sharedPool;
+        return configuration.getWorkerCount() > 0 ? new WorkerPool(configuration, metrics) : sharedPool;
     }
 
     @Nullable
@@ -77,8 +77,7 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
     ) {
         final T server;
         if (configuration.isEnabled()) {
-
-            final WorkerPool localPool = configureWorkerPool(configuration, sharedWorkerPool);
+            final WorkerPool localPool = configureWorkerPool(configuration, sharedWorkerPool, metrics);
             final boolean local = localPool != sharedWorkerPool;
             server = factory.create(configuration, cairoEngine, localPool, local, functionFactoryCache, metrics);
 

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -70,7 +70,8 @@ public class CairoEngine implements Closeable, WriterSource {
     private long tableIdFd = -1;
     private long tableIdMem = 0;
 
-    // Kept for embedded API purposes.
+    // Kept for embedded API purposes. The second constructor (the one with metrics)
+    // should be preferred for internal use.
     public CairoEngine(CairoConfiguration configuration) {
         this(configuration, Metrics.disabled());
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -26,6 +26,7 @@ package io.questdb.cairo;
 
 import io.questdb.MessageBus;
 import io.questdb.MessageBusImpl;
+import io.questdb.Metrics;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.vm.MemoryFCRImpl;
@@ -177,18 +178,19 @@ public class TableWriter implements Closeable {
     private ObjList<Runnable> activeNullSetters;
     private int rowActon = ROW_ACTION_OPEN_PARTITION;
     private long committedMasterRef;
+    private final Metrics metrics;
 
     // ILP related
     private double commitIntervalFraction;
     private long commitIntervalDefault;
     private long commitInterval;
 
-    public TableWriter(CairoConfiguration configuration, CharSequence tableName) {
-        this(configuration, tableName, null, new MessageBusImpl(configuration), true, DefaultLifecycleManager.INSTANCE, configuration.getRoot());
+    public TableWriter(CairoConfiguration configuration, CharSequence tableName, Metrics metrics) {
+        this(configuration, tableName, null, new MessageBusImpl(configuration), true, DefaultLifecycleManager.INSTANCE, configuration.getRoot(), metrics);
     }
 
-    public TableWriter(CairoConfiguration configuration, CharSequence tableName, @NotNull MessageBus messageBus) {
-        this(configuration, tableName, messageBus, true, DefaultLifecycleManager.INSTANCE);
+    public TableWriter(CairoConfiguration configuration, CharSequence tableName, @NotNull MessageBus messageBus, Metrics metrics) {
+        this(configuration, tableName, messageBus, true, DefaultLifecycleManager.INSTANCE, metrics);
     }
 
     public TableWriter(
@@ -196,9 +198,10 @@ public class TableWriter implements Closeable {
             CharSequence tableName,
             @NotNull MessageBus messageBus,
             boolean lock,
-            LifecycleManager lifecycleManager
+            LifecycleManager lifecycleManager,
+            Metrics metrics
     ) {
-        this(configuration, tableName, messageBus, null, lock, lifecycleManager, configuration.getRoot());
+        this(configuration, tableName, messageBus, null, lock, lifecycleManager, configuration.getRoot(), metrics);
     }
 
     public TableWriter(
@@ -208,10 +211,12 @@ public class TableWriter implements Closeable {
             MessageBus ownMessageBus,
             boolean lock,
             LifecycleManager lifecycleManager,
-            CharSequence root
+            CharSequence root,
+            Metrics metrics
     ) {
         LOG.info().$("open '").utf8(tableName).$('\'').$();
         this.configuration = configuration;
+        this.metrics = metrics;
         this.ownMessageBus = ownMessageBus;
         if (ownMessageBus != null) {
             this.messageBus = ownMessageBus;
@@ -1261,6 +1266,7 @@ public class TableWriter implements Closeable {
                 o3MasterRef = -1;
                 LOG.info().$("tx rollback complete [name=").$(tableName).$(']').$();
                 processCommandQueue(false);
+                metrics.tableWriter().incrementRollbacks();
             } catch (Throwable e) {
                 LOG.critical().$("could not perform rollback [name=").$(tableName).$(", msg=").$(e.getMessage()).$(']').$();
                 distressed = true;
@@ -1829,12 +1835,18 @@ public class TableWriter implements Closeable {
                 syncColumns(commitMode);
             }
 
+            final long committedRowCount = txWriter.getCommittedFixedRowCount() + txWriter.getCommittedTransientRowCount();
+            final long rowsAdded = txWriter.getRowCount() - committedRowCount;
+
             updateIndexes();
             txWriter.commit(commitMode, this.denseSymbolMapWriters);
 
             // Bookmark masterRef to track how many rows is in uncommitted state
             this.committedMasterRef = masterRef;
             o3ProcessPartitionRemoveCandidates();
+
+            metrics.tableWriter().incrementCommits();
+            metrics.tableWriter().addCommittedRows(rowsAdded);
         }
     }
 
@@ -2746,6 +2758,9 @@ public class TableWriter implements Closeable {
             distressed = true;
             throw e;
         }
+
+        metrics.tableWriter().incrementO3Commits();
+
         return false;
     }
 
@@ -2996,13 +3011,13 @@ public class TableWriter implements Closeable {
     private long o3MoveUncommitted(final int timestampIndex) {
         final long committedRowCount = txWriter.getCommittedFixedRowCount() + txWriter.getCommittedTransientRowCount();
         final long rowsAdded = txWriter.getRowCount() - committedRowCount;
-        long transientRowsAdded = Math.min(txWriter.getTransientRowCount(), rowsAdded);
-        final long committedTransientRowCount = txWriter.getTransientRowCount() - transientRowsAdded;
+        final long transientRowsAdded = Math.min(txWriter.getTransientRowCount(), rowsAdded);
         if (transientRowsAdded > 0) {
             LOG.debug()
                     .$("o3 move uncommitted [table=").$(tableName)
                     .$(", transientRowsAdded=").$(transientRowsAdded)
                     .I$();
+            final long committedTransientRowCount = txWriter.getTransientRowCount() - transientRowsAdded;
             return o3ScheduleMoveUncommitted0(
                     timestampIndex,
                     transientRowsAdded,

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
@@ -22,38 +22,39 @@
  *
  ******************************************************************************/
 
-package io.questdb.metrics;
+package io.questdb.cairo;
 
-import io.questdb.std.str.CharSink;
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.MetricsRegistry;
 
-class NullCounter implements Counter, CounterWithOneLabel, CounterWithTwoLabels {
-    static final NullCounter INSTANCE = new NullCounter();
+public class TableWriterMetrics {
 
-    private NullCounter() {
+    // Includes all types of commits (in-order and o3)
+    private final Counter commitCounter;
+    private final Counter o3CommitCounter;
+    private final Counter committedRowCounter;
+    private final Counter rollbackCounter;
+
+    public TableWriterMetrics(MetricsRegistry metricsRegistry) {
+        this.commitCounter = metricsRegistry.newCounter("commits");
+        this.o3CommitCounter = metricsRegistry.newCounter("o3_commits");
+        this.committedRowCounter = metricsRegistry.newCounter("committed_rows");
+        this.rollbackCounter = metricsRegistry.newCounter("rollbacks");
     }
 
-    @Override
-    public void inc() {
+    public void incrementCommits() {
+        commitCounter.inc();
     }
 
-    @Override
-    public void add(long value) {
+    public void incrementO3Commits() {
+        o3CommitCounter.inc();
     }
 
-    @Override
-    public long get() {
-        return 0;
+    public void addCommittedRows(long rows) {
+        committedRowCounter.add(rows);
     }
 
-    @Override
-    public void inc(short label0) {
-    }
-
-    @Override
-    public void inc(short label0, short label1) {
-    }
-
-    @Override
-    public void scrapeIntoPrometheus(CharSink sink) {
+    public void incrementRollbacks() {
+        rollbackCounter.inc();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.http;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoSecurityContext;
 import io.questdb.cairo.security.CairoSecurityContextImpl;
 import io.questdb.cutlass.http.ex.*;
@@ -49,6 +50,7 @@ public class HttpConnectionContext implements IOContext, Locality, Mutable, Retr
     private final NetworkFacade nf;
     private final long multipartIdleSpinCount;
     private final CairoSecurityContext cairoSecurityContext;
+    private final Metrics metrics;
     private final boolean dumpNetworkTraffic;
     private final boolean allowDeflateBeforeSend;
     private final MultipartParserState multipartParserState = new MultipartParserState();
@@ -67,7 +69,7 @@ public class HttpConnectionContext implements IOContext, Locality, Mutable, Retr
     private long totalBytesSent;
     private int receivedBytes;
 
-    public HttpConnectionContext(HttpContextConfiguration configuration) {
+    public HttpConnectionContext(HttpContextConfiguration configuration, Metrics metrics) {
         this.nf = configuration.getNetworkFacade();
         this.csPool = new ObjectPool<>(DirectByteCharSequence.FACTORY, configuration.getConnectionStringPoolCapacity());
         this.headerParser = new HttpHeaderParser(configuration.getRequestHeaderBufferSize(), csPool);
@@ -82,6 +84,7 @@ public class HttpConnectionContext implements IOContext, Locality, Mutable, Retr
         this.cairoSecurityContext = new CairoSecurityContextImpl(!configuration.readOnlySecurityContext());
         this.serverKeepAlive = configuration.getServerKeepAlive();
         this.onPeerDisconnect = configuration.onPeerDisconnect();
+        this.metrics = metrics;
     }
 
     @Override
@@ -204,6 +207,10 @@ public class HttpConnectionContext implements IOContext, Locality, Mutable, Retr
 
     public CairoSecurityContext getCairoSecurityContext() {
         return cairoSecurityContext;
+    }
+
+    public Metrics getMetrics() {
+        return metrics;
     }
 
     public HttpChunkedResponseSocket getChunkedResponseSocket() {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -288,8 +288,7 @@ public class HttpServer implements Closeable {
                 configuration.getJsonQueryProcessorConfiguration(),
                 cairoEngine,
                 workerPool.getWorkerCount(),
-                functionFactoryCache,
-                metrics);
+                functionFactoryCache);
         addDefaultEndpoints(s, configuration, cairoEngine, workerPool, jsonQueryProcessorBuilder, functionFactoryCache);
         return s;
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.http.processors;
+
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.MetricsRegistry;
+
+public class HealthCheckMetrics {
+
+    private final Counter unhandledErrorsCounter;
+
+    public HealthCheckMetrics(MetricsRegistry metricsRegistry) {
+        this.unhandledErrorsCounter = metricsRegistry.newCounter("unhandled_errors");
+    }
+
+    public void incrementUnhandledErrors() {
+        unhandledErrorsCounter.inc();
+    }
+
+    public long unhandledErrorsCount() {
+        return unhandledErrorsCounter.get();
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
@@ -29,17 +29,17 @@ import io.questdb.metrics.MetricsRegistry;
 
 public class HealthCheckMetrics {
 
-    private final Counter unhandledErrorsCounter;
+    private final Counter unhandledErrorCounter;
 
     public HealthCheckMetrics(MetricsRegistry metricsRegistry) {
-        this.unhandledErrorsCounter = metricsRegistry.newCounter("unhandled_errors");
+        this.unhandledErrorCounter = metricsRegistry.newCounter("unhandled_errors");
     }
 
     public void incrementUnhandledErrors() {
-        unhandledErrorsCounter.inc();
+        unhandledErrorCounter.inc();
     }
 
     public long unhandledErrorsCount() {
-        return unhandledErrorsCounter.get();
+        return unhandledErrorCounter.get();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
@@ -31,11 +31,24 @@ import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 
 public class HealthCheckProcessor implements HttpRequestProcessor {
+
     @Override
     public void onRequestComplete(HttpConnectionContext context) throws PeerDisconnectedException, PeerIsSlowToReadException {
         HttpChunkedResponseSocket r = context.getChunkedResponseSocket();
+        final HealthCheckMetrics metrics = context.getMetrics().healthCheck();
+        final long unhandledErrors = metrics.unhandledErrorsCount();
+        if (unhandledErrors > 0) {
+            r.status(500, "text/plain");
+            r.sendHeader();
+            r.put("Status: Unhealthy\nUnhandled errors: ");
+            r.put(unhandledErrors);
+            r.sendChunk(true);
+            return;
+        }
+
         r.status(200, "text/plain");
         r.sendHeader();
-        r.done();
+        r.put("Status: Healthy");
+        r.sendChunk(true);
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -464,6 +464,8 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             state.info().$("query cancelled [q=`").utf8(state.getQuery()).$("`, reason=`").$(((CairoException) e).getFlyweightMessage()).$("`]").$();
         } else {
             state.error().$("internal error [q=`").utf8(state.getQuery()).$("`, ex=").$(e).$(']').$();
+            // This is a critical error, so we treat it as an unhandled one.
+            metrics.healthCheck().incrementUnhandledErrors();
         }
         sendException(socket, 0, message, state.getQuery(), configuration.getKeepAliveHeader());
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -462,6 +462,8 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
         if (e instanceof CairoException && ((CairoException) e).isInterruption()) {
             state.info().$("query cancelled [q=`").utf8(state.getQuery()).$("`, reason=`").$(((CairoException) e).getFlyweightMessage()).$("`]").$();
+        } else if (e instanceof HttpException) {
+            state.error().$("internal HTTP server error [q=`").utf8(state.getQuery()).$("`, reason=`").$(((HttpException) e).getFlyweightMessage()).$("`]").$();
         } else {
             state.error().$("internal error [q=`").utf8(state.getQuery()).$("`, ex=").$(e).$(']').$();
             // This is a critical error, so we treat it as an unhandled one.

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -67,27 +67,24 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
     public JsonQueryProcessor(
             JsonQueryProcessorConfiguration configuration,
             CairoEngine engine,
-            int workerCount,
-            Metrics metrics
+            int workerCount
     ) {
-        this(configuration, engine, workerCount, null, metrics);
+        this(configuration, engine, workerCount, null);
     }
 
     public JsonQueryProcessor(
             JsonQueryProcessorConfiguration configuration,
             CairoEngine engine,
             int workerCount,
-            @Nullable FunctionFactoryCache functionFactoryCache,
-            Metrics metrics
+            @Nullable FunctionFactoryCache functionFactoryCache
     ) {
-        this(configuration, engine, new SqlCompiler(engine, functionFactoryCache), metrics, new SqlExecutionContextImpl(engine, workerCount));
+        this(configuration, engine, new SqlCompiler(engine, functionFactoryCache), new SqlExecutionContextImpl(engine, workerCount));
     }
 
     public JsonQueryProcessor(
             JsonQueryProcessorConfiguration configuration,
             CairoEngine engine,
             SqlCompiler sqlCompiler,
-            Metrics metrics,
             SqlExecutionContextImpl sqlExecutionContext
     ) {
         this.configuration = configuration;
@@ -113,7 +110,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         this.sqlExecutionContext = sqlExecutionContext;
         this.nanosecondClock = engine.getConfiguration().getNanosecondClock();
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(configuration.getCircuitBreakerConfiguration());
-        this.metrics = metrics;
+        this.metrics = engine.getMetrics();
         this.alterStartTimeout = engine.getConfiguration().getWriterAsyncCommandBusyWaitTimeout();
         this.alterStartFullTimeoutNs = engine.getConfiguration().getWriterAsyncCommandMaxTimeout() * 1000;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpAuthConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpAuthConnectionContext.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.line.tcp;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -72,8 +73,8 @@ class LineTcpAuthConnectionContext extends LineTcpConnectionContext {
 
     private AuthState authState;
 
-    LineTcpAuthConnectionContext(LineTcpReceiverConfiguration configuration, AuthDb authDb, LineTcpMeasurementScheduler scheduler) {
-        super(configuration, scheduler);
+    LineTcpAuthConnectionContext(LineTcpReceiverConfiguration configuration, AuthDb authDb, LineTcpMeasurementScheduler scheduler, Metrics metrics) {
+        super(configuration, scheduler, metrics);
         if (configuration.getNetMsgBufferSize() < MIN_BUF_SIZE) {
             throw CairoException.instance(0).put("Minimum buffer length is ").put(MIN_BUF_SIZE);
         }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -122,7 +122,8 @@ class LineTcpMeasurementScheduler implements Closeable {
                         subSeq,
                         milliClock,
                         commitIntervalDefault,
-                        this
+                        this,
+                        engine.getMetrics()
                 );
                 writerWorkerPool.assign(i, (Job) lineTcpWriterJob);
                 writerWorkerPool.assign(i, (Closeable) lineTcpWriterJob);
@@ -137,7 +138,8 @@ class LineTcpMeasurementScheduler implements Closeable {
                     subSeq,
                     milliClock,
                     commitIntervalDefault,
-                    this
+                    this,
+                    engine.getMetrics()
             );
             writerWorkerPool.assign(0, (Job) lineTcpWriterJob);
             writerWorkerPool.assign(0, (Closeable) lineTcpWriterJob);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.line.tcp;
 
+import io.questdb.Metrics;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.log.Log;
@@ -77,15 +78,18 @@ public class LineTcpReceiver implements Closeable {
             LineTcpReceiverConfiguration lineConfiguration,
             WorkerPool sharedWorkerPool,
             Log log,
-            CairoEngine cairoEngine
+            CairoEngine cairoEngine,
+            Metrics metrics
     ) {
         if (!lineConfiguration.isEnabled()) {
             return null;
         }
 
         ObjList<WorkerPool> dedicatedPools = new ObjList<>(2);
-        WorkerPool ioWorkerPool = WorkerPoolAwareConfiguration.configureWorkerPool(lineConfiguration.getIOWorkerPoolConfiguration(), sharedWorkerPool);
-        WorkerPool writerWorkerPool = WorkerPoolAwareConfiguration.configureWorkerPool(lineConfiguration.getWriterWorkerPoolConfiguration(), sharedWorkerPool);
+        WorkerPool ioWorkerPool = WorkerPoolAwareConfiguration.configureWorkerPool(
+                lineConfiguration.getIOWorkerPoolConfiguration(), sharedWorkerPool, metrics);
+        WorkerPool writerWorkerPool = WorkerPoolAwareConfiguration.configureWorkerPool(
+                lineConfiguration.getWriterWorkerPoolConfiguration(), sharedWorkerPool, metrics);
         if (ioWorkerPool != sharedWorkerPool) {
             ioWorkerPool.assignCleaner(Path.CLEANER);
             dedicatedPools.add(ioWorkerPool);

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1346,6 +1346,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
             }
             throw e;
         }
+        throw new NullPointerException("boom");
     }
 
     private void executeTag() {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1346,7 +1346,6 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
             }
             throw e;
         }
-        throw new NullPointerException("boom");
     }
 
     private void executeTag() {

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -28,8 +28,8 @@ import io.questdb.MessageBus;
 import io.questdb.PropServerConfiguration;
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.WriterPool;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.text.Atomicity;
@@ -1955,7 +1955,7 @@ public class SqlCompiler implements Closeable {
 
     //sets insertCount to number of copied rows
     private TableWriter copyTableData(CharSequence tableName, RecordCursor cursor, RecordMetadata cursorMetadata) {
-        TableWriter writer = new TableWriter(configuration, tableName, messageBus, false, DefaultLifecycleManager.INSTANCE);
+        TableWriter writer = new TableWriter(configuration, tableName, messageBus, false, DefaultLifecycleManager.INSTANCE, engine.getMetrics());
         try {
             RecordMetadata writerMetadata = writer.getMetadata();
             entityColumnFilter.of(writerMetadata.getColumnCount());

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -24,6 +24,7 @@
 
 package io.questdb.log;
 
+import io.questdb.Metrics;
 import io.questdb.mp.*;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
@@ -313,7 +314,7 @@ public class LogFactory implements Closeable {
             public boolean isDaemonPool() {
                 return true;
             }
-        });
+        }, Metrics.disabled());
         assign(workerPool);
         workerPool.start(null);
     }

--- a/core/src/main/java/io/questdb/metrics/Counter.java
+++ b/core/src/main/java/io/questdb/metrics/Counter.java
@@ -28,7 +28,11 @@ import org.jetbrains.annotations.TestOnly;
 
 public interface Counter extends Scrapable {
 
-    void inc();
+    default void inc() {
+        add(1);
+    }
+
+    void add(long value);
 
     @TestOnly
     long get();

--- a/core/src/main/java/io/questdb/metrics/CounterImpl.java
+++ b/core/src/main/java/io/questdb/metrics/CounterImpl.java
@@ -39,8 +39,8 @@ class CounterImpl implements Counter {
     }
 
     @Override
-    public void inc() {
-        counter.increment();
+    public void add(long value) {
+        counter.add(value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -24,6 +24,7 @@
 
 package io.questdb.mp;
 
+import io.questdb.Metrics;
 import io.questdb.log.Log;
 import io.questdb.std.ObjHashSet;
 import io.questdb.std.Os;
@@ -45,6 +46,7 @@ public class Worker extends Thread {
     private volatile int running = 0;
     private final long yieldThreshold;
     private final long sleepThreshold;
+    private final Metrics metrics;
 
     public Worker(
             final ObjHashSet<? extends Job> jobs,
@@ -57,7 +59,8 @@ public class Worker extends Thread {
             String poolName,
             long yieldThreshold,
             long sleepThreshold,
-            long sleepMs
+            long sleepMs,
+            Metrics metrics
     ) {
         this.log = log;
         this.jobs = jobs;
@@ -70,6 +73,7 @@ public class Worker extends Thread {
         this.yieldThreshold = yieldThreshold;
         this.sleepThreshold = sleepThreshold;
         this.sleepMs = sleepMs;
+        this.metrics = metrics;
     }
 
     public int getWorkerId() {
@@ -153,6 +157,7 @@ public class Worker extends Thread {
     }
 
     private void onError(int i, Throwable e) throws Throwable {
+        metrics.healthCheck().incrementUnhandledErrors();
         // Log error even when halt on error is set
         if (log != null) {
             log.error().$("unhandled error [job=").$(jobs.get(i).toString()).$(", ex=").$(e).$(']').$();

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -24,6 +24,7 @@
 
 package io.questdb.mp;
 
+import io.questdb.Metrics;
 import io.questdb.log.Log;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjHashSet;
@@ -48,8 +49,9 @@ public class WorkerPool {
     private final long yieldThreshold;
     private final long sleepThreshold;
     private final long sleepMs;
+    private final Metrics metrics;
 
-    public WorkerPool(WorkerPoolConfiguration configuration) {
+    public WorkerPool(WorkerPoolConfiguration configuration, Metrics metrics) {
         this.workerCount = configuration.getWorkerCount();
         this.workerAffinity = configuration.getWorkerAffinity();
         this.halted = new SOCountDownLatch(workerCount);
@@ -59,6 +61,7 @@ public class WorkerPool {
         this.yieldThreshold = configuration.getYieldThreshold();
         this.sleepThreshold = configuration.getSleepThreshold();
         this.sleepMs = configuration.getSleepMs();
+        this.metrics = metrics;
 
         assert workerAffinity.length == workerCount;
 
@@ -144,7 +147,8 @@ public class WorkerPool {
                         poolName,
                         yieldThreshold,
                         sleepThreshold,
-                        sleepMs
+                        sleepMs,
+                        metrics
                 );
                 worker.setDaemon(daemons);
                 workers.add(worker);

--- a/core/src/main/java/io/questdb/network/NoSpaceLeftInResponseBufferException.java
+++ b/core/src/main/java/io/questdb/network/NoSpaceLeftInResponseBufferException.java
@@ -27,5 +27,10 @@ package io.questdb.network;
 import io.questdb.cutlass.http.HttpException;
 
 public class NoSpaceLeftInResponseBufferException extends HttpException {
-    public final static NoSpaceLeftInResponseBufferException INSTANCE = new NoSpaceLeftInResponseBufferException();
+    public final static NoSpaceLeftInResponseBufferException INSTANCE;
+
+    static {
+        INSTANCE = new NoSpaceLeftInResponseBufferException();
+        INSTANCE.put("no space left in response buffer");
+    }
 }

--- a/core/src/test/java/io/questdb/EmbeddedApiTest.java
+++ b/core/src/test/java/io/questdb/EmbeddedApiTest.java
@@ -77,8 +77,7 @@ public class EmbeddedApiTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
-
+            }, Metrics.disabled());
 
             Rnd rnd = new Rnd();
             try (

--- a/core/src/test/java/io/questdb/PerformanceTest.java
+++ b/core/src/test/java/io/questdb/PerformanceTest.java
@@ -76,7 +76,7 @@ public class PerformanceTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter w = new TableWriter(configuration, "quote")) {
+            try (TableWriter w = new TableWriter(configuration, "quote", Metrics.disabled())) {
                 for (int i = -count; i < count; i++) {
                     if (i == 0) {
                         t = System.nanoTime();
@@ -164,7 +164,7 @@ public class PerformanceTest extends AbstractCairoTest {
 
         CountDownLatch stopLatch = new CountDownLatch(2);
         CountDownLatch startLatch = new CountDownLatch(2);
-        try (TableWriter w = new TableWriter(configuration, "quote");
+        try (TableWriter w = new TableWriter(configuration, "quote", Metrics.disabled());
              TableReader reader = new TableReader(configuration, "quote")) {
             // Writing
             new Thread(() -> {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -183,7 +183,7 @@ public class AbstractCairoTest {
                 return 512;
             }
         };
-        engine = new CairoEngine(configuration);
+        engine = new CairoEngine(configuration, metrics);
         messageBus = engine.getMessageBus();
     }
 

--- a/core/src/test/java/io/questdb/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/cairo/BitmapIndexTest.java
@@ -688,7 +688,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += timestampIncrement);
                     row.putStr(0, rnd.nextChars(20));

--- a/core/src/test/java/io/questdb/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/cairo/CairoEngineTest.java
@@ -312,7 +312,7 @@ public class CairoEngineTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             createX();
 
-            try (TableWriter ignored1 = new TableWriter(configuration, "x")) {
+            try (TableWriter ignored1 = new TableWriter(configuration, "x", metrics)) {
 
                 try (CairoEngine engine = new CairoEngine(configuration)) {
                     try {

--- a/core/src/test/java/io/questdb/cairo/CairoTestUtils.java
+++ b/core/src/test/java/io/questdb/cairo/CairoTestUtils.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo;
 
+import io.questdb.Metrics;
 import io.questdb.std.Numbers;
 import io.questdb.std.Rnd;
 
@@ -116,7 +117,7 @@ public class CairoTestUtils {
             create(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, "x")) {
+        try (TableWriter writer = new TableWriter(configuration, "x", Metrics.disabled())) {
             for (int i = 0; i < n; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putByte(0, rnd.nextByte());

--- a/core/src/test/java/io/questdb/cairo/DoubleReloadTest.java
+++ b/core/src/test/java/io/questdb/cairo/DoubleReloadTest.java
@@ -41,7 +41,7 @@ public class DoubleReloadTest extends AbstractCairoTest {
 
         try (
                 TableReader reader = new TableReader(configuration, "int_test");
-                TableWriter w = new TableWriter(configuration, "int_test")
+                TableWriter w = new TableWriter(configuration, "int_test", metrics)
         ) {
             reader.reload();
 

--- a/core/src/test/java/io/questdb/cairo/FullBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullBwdDataFrameCursorTest.java
@@ -74,7 +74,7 @@ public class FullBwdDataFrameCursorTest extends AbstractCairoTest {
             long increment = 3600000000L * 8;
             int N = 10;
 
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = w.newRow(timestamp);
                     row.putInt(0, rnd.nextInt());

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorFactoryTest.java
@@ -59,7 +59,7 @@ public class FullFwdDataFrameCursorFactoryTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -84,7 +84,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             long timestamp;
             final Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 timestamp = TimestampFormatUtils.parseTimestamp("1970-01-03T08:00:00.000Z");
 
                 TableWriter.Row row = writer.newRow(timestamp);
@@ -753,7 +753,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             }, null)) {
 
                 long timestamp = 0;
-                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler)) {
+                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler, metrics)) {
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = writer.newRow(timestamp);
                         r.putSym(0, sg.symA[rnd.nextPositiveInt() % S]);
@@ -1052,7 +1052,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             eRnd.syncWith(rnd);
 
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "ABC")) {
+            try (TableWriter writer = new TableWriter(configuration, "ABC", metrics)) {
                 for (int i = 0; i < (long) N; i++) {
                     TableWriter.Row r = writer.newRow(timestamp += increment);
                     r.putSym(0, sg.symA[rnd.nextPositiveInt() % sg.S]);
@@ -1067,7 +1067,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 TestUtils.assertContains(e.getFlyweightMessage(), "remove");
             }
 
-            new TableWriter(AbstractCairoTest.configuration, "ABC").close();
+            new TableWriter(AbstractCairoTest.configuration, "ABC", metrics).close();
 
             Assert.assertTrue(ff.wasCalled());
 
@@ -1167,7 +1167,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             if (!empty) {
                 timestamp = sg.appendABC(AbstractCairoTest.configuration, rnd, N, timestamp, increment);
             }
-            try (TableWriter writer = new TableWriter(configuration, "ABC")) {
+            try (TableWriter writer = new TableWriter(configuration, "ABC", metrics)) {
                 // first batch without problems
                 try {
                     for (int i = 0; i < (long) N; i++) {
@@ -1206,7 +1206,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             // ft table is empty constructor should only attempt to recover non-partitioned ones
             if (empty && partitionBy == PartitionBy.NONE) {
                 try {
-                    new TableWriter(configuration, "ABC");
+                    new TableWriter(configuration, "ABC", metrics);
                     Assert.fail();
                 } catch (CairoException ignore) {
                 }
@@ -1311,7 +1311,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             }
 
             try {
-                new TableWriter(configuration, "ABC");
+                new TableWriter(configuration, "ABC", metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -1408,7 +1408,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 }
 
                 long timestamp = 0;
-                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler)) {
+                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler, metrics)) {
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = writer.newRow(timestamp += increment);
                         r.putSym(0, sg.symA[rnd.nextPositiveInt() % S]);
@@ -1541,7 +1541,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 }, metrics);
                 workerPool.assign(new ColumnIndexerJob(workScheduler));
 
-                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler)) {
+                try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler, metrics)) {
                     try {
                         for (int i = 0; i < (long) N; i++) {
                             TableWriter.Row r = writer.newRow(timestamp += increment);
@@ -1578,7 +1578,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 // constructor must attempt to recover non-partitioned empty table
                 if (empty && partitionBy == PartitionBy.NONE) {
                     try {
-                        new TableWriter(configuration, "ABC");
+                        new TableWriter(configuration, "ABC", metrics);
                         Assert.fail();
                     } catch (CairoException ignore) {
                     }
@@ -1657,7 +1657,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -1733,7 +1733,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -1804,7 +1804,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -1881,7 +1881,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -1958,7 +1958,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -2061,7 +2061,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -2139,7 +2139,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -2214,7 +2214,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 populateTable(writer, symbols, rnd, timestamp, increment, M);
                 writer.commit();
             }
@@ -2263,7 +2263,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 timestamp = populateTable(writer, symbols, rnd, timestamp, increment, M / 2);
 
                 writer.addIndex("a", configuration.getIndexValueBlockSize());
@@ -2318,7 +2318,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
             // prepare the data, make sure rollback does the job
             long timestamp = 0;
 
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 timestamp = populateTable(writer, symbols, rnd, timestamp, increment, M);
                 writer.commit();
                 timestamp = populateTable(writer, symbols, rnd, timestamp, increment, M);
@@ -2368,7 +2368,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
 
                 for (int i = 0; i < M / 2; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
@@ -2452,7 +2452,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
         }
 
         long appendABC(CairoConfiguration configuration, Rnd rnd, long N, long timestamp, long increment) {
-            try (TableWriter writer = new TableWriter(configuration, "ABC")) {
+            try (TableWriter writer = new TableWriter(configuration, "ABC", metrics)) {
                 // first batch without problems
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow(timestamp += increment);

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -1400,7 +1400,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                         public boolean haltOnError() {
                             return false;
                         }
-                    });
+                    }, metrics);
                     workerPool.assign(new ColumnIndexerJob(workScheduler));
                     workerPool.start(LOG);
                 } else {
@@ -1538,7 +1538,7 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                     public boolean haltOnError() {
                         return false;
                     }
-                });
+                }, metrics);
                 workerPool.assign(new ColumnIndexerJob(workScheduler));
 
                 try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler)) {

--- a/core/src/test/java/io/questdb/cairo/IntervalBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/IntervalBwdDataFrameCursorTest.java
@@ -370,7 +370,7 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
 
                 assertEquals("", record, cursor);
 
-                try (TableWriter writer = new TableWriter(configuration, "x")) {
+                try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                     for (int i = 0; i < rowCount; i++) {
                         TableWriter.Row row = writer.newRow(timestamp);
                         row.putSym(0, rnd.nextChars(4));
@@ -573,7 +573,7 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < rowCount; i++) {
                     TableWriter.Row row = writer.newRow(timestamp);
                     row.putSym(0, rnd.nextChars(4));

--- a/core/src/test/java/io/questdb/cairo/IntervalFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/IntervalFwdDataFrameCursorTest.java
@@ -403,7 +403,7 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
 
                 assertEquals("", record, cursor);
 
-                try (TableWriter writer = new TableWriter(configuration, "x")) {
+                try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                     for (int i = 0; i < rowCount; i++) {
                         TableWriter.Row row = writer.newRow(timestamp);
                         row.putSym(0, rnd.nextChars(4));
@@ -606,7 +606,7 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < rowCount; i++) {
                     TableWriter.Row row = writer.newRow(timestamp);
                     row.putSym(0, rnd.nextChars(4));

--- a/core/src/test/java/io/questdb/cairo/TableReadFailTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReadFailTest.java
@@ -89,9 +89,7 @@ public class TableReadFailTest extends AbstractCairoTest {
                 // home path at txn file
                 path.of(configuration.getRoot()).concat("x").concat(TableUtils.TXN_FILE_NAME).$();
 
-                try (TableWriter w = new TableWriter(configuration, "x")) {
-
-
+                try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = w.newRow();
                         r.putInt(0, rnd.nextInt());
@@ -147,7 +145,7 @@ public class TableReadFailTest extends AbstractCairoTest {
                 // make sure reload functions correctly
                 Assert.assertFalse(reader.reload());
 
-                try (TableWriter w = new TableWriter(configuration, "x")) {
+                try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                     // add more data
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = w.newRow();

--- a/core/src/test/java/io/questdb/cairo/TableReaderMetadataTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderMetadataTest.java
@@ -334,7 +334,7 @@ public class TableReaderMetadataTest extends AbstractCairoTest {
 
                     tableId = metadata.getId();
                     long structVersion;
-                    try (TableWriter writer = new TableWriter(configuration, "all")) {
+                    try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
                         manipulator.restructure(writer);
                         structVersion = writer.getStructureVersion();
                     }

--- a/core/src/test/java/io/questdb/cairo/TableReaderMetadataTimestampTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderMetadataTimestampTest.java
@@ -205,7 +205,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                     Assert.assertEquals(12, metadata.getColumnCount());
                     Assert.assertEquals(expectedInitialTimestampIndex, metadata.getTimestampIndex());
                     long structureVersion;
-                    try (TableWriter writer = new TableWriter(configuration, "all")) {
+                    try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
                         writer.removeColumn("timestamp");
                         structureVersion = writer.getStructureVersion();
                     }
@@ -241,7 +241,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                     Assert.assertEquals(12, metadata.getColumnCount());
                     Assert.assertEquals(expectedInitialTimestampIndex, metadata.getTimestampIndex());
                     long structVersion;
-                    try (TableWriter writer = new TableWriter(configuration, "all")) {
+                    try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
                         manipulator.restructure(writer);
                         structVersion = writer.getStructureVersion();
                     }

--- a/core/src/test/java/io/questdb/cairo/TableReaderReloadTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderReloadTest.java
@@ -107,7 +107,7 @@ public class TableReaderReloadTest extends AbstractCairoTest {
         }
 
         long timestamp = 0;
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
 
             try (TableReader reader = new TableReader(configuration, "all")) {
                 Assert.assertFalse(reader.reload());

--- a/core/src/test/java/io/questdb/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderTest.java
@@ -1658,7 +1658,7 @@ public class TableReaderTest extends AbstractCairoTest {
             CairoTestUtils.createTableWithVersionAndId(model, ColumnType.VERSION, 1);
 
             TestUtils.assertMemoryLeak(() -> {
-                try (TableWriter w = new TableWriter(configuration, "all")) {
+                try (TableWriter w = new TableWriter(configuration, "all", metrics)) {
                     TableWriter.Row r = w.newRow(Numbers.LONG_NaN);
                     r.putInt(0, 100);
                     r.append();
@@ -1687,7 +1687,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
             char[] data = {'a', 'b', 'f', 'g'};
-            try (TableWriter writer = new TableWriter(configuration, "char_test")) {
+            try (TableWriter writer = new TableWriter(configuration, "char_test", metrics)) {
 
                 for (int i = 0, n = data.length; i < n; i++) {
                     TableWriter.Row r = writer.newRow();
@@ -1792,7 +1792,7 @@ public class TableReaderTest extends AbstractCairoTest {
             new Thread(() -> {
                 try {
                     startBarrier.await();
-                    try (TableWriter writer = new TableWriter(configuration, "w")) {
+                    try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
                         for (int i = 0; i < N * scale; i++) {
                             TableWriter.Row row = writer.newRow();
                             row.putLong(0, list.getQuick(i % N));
@@ -1855,14 +1855,14 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 TableWriter.Row r = w.newRow();
                 r.putLong256(0, 1, 2, 3, 4);
                 r.append();
                 w.commit();
             }
 
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 TableWriter.Row r = w.newRow();
                 r.putLong256(0, 5, 6, 7, 8);
                 r.append();
@@ -2039,7 +2039,7 @@ public class TableReaderTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             CairoTestUtils.createAllTable(configuration, PartitionBy.NONE);
 
-            try (TableWriter w = new TableWriter(configuration, "all")) {
+            try (TableWriter w = new TableWriter(configuration, "all", metrics)) {
                 TableWriter.Row r = w.newRow(1000000); // <-- higher timestamp
                 r.putInt(0, 10);
                 r.putByte(1, (byte) 56);
@@ -2073,7 +2073,7 @@ public class TableReaderTest extends AbstractCairoTest {
 
             long N = 280000000;
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow();
                     r.putLong(0, rnd.nextLong());
@@ -2101,7 +2101,7 @@ public class TableReaderTest extends AbstractCairoTest {
         CairoTestUtils.createAllTable(configuration, PartitionBy.NONE);
         int N = 10000;
         Rnd rnd = new Rnd();
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
             int col = writer.getMetadata().getColumnIndex("str");
             for (int i = 0; i < N; i++) {
                 TableWriter.Row r = writer.newRow();
@@ -2161,11 +2161,11 @@ public class TableReaderTest extends AbstractCairoTest {
     public void testReadEmptyTable() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             CairoTestUtils.createAllTable(configuration, PartitionBy.NONE);
-            try (TableWriter ignored1 = new TableWriter(configuration, "all")) {
+            try (TableWriter ignored1 = new TableWriter(configuration, "all", metrics)) {
 
                 // open another writer, which should fail
                 try {
-                    new TableWriter(configuration, "all");
+                    new TableWriter(configuration, "all", metrics);
                     Assert.fail();
                 } catch (CairoException ignored) {
 
@@ -2187,7 +2187,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = new TableWriter(configuration, "w")) {
+        try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2221,7 +2221,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = new TableWriter(configuration, "w")) {
+        try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()));
@@ -2255,7 +2255,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = new TableWriter(configuration, "w")) {
+        try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2289,7 +2289,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = new TableWriter(configuration, "w")) {
+        try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2333,8 +2333,10 @@ public class TableReaderTest extends AbstractCairoTest {
             int count = 1000000;
             AtomicInteger reloadCount = new AtomicInteger(0);
 
-            try (TableWriter writer = new TableWriter(configuration, "x"); TableReader reader = new TableReader(configuration, "x")) {
-
+            try (
+                    TableWriter writer = new TableWriter(configuration, "x", metrics);
+                    TableReader reader = new TableReader(configuration, "x")
+            ) {
                 new Thread(() -> {
                     try {
                         barrier.await();
@@ -2393,7 +2395,7 @@ public class TableReaderTest extends AbstractCairoTest {
                     }
 
                     try (
-                            TableWriter w = new TableWriter(configuration, "w");
+                            TableWriter w = new TableWriter(configuration, "w", metrics);
                             TableReader r = new TableReader(configuration, "w")
                     ) {
                         // Create and cancel row to ensure partition entry and NULL max timestamp
@@ -2475,7 +2477,7 @@ public class TableReaderTest extends AbstractCairoTest {
             final int M = 1_000_000;
             final Rnd rnd = new Rnd();
 
-            try (TableWriter writer = new TableWriter(configuration, tableName)) {
+            try (TableWriter writer = new TableWriter(configuration, tableName, metrics)) {
                 long timestamp = TimestampFormatUtils.parseUTCTimestamp("2019-01-31T10:00:00.000001Z");
                 long timestampStep = 500;
 
@@ -2542,7 +2544,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "tab")) {
+            try (TableWriter writer = new TableWriter(configuration, "tab", metrics)) {
                 TableWriter.Row r = writer.newRow();
                 r.putSym(0, "hello");
                 r.append();
@@ -2589,7 +2591,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "w")) {
+            try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
 
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
@@ -2724,7 +2726,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "w")) {
+            try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
 
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
@@ -2821,7 +2823,7 @@ public class TableReaderTest extends AbstractCairoTest {
             int N = 1000;
             long ts = TimestampFormatUtils.parseTimestamp("2018-01-06T10:00:00.000Z");
             final Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 sink.clear();
                 writer.getMetadata().toJson(sink);
                 TestUtils.assertEquals(expected, sink);
@@ -2881,7 +2883,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     row.putStr(0, rnd.nextChars(10));
@@ -2984,7 +2986,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     row.putSym(0, rnd.nextChars(10));
@@ -3100,7 +3102,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     row.putStr(0, rnd.nextChars(10));
@@ -3203,7 +3205,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 appendTwoSymbols(writer, rnd);
                 writer.commit();
 
@@ -3312,7 +3314,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 appendTwoSymbols(writer, rnd);
                 writer.commit();
 
@@ -3417,7 +3419,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 appendTwoSymbols(writer, rnd);
                 writer.commit();
 
@@ -3522,7 +3524,7 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // populate table and delete column
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 appendTwoSymbols(writer, rnd);
                 writer.commit();
 
@@ -3883,7 +3885,7 @@ public class TableReaderTest extends AbstractCairoTest {
     }
 
     private long testAppend(Rnd rnd, CairoConfiguration configuration, long ts, int count, long inc, long blob, int testPartitionSwitch) {
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
             return testAppend(writer, rnd, ts, count, inc, blob, testPartitionSwitch, TableReaderTest.BATCH1_GENERATOR);
         }
     }
@@ -3970,7 +3972,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 try {
                     startBarrier.await();
                     long timestampUs = TimestampFormatUtils.parseTimestamp("2017-12-11T00:00:00.000Z");
-                    try (TableWriter writer = new TableWriter(configuration, "w")) {
+                    try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
                         for (int i = 0; i < N; i++) {
                             TableWriter.Row row = writer.newRow(timestampUs);
                             row.putLong(0, i);
@@ -4101,7 +4103,7 @@ public class TableReaderTest extends AbstractCairoTest {
 
                     // writer will inflate last partition in order to optimise appends
                     // reader must be able to cope with that
-                    try (TableWriter writer = new TableWriter(configuration, "all")) {
+                    try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
 
                         // this is a bit of paranoid check, but make sure our reader doesn't flinch when new writer is open
                         assertCursor(cursor, ts, increment, blob, 2L * count, BATCH1_ASSERTER);
@@ -4249,7 +4251,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "w")) {
+            try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
 
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
@@ -4319,7 +4321,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "w")) {
+            try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
 
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
@@ -4389,7 +4391,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "w")) {
+            try (TableWriter writer = new TableWriter(configuration, "w", metrics)) {
 
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;

--- a/core/src/test/java/io/questdb/cairo/TableReaderTxnScoreboardInteractionTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderTxnScoreboardInteractionTest.java
@@ -119,7 +119,7 @@ public class TableReaderTxnScoreboardInteractionTest extends AbstractCairoTest {
                 Assert.assertEquals(0, reader.getTxn());
             }
 
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 addRow(w);
 
                 final TxnScoreboard txnScoreboard = w.getTxnScoreboard();

--- a/core/src/test/java/io/questdb/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableWriterTest.java
@@ -49,8 +49,6 @@ import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.questdb.PropServerConfiguration.COMMIT_INTERVAL_DEFAULT;
-
 public class TableWriterTest extends AbstractCairoTest {
 
     public static final String PRODUCT = "product";
@@ -62,7 +60,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 100000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -80,7 +78,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10000;
             create(FF, PartitionBy.DAY, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 Rnd rnd = new Rnd();
                 populateProducts(writer, rnd, ts, N, 60000 * 1000L);
@@ -116,7 +114,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT);
+                }, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
 
@@ -204,7 +202,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long interval = 60000L * 1000L;
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             ts = populateProducts(writer, rnd, ts, count, interval);
             Assert.assertEquals(count, writer.size());
             writer.addColumn("abc", ColumnType.STRING);
@@ -215,7 +213,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             populateTable2(writer, rnd, count, ts, interval);
             writer.commit();
             Assert.assertEquals(2 * count, writer.size());
@@ -225,7 +223,7 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testAddColumnDuplicate() throws Exception {
         long ts = populateTable(FF, PartitionBy.MONTH);
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             try {
                 writer.addColumn("supplier", ColumnType.BOOLEAN);
                 Assert.fail();
@@ -364,7 +362,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT)) {
+        }, PRODUCT, metrics)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -394,7 +392,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testAddColumnNonPartitioned() throws Exception {
         int N = 100000;
         create(FF, PartitionBy.NONE, N);
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -409,7 +407,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testAddColumnPartitioned() throws Exception {
         int N = 10000;
         create(FF, PartitionBy.DAY, N);
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -493,7 +491,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 Assert.assertEquals(20, writer.columns.size());
                 writer.addColumn("abc", ColumnType.STRING);
                 Assert.assertEquals(22, writer.columns.size());
@@ -618,7 +616,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             final int N = 1000;
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 final Rnd rnd = new Rnd();
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = w.newRow();
@@ -660,7 +658,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             final int N = 1000;
-            try (TableWriter w = new TableWriter(configuration, "x")) {
+            try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                 final Rnd rnd = new Rnd();
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = w.newRow();
@@ -711,7 +709,7 @@ public class TableWriterTest extends AbstractCairoTest {
         int N = 10000;
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 TableWriter.Row r = writer.newRow(ts);
@@ -747,7 +745,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 ts = populateProducts(writer, rnd, ts, N, 60 * 60000 * 1000L);
                 writer.commit();
@@ -762,7 +760,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -776,7 +774,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             DefaultCairoConfiguration configuration = new DefaultCairoConfiguration(root);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 populateProducts(writer, rnd, ts, 1, 0);
                 writer.commit();
@@ -803,7 +801,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(2, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(AbstractCairoTest.configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(AbstractCairoTest.configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(2, writer.size());
             }
 
@@ -846,7 +844,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 // add 48 hours
                 ts = populateProducts(writer, rnd, ts, N / 2, increment);
@@ -880,10 +878,8 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
-
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
-
 
                 TableWriter.Row r = writer.newRow(ts);
                 r.putInt(0, 1234);
@@ -928,7 +924,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.DAY, 4);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 TableWriter.Row r = writer.newRow(ts);
                 r.cancel();
@@ -946,7 +942,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
             int N = 94;
             create(FF, PartitionBy.DAY, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 // add 48 hours
                 ts = populateProducts(writer, rnd, ts, N / 2, increment);
@@ -975,7 +971,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testCancelFirstRowSecondPartition() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.DAY, 4);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.newRow(TimestampFormatUtils.parseTimestamp("2013-03-01T00:00:00.000Z")).append();
                 writer.newRow(TimestampFormatUtils.parseTimestamp("2013-03-01T00:00:00.000Z")).append();
 
@@ -994,7 +990,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             // Last 2 rows are not committed, expect size to revert to 2
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(2, writer.size());
             }
         });
@@ -1010,7 +1006,7 @@ public class TableWriterTest extends AbstractCairoTest {
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
             try (MemoryARW vmem = Vm.getARWInstance(FF.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
-                try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+                try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;
 
@@ -1047,7 +1043,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             final int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 int cancelCount = 0;
@@ -1085,7 +1081,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long interval = 60000 * 1000L;
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             ts = populateProducts(writer, rnd, ts, N, interval);
 
             Assert.assertEquals(N, writer.size());
@@ -1106,7 +1102,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             populateTable2(writer, rnd, N, ts, interval);
             writer.commit();
             Assert.assertEquals(2 * N, writer.size());
@@ -1143,7 +1139,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT)) {
+                }, PRODUCT, metrics)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;
 
@@ -1191,7 +1187,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -1210,7 +1206,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(N + 1, writer.size());
             }
         });
@@ -1260,7 +1256,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT);
+                }, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -1550,7 +1546,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testCloseActivePartitionAndRollback() throws Exception {
         int N = 10000;
         create(FF, PartitionBy.DAY, N);
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
             populateProducts(writer, rnd, ts, N, 6 * 60000 * 1000L);
@@ -1590,13 +1586,13 @@ public class TableWriterTest extends AbstractCairoTest {
             int N = 10000;
             create(FF, PartitionBy.DAY, N);
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 populateProducts(writer, new Rnd(), TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z"), N, 60000 * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -1615,7 +1611,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return 1024 * 1024; //1MB
                 }
             };
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -1627,7 +1623,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2014-03-04T00:00:00.000Z");
                 Assert.assertEquals(0, writer.size());
                 populateProducts(writer, rnd, ts, N, increment);
@@ -1689,7 +1685,7 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testGetColumnIndex() {
         CairoTestUtils.createAllTable(configuration, PartitionBy.NONE);
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
             Assert.assertEquals(1, writer.getColumnIndex("short"));
             try {
                 writer.getColumnIndex("bad");
@@ -1712,12 +1708,12 @@ public class TableWriterTest extends AbstractCairoTest {
                 mem.putLong(40, 9990001L);
                 mem.jumpTo(48);
             }
-            try (TableWriter writer = new TableWriter(configuration, "all")) {
+            try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
                 Assert.assertNotNull(writer);
                 Assert.assertTrue(writer.isOpen());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "all")) {
+            try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
                 Assert.assertNotNull(writer);
                 Assert.assertTrue(writer.isOpen());
             }
@@ -1847,7 +1843,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
 
-            try (TableWriter writer = new TableWriter(configuration, "weather")) {
+            try (TableWriter writer = new TableWriter(configuration, "weather", metrics)) {
                 TableWriter.Row r;
                 r = writer.newRow(IntervalUtils.parseFloorPartialDate("2021-01-31"));
                 r.putDouble(0, 1.0);
@@ -1898,7 +1894,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     631152000000000L,
                     631160000000000L
             };
-            try (TableWriter writer = new TableWriter(configuration, "weather")) {
+            try (TableWriter writer = new TableWriter(configuration, "weather", metrics)) {
                 TableWriter.Row r = writer.newRow(tss[1]);
                 r.putDouble(0, 1.0);
                 r.append();
@@ -1948,7 +1944,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             try {
-                new TableWriter(configuration, "x");
+                new TableWriter(configuration, "x", metrics);
                 Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "only supported");
@@ -1963,7 +1959,7 @@ public class TableWriterTest extends AbstractCairoTest {
             try (Path path = new Path()) {
                 Assert.assertTrue(FF.remove(path.of(root).concat("all").concat(TableUtils.TXN_FILE_NAME).$()));
                 try {
-                    new TableWriter(configuration, "all");
+                    new TableWriter(configuration, "all", metrics);
                     Assert.fail();
                 } catch (CairoException ignore) {
                 }
@@ -2201,7 +2197,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
 
                 append10KProducts(ts, rnd, writer);
 
@@ -2214,7 +2210,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
                 append10KNoTimestamp(rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -2234,7 +2230,7 @@ public class TableWriterTest extends AbstractCairoTest {
             CairoTestUtils.create(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, "ABC")) {
+        try (TableWriter writer = new TableWriter(configuration, "ABC", metrics)) {
             try {
                 writer.removeColumn("timestamp");
                 Assert.fail();
@@ -2438,7 +2434,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
 
                 append10KProducts(ts, rnd, writer);
 
@@ -2451,7 +2447,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
                 append10KProducts(writer.getMaxTimestamp(), rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -2472,7 +2468,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
 
                 append10KProducts(ts, rnd, writer);
 
@@ -2485,7 +2481,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
                 append10KProducts(writer.getMaxTimestamp(), rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -2528,7 +2524,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT)) {
+        }, PRODUCT, metrics)) {
 
             ts = populateProducts(writer, rnd, ts, N, increment);
             writer.commit();
@@ -2579,7 +2575,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT)) {
+        }, PRODUCT, metrics)) {
 
             ts = populateProducts(writer, rnd, ts, N, increment);
             writer.commit();
@@ -2619,12 +2615,12 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.YEAR, 4);
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.truncate();
                 Assert.assertEquals(0, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(0, writer.size());
             }
         });
@@ -2640,7 +2636,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 path.of(configuration.getRoot()).concat(PRODUCT).concat("somethingortheother").slash$();
                 Assert.assertEquals(0, configuration.getFilesFacade().mkdirs(path, configuration.getMkDirMode()));
 
-                new TableWriter(configuration, PRODUCT).close();
+                new TableWriter(configuration, PRODUCT, metrics).close();
 
                 Assert.assertFalse(configuration.getFilesFacade().exists(path));
             }
@@ -2651,7 +2647,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testTableDoesNotExist() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try {
-                new TableWriter(configuration, PRODUCT);
+                new TableWriter(configuration, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException e) {
                 LOG.info().$((Sinkable) e).$();
@@ -2663,9 +2659,9 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testTableLock() {
         CairoTestUtils.createAllTable(configuration, PartitionBy.NONE);
 
-        try (TableWriter ignored = new TableWriter(configuration, "all")) {
+        try (TableWriter ignored = new TableWriter(configuration, "all", metrics)) {
             try {
-                new TableWriter(configuration, "all");
+                new TableWriter(configuration, "all", metrics);
                 Assert.fail();
             } catch (CairoException ignored2) {
             }
@@ -2682,7 +2678,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return getFilesFacade().getPageSize();
                 }
             };
-            try (TableWriter w = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter w = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 Rnd rnd = new Rnd();
@@ -2705,7 +2701,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testToString() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.NONE, 4);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals("TableWriter{name=product}", writer.toString());
             }
         });
@@ -2715,7 +2711,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testCommitInterval() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.NONE, 4);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.updateCommitInterval(0.0, 1000);
                 writer.setMetaCommitLag(5_000_000);
                 Assert.assertEquals(1000, writer.getCommitInterval());
@@ -2760,7 +2756,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         Rnd rnd = new Rnd();
-        try (TableWriter writer = new TableWriter(configuration, name)) {
+        try (TableWriter writer = new TableWriter(configuration, name, metrics)) {
             for (int i = 0; i < 1000000; i++) {
                 TableWriter.Row r = writer.newRow();
                 r.putStr(0, rnd.nextChars(5));
@@ -2804,7 +2800,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT);
+                }, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -2956,7 +2952,7 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     private void appendAndAssert10K(long ts, Rnd rnd) {
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             Assert.assertEquals(20, writer.columns.size());
             populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
             writer.commit(CommitMode.SYNC);
@@ -2971,7 +2967,7 @@ public class TableWriterTest extends AbstractCairoTest {
             CairoTestUtils.createTable(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, tableName)) {
+        try (TableWriter writer = new TableWriter(configuration, tableName, metrics)) {
             TableWriter.Row r = writer.newRow();
             r.putGeoStr(0, hash);
             r.append();
@@ -3059,7 +3055,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
         long interval = 60000L * 1000L;
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             ts = populateProducts(writer, rnd, ts, n, interval);
             writer.commit(CommitMode.NOSYNC);
 
@@ -3076,7 +3072,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             populateTable2(writer, rnd, n, ts, interval);
             Assert.assertEquals(3 * n, writer.size());
             writer.commit();
@@ -3112,7 +3108,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT)) {
+        }, PRODUCT, metrics)) {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             ts = populateProducts(writer, new Rnd(), ts, N, 60000L * 1000L);
             writer.commit();
@@ -3150,7 +3146,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, name)) {
+            }, name, metrics)) {
 
                 ts = append10KProducts(ts, rnd, writer);
 
@@ -3166,7 +3162,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, name)) {
+            try (TableWriter writer = new TableWriter(configuration, name, metrics)) {
                 append10KNoSupplier(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3196,7 +3192,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, name)) {
+            }, name, metrics)) {
 
                 ts = append10KProducts(ts, rnd, writer);
 
@@ -3212,7 +3208,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, name)) {
+            try (TableWriter writer = new TableWriter(configuration, name, metrics)) {
                 append10KWithNewName(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3226,17 +3222,17 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             create(FF, partitionBy, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 ts = populateProducts(writer, rnd, ts, N, 60L * 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.addColumn("xyz", ColumnType.STRING);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 for (int i = 0; i < N; i++) {
                     ts = populateRow(writer, rnd, ts, 60L * 60000 * 1000L);
                 }
@@ -3256,7 +3252,7 @@ public class TableWriterTest extends AbstractCairoTest {
             };
             long ts = populateTable();
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(20000, writer.size());
@@ -3271,7 +3267,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             try {
-                new TableWriter(configuration, PRODUCT);
+                new TableWriter(configuration, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -3290,7 +3286,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return ff;
                 }
             };
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(20, writer.columns.size());
                 ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
@@ -3306,7 +3302,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(30000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(40000, writer.size());
@@ -3320,19 +3316,19 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             create(FF, partitionBy, N);
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 ts = populateProducts(writer, rnd, ts, N, 60L * 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.addIndex("supplier", configuration.getIndexValueBlockSize());
                 Assert.fail();
             } catch (CairoException ignored) {
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow(ts += 60L * 60000 * 1000L);
                     r.putInt(0, rnd.nextPositiveInt());
@@ -3347,7 +3343,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             // another attempt to create index
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 writer.addIndex("supplier", configuration.getIndexValueBlockSize());
             }
         });
@@ -3361,7 +3357,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public FilesFacade getFilesFacade() {
                 return TableWriterTest.FF;
             }
-        }, "all")) {
+        }, "all", metrics)) {
             long size = writer.size();
             for (int i = 0; i < 10000; i++) {
                 TableWriter.Row r = writer.newRow(ts += 60L * 60000L * 1000L);
@@ -3429,7 +3425,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT);
+                }, PRODUCT, metrics);
                 Assert.fail();
             } catch (CairoException e) {
                 LOG.info().$((Sinkable) e).$();
@@ -3450,7 +3446,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testO3RecordsFail(int N) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -3488,7 +3484,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertTrue(failureCount > 0);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -3496,7 +3492,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testO3RecordsNewerThanOlder(int N, CairoConfiguration configuration) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts;
                 long ts1 = TimestampFormatUtils.parseTimestamp("2013-03-04T04:00:00.000Z");
@@ -3526,7 +3522,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -3538,7 +3534,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
 
                 // optional
                 writer.warmUp();
@@ -3566,7 +3562,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
                 append10KNoSupplier(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3584,7 +3580,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -3600,7 +3596,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3614,7 +3610,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
 
                 // optional
                 writer.warmUp();
@@ -3659,7 +3655,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), metrics)) {
                 append10KWithNewName(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3677,7 +3673,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -3693,7 +3689,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3705,7 +3701,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
         Rnd rnd = new Rnd();
         final long increment = 60000L * 1000L;
-        try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+        try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
             ts = populateProducts(writer, rnd, ts, N / 2, increment);
             writer.commit();
 
@@ -3759,7 +3755,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, "all");
+                }, "all", metrics);
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -3777,7 +3773,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
         int N = 1000;
         Rnd rnd = new Rnd();
-        try (TableWriter writer = new TableWriter(configuration, "x")) {
+        try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
             Assert.assertEquals(cacheFlag, writer.isSymbolMapWriterCached(0));
             Assert.assertNotEquals(cacheFlag, writer.isSymbolMapWriterCached(2));
             for (int i = 0; i < N; i++) {
@@ -3915,7 +3911,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return 1024 * 1024;
                 }
             };
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -3939,7 +3935,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2014-03-04T00:00:00.000Z");
                 Assert.assertEquals(0, writer.size());
                 populateProducts(writer, rnd, ts, 1000, increment);
@@ -3948,7 +3944,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             // open writer one more time and just assert the size
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 Assert.assertEquals(1000, writer.size());
             }
         });
@@ -3961,7 +3957,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 Rnd rnd = new Rnd();
                 populateProducts(writer, rnd, ts, N, 60 * 60000L * 1000L);
@@ -3981,7 +3977,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT)) {
+            }, PRODUCT, metrics)) {
                 ts = populateProducts(writer, rnd, ts, 10000, 60000 * 1000L);
                 writer.commit();
 
@@ -4009,7 +4005,7 @@ public class TableWriterTest extends AbstractCairoTest {
             create(FF, PartitionBy.DAY, N);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4020,7 +4016,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
@@ -4040,7 +4036,7 @@ public class TableWriterTest extends AbstractCairoTest {
             create(FF, PartitionBy.DAY, N);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4051,7 +4047,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = new TableWriter(configuration, PRODUCT)) {
+            try (TableWriter writer = new TableWriter(configuration, PRODUCT, metrics)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());

--- a/core/src/test/java/io/questdb/cairo/map/CompactMapTest.java
+++ b/core/src/test/java/io/questdb/cairo/map/CompactMapTest.java
@@ -192,7 +192,7 @@ public class CompactMapTest extends AbstractCairoTest {
             BytecodeAssembler asm = new BytecodeAssembler();
             final int N = 1000;
             final Rnd rnd = new Rnd();
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     long rndGeohash = GeoHashes.fromCoordinatesDeg(rnd.nextDouble() * 180 - 90, rnd.nextDouble() * 360 - 180, precisionBits);

--- a/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
+++ b/core/src/test/java/io/questdb/cairo/map/FastMapTest.java
@@ -293,7 +293,7 @@ public class FastMapTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     long rndGeohash = GeoHashes.fromCoordinatesDeg(rnd.nextDouble() * 180 - 90, rnd.nextDouble() * 360 - 180, precisionBits);
@@ -980,7 +980,7 @@ public class FastMapTest extends AbstractCairoTest {
             CairoTestUtils.create(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, "x")) {
+        try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
             for (int i = 0; i < n; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putByte(0, rnd.nextByte());

--- a/core/src/test/java/io/questdb/cairo/map/RecordValueSinkFactoryTest.java
+++ b/core/src/test/java/io/questdb/cairo/map/RecordValueSinkFactoryTest.java
@@ -55,7 +55,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
 
         final int N = 1024;
         final Rnd rnd = new Rnd();
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
 
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow();
@@ -139,7 +139,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
 
         final int N = 1024;
         final Rnd rnd = new Rnd();
-        try (TableWriter writer = new TableWriter(configuration, "all")) {
+        try (TableWriter writer = new TableWriter(configuration, "all", metrics)) {
 
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow();

--- a/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
@@ -248,7 +248,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 CairoTestUtils.create(model);
             }
 
-            try (TableWriter w = new TableWriter(configuration, names[i])) {
+            try (TableWriter w = new TableWriter(configuration, names[i], metrics)) {
                 for (int k = 0; k < 10; k++) {
                     TableWriter.Row r = w.newRow();
                     r.putDate(0, dataRnd.nextLong());

--- a/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/WriterPoolTest.java
@@ -200,7 +200,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             // check that we can't create standalone writer either
             try {
-                new TableWriter(configuration, "z");
+                new TableWriter(configuration, "z", metrics);
                 Assert.fail();
             } catch (CairoException ignored) {
             }
@@ -208,7 +208,7 @@ public class WriterPoolTest extends AbstractCairoTest {
             pool.unlock("z");
 
             // check if we can create standalone writer after pool unlocked it
-            writer = new TableWriter(configuration, "z");
+            writer = new TableWriter(configuration, "z", metrics);
             Assert.assertNotNull(writer);
             writer.close();
 
@@ -595,7 +595,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock("x", "testing"));
 
-            TableWriter writer = new TableWriter(configuration, "x", messageBus, false, DefaultLifecycleManager.INSTANCE);
+            TableWriter writer = new TableWriter(configuration, "x", messageBus, false, DefaultLifecycleManager.INSTANCE, metrics);
             for (int i = 0; i < 100; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putDate(0, i);
@@ -821,7 +821,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             pool.close();
 
-            TableWriter writer = new TableWriter(configuration, "z");
+            TableWriter writer = new TableWriter(configuration, "z", metrics);
             Assert.assertNotNull(writer);
             writer.close();
         });
@@ -905,7 +905,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
     private void assertWithPool(PoolAwareCode code, CairoConfiguration configuration) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (WriterPool pool = new WriterPool(configuration, messageBus)) {
+            try (WriterPool pool = new WriterPool(configuration, messageBus, metrics)) {
                 code.run(pool);
             }
         });

--- a/core/src/test/java/io/questdb/cutlass/http/HealthCheckTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HealthCheckTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.http;
+
+import io.questdb.Metrics;
+import io.questdb.network.NetworkFacadeImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class HealthCheckTest {
+
+    private static final String healthCheckRequest = "GET /status HTTP/1.1\r\n" +
+            "Host: localhost:9003\r\n" +
+            "User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36\r\n" +
+            "Accept: */*\r\n" +
+            "Accept-Encoding: gzip, deflate, br\r\n" +
+            "\r\n";
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void testHealthy() throws Exception {
+        new HttpHealthCheckTestBuilder()
+                .withTempFolder(temp)
+                .run(engine -> {
+                    String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                            "Server: questDB/1.0\r\n" +
+                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                            "Transfer-Encoding: chunked\r\n" +
+                            "Content-Type: text/plain\r\n" +
+                            "\r\n" +
+                            "0f\r\n" +
+                            "Status: Healthy\r\n" +
+                            "00\r\n" +
+                            "\r\n";
+
+                    new SendAndReceiveRequestBuilder()
+                            .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
+                            .withExpectDisconnect(false)
+                            .withPrintOnly(false)
+                            .withRequestCount(1)
+                            .withPauseBetweenSendAndReceive(0)
+                            .execute(healthCheckRequest, expectedResponse);
+                });
+    }
+
+    @Test
+    public void testUnhealthyWhenMetricsEnabled() throws Exception {
+        new HttpHealthCheckTestBuilder()
+                .withTempFolder(temp)
+                .withInjectedUnhandledError()
+                .run(engine -> {
+                    String expectedResponse = "HTTP/1.1 500 Internal server error\r\n" +
+                            "Server: questDB/1.0\r\n" +
+                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                            "Transfer-Encoding: chunked\r\n" +
+                            "Content-Type: text/plain\r\n" +
+                            "\r\n" +
+                            "25\r\n" +
+                            "Status: Unhealthy\n" +
+                            "Unhandled errors: 1\r\n" +
+                            "00\r\n" +
+                            "\r\n";
+
+                    new SendAndReceiveRequestBuilder()
+                            .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
+                            .withExpectDisconnect(false)
+                            .withPrintOnly(false)
+                            .withRequestCount(1)
+                            .withPauseBetweenSendAndReceive(0)
+                            .execute(healthCheckRequest, expectedResponse);
+                });
+    }
+
+    @Test
+    public void testUnhealthyWhenMetricsDisabled() throws Exception {
+        new HttpHealthCheckTestBuilder()
+                .withTempFolder(temp)
+                .withMetrics(Metrics.disabled())
+                .withInjectedUnhandledError()
+                .run(engine -> {
+                    // Unhandled error detection is based on metrics,
+                    // so we expect the health check to return HTTP 200.
+                    String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                            "Server: questDB/1.0\r\n" +
+                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                            "Transfer-Encoding: chunked\r\n" +
+                            "Content-Type: text/plain\r\n" +
+                            "\r\n" +
+                            "0f\r\n" +
+                            "Status: Healthy\r\n" +
+                            "00\r\n" +
+                            "\r\n";
+
+                    new SendAndReceiveRequestBuilder()
+                            .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
+                            .withExpectDisconnect(false)
+                            .withPrintOnly(false)
+                            .withRequestCount(1)
+                            .withPauseBetweenSendAndReceive(0)
+                            .execute(healthCheckRequest, expectedResponse);
+                });
+    }
+}

--- a/core/src/test/java/io/questdb/cutlass/http/HealthCheckTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HealthCheckTest.java
@@ -38,14 +38,40 @@ public class HealthCheckTest {
             "Accept: */*\r\n" +
             "Accept-Encoding: gzip, deflate, br\r\n" +
             "\r\n";
+    private static final String healthCheckOnRootRequest = "GET / HTTP/1.1\r\n" +
+            "Host: localhost:9003\r\n" +
+            "User-Agent: Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36\r\n" +
+            "Accept: */*\r\n" +
+            "Accept-Encoding: gzip, deflate, br\r\n" +
+            "\r\n";
 
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
     @Test
-    public void testHealthy() throws Exception {
+    public void testHealthyViaStatusPathWhenMetricsEnabled() throws Exception {
+        testHealthy(Metrics.enabled(), healthCheckRequest);
+    }
+
+    @Test
+    public void testHealthyViaStatusPathWhenMetricsDisabled() throws Exception {
+        testHealthy(Metrics.disabled(), healthCheckRequest);
+    }
+
+    @Test
+    public void testHealthyViaRootPathWhenMetricsEnabled() throws Exception {
+        testHealthy(Metrics.enabled(), healthCheckOnRootRequest);
+    }
+
+    @Test
+    public void testHealthyViaRootPathWhenMetricsDisabled() throws Exception {
+        testHealthy(Metrics.disabled(), healthCheckOnRootRequest);
+    }
+
+    private void testHealthy(Metrics metrics, String request) throws Exception {
         new HttpHealthCheckTestBuilder()
                 .withTempFolder(temp)
+                .withMetrics(metrics)
                 .run(engine -> {
                     String expectedResponse = "HTTP/1.1 200 OK\r\n" +
                             "Server: questDB/1.0\r\n" +
@@ -64,58 +90,49 @@ public class HealthCheckTest {
                             .withPrintOnly(false)
                             .withRequestCount(1)
                             .withPauseBetweenSendAndReceive(0)
-                            .execute(healthCheckRequest, expectedResponse);
+                            .execute(request, expectedResponse);
                 });
     }
 
     @Test
     public void testUnhealthyWhenMetricsEnabled() throws Exception {
-        new HttpHealthCheckTestBuilder()
-                .withTempFolder(temp)
-                .withInjectedUnhandledError()
-                .run(engine -> {
-                    String expectedResponse = "HTTP/1.1 500 Internal server error\r\n" +
-                            "Server: questDB/1.0\r\n" +
-                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                            "Transfer-Encoding: chunked\r\n" +
-                            "Content-Type: text/plain\r\n" +
-                            "\r\n" +
-                            "25\r\n" +
-                            "Status: Unhealthy\n" +
-                            "Unhandled errors: 1\r\n" +
-                            "00\r\n" +
-                            "\r\n";
-
-                    new SendAndReceiveRequestBuilder()
-                            .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
-                            .withExpectDisconnect(false)
-                            .withPrintOnly(false)
-                            .withRequestCount(1)
-                            .withPauseBetweenSendAndReceive(0)
-                            .execute(healthCheckRequest, expectedResponse);
-                });
+        final String expectedResponse = "HTTP/1.1 500 Internal server error\r\n" +
+                "Server: questDB/1.0\r\n" +
+                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "25\r\n" +
+                "Status: Unhealthy\n" +
+                "Unhandled errors: 1\r\n" +
+                "00\r\n" +
+                "\r\n";
+        testUnhealthy(Metrics.enabled(), expectedResponse);
     }
 
     @Test
     public void testUnhealthyWhenMetricsDisabled() throws Exception {
+        // Unhandled error detection is based on metrics,
+        // so we expect the health check to return HTTP 200.
+        final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                "Server: questDB/1.0\r\n" +
+                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "0f\r\n" +
+                "Status: Healthy\r\n" +
+                "00\r\n" +
+                "\r\n";
+        testUnhealthy(Metrics.disabled(), expectedResponse);
+    }
+
+    public void testUnhealthy(Metrics metrics, String expectedResponse) throws Exception {
         new HttpHealthCheckTestBuilder()
                 .withTempFolder(temp)
-                .withMetrics(Metrics.disabled())
+                .withMetrics(metrics)
                 .withInjectedUnhandledError()
                 .run(engine -> {
-                    // Unhandled error detection is based on metrics,
-                    // so we expect the health check to return HTTP 200.
-                    String expectedResponse = "HTTP/1.1 200 OK\r\n" +
-                            "Server: questDB/1.0\r\n" +
-                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                            "Transfer-Encoding: chunked\r\n" +
-                            "Content-Type: text/plain\r\n" +
-                            "\r\n" +
-                            "0f\r\n" +
-                            "Status: Healthy\r\n" +
-                            "00\r\n" +
-                            "\r\n";
-
                     new SendAndReceiveRequestBuilder()
                             .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
                             .withExpectDisconnect(false)

--- a/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -95,7 +95,7 @@ public class HttpHealthCheckTestBuilder {
 
             DefaultCairoConfiguration cairoConfiguration = new DefaultCairoConfiguration(baseDir);
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration, metrics);
                     HttpServer ignored = HttpServer.createMin(httpConfiguration, workerPool, LOG, engine, null, metrics)
             ) {
                 workerPool.start(LOG);

--- a/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -27,44 +27,44 @@ package io.questdb.cutlass.http;
 import io.questdb.Metrics;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.DefaultCairoConfiguration;
-import io.questdb.cutlass.http.processors.PrometheusMetricsProcessor;
 import io.questdb.cutlass.http.processors.QueryCache;
+import io.questdb.griffin.SqlException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.Scrapable;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.std.Os;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.Arrays;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
 
-public class HttpMinTestBuilder {
+public class HttpHealthCheckTestBuilder {
 
-    private static final Log LOG = LogFactory.getLog(HttpMinTestBuilder.class);
+    private static final Log LOG = LogFactory.getLog(HttpHealthCheckTestBuilder.class);
+
+    private Metrics metrics;
     private TemporaryFolder temp;
-    private Scrapable scrapable;
+    private boolean injectUnhandledError;
 
-    public HttpMinTestBuilder withTempFolder(TemporaryFolder temp) {
-        this.temp = temp;
-        return this;
-    }
-
-    public HttpMinTestBuilder withScrapable(Scrapable scrapable) {
-        this.scrapable = scrapable;
-        return this;
-    }
-
-    public void run(HttpQueryTestBuilder.HttpClientCode code) throws Exception {
-        final int[] workerAffinity = new int[1];
+    public void run(HttpClientCode code) throws Exception {
+        final int workerCount = 1;
+        final int[] workerAffinity = new int[workerCount];
         Arrays.fill(workerAffinity, -1);
 
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
-                    .withBaseDir(temp.getRoot().getAbsolutePath())
+                    .withBaseDir(baseDir)
                     .build();
+            QueryCache.configure(httpConfiguration);
+
+            if (metrics == null) {
+                metrics = Metrics.enabled();
+            }
 
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
@@ -74,36 +74,40 @@ public class HttpMinTestBuilder {
 
                 @Override
                 public int getWorkerCount() {
-                    return workerAffinity.length;
+                    return workerCount;
                 }
 
                 @Override
                 public boolean haltOnError() {
                     return false;
                 }
-            }, Metrics.disabled());
+            }, metrics);
+
+            if (injectUnhandledError) {
+                final AtomicBoolean alreadyErrored = new AtomicBoolean();
+                workerPool.assign(workerId -> {
+                    if (!alreadyErrored.getAndSet(true)) {
+                        throw new NullPointerException("you'd better not handle me");
+                    }
+                    return false;
+                });
+            }
 
             DefaultCairoConfiguration cairoConfiguration = new DefaultCairoConfiguration(baseDir);
-
             try (
                     CairoEngine engine = new CairoEngine(cairoConfiguration);
-                    HttpServer httpServer = new HttpServer(httpConfiguration, Metrics.disabled(), workerPool, false)
+                    HttpServer ignored = HttpServer.createMin(httpConfiguration, workerPool, LOG, engine, null, metrics)
             ) {
-                httpServer.bind(new HttpRequestProcessorFactory() {
-                    @Override
-                    public HttpRequestProcessor newInstance() {
-                        return new PrometheusMetricsProcessor(scrapable);
-                    }
-
-                    @Override
-                    public String getUrl() {
-                        return "/metrics";
-                    }
-                });
-
-                QueryCache.configure(httpConfiguration);
-
                 workerPool.start(LOG);
+
+                if (injectUnhandledError && metrics.isEnabled()) {
+                    for (int i = 0; i < 40; i++) {
+                        if (metrics.healthCheck().unhandledErrorsCount() > 0) {
+                            break;
+                        }
+                        Os.sleep(50);
+                    }
+                }
 
                 try {
                     code.run(engine);
@@ -112,5 +116,25 @@ public class HttpMinTestBuilder {
                 }
             }
         });
+    }
+
+    public HttpHealthCheckTestBuilder withMetrics(Metrics metrics) {
+        this.metrics = metrics;
+        return this;
+    }
+
+    public HttpHealthCheckTestBuilder withInjectedUnhandledError() {
+        this.injectUnhandledError = true;
+        return this;
+    }
+
+    public HttpHealthCheckTestBuilder withTempFolder(TemporaryFolder temp) {
+        this.temp = temp;
+        return this;
+    }
+
+    @FunctionalInterface
+    public interface HttpClientCode {
+        void run(CairoEngine engine) throws InterruptedException, SqlException, BrokenBarrierException;
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
@@ -86,7 +86,7 @@ public class HttpMinTestBuilder {
             DefaultCairoConfiguration cairoConfiguration = new DefaultCairoConfiguration(baseDir);
 
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration, Metrics.disabled());
                     HttpServer httpServer = new HttpServer(httpConfiguration, Metrics.disabled(), workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -131,7 +131,7 @@ public class HttpQueryTestBuilder {
                 };
             }
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration, metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 TelemetryJob telemetryJob = null;
@@ -180,7 +180,6 @@ public class HttpQueryTestBuilder {
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
                                 new SqlCompiler(engine, null),
-                                metrics,
                                 sqlExecutionContext
                         );
                     }
@@ -223,12 +222,7 @@ public class HttpQueryTestBuilder {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
-                        return new JsonQueryProcessor(
-                                httpConfiguration.getJsonQueryProcessorConfiguration(),
-                                engine,
-                                1,
-                                metrics
-                        );
+                        return new JsonQueryProcessor(httpConfiguration.getJsonQueryProcessorConfiguration(), engine, 1);
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -83,6 +83,9 @@ public class HttpQueryTestBuilder {
             final DefaultHttpServerConfiguration httpConfiguration = serverConfigBuilder
                     .withBaseDir(baseDir)
                     .build();
+            if (metrics == null) {
+                metrics = Metrics.enabled();
+            }
 
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
@@ -99,7 +102,7 @@ public class HttpQueryTestBuilder {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, metrics);
             if (workerCount > 1) {
                 workerPool.assignCleaner(Path.CLEANER);
             }
@@ -129,7 +132,7 @@ public class HttpQueryTestBuilder {
             }
             try (
                     CairoEngine engine = new CairoEngine(cairoConfiguration);
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 TelemetryJob telemetryJob = null;
                 if (telemetry) {
@@ -177,7 +180,7 @@ public class HttpQueryTestBuilder {
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
                                 new SqlCompiler(engine, null),
-                                metrics != null ? metrics : Metrics.enabled(),
+                                metrics,
                                 sqlExecutionContext
                         );
                     }
@@ -224,7 +227,7 @@ public class HttpQueryTestBuilder {
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
                                 1,
-                                metrics != null ? metrics : Metrics.enabled()
+                                metrics
                         );
                     }
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -279,7 +279,7 @@ public class IODispatcherTest {
                             return nf;
                         }
                     },
-                    (fd, dispatcher1) -> new HttpConnectionContext(httpContextConfiguration).of(fd, dispatcher1)
+                    (fd, dispatcher1) -> new HttpConnectionContext(httpContextConfiguration, metrics).of(fd, dispatcher1)
             )) {
 
                 // spin up dispatcher thread
@@ -346,11 +346,11 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<HttpConnectionContext>() {
+                    new IOContextFactory<>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
-                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()) {
+                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics) {
                                 @Override
                                 public void close() {
                                     // it is possible that context is closed twice in error
@@ -1491,10 +1491,10 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -1964,10 +1964,10 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -2587,11 +2587,11 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
 
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -3751,11 +3751,11 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
 
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -3959,10 +3959,10 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
@@ -4050,10 +4050,10 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -4157,11 +4157,11 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
 
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
-                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)
+                    HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -4422,12 +4422,12 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     configuration,
-                    new IOContextFactory<HttpConnectionContext>() {
+                    new IOContextFactory<>() {
                         @SuppressWarnings("resource")
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             openCount.incrementAndGet();
-                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()) {
+                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics) {
                                 @Override
                                 public void close() {
                                     closeCount.incrementAndGet();
@@ -4919,8 +4919,8 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
-            try (HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+            }, Metrics.disabled());
+            try (HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
@@ -5087,8 +5087,8 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
-            try (HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+            }, Metrics.disabled());
+            try (HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
@@ -5251,8 +5251,8 @@ public class IODispatcherTest {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
-            try (HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, false)) {
+            }, Metrics.disabled());
+            try (HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public HttpRequestProcessor newInstance() {
@@ -5467,11 +5467,11 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<HttpConnectionContext>() {
+                    new IOContextFactory<>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
-                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()) {
+                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics) {
                                 @Override
                                 public void close() {
                                     // it is possible that context is closed twice in error
@@ -5635,11 +5635,11 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<HttpConnectionContext>() {
+                    new IOContextFactory<>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
-                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()) {
+                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics) {
                                 @Override
                                 public void close() {
                                     // it is possible that context is closed twice in error
@@ -5797,11 +5797,11 @@ public class IODispatcherTest {
                             return 500;
                         }
                     },
-                    new IOContextFactory<HttpConnectionContext>() {
+                    new IOContextFactory<>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
-                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()) {
+                            return new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics) {
                                 @Override
                                 public void close() {
                                     // it is possible that context is closed twice in error
@@ -6055,7 +6055,7 @@ public class IODispatcherTest {
             final SOCountDownLatch senderHalt = new SOCountDownLatch(senderCount);
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    (fd, dispatcher1) -> new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration()).of(fd, dispatcher1)
+                    (fd, dispatcher1) -> new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics).of(fd, dispatcher1)
             )) {
 
                 // server will publish status of each request to this queue

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -109,7 +109,7 @@ public class IODispatcherTest {
             CairoTestUtils.create(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, "y")) {
+        try (TableWriter writer = new TableWriter(configuration, "y", metrics)) {
             for (int i = 0; i < n; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putSym(0, "ok\0ok");
@@ -660,7 +660,7 @@ public class IODispatcherTest {
         final String baseDir = temp.getRoot().getAbsolutePath();
         final CairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
         try (
-                CairoEngine cairoEngine = new CairoEngine(configuration);
+                CairoEngine cairoEngine = new CairoEngine(configuration, metrics);
                 HttpServer ignored = HttpServer.create(
                         new DefaultHttpServerConfiguration(
                                 new DefaultHttpContextConfiguration() {
@@ -729,7 +729,7 @@ public class IODispatcherTest {
         final String baseDir = temp.getRoot().getAbsolutePath();
         final CairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
         try (
-                CairoEngine cairoEngine = new CairoEngine(configuration);
+                CairoEngine cairoEngine = new CairoEngine(configuration, metrics);
                 HttpServer ignored = HttpServer.create(
                         new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
                             @Override
@@ -1493,7 +1493,7 @@ public class IODispatcherTest {
                 }
             }, Metrics.disabled());
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -1966,7 +1966,7 @@ public class IODispatcherTest {
                 }
             }, Metrics.disabled());
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -1987,8 +1987,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics
+                                workerPool.getWorkerCount()
                         );
                     }
 
@@ -2590,7 +2589,7 @@ public class IODispatcherTest {
             }, Metrics.disabled());
 
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -2611,8 +2610,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics
+                                workerPool.getWorkerCount()
                         );
                     }
 
@@ -3754,7 +3752,7 @@ public class IODispatcherTest {
             }, Metrics.disabled());
 
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -3775,8 +3773,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics
+                                workerPool.getWorkerCount()
                         );
                     }
 
@@ -3961,7 +3958,7 @@ public class IODispatcherTest {
                 }
             }, Metrics.disabled());
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
@@ -3981,8 +3978,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics);
+                                workerPool.getWorkerCount());
                     }
 
                     @Override
@@ -4052,7 +4048,7 @@ public class IODispatcherTest {
                 }
             }, Metrics.disabled());
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -4073,8 +4069,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics);
+                                workerPool.getWorkerCount());
                     }
 
                     @Override
@@ -4160,7 +4155,7 @@ public class IODispatcherTest {
             }, Metrics.disabled());
 
             try (
-                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir));
+                    CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, false)
             ) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
@@ -4181,8 +4176,7 @@ public class IODispatcherTest {
                         return new JsonQueryProcessor(
                                 httpConfiguration.getJsonQueryProcessorConfiguration(),
                                 engine,
-                                workerPool.getWorkerCount(),
-                                metrics
+                                workerPool.getWorkerCount()
                         );
                     }
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -346,7 +346,7 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<>() {
+                    new IOContextFactory<HttpConnectionContext>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
@@ -4422,7 +4422,7 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     configuration,
-                    new IOContextFactory<>() {
+                    new IOContextFactory<HttpConnectionContext>() {
                         @SuppressWarnings("resource")
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
@@ -5467,7 +5467,7 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<>() {
+                    new IOContextFactory<HttpConnectionContext>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
@@ -5635,7 +5635,7 @@ public class IODispatcherTest {
 
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
                     new DefaultIODispatcherConfiguration(),
-                    new IOContextFactory<>() {
+                    new IOContextFactory<HttpConnectionContext>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();
@@ -5797,7 +5797,7 @@ public class IODispatcherTest {
                             return 500;
                         }
                     },
-                    new IOContextFactory<>() {
+                    new IOContextFactory<HttpConnectionContext>() {
                         @Override
                         public HttpConnectionContext newInstance(long fd, IODispatcher<HttpConnectionContext> dispatcher1) {
                             connectLatch.countDown();

--- a/core/src/test/java/io/questdb/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/MetricsIODispatcherTest.java
@@ -31,9 +31,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class MetricsIODispatcher {
+public class MetricsIODispatcherTest {
 
-    private static final String PrometheusRequest = "GET /metrics HTTP/1.1\r\n" +
+    private static final String prometheusRequest = "GET /metrics HTTP/1.1\r\n" +
             "Host: localhost:9003\r\n" +
             "User-Agent: Prometheus/2.22.0\r\n" +
             "Accept: application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1\r\n" +
@@ -50,7 +50,7 @@ public class MetricsIODispatcher {
 
         new HttpMinTestBuilder()
                 .withTempFolder(temp)
-                .withMetrics(metrics)
+                .withScrapable(metrics)
                 .run(engine -> {
                     metrics.markQueryStart();
                     metrics.markSyntaxError();
@@ -62,22 +62,22 @@ public class MetricsIODispatcher {
                             "Transfer-Encoding: chunked\r\n" +
                             "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n" +
                             "\r\n" +
-                            "02b4\r\n" +
-                            "# TYPE questdb_json_queries_total counter\n" +
-                            "questdb_json_queries_total 1\n" +
+                            "02f0\r\n" +
+                            "# TYPE questdb_test_json_queries_total counter\n" +
+                            "questdb_test_json_queries_total 1\n" +
                             "\n" +
-                            "# TYPE questdb_json_queries_failed_total counter\n" +
-                            "questdb_json_queries_failed_total{reason=\"cancelled\"} 0\n" +
-                            "questdb_json_queries_failed_total{reason=\"syntax_error\"} 1\n" +
+                            "# TYPE questdb_test_json_queries_failed_total counter\n" +
+                            "questdb_test_json_queries_failed_total{reason=\"cancelled\"} 0\n" +
+                            "questdb_test_json_queries_failed_total{reason=\"syntax_error\"} 1\n" +
                             "\n" +
-                            "# TYPE questdb_compiled_json_queries_failed_total counter\n" +
-                            "questdb_compiled_json_queries_failed_total{type=\"insert\",reason=\"cancelled\"} 1\n" +
-                            "questdb_compiled_json_queries_failed_total{type=\"insert\",reason=\"syntax_error\"} 0\n" +
-                            "questdb_compiled_json_queries_failed_total{type=\"select\",reason=\"cancelled\"} 0\n" +
-                            "questdb_compiled_json_queries_failed_total{type=\"select\",reason=\"syntax_error\"} 0\n" +
+                            "# TYPE questdb_test_compiled_json_queries_failed_total counter\n" +
+                            "questdb_test_compiled_json_queries_failed_total{type=\"insert\",reason=\"cancelled\"} 1\n" +
+                            "questdb_test_compiled_json_queries_failed_total{type=\"insert\",reason=\"syntax_error\"} 0\n" +
+                            "questdb_test_compiled_json_queries_failed_total{type=\"select\",reason=\"cancelled\"} 0\n" +
+                            "questdb_test_compiled_json_queries_failed_total{type=\"select\",reason=\"syntax_error\"} 0\n" +
                             "\n" +
-                            "# TYPE questdb_json_queries_running gauge\n" +
-                            "questdb_json_queries_running 1\n" +
+                            "# TYPE questdb_test_json_queries_running gauge\n" +
+                            "questdb_test_json_queries_running 1\n" +
                             "\n" +
                             "\r\n" +
                             "00\r\n" +
@@ -89,7 +89,7 @@ public class MetricsIODispatcher {
                             .withPrintOnly(false)
                             .withRequestCount(1)
                             .withPauseBetweenSendAndReceive(0)
-                            .execute(PrometheusRequest, expectedResponse);
+                            .execute(prometheusRequest, expectedResponse);
                 });
     }
 
@@ -107,13 +107,13 @@ public class MetricsIODispatcher {
         private final MetricsRegistry metricsRegistry;
 
         public TestMetrics(MetricsRegistry metricsRegistry) {
-            this.queriesCounter = metricsRegistry.newCounter("json_queries");
-            this.failedQueriesCounter = metricsRegistry.newCounter("json_queries_failed", "reason", REASON_ID_TO_NAME);
-            this.failedCompiledQueriesCounter = metricsRegistry.newCounter("compiled_json_queries_failed",
+            this.queriesCounter = metricsRegistry.newCounter("test_json_queries");
+            this.failedQueriesCounter = metricsRegistry.newCounter("test_json_queries_failed", "reason", REASON_ID_TO_NAME);
+            this.failedCompiledQueriesCounter = metricsRegistry.newCounter("test_compiled_json_queries_failed",
                     "type", QUERY_TYPE_ID_TO_NAME,
                     "reason", REASON_ID_TO_NAME
             );
-            this.runningQueries = metricsRegistry.newGauge("json_queries_running");
+            this.runningQueries = metricsRegistry.newGauge("test_json_queries_running");
             this.metricsRegistry = metricsRegistry;
         }
 

--- a/core/src/test/java/io/questdb/cutlass/http/WaitProcessorTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/WaitProcessorTest.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class WaitProcessorTests {
+public class WaitProcessorTest {
     private long currentTimeMs;
     private int job1Attempts = 0;
     private final HttpRequestProcessorSelector emptySelector = createEmptySelector();

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -59,7 +59,7 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
 
     private final ThreadLocal<Socket> tlSocket = new ThreadLocal<>();
 
-    protected final WorkerPool sharedWorkerPool = new WorkerPool(getWorkerPoolConfiguration());
+    protected final WorkerPool sharedWorkerPool = new WorkerPool(getWorkerPoolConfiguration(), metrics);
     protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
         return new WorkerPoolConfiguration() {
             private final int[] affinity = {-1};
@@ -175,7 +175,7 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
         this.minIdleMsBeforeWriterRelease = minIdleMsBeforeWriterRelease;
         assertMemoryLeak(() -> {
             final Path path = new Path(4096);
-            try (LineTcpReceiver receiver = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine)) {
+            try (LineTcpReceiver receiver = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine, metrics)) {
                 sharedWorkerPool.assignCleaner(Path.CLEANER);
                 try (Closeable ignored = O3Utils.setupWorkerPool(sharedWorkerPool, engine.getMessageBus())) {
                     if (needMaintenanceJob) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -275,9 +275,9 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
             }
         };
         if (authDb == null) {
-            context = new LineTcpConnectionContext(lineTcpConfiguration, scheduler);
+            context = new LineTcpConnectionContext(lineTcpConfiguration, scheduler, metrics);
         } else {
-            context = new LineTcpAuthConnectionContext(lineTcpConfiguration, authDb, scheduler);
+            context = new LineTcpAuthConnectionContext(lineTcpConfiguration, authDb, scheduler, metrics);
         }
         Assert.assertNull(context.getDispatcher());
         context.of(FD, new IODispatcher<LineTcpConnectionContext>() {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -129,7 +129,7 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
                 affinityByThread = new int[workerCount];
                 Arrays.fill(affinityByThread, -1);
             }
-        });
+        }, metrics);
     }
 
     protected void assertTable(CharSequence expected, CharSequence tableName) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpO3Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpO3Test.java
@@ -161,9 +161,9 @@ public class LineTcpO3Test extends AbstractCairoTest {
             Assert.assertTrue(clientFd >= 0);
 
             long ilpSockAddr = Net.sockaddr(Net.parseIPv4("127.0.0.1"), lineConfiguration.getDispatcherConfiguration().getBindPort());
-            WorkerPool sharedWorkerPool = new WorkerPool(sharedWorkerPoolConfiguration);
+            WorkerPool sharedWorkerPool = new WorkerPool(sharedWorkerPoolConfiguration, metrics);
             try (
-                    LineTcpReceiver ignored = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine);
+                    LineTcpReceiver ignored = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine, metrics);
                     SqlCompiler compiler = new SqlCompiler(engine);
                     SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1)
             ) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpO3Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpO3Test.java
@@ -97,7 +97,7 @@ public class LineTcpO3Test extends AbstractCairoTest {
         configuration = serverConf.getCairoConfiguration();
         lineConfiguration = serverConf.getLineTcpReceiverConfiguration();
         sharedWorkerPoolConfiguration = serverConf.getWorkerPoolConfiguration();
-        engine = new CairoEngine(configuration);
+        engine = new CairoEngine(configuration, metrics);
         messageBus = engine.getMessageBus();
         LOG.info().$("setup engine completed").$();
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1007,7 +1007,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             });
 
             minIdleMsBeforeWriterRelease = 100;
-            try (LineTcpReceiver ignored = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine)) {
+            try (LineTcpReceiver ignored = LineTcpReceiver.create(lineConfiguration, sharedWorkerPool, LOG, engine, metrics)) {
                 long startEpochMs = System.currentTimeMillis();
                 sharedWorkerPool.assignCleaner(Path.CLEANER);
                 sharedWorkerPool.start(LOG);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/SymbolCacheTest.java
@@ -160,7 +160,7 @@ public class SymbolCacheTest extends AbstractGriffinTest {
             ) {
                 CairoTestUtils.create(model);
                 try (
-                        TableWriter writer = new TableWriter(configuration, tableName);
+                        TableWriter writer = new TableWriter(configuration, tableName, metrics);
                         MemoryMR txMem = Vm.getMRInstance()
                 ) {
                     int symColIndex1 = writer.getColumnIndex("symCol1");

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpInsertTest.java
@@ -83,7 +83,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                                      Consumer<AbstractLineSender> senderConsumer,
                                      String... expectedExtraStringColumns) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
+            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
                 final SOCountDownLatch waitForData = new SOCountDownLatch(1);
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                     if (event == PoolListener.EV_RETURN && Chars.equals(tableName, name)) {

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserImplTest.java
@@ -425,7 +425,7 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
         };
 
         // open writer so that pool cannot have it
-        try (TableWriter ignored = new TableWriter(configuration, "x")) {
+        try (TableWriter ignored = new TableWriter(configuration, "x", metrics)) {
             assertThat(expected, lines, "x", configuration);
         }
     }

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserSupportTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpParserSupportTest.java
@@ -265,7 +265,7 @@ public class LineUdpParserSupportTest extends LineUdpInsertTest {
             Consumer<AbstractLineSender> senderConsumer
     ) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration)) {
+            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
                 final SOCountDownLatch waitForData = new SOCountDownLatch(1);
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                     if (event == PoolListener.EV_RETURN && Chars.equals(tableName, name)) {

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
@@ -238,12 +238,8 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
                     "blue\tx square\t3.4000000000000004\t1970-01-01T00:01:40.000000Z\n";
 
             try (CairoEngine engine = new CairoEngine(configuration)) {
-
-
                 try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, null, metrics)) {
-
                     // create table
-
                     try (TableModel model = new TableModel(configuration, "tab", PartitionBy.NONE)
                             .col("colour", ColumnType.SYMBOL)
                             .col("shape", ColumnType.SYMBOL)

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.pgwire;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.TableReader;
@@ -4666,7 +4667,7 @@ create table tab as (
             }
         };
 
-        WorkerPool pool = new WorkerPool(conf);
+        WorkerPool pool = new WorkerPool(conf, metrics);
         pool.assign(engine.getEngineMaintenanceJob());
         try (
                 final PGWireServer ignored = PGWireServer.create(

--- a/core/src/test/java/io/questdb/griffin/AbstractO3Test.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractO3Test.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cairo.*;
 import io.questdb.griffin.engine.functions.rnd.SharedRandom;
@@ -259,7 +260,8 @@ public class AbstractO3Test {
                             public boolean isEnabled() {
                                 return true;
                             }
-                        }
+                        },
+                        Metrics.disabled()
                 );
 
                 final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {

--- a/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
+++ b/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -275,7 +276,8 @@ public class LatestByParallelTest {
                             public boolean isEnabled() {
                                 return true;
                             }
-                        }
+                        },
+                        Metrics.disabled()
                 );
 
                 final CairoConfiguration configuration = new DefaultCairoConfiguration(root) {

--- a/core/src/test/java/io/questdb/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3FailureTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cairo.*;
 import io.questdb.log.Log;
@@ -3526,7 +3527,7 @@ public class O3FailureTest extends AbstractO3Test {
                 public boolean isEnabled() {
                     return true;
                 }
-            });
+            }, Metrics.disabled());
 
             pool1.assign(new Job() {
                 private boolean toRun = true;
@@ -3565,7 +3566,7 @@ public class O3FailureTest extends AbstractO3Test {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
 
             pool2.assign(new Job() {
                 private boolean toRun = true;

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.WorkerPoolAwareConfiguration;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
@@ -1229,7 +1230,7 @@ public class O3Test extends AbstractO3Test {
                 public boolean isEnabled() {
                     return true;
                 }
-            });
+            }, Metrics.disabled());
 
             pool1.assign(new Job() {
                 private boolean toRun = true;
@@ -1268,7 +1269,7 @@ public class O3Test extends AbstractO3Test {
                 public boolean haltOnError() {
                     return false;
                 }
-            });
+            }, Metrics.disabled());
 
             pool2.assign(new Job() {
                 private boolean toRun = true;

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -361,7 +361,7 @@ public class O3Test extends AbstractO3Test {
             IntList newColTypes = new IntList();
             CyclicBarrier barrier = new CyclicBarrier(1);
 
-            try (TableWriter writer = new TableWriter(configuration, model.getName())) {
+            try (TableWriter writer = new TableWriter(configuration, model.getName(), Metrics.disabled())) {
                 Thread writerT = new Thread(() -> {
                     try {
                         int i = 0;

--- a/core/src/test/java/io/questdb/griffin/PartitionDeleteTest.java
+++ b/core/src/test/java/io/questdb/griffin/PartitionDeleteTest.java
@@ -39,7 +39,7 @@ public class PartitionDeleteTest extends AbstractGriffinTest {
         compiler.compile("create table events (sequence long, event binary, timestamp timestamp) timestamp(timestamp) partition by DAY", sqlExecutionContext);
         engine.releaseAllWriters();
 
-        try (TableWriter w = new TableWriter(configuration, "events")) {
+        try (TableWriter w = new TableWriter(configuration, "events", metrics)) {
             long ts = TimestampFormatUtils.parseTimestamp("2020-06-30T00:00:00.000000Z");
             for (int i = 0; i < 10; i++) {
                 TableWriter.Row r = w.newRow(ts);
@@ -69,7 +69,7 @@ public class PartitionDeleteTest extends AbstractGriffinTest {
 
             }
 
-            try (TableWriter w = new TableWriter(configuration, "events")) {
+            try (TableWriter w = new TableWriter(configuration, "events", metrics)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2020-07-02T00:00:00.000000Z");
                 for (int i = 0; i < 10; i++) {
                     TableWriter.Row row = w.newRow(ts);

--- a/core/src/test/java/io/questdb/griffin/TableRepairTest.java
+++ b/core/src/test/java/io/questdb/griffin/TableRepairTest.java
@@ -58,7 +58,7 @@ public class TableRepairTest extends AbstractGriffinTest {
 
                 // repair by opening and closing writer
 
-                try (TableWriter w = new TableWriter(configuration, "tst")) {
+                try (TableWriter w = new TableWriter(configuration, "tst", metrics)) {
                     Assert.assertTrue(reader.reload());
                     Assert.assertEquals(95040, reader.size());
                     Assert.assertEquals(950390000000L, w.getMaxTimestamp());
@@ -97,7 +97,7 @@ public class TableRepairTest extends AbstractGriffinTest {
 
                 // repair by opening and closing writer
 
-                new TableWriter(configuration, "tst").close();
+                new TableWriter(configuration, "tst", metrics).close();
 
                 Assert.assertTrue(reader.reload());
                 Assert.assertEquals(91360, reader.size());

--- a/core/src/test/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactoryTest.java
@@ -67,7 +67,7 @@ public class DataFrameRecordCursorFactoryTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -147,7 +147,7 @@ public class DataFrameRecordCursorFactoryTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = new TableWriter(configuration, "x")) {
+            try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
                 int iIndex = writer.getColumnIndex("i");
                 int jIndex = -1;
                 int sIndex = -1;

--- a/core/src/test/java/io/questdb/jit/CompiledFilterIRSerializerTest.java
+++ b/core/src/test/java/io/questdb/jit/CompiledFilterIRSerializerTest.java
@@ -89,7 +89,7 @@ public class CompiledFilterIRSerializerTest extends BaseFunctionFactoryTest {
             CairoTestUtils.create(model);
         }
 
-        try (TableWriter writer = new TableWriter(configuration, "x")) {
+        try (TableWriter writer = new TableWriter(configuration, "x", metrics)) {
             TableWriter.Row row = writer.newRow();
             row.putSym(writer.getColumnIndex("asymbol"), KNOWN_SYMBOL_1);
             row.putSym(writer.getColumnIndex("anothersymbol"), KNOWN_SYMBOL_2);


### PR DESCRIPTION
Implements https://github.com/questdb/rfc/discussions/47

Also includes the following:
* Fixes NPE on root path health check with enabled metrics (`curl -v http://127.0.0.1:9003` on an instance with enabled metrics to reproduce)
* Exposes basic table writer metrics

New metrics are the following (a fragment from the `/metrics` endpoint's response):
```
# TYPE questdb_unhandled_errors_total counter
questdb_unhandled_errors_total 0

# TYPE questdb_commits_total counter
questdb_commits_total 600

# TYPE questdb_o3_commits_total counter
questdb_o3_commits_total 0

# TYPE questdb_committed_rows_total counter
questdb_committed_rows_total 599001

# TYPE questdb_rollbacks_total counter
questdb_rollbacks_total 0
```

`questdb_committed_rows_total` visualized in Prometheus:
![Screenshot from 2022-02-10 17-40-16](https://user-images.githubusercontent.com/37772591/153431344-3933f1c8-f0e5-4a7e-951f-4bb4449753e7.png)
