### PR TITLE
feat(UI): support `query` and `executeQuery` URL params for inserting and executing queries in web console

### DIFF
--- a/ui/src/scenes/Editor/Monaco/index.tsx
+++ b/ui/src/scenes/Editor/Monaco/index.tsx
@@ -186,16 +186,21 @@ const MonacoEditor = () => {
           dispatch(actions.query.cleanupNotifications())
         },
       })
-
-      // Insert query, if one is found in the URL
-      const params = new URLSearchParams(window.location.search)
-      const query = params.get("query")
-      if (query) {
-        appendQuery(editor, query)
-      }
     }
 
     loadPreferences(editor)
+
+    // Insert query, if one is found in the URL
+    const params = new URLSearchParams(window.location.search)
+    const query = params.get("query")
+    if (query) {
+      appendQuery(editor, query)
+    }
+
+    const executeQuery = params.get("executeQuery")
+    if (executeQuery) {
+      toggleRunning()
+    }
   }
 
   useEffect(() => {

--- a/ui/src/scenes/Editor/Monaco/index.tsx
+++ b/ui/src/scenes/Editor/Monaco/index.tsx
@@ -186,6 +186,13 @@ const MonacoEditor = () => {
           dispatch(actions.query.cleanupNotifications())
         },
       })
+
+      // Insert query, if one is found in the URL
+      const params = new URLSearchParams(window.location.search)
+      const query = params.get("query")
+      if (query) {
+        appendQuery(editor, query)
+      }
     }
 
     loadPreferences(editor)

--- a/ui/src/scenes/Editor/Monaco/utils.ts
+++ b/ui/src/scenes/Editor/Monaco/utils.ts
@@ -303,6 +303,7 @@ const getTextFixes = ({
     selectStartOffset: 0,
   }
 
+  console.log(position)
   const rules: Rule[] = [
     {
       when: () => model?.getValue() === "",
@@ -341,8 +342,8 @@ const getTextFixes = ({
     },
 
     {
-      when: () => inMiddle && lineAtCursor !== "",
-      then: () => ({ prefix: 1, suffix: 1 }),
+      when: () => inMiddle && lineAtCursor !== "" && nextLine === "",
+      then: () => ({ prefix: 1, suffix: 1, selectStartOffset: 1 }),
     },
 
     {

--- a/ui/src/scenes/Editor/Monaco/utils.ts
+++ b/ui/src/scenes/Editor/Monaco/utils.ts
@@ -373,7 +373,6 @@ export const appendQuery = (editor: IStandaloneCodeEditor, query: string) => {
     const position = editor.getPosition()
 
     if (position) {
-      const isLineEmpty = model.getLineContent(position.lineNumber) === ""
       const newLines = query.split("\n")
 
       const {
@@ -388,37 +387,24 @@ export const appendQuery = (editor: IStandaloneCodeEditor, query: string) => {
 
       const positionInsert = {
         lineStart: position.lineNumber + lineStartOffset,
-        lineEnd: position.lineNumber + (isLineEmpty ? 0 : 1) + newLines.length,
+        lineEnd: position.lineNumber + newLines.length,
         columnStart: 0,
-        columnEnd: newLines.sort((a, b) => b.length - a.length)[0].length + 1,
+        columnEnd: newLines[newLines.length - 1].length + 1,
       }
 
       const positionSelect = {
-        lineStart: position.lineNumber + lineStartOffset + selectStartOffset,
+        lineStart: positionInsert.lineStart + selectStartOffset,
         lineEnd:
-          position.lineNumber +
-          lineStartOffset +
-          selectStartOffset +
-          (newLines.length - 1),
+          positionInsert.lineStart + selectStartOffset + (newLines.length - 1),
         columnStart: 0,
         columnEnd: positionInsert.columnEnd,
       }
-
-      const [prefixString, suffixString] = [
-        "\n".repeat(prefix),
-        "\n".repeat(suffix),
-      ]
-
-      const newQuery = `${prefixString}${query}${suffixString}`
-
-      console.log(JSON.stringify({ positionInsert, positionSelect }))
-      console.log(newQuery)
 
       insertText({
         editor,
         lineNumber: positionInsert.lineStart,
         column: positionInsert.columnStart,
-        text: newQuery,
+        text: `${"\n".repeat(prefix)}${query}${"\n".repeat(suffix)}`,
       })
 
       editor.setSelection({
@@ -428,6 +414,7 @@ export const appendQuery = (editor: IStandaloneCodeEditor, query: string) => {
         endColumn: positionSelect.columnEnd,
       })
     }
+
     editor.focus()
   }
 }

--- a/ui/src/utils/fromFetch.ts
+++ b/ui/src/utils/fromFetch.ts
@@ -47,7 +47,9 @@ export const fromFetch = <T extends Record<string, any>>(
   return rxFromFetch(url, init).pipe(
     switchMap((response) => {
       if (response.ok) {
-        if (response.headers.get("content-type") === "application/json") {
+        if (
+          response.headers.get("content-type")?.startsWith("application/json")
+        ) {
           return response.json()
         }
 


### PR DESCRIPTION
This PR updates web console to support `query` and `executeQuery` URL params.

* `query`:
  Adding `?query=select * from 'telemetry'` as URL param to the web
  console will fill the web console code editor with `select * from 'telemetry'`, for example:
  ```
  http://localhost:9000/?query=select * from 'telemetry'
  ```

* `executeQuery`:
  Adding `?executeQuery=true` will execute query which is
  available in the editor, as soon as the web console loads.

To achieve this, the code looks at URL query params, extracts values of
`query` and `executeQuery` and runs the following:

1. for inserting value of `query` in editor, `appendQuery(query)` is
   used. An already existing utility function.
2. to run the query, `toggleRun()` is called. The same function is
   already used when user clicks `Run` button.

Unfortunately, `appendQuery` had some bugs which this PR fixes. Those
fixes are the bigger part of this PR.

An example of bug:

1. open https://demo.questdb.io/
2. clean the editor from any queries, if there are any
3. add `Example query` (doing so uses `appendQuery` function behind the
   scenes)
4. add another `Example query`
5. you should have line 1 and line 3 filled with some example queries,
   and line 2 should be empty
6. click on line 2, so that text cursor is on line 2
7. add another `Example query`
8. observe that the editor is now filled with misaligned queries. In
   addition, the last added query is not selected (which is required for
   `executeQuery=true` to work correclty)

`appendQuery` should do these things correctly:

1. add new text at the position of the cursor
2. surround that text with new lines, and do so correctly. For example,
   new lines should not be duplicated, no new lines should be added
   before the first line etc.
3. select newly appended text, so that clicking `Run` (or invoking
   `toggleRun()` programmatically) would execute only selected query.
   This is crucial, because if selection is incorrect, then executed
   query might fail or yield unexpected results.

This is a lengthy explanation, but the goal is to explain why the
changes in `ui/src/scenes/Editor/Monaco/utils.ts` were done.

---

These changes and bug reproduction is tricky, therefore there are some
tests written in https://github.com/questdb/ui/blob/main/packages/browser-tests/cypress/integration/console/editor.spec.js

Due to how web console is setup at the moment, it's not trivial to run
those tests in CI. Therefore at the moment they can only be run locally
in dev environment.
