### PR TITLE
fix(sql): fix parsing of timestamps that have 0 micros

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/BindVariableServiceImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/BindVariableServiceImpl.java
@@ -1007,7 +1007,7 @@ public class BindVariableServiceImpl implements BindVariableService {
 
     static {
         final DateFormatCompiler milliCompiler = new DateFormatCompiler();
-        final DateFormat pgDateTimeFormat = milliCompiler.compile("yyyy-MM-dd HH:mm:ssz");
+        final DateFormat pgDateTimeFormat = milliCompiler.compile("y-MM-dd HH:mm:ssz");
 
         DATE_FORMATS = new DateFormat[]{
                 pgDateTimeFormat,

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -1288,7 +1288,7 @@ public class PGJobContextTest extends BasePGTest {
 
                     insert.execute();
                     Assert.assertEquals(1, insert.getUpdateCount());
-                    micros += 1000;
+                    micros += 1;
 
                     if (i % 128 == 0) {
                         connection.commit();


### PR DESCRIPTION
Fixes the bug mentioned in this comment: https://github.com/questdb/questdb/issues/1359#issuecomment-929566532. Note that this PR only fixes the bug mentioned in the comment, it doesn't actually fix issue #1359 as a whole.

---

When constructing a `Timestamp` object from a precise source of microseconds, the `Timestamp` represents an epoch time that looks something like this: `1632857409651937`. The driver serializes this `Timestamp` like so: `53713-03-11 14:40:51.937+00`. QuestDB is currently able to parse this just fine.

If instead we construct a `Timestamp` object from microseconds that only have millisecond level precision, the `Timestamp` represents an epoch time that looks like: `1632857409651000` (notice the zero digits at the end). The driver skips over serializing the microsecond portion as it is all zero and serializes the `Timestamp` like so: `53713-03-11 14:40:51+00`. QuestDB is **unable** to parse this without the fix in this PR as it is confused when there is no decimal.

Also expands the test to cover the case this PR fixes.