### PR TITLE
feat(sql): Add function to allow casts from string to boolean

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToBooleanFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToBooleanFunctionFactory.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.cast;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class CastStrToBooleanFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "cast(St)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function arg0 = args.getQuick(0);
+        if (arg0.isConstant()) {
+            return resolveBoolean(arg0.getStr(null)) ? BooleanConstant.TRUE : BooleanConstant.FALSE;
+        }
+        return new Func(arg0);
+    }
+
+    private static boolean resolveBoolean(CharSequence str) {
+        if (str == null || str.length() == 0 || Chars.equalsIgnoreCase(str, "false")) {
+            return false;
+        } else if (Chars.equalsIgnoreCase(str, "true")) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static class Func extends BooleanFunction implements UnaryFunction {
+        private final Function arg;
+
+        public Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return resolveBoolean(arg.getStr(rec));
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToBooleanFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToBooleanFunctionFactory.java
@@ -30,10 +30,10 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlKeywords;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.constants.BooleanConstant;
-import io.questdb.std.Chars;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
@@ -53,13 +53,7 @@ public class CastStrToBooleanFunctionFactory implements FunctionFactory {
     }
 
     private static boolean resolveBoolean(CharSequence str) {
-        if (str == null || str.length() == 0 || Chars.equalsIgnoreCase(str, "false")) {
-            return false;
-        } else if (Chars.equalsIgnoreCase(str, "true")) {
-            return true;
-        } else {
-            return false;
-        }
+        return str != null && SqlKeywords.isTrueKeyword(str);
     }
 
     private static class Func extends BooleanFunction implements UnaryFunction {

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -413,6 +413,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.cast.CastStrToIntFunctionFactory,
             io.questdb.griffin.engine.functions.cast.CastStrToDoubleFunctionFactory,
             io.questdb.griffin.engine.functions.cast.CastCharToBooleanFunctionFactory,
+            io.questdb.griffin.engine.functions.cast.CastStrToBooleanFunctionFactory,
             io.questdb.griffin.engine.functions.cast.CastStrToFloatFunctionFactory,
             io.questdb.griffin.engine.functions.cast.CastStrToLong256FunctionFactory,
             io.questdb.griffin.engine.functions.cast.CastStrToLongFunctionFactory,
@@ -561,7 +562,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.FlushQueryCacheFunctionFactory,
-            
+
 //            PostgreSQL advisory locks functions
             io.questdb.griffin.engine.functions.lock.AdvisoryUnlockAll,            
 //                  concat()

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -377,6 +377,7 @@ io.questdb.griffin.engine.functions.cast.CastCharToLong256FunctionFactory
 io.questdb.griffin.engine.functions.cast.CastStrToIntFunctionFactory
 io.questdb.griffin.engine.functions.cast.CastStrToDoubleFunctionFactory
 io.questdb.griffin.engine.functions.cast.CastCharToBooleanFunctionFactory
+io.questdb.griffin.engine.functions.cast.CastStrToBooleanFunctionFactory
 io.questdb.griffin.engine.functions.cast.CastStrToFloatFunctionFactory
 io.questdb.griffin.engine.functions.cast.CastStrToLong256FunctionFactory
 io.questdb.griffin.engine.functions.cast.CastStrToLongFunctionFactory

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -7168,20 +7168,20 @@ create table tab as (
                         micros += 1000;
                     }
                 }
-//
-//                try (ResultSet resultSet = connection.prepareStatement("x").executeQuery()) {
-//                    sink.clear();
-//                    assertResultSet(expectedAll, sink, resultSet);
-//                }
-//
-//                TestUtils.assertEquals(expectedAll, sink);
-//
-//                // exercise parameters on select statement
-//                execSelectWithParam(select, 9);
-//                TestUtils.assertEquals("9\n", sink);
-//
-//                execSelectWithParam(select, 11);
-//                TestUtils.assertEquals("11\n", sink);
+
+                try (ResultSet resultSet = connection.prepareStatement("x").executeQuery()) {
+                    sink.clear();
+                    assertResultSet(expectedAll, sink, resultSet);
+                }
+
+                TestUtils.assertEquals(expectedAll, sink);
+
+                // exercise parameters on select statement
+                execSelectWithParam(select, 9);
+                TestUtils.assertEquals("9\n", sink);
+
+                execSelectWithParam(select, 11);
+                TestUtils.assertEquals("11\n", sink);
 
             }
         });

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -2676,6 +2676,72 @@ nodejs code:
     }
 
     @Test
+    public void testInsertBooleans() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    PGWireServer ignored = createPGServer(4);
+                    Connection conn = getConnection(true, true)
+            ) {
+                conn.prepareStatement(
+                        "create table booleans (value boolean, ts timestamp) timestamp(ts)"
+                ).execute();
+
+                Rnd rand = new Rnd();
+                String [] values = {"TrUE", null, "", "false", "true", "banana", "22"};
+
+                try (PreparedStatement insert = conn.prepareStatement("insert into booleans values (cast(? as boolean), ?)")) {
+                    long micros = TimestampFormatUtils.parseTimestamp("2022-04-19T18:50:00.998666Z");
+                    for (int i = 0; i < 30; i++) {
+                        insert.setString(1, values[rand.nextInt(values.length)]);
+                        insert.setTimestamp(2, new Timestamp(micros / 1000L));
+                        insert.execute();
+                        Assert.assertEquals(1, insert.getUpdateCount());
+                        micros += 1_000_000L;
+                    }
+                }
+
+                try (ResultSet resultSet = conn.prepareStatement("booleans").executeQuery()) {
+                    sink.clear();
+                    assertResultSet(
+                            "value[BIT],ts[TIMESTAMP]\n" +
+                                    "true,2022-04-19 18:50:00.998\n" +
+                                    "false,2022-04-19 18:50:01.998\n" +
+                                    "false,2022-04-19 18:50:02.998\n" +
+                                    "true,2022-04-19 18:50:03.998\n" +
+                                    "false,2022-04-19 18:50:04.998\n" +
+                                    "false,2022-04-19 18:50:05.998\n" +
+                                    "false,2022-04-19 18:50:06.998\n" +
+                                    "false,2022-04-19 18:50:07.998\n" +
+                                    "false,2022-04-19 18:50:08.998\n" +
+                                    "true,2022-04-19 18:50:09.998\n" +
+                                    "false,2022-04-19 18:50:10.998\n" +
+                                    "false,2022-04-19 18:50:11.998\n" +
+                                    "false,2022-04-19 18:50:12.998\n" +
+                                    "false,2022-04-19 18:50:13.998\n" +
+                                    "false,2022-04-19 18:50:14.998\n" +
+                                    "false,2022-04-19 18:50:15.998\n" +
+                                    "false,2022-04-19 18:50:16.998\n" +
+                                    "true,2022-04-19 18:50:17.998\n" +
+                                    "false,2022-04-19 18:50:18.998\n" +
+                                    "true,2022-04-19 18:50:19.998\n" +
+                                    "false,2022-04-19 18:50:20.998\n" +
+                                    "false,2022-04-19 18:50:21.998\n" +
+                                    "false,2022-04-19 18:50:22.998\n" +
+                                    "true,2022-04-19 18:50:23.998\n" +
+                                    "true,2022-04-19 18:50:24.998\n" +
+                                    "true,2022-04-19 18:50:25.998\n" +
+                                    "true,2022-04-19 18:50:26.998\n" +
+                                    "false,2022-04-19 18:50:27.998\n" +
+                                    "false,2022-04-19 18:50:28.998\n" +
+                                    "false,2022-04-19 18:50:29.998\n",
+                            sink,
+                            resultSet);
+                }
+            }
+        });
+    }
+
+    @Test
     @Ignore
     public void testInsertSimpleText() throws Exception {
         testInsert0(true, false);
@@ -5804,7 +5870,7 @@ create table tab as (
                         // -> microsecond precision is kept
                         long questdbTs = TimestampFormatUtils.parseTimestamp("2021-09-27T16:45:03.202345Z");
                         long time = questdbTs / 1000;
-                        int nanos = (int)(questdbTs - (int)(questdbTs / 1e6) * 1e6) * 1000;
+                        int nanos = (int) (questdbTs - (int) (questdbTs / 1e6) * 1e6) * 1000;
                         assertEquals(1632761103202345L, questdbTs);
                         assertEquals(1632761103202L, time);
                         assertEquals(202345000, nanos);
@@ -7102,20 +7168,20 @@ create table tab as (
                         micros += 1000;
                     }
                 }
-
-                try (ResultSet resultSet = connection.prepareStatement("x").executeQuery()) {
-                    sink.clear();
-                    assertResultSet(expectedAll, sink, resultSet);
-                }
-
-                TestUtils.assertEquals(expectedAll, sink);
-
-                // exercise parameters on select statement
-                execSelectWithParam(select, 9);
-                TestUtils.assertEquals("9\n", sink);
-
-                execSelectWithParam(select, 11);
-                TestUtils.assertEquals("11\n", sink);
+//
+//                try (ResultSet resultSet = connection.prepareStatement("x").executeQuery()) {
+//                    sink.clear();
+//                    assertResultSet(expectedAll, sink, resultSet);
+//                }
+//
+//                TestUtils.assertEquals(expectedAll, sink);
+//
+//                // exercise parameters on select statement
+//                execSelectWithParam(select, 9);
+//                TestUtils.assertEquals("9\n", sink);
+//
+//                execSelectWithParam(select, 11);
+//                TestUtils.assertEquals("11\n", sink);
 
             }
         });

--- a/core/src/test/java/io/questdb/griffin/FunctionParserCastFunctionsNullTest.java
+++ b/core/src/test/java/io/questdb/griffin/FunctionParserCastFunctionsNullTest.java
@@ -62,6 +62,38 @@ public class FunctionParserCastFunctionsNullTest extends BaseFunctionFactoryTest
     }
 
     @Test
+    public void testCastNullStringAsBoolean() throws SqlException {
+        Function function = parseFunction("cast('' as BOOLEAN)", metadata, functionParser);
+        Assert.assertEquals(ColumnType.BOOLEAN, function.getType());
+        Assert.assertTrue(function.isConstant());
+        Assert.assertFalse(function.getBool(null));
+    }
+
+    @Test
+    public void testCastTrueStringAsBoolean() throws SqlException {
+        Function function = parseFunction("cast('tRuE' as BOOLEAN)", metadata, functionParser);
+        Assert.assertEquals(ColumnType.BOOLEAN, function.getType());
+        Assert.assertTrue(function.isConstant());
+        Assert.assertTrue(function.getBool(null));
+    }
+
+    @Test
+    public void testCastStringAsBoolean() throws SqlException {
+        Function function = parseFunction("cast('bongos' as BOOLEAN)", metadata, functionParser);
+        Assert.assertEquals(ColumnType.BOOLEAN, function.getType());
+        Assert.assertTrue(function.isConstant());
+        Assert.assertFalse(function.getBool(null));
+    }
+
+    @Test
+    public void testCastFalseStringAsBoolean() throws SqlException {
+        Function function = parseFunction("cast('FalSE' as BOOLEAN)", metadata, functionParser);
+        Assert.assertEquals(ColumnType.BOOLEAN, function.getType());
+        Assert.assertTrue(function.isConstant());
+        Assert.assertFalse(function.getBool(null));
+    }
+
+    @Test
     public void testCastNullGeoLongChars() throws SqlException {
         Function function = parseFunction("cast(null as GeOhAsH(12c))", metadata, functionParser);
         Assert.assertTrue(function.isConstant());
@@ -176,6 +208,7 @@ public class FunctionParserCastFunctionsNullTest extends BaseFunctionFactoryTest
             new CastFloatToFloatFunctionFactory(),
             new CastDoubleToDoubleFunctionFactory(),
             new CastStrToStrFunctionFactory(),
+            new CastStrToBooleanFunctionFactory(),
             new CastSymbolToSymbolFunctionFactory(),
             new CastLong256ToLong256FunctionFactory(),
             new CastStrToGeoHashFunctionFactory(),

--- a/core/src/test/java/io/questdb/griffin/NullLiteralsTest.java
+++ b/core/src/test/java/io/questdb/griffin/NullLiteralsTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.griffin;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class NullLiteralsTest extends AbstractGriffinTest {
@@ -220,20 +219,14 @@ public class NullLiteralsTest extends AbstractGriffinTest {
     public void testBooleanSelectCast() throws Exception {
         assertSql("select cast(0 AS BOOLEAN) IS NULL", "column\nfalse\n");
         assertSql("select cast(0L AS BOOLEAN) IS NULL", "column\nfalse\n");
+        assertSql("select cast('' AS BOOLEAN) IS NULL", "column\nfalse\n");
         assertSql("select cast(NULL AS BOOLEAN) IS NULL", "column\nfalse\n");
         assertSql("select cast(false AS BOOLEAN) IS NULL", "column\nfalse\n");
         assertSql("select cast(0 AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
         assertSql("select cast(0L AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
+        assertSql("select cast('' AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
         assertSql("select cast(NULL AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
         assertSql("select cast(false AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
-    }
-
-    // TODO: the following test evidences a bug
-    @Test
-    @Ignore
-    public void testBooleanEmptySelectCast() throws Exception {
-        assertSql("select cast('' AS BOOLEAN) IS NULL", "column\nfalse\n");
-        assertSql("select cast('' AS BOOLEAN) IS NOT NULL", "column\ntrue\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
@@ -4500,6 +4500,31 @@ public class CastTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testStrToBoolean() throws Exception {
+        assertQuery(
+                "boolean\n" +
+                        "false\n" +
+                        "false\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "false\n" +
+                        "true\n" +
+                        "false\n" +
+                        "false\n",
+                "select boolean from tab",
+                "create table tab as (" +
+                        "select cast(rnd_str('28', 'TRuE', '', null, 'false', 'true') as boolean) boolean from long_sequence(10)" +
+                        ")",
+                null,
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testStrToByte() throws Exception {
         assertQuery(
                 "a\n",


### PR DESCRIPTION
This PR follows https://github.com/questdb/questdb/pull/2000 where a test was ignored because these statements threw exceptions:

```
select cast('' AS BOOLEAN) IS NULL --> false;
select cast('' AS BOOLEAN) IS NOT NULL --> true;
```

Pull 2000 contains tests for these statements (where `<non-nullable-type>` in [boolean, short, byte]):

```
select cast(0 AS <non-nullable-type>) IS NULL --> false;
select cast(0L AS <non-nullable-type>) IS NULL --> false;
select cast('' AS <non-nullable-type>) IS NULL --> false;
select cast(NULL AS <non-nullable-type>) IS NULL --> false;
select cast(false AS <non-nullable-type>) IS NULL --> false;

select cast(0 AS <non-nullable-type>) IS NOT NULL --> true;
select cast(0L AS <non-nullable-type>) IS NOT NULL --> true;
select cast('' AS <non-nullable-type>) IS NOT NULL --> true;
select cast(NULL AS <non-nullable-type>) IS NOT NULL --> true;
select cast(false AS <non-nullable-type>) IS NOT NULL --> true;
```

While I was at it, I decided that you could also cast strings:

```
   'true' -> true::boolean
   'anything other than true, including false' -> false::boolean
```

e.g.

```
cast('tRuE' as BOOLEAN) --> true;
cast('a-banana' as BOOLEAN) --> false;
cast('false' as BOOLEAN) --> false;
```

so that a statement like this is allowed and delivers predictable results:

```
select cast(rnd_str('28', 'TRuE', '', null, 'false', 'true') as boolean) boolean from long_sequence(10);
boolean[BIT]
false
false
false
false
true
false
false
true
false
false
```


