### PR TITLE
fix(core): fixed TableReader double free events

### DIFF
--- a/core/src/main/java/io/questdb/cairo/AbstractFullDataFrameCursor.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractFullDataFrameCursor.java
@@ -26,6 +26,7 @@ package io.questdb.cairo;
 
 import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.DataFrameCursor;
+import io.questdb.std.Misc;
 
 public abstract class AbstractFullDataFrameCursor implements DataFrameCursor {
     protected final FullTableDataFrame frame = new FullTableDataFrame();
@@ -35,10 +36,7 @@ public abstract class AbstractFullDataFrameCursor implements DataFrameCursor {
 
     @Override
     public void close() {
-        if (reader != null) {
-            reader.close();
-            reader = null;
-        }
+        reader = Misc.free(reader);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/AbstractIntervalDataFrameCursor.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractIntervalDataFrameCursor.java
@@ -31,6 +31,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.model.RuntimeIntrinsicIntervalModel;
 import io.questdb.std.LongList;
+import io.questdb.std.Misc;
 
 public abstract class AbstractIntervalDataFrameCursor implements DataFrameCursor {
     static final int SCAN_UP = -1;
@@ -77,10 +78,7 @@ public abstract class AbstractIntervalDataFrameCursor implements DataFrameCursor
 
     @Override
     public void close() {
-        if (reader != null) {
-            reader.close();
-            reader = null;
-        }
+        reader = Misc.free(reader);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -34,7 +34,6 @@ import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.ConcurrentHashMap;
-import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 import java.util.Arrays;
@@ -331,9 +330,7 @@ public class ReaderPool extends AbstractPool implements ResourcePool<TableReader
             return !closed || !Unsafe.cas(e.allocations, index, UNALLOCATED, owner);
         }
 
-        LOG.error().$('\'').$(name).$("' is available [at=").$(e.index).$(':').$(index).$(']').$();
-        return true;
-
+        throw CairoException.instance(0).put("double close [table=").put(name).put(", index=").put(index).put(']');
     }
 
     public static class Entry {

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -70,9 +70,9 @@ import static io.questdb.griffin.model.ExpressionNode.LITERAL;
 import static io.questdb.griffin.model.QueryModel.*;
 
 public class SqlCodeGenerator implements Mutable, Closeable {
-    private static final Log LOG = LogFactory.getLog(SqlCodeGenerator.class);
     public static final int GKK_VANILLA_INT = 0;
     public static final int GKK_HOUR_INT = 1;
+    private static final Log LOG = LogFactory.getLog(SqlCodeGenerator.class);
     private static final IntHashSet limitTypes = new IntHashSet();
     private static final FullFatJoinGenerator CREATE_FULL_FAT_LT_JOIN = SqlCodeGenerator::createFullFatLtJoin;
     private static final FullFatJoinGenerator CREATE_FULL_FAT_AS_OF_JOIN = SqlCodeGenerator::createFullFatAsOfJoin;
@@ -90,7 +90,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final WhereClauseParser whereClauseParser = new WhereClauseParser();
     private final CompiledFilterIRSerializer jitIRSerializer = new CompiledFilterIRSerializer();
     private final MemoryCARW jitIRMem;
-    private boolean enableJitNullChecks = true;
     private final boolean enableJitDebug;
     private final FunctionParser functionParser;
     private final CairoEngine engine;
@@ -117,17 +116,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final ObjObjHashMap<IntList, ObjList<AnalyticFunction>> grouppedAnalytic = new ObjObjHashMap<>();
     private final IntList recordFunctionPositions = new IntList();
     private final IntList groupByFunctionPositions = new IntList();
-    private boolean fullFatJoins = false;
     private final LongList prefixes = new LongList();
-
-    static {
-        joinsRequiringTimestamp[JOIN_INNER] = false;
-        joinsRequiringTimestamp[JOIN_OUTER] = false;
-        joinsRequiringTimestamp[JOIN_CROSS] = false;
-        joinsRequiringTimestamp[JOIN_ASOF] = true;
-        joinsRequiringTimestamp[JOIN_SPLICE] = true;
-        joinsRequiringTimestamp[JOIN_LT] = true;
-    }
+    private boolean enableJitNullChecks = true;
+    private boolean fullFatJoins = false;
 
     public SqlCodeGenerator(
             CairoEngine engine,
@@ -309,6 +300,28 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
     private RecordMetadata calculateSetMetadata(RecordMetadata masterMetadata) {
         return GenericRecordMetadata.removeTimestamp(masterMetadata);
+    }
+
+    // Check if lo, hi is set and lo >=0 while hi < 0 (meaning - return whole result set except some rows at start and some at the end)
+    // because such case can't really be optimized by topN/bottomN
+    private boolean canBeOptimized(QueryModel model, SqlExecutionContext context, Function loFunc, Function hiFunc) {
+        if (model.getLimitLo() == null && model.getLimitHi() == null) {
+            return false;
+        }
+
+        if (loFunc != null && loFunc.isConstant() &&
+                hiFunc != null && hiFunc.isConstant()) {
+            try {
+                loFunc.init(null, context);
+                hiFunc.init(null, context);
+
+                return !(loFunc.getLong(null) >= 0 && hiFunc.getLong(null) < 0);
+            } catch (SqlException ex) {
+                LOG.error().$("Failed to initialize lo or hi functions [").$("error=").$(ex.getMessage()).I$();
+            }
+        }
+
+        return true;
     }
 
     @Nullable
@@ -763,55 +776,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         return new FilteredRecordCursorFactory(factory, f);
     }
 
-    @NotNull
-    private RecordCursorFactory generateLatestBy(RecordCursorFactory factory, QueryModel model) throws SqlException {
-        final ObjList<ExpressionNode> latestBy = model.getLatestBy();
-        if (latestBy.size() == 0) {
-            return factory;
-        }
-
-        final int timestampIndex = getTimestampIndex(model, factory);
-        if (timestampIndex == -1) {
-            Misc.free(factory);
-            throw SqlException.$(model.getModelPosition(), "latest by query does not provide dedicated TIMESTAMP column");
-        }
-
-        final RecordMetadata metadata = factory.getMetadata();
-        prepareLatestByColumnIndexes(latestBy, metadata);
-
-        if (!factory.recordCursorSupportsRandomAccess()) {
-            return new LatestByRecordCursorFactory(
-                    configuration,
-                    factory,
-                    RecordSinkFactory.getInstance(asm, metadata, listColumnFilterA, false),
-                    keyTypes,
-                    timestampIndex
-            );
-        }
-
-        boolean orderedByTimestampAsc = false;
-        final QueryModel nested = model.getNestedModel();
-        assert nested != null;
-        final LowerCaseCharSequenceIntHashMap orderBy = nested.getOrderHash();
-        CharSequence timestampColumn = metadata.getColumnName(timestampIndex);
-        if (orderBy.get(timestampColumn) == QueryModel.ORDER_DIRECTION_ASCENDING) {
-            // ORDER BY the timestamp column case.
-            orderedByTimestampAsc = true;
-        } else if (timestampIndex == metadata.getTimestampIndex() && orderBy.size() == 0) {
-            // Empty ORDER BY, but the timestamp column in the designated timestamp.
-            orderedByTimestampAsc = true;
-        }
-
-        return new LatestByLightRecordCursorFactory(
-                configuration,
-                factory,
-                RecordSinkFactory.getInstance(asm, metadata, listColumnFilterA, false),
-                keyTypes,
-                timestampIndex,
-                orderedByTimestampAsc
-        );
-    }
-
     private RecordCursorFactory generateFunctionQuery(QueryModel model) throws SqlException {
         final Function function = model.getTableNameFunction();
         assert function != null;
@@ -1043,9 +1007,58 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     }
 
     @NotNull
+    private RecordCursorFactory generateLatestBy(RecordCursorFactory factory, QueryModel model) throws SqlException {
+        final ObjList<ExpressionNode> latestBy = model.getLatestBy();
+        if (latestBy.size() == 0) {
+            return factory;
+        }
+
+        final int timestampIndex = getTimestampIndex(model, factory);
+        if (timestampIndex == -1) {
+            Misc.free(factory);
+            throw SqlException.$(model.getModelPosition(), "latest by query does not provide dedicated TIMESTAMP column");
+        }
+
+        final RecordMetadata metadata = factory.getMetadata();
+        prepareLatestByColumnIndexes(latestBy, metadata);
+
+        if (!factory.recordCursorSupportsRandomAccess()) {
+            return new LatestByRecordCursorFactory(
+                    configuration,
+                    factory,
+                    RecordSinkFactory.getInstance(asm, metadata, listColumnFilterA, false),
+                    keyTypes,
+                    timestampIndex
+            );
+        }
+
+        boolean orderedByTimestampAsc = false;
+        final QueryModel nested = model.getNestedModel();
+        assert nested != null;
+        final LowerCaseCharSequenceIntHashMap orderBy = nested.getOrderHash();
+        CharSequence timestampColumn = metadata.getColumnName(timestampIndex);
+        if (orderBy.get(timestampColumn) == QueryModel.ORDER_DIRECTION_ASCENDING) {
+            // ORDER BY the timestamp column case.
+            orderedByTimestampAsc = true;
+        } else if (timestampIndex == metadata.getTimestampIndex() && orderBy.size() == 0) {
+            // Empty ORDER BY, but the timestamp column in the designated timestamp.
+            orderedByTimestampAsc = true;
+        }
+
+        return new LatestByLightRecordCursorFactory(
+                configuration,
+                factory,
+                RecordSinkFactory.getInstance(asm, metadata, listColumnFilterA, false),
+                keyTypes,
+                timestampIndex,
+                orderedByTimestampAsc
+        );
+    }
+
+    @NotNull
     private RecordCursorFactory generateLatestByTableQuery(
             QueryModel model,
-            TableReader reader,
+            @Transient TableReader reader,
             RecordMetadata metadata,
             String tableName,
             IntrinsicModel intrinsicModel,
@@ -1268,31 +1281,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         return new LimitRecordCursorFactory(factory, loFunc, hiFunc);
     }
 
-    private Function toFunction(SqlExecutionContext executionContext,
-                                ExpressionNode limit,
-                                ConstantFunction defaultValue) throws SqlException {
-        if (limit == null) {
-            return defaultValue;
-        }
-
-        final Function func = functionParser.parseFunction(limit, EmptyRecordMetadata.INSTANCE, executionContext);
-        final int type = func.getType();
-        if (limitTypes.excludes(type)) {
-            throw SqlException.$(limit.position, "invalid type: ").put(ColumnType.nameOf(type));
-        }
-        return func;
-    }
-
-    @Nullable
-    private Function getHiFunction(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
-        return toFunction(executionContext, model.getLimitHi(), null);
-    }
-
-    @NotNull
-    private Function getLoFunction(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
-        return toFunction(executionContext, model.getLimitLo(), LongConstant.ZERO);
-    }
-
     private RecordCursorFactory generateNoSelect(
             QueryModel model,
             SqlExecutionContext executionContext
@@ -1424,28 +1412,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
     }
 
-    // Check if lo, hi is set and lo >=0 while hi < 0 (meaning - return whole result set except some rows at start and some at the end)
-    // because such case can't really be optimized by topN/bottomN
-    private boolean canBeOptimized(QueryModel model, SqlExecutionContext context, Function loFunc, Function hiFunc) {
-        if (model.getLimitLo() == null && model.getLimitHi() == null) {
-            return false;
-        }
-
-        if (loFunc != null && loFunc.isConstant() &&
-                hiFunc != null && hiFunc.isConstant()) {
-            try {
-                loFunc.init(null, context);
-                hiFunc.init(null, context);
-
-                return !(loFunc.getLong(null) >= 0 && hiFunc.getLong(null) < 0);
-            } catch (SqlException ex) {
-                LOG.error().$("Failed to initialize lo or hi functions [").$("error=").$(ex.getMessage()).I$();
-            }
-        }
-
-        return true;
-    }
-
     private RecordCursorFactory generateQuery(QueryModel model, SqlExecutionContext executionContext, boolean processJoins) throws SqlException {
         RecordCursorFactory factory = generateQuery0(model, executionContext, processJoins);
         if (model.getUnionModel() != null) {
@@ -1530,7 +1496,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             final ObjList<ExpressionNode> sampleByFill = model.getSampleByFill();
             final TimestampSampler timestampSampler;
             if (sampleByUnits == null) {
-                 timestampSampler = TimestampSamplerFactory.getInstance(sampleByNode.token, sampleByNode.position);
+                timestampSampler = TimestampSamplerFactory.getInstance(sampleByNode.token, sampleByNode.position);
             } else {
                 Function sampleByPeriod = functionParser.parseFunction(
                         sampleByNode,
@@ -2036,7 +2002,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             ObjList<CharSequence> updateColumnNames = model.getUpdateTableColumnNames();
             IntList updateColumnTypes = model.getUpdateTableColumnTypes();
 
-            for(int i = 0, n = columns.size(); i < n; i++) {
+            for (int i = 0, n = columns.size(); i < n; i++) {
                 QueryColumn queryColumn = columns.getQuick(i);
                 CharSequence columnName = queryColumn.getAlias();
                 int index = metadata.getColumnIndexQuiet(queryColumn.getAst().token);
@@ -2634,12 +2600,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             // topDownColumnCount can be 0 for 'select count()' queries
 
             int readerTimestampIndex;
-            try {
-                readerTimestampIndex = getTimestampIndex(model, readerMeta);
-            } catch (SqlException e) {
-                Misc.free(reader);
-                throw e;
-            }
+            readerTimestampIndex = getTimestampIndex(model, readerMeta);
 
             // Latest by on a table requires provided timestamp column to be the designated timestamp.
             if (latestBy.size() > 0 && readerTimestampIndex != readerMeta.getTimestampIndex()) {
@@ -2664,10 +2625,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         int type = readerMeta.getColumnType(columnIndex);
                         int typeSize = ColumnType.sizeOf(type);
 
-//                        if (framingSupported && (typeSize < Byte.BYTES || typeSize > Double.BYTES)) {
-//                             we don't frame non-primitive types yet
-//                            framingSupported = false;
-//                        }
                         columnIndexes.add(columnIndex);
                         columnSizes.add((Numbers.msb(typeSize)));
 
@@ -3085,58 +3042,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
     }
 
-    private boolean isOrderDescendingByDesignatedTimestampOnly(QueryModel model) {
-        return model.getOrderByAdvice().size() == 1 && model.getTimestamp() != null &&
-                Chars.equalsIgnoreCase(model.getOrderByAdvice().getQuick(0).token, model.getTimestamp().token) &&
-                getOrderByDirectionOrDefault(model, 0) == ORDER_DIRECTION_DESCENDING;
-    }
-
-    private int prepareLatestByColumnIndexes(ObjList<ExpressionNode> latestBy, RecordMetadata myMeta) throws SqlException {
-        keyTypes.clear();
-        listColumnFilterA.clear();
-
-        final int latestByColumnCount = latestBy.size();
-        if (latestByColumnCount > 0) {
-            // validate the latest by against the current reader
-            // first check if column is valid
-            for (int i = 0; i < latestByColumnCount; i++) {
-                final ExpressionNode latestByNode = latestBy.getQuick(i);
-                final int index = myMeta.getColumnIndexQuiet(latestByNode.token);
-                if (index == -1) {
-                    throw SqlException.invalidColumn(latestByNode.position, latestByNode.token);
-                }
-
-                // check the type of the column, not all are supported
-                int columnType = myMeta.getColumnType(index);
-                switch (ColumnType.tagOf(columnType)) {
-                    case ColumnType.BOOLEAN:
-                    case ColumnType.CHAR:
-                    case ColumnType.SHORT:
-                    case ColumnType.INT:
-                    case ColumnType.LONG:
-                    case ColumnType.LONG256:
-                    case ColumnType.STRING:
-                    case ColumnType.SYMBOL:
-                        // we are reusing collections which leads to confusing naming for this method
-                        // keyTypes are types of columns we collect 'latest by' for
-                        keyTypes.add(columnType);
-                        // listColumnFilterA are indexes of columns we collect 'latest by' for
-                        listColumnFilterA.add(index + 1);
-                        break;
-
-                    default:
-                        throw SqlException
-                                .position(latestByNode.position)
-                                .put(latestByNode.token)
-                                .put(" (")
-                                .put(ColumnType.nameOf(columnType))
-                                .put("): invalid type, only [BOOLEAN, SHORT, INT, LONG, LONG256, CHAR, STRING, SYMBOL] are supported in LATEST BY");
-                }
-            }
-        }
-        return latestByColumnCount;
-    }
-
     private RecordCursorFactory generateUnionAllFactory(
             QueryModel model,
             RecordCursorFactory masterFactory,
@@ -3189,6 +3094,16 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         return unionFactory;
     }
 
+    @Nullable
+    private Function getHiFunction(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
+        return toFunction(executionContext, model.getLimitHi(), null);
+    }
+
+    @NotNull
+    private Function getLoFunction(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
+        return toFunction(executionContext, model.getLimitLo(), LongConstant.ZERO);
+    }
+
     private int getTimestampIndex(QueryModel model, RecordCursorFactory factory) throws SqlException {
         final RecordMetadata metadata = factory.getMetadata();
         try {
@@ -3212,6 +3127,12 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             return timestampIndex;
         }
         return metadata.getTimestampIndex();
+    }
+
+    private boolean isOrderDescendingByDesignatedTimestampOnly(QueryModel model) {
+        return model.getOrderByAdvice().size() == 1 && model.getTimestamp() != null &&
+                Chars.equalsIgnoreCase(model.getOrderByAdvice().getQuick(0).token, model.getTimestamp().token) &&
+                getOrderByDirectionOrDefault(model, 0) == ORDER_DIRECTION_DESCENDING;
     }
 
     private boolean isSingleColumnFunction(ExpressionNode ast, CharSequence name) {
@@ -3254,6 +3175,52 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
     }
 
+    private int prepareLatestByColumnIndexes(ObjList<ExpressionNode> latestBy, RecordMetadata myMeta) throws SqlException {
+        keyTypes.clear();
+        listColumnFilterA.clear();
+
+        final int latestByColumnCount = latestBy.size();
+        if (latestByColumnCount > 0) {
+            // validate the latest by against the current reader
+            // first check if column is valid
+            for (int i = 0; i < latestByColumnCount; i++) {
+                final ExpressionNode latestByNode = latestBy.getQuick(i);
+                final int index = myMeta.getColumnIndexQuiet(latestByNode.token);
+                if (index == -1) {
+                    throw SqlException.invalidColumn(latestByNode.position, latestByNode.token);
+                }
+
+                // check the type of the column, not all are supported
+                int columnType = myMeta.getColumnType(index);
+                switch (ColumnType.tagOf(columnType)) {
+                    case ColumnType.BOOLEAN:
+                    case ColumnType.CHAR:
+                    case ColumnType.SHORT:
+                    case ColumnType.INT:
+                    case ColumnType.LONG:
+                    case ColumnType.LONG256:
+                    case ColumnType.STRING:
+                    case ColumnType.SYMBOL:
+                        // we are reusing collections which leads to confusing naming for this method
+                        // keyTypes are types of columns we collect 'latest by' for
+                        keyTypes.add(columnType);
+                        // listColumnFilterA are indexes of columns we collect 'latest by' for
+                        listColumnFilterA.add(index + 1);
+                        break;
+
+                    default:
+                        throw SqlException
+                                .position(latestByNode.position)
+                                .put(latestByNode.token)
+                                .put(" (")
+                                .put(ColumnType.nameOf(columnType))
+                                .put("): invalid type, only [BOOLEAN, SHORT, INT, LONG, LONG256, CHAR, STRING, SYMBOL] are supported in LATEST BY");
+                }
+            }
+        }
+        return latestByColumnCount;
+    }
+
     private void processJoinContext(
             boolean vanillaMaster,
             JoinContext jc,
@@ -3282,8 +3249,28 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
     }
 
+    // used in tests
+    void setEnableJitNullChecks(boolean value) {
+        enableJitNullChecks = value;
+    }
+
     void setFullFatJoins(boolean fullFatJoins) {
         this.fullFatJoins = fullFatJoins;
+    }
+
+    private Function toFunction(SqlExecutionContext executionContext,
+                                ExpressionNode limit,
+                                ConstantFunction defaultValue) throws SqlException {
+        if (limit == null) {
+            return defaultValue;
+        }
+
+        final Function func = functionParser.parseFunction(limit, EmptyRecordMetadata.INSTANCE, executionContext);
+        final int type = func.getType();
+        if (limitTypes.excludes(type)) {
+            throw SqlException.$(limit.position, "invalid type: ").put(ColumnType.nameOf(type));
+        }
+        return func;
     }
 
     private IntList toOrderIndices(RecordMetadata m, ObjList<ExpressionNode> orderBy, IntList orderByDirection) throws SqlException {
@@ -3352,11 +3339,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         return ColumnType.isString(columnType) ? Record.GET_STR : Record.GET_SYM;
     }
 
-    // used in tests
-    void setEnableJitNullChecks(boolean value) {
-        enableJitNullChecks = value;
-    }
-
     @FunctionalInterface
     public interface FullFatJoinGenerator {
         RecordCursorFactory create(
@@ -3373,6 +3355,15 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 RecordValueSink slaveValueSink,
                 IntList columnIndex
         );
+    }
+
+    static {
+        joinsRequiringTimestamp[JOIN_INNER] = false;
+        joinsRequiringTimestamp[JOIN_OUTER] = false;
+        joinsRequiringTimestamp[JOIN_CROSS] = false;
+        joinsRequiringTimestamp[JOIN_ASOF] = true;
+        joinsRequiringTimestamp[JOIN_SPLICE] = true;
+        joinsRequiringTimestamp[JOIN_LT] = true;
     }
 
     static {

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -173,13 +173,12 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
     @Override
     protected RecordCursor getCursorInstance(DataFrameCursor dataFrameCursor, SqlExecutionContext executionContext)
             throws SqlException {
-        try (TableReader reader = dataFrameCursor.getTableReader()) {
-            if (reader.getSymbolMapReader(columnIndex).getSymbolCount() > maxSymbolNotEqualsCount) {
-                throw ReaderOutOfDateException.of(reader.getTableName());
-            }
-            Function.init(keyExcludedValueFunctions, reader, executionContext);
+        TableReader reader = dataFrameCursor.getTableReader();
+        if (reader.getSymbolMapReader(columnIndex).getSymbolCount() > maxSymbolNotEqualsCount) {
+            throw ReaderOutOfDateException.of(reader.getTableName());
         }
-        this.recalculateIncludedValues(dataFrameCursor.getTableReader());
+        Function.init(keyExcludedValueFunctions, reader, executionContext);
+        this.recalculateIncludedValues(reader);
         this.cursor.of(dataFrameCursor, executionContext);
         if (filter != null) {
             filter.init(this.cursor, executionContext);

--- a/core/src/test/java/io/questdb/cairo/TableReaderTailRecordCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderTailRecordCursorTest.java
@@ -219,11 +219,15 @@ public class TableReaderTailRecordCursorTest extends AbstractGriffinTest {
                     Rnd rnd = new Rnd();
                     appendRecords(0, n, timestampIncrement, writer, ts, addr, rnd);
                     ts = n * timestampIncrement;
-                    try (
-                            TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "xyz", TableUtils.ANY_TABLE_ID, TableUtils.ANY_TABLE_VERSION);
-                            TableReaderTailRecordCursor cursor = new TableReaderTailRecordCursor()
-                    ) {
-                        cursor.of(reader);
+                    try (TableReaderTailRecordCursor cursor = new TableReaderTailRecordCursor()) {
+                        cursor.of(
+                                engine.getReader(
+                                        AllowAllCairoSecurityContext.INSTANCE,
+                                        "xyz",
+                                        TableUtils.ANY_TABLE_ID,
+                                        TableUtils.ANY_TABLE_VERSION
+                                )
+                        );
                         cursor.toBottom();
 
                         Assert.assertFalse(cursor.reload());
@@ -278,11 +282,15 @@ public class TableReaderTailRecordCursorTest extends AbstractGriffinTest {
                     Rnd rnd = new Rnd();
                     appendRecords(0, n, timestampIncrement, writer, ts, addr, rnd);
                     ts = n * timestampIncrement;
-                    try (
-                            TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, "xyz", TableUtils.ANY_TABLE_ID, TableUtils.ANY_TABLE_VERSION);
-                            TableReaderTailRecordCursor cursor = new TableReaderTailRecordCursor()
-                    ) {
-                        cursor.of(reader);
+                    try (TableReaderTailRecordCursor cursor = new TableReaderTailRecordCursor()) {
+                        cursor.of(
+                                engine.getReader(
+                                        AllowAllCairoSecurityContext.INSTANCE,
+                                        "xyz",
+                                        TableUtils.ANY_TABLE_ID,
+                                        TableUtils.ANY_TABLE_VERSION
+                                )
+                        );
                         Assert.assertTrue(cursor.reload());
                         int count = 0;
                         Record record = cursor.getRecord();

--- a/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/cairo/pool/ReaderPoolTest.java
@@ -801,14 +801,12 @@ public class ReaderPoolTest extends AbstractCairoTest {
             Assert.assertEquals(1, pool.getBusyCount());
             reader.close();
             Assert.assertEquals(0, pool.getBusyCount());
-            reader.close();
-
-            reader = pool.get("u");
-            Assert.assertNotNull(reader);
-            Assert.assertTrue(reader.isOpen());
-            reader.close();
-
-            Assert.assertEquals("[10,1,11,1]", listener.events.toString());
+            try {
+                reader.close();
+                Assert.fail();
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "double close");
+            }
         });
     }
 


### PR DESCRIPTION
A SQL execution path was using `TableReader` instance _after_ it was returned to pool. This lead to the same instance being used by multiple threads with flurry of random errors and memory corruption.

Additionally I made it an error to return reader instance to pool twice and fixed tests that did just that.