### PR TITLE
fix(cairo): handling of buffer overflow in async command queue

### DIFF
--- a/core/src/main/java/io/questdb/MessageBusImpl.java
+++ b/core/src/main/java/io/questdb/MessageBusImpl.java
@@ -112,7 +112,7 @@ public class MessageBusImpl implements MessageBus {
 
         this.tableWriterEventQueue = new RingQueue<>(
                 TableWriterTask::new,
-                2048,
+                configuration.getWriterCommandQueueSlotSize(),
                 configuration.getWriterCommandQueueCapacity(),
                 MemoryTag.NATIVE_REPL
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -237,6 +237,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long writerDataIndexValueAppendPageSize;
     private final long writerAsyncCommandBusyWaitTimeout;
     private final int writerAsyncCommandQueueCapacity;
+    private final long writerAsyncCommandQueueSlotSize;
     private final int writerTickRowsCountMod;
     private final long writerAsyncCommandMaxWaitTimeout;
     private final int o3PartitionPurgeListCapacity;
@@ -876,6 +877,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.writerAsyncCommandMaxWaitTimeout = getLong(properties, env, "cairo.writer.alter.max.wait.timeout.micro", 30_000_000L);
             this.writerTickRowsCountMod = Numbers.ceilPow2(getInt(properties, env, "cairo.writer.tick.rows.count", 1024)) - 1;
             this.writerAsyncCommandQueueCapacity = Numbers.ceilPow2(getInt(properties, env, "cairo.writer.command.queue.capacity", 32));
+            this.writerAsyncCommandQueueSlotSize = Numbers.ceilPow2(getLongSize(properties, env, "cairo.writer.command.queue.slot.size", 2048));
 
             this.buildInformation = buildInformation;
             this.binaryEncodingMaxLength = getInt(properties, env, "binarydata.encoding.maxlength", 32768);
@@ -2190,6 +2192,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getWriterCommandQueueCapacity() {
             return writerAsyncCommandQueueCapacity;
+        }
+
+        @Override
+        public long getWriterCommandQueueSlotSize() {
+            return writerAsyncCommandQueueSlotSize;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -323,6 +323,8 @@ public interface CairoConfiguration {
 
     int getWriterCommandQueueCapacity();
 
+    long getWriterCommandQueueSlotSize();
+
     long getWriterFileOpenOpts();
 
     int getWriterTickRowsCountMod();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -673,6 +673,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public long getWriterCommandQueueSlotSize() {
+        return 1024;
+    }
+
+    @Override
     public int getWriterTickRowsCountMod() {
         return 1024 - 1;
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -317,7 +317,7 @@ public class TableWriter implements Closeable {
             this.slaveTxReader = new TxReader(ff);
             commandQueue = new RingQueue<>(
                     TableWriterTask::new,
-                    2048,
+                    configuration.getWriterCommandQueueSlotSize(),
                     configuration.getWriterCommandQueueCapacity(),
                     MemoryTag.NATIVE_REPL
             );

--- a/core/src/main/java/io/questdb/mp/RingQueue.java
+++ b/core/src/main/java/io/questdb/mp/RingQueue.java
@@ -68,6 +68,8 @@ public class RingQueue<T> implements Closeable {
         this.memory = Unsafe.calloc(memorySize, memoryTag);
         long p = memory;
         for (int i = 0; i < cycle; i++) {
+            // intention is that whatever comes out of the factory it should work with the
+            // memory allocated by the queue for this slot and should not reallocate ever
             buf[i] = factory.newInstance(p, slotSize);
             p += slotSize;
         }

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -280,6 +280,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(10_000, configuration.getLineTcpReceiverConfiguration().getWriterIdleTimeout());
         Assert.assertEquals(0, configuration.getCairoConfiguration().getSampleByIndexSearchPageSize());
         Assert.assertEquals(32, configuration.getCairoConfiguration().getWriterCommandQueueCapacity());
+        Assert.assertEquals(2048, configuration.getCairoConfiguration().getWriterCommandQueueSlotSize());
         Assert.assertEquals(500_000, configuration.getCairoConfiguration().getWriterAsyncCommandBusyWaitTimeout());
         Assert.assertEquals(30_000_000, configuration.getCairoConfiguration().getWriterAsyncCommandMaxTimeout());
         Assert.assertEquals(1023, configuration.getCairoConfiguration().getWriterTickRowsCountMod());
@@ -631,6 +632,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(64, configuration.getCairoConfiguration().getCreateTableModelPoolCapacity());
             Assert.assertEquals(2001, configuration.getCairoConfiguration().getSampleByIndexSearchPageSize());
             Assert.assertEquals(16, configuration.getCairoConfiguration().getWriterCommandQueueCapacity());
+            Assert.assertEquals(4096, configuration.getCairoConfiguration().getWriterCommandQueueSlotSize());
             Assert.assertEquals(333000, configuration.getCairoConfiguration().getWriterAsyncCommandBusyWaitTimeout());
             Assert.assertEquals(7770001, configuration.getCairoConfiguration().getWriterAsyncCommandMaxTimeout());
             Assert.assertEquals(15, configuration.getCairoConfiguration().getWriterTickRowsCountMod());

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -86,6 +86,7 @@ public class AbstractCairoTest {
     protected static boolean hideTelemetryTable = false;
     private static TelemetryConfiguration telemetryConfiguration;
     protected static int writerCommandQueueCapacity = 4;
+    protected static long writerCommandQueueSlotSize = 2048L;
 
     @BeforeClass
     public static void setUpStatic() {
@@ -233,6 +234,11 @@ public class AbstractCairoTest {
             @Override
             public int getWriterCommandQueueCapacity() {
                 return writerCommandQueueCapacity;
+            }
+
+            @Override
+            public long getWriterCommandQueueSlotSize() {
+                return writerCommandQueueSlotSize;
             }
         };
         engine = new CairoEngine(configuration, metrics);

--- a/core/src/test/java/io/questdb/griffin/TableWriterAsyncCmdTest.java
+++ b/core/src/test/java/io/questdb/griffin/TableWriterAsyncCmdTest.java
@@ -420,6 +420,27 @@ public class TableWriterAsyncCmdTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testCommandQueueBufferOverflow() throws Exception {
+        long tmpWriterCommandQueueSlotSize = writerCommandQueueSlotSize;
+        writerCommandQueueSlotSize = 4L;
+        assertMemoryLeak(() -> {
+            compile("create table product (timestamp timestamp)", sqlExecutionContext);
+
+            // Get the lock so command has to be serialized to writer command queue
+            try (TableWriter writer = engine.getWriter(sqlExecutionContext.getCairoSecurityContext(), "product", "test lock")) {
+                CompiledQuery cc = compiler.compile("ALTER TABLE product add column colTest int", sqlExecutionContext);
+                try {
+                    cc.execute(commandReplySequence);
+                    Assert.fail();
+                } catch (CairoException exception) {
+                    TestUtils.assertContains(exception.getFlyweightMessage(), "async command/event queue buffer overflow");
+                }
+            }
+        });
+        writerCommandQueueSlotSize = tmpWriterCommandQueueSlotSize;
+    }
+
+    @Test
     public void testInvalidAlterDropPartitionStatementQueued() throws Exception {
         assertMemoryLeak(() -> {
             compile("create table product (timestamp timestamp, name symbol nocache)", sqlExecutionContext);

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -121,6 +121,7 @@ cairo.writer.alter.busy.wait.timeout.micro=333000
 cairo.writer.alter.max.wait.timeout.micro=7770001
 cairo.writer.tick.rows.count=15
 cairo.writer.command.queue.capacity=16
+cairo.writer.command.queue.slot.size=4K
 
 cairo.rnd.memory.page.size=16K
 cairo.rnd.memory.max.pages=32


### PR DESCRIPTION
TableWriter can be asked to run commands asynchronously if the writer is busy.
When this happens the command is serialised into a task and put on the writer's async command queue.
Each task owns a slot on the queue's buffer and it uses the memory of that specific slot.

If the serialised command could not fit in the memory assigned to the slot the task tried to reallocate memory.
There were two issues with this:
- the newly allocated memory was never released
- in principle the task should not allocate its own memory, it should use the memory slot given to it by the queue and the pointer should be made final

Removed memory resizing and changed the task to throw an exception on buffer overflow.
ILP deals with the situation the same way.