### PR TITLE
Fixed long overflow problem

### DIFF
--- a/core/src/main/java/io/questdb/mp/SOCountDownLatch.java
+++ b/core/src/main/java/io/questdb/mp/SOCountDownLatch.java
@@ -63,10 +63,11 @@ public class SOCountDownLatch implements CountDownLatchSPI {
         }
 
         while (true) {
-            long deadline = System.nanoTime() + nanos;
+            long start = System.nanoTime();
             LockSupport.parkNanos(nanos);
+            long elapsed = System.nanoTime() - start;
 
-            if (System.nanoTime() < deadline) {
+            if (elapsed < nanos) {
                 // this could be spurious wakeup, ignore if count is non-zero
                 if (getCount() == 0) {
                     return true;


### PR DESCRIPTION
Closes https://github.com/questdb/questdb/issues/1883

Original issue states to review as to how to properly prevent possible over flow from long. Nanos should not be added to the System.nanoTime().

The requested change will determine the await by comparing the elapsed time to the allotted deadline. 

**Docs for System.nanoTime():**
--------------------------------------------------------------------------------
For example, to measure how long some code takes to execute:
  long startTime = System.nanoTime();   // ... the code being measured ...   long elapsedNanos = System.nanoTime() - startTime;
To compare elapsed time against a timeout, use
  if (System.nanoTime() - startTime >= timeoutNanos) ...
instead of
  if (System.nanoTime() >= startTime + timeoutNanos) ...
because of the possibility of numerical overflow.
---------------------------------------------------------------------------------



