### PR TITLE
chore(ui): add help button in web console

### DIFF
--- a/ui/src/scenes/Editor/Menu/index.tsx
+++ b/ui/src/scenes/Editor/Menu/index.tsx
@@ -33,10 +33,12 @@ import { Menu as _MenuIcon } from "@styled-icons/remix-fill/Menu"
 import { Play } from "@styled-icons/remix-line/Play"
 import { Stop } from "@styled-icons/remix-line/Stop"
 import { Database2 } from "@styled-icons/remix-line/Database2"
+import { HelpCircle } from "@styled-icons/boxicons-regular/HelpCircle"
 
 import {
   ErrorButton,
   Input,
+  Link,
   PaneMenu,
   PopperHover,
   PopperToggle,
@@ -112,6 +114,10 @@ const SideMenuMenuButton = styled(TransparentButton)`
     opacity: 1;
     transition: opacity ${TransitionDuration.REG}ms;
   }
+`
+
+const HelpButton = styled(SecondaryButton)`
+  margin-right: 1rem;
 `
 
 const Menu = () => {
@@ -215,6 +221,26 @@ const Menu = () => {
       )}
 
       <Separator />
+
+      <PopperHover
+        delay={350}
+        placement="bottom"
+        trigger={
+          <HelpButton>
+            <Link
+              color="draculaForeground"
+              hoverColor="draculaForeground"
+              href="https://questdb.io/docs/reference/web-console/"
+              rel="noreferrer"
+              target="_blank"
+            >
+              <HelpCircle size="18px" />
+            </Link>
+          </HelpButton>
+        }
+      >
+        <Tooltip>Go to Web Console help</Tooltip>
+      </PopperHover>
 
       <DocsearchInput
         id="docsearch-input"


### PR DESCRIPTION
Added a button to navigate to Web Console docs. 
In the future this can also trigger an in-app help center, similar to other applications.

<img width="303" alt="CleanShot 2022-03-15 at 15 46 52@2x" src="https://user-images.githubusercontent.com/1871646/158404146-1d4cb882-3890-410b-861f-f5f5312e0819.png">

