### PR TITLE
feat(http): use status code 400 to indicate errors

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -284,9 +284,10 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
 
     protected static void header(
             HttpChunkedResponseSocket socket,
-            CharSequence keepAliveHeader
+            CharSequence keepAliveHeader,
+            int status_code
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        socket.status(200, "application/json; charset=utf-8");
+        socket.status(status_code, "application/json; charset=utf-8");
         socket.headers().setKeepAlive(keepAliveHeader);
         socket.sendHeader();
     }
@@ -316,7 +317,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
     private static void sendConfirmation(JsonQueryProcessorState state, CharSequence keepAliveHeader) throws PeerDisconnectedException, PeerIsSlowToReadException {
         final HttpConnectionContext context = state.getHttpConnectionContext();
         final HttpChunkedResponseSocket socket = context.getChunkedResponseSocket();
-        header(socket, keepAliveHeader);
+        header(socket, keepAliveHeader, 200);
         socket.put('{').putQuoted("ddl").put(':').putQuoted("OK").put('}').put('\n');
         socket.sendChunk(true);
         readyForNextRequest(context);
@@ -329,7 +330,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             CharSequence query,
             CharSequence keepAliveHeader
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        header(socket, keepAliveHeader);
+        header(socket, keepAliveHeader, 400);
         JsonQueryProcessorState.prepareExceptionJson(socket, position, message, query);
     }
 
@@ -446,7 +447,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         final HttpConnectionContext context = state.getHttpConnectionContext();
         try {
             if (state.of(factory, sqlExecutionContext)) {
-                header(context.getChunkedResponseSocket(), keepAliveHeader);
+                header(context.getChunkedResponseSocket(), keepAliveHeader, 200);
                 doResumeSend(state, context);
                 metrics.jsonQuery().markComplete();
             } else {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -381,7 +381,7 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
         if (start == hi) {
             info().$("empty column in list '").$(columnNames).$('\'').$();
             HttpChunkedResponseSocket socket = getHttpConnectionContext().getChunkedResponseSocket();
-            JsonQueryProcessor.header(socket, "");
+            JsonQueryProcessor.header(socket, "", 400);
             socket.put('{').
                     putQuoted("query").put(':').encodeUtf8AndQuote(query).put(',').
                     putQuoted("error").put(':').putQuoted("empty column in list");
@@ -394,7 +394,7 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
         if (columnIndex == RecordMetadata.COLUMN_NOT_FOUND) {
             info().$("invalid column in list: '").$(columnNames, start, hi).$('\'').$();
             HttpChunkedResponseSocket socket = getHttpConnectionContext().getChunkedResponseSocket();
-            JsonQueryProcessor.header(socket, "");
+            JsonQueryProcessor.header(socket, "", 400);
             socket.put('{').
                     putQuoted("query").put(':').encodeUtf8AndQuote(query).put(',').
                     putQuoted("error").put(':').put('\'').put("invalid column in list: ").put(columnNames, start, hi).put('\'');
@@ -637,7 +637,7 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
             } catch (Utf8Exception e) {
                 info().$("utf8 error when decoding column list '").$(columnNames).$('\'').$();
                 HttpChunkedResponseSocket socket = getHttpConnectionContext().getChunkedResponseSocket();
-                JsonQueryProcessor.header(socket, "");
+                JsonQueryProcessor.header(socket, "", 400);
                 socket.put('{').
                         putQuoted("error").put(':').putQuoted("utf8 error in column list");
                 socket.put('}');

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -148,7 +148,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
                         }
                     } while (runQuery);
                     state.metadata = state.recordCursorFactory.getMetadata();
-                    header(context.getChunkedResponseSocket(), state);
+                    header(context.getChunkedResponseSocket(), state, 200);
                     resumeSend(context);
                 } catch (CairoException e) {
                     state.setQueryCacheable(e.isCacheable());
@@ -321,8 +321,8 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         return LOG.error().$('[').$(state.getFd()).$("] ");
     }
 
-    protected void header(HttpChunkedResponseSocket socket, TextQueryProcessorState state) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        socket.status(200, "text/csv; charset=utf-8");
+    protected void header(HttpChunkedResponseSocket socket, TextQueryProcessorState state, int status_code) throws PeerDisconnectedException, PeerIsSlowToReadException {
+        socket.status(status_code, "text/csv; charset=utf-8");
         if (state.fileName != null && state.fileName.length() > 0) {
             socket.headers().put("Content-Disposition: attachment; filename=\"").put(state.fileName).put(".csv\"").put(Misc.EOL);
         } else {
@@ -541,7 +541,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
             CharSequence message,
             TextQueryProcessorState state
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        header(socket, state);
+        header(socket, state, 400);
         JsonQueryProcessorState.prepareExceptionJson(socket, position, message, state.query);
     }
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -620,7 +620,7 @@ public class IODispatcherTest {
                         ",2200\r\n" +
                         ",11\r\n" +
                         ",2200\r\n" +
-                        "\r\n"+
+                        "\r\n" +
                         "00\r\n" +
                         "\r\n"
         );
@@ -2345,7 +2345,7 @@ public class IODispatcherTest {
                         "Accept-Encoding: gzip, deflate, br\r\n" +
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -2966,7 +2966,7 @@ public class IODispatcherTest {
                         "Accept-Encoding: gzip, deflate, br\r\n" +
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -2992,7 +2992,7 @@ public class IODispatcherTest {
                         "Accept-Encoding: gzip, deflate, br\r\n" +
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -3146,7 +3146,7 @@ public class IODispatcherTest {
                         "Accept-Encoding: gzip, deflate, br\r\n" +
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -3170,7 +3170,7 @@ public class IODispatcherTest {
                         "Accept-Encoding: gzip, deflate, br\r\n" +
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -3237,7 +3237,7 @@ public class IODispatcherTest {
                         "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                         "Cookie: _ga=GA1.1.2124932001.1573824669; _gid=GA1.1.1731187971.1580598042\r\n" +
                         "\r\n",
-                "HTTP/1.1 200 OK\r\n" +
+                "HTTP/1.1 400 Bad request\r\n" +
                         "Server: questDB/1.0\r\n" +
                         "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                         "Transfer-Encoding: chunked\r\n" +
@@ -4100,7 +4100,7 @@ public class IODispatcherTest {
                             "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
                             "\r\n";
 
-                    String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                    String expectedResponse = "HTTP/1.1 400 Bad request\r\n" +
                             "Server: questDB/1.0\r\n" +
                             "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                             "Transfer-Encoding: chunked\r\n" +
@@ -6235,6 +6235,87 @@ public class IODispatcherTest {
                 1
         );
     }
+
+    @Test
+    public void testTextQueryInsertViaWrongEndpoint() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(temp)
+                .withWorkerCount(2)
+                .withHttpServerConfigBuilder(
+                        new HttpServerConfigurationBuilder()
+                                .withNetwork(NetworkFacadeImpl.INSTANCE)
+                                .withDumpingTraffic(false)
+                                .withAllowDeflateBeforeSend(false)
+                                .withHttpProtocolVersion("HTTP/1.1 ")
+                                .withServerKeepAlive(true)
+                )
+                .run((engine) -> {
+                            SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1);
+                            try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                                sendAndReceive(
+                                        NetworkFacadeImpl.INSTANCE,
+                                        "GET /exec?query=create%20table%20tab%20(x%20int) HTTP/1.1\r\n" +
+                                                "Host: localhost:9000\r\n" +
+                                                "Connection: keep-alive\r\n" +
+                                                "Accept: */*\r\n" +
+                                                "X-Requested-With: XMLHttpRequest\r\n" +
+                                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36\r\n" +
+                                                "Sec-Fetch-Site: same-origin\r\n" +
+                                                "Sec-Fetch-Mode: cors\r\n" +
+                                                "Referer: http://localhost:9000/index.html\r\n" +
+                                                "Accept-Encoding: gzip, deflate, br\r\n" +
+                                                "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                                                "\r\n",
+                                        "HTTP/1.1 200 OK\r\n" +
+                                                "Server: questDB/1.0\r\n" +
+                                                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                                "Transfer-Encoding: chunked\r\n" +
+                                                "Content-Type: application/json; charset=utf-8\r\n" +
+                                                "Keep-Alive: timeout=5, max=10000\r\n" +
+                                                "\r\n" +
+                                                JSON_DDL_RESPONSE,
+                                        1,
+                                        0,
+                                        false,
+                                        true
+                                );
+
+                                sendAndReceive(
+                                        NetworkFacadeImpl.INSTANCE,
+                                        "GET /exp?query=insert%20into%20tab%20value%20(1) HTTP/1.1\r\n" +
+                                                "Host: localhost:9000\r\n" +
+                                                "Connection: keep-alive\r\n" +
+                                                "Accept: */*\r\n" +
+                                                "X-Requested-With: XMLHttpRequest\r\n" +
+                                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36\r\n" +
+                                                "Sec-Fetch-Site: same-origin\r\n" +
+                                                "Sec-Fetch-Mode: cors\r\n" +
+                                                "Referer: http://localhost:9000/index.html\r\n" +
+                                                "Accept-Encoding: gzip, deflate, br\r\n" +
+                                                "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                                                "\r\n",
+                                        "HTTP/1.1 400 Bad request\r\n" +
+                                                "Server: questDB/1.0\r\n" +
+                                                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                                "Transfer-Encoding: chunked\r\n" +
+                                                "Content-Type: text/csv; charset=utf-8\r\n" +
+                                                "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                                                "Keep-Alive: timeout=5, max=10000\r\n" +
+                                                "\r\n" +
+                                                "5b\r\n" +
+                                                "{\"query\":\"insert into tab value (1)\",\"error\":\"'select' or 'values' expected\",\"position\":16}\r\n" +
+                                                "00\r\n" +
+                                                "\r\n",
+                                        1,
+                                        0,
+                                        false,
+                                        true
+                                );
+                            }
+                        }
+                );
+    }
+
 
     @Test
     public void testTextQueryPseudoRandomStability() throws Exception {

--- a/ui/src/utils/questdb.ts
+++ b/ui/src/utils/questdb.ts
@@ -228,7 +228,7 @@ export class Client {
       }
     }
 
-    if (response.ok) {
+    if (response.ok || response.status == 400) {
       const fetchTime = (new Date().getTime() - start.getTime()) * 1e6
       const data = (await response.json()) as RawResult
 


### PR DESCRIPTION
Closes #359 

The existing codes are already able to detect the errors and an error message will be returned, it's more reasonable to use the status code 400 with it to help the users know that something wrong happened, since checking the status code is always easier than checking the body.

---

#1949 is closed, leaving behind several problems, some are solved in this PR.
However, I still have a question:

- ~I'm not familiar with NGINX so far 😭 I'd appreciate it if you could simply point me in the right direction on how to test it.~ (solved)
  > NGINX reverse proxy has to be tested for no adverse effects of changing the code. This step is manual.