### PR TITLE
fix(sql): fix order by aliased column positions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2767,7 +2767,10 @@ class SqlOptimiser {
         QueryModel baseParent = model;
 
         while (base.getBottomUpColumns().size() > 0) {
-            baseParent = base;
+            // Check if the model contains the full list of selected columns and, thus, can be used as the parent.
+            if (!base.isSelectTranslation()) {
+                baseParent = base;
+            }
             base = base.getNestedModel();
         }
 
@@ -2776,7 +2779,6 @@ class SqlOptimiser {
         if (sz > 0) {
             final ObjList<QueryColumn> columns = baseParent.getBottomUpColumns();
             final int columnCount = columns.size();
-            // for each order by column check how deep we need to go between "model" and "base"
             for (int i = 0; i < sz; i++) {
                 final ExpressionNode orderBy = orderByNodes.getQuick(i);
                 final CharSequence column = orderBy.token;
@@ -2890,8 +2892,6 @@ class SqlOptimiser {
         analyticModel.setSelectModelType(QueryModel.SELECT_MODEL_ANALYTIC);
         final QueryModel translatingModel = queryModelPool.next();
         translatingModel.setSelectModelType(QueryModel.SELECT_MODEL_CHOOSE);
-        final QueryModel analyticTranslatingModel = queryModelPool.next();
-        analyticTranslatingModel.setSelectModelType(QueryModel.SELECT_MODEL_CHOOSE);
         // this is dangling model, which isn't chained with any other
         // we use it to ensure expression and alias uniqueness
         final QueryModel cursorModel = queryModelPool.next();
@@ -3143,6 +3143,7 @@ class SqlOptimiser {
             translatingModel.setNestedModel(baseModel);
             translatingModel.moveLimitFrom(model);
             translatingModel.moveAliasFrom(model);
+            translatingModel.setSelectTranslation(true);
         }
 
         if (useInnerModel) {

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -117,6 +117,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     //and doesn't need to be enforced by LimitRecordCursor. We need it to detect whether current factory implements limit from this or inner query .    
     private boolean isLimitImplemented;
 
+    // A flag to mark intermediate SELECT translation models. Such models do not contain the full list of selected
+    // columns (e.g. they lack virtual columns), so they should be skipped when rewriting positional ORDER BY.
+    private boolean isSelectTranslation = false;
+
     private int selectModelType = SELECT_MODEL_NONE;
     private boolean nestedModelIsSubQuery = false;
     private boolean distinct = false;
@@ -215,6 +219,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         clearSampleBy();
         orderBy.clear();
         orderByDirection.clear();
+        isSelectTranslation = false;
         groupBy.clear();
         dependencies.clear();
         parsedWhere.clear();
@@ -723,6 +728,14 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public void setNestedModelIsSubQuery(boolean nestedModelIsSubQuery) {
         this.nestedModelIsSubQuery = nestedModelIsSubQuery;
+    }
+
+    public boolean isSelectTranslation() {
+        return isSelectTranslation;
+    }
+
+    public void setSelectTranslation(boolean isSelectTranslation) {
+        this.isSelectTranslation = isSelectTranslation;
     }
 
     public boolean isTopDownNameMissing(CharSequence columnName) {

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -6161,7 +6161,23 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         ") timestamp(k) partition by NONE",
                 13, "unsupported column type: BINARY"
         );
+    }
 
+    @Test
+    public void testFailsForOrderByPositionWithColumnAliasesAndInvalidAggregateFuncCall() throws Exception {
+        // This query was leading to an NPE in the past.
+        assertFailure("select b col_1, count(a) col_cnt from x order by 2 desc",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from" +
+                        " long_sequence(20)" +
+                        ") timestamp(k) partition by DAY",
+                16,
+                "unexpected argument for function: count. expected args: (). actual args: (DOUBLE)");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -6137,6 +6137,118 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testOrderByPositionalOnAliasedVirtualColumn() throws Exception {
+        final String expected = "col_1\tcol_2\tcol_sum\n" +
+                "1326447242\t592859671\t1919306913\n" +
+                "-1436881714\t-1575378703\t1282706879\n" +
+                "-1191262516\t-2041844972\t1061859808\n" +
+                "1868723706\t-847531048\t1021192658\n" +
+                "1548800833\t-727724771\t821076062\n" +
+                "-409854405\t339631474\t-70222931\n" +
+                "-1148479920\t315515118\t-832964802\n" +
+                "73575701\t-948263339\t-874687638\n" +
+                "1569490116\t1573662097\t-1151815083\n" +
+                "806715481\t1545253512\t-1942998303\n";
+
+        assertQuery(expected,
+                "select a col_1, b col_2, a+b col_sum from x order by 3 desc, 2, 1 desc",
+                "create table x as (" +
+                        "select" +
+                        " rnd_int() a," +
+                        " rnd_int() b," +
+                        " timestamp_sequence(0, 1000000000) k" +
+                        " from" +
+                        " long_sequence(10)" +
+                        ") timestamp(k) partition by NONE",
+                null,
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testOrderByPositionalOnVirtualColumn() throws Exception {
+        final String expected = "a\tb\tcolumn\n" +
+                "1326447242\t592859671\t1919306913\n" +
+                "-1436881714\t-1575378703\t1282706879\n" +
+                "-1191262516\t-2041844972\t1061859808\n" +
+                "1868723706\t-847531048\t1021192658\n" +
+                "1548800833\t-727724771\t821076062\n" +
+                "-409854405\t339631474\t-70222931\n" +
+                "-1148479920\t315515118\t-832964802\n" +
+                "73575701\t-948263339\t-874687638\n" +
+                "1569490116\t1573662097\t-1151815083\n" +
+                "806715481\t1545253512\t-1942998303\n";
+
+        assertQuery(expected,
+                "select a, b, a+b from x order by 3 desc, 2, 1 desc",
+                "create table x as (" +
+                        "select" +
+                        " rnd_int() a," +
+                        " rnd_int() b," +
+                        " timestamp_sequence(0, 1000000000) k" +
+                        " from" +
+                        " long_sequence(10)" +
+                        ") timestamp(k) partition by NONE",
+                null,
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testOrderByPositionalOnAliasedAggregateColumn() throws Exception {
+        final String expected = "col_1\tcol_cnt\n" +
+                "0\t3\n" +
+                "1\t3\n" +
+                "4\t3\n" +
+                "5\t1\n";
+
+        assertQuery(expected,
+                "select a col_1, count(*) col_cnt from x order by 2 desc, 1 asc",
+                "create table x as (" +
+                        "select" +
+                        " rnd_int(0,5,0) a," +
+                        " rnd_int() b," +
+                        " timestamp_sequence(0, 1000000000) k" +
+                        " from" +
+                        " long_sequence(10)" +
+                        ") timestamp(k) partition by NONE",
+                null,
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testOrderByPositionalOnAggregateColumn() throws Exception {
+        final String expected = "a\tcount\n" +
+                "0\t3\n" +
+                "1\t3\n" +
+                "4\t3\n" +
+                "5\t1\n";
+
+        assertQuery(expected,
+                "select a, count(*) from x order by 2 desc, 1 asc",
+                "create table x as (" +
+                        "select" +
+                        " rnd_int(0,5,0) a," +
+                        " rnd_int() b," +
+                        " timestamp_sequence(0, 1000000000) k" +
+                        " from" +
+                        " long_sequence(10)" +
+                        ") timestamp(k) partition by NONE",
+                null,
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testOrderByUnsupportedType() throws Exception {
         assertFailure(
                 "x order by a,m,n",

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -4546,6 +4546,95 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testOrderByPositionColumnAliases() throws Exception {
+        assertQuery(
+                "select-choose x c1, y c2 from (select [x, y] from tab) order by c2, c1",
+                "select x c1, y c2 from tab order by 2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+                        .col("z", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByPositionWithVirtualColumn() throws Exception {
+        assertQuery(
+                "select-virtual x, y, x + y column from (select [x, y] from tab) order by column, y, x",
+                "select x, y, x+y from tab order by 3,2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByWithColumnAliasesAndVirtualColumn() throws Exception {
+        assertQuery(
+                "select-virtual c1, c2, c1 + c2 c3 from (select-choose [x c1, y c2] x c1, y c2 from (select [x, y] from tab)) order by c3, c2, c1",
+                "select x c1, y c2, x+y c3 from tab order by c3,c2,c1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByPositionWithColumnAliasesAndVirtualColumn() throws Exception {
+        assertQuery(
+                "select-virtual c1, c2, c1 + c2 c3 from (select-choose [x c1, y c2] x c1, y c2 from (select [x, y] from tab)) order by c3, c2, c1",
+                "select x c1, y c2, x+y c3 from tab order by 3,2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByPositionWithAggregateColumn() throws Exception {
+        assertQuery(
+                "select-group-by x, y, count() count from (select [x, y] from tab) order by count, y, x",
+                "select x, y, count() from tab order by 3,2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByWithColumnAliasesAndAggregateColumn() throws Exception {
+        assertQuery(
+                "select-group-by c1, c2, count() c3 from (select-choose [x c1, y c2] x c1, y c2 from (select [x, y] from tab)) order by c3, c2, c1",
+                "select x c1, y c2, count() c3 from tab order by c3,c2,c1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByPositionWithColumnAliasesAndAggregateColumn() throws Exception {
+        assertQuery(
+                "select-group-by c1, c2, count() c3 from (select-choose [x c1, y c2] x c1, y c2 from (select [x, y] from tab)) order by c3, c2, c1",
+                "select x c1, y c2, count() c3 from tab order by 3,2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
+    public void testOrderByWithWildcardAndVirtualColumn() throws Exception {
+        assertQuery(
+                "select-virtual x, y, x + y c3 from (select [x, y] from tab) order by c3, y, x",
+                "select *, x+y c3 from tab order by 3,2,1",
+                modelOf("tab")
+                        .col("x", ColumnType.INT)
+                        .col("y", ColumnType.INT)
+        );
+    }
+
+    @Test
     public void testOrderByPositionCorrupt() throws Exception {
         assertSyntaxError(
                 "tab order by 3a, 1",
@@ -4555,7 +4644,6 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         .col("x", ColumnType.INT)
                         .col("y", ColumnType.INT)
                         .col("z", ColumnType.INT)
-
         );
     }
 


### PR DESCRIPTION
Fixes positional ORDER BY in combination with column aliases. Such
combination was leading to a translating model being used to look
up the ORDER BY columns. Due to their nature, translating models
may not contain the full list of columns, so such queries ended up
with either "order column position is out of range" error or an NPE
in SqlOptimiser#getOrderByAdvice.