### PR TITLE
Add geohash support for CSV import and export

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -233,7 +233,6 @@ public final class ColumnType {
     }
 
     public static short tagOf(CharSequence name) {
-        // return (short) (nameTypeMap.get(name) & 0xFF);
         return (short) nameTypeMap.get(name);
     }
 

--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -130,10 +130,6 @@ public final class ColumnType {
         return columnType == BINARY;
     }
 
-    public static boolean isLong256(int columnType) {
-        return columnType == LONG256;
-    }
-
     public static boolean isBoolean(int columnType) {
         return columnType == ColumnType.BOOLEAN;
     }
@@ -237,7 +233,12 @@ public final class ColumnType {
     }
 
     public static short tagOf(CharSequence name) {
+        // return (short) (nameTypeMap.get(name) & 0xFF);
         return (short) nameTypeMap.get(name);
+    }
+
+    public static int typeOf(CharSequence name) {
+        return nameTypeMap.get(name);
     }
 
     public static long truncateGeoHashBits(long value, int fromBits, int toBits) {
@@ -306,19 +307,6 @@ public final class ColumnType {
         typeNameMap.put(VAR_ARG, "VARARG");
         typeNameMap.put(GEOHASH, "GEOHASH");
 
-        StringSink sink = new StringSink();
-
-        for (int b = 1; b <= GEO_HASH_MAX_BITS_LENGTH; b++) {
-            sink.clear();
-
-            if (b % 5 != 0) {
-                sink.put("GEOHASH(").put(b).put("b)");
-            } else {
-                sink.put("GEOHASH(").put(b / 5).put("c)");
-            }
-            typeNameMap.put(getGeoHashTypeWithBits(b), sink.toString());
-        }
-
         nameTypeMap.put("boolean", BOOLEAN);
         nameTypeMap.put("byte", BYTE);
         nameTypeMap.put("double", DOUBLE);
@@ -341,6 +329,20 @@ public final class ColumnType {
         nameTypeMap.put("bigint", LONG);
         nameTypeMap.put("real", FLOAT);
         nameTypeMap.put("bytea", STRING);
+
+        StringSink sink = new StringSink();
+        for (int b = 1; b <= GEO_HASH_MAX_BITS_LENGTH; b++) {
+            sink.clear();
+            if (b % 5 != 0) {
+                sink.put("GEOHASH(").put(b).put("b)");
+            } else {
+                sink.put("GEOHASH(").put(b / 5).put("c)");
+            }
+            String name = sink.toString();
+            int type = getGeoHashTypeWithBits(b);
+            typeNameMap.put(type, name);
+            nameTypeMap.put(name, type);
+        }
 
         TYPE_SIZE_POW2[UNDEFINED] = -1;
         TYPE_SIZE_POW2[BOOLEAN] = 0;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -680,17 +680,7 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
             columnType = ColumnType.STRING;
         }
 
-        int flags = 0;
-        int bitSize = ColumnType.getGeoHashBits(columnType);
-        if (bitSize > 0) {
-            if (bitSize % 5 == 0) {
-                // It's 5 bit per char. If it's integer number of chars value to be serialized as chars
-                flags = -bitSize / 5;
-            } else {
-                // value to be serialized as bit array
-                flags = bitSize;
-            }
-        }
+        int flags = GeoHashes.getBitFlags(columnType);
         this.columnTypesAndFlags.add(columnType);
         this.columnTypesAndFlags.add(flags);
         this.columnNames.add(metadata.getColumnName(i));

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -325,6 +325,10 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
         putStringOrNull(socket, rec.getStr(col));
     }
 
+    private static void putRecValue(HttpChunkedResponseSocket socket) {
+        putStringOrNull(socket, null);
+    }
+
     private static void putSymValue(HttpChunkedResponseSocket socket, Record rec, int col) {
         putStringOrNull(socket, rec.getSym(col));
     }
@@ -536,6 +540,9 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
                     break;
                 case ColumnType.GEOLONG:
                     putGeoHashStringLongValue(socket, record, columnIdx, columnTypesAndFlags.getQuick(2 * columnIndex + 1));
+                    break;
+                case ColumnType.RECORD:
+                    putRecValue(socket);
                     break;
                 default:
                     assert false : "Not supported type in output " + ColumnType.nameOf(columnType);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -486,15 +486,28 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
             case ColumnType.LONG256:
                 rec.getLong256(col, socket);
                 break;
+            case ColumnType.GEOBYTE:
+                putGeoHashStringValue(socket, rec.getGeoByte(col), type);
+                break;
+            case ColumnType.GEOSHORT:
+                putGeoHashStringValue(socket, rec.getGeoShort(col), type);
+                break;
+            case ColumnType.GEOINT:
+                putGeoHashStringValue(socket, rec.getGeoInt(col), type);
+                break;
+            case ColumnType.GEOLONG:
+                putGeoHashStringValue(socket, rec.getGeoLong(col), type);
+                break;
             default:
                 assert false;
         }
     }
 
-    private static void putGeoHashStringValue(HttpChunkedResponseSocket socket, long value, int bitFlags) {
+    private static void putGeoHashStringValue(HttpChunkedResponseSocket socket, long value, int type) {
         if (value == GeoHashes.NULL) {
             socket.put("null");
         } else {
+            int bitFlags = GeoHashes.getBitFlags(type);
             socket.put('\"');
             if (bitFlags < 0) {
                 GeoHashes.appendCharsUnsafe(value, -bitFlags, socket);
@@ -504,7 +517,6 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
             socket.put('\"');
         }
     }
-
 
     private void sendConfirmation(HttpChunkedResponseSocket socket) throws PeerDisconnectedException, PeerIsSlowToReadException {
         socket.put("DDL Success\n");

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1019,16 +1019,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
 
         for (int i = 0; i < columnCount; i++) {
             int columnType = m.getColumnType(i);
-            int flags = 0;
-            if (ColumnType.isGeoHash(columnType)) {
-                final int bits = ColumnType.getGeoHashBits(columnType);
-                if (bits > 0 && bits % 5 == 0) {
-                    // It's 5 bit per char. If it's integer number of chars value to be serialized as chars
-                    flags = -bits / 5;
-                } else {
-                    flags = bits;
-                }
-            }
+            int flags = GeoHashes.getBitFlags(columnType);
             activeSelectColumnTypes.setQuick(2 * i, columnType);
             activeSelectColumnTypes.setQuick(2 * i + 1, flags);
         }

--- a/core/src/main/java/io/questdb/cutlass/text/TextMetadataParser.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextMetadataParser.java
@@ -142,7 +142,7 @@ public class TextMetadataParser implements JsonParser, Mutable, Closeable {
                         name = copy(tag);
                         break;
                     case P_TYPE:
-                        type = ColumnType.tagOf(tag);
+                        type = ColumnType.typeOf(tag);
                         if (type == -1) {
                             throw JsonException.$(position, "Invalid type");
                         }

--- a/core/src/main/java/io/questdb/cutlass/text/types/GeoHashAdapter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/GeoHashAdapter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.text.types;
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableWriter;
+import io.questdb.griffin.SqlKeywords;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.str.DirectByteCharSequence;
+
+public final class GeoHashAdapter extends AbstractTypeAdapter {
+
+    private static final IntObjHashMap<GeoHashAdapter> typeToAdapterMap = new IntObjHashMap<>();
+
+    private final int type;
+
+    private GeoHashAdapter(int type) {
+        this.type = type;
+    }
+
+    public static GeoHashAdapter getInstance(int columnType) {
+        final int index = typeToAdapterMap.keyIndex(columnType);
+        if (index > -1) {
+            return null;
+        }
+        return typeToAdapterMap.valueAtQuick(index);
+    }
+
+    @Override
+    public int getType() {
+        return type;
+    }
+
+    @Override
+    public boolean probe(CharSequence text) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(TableWriter.Row row, int column, DirectByteCharSequence value) {
+        row.putGeoStr(column, SqlKeywords.isNullKeyword(value) ? null : value);
+    }
+
+    static {
+        for (int b = 1; b <= ColumnType.GEO_HASH_MAX_BITS_LENGTH; b++) {
+            int type = ColumnType.getGeoHashTypeWithBits(b);
+            typeToAdapterMap.put(type, new GeoHashAdapter(type));
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
@@ -126,6 +126,11 @@ public class TypeManager implements Mutable {
                 return nextSymbolAdapter(false);
             case ColumnType.LONG256:
                 return Long256Adapter.INSTANCE;
+            case ColumnType.GEOBYTE:
+            case ColumnType.GEOSHORT:
+            case ColumnType.GEOINT:
+            case ColumnType.GEOLONG:
+                return GeoHashAdapter.getInstance(columnType);
             default:
                 throw CairoException.instance(0).put("no adapter for type [id=").put(columnType).put(", name=").put(ColumnType.nameOf(columnType)).put(']');
         }

--- a/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
@@ -130,7 +130,10 @@ public class TypeManager implements Mutable {
             case ColumnType.GEOSHORT:
             case ColumnType.GEOINT:
             case ColumnType.GEOLONG:
-                return GeoHashAdapter.getInstance(columnType);
+                GeoHashAdapter adapter = GeoHashAdapter.getInstance(columnType);
+                if (adapter != null) {
+                    return adapter;
+                }
             default:
                 throw CairoException.instance(0).put("no adapter for type [id=").put(columnType).put(", name=").put(ColumnType.nameOf(columnType)).put(']');
         }

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -2834,6 +2834,76 @@ public class IODispatcherTest {
 
     @Test
     public void testJsonQueryGeoHashColumnChars() throws Exception {
+        testHttpQueryGeoHashColumnChars(
+                "GET /query?query=SELECT+*+FROM+y HTTP/1.1\r\n" +
+                        "Host: localhost:9000\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Accept: */*\r\n" +
+                        "X-Requested-With: XMLHttpRequest\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36\r\n" +
+                        "Sec-Fetch-Site: same-origin\r\n" +
+                        "Sec-Fetch-Mode: cors\r\n" +
+                        "Referer: http://localhost:9000/index.html\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "0166\r\n" +
+                        "{\"query\":\"SELECT * FROM y\",\"columns\":[" +
+                        "{\"name\":\"geo1\",\"type\":\"GEOHASH(1c)\"}," +
+                        "{\"name\":\"geo2\",\"type\":\"GEOHASH(3c)\"}," +
+                        "{\"name\":\"geo4\",\"type\":\"GEOHASH(6c)\"}," +
+                        "{\"name\":\"geo8\",\"type\":\"GEOHASH(12c)\"}," +
+                        "{\"name\":\"geo01\",\"type\":\"GEOHASH(1b)\"}" +
+                        "],\"dataset\":[" +
+                        "[null,null,\"questd\",\"u10m99dd3pbj\",\"1\"]," +
+                        "[\"u\",\"u10\",\"questd\",null,\"1\"]," +
+                        "[\"q\",\"u10\",\"questd\",\"questdb12345\",\"1\"]" +
+                        "],\"count\":3}\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    @Test
+    public void testTextQueryGeoHashColumnChars() throws Exception {
+        testHttpQueryGeoHashColumnChars(
+                "GET /exp?query=SELECT+*+FROM+y HTTP/1.1\r\n" +
+                        "Host: localhost:9000\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: */*\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: text/csv; charset=utf-8\r\n" +
+                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "90\r\n" +
+                        "\"geo1\",\"geo2\",\"geo4\",\"geo8\",\"geo01\"\r\n" +
+                        "null,null,\"questd\",\"u10m99dd3pbj\",\"1\"\r\n" +
+                        "\"u\",\"u10\",\"questd\",null,\"1\"\r\n" +
+                        "\"q\",\"u10\",\"questd\",\"questdb12345\",\"1\"\r\n" +
+                        "\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    private void testHttpQueryGeoHashColumnChars(String request, String response) throws Exception {
         new HttpQueryTestBuilder()
                 .withWorkerCount(1)
                 .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder()
@@ -2854,25 +2924,7 @@ public class IODispatcherTest {
                                 "from long_sequence(3)\n" +
                                 ")", executionContext);
 
-                        String request = "SELECT+*+FROM+y";
-                        new SendAndReceiveRequestBuilder().executeWithStandardHeaders(
-                                "GET /query?query=" + request + " HTTP/1.1\r\n",
-                                "0166\r\n" +
-                                        "{\"query\":\"SELECT * FROM y\",\"columns\":[" +
-                                        "{\"name\":\"geo1\",\"type\":\"GEOHASH(1c)\"}," +
-                                        "{\"name\":\"geo2\",\"type\":\"GEOHASH(3c)\"}," +
-                                        "{\"name\":\"geo4\",\"type\":\"GEOHASH(6c)\"}," +
-                                        "{\"name\":\"geo8\",\"type\":\"GEOHASH(12c)\"}," +
-                                        "{\"name\":\"geo01\",\"type\":\"GEOHASH(1b)\"}" +
-                                        "],\"dataset\":[" +
-                                        "[null,null,\"questd\",\"u10m99dd3pbj\",\"1\"]," +
-                                        "[\"u\",\"u10\",\"questd\",null,\"1\"]," +
-                                        "[\"q\",\"u10\",\"questd\",\"questdb12345\",\"1\"]" +
-                                        "],\"count\":3}\r\n" +
-                                        "00\r\n" +
-                                        "\r\n"
-
-                        );
+                        new SendAndReceiveRequestBuilder().execute(request, response);
                     }
                 });
     }

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -557,6 +557,74 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testJsonRecordTypeSelect() throws Exception {
+        testJsonQuery(
+                1,
+                "GET /exec?limit=0%2C1000&explain=true&count=true&src=con&query=%0D%0A%0D%0A%0D%0Aselect%20pg_catalog.pg_class()%20x%2C%20(pg_catalog.pg_class()).relnamespace%20from%20long_sequence(2) HTTP/1.1\r\n" +
+                        "Host: localhost:9000\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Accept: */*\r\n" +
+                        "X-Requested-With: XMLHttpRequest\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36\r\n" +
+                        "Sec-Fetch-Site: same-origin\r\n" +
+                        "Sec-Fetch-Mode: cors\r\n" +
+                        "Referer: http://localhost:9000/index.html\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "Cookie: _ga=GA1.1.2124932001.1573824669; _gid=GA1.1.1731187971.1580598042\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "011d\r\n" +
+                        "{\"query\":\"\\r\\n\\r\\n\\r\\nselect pg_catalog.pg_class() x, (pg_catalog.pg_class()).relnamespace from long_sequence(2)\",\"columns\":[{\"name\":\"x1\",\"type\":\"RECORD\"},{\"name\":\"column\",\"type\":\"INT\"}],\"dataset\":[[null,11],[null,2200],[null,11],[null,2200]],\"count\":4,\"explain\":{\"jitCompiled\":false}}\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    @Test
+    public void testExpRecordTypeSelect() throws Exception {
+        testJsonQuery(
+                1,
+                "GET /exp?limit=0%2C1000&explain=true&count=true&src=con&query=%0D%0A%0D%0A%0D%0Aselect%20pg_catalog.pg_class()%20x%2C%20(pg_catalog.pg_class()).relnamespace%20from%20long_sequence(2) HTTP/1.1\r\n" +
+                        "Host: localhost:9000\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Accept: */*\r\n" +
+                        "X-Requested-With: XMLHttpRequest\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36\r\n" +
+                        "Sec-Fetch-Site: same-origin\r\n" +
+                        "Sec-Fetch-Mode: cors\r\n" +
+                        "Referer: http://localhost:9000/index.html\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "Cookie: _ga=GA1.1.2124932001.1573824669; _gid=GA1.1.1731187971.1580598042\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: text/csv; charset=utf-8\r\n" +
+                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "27\r\n" +
+                        "\"x1\",\"column\"\r\n" +
+                        ",11\r\n" +
+                        ",2200\r\n" +
+                        ",11\r\n" +
+                        ",2200\r\n" +
+                        "\r\n"+
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    @Test
     public void testFailsOnBadCommitLag() throws Exception {
         String command = "POST /upload?fmt=json&" +
                 "commitLag=2seconds+please&" +

--- a/core/src/test/java/io/questdb/cutlass/http/SendAndReceiveRequestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/SendAndReceiveRequestBuilder.java
@@ -359,7 +359,6 @@ public class SendAndReceiveRequestBuilder {
         }
     }
 
-
     @FunctionalInterface
     public interface RequestAction {
         void run(RequestExecutor executor) throws InterruptedException, BrokenBarrierException;

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -57,6 +57,24 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testRecordJoinExpansion() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table x(a int)", sqlExecutionContext);
+            TestUtils.assertSql(
+                    compiler,
+                    sqlExecutionContext,
+                    "select pg_catalog.pg_class() x, (pg_catalog.pg_class()).relnamespace from long_sequence(2)",
+                    sink,
+                    "x1\tcolumn\n" +
+                            "\t11\n" +
+                            "\t2200\n" +
+                            "\t11\n" +
+                            "\t2200\n"
+            );
+        });
+    }
+
+    @Test
     public void testAvgDoubleColumn() throws Exception {
         final String expected = "a\tk\n";
 


### PR DESCRIPTION
Just like with ILP, CSV import supports geohash strings only (no geohash literals), so `u33d8` instead of `#u33d8`.

Also fixes JSON and Text processors failure on RECORD column type.

Docs PR: https://github.com/questdb/questdb.io/pull/772