### PR TITLE
fix(pgwire): fix persistent function parser issue

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -321,7 +321,6 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     }
 
     @Override
-
     public void close() {
         clear();
         // fd == -1 is only when context is closed

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -85,6 +85,9 @@ public class PGWireServer implements Closeable {
                         context.getDispatcher().disconnect(context, operation == IOOperation.READ ? DISCONNECT_REASON_PEER_DISCONNECT_AT_RECV : DISCONNECT_REASON_PEER_DISCONNECT_AT_SEND);
                     } catch (BadProtocolException e) {
                         context.getDispatcher().disconnect(context, DISCONNECT_REASON_PROTOCOL_VIOLATION);
+                    } catch (Throwable e) {//must remain last in catch list!
+                        LOG.error().$(e).$();
+                        context.getDispatcher().disconnect(context, DISCONNECT_REASON_SERVER_ERROR);
                     }
                 };
 

--- a/core/src/main/java/io/questdb/griffin/FunctionParser.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionParser.java
@@ -244,7 +244,9 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor, Mutab
                 traverseAlgo.traverse(node, this);
             } catch (SqlException e) {
                 // release parsed functions
-                Misc.free(functionStack.poll());
+                for (int i = functionStack.size(); i > 0; i--) {
+                    Misc.free(functionStack.poll());
+                }
                 positionStack.clear();
                 throw e;
             }

--- a/core/src/main/java/io/questdb/network/IODispatcher.java
+++ b/core/src/main/java/io/questdb/network/IODispatcher.java
@@ -47,6 +47,11 @@ public interface IODispatcher<C extends IOContext> extends Closeable, Job {
     int DISCONNECT_REASON_PEER_DISCONNECT_AT_RECV = 15;
     int DISCONNECT_REASON_TEST = 16;
 
+    /**
+     * Unexpected server error caused connection disconnect (to avoid client working with potentially corrupt server state).
+     */
+    int DISCONNECT_REASON_SERVER_ERROR = 17;
+
     void disconnect(C context, int reason);
 
     int getConnectionCount();

--- a/core/src/test/java/io/questdb/griffin/FunctionParserErrorTest.java
+++ b/core/src/test/java/io/questdb/griffin/FunctionParserErrorTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin;
+
+import org.hamcrest.MatcherAssert;
+
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.Test;
+
+public class FunctionParserErrorTest extends AbstractGriffinTest {
+
+    @Test
+    public void testFunctionParserErrorIsNotPersistent() throws Exception {
+        try {
+            assertQuery("",
+                    "select * from " +
+                            "(select cast(x as timestamp) ts, cast('0x05cb69971d94a00000192178ef80f0' as long256) as id, x from long_sequence(10) ) " +
+                            "where ts between '2022-03-20' AND id <> '0x05ab6d9fabdabb00066a5db735d17a' AND id <> '0x05aba84839b9c7000006765675e630' AND id <> '0x05abc58d80ba1f000001ed05351873'",
+                    null, null, true, false, true);
+        } catch (SqlException e) {
+            MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: between"));
+        }
+
+        runTestQuery();
+    }
+
+    private void runTestQuery() throws Exception {
+        assertQuery("x\n1\n",
+                "select x from long_sequence(1) where x < 10 and x > 0",
+                null, null, true, false, false);
+    }
+
+    @Test
+    public void testFunctionParserErrorIsNotPersistent2() throws Exception {
+        try {
+            assertQuery("",
+                    "select abs(log(1,2), 4) + 10+'asdf' from long_sequence(1);",
+                    null, null, true, false, true);
+        } catch (SqlException e) {
+            MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: log"));
+        }
+
+        runTestQuery();
+    }
+
+    @Test
+    public void testFunctionParserErrorIsNotPersistent3() throws Exception {
+        try {
+            assertQuery("",
+                    "select abs(1,2,3,4) from long_sequence(1)",
+                    null, null, true, false, true);
+        } catch (SqlException e) {
+            MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: abs"));
+        }
+
+        runTestQuery();
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/FunctionParserErrorTest.java
+++ b/core/src/test/java/io/questdb/griffin/FunctionParserErrorTest.java
@@ -28,6 +28,7 @@ import org.hamcrest.MatcherAssert;
 
 import static org.hamcrest.CoreMatchers.*;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class FunctionParserErrorTest extends AbstractGriffinTest {
@@ -40,17 +41,12 @@ public class FunctionParserErrorTest extends AbstractGriffinTest {
                             "(select cast(x as timestamp) ts, cast('0x05cb69971d94a00000192178ef80f0' as long256) as id, x from long_sequence(10) ) " +
                             "where ts between '2022-03-20' AND id <> '0x05ab6d9fabdabb00066a5db735d17a' AND id <> '0x05aba84839b9c7000006765675e630' AND id <> '0x05abc58d80ba1f000001ed05351873'",
                     null, null, true, false, true);
+            Assert.fail();
         } catch (SqlException e) {
             MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: between"));
         }
 
         runTestQuery();
-    }
-
-    private void runTestQuery() throws Exception {
-        assertQuery("x\n1\n",
-                "select x from long_sequence(1) where x < 10 and x > 0",
-                null, null, true, false, false);
     }
 
     @Test
@@ -59,6 +55,7 @@ public class FunctionParserErrorTest extends AbstractGriffinTest {
             assertQuery("",
                     "select abs(log(1,2), 4) + 10+'asdf' from long_sequence(1);",
                     null, null, true, false, true);
+            Assert.fail();
         } catch (SqlException e) {
             MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: log"));
         }
@@ -72,10 +69,17 @@ public class FunctionParserErrorTest extends AbstractGriffinTest {
             assertQuery("",
                     "select abs(1,2,3,4) from long_sequence(1)",
                     null, null, true, false, true);
+            Assert.fail();
         } catch (SqlException e) {
             MatcherAssert.assertThat(e.getMessage(), containsString("unexpected argument for function: abs"));
         }
 
         runTestQuery();
+    }
+
+    private void runTestQuery() throws Exception {
+        assertQuery("x\n1\n",
+                "select x from long_sequence(1) where x < 10 and x > 0",
+                null, null, true, false, false);
     }
 }

--- a/ui/src/scenes/Editor/Monaco/utils.ts
+++ b/ui/src/scenes/Editor/Monaco/utils.ts
@@ -321,7 +321,7 @@ const getTextFixes = ({
     {
       when: () => isFirstLine && lineAtCursor !== "",
       then: () => ({
-        prefix: 1,
+        prefix: nextLine === "" ? 1 : 2,
         suffix: 1,
         selectStartOffset: 1,
       }),


### PR DESCRIPTION
Also - disconnect on unexpected errors to fix jdbc client lockup .

It's probably better to report such errors back to client but : 
1. simply returning "internal server error" in cursor phases doesn't seem to work and client still hangs
2. disconnecting should 'fix' potential server state corruption (as was the case with function parser)