### PR TITLE
feat(ui): add red dot indicator on "Example Queries" button

### DIFF
--- a/ui/src/providers/LocalStorageProvider/index.tsx
+++ b/ui/src/providers/LocalStorageProvider/index.tsx
@@ -45,6 +45,7 @@ const defaultConfig: LocalConfig = {
   queryText: "",
   editorSplitterBasis: 350,
   resultsSplitterBasis: 350,
+  exampleQueriesVisited: false,
 }
 
 type ContextProps = {
@@ -57,6 +58,7 @@ type ContextProps = {
   editorSplitterBasis: number
   resultsSplitterBasis: number
   updateSettings: (key: StoreKey, value: SettingsType) => void
+  exampleQueriesVisited: boolean
 }
 
 const defaultValues: ContextProps = {
@@ -69,6 +71,7 @@ const defaultValues: ContextProps = {
   editorSplitterBasis: 350,
   resultsSplitterBasis: 350,
   updateSettings: (key: StoreKey, value: SettingsType) => undefined,
+  exampleQueriesVisited: false,
 }
 
 export const LocalStorageContext = createContext<ContextProps>(defaultValues)
@@ -113,6 +116,10 @@ export const LocalStorageProvider = ({
     ),
   )
 
+  const [exampleQueriesVisited, setExampleQueriesVisited] = useState<boolean>(
+    getValue(StoreKey.EXAMPLE_QUERIES_VISITED) === "true",
+  )
+
   const updateSettings = (key: StoreKey, value: SettingsType) => {
     setValue(key, value.toString())
     refreshSettings(key)
@@ -129,6 +136,9 @@ export const LocalStorageProvider = ({
         break
       case StoreKey.EDITOR_LINE:
         setEditorLine(parseInteger(value, defaultConfig.editorLine))
+        break
+      case StoreKey.EXAMPLE_QUERIES_VISITED:
+        setExampleQueriesVisited(value === "true")
         break
       case StoreKey.NOTIFICATION_ENABLED:
         setIsNotificationEnabled(
@@ -168,6 +178,7 @@ export const LocalStorageProvider = ({
         editorSplitterBasis,
         resultsSplitterBasis,
         updateSettings,
+        exampleQueriesVisited,
       }}
     >
       {children}

--- a/ui/src/providers/LocalStorageProvider/types.ts
+++ b/ui/src/providers/LocalStorageProvider/types.ts
@@ -33,4 +33,5 @@ export type LocalConfig = {
   queryText: string
   editorSplitterBasis: number
   resultsSplitterBasis: number
+  exampleQueriesVisited: boolean
 }

--- a/ui/src/scenes/Editor/Menu/index.tsx
+++ b/ui/src/scenes/Editor/Menu/index.tsx
@@ -78,9 +78,25 @@ const DocsearchInput = styled(Input)`
   white-space: nowrap;
 `
 
-const QueryPickerButton = styled(SecondaryButton)`
+const QueryPickerButton = styled(SecondaryButton)<{
+  $firstTimeVisitor: boolean
+}>`
+  position: relative;
   margin: 0 1rem;
   flex: 0 0 auto;
+
+  ${({ $firstTimeVisitor }) =>
+    $firstTimeVisitor &&
+    `&:after {
+    border-radius: 50%;
+    content: "";
+    background: #dc4949;
+    width: 8px;
+    height: 8px;
+    position: absolute;
+    top: -3px;
+    right: -3px;
+  }`}
 `
 
 const MenuIcon = styled(_MenuIcon)`
@@ -155,12 +171,19 @@ const Menu = () => {
   const running = useSelector(selectors.query.getRunning)
   const opened = useSelector(selectors.console.getSideMenuOpened)
   const { sm } = useScreenSize()
-  const { resultsSplitterBasis, updateSettings } = useLocalStorage()
+  const {
+    resultsSplitterBasis,
+    exampleQueriesVisited,
+    updateSettings,
+  } = useLocalStorage()
 
   const handleClick = useCallback(() => {
     dispatch(actions.query.toggleRunning())
   }, [dispatch])
   const handleToggle = useCallback((active) => {
+    if (!exampleQueriesVisited && active) {
+      updateSettings(StoreKey.EXAMPLE_QUERIES_VISITED, true)
+    }
     setPopperActive(active)
   }, [])
   const handleHidePicker = useCallback(() => {
@@ -238,7 +261,7 @@ const Menu = () => {
           active={popperActive}
           onToggle={handleToggle}
           trigger={
-            <QueryPickerButton onClick={handleClick}>
+            <QueryPickerButton $firstTimeVisitor={!exampleQueriesVisited}>
               <Add size="18px" />
               <span>Example queries</span>
             </QueryPickerButton>

--- a/ui/src/scenes/Editor/Menu/index.tsx
+++ b/ui/src/scenes/Editor/Menu/index.tsx
@@ -79,14 +79,14 @@ const DocsearchInput = styled(Input)`
 `
 
 const QueryPickerButton = styled(SecondaryButton)<{
-  $firstTimeVisitor: boolean
+  firstTimeVisitor: boolean
 }>`
   position: relative;
   margin: 0 1rem;
   flex: 0 0 auto;
 
-  ${({ $firstTimeVisitor }) =>
-    $firstTimeVisitor &&
+  ${({ firstTimeVisitor }) =>
+    firstTimeVisitor &&
     `&:after {
     border-radius: 50%;
     content: "";
@@ -261,7 +261,7 @@ const Menu = () => {
           active={popperActive}
           onToggle={handleToggle}
           trigger={
-            <QueryPickerButton $firstTimeVisitor={!exampleQueriesVisited}>
+            <QueryPickerButton firstTimeVisitor={!exampleQueriesVisited}>
               <Add size="18px" />
               <span>Example queries</span>
             </QueryPickerButton>

--- a/ui/src/utils/localStorage/types.ts
+++ b/ui/src/utils/localStorage/types.ts
@@ -27,6 +27,7 @@ export enum StoreKey {
   QUERY_TEXT = "query.text",
   EDITOR_LINE = "editor.line",
   EDITOR_COL = "editor.col",
+  EXAMPLE_QUERIES_VISITED = "editor.exampleQueriesVisited",
   NOTIFICATION_ENABLED = "notification.enabled",
   NOTIFICATION_DELAY = "notification.delay",
   EDITOR_SPLITTER_BASIS = "splitter.editor.basis",


### PR DESCRIPTION
This PR adds a little red dot on the "Example Queries" button at the top of the editor.

Once user opens the popup, the red dot disappears. This state is saved in local storage.

![image](https://user-images.githubusercontent.com/4284659/160645169-d0bc855d-f331-46ae-95fc-ae03a3421fdc.png)
