### PR TITLE
chore(conf): add default values for ILP props

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -85,7 +85,6 @@ class LineTcpConnectionContext implements IOContext, Mutable {
         this.fd = -1;
         Unsafe.free(recvBufStart, recvBufEnd - recvBufStart, MemoryTag.NATIVE_DEFAULT);
         recvBufStart = recvBufEnd = recvBufPos = 0;
-        parser.close();
         floatingDirectCharSink.close();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -33,9 +33,8 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.DirectByteCharSequence;
 
-import java.io.Closeable;
+public class LineTcpParser {
 
-public class LineTcpParser implements Closeable {
     public static final long NULL_TIMESTAMP = Numbers.LONG_NaN;
     public static final byte ENTITY_TYPE_NULL = 0;
     public static final byte ENTITY_TYPE_TAG = 1;
@@ -60,6 +59,7 @@ public class LineTcpParser implements Closeable {
     public static final byte ENTITY_TYPE_CHAR = 19;
     static final byte ENTITY_TYPE_NONE = (byte) 0xff; // visible for testing
     private static final Log LOG = LogFactory.getLog(LineTcpParser.class);
+
     private final DirectByteCharSequence measurementName = new DirectByteCharSequence();
     private final DirectByteCharSequence charSeq = new DirectByteCharSequence();
     private final ObjList<ProtoEntity> entityCache = new ObjList<>();
@@ -78,17 +78,17 @@ public class LineTcpParser implements Closeable {
     private EntityHandler entityHandler;
     private long timestamp;
     private final EntityHandler entityTimestampHandler = this::expectTimestamp;
-    private int nQuoteCharacters;    private final EntityHandler entityTableHandler = this::expectTableName;
-    private boolean scape;    private final EntityHandler entityValueHandler = this::expectEntityValue;
-    private boolean nextValueCanBeOpenQuote;    private final EntityHandler entityNameHandler = this::expectEntityName;
+    private int nQuoteCharacters;
+    private final EntityHandler entityTableHandler = this::expectTableName;
+    private boolean scape;
+    private final EntityHandler entityValueHandler = this::expectEntityValue;
+    private boolean nextValueCanBeOpenQuote;
+    private final EntityHandler entityNameHandler = this::expectEntityName;
     private boolean hasNonAscii;
+
     public LineTcpParser(boolean stringAsTagSupported, boolean symbolAsFieldSupported) {
         this.stringAsTagSupported = stringAsTagSupported;
         this.symbolAsFieldSupported = symbolAsFieldSupported;
-    }
-
-    @Override
-    public void close() {
     }
 
     public long getBufferAddress() {

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -350,6 +350,8 @@ query.timeout.sec=60
 
 # Maximum number of uncommitted rows in TCP ILP
 #cairo.max.uncommitted.rows=500000
+# Expected maximum time lag for out-of-order rows in milliseconds
+#cairo.commit.lag=300000
 
 # Memory page size per column for O3 operations. Please be aware O3 will use 2x of this RAM per column
 #cairo.o3.column.memory.size=16M
@@ -442,9 +444,16 @@ query.timeout.sec=60
 #line.tcp.io.worker.sleep.threshold=10000
 #line.tcp.io.halt.on.error=false
 
-# Maximum amount of time in between maintenance jobs, these will commit uncommited data
+# Commit lag fraction. Used to calculate commit interval for the table according to the following formula:
+# commitInterval = commitLag ∗ fraction
+# The calculated commit interval defines how long uncommitted data will need to remain uncommitted.
+#line.tcp.commit.interval.fraction=0.5
+# Default commit interval in milliseconds. Used when no commit lag set for a table or the fraction is set to 0.
+#line.tcp.commit.interval.default=2000
+
+# Maximum amount of time in between maintenance jobs in milliseconds, these will commit uncommitted data
 #line.tcp.maintenance.job.interval=30000
-# Minimum amount of idle time before a table writer is released
+# Minimum amount of idle time before a table writer is released in milliseconds
 #line.tcp.min.idle.ms.before.writer.release=30000
 
 ################ PG Wire settings ##################

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -445,7 +445,7 @@ query.timeout.sec=60
 #line.tcp.io.halt.on.error=false
 
 # Commit lag fraction. Used to calculate commit interval for the table according to the following formula:
-# commitInterval = commitLag ∗ fraction
+# commit_interval = commit_lag ∗ fraction
 # The calculated commit interval defines how long uncommitted data will need to remain uncommitted.
 #line.tcp.commit.interval.fraction=0.5
 # Default commit interval in milliseconds. Used when no commit lag set for a table or the fraction is set to 0.

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -382,7 +382,7 @@ line.tcp.auth.db.path=conf/auth.txt
 #line.tcp.io.halt.on.error=false
 
 # Commit lag fraction. Used to calculate commit interval for the table according to the following formula:
-# commitInterval = commitLag ∗ fraction
+# commit_interval = commit_lag ∗ fraction
 # The calculated commit interval defines how long uncommitted data will need to remain uncommitted.
 #line.tcp.commit.interval.fraction=0.5
 # Default commit interval in milliseconds. Used when no commit lag set for a table or the fraction is set to 0.

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -297,6 +297,8 @@ http.enabled=true
 
 # Maximum number of uncommitted rows in TCP ILP
 #cairo.max.uncommitted.rows=500000
+# Expected maximum time lag for out-of-order rows in milliseconds
+#cairo.commit.lag=300000
 
 # sets the maximum size of the page frames used in SQL queries
 #cairo.sql.page.frame.max.size=8M
@@ -379,9 +381,16 @@ line.tcp.auth.db.path=conf/auth.txt
 #line.tcp.io.worker.sleep.threshold=10000
 #line.tcp.io.halt.on.error=false
 
-# Maximum amount of time in between maintenance jobs, these will commit uncommited data
+# Commit lag fraction. Used to calculate commit interval for the table according to the following formula:
+# commitInterval = commitLag ∗ fraction
+# The calculated commit interval defines how long uncommitted data will need to remain uncommitted.
+#line.tcp.commit.interval.fraction=0.5
+# Default commit interval in milliseconds. Used when no commit lag set for a table or the fraction is set to 0.
+#line.tcp.commit.interval.default=2000
+
+# Maximum amount of time in between maintenance jobs in milliseconds, these will commit uncommitted data
 #line.tcp.maintenance.job.interval=30000
-# Minimum amount of idle time before a table writer is released
+# Minimum amount of idle time before a table writer is released in milliseconds
 #line.tcp.min.idle.ms.before.writer.release=30000
 
 ################ PG Wire settings ##################


### PR DESCRIPTION
Also removes redundant close() method in LineTcpParser and fixes formatting.