### PR TITLE
docs(CONTRIBUTING): remove section about commit squashing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,31 +192,6 @@ auto-generate release notes. We require all commit comments to conform. To that
 end, commits have to be granular enough to be successfully described using this
 method.
 
-## Squashing commits
-
-When submitting a pull request to QuestDB, we ask that you squash your commits
-before we merge.
-
-Some applications that interact with git repos will provide a user interface for
-squashing. Refer to your application's document for more information.
-
-If you're familiar with the terminal, you can do the following:
-
-- Make sure your branch is up to date with the master branch.
-- Run `git rebase -i master`.
-- You should see a list of commits, each commit starting with the word "pick".
-- Make sure the first commit says "pick" and change the rest from "pick" to
-  "squash". -- This will squash each commit into the previous commit, which will
-  continue until every commit is squashed into the first commit.
-- Save and close the editor.
-- It will give you the opportunity to change the commit message.
-- Save and close the editor again.
-- Then you have to force push the final, squashed commit:
-  `git push --force-with-lease origin`.
-
-Squashing commits can be a tricky process but once you figure it out, it is
-really helpful and keeps our repository concise and clean.
-
 ## FAQ
 
 ### Why does the server work, but the UI returns a `404` on [localhost:9000](http://localhost:9000)?


### PR DESCRIPTION
Squashing commits can be done through github UI, while merging a PR,
thus this requirement is redundant.

![](https://cloudfour.com/wp-content/uploads/2019/10/github-merge-options.png)

Removing this requirement makes contribution a little bit easier, as
less work needs to be done.
