### PR TITLE
fix(ui): adjust regex to allow brackets in editor tokens

### DIFF
--- a/ui/src/scenes/Editor/Monaco/questdb-sql/conf.ts
+++ b/ui/src/scenes/Editor/Monaco/questdb-sql/conf.ts
@@ -4,8 +4,9 @@ export const conf: monaco.languages.LanguageConfiguration = {
   /**
    * Override the default word definition regex to also allow single quotes and dots.
    * This way we can highlight table names escaped with quotes and the ones created from CSV files.
+   * An additional example is a "bad integer" error, i.e. (20000) - needs brackets to be allowed as well.
    */
-  wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\"\,\<\>\/\?\s]+)/g,
+  wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\-\=\+\[\{\]\}\\\|\;\:\"\,\<\>\/\?\s]+)/g,
   comments: {
     lineComment: "--",
     blockComment: ["/*", "*/"],


### PR DESCRIPTION
### Error description
SQL editor has a definition of what a word (token) is - by default it does not allow certain special characters to be present, including brackets. Therefore, the logic that finds a word to highlight at a given position gets nothing, as a token starting with `(` is immediately discarded.

A good use case for having them allowed is a `bad integer` type of issue:

```
CREATE TABLE table_name (
  column_name symbol index CAPACITY (200000),
)
```

The above should highlight the `(200000)` as an error.

### Fix
Allow brackets in word matching regex.
