### PR TITLE
fix(sql): fixed set operations/distinct and column pushdown

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -1791,6 +1791,12 @@ class SqlOptimiser {
                             // whenever nested model has explicitly defined columns it must also
                             // have its own nested model, where we assign new "where" clauses
                             addWhereNode(nested, node);
+                            //where clause pushed from parent applies to all SET-op models
+                            QueryModel unionModel = nested.getUnionModel();
+                            while (unionModel != null) {
+                                addWhereNode(unionModel, node);
+                                unionModel = unionModel.getUnionModel();
+                            }
                         } catch (NonLiteralException ignore) {
                             // keep node where it is
                             addWhereNode(parent, node);
@@ -1984,7 +1990,7 @@ class SqlOptimiser {
             moveWhereInsideSubQueries(rewrittenModel);
             eraseColumnPrefixInWhereClauses(rewrittenModel);
             moveTimestampToChooseModel(rewrittenModel);
-            propagateTopDownColumns(rewrittenModel);
+            propagateTopDownColumns(rewrittenModel, rewrittenModel.allowsColumnsChange());
             return rewrittenModel;
         } catch (SqlException e) {
             // at this point models may have functions than need to be freed
@@ -2305,16 +2311,41 @@ class SqlOptimiser {
         }
     }
 
-    private void propagateTopDownColumns(QueryModel model) {
-        propagateTopDownColumns0(model, true, null);
+    private void propagateTopDownColumns(QueryModel model, boolean allowColumnChange) {
+        propagateTopDownColumns0(model, true, null, allowColumnChange);
     }
 
-    private void propagateTopDownColumns0(QueryModel model, boolean topLevel, @Nullable QueryModel papaModel) {
+    /*
+        Pushes columns from top to bottom models .    
+    
+        Adding or removing columns to/from union, except, intersect should not happen!
+        UNION/INTERSECT/EXCEPT-ed columns MUST be exactly as specified in the query, otherwise they might produce different result, e.g.
+         
+        select a from (
+            select 1 as a, 'b' as status
+            union 
+            select 1 as a, 'c' as status
+        )
+        
+        Now if we push a top-to-bottom and remove b from union column list then we'll get a single '1' but we should get two !
+        Same thing applies to INTERSECT & EXCEPT
+        The only thing that'd be safe to add SET models is a constant literal (but what's the point?) .  
+        Column/expression pushdown should (probably) ONLY happen for UNION with ALL!
+          
+        allowColumnsChange - determines whether changing columns of given model is acceptable. 
+        It is not for columns used in distinct, except, intersect, union (even transitively for the latter three!).    
+    */
+    private void propagateTopDownColumns0(QueryModel model, boolean topLevel, @Nullable QueryModel papaModel, boolean allowColumnsChange) {
+        //copy columns to 'protect' column list that shouldn't be modified
+        if (!allowColumnsChange && model.getBottomUpColumns().size() > 0) {
+            model.copyBottomToTopColumns();
+        }
 
         // skip over NONE model that does not have table name
         final QueryModel nested = skipNoneTypeModels(model.getNestedModel());
         model.setNestedModel(nested);
         final boolean nestedIsFlex = modelIsFlex(nested);
+        final boolean nestedAllowsColumnChange = nested != null && nested.allowsColumnsChange();
 
         final QueryModel union = skipNoneTypeModels(model.getUnionModel());
 
@@ -2339,7 +2370,7 @@ class SqlOptimiser {
                     }
                 }
             }
-            propagateTopDownColumns0(jm, false, model);
+            propagateTopDownColumns0(jm, false, model, true);
 
             // process post-join-where
             final ExpressionNode postJoinWhere = jm.getPostJoinWhereClause();
@@ -2362,18 +2393,35 @@ class SqlOptimiser {
         }
 
         // latest by
-        emitLiteralsTopDown(model.getLatestBy(), model);
-
-        // propagate explicit timestamp declaration
-        if (model.getTimestamp() != null && nestedIsFlex) {
-            emitLiteralsTopDown(model.getTimestamp(), nested);
+        if (model.getLatestBy().size() > 0) {
+            emitLiteralsTopDown(model.getLatestBy(), model);
         }
 
-        // where clause
+        // propagate explicit timestamp declaration
+        if (model.getTimestamp() != null &&
+                nestedIsFlex &&
+                nestedAllowsColumnChange) {
+            emitLiteralsTopDown(model.getTimestamp(), nested);
+
+            QueryModel unionModel = nested.getUnionModel();
+            while (unionModel != null) {
+                emitLiteralsTopDown(model.getTimestamp(), unionModel);
+                unionModel = unionModel.getUnionModel();
+            }
+        }
+
         if (model.getWhereClause() != null) {
-            emitLiteralsTopDown(model.getWhereClause(), model);
-            if (nested != null) {
+            if (allowColumnsChange) {
+                emitLiteralsTopDown(model.getWhereClause(), model);
+            }
+            if (nested != null && nestedAllowsColumnChange) {
                 emitLiteralsTopDown(model.getWhereClause(), nested);
+
+                QueryModel unionModel = nested.getUnionModel();
+                while (unionModel != null) {
+                    emitLiteralsTopDown(model.getWhereClause(), unionModel);
+                    unionModel = unionModel.getUnionModel();
+                }
             }
         }
 
@@ -2382,18 +2430,25 @@ class SqlOptimiser {
             emitLiteralsTopDown(model.getOrderBy(), model);
         }
 
-        if (nestedIsFlex) {
+        if (nestedIsFlex && nestedAllowsColumnChange) {
             emitColumnLiteralsTopDown(model.getColumns(), nested);
+
+            QueryModel unionModel = nested.getUnionModel();
+            while (unionModel != null) {
+                emitColumnLiteralsTopDown(model.getColumns(), unionModel);
+                unionModel = unionModel.getUnionModel();
+            }
         }
 
         // go down the nested path
         if (nested != null) {
-            propagateTopDownColumns0(nested, false, null);
+            propagateTopDownColumns0(nested, false, null, nestedAllowsColumnChange);
         }
 
         final QueryModel unionModel = model.getUnionModel();
         if (unionModel != null) {
-            propagateTopDownColumns(unionModel);
+            //we've to use this value because union-ed models don't have a back-reference and might not know they participate in set operation 
+            propagateTopDownColumns(unionModel, allowColumnsChange);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -789,11 +789,7 @@ public final class SqlParser {
             if (isUnionKeyword(tok)) {
                 tok = tok(lexer, "all or select");
                 if (isAllKeyword(tok)) {
-                    if (!model.isDistinct()) {
-                        prevModel.setSetOperationType(QueryModel.SET_OPERATION_UNION_ALL);
-                    } else {
-                        prevModel.setSetOperationType(QueryModel.SET_OPERATION_UNION);
-                    }
+                    prevModel.setSetOperationType(QueryModel.SET_OPERATION_UNION_ALL);
                 } else {
                     prevModel.setSetOperationType(QueryModel.SET_OPERATION_UNION);
                     lexer.unparse();

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -312,7 +312,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
         try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-            Assert.assertEquals(supportsRandomAccess, factory.recordCursorSupportsRandomAccess());
+            Assert.assertEquals("supports random access", supportsRandomAccess, factory.recordCursorSupportsRandomAccess());
             if (
                     assertCursor(
                             expected,

--- a/core/src/test/java/io/questdb/griffin/AbstractSqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractSqlParserTest.java
@@ -143,10 +143,10 @@ public class AbstractSqlParserTest extends AbstractGriffinTest {
             ExecutionModel model = compiler.testCompileModel(query, sqlExecutionContext);
             Assert.assertEquals(model.getModelType(), modelType);
             ((Sinkable) model).toSink(sink);
+            TestUtils.assertEquals(expected, sink);
             if (model instanceof QueryModel && model.getModelType() == ExecutionModel.QUERY) {
                 validateTopDownColumns((QueryModel) model);
             }
-            TestUtils.assertEquals(expected, sink);
         }, tableModels);
     }
 

--- a/core/src/test/java/io/questdb/griffin/NestedSetOperationTest.java
+++ b/core/src/test/java/io/questdb/griffin/NestedSetOperationTest.java
@@ -1,0 +1,744 @@
+package io.questdb.griffin;
+
+import org.junit.Test;
+
+/**
+ * Tests set operations that occur in subquery.
+ */
+public class NestedSetOperationTest extends AbstractGriffinTest {
+
+    @Test
+    public void testColumnPushdownWithDistinctAndUnionAll() throws Exception {
+        assertQuery("c\n" +
+                        "0\n" +
+                        "0\n" +
+                        "0\n" +
+                        "0\n",
+                "select c from " +
+                        "(select distinct a c, b from test " +   //0,1 ; 0,2; 
+                        "union all " +
+                        "select distinct c, d b from test)",    //0,1 ; 0,2; 
+                "create table test as (" +
+                        "select 0 as a, x as b, 0 as c, x as d from long_sequence(2)" +
+                        ")", null, false, true);
+    }
+
+    @Test
+    public void testGroupByPushdownWithUnionQuery() throws Exception {
+        assertQuery("id\tminv\tmaxv\n" +
+                        "1\t2\t3\n",
+                "select id, min(val) as minv, max(val) as maxv  from ( " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 1 as id, 3 as val, cast(1 as timestamp) ts ) " +
+                        "group by id ", null, null, true, false, true);
+    }
+
+    @Test
+    public void testGroupByPushdownWithExceptQueryReturnsNoRows() throws Exception {
+        assertQuery("id\tminv\tmaxv\n",
+                "select id, min(val) as minv, max(val) as maxv  from ( " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts ) " +
+                        "group by id ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testGroupByPushdownWithIntersectQueryReturnsNoRows() throws Exception {
+        assertQuery("id\tminv\tmaxv\n",
+                "select id, min(val) as minv, max(val) as maxv  from ( " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 3 as val, cast(1 as timestamp) ts ) " +
+                        "group by id ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testGroupByPushdownWithIntersectQueryReturnsCommonRow() throws Exception {
+        assertQuery("id\tminv\tmaxv\n" +
+                        "1\t2\t2\n",
+                "select id, min(val) as minv, max(val) as maxv  from ( " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 2 as val, cast(1 as timestamp) ts ) " +
+                        "group by id ", null, null, true, false, true);
+    }
+
+    //latest by pushdown test - start
+    @Test
+    public void testLatestByPushdownWithUnionQueryOnTableReturnsLatestRow() throws Exception {
+        assertQuery("ts\tstatus\tamount\n" +
+                        "1970-01-01T00:00:00.000002Z\topen\t101\n",
+                "select * from ( " +
+                        "select *  from test where amount = 101 " +
+                        "union " +
+                        "select * from test where amount = 100 ) latest on ts partition by status ",
+                "create table test as ( " +
+                        "select cast(1 as timestamp) as ts, 'open' as status, 100 as amount from long_sequence(1) " +
+                        "union all " +
+                        "select cast(2 as timestamp) as ts, 'open' as status, 101 as amount from long_sequence(1) " +
+                        ") timestamp(ts)", null, false, false, true);
+    }
+
+    //latest by pushdown test - end  
+
+    //order by pushdown test - start
+    //order by can be triggered by using column other than one in select clause in order by clause - but not on top level !
+    @Test
+    public void testOrderByPushdownWithUnionAllQueryReturnsAllRows() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t2\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, true);
+    }
+
+    @Test
+    public void testOrderByPushdownWithUnionQueryReturnsOneUniqueRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t3\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't3' as rec_type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 1 as id, 't3' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    @Test
+    public void testOrderByPushdownWithUnionQueryReturnsAllUniqueRows() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n" +
+                        "t2\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select '1 ' as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select '1 ' as id, 't2' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    @Test
+    public void testOrderByPushdownWithIntersectQueryReturnsNoCommonRow() throws Exception {
+        assertQuery("rec_type\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 't2' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    @Test
+    public void testOrderByPushdownWithIntersectQueryReturnsCommonRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    @Test
+    public void testOrderByPushdownWithExceptQueryReturnsFirstRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 1 as id, 't2' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    @Test
+    public void testOrderByPushdownWithExceptQueryReturnsNoRows() throws Exception {
+        assertQuery("rec_type\n",
+                "select rec_type from ( " +
+                        "select rec_type from (" +
+                        "select * from (" +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts ) )" +
+                        "order by id desc )", null, null, true, false, false);
+    }
+
+    //order by pushdown test - end
+
+    //where clause pushdown tests start
+    @Test
+    public void testWhereClausePushdownWithExceptQueryReturnsFirstRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 2 as id, 't1' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id!=0 ", null, null, true, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithExceptEmptySetQueryReturnsFirstRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 2 as id, 't1' as rec_type, cast(2 as timestamp) ts from long_sequence(1) where x < 0 ) " +
+                        "where id!=0 ", null, null, true, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithExceptQueryReturnsNoRows() throws Exception {
+        assertQuery("rec_type\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts ) " +
+                        "where id<10 ", null, null, true, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithIntersectQueryReturnsZeroRows() throws Exception {
+        assertQuery("rec_type\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 2 as id, 't1' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id!=0 ", null, null, true, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithIntersectQueryReturnsCommonRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts ) " +
+                        "where id<10 ", null, null, true, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithUnionAllQueryReturnsOneMatchingRows() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id=1 ", null, null, false, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithUnionAllQueryReturnsAllMatchingRows() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n" +
+                        "t2\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id<10 ", null, null, false, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithUnionQueryReturnsOneRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id=1 ", null, null, false, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWithUnionQueryReturnsAllRows() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n" +
+                        "t2\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts ) " +
+                        "where id>0 ", null, null, false, false);
+    }
+
+    @Test
+    public void testWhereClausePushdownWith2UnionQueryReturnsOnlyMatchingRow() throws Exception {
+        assertQuery("rec_type\n" +
+                        "t1\n",
+                "select rec_type from ( " +
+                        "select 1 as id, 't1' as rec_type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 2 as id, 't2' as rec_type, cast(2 as timestamp) ts " +
+                        "union " +
+                        "select 3 as id, 't3' as rec_type, cast(2 as timestamp) ts " +
+                        ") " +
+                        "where id=1 ", null, null, false, false);
+    }
+
+
+    //where clause pushdown tests end
+
+    //timestamp pushdown tests start
+    //to test timestamp pushdown we've to specify it using timestamp clause - timestamp(ts) in a way that could clash 
+    //with column of different type (e.g. string or symbol) in set component other than first
+    @Test
+    public void testTimestampPushdownWith2UnionQueryReturnsAllDistinctRows() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000002Z\n" +
+                        "st\t1970-01-01T00:00:00.000003Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts " +
+                        "union " +
+                        "select 3 as id, 'st' as type, cast(3 as timestamp) ts ) timestamp(ts)  ",
+                null, "ts", false, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithUnionQueryReturnsAllDistinctRows() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000002Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts ) timestamp(ts)  ", null, "ts", false, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithUnionQueryReturnsReturnsOnlyDistinctRow() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n",
+                "select type,ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts ) timestamp(ts)  ", null, "ts", false, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithUnionAllQueryReturnsAllRows0() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000002Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts ) timestamp(ts)  ", null, "ts", false, false, true);
+    }
+
+    @Test
+    public void testTimestampPushdownWith2UnionAllQueryReturnsAllRows0() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000002Z\n" +
+                        "st\t1970-01-01T00:00:00.000003Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts " +
+                        "union all " +
+                        "select 3 as id, 'st' as type, cast(3 as timestamp) ts ) timestamp(ts)  ",
+                null, "ts", false, false, true);
+    }
+
+    @Test
+    public void testTimestampPushdownWithUnionAllQueryReturnsAllRows1() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000002Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts ) timestamp(ts)  ", null, "ts", false, false, true);
+    }
+
+    //same as above but with duplicate rows
+    @Test
+    public void testTimestampPushdownWithUnionAllQueryReturnsAllRows2() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "union all " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts ) timestamp(ts)  ", null, "ts", false, false, true);
+    }
+
+    @Test
+    public void testTimestampPushdownWithIntersectQueryReturnsZeroRecords() throws Exception {
+        assertQuery("type\tts\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts ) timestamp(ts)  ", null, "ts", true, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithIntersectQueryReturnsOneCommonRecords() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "intersect " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts ) timestamp(ts)  ", null, "ts", true, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithExceptQueryReturnsOneRecord() throws Exception {
+        assertQuery("type\tts\n" +
+                        "st\t1970-01-01T00:00:00.000001Z\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 2 as id, 'st' as type, cast(2 as timestamp) ts ) timestamp(ts)  ", null, "ts", true, false);
+    }
+
+    @Test
+    public void testTimestampPushdownWithExceptQueryReturnsZeroRecords() throws Exception {
+        assertQuery("type\tts\n",
+                "select type, ts from ( " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts " +
+                        "except " +
+                        "select 1 as id, 'st' as type, cast(1 as timestamp) ts ) timestamp(ts)  ", null, "ts", true, false);
+    }
+    //timestamp pushdown tests end 
+
+    //select columns pushdown with real tables 
+    @Test
+    public void testColumnsPushdownWithUnionAllQueryOnTableReturnsAllRowsOnTable() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "union all " +
+                        "select * from test where id = 2 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWith2UnionAllQueryOnTableReturnsAllRowsOnTable() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "union all " +
+                        "select * from test where id = 2 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionQueryOnTableReturnsAllRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "union " +
+                        "select * from test where id = 2 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionQueryOnTableReturnsOnlyDistinctRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "union " +
+                        "select * from test where id = 1 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWith2UnionQueryOnTableReturnsOnlyDistinctRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "union " +
+                        "select * from test where id = 1 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithExceptQueryOnTableReturnsAllRowsFromFirstTable() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "except " +
+                        "select * from test where id = 2 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, true, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithExceptQueryOnTableReturnsNoRows() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "except " +
+                        "select * from test where id = 1 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, true, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithIntersectQueryOnTableReturnsCommonRow() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "intersect  " +
+                        "select * from test where id = 1 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, true, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithIntersectQueryOnTableReturnsNoRows() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select * from test where id = 1 " +
+                        "intersect " +
+                        "select * from test where id = 2 ) ",
+                "create table test as ( " +
+                        "select 1 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'abc' status from long_sequence(1) " +
+                        ")", null, true, false);
+    }
+
+    //select columns pushdown with virtual selects - start
+    @Test
+    public void testColumnsPushdownWithUnionQueryReturnsAllRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "def\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union " +
+                        "select 2 as id, 100 as amount, 'def' status ) ", null, null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWith2UnionQueryReturnsAllRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "def\n" +
+                        "ghi\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union " +
+                        "select 2 as id, 100 as amount, 'def' status " +
+                        "union " +
+                        "select 3 as id, 100 as amount, 'ghi' status ) ", null, null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionQueryReturnsAllRows2() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union " +
+                        "select 2 as id, 100 as amount, 'abc' status ) ", null, null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionQueryReturnsOnlyDistinctRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union " +
+                        "select 1 as id, 100 as amount, 'abc' status ) ", null, null, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionAllQueryReturnsAllRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "def\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 2 as id, 100 as amount, 'def' status ) ", null, null, false, false, true);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionAllQueryReturnsAllRepeatingRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 1 as id, 100 as amount, 'abc' status ) ", null, null, false, false, true);
+    }
+
+    @Test
+    public void testColumnsPushdownWithIntersectQueryReturnsZeroRows() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "intersect " +
+                        "select 2 as id, 100 as amount, 'def' status ) ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithIntersectQueryReturnsZeroRows2() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "intersect " +
+                        "select 2 as id, 101 as amount, 'abc' status ) ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithIntersectQueryReturnsSharedRows() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "intersect " +
+                        "select 1 as id, 100 as amount, 'abc' status ) ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithExceptQueryReturnsZeroRows() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 100 as amount, 'abc' status ) ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithExceptQueryReturnsDistinctRow() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 100 as amount, 'def' status ) ", null, null, true, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithExceptQueryReturnsDistinctRow2() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 101 as amount, 'abc' status ) ", null, null, true, false, false);
+    }
+
+    //test with combinations of set operations, e.g. union with union all 
+    @Test
+    public void testColumnsPushdownWithUnionAllAndUnionOpsQueryReturnsDistinctRow2() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n" +
+                        "abc\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "union " +
+                        "select 2 as id, 100 as amount, 'abc' status ) ", null, null, false, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithUnionAllAndExceptOpsQueryReturnsUniqueRow() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 100 as amount, 'abc' status ) ", null, null, false, false, false);
+    }
+
+    @Test
+    public void testColumnsPushdownWithAllSetOpsQueryReturnsOneRow() throws Exception {
+        assertQuery("status\n" +
+                        "abc\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "union " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "intersect " +
+                        "select 1 as id, 101 as amount, 'abc' status  ) ", null, null, false, false, false);
+    }
+
+
+    @Test
+    public void testColumnsPushdownWithAllSetOpsQueryReturnsNoRows() throws Exception {
+        assertQuery("status\n",
+                "select status from ( " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "union all " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "union " +
+                        "select 1 as id, 101 as amount, 'abc' status " +
+                        "except " +
+                        "select 1 as id, 100 as amount, 'abc' status " +
+                        "intersect " +
+                        "select 2 as id, 101 as amount, 'abc' status  ) ", null, null, false, false, false);
+    }
+
+    //select columns pushdown with virtual selects - end 
+
+}

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -3560,7 +3560,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testJoinTimestampPropagationWhenTimestampNotSelected() throws SqlException {
         assertQuery(
-                "select-distinct id from (select-choose [id] id from (select-choose [a.id id] a.created ts_stop, a.id id, b.created ts_start, b.id id1 from (select [id, created] from (select-choose [id, created] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 101 and id != '0x05ab1e873d165b00000005743f2c17') order by created) timestamp (created)) a lt join select [id, created] from (select-choose [id] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 100) order by created) timestamp (created)) b on b.id = a.id post-join-where a.created - b.created > 10000000000) a))",
+                "select-distinct [id] id from (select-choose [id] id from (select-choose [a.id id] a.created ts_stop, a.id id, b.created ts_start, b.id id1 from (select [id, created] from (select-choose [id, created] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 101 and id != '0x05ab1e873d165b00000005743f2c17') order by created) timestamp (created)) a lt join select [id, created] from (select-choose [id] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 100) order by created) timestamp (created)) b on b.id = a.id post-join-where a.created - b.created > 10000000000) a))",
                 "with \n" +
                         "    starts as ((telemetry_users where event = 100 order by created) timestamp(created)),\n" +
                         "    stops as ((telemetry_users where event = 101 order by created) timestamp(created))\n" +
@@ -4690,10 +4690,22 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testOrderByPropagation() throws SqlException {
         assertQuery(
-                "select-choose id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType from (select-choose [C.contactId id, contactlist.customName customName, contactlist.name name, contactlist.email email, contactlist.country_name country_name, contactlist.country_code country_code, contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, timestamp] C.contactId id, contactlist.customName customName, contactlist.name name, contactlist.email email, contactlist.country_name country_name, contactlist.country_code country_code, contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, timestamp from (select [contactId] from (select-distinct [contactId] contactId from (select-choose [contactId] contactId from (select-choose [contactId, groupId] contactId, groupId, timestamp from (select [groupId, contactId] from contact_events latest on timestamp partition by _id) where groupId = 'qIqlX6qESMtTQXikQA46') eventlist) except select-choose [_id contactId] _id contactId from (select-choose [_id, notRealType] _id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp from (select [notRealType, _id] from contacts latest on timestamp partition by _id) where notRealType = 'bot') contactlist) C join select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] from (select-choose [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] _id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp from (select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] from contacts latest on timestamp partition by _id)) contactlist on contactlist._id = C.contactId) C order by timestamp desc)",
+                "select-choose id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType from " +
+                        "(select-choose [C.contactId id, contactlist.customName customName, contactlist.name name, contactlist.email email, contactlist.country_name country_name, contactlist.country_code country_code, contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, timestamp] C.contactId id, contactlist.customName customName, contactlist.name name, contactlist.email email, contactlist.country_name country_name, contactlist.country_code country_code, contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, timestamp from " +
+                        "(select [contactId] from (select-distinct [contactId] contactId from (select-choose [contactId] contactId from " +
+                        "(select-choose [contactId, groupId] contactId, groupId, timestamp from " +
+                        "(select [groupId, contactId] from contact_events latest on timestamp partition by contactId) where groupId = 'qIqlX6qESMtTQXikQA46') eventlist) " +
+                        "except " +
+                        "select-choose [_id contactId] _id contactId from " +
+                        "(select-choose [_id, notRealType] _id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp from " +
+                        "(select [notRealType, _id] from contacts latest on timestamp partition by _id) where notRealType = 'bot') contactlist) C " +
+                        "join " +
+                        "select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] from " +
+                        "(select-choose [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] _id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp from " +
+                        "(select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] from contacts latest on timestamp partition by _id)) contactlist on contactlist._id = C.contactId) C order by timestamp desc)",
                 "WITH \n" +
                         "contactlist AS (SELECT * FROM contacts LATEST ON timestamp PARTITION BY _id ORDER BY timestamp),\n" +
-                        "eventlist AS (SELECT * FROM contact_events LATEST ON timestamp PARTITION BY _id ORDER BY timestamp),\n" +
+                        "eventlist AS (SELECT * FROM contact_events LATEST ON timestamp PARTITION BY contactId ORDER BY timestamp),\n" +
                         "C AS (\n" +
                         "    SELECT DISTINCT contactId FROM eventlist WHERE groupId = 'qIqlX6qESMtTQXikQA46'\n" +
                         "    EXCEPT\n" +
@@ -4961,7 +4973,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testQueryExceptQuery() throws SqlException {
         assertQuery(
-                "select-choose a, b, c, x, y, z from (select [a, b, c, x, y, z] from x) except select-choose a, b, c, x, y, z from (select [a, b, c, x, y, z] from y)",
+                "select-choose [a, b, c, x, y, z] a, b, c, x, y, z from (select [a, b, c, x, y, z] from x) except select-choose [a, b, c, x, y, z] a, b, c, x, y, z from (select [a, b, c, x, y, z] from y)",
                 "select * from x except select* from y",
                 modelOf("x")
                         .col("a", ColumnType.INT)
@@ -4983,7 +4995,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testQueryIntersectQuery() throws SqlException {
         assertQuery(
-                "select-choose a, b, c, x, y, z from (select [a, b, c, x, y, z] from x) intersect select-choose a, b, c, x, y, z from (select [a, b, c, x, y, z] from y)",
+                "select-choose [a, b, c, x, y, z] a, b, c, x, y, z from (select [a, b, c, x, y, z] from x) intersect select-choose [a, b, c, x, y, z] a, b, c, x, y, z from (select [a, b, c, x, y, z] from y)",
                 "select * from x intersect select* from y",
                 modelOf("x")
                         .col("a", ColumnType.INT)
@@ -5236,7 +5248,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testSelectAfterOrderBy() throws SqlException {
-        assertQuery("select-distinct Schema from (select-choose [Schema] Schema from (select-virtual [Schema, Name] Schema, Name, switch(relkind,'r','table','v','view','m','materialized view','i','index','S','sequence','s','special','f','foreign table','p','table','I','index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c outer join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r','p','v','m','S','f','') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name))",
+        assertQuery("select-distinct [Schema] Schema from (select-choose [Schema] Schema from (select-virtual [Schema, Name] Schema, Name, switch(relkind,'r','table','v','view','m','materialized view','i','index','S','sequence','s','special','f','foreign table','p','table','I','index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c outer join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r','p','v','m','S','f','') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name))",
                 "select distinct Schema from \n" +
                         "(SELECT n.nspname                              as \"Schema\",\n" +
                         "       c.relname                              as \"Name\",\n" +
@@ -5358,7 +5370,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinct() throws SqlException {
         assertQuery(
-                "select-distinct a, b from (select-choose [a, b] a, b from (select [a, b] from tab))",
+                "select-distinct [a, b] a, b from (select-choose [a, b] a, b from (select [a, b] from tab))",
                 "select distinct a, b from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -5369,7 +5381,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctArithmetic() throws SqlException {
         assertQuery(
-                "select-distinct column from (select-virtual [a + b column] a + b column from (select [b, a] from tab))",
+                "select-distinct [column] column from (select-virtual [a + b column] a + b column from (select [b, a] from tab))",
                 "select distinct a + b from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -5380,7 +5392,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctGroupByFunction() throws SqlException {
         assertQuery(
-                "select-distinct a, bb from (select-group-by [a, sum(b) bb] a, sum(b) bb from (select [a, b] from tab))",
+                "select-distinct [a, bb] a, bb from (select-group-by [a, sum(b) bb] a, sum(b) bb from (select [a, b] from tab))",
                 "select distinct a, sum(b) bb from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -5391,7 +5403,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctGroupByFunctionArithmetic() throws SqlException {
         assertQuery(
-                "select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab)))",
+                "select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab)))",
                 "select distinct a, sum(b)+sum(c) bb from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -5402,7 +5414,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testSelectDistinctGroupByFunctionArithmeticLimit() throws SqlException {
-        assertQuery("select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab))) limit 10",
+        assertQuery("select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab))) limit 10",
                 "select distinct a, sum(b)+sum(c) bb from tab limit 10",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -5413,7 +5425,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testSelectDistinctGroupByFunctionArithmeticOrderByLimit() throws SqlException {
-        assertQuery("select-distinct a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from " +
+        assertQuery("select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from " +
                         "(select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 " +
                         "from (select [a, c, b] from tab))) order by a limit 10",
                 "select distinct a, sum(b)+sum(c) bb from tab order by a limit 10",
@@ -5426,7 +5438,10 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testSelectDistinctUnion() throws SqlException {
-        assertQuery("select-choose c from (select-distinct [c] c, b from (select-choose [a c] a c, b from (select [a] from trips)) union select-distinct [c] c, b from (select-choose [c] c, d b from (select [c] from trips)))",
+        assertQuery("select-choose c from (" +
+                        "select-distinct [c, b] c, b from (select-choose [a c, b] a c, b from (select [a, b] from trips)) " +
+                        "union all " +
+                        "select-distinct [c, b] c, b from (select-choose [c, d b] c, d b from (select [c, d] from trips)))",
                 "select c from (select distinct a c, b from trips union all select distinct c, d b from trips)",
                 modelOf("trips")
                         .col("a", ColumnType.INT)
@@ -6205,7 +6220,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testUnion() throws SqlException {
-        assertQuery("select-choose x from (select [x] from a) union select-choose y from (select [y] from b) union select-choose z from (select [z] from c)",
+        assertQuery("select-choose [x] x from (select [x] from a) union select-choose [y] y from (select [y] from b) union select-choose [z] z from (select [z] from c)",
                 "select * from a union select * from b union select * from c",
                 modelOf("a").col("x", ColumnType.INT),
                 modelOf("b").col("y", ColumnType.INT),
@@ -6216,7 +6231,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionAllInSubQuery() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose y from (select [y] from b) union all select-choose z from (select [z] from c))",
+                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose [y] y from (select [y] from b) union all select-choose [z] z from (select [z] from c))",
                 "select x from (select * from a union select * from b union all select * from c)",
                 modelOf("a").col("x", ColumnType.INT),
                 modelOf("b").col("y", ColumnType.INT),
@@ -6265,7 +6280,15 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionJoinReorder3() throws Exception {
         assertQuery(
-                "select-virtual 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8 from (long_sequence(1)) union select-choose orders.orderId orderId, customers.customerId customerId, shippers.shipper shipper, d.orderId orderId1, d.productId productId, suppliers.supplier supplier, products.productId productId1, products.supplier supplier1 from (select [orderId] from orders join select [shipper] from shippers on shippers.shipper = orders.orderId join (select [orderId, productId] from orderDetails d where productId = orderId) d on d.productId = shippers.shipper join select [productId, supplier] from products on products.productId = d.productId join select [supplier] from suppliers on suppliers.supplier = products.supplier cross join select [customerId] from customers const-where 1 = 1)",
+                "select-virtual [1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8] 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8 from (long_sequence(1)) union " +
+                        "select-choose [orders.orderId orderId, customers.customerId customerId, shippers.shipper shipper, d.orderId orderId1, d.productId productId, suppliers.supplier supplier, products.productId productId1, products.supplier supplier1] " +
+                        "orders.orderId orderId, customers.customerId customerId, shippers.shipper shipper, d.orderId orderId1, d.productId productId, suppliers.supplier supplier, products.productId productId1, products.supplier supplier1 " +
+                        "from (select [orderId] from orders join select [shipper] " +
+                        "from shippers on shippers.shipper = orders.orderId join (select [orderId, productId] " +
+                        "from orderDetails d where productId = orderId) d on d.productId = shippers.shipper " +
+                        "join select [productId, supplier] from products on products.productId = d.productId join select [supplier] " +
+                        "from suppliers on suppliers.supplier = products.supplier cross " +
+                        "join select [customerId] from customers const-where 1 = 1)",
                 "select 1, 2, 3, 4, 5, 6, 7, 8 from long_sequence(1)" +
                         " union " +
                         "orders" +
@@ -6287,7 +6310,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionKeepOrderBy() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose y from (select [y] from b) union all select-choose z from (select [z] from c order by z))",
+                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose [y] y from (select [y] from b) union all select-choose [z] z from (select [z] from c order by z))",
                 "select x from (select * from a union select * from b union all select * from c order by z)",
                 modelOf("a").col("x", ColumnType.INT),
                 modelOf("b").col("y", ColumnType.INT),
@@ -6298,7 +6321,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionKeepOrderByIndex() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose y from (select [y] from b) union all select-choose z from (select [z] from c order by z))",
+                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose [y] y from (select [y] from b) union all select-choose [z] z from (select [z] from c order by z))",
                 "select x from (select * from a union select * from b union all select * from c order by 1)",
                 modelOf("a").col("x", ColumnType.INT),
                 modelOf("b").col("y", ColumnType.INT),
@@ -6309,8 +6332,23 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionKeepOrderByWhenSampleByPresent() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x, t from (select [x] from a) union select-choose y, t from (select [y, t] from b) union all select-virtual 'a' k, sum from (select-group-by [sum(z) sum] sum(z) sum from (select-choose [t, z] z, t from (select [t, z] from c order by t)) timestamp (t) sample by 6h)) order by x",
-                "select x from (select * from a union select * from b union all select 'a' k, sum(z) from (c order by t) timestamp(t) sample by 6h) order by x",
+                "select-choose x from " +
+                        "(select-choose [x, t] x, t from (select [x, t] from a) " +
+                        "union " +
+                        "select-choose [y, t] y, t from (select [y, t] from b) " +
+                        "union all " +
+                        "select-virtual ['a' k, sum] 'a' k, sum from " +
+                        "(select-group-by [sum(z) sum] sum(z) sum from " +
+                        "(select-choose [t, z] z, t from (select [t, z] from c order by t)) " +
+                        "timestamp (t) sample by 6h)" +
+                        ") order by x",
+                "select x from " +
+                        "(select * from a " +
+                        "union " +
+                        "select * from b " +
+                        "union all " +
+                        "select 'a' k, sum(z) from (c order by t) timestamp(t) sample by 6h" +
+                        ") order by x",
                 modelOf("a").col("x", ColumnType.INT).col("t", ColumnType.TIMESTAMP),
                 modelOf("b").col("y", ColumnType.INT).col("t", ColumnType.TIMESTAMP),
                 modelOf("c").col("z", ColumnType.INT).col("t", ColumnType.TIMESTAMP)
@@ -6320,7 +6358,12 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionMoveWhereIntoSubQuery() throws Exception {
         assertQuery(
-                "select-virtual 1 1, 2 2, 3 3 from (long_sequence(1)) union select-choose c.customerId customerId, o.customerId customerId1, o.x x from (select [customerId] from customers c outer join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c",
+                "select-virtual [1 1, 2 2, 3 3] 1 1, 2 2, 3 3 from (long_sequence(1)) " +
+                        "union " +
+                        "select-choose [c.customerId customerId, o.customerId customerId1, o.x x] c.customerId customerId, o.customerId customerId1, o.x x from " +
+                        "(select [customerId] from customers c outer join " +
+                        "select [customerId, x] from (select-choose [customerId, x] customerId, x from " +
+                        "(select [customerId, x] from orders o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c",
                 "select 1, 2, 3 from long_sequence(1)" +
                         " union " +
                         "customers c" +
@@ -6336,7 +6379,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionRemoveOrderBy() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose y from (select [y] from b) union all select-choose z from (select [z] from c)) order by x",
+                "select-choose x from (select-choose [x] x from (select [x] from a) union select-choose [y] y from (select [y] from b) union all select-choose [z] z from (select [z] from c)) order by x",
                 "select x from (select * from a union select * from b union all select * from c order by z) order by x",
                 modelOf("a").col("x", ColumnType.INT),
                 modelOf("b").col("y", ColumnType.INT),
@@ -6347,7 +6390,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testUnionRemoveRedundantOrderBy() throws SqlException {
         assertQuery(
-                "select-choose x from (select-choose [x] x, t from (select [x] from a) union select-choose y, t from (select [y, t] from b) union all select-virtual 1 1, sum from (select-group-by [sum(z) sum] sum(z) sum from (select-choose [t, z] z, t from (select [t, z] from c order by t)) timestamp (t) sample by 6h)) order by x",
+                "select-choose x from (select-choose [x, t] x, t from (select [x, t] from a) union select-choose [y, t] y, t from (select [y, t] from b) union all select-virtual [1 1, sum] 1 1, sum from (select-group-by [sum(z) sum] sum(z) sum from (select-choose [t, z] z, t from (select [t, z] from c order by t)) timestamp (t) sample by 6h)) order by x",
                 "select x from (select * from a union select * from b union all select 1, sum(z) from (c order by t, t) timestamp(t) sample by 6h) order by x",
                 modelOf("a").col("x", ColumnType.INT).col("t", ColumnType.TIMESTAMP),
                 modelOf("b").col("y", ColumnType.INT).col("t", ColumnType.TIMESTAMP),
@@ -6492,7 +6535,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testWithTwoAliasesExcept() throws SqlException {
         assertQuery(
-                "select-choose a from (select-choose [a] a from (select [a] from tab)) x except select-choose a from (select-choose [a] a from (select [a] from tab)) y",
+                "select-choose [a] a from (select-choose [a] a from (select [a] from tab)) x except select-choose [a] a from (select-choose [a] a from (select [a] from tab)) y",
                 "with x as (select * from tab)," +
                         " y as (select * from tab)" +
                         " select * from x except select * from y",
@@ -6503,7 +6546,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testWithTwoAliasesIntersect() throws SqlException {
         assertQuery(
-                "select-choose a from (select-choose [a] a from (select [a] from tab)) x intersect select-choose a from (select-choose [a] a from (select [a] from tab)) y",
+                "select-choose [a] a from (select-choose [a] a from (select [a] from tab)) x intersect select-choose [a] a from (select-choose [a] a from (select [a] from tab)) y",
                 "with x as (select * from tab)," +
                         " y as (select * from tab)" +
                         " select * from x intersect select * from y",
@@ -6514,7 +6557,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testWithTwoAliasesUnion() throws SqlException {
         assertQuery(
-                "select-choose a from (select-choose [a] a from (select [a] from tab)) x union select-choose a from (select-choose [a] a from (select [a] from tab)) y",
+                "select-choose [a] a from (select-choose [a] a from (select [a] from tab)) x union select-choose [a] a from (select-choose [a] a from (select [a] from tab)) y",
                 "with x as (select * from tab)," +
                         " y as (select * from tab)" +
                         " select * from x union select * from y",
@@ -6525,7 +6568,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testWithUnionWith() throws SqlException {
         assertQuery(
-                "select-choose a from (select-choose [a] a from (select [a] from tab)) x union select-choose a from (select-choose [a] a from (select [a] from tab)) y",
+                "select-choose [a] a from (select-choose [a] a from (select [a] from tab)) x union select-choose [a] a from (select-choose [a] a from (select [a] from tab)) y",
                 "with x as (select * from tab) select * from x union with " +
                         " y as (select * from tab) select * from y",
                 modelOf("tab").col("a", ColumnType.INT)

--- a/core/src/test/java/io/questdb/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/griffin/UnionTest.java
@@ -174,10 +174,26 @@ public class UnionTest extends AbstractGriffinTest {
                     "CAR\n" +
                     "VAN\n" +
                     "PLANE\n" +
+                    "PLANE\n" +
+                    "PLANE\n" +
                     "BICYCLE\n" +
                     "SCOOTER\n" +
+                    "SCOOTER\n" +
+                    "SCOOTER\n" +
+                    "SCOOTER\n" +
                     "HELICOPTER\n" +
-                    "MOTORBIKE\n";
+                    "MOTORBIKE\n" +
+                    "HELICOPTER\n" +
+                    "HELICOPTER\n" +
+                    "VAN\n" +
+                    "HELICOPTER\n" +
+                    "HELICOPTER\n" +
+                    "HELICOPTER\n" +
+                    "MOTORBIKE\n" +
+                    "MOTORBIKE\n" +
+                    "HELICOPTER\n" +
+                    "MOTORBIKE\n" +
+                    "HELICOPTER\n";
 
             compiler.compile(
                     "CREATE TABLE x as " +
@@ -199,7 +215,7 @@ public class UnionTest extends AbstractGriffinTest {
                             " rnd_symbol('PLANE', 'BICYCLE', 'SCOOTER') t " +
                             " FROM long_sequence(7) x)",
                     sqlExecutionContext
-            );
+            ); //produces PLANE PLANE BICYCLE SCOOTER SCOOTER SCOOTER SCOOTER
 
             compiler.compile(
                     "CREATE TABLE z as " +
@@ -207,10 +223,10 @@ public class UnionTest extends AbstractGriffinTest {
                             " rnd_symbol('MOTORBIKE', 'HELICOPTER', 'VAN') t " +
                             " FROM long_sequence(13) x)",
                     sqlExecutionContext
-            );
+            ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
 
             try (RecordCursorFactory factory = compiler.compile("select distinct t from x union all y union all z", sqlExecutionContext).getRecordCursorFactory()) {
-                assertCursor(expected2, factory, false, true, false);
+                assertCursor(expected2, factory, false, true, true);
             }
         });
     }
@@ -232,7 +248,12 @@ public class UnionTest extends AbstractGriffinTest {
                     "CAR\n" +
                     "VAN\n" +
                     "PLANE\n" +
+                    "PLANE\n" +
+                    "PLANE\n" +
                     "BICYCLE\n" +
+                    "SCOOTER\n" +
+                    "SCOOTER\n" +
+                    "SCOOTER\n" +
                     "SCOOTER\n";
 
             compiler.compile(
@@ -255,10 +276,10 @@ public class UnionTest extends AbstractGriffinTest {
                             " rnd_symbol('PLANE', 'BICYCLE', 'SCOOTER') t " +
                             " FROM long_sequence(7) x)",
                     sqlExecutionContext
-            );
+            );//produces PLANE PLANE BICYCLE SCOOTER SCOOTER SCOOTER SCOOTER
 
             try (RecordCursorFactory factory = compiler.compile("select distinct t from x union all y", sqlExecutionContext).getRecordCursorFactory()) {
-                assertCursor(expected2, factory, false, true, false);
+                assertCursor(expected2, factory, false, true, true);
             }
         });
     }


### PR DESCRIPTION
Fixes https://github.com/questdb/questdb/issues/1910
by 
1. preventing column/where/timestamp/order by pushdown through select distinct or union/except/intersect because that can change output  . For such models bottom columns are added to top set  . 
2. pushing column/where/timestamp/order by all participants of union all instead of just the nested model (that was causing type errors) 
3. fixing various bugs here and there (e.g. select distinct  from X union all Y != select from X union Y  )

