### PR TITLE
fix(sql): fix brace matching inside cast

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -74,7 +74,7 @@ mvn -pl !benchmarks clean deploy -DskipTests -P build-web-console,maven-central-
 To run with the Web Console, you need to rebuild to include the pre-packaged
 `/core/src/main/resources/io/questdb/site/public.zip`.
 
-``bash
+```bash
 mvn clean package --batch-mode --quiet -DskipTests -P build-web-console,build-binaries
 ```
 


### PR DESCRIPTION
Fixes #1452 

The original problem description "Expression parser does not always parse CASE statement correctly" is actually that, braces inside `CAST` are not properly matched, thus any nested arithmetic with braces will cause the error.