### PR TITLE
fix(UI): fix errors in WebConsole browser console

### DIFF
--- a/core/src/main/assembly/web-console.xml
+++ b/core/src/main/assembly/web-console.xml
@@ -36,6 +36,7 @@
             </includes>
             <excludes>
                 <exclude>**/*.woff</exclude>
+                <exclude>**/*.ttf</exclude>
             </excludes>
             <outputDirectory>.</outputDirectory>
             <fileMode>755</fileMode>
@@ -46,6 +47,7 @@
             <directory>../ui/dist</directory>
             <includes>
                 <include>**/*.woff</include>
+                <include>**/*.ttf</include>
             </includes>
             <outputDirectory>.</outputDirectory>
             <fileMode>755</fileMode>

--- a/ui/post-build.js
+++ b/ui/post-build.js
@@ -27,11 +27,14 @@ const path = require("path")
 const monacoConfig = require("./monaco.config")
 
 const removeLine = (filePath) => {
-  const content = fs.readFileSync(filePath, "utf8").split("\n")
-  const contentWithoutSourceMap = content
-    .filter((line) => !line.startsWith("//# sourceMappingURL="))
-    .join("\n")
-  fs.writeFileSync(filePath, contentWithoutSourceMap, "utf8")
+  // only interested in css and javascript files. Other files, like css or fonts are ignored
+  if (filePath.endsWith(".js") || filePath.endsWith(".css")) {
+    const content = fs.readFileSync(filePath, "utf8").split("\n")
+    const contentWithoutSourceMap = content
+      .filter((line) => !line.startsWith("//# sourceMappingURL="))
+      .join("\n")
+    fs.writeFileSync(filePath, contentWithoutSourceMap, "utf8")
+  }
 }
 
 const isFile = (filePath) => {

--- a/ui/post-build.js
+++ b/ui/post-build.js
@@ -27,7 +27,7 @@ const path = require("path")
 const monacoConfig = require("./monaco.config")
 
 const removeLine = (filePath) => {
-  // only interested in css and javascript files. Other files, like css or fonts are ignored
+  // only interested in css and javascript files. Other files, like images or fonts are ignored
   if (filePath.endsWith(".js") || filePath.endsWith(".css")) {
     const content = fs.readFileSync(filePath, "utf8").split("\n")
     const contentWithoutSourceMap = content


### PR DESCRIPTION
Fixes #1866

The font file got corrupted during build process, which changed the line
endings of a `.ttf` file. After that the file was not considered valid
by the browser, and font was not rendered as expected.

This PR adds `**/*.ttf` glob to `<exclude>` statement. That way line
endings are not changed, as by default maven assembly plugin uses
`<lineEndings>keep</lineEndings>`
