### PR TITLE
fix(ui): fix another `appendQuery` erroneous case

### DIFF
--- a/ui/src/scenes/Editor/Monaco/utils.ts
+++ b/ui/src/scenes/Editor/Monaco/utils.ts
@@ -321,7 +321,7 @@ const getTextFixes = ({
     {
       when: () => isFirstLine && lineAtCursor !== "",
       then: () => ({
-        prefix: 1,
+        prefix: nextLine === "" ? 1 : 2,
         suffix: 1,
         selectStartOffset: 1,
       }),


### PR DESCRIPTION
This PR fixes the issue of the following scenario:

1. open https://demo.questdb.io/
1. clear editor from any queries
1. type 'trades' (no semicolon)
1. press Run
1. open https://demo.questdb.io/?query=select%20*%20from%20trades%20latest%20on%20timestamp%20partition%20by%20symbol&executeQuery=true
1. observe that executed query is the wrong one (just 'trades', not the one from URL query)

`appendQuery` should correctly append and select query when cursor
position is first line which is not empty and there's more content after it.

covered by tests [here](https://github.com/questdb/ui/blob/main/packages/browser-tests/cypress/integration/console/editor.spec.js#L56-L76)

