### PR TITLE
chore(ilp): ilp tcp commit test fix

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -361,8 +361,8 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
 
     void runTest() throws Exception {
         runTest((factoryType, thread, name, event, segment, position) -> {
-            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_LOCK_SUCCESS) {
-                handleWriterLockSuccessEvent(name);
+            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_UNLOCKED) {
+                handleWriterUnlockEvent(name);
             }
             if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
                 handleWriterReturnEvent(name);
@@ -370,7 +370,7 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         }, 250);
     }
 
-    void handleWriterLockSuccessEvent(CharSequence name) {
+    void handleWriterUnlockEvent(CharSequence name) {
         final String tableName = name.toString();
         tableNames.putIfAbsent(tableName.toLowerCase(), tableName);
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpCommitTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpCommitTest.java
@@ -133,8 +133,8 @@ public class LineTcpCommitTest extends AbstractLineTcpReceiverFuzzTest {
         initLoadParameters(20, 5, 2, 2, 50, true);
 
         runTest((factoryType, thread, name, event, segment, position) -> {
-            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_LOCK_SUCCESS) {
-                handleWriterLockSuccessEvent(name);
+            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_UNLOCKED) {
+                handleWriterUnlockEvent(name);
             }
         }, minIdleMsBeforeWriterRelease);
     }


### PR DESCRIPTION
Fix for ILP commit and fuzz tests.
The test needs to detect when tables are created, this relied on checking for table lock events.
This is incorrect because the lock is acquired before the table is created.
Instead we can check for table unlock events.
The very first unlock happens just after the table has been created.

Closes #1891
