### PR TITLE
fix(sql): distinct, order by & limit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/OrderByMnemonic.java
+++ b/core/src/main/java/io/questdb/griffin/OrderByMnemonic.java
@@ -25,7 +25,13 @@
 package io.questdb.griffin;
 
 public class OrderByMnemonic {
+
+    //Order is unknown at this stage and needs to be checked. It might be optional .    
     public static final int ORDER_BY_UNKNOWN = 0;
+
+    //Order is required by current stage/nested model (even though it might still be unknown) 
     public static final int ORDER_BY_REQUIRED = 1;
+
+    //Order is known and needs to be maintained at current stage/nested model 
     public static final int ORDER_BY_INVARIANT = 2;
 }

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -1271,7 +1271,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         ExpressionNode limitLo = model.getLimitLo();
         ExpressionNode limitHi = model.getLimitHi();
 
-        if ((limitLo == null && limitHi == null) || factory.implementsLimit()) {
+        //we've to check model otherwise we could be skipping limit in outer query that's actually different from the one in inner query!
+        if ((limitLo == null && limitHi == null) ||
+                (factory.implementsLimit() && model.isLimitImplemented())) {
             return factory;
         }
 
@@ -1370,6 +1372,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 if (recordCursorFactory.recordCursorSupportsRandomAccess()) {
                     if (canBeOptimized(model, executionContext, loFunc, hiFunc)) {
+                        model.setLimitImplemented(true);
                         return new LimitedSizeSortedLightRecordCursorFactory(
                                 configuration,
                                 orderedMetadata,

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -109,8 +109,14 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     private int joinType;
     private int joinKeywordPosition;
     private IntList orderedJoinModels = orderedJoinModels2;
+
     private ExpressionNode limitLo;
     private ExpressionNode limitHi;
+
+    //simple flag to mark when limit x,y in current model (part of query) is already taken care of by existing factories e.g. LimitedSizeSortedLightRecordCursorFactory
+    //and doesn't need to be enforced by LimitRecordCursor. We need it to detect whether current factory implements limit from this or inner query .    
+    private boolean isLimitImplemented;
+
     private int selectModelType = SELECT_MODEL_NONE;
     private boolean nestedModelIsSubQuery = false;
     private boolean distinct = false;
@@ -231,6 +237,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         orderedJoinModels = orderedJoinModels2;
         limitHi = null;
         limitLo = null;
+        isLimitImplemented = false;
         timestamp = null;
         sqlNodeStack.clear();
         joinColumns.clear();
@@ -353,6 +360,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public LowerCaseCharSequenceObjHashMap<WithClauseModel> getWithClauses() {
         return withClauseModel;
+    }
+
+    public boolean isLimitImplemented() {
+        return isLimitImplemented;
     }
 
     public boolean isUpdate() {
@@ -501,6 +512,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public int getModelPosition() {
         return modelPosition;
+    }
+
+    public void setLimitImplemented(boolean limitImplemented) {
+        isLimitImplemented = limitImplemented;
     }
 
     public void setModelPosition(int modelPosition) {

--- a/core/src/test/java/io/questdb/griffin/DistinctWhitLimitTest.java
+++ b/core/src/test/java/io/questdb/griffin/DistinctWhitLimitTest.java
@@ -1,0 +1,386 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin;
+
+import org.junit.Test;
+
+/*
+ * This class tests various distinct with order by and limit combinations.
+ */
+public class DistinctWhitLimitTest extends AbstractGriffinTest {
+
+    @Test
+    public void testDistinctWithLimitOnLongColumn() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "select DISTINCT id FROM limtest LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select 10-x as id from long_sequence(9)) ",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctWithOrderByLimitOnLongColumn() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "select DISTINCT id FROM limtest order by id desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select 10-x as id, rnd_double() as reading  from long_sequence(9) order by 2) ",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctWithLimitOnLongColumnInSubquery() throws Exception {
+        assertQuery("id\n3\n2\n",
+                "select DISTINCT id FROM ( select * from limtest order by id asc LIMIT 3) order by id desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select 10-x as id, rnd_double() as reading  from long_sequence(9) order by 2) ",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctWithLimitOnStringColumn() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "select DISTINCT id FROM limtest order by id desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as string) as id, rnd_double() as reading  from long_sequence(9) order by 2)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnWithLimitWithoutOrderBy() throws Exception {
+        assertQuery("id\n1\n2\n",
+                "select DISTINCT id FROM limtest order by id asc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9) order by 2)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnWithLimitOrderByDescInSubquery() throws Exception {
+        assertQuery("id\n8\n9\n",
+                "select DISTINCT id FROM ( select id from limtest order by id desc LIMIT 2) order by id asc",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedRepeatingSymbolColumnWithLimitOrderByDescInSubqueryV2() throws Exception {
+        assertQuery("id\n1\n2\n",
+                "select DISTINCT id FROM ( select id from limtest order by id desc LIMIT 4) order by id asc",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x%3 as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedRepeatingSymbolColumnWithLimitOrderByAscInSubqueryV2() throws Exception {
+        assertQuery("id\n1\n0\n",
+                "select DISTINCT id FROM ( select id from limtest order by id asc LIMIT 4) order by id desc",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x%3 as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnWithLimitOrderByDesc() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "select DISTINCT id FROM limtest order by id desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnWithLimitOrderByDescV2() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "select DISTINCT id FROM (select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9)) order by id desc LIMIT 2",
+                null, true, true);
+    }
+
+    @Test
+    public void testDistinctOnTwoNonIndexedColumnsWithLimitOrderByDesc() throws Exception {
+        assertQuery("id\treading\n" +
+                        "9\t9.0\n" +
+                        "8\t8.0\n",
+                "select DISTINCT id, reading FROM limtest order by id desc, reading desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select x as id, cast(x as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnTwoNonIndexedColumnsWithLimitOrderByAsc() throws Exception {
+        assertQuery("id\treading\n" +
+                        "1\t1.0\n" +
+                        "2\t2.0\n",
+                "select DISTINCT id, reading FROM limtest order by id asc, reading asc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select x as id, cast(x as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnTwoNonIndexedColumnsWithLimitOrderByAscAndDesc() throws Exception {
+        assertQuery("id\treading\n" +
+                        "0\t1.0\n" +
+                        "1\t1.0\n",
+                "select DISTINCT id, reading FROM limtest order by id asc, reading desc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select x%5 as id, cast(x%2 as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnTwoNonIndexedColumnsWithLimitOrderByDescAndAsc() throws Exception {
+        assertQuery("id\treading\n" +
+                        "4\t0.0\n" +
+                        "4\t1.0\n",
+                "select DISTINCT id, reading FROM limtest order by id desc, reading asc LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select x%5 as id, cast(x%2 as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+
+    @Test
+    public void testDistinctOnThreeNonIndexedColumnsWithLimitOrderByChangingInOuterQuery() throws Exception {
+        assertQuery("id\treading\tst\n" +
+                        "4\t0.0\ts1\n" +
+                        "3\t0.0\ts1\n" +
+                        "2\t1.0\ts1\n",
+                "select DISTINCT id, reading, st from " +
+                        "( select *  from test order by st desc, reading asc, id desc  LIMIT 5) " + //1,0,3 1,0,4 1,1,2 1,1,1 1,2,0   
+                        "order by id desc, reading asc LIMIT 3",
+                "CREATE TABLE test as (" +
+                        "select x%5 as id, cast(x%3 as double) as reading, 's' || x%2 as st  " +
+                        "from long_sequence(9) order by 2)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelDistinct() throws Exception {
+        assertQuery("id\treading\n" +
+                        "3\t1.0\n" +
+                        "2\t0.0\n",
+                "select DISTINCT id, reading from " +
+                        "( select distinct id, reading  from test order by reading asc, id desc  LIMIT 3) " + //  2,0 0,0 3,1 1,1
+                        "order by id desc, reading asc LIMIT 2",
+                "CREATE TABLE test as (" +  // 1,1 2,0 3,1 0,0 1,1 2,0 3,1 0,0 1,1
+                        "select cast( x%4 as int) as id, cast(x%2 as double) as reading, rnd_double() as rnd " +
+                        "from long_sequence(9) order by 3)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelOrderBy() throws Exception {
+        assertQuery("id\treading\n" +
+                        "0\t0.0\n" +
+                        "0\t0.0\n",
+                "select id, reading from " + // 0,0 0,0 2,0 2,0
+                        "( select id, reading  from test order by reading asc, id desc  LIMIT 4) " + // 2,0 2,0 0,0 0,0 3,1 3,1 1,1 1,1 1,1
+                        "order by id asc, reading asc LIMIT 2",
+                "CREATE TABLE test as (" +  // 1,1 2,0 3,1 0,0 1,1 2,0 3,1 0,0 1,1
+                        "select cast( x%4 as int) as id, cast(x%2 as double) as reading, rnd_double() as rnd " +
+                        "from long_sequence(9) order by 3)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelOrderByWithInnerQueryUsingTableOrder() throws Exception {
+        assertQuery("id\n" +
+                        "5\n" +
+                        "4\n",
+                "select id from " +
+                        "( select id from test LIMIT 5) " +
+                        "order by id desc LIMIT 2",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelOrderByWithOuterQueryUsingCurrentOrder() throws Exception {
+        assertQuery("id\n" +
+                        "9\n" +
+                        "8\n",
+                "select id from " +
+                        "( select id from test order by id desc LIMIT 5) " +
+                        " LIMIT 2",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelOrderByWithLimit() throws Exception {
+        assertQuery("id\n" +
+                        "3\n4\n5\n6\n7\n",
+                "select id from " +
+                        "( select id from  " +
+                        "  ( select id from " +
+                        "   ( select id from test order by id desc LIMIT 8) " +
+                        "    order by id asc LIMIT 7) " +
+                        "   order by id desc LIMIT 6) " +
+                        "order by id asc limit 5",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultilevelLimit() throws Exception {
+        assertQuery("id\n" +
+                        "1\n2\n3\n4\n5\n",
+                "select id from " +
+                        "( select id from  " +
+                        "  ( select id from " +
+                        "   ( select id from test LIMIT 8) " +
+                        "    LIMIT 7) " +
+                        "   LIMIT 6) " +
+                        "LIMIT 5",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultiLimitAndOrderOnDifferentDepth() throws Exception {
+        assertQuery("id\n" +
+                        "9\n8\n7\n6\n5\n",
+                "select id from " +
+                        "( select id from  " +
+                        "  ( select id from " +
+                        "   ( select id from test order by id desc) " +
+                        "    ) " +
+                        "   ) " +
+                        "LIMIT 5",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testMultiOrderAndLimitOnDifferentDepth() throws Exception {
+        assertQuery("id\n" +
+                        "5\n4\n3\n2\n1\n",
+                "select id from " +
+                        "( select id from  " +
+                        "  ( select id from " +
+                        "   ( select id from test limit 5) " +
+                        "    ) " +
+                        "   ) " +
+                        "order by id desc",
+                "CREATE TABLE test as ( select x as id from long_sequence(9) )",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnInSubqueryWithOrderByDescInOuterQuery() throws Exception {
+        assertQuery("id\n5\n4\n3\n2\n1\n0\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ) ORDER BY id desc",
+                "CREATE TABLE limtest as (select cast((x%6) as symbol) as id from long_sequence(20))",
+                null, true, true, true);
+    }
+
+    @Test//values in symbol key file aren't sorted and usually reflect first insert order 
+    public void testDistinctOnNonIndexedSymbolColumnInSubqueryWithLimitInOuterQuery() throws Exception {
+        assertQuery("id\n1\n2\n3\n4\n5\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ) limit 5",
+                "CREATE TABLE limtest as (select cast((x%6) as symbol) as id from long_sequence(20))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnInSubqueryWithOrderByDescLimitInOuterQuery() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ) ORDER BY id desc LIMIT 2 ",
+                "CREATE TABLE limtest as (select cast((x%10) as symbol) as id from long_sequence(20))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnInSubqueryOrderByAscWithLimitInOuterQuery() throws Exception {
+        assertQuery("id\n1\n2\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ORDER BY id asc ) LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnIndexedSymbolColumnInSubqueryOrderByAscWithLimitInOuterQuery() throws Exception {
+        assertQuery("id\n1\n2\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ORDER BY id asc ) LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9)), index(id)",
+                null, true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnNonIndexedSymbolColumnInSubqueryOrderByDescWithLimitInOuterQuery() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ORDER BY id desc ) LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
+                null,
+                true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnIndexedSymbolColumnInSubqueryOrderByDescWithLimitInOuterQuery() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "SELECT * from ( select DISTINCT id FROM limtest ORDER BY id desc ) LIMIT 2",
+                "CREATE TABLE limtest as (" +
+                        "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9)), index(id)",
+                null,
+                true, true, true);
+    }
+
+    @Test
+    public void testDistinctOnIndexedSymbolColumnWithLimitInInnerQuery() throws Exception {
+        assertQuery("id\n1\n2\n",
+                "SELECT DISTINCT id from ( select id FROM test LIMIT 2 ) ",
+                "CREATE TABLE test as (" +
+                        "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9)), index(id)",
+                null,
+                true, true, false);
+    }
+
+    @Test
+    public void testDistinctOnIndexedSymbolColumnWithOrderByLimitInInnerQuery() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "SELECT DISTINCT id from ( select id FROM test ORDER BY id desc LIMIT 2 ) ",
+                "CREATE TABLE test as (" +
+                        "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9) order by 2), index(id)",
+                null,
+                true, true, false);
+    }
+
+    @Test
+    public void testDistinctOnIndexedSymbolColumnWithWhereOrderByLimitInInnerQuery() throws Exception {
+        assertQuery("id\n9\n8\n",
+                "SELECT DISTINCT id from test where rnd_double() >= 0.0 ORDER BY id desc LIMIT 2 ",
+                "CREATE TABLE test as (" +
+                        "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9) order by 2), index(id)",
+                null,
+                true, true, true);
+    }
+
+}

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -5314,8 +5314,21 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testSelectDistinctGroupByFunctionArithmeticLimit() throws SqlException {
-        assertQuery("select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab)) limit 10)",
+        assertQuery("select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab))) limit 10",
                 "select distinct a, sum(b)+sum(c) bb from tab limit 10",
+                modelOf("tab")
+                        .col("a", ColumnType.STRING)
+                        .col("b", ColumnType.LONG)
+                        .col("c", ColumnType.LONG)
+        );
+    }
+
+    @Test
+    public void testSelectDistinctGroupByFunctionArithmeticOrderByLimit() throws SqlException {
+        assertQuery("select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from " +
+                        "(select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 " +
+                        "from (select [a, c, b] from tab))) order by a limit 10",
+                "select distinct a, sum(b)+sum(c) bb from tab order by a limit 10",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
                         .col("b", ColumnType.LONG)


### PR DESCRIPTION
…subqueries with limit clause ; outer query  ordering skipping

Fixes several issues : 
- too agressive order by removal in subqueries (across limit)
- distinct not applying limit in simple queries - https://github.com/questdb/questdb/issues/1854  
- order by getting ignored if LimitedSizeSortedLightRecordCursorFactory comes from nested model, e.g. 

```
select * from 
( select id from test order by id desc limit 10)
order by id asc  <- this one was ignored
```

