### PR TITLE
feat(ui): improve "Example Queries" popup to support groups

### DIFF
--- a/ui/src/scenes/Editor/QueryPicker/Row/index.tsx
+++ b/ui/src/scenes/Editor/QueryPicker/Row/index.tsx
@@ -22,20 +22,23 @@
  *
  ******************************************************************************/
 
-import React, { useCallback } from "react"
+import React from "react"
 import styled, { css } from "styled-components"
 import { FileCode } from "@styled-icons/remix-line/FileCode"
 
 import { Text, TransitionDuration } from "components"
-import { QueryShape } from "types"
+import type { Query } from "types"
 import { color } from "utils"
+
+type MouseAction = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 
 type Props = Readonly<{
   active: boolean
   hidePicker: () => void
-  onHover: (query?: QueryShape) => void
-  onAdd: (query: QueryShape) => void
-  query: QueryShape
+  onMouseEnter: MouseAction
+  onMouseLeave: MouseAction
+  onClick: MouseAction
+  query: Query
 }>
 
 const activeStyles = css`
@@ -59,7 +62,7 @@ const Wrapper = styled.div<{ active: boolean }>`
   }
 `
 
-const Query = styled(Text)`
+const Value = styled(Text)`
   flex: 1 1 auto;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -78,37 +81,25 @@ const Name = styled(Text)`
   flex: 0 0 auto;
 `
 
-const Row = ({ active, onHover, onAdd, query }: Props) => {
-  const handleClick = useCallback(() => {
-    onAdd(query)
-  }, [query, onAdd])
-  const handleMouseEnter = useCallback(() => {
-    onHover(query)
-  }, [query, onHover])
-  const handleMouseLeave = useCallback(() => {
-    onHover()
-  }, [onHover])
+const Row = ({ active, onMouseEnter, onMouseLeave, onClick, query }: Props) => (
+  <Wrapper
+    active={active}
+    onClick={onClick}
+    onMouseEnter={onMouseEnter}
+    onMouseLeave={onMouseLeave}
+  >
+    <FileIcon size="12px" />
 
-  return (
-    <Wrapper
-      active={active}
-      onClick={handleClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <FileIcon size="12px" />
+    {query.name && (
+      <Name color="draculaForeground" size="sm">
+        {query.name}
+      </Name>
+    )}
 
-      {query.name && (
-        <Name color="draculaForeground" size="sm">
-          {query.name}
-        </Name>
-      )}
-
-      <Query color="draculaForeground" size="sm">
-        {query.value}
-      </Query>
-    </Wrapper>
-  )
-}
+    <Value color="draculaForeground" size="sm">
+      {query.value}
+    </Value>
+  </Wrapper>
+)
 
 export default Row

--- a/ui/src/store/Console/types.ts
+++ b/ui/src/store/Console/types.ts
@@ -24,15 +24,21 @@
 
 import { ModalId } from "consts"
 
-export type QueryShape = Readonly<{
+export type Query = {
   name?: string
   value: string
-}>
+}
+
+export type QueryGroup = {
+  title?: string
+  description?: string
+  queries: Query[]
+}
 
 export type ConsoleConfigShape = Readonly<{
   githubBanner: boolean
   readOnly?: boolean
-  savedQueries: QueryShape[]
+  savedQueries: Array<Query | QueryGroup>
 }>
 
 export type ConsoleStateShape = Readonly<{


### PR DESCRIPTION
This PR updates the "Example Queries" popup with a support to
display queries in groups.

For example, queries related to geohashing can be under a single group.

Depending on `savedQueries` array in
`assets/console-configuration.json`, the popup can look like so:

![example of example queries](https://user-images.githubusercontent.com/4284659/160557046-8203eee6-e7ee-4576-91af-5c8f56d4173d.png)

the `savedQueries` array in `assets/console-configuration.json` is what
governs this list. The array for what's seen in the screenshot is
roughly this (truncated for brevity):

```json
{
  "savedQueries": [
    {
      "title": "Trading",
      "description": "Examples of crypto currency trading queries",
      "queries": [
        {
          "name": "All BTC trades",
          "value": "select * from trade where symbol = 'BTC'"
        },
        // ...
      ]
    },
    {
      "title": "Geohash",
      "description": "Queries for geohashes",
      "queries": [
        {
          "name": "Current positions within a geohash area",
          "value": "pos latest by id where geo6 within(#wtq);"
        },
        // ...
      ]
    }
  ]
}
```

This PR ensures that json schema used previously still works well. This
kind of `assets/console-configuration.json` still works just like
before:

```json
"savedQueries": [
  { "name": "some name", "value": "some query" }
]
```

Both schemes can work together, this PR really just makes previous
schema nestable, so we can do this:

```json
{
  "savedQueries": [
    { "name": "some name", "value": "some query" },
    {
      "title": "some group",
      "description": "this is a group of queries",
      "queries": [{ "name": "query in a group", "value": "some query" }]
    }
  ]
}
```

Just a tree, traversed in BFS style
