### PR TITLE
fix(cairo): load text_loader.json as a file if cannot be found as a resource

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -715,7 +715,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             );
 
             try (JsonLexer lexer = new JsonLexer(1024, 1024)) {
-                inputFormatConfiguration.parseConfiguration(lexer, sqlCopyFormatsFile);
+                inputFormatConfiguration.parseConfiguration(lexer, confRoot, sqlCopyFormatsFile);
             }
 
             this.inputRoot = getString(properties, env, "cairo.sql.copy.root", null);

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -41,7 +41,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     private final CharSequence root;
     private final CharSequence confRoot;
 
-    private final TextConfiguration textConfiguration = new DefaultTextConfiguration();
+    private final TextConfiguration textConfiguration;
 
     private final DefaultTelemetryConfiguration telemetryConfiguration = new DefaultTelemetryConfiguration();
 
@@ -53,6 +53,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     public DefaultCairoConfiguration(CharSequence root) {
         this.root = Chars.toString(root);
         this.confRoot = PropServerConfiguration.confRoot(root);
+        this.textConfiguration = new DefaultTextConfiguration(Chars.toString(confRoot));
         Rnd rnd = new Rnd(NanosecondClockImpl.INSTANCE.getTicks(), MicrosecondClockImpl.INSTANCE.getTicks());
         this.databaseIdLo = rnd.nextLong();
         this.databaseIdHi = rnd.nextLong();

--- a/core/src/main/java/io/questdb/cutlass/text/DefaultTextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/text/DefaultTextConfiguration.java
@@ -38,10 +38,14 @@ public class DefaultTextConfiguration implements TextConfiguration {
     private final InputFormatConfiguration inputFormatConfiguration;
 
     public DefaultTextConfiguration() {
-        this("/text_loader.json");
+        this(null);
     }
 
-    public DefaultTextConfiguration(String resourceName) {
+    public DefaultTextConfiguration(String confRoot) {
+        this(confRoot, "/text_loader.json");
+    }
+
+    public DefaultTextConfiguration(String confRoot, String resourceName) {
         this.inputFormatConfiguration = new InputFormatConfiguration(
                 new DateFormatFactory(),
                 DateLocaleFactory.INSTANCE,
@@ -50,7 +54,7 @@ public class DefaultTextConfiguration implements TextConfiguration {
         );
 
         try (JsonLexer lexer = new JsonLexer(1024, 1024)) {
-            inputFormatConfiguration.parseConfiguration(lexer, resourceName);
+            inputFormatConfiguration.parseConfiguration(lexer, confRoot, resourceName);
         } catch (JsonException e) {
             throw new CairoError(e);
         }

--- a/core/src/test/java/io/questdb/cutlass/text/types/TypeManagerTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/types/TypeManagerTest.java
@@ -133,7 +133,7 @@ public class TypeManagerTest {
 
     @Test
     public void testResourceNotFound() {
-        assertFailure("/textloader/types/not_found.json", 0, "could not find [resource=/textloader/types/not_found.json]");
+        assertFailure("/textloader/types/not_found.json", 0, "could not find input format config [confRoot=, configFileName=/textloader/types/not_found.json]");
     }
 
     @Test
@@ -209,8 +209,8 @@ public class TypeManagerTest {
                 DateFormatUtils.enLocale
         );
 
-        inputFormatConfiguration.parseConfiguration(jsonLexer, fileResource);
-        return new TypeManager(new DefaultTextConfiguration(fileResource), utf8Sink);
+        inputFormatConfiguration.parseConfiguration(jsonLexer, null, fileResource);
+        return new TypeManager(new DefaultTextConfiguration(null, fileResource), utf8Sink);
     }
 
     private void testIllegalParameterForGetTypeAdapter(int columnType) {


### PR DESCRIPTION
QuestDB doc says that a custom version of text_loader.json can be loaded from the conf directory if the below property is set:
```
cairo.sql.copy.formats.file=text_loader_custom.json
``` 
This did not work.
The PR fixes the issue by falling back to loading the file from the conf dir if it cannot be found as a resource.

Closes #1928