### PR TITLE
Add two tests to the PGWire protocol to exemplify use of java.sql.Timestamp 

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -5663,6 +5663,174 @@ create table tab as (
     }
 
     @Test
+    public void testTimestamp() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (final PGWireServer ignored = createPGServer(1)) {
+                try (final Connection connection = getConnection(false, true)) {
+
+                    connection.setAutoCommit(false);
+                    connection.prepareStatement("CREATE TABLE ts (id INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY MONTH").execute();
+                    connection.prepareStatement("INSERT INTO ts VALUES(0, '2021-09-27T16:45:03.202345Z')").execute();
+                    connection.commit();
+                    connection.setAutoCommit(true);
+
+                    // select the timestamp that we just inserted
+                    Timestamp ts;
+                    try (PreparedStatement statement = connection.prepareStatement("SELECT ts FROM ts")) {
+                        try (ResultSet rs = statement.executeQuery()) {
+                            assertTrue(rs.next());
+                            ts = rs.getTimestamp("ts");
+                        }
+                    }
+
+                    // NOTE: java.sql.Timestamp takes milliseconds from epoch as constructor parameter,
+                    // which is processed and stored internally coupling ts.getTime() and ts.getNanos():
+                    //   - ts.getTime(): the last 3 digits account for millisecond precision, e.g. 1632761103202L -> 202 milliseconds.
+                    //   - ts.getNanos(): the first 3 digits match the last 3 digits from ts.getTime(), then
+                    //         3 more digits follow for micros, and 3 more for nanos,, e.g. 202345000 -> (202)milli(345)micro(000)nano
+                    assertEquals(1632761103202L, ts.getTime());
+                    assertEquals(202345000, ts.getNanos());
+                    assertEquals("2021-09-27 16:45:03.202345", ts.toString());
+
+                    sink.clear();
+                    try (PreparedStatement ps = connection.prepareStatement("INSERT INTO ts VALUES (?, ?)")) {
+                        int rowId = 1;
+
+                        // Case 1: insert timestamp as we selected it, no modifications
+                        // -> microsecond precision is kept
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, ts);
+                        ps.execute();
+
+                        // Case 2: we create a timestamp from another, but there is a catch, we must set the nanos too
+                        // -> microsecond precision is kept
+                        Timestamp aTs = new Timestamp(ts.getTime());
+                        aTs.setNanos(ts.getNanos());
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, aTs);
+                        ps.execute();
+
+                        // Case 3: we create a timestamp from another, and clear the micro precision
+                        // -> microsecond precision is dropped by us
+                        Timestamp bTs = new Timestamp(ts.getTime() * 1000);
+                        bTs.setNanos(202000000);
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, bTs);
+                        ps.execute();
+
+                        // Case 4: if we forget to setNanos, we get a broken timestamp
+                        // -> this results in a broken timestamp 1970-...
+                        Timestamp kaputTs = new Timestamp(ts.getTime());
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, kaputTs);
+                        ps.execute();
+
+                        // Case 4: if we setNanos to 0, we also get a broken timestamp! UNLESS we scale up time
+                        // to trick the constructor
+                        // -> microsecond precision is dropped by us, we keep millisecond precision
+                        Timestamp cTs = new Timestamp(ts.getTime() * 1000);
+                        cTs.setNanos(0); // <=== THIS requires ---- ^ ^
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, cTs);
+                        ps.execute();
+
+                        // Case 5: we use space-age mathematics to produce a long number which is
+                        // equivalent to a QuestDB timestamp WITH MICROSECOND precision, and then
+                        // we can feed it to java.sql.Timestamp without worrying for setNanos.
+                        // -> microsecond precision is lost in this case [*]
+                        long epochMicroNoMillis = (ts.getTime() / 1000) * 1000000;
+                        long actualTimestamp = epochMicroNoMillis + (ts.getNanos() / 1000);
+                        actualTimestamp = (actualTimestamp / 1000) * 1000; // [*] drop micros
+                        Timestamp dTs = new Timestamp(actualTimestamp);
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, dTs);
+                        ps.execute();
+
+                        // Case 6: the complementary approach to Case 5, where we take a QuestDB
+                        // timestamp WITH microsecond precision and we massage it to extract two
+                        // numbers that can be used to create a java.sql.Timestamp.
+                        // -> microsecond precision is kept
+                        long questdbTs = TimestampFormatUtils.parseTimestamp("2021-09-27T16:45:03.202345Z");
+                        long time = questdbTs / 1000;
+                        int nanos = (int)(questdbTs - (int)(questdbTs / 1e6) * 1e6) * 1000;
+                        assertEquals(1632761103202345L, questdbTs);
+                        assertEquals(1632761103202L, time);
+                        assertEquals(202345000, nanos);
+                        Timestamp eTs = new Timestamp(time);
+                        eTs.setNanos(nanos);
+                        ps.setInt(1, rowId++);
+                        ps.setTimestamp(2, eTs);
+                        ps.execute();
+                    }
+
+                    try (PreparedStatement statement = connection.prepareStatement("SELECT id as Case, ts FROM ts ORDER BY id ASC")) {
+                        sink.clear();
+                        try (ResultSet rs = statement.executeQuery()) {
+                            assertResultSet(
+                                    "Case[INTEGER],ts[TIMESTAMP]\n" +
+                                            "0,2021-09-27 16:45:03.202345\n" +
+                                            "1,2021-09-27 16:45:03.202345\n" +
+                                            "2,2021-09-27 16:45:03.202345\n" +
+                                            "3,2021-09-27 16:45:03.202202\n" +
+                                            "4,1970-01-19 21:32:41.103202\n" +
+                                            "5,2021-09-27 16:45:03.202\n" +
+                                            "6,2021-09-27 16:45:03.202\n" +
+                                            "7,2021-09-27 16:45:03.202345\n",
+                                    sink,
+                                    rs
+                            );
+                        }
+                    }
+                    connection.prepareStatement("drop table ts").execute();
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTimestampSentEqualsReceived() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+
+            final Timestamp expectedTs = new Timestamp(1632761103202L); // '2021-09-27T16:45:03.202000Z'
+            assertEquals(1632761103202L, expectedTs.getTime());
+            assertEquals(202000000, expectedTs.getNanos());
+
+            try (final PGWireServer ignored = createPGServer(1)) {
+                try (final Connection conn = getConnection(false, true)) {
+                    conn.setAutoCommit(false);
+                    conn.prepareStatement("CREATE TABLE ts (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY MONTH").execute();
+                    conn.commit();
+                    conn.setAutoCommit(true);
+
+                    // insert
+                    final Timestamp ts = Timestamp.valueOf("2021-09-27 16:45:03.202");
+                    assertEquals(expectedTs.getTime(), ts.getTime());
+                    assertEquals(expectedTs.getNanos(), ts.getNanos());
+                    try (PreparedStatement insert = conn.prepareStatement("INSERT INTO ts VALUES (?)")) {
+                        // QuestDB timestamps have MICROSECOND precision and require you to be aware
+                        // of it if you use java.sql.Timestamp's constructor
+                        insert.setTimestamp(1, new Timestamp(ts.getTime() * 1000));
+                        insert.execute();
+                    }
+
+                    // select
+                    final Timestamp tsBack;
+                    try (ResultSet queryResult = conn.prepareStatement("SELECT * FROM ts").executeQuery()) {
+                        queryResult.next();
+                        tsBack = queryResult.getTimestamp("ts");
+                    }
+                    assertEquals(expectedTs.getTime(), tsBack.getTime());
+                    assertEquals(expectedTs.getNanos(), tsBack.getNanos());
+                    assertEquals(expectedTs, tsBack);
+
+                    // cleanup
+                    conn.prepareStatement("drop table ts").execute();
+                }
+            }
+        });
+    }
+
+    @Test
     public void testUnsupportedParameterType() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (


### PR DESCRIPTION
This PR is in response to https://github.com/questdb/questdb/issues/1359 

Two tests have been added to exemplify the use of java.sql.Timestamp, and to verify that my understanding is correct.