### PR TITLE
fix(sql): fix timestamp designated timestamp column data type validation

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -500,7 +500,11 @@ public final class SqlParser {
         ExpressionNode timestamp = parseTimestamp(lexer, tok);
         if (timestamp != null) {
             // ignore index, validate column
-            getCreateTableColumnIndex(model, timestamp.token, timestamp.position);
+            int timestampIdx = getCreateTableColumnIndex(model, timestamp.token, timestamp.position);
+            int timestampType = model.getColumnType(timestampIdx);
+            if (timestampType != ColumnType.TIMESTAMP && timestampType != -1) { //type can be -1 for create table as select because types aren't known yet
+                throw SqlException.position(timestamp.position).put("TIMESTAMP column expected [actual=").put(ColumnType.nameOf(timestampType)).put(']');
+            }
             model.setTimestamp(timestamp);
             tok = optTok(lexer);
         }

--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -6823,6 +6823,15 @@ public class SqlParserTest extends AbstractSqlParserTest {
         );
     }
 
+    @Test
+    public void testInvalidTypeUsedAsDesignatedTimestamp() throws Exception {
+        assertSyntaxError(
+                "CREATE TABLE ts_test ( close_date date ) timestamp(close_date);",
+                51,
+                "TIMESTAMP column expected [actual=DATE]"
+        );
+    }
+
     private void assertCreateTable(String expected, String ddl, TableModel... tableModels) throws SqlException {
         assertModel(expected, ddl, ExecutionModel.CREATE_TABLE, tableModels);
     }


### PR DESCRIPTION
Fixed inadequate designated timestamp column validation in CREATE TABLE statement.  

Example : 

```sql
CREATE TABLE ts_test (
  close_date timestamp
) timestamp(close_date);

Invalid metadata at fd=1096. Timestamp column must be TIMESTAMP, but found DATE

select * from ts_test; 

[-100]: Metadata read timeout. Last error: Metadata read timeout. Last error:

alter table ts_test add column ( x int);

table 'ts_test' could not be altered: [-100]: Metadata read timeout. Last error: Metadata read timeout. Last error:

create table ts_test (x int);

cannot acquire table lock [lockedReason=createTable]

drop table ts_test;

Could not lock 'ts_test' [reason='createTable']
```