### PR TITLE
feat(config): Made config validation optional, but enabled for new installs.

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -56,7 +56,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.*;
-import java.util.function.BiConsumer;
 
 public class PropServerConfiguration implements ServerConfiguration {
     public static final String CONFIG_DIRECTORY = "conf";
@@ -3040,6 +3039,23 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
+    private static void registerDeprecated(PropertyKey old, PropertyKey... replacements) {
+        StringBuilder sb = new StringBuilder("Replaced by ");
+        for (int index = 0; index < replacements.length; ++index) {
+            if (index > 0) {
+                sb.append(index < (replacements.length - 1)
+                    ? ", "
+                    : " and ");
+            }
+            String replacement = replacements[index].getPropertyPath();
+            sb.append('`');
+            sb.append(replacement);
+            sb.append('`');
+        }
+        sb.append('.');
+        DEPRECATED_SETTINGS.put(old, sb.toString());
+    }
+
     static {
         WRITE_FO_OPTS.put("o_direct", (int) CairoConfiguration.O_DIRECT);
         WRITE_FO_OPTS.put("o_sync", (int) CairoConfiguration.O_SYNC);
@@ -3050,63 +3066,56 @@ public class PropServerConfiguration implements ServerConfiguration {
             "line.tcp.commit.timeout",
             "Replaced by `line.tcp.commit.interval.default` and `line.tcp.commit.interval.fraction`.");
 
-        BiConsumer<PropertyKey, PropertyKey> registerDeprecated =
-            (PropertyKey oldSetting, PropertyKey newSetting) -> {
-                DEPRECATED_SETTINGS.put(
-                    oldSetting,
-                    "Replaced by `" + newSetting.getPropertyPath() +"`.");
-            };
-
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_MIN_BIND_TO,
             PropertyKey.HTTP_MIN_NET_BIND_TO);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_MIN_NET_IDLE_CONNECTION_TIMEOUT,
             PropertyKey.HTTP_MIN_NET_CONNECTION_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_MIN_NET_QUEUED_CONNECTION_TIMEOUT,
             PropertyKey.HTTP_MIN_NET_CONNECTION_QUEUE_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_MIN_NET_SND_BUF_SIZE,
             PropertyKey.HTTP_MIN_NET_CONNECTION_SNDBUF);
-        DEPRECATED_SETTINGS.put(
+        registerDeprecated(
             PropertyKey.HTTP_NET_RCV_BUF_SIZE,
-            "Replaced by `" + PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF.getPropertyPath() +
-            "` and `" + PropertyKey.HTTP_NET_CONNECTION_RCVBUF.getPropertyPath() + "`.");
-        registerDeprecated.accept(
+            PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF,
+            PropertyKey.HTTP_NET_CONNECTION_RCVBUF);
+        registerDeprecated(
             PropertyKey.HTTP_NET_ACTIVE_CONNECTION_LIMIT,
             PropertyKey.HTTP_NET_CONNECTION_LIMIT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_NET_IDLE_CONNECTION_TIMEOUT,
             PropertyKey.HTTP_NET_CONNECTION_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_NET_QUEUED_CONNECTION_TIMEOUT,
             PropertyKey.HTTP_NET_CONNECTION_QUEUE_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.HTTP_NET_SND_BUF_SIZE,
             PropertyKey.HTTP_NET_CONNECTION_SNDBUF);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.PG_NET_ACTIVE_CONNECTION_LIMIT,
             PropertyKey.PG_NET_CONNECTION_LIMIT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.PG_NET_IDLE_TIMEOUT,
             PropertyKey.PG_NET_CONNECTION_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.PG_NET_RECV_BUF_SIZE,
             PropertyKey.PG_NET_CONNECTION_RCVBUF);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.LINE_TCP_NET_ACTIVE_CONNECTION_LIMIT,
             PropertyKey.LINE_TCP_NET_CONNECTION_LIMIT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.LINE_TCP_NET_IDLE_TIMEOUT,
             PropertyKey.LINE_TCP_NET_CONNECTION_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.LINE_TCP_NET_QUEUED_TIMEOUT,
             PropertyKey.LINE_TCP_NET_CONNECTION_QUEUE_TIMEOUT);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.LINE_TCP_NET_RECV_BUF_SIZE,
             PropertyKey.LINE_TCP_NET_CONNECTION_RCVBUF);
-        registerDeprecated.accept(
+        registerDeprecated(
             PropertyKey.LINE_TCP_DEFAULT_PARTITION_BY,
             PropertyKey.LINE_DEFAULT_PARTITION_BY);
     }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3039,7 +3039,10 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private static void registerDeprecated(PropertyKey old, PropertyKey... replacements) {
+    private static <KeyT> void registerReplacements(
+            Map<KeyT, String> map,
+            KeyT old,
+            PropertyKey... replacements) {
         StringBuilder sb = new StringBuilder("Replaced by ");
         for (int index = 0; index < replacements.length; ++index) {
             if (index > 0) {
@@ -3052,8 +3055,15 @@ public class PropServerConfiguration implements ServerConfiguration {
             sb.append(replacement);
             sb.append('`');
         }
-        sb.append('.');
-        DEPRECATED_SETTINGS.put(old, sb.toString());
+        map.put(old, sb.toString());
+    }
+
+    private static void registerObsolete(String old, PropertyKey... replacements) {
+        registerReplacements(OBSOLETE_SETTINGS, old, replacements);
+    }
+
+    private static void registerDeprecated(PropertyKey old, PropertyKey... replacements) {
+        registerReplacements(DEPRECATED_SETTINGS, old, replacements);
     }
 
     static {
@@ -3062,9 +3072,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         WRITE_FO_OPTS.put("o_async", (int) CairoConfiguration.O_ASYNC);
         WRITE_FO_OPTS.put("o_none", (int) CairoConfiguration.O_NONE);
 
-        OBSOLETE_SETTINGS.put(
+        registerObsolete(
             "line.tcp.commit.timeout",
-            "Replaced by `line.tcp.commit.interval.default` and `line.tcp.commit.interval.fraction`.");
+            PropertyKey.LINE_TCP_COMMIT_INTERVAL_DEFAULT,
+            PropertyKey.LINE_TCP_COMMIT_INTERVAL_FRACTION);
+        registerObsolete(
+            "cairo.timestamp.locale",
+            PropertyKey.CAIRO_DATE_LOCALE);
+        registerObsolete(
+            "pg.timestamp.locale",
+            PropertyKey.PG_DATE_LOCALE);
 
         registerDeprecated(
             PropertyKey.HTTP_MIN_BIND_TO,

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -380,7 +380,9 @@ public class PropServerConfiguration implements ServerConfiguration {
             Log log,
             final BuildInformation buildInformation
     ) throws ServerConfigurationException, JsonException {
-        validateProperties(properties);
+        if (getBoolean(properties, env, PropertyKey.CONFIG_VALIDATION_ENABLED, false)) {
+            validateProperties(properties);
+        }
 
         this.log = log;
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3047,7 +3047,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         for (int index = 0; index < replacements.length; ++index) {
             if (index > 0) {
                 sb.append(index < (replacements.length - 1)
-                    ? ", "
+                    ?  ", "
                     : " and ");
             }
             String replacement = replacements[index].getPropertyPath();

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -468,7 +468,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 // deprecated
                 this.httpMinNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_RCV_BUF_SIZE, 1024);
                 this.httpMinNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF, this.httpMinNetConnectionRcvBuf);
-                this.httpMinNetConnectionHint = getBoolean(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF, false);
+                this.httpMinNetConnectionHint = getBoolean(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_HINT, false);
             }
 
             this.httpServerEnabled = getBoolean(properties, env, PropertyKey.HTTP_ENABLED, true);

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3047,7 +3047,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         for (int index = 0; index < replacements.length; ++index) {
             if (index > 0) {
                 sb.append(index < (replacements.length - 1)
-                    ?  ", "
+                    ? ", "
                     : " and ");
             }
             String replacement = replacements[index].getPropertyPath();

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3186,8 +3186,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         StringBuilder sb = new StringBuilder("Configuration issues:\n");
 
-        if (!incorrect.isEmpty())
-        {
+        if (!incorrect.isEmpty()) {
             isError = true;
             sb.append("    Invalid settings (not recognized, probable typos):\n");
             for (String key : incorrect)
@@ -3198,8 +3197,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             }
         }
 
-        if (!obsolete.isEmpty())
-        {
+        if (!obsolete.isEmpty()) {
             isError = true;
             sb.append("    Obsolete settings (no longer recognized):\n");
             for (Map.Entry<String, String> entry : obsolete.entrySet()) {
@@ -3211,8 +3209,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             }
         }
 
-        if (!deprecated.isEmpty())
-        {
+        if (!deprecated.isEmpty()) {
             sb.append("    Deprecated settings (recognized but superseded by newer settings):\n");
             for (Map.Entry<String, String> entry : deprecated.entrySet()) {
                 sb.append("        * ");

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -56,6 +56,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.*;
+import java.util.function.BiConsumer;
 
 public class PropServerConfiguration implements ServerConfiguration {
     public static final String CONFIG_DIRECTORY = "conf";
@@ -442,7 +443,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 this.httpMinWorkerYieldThreshold = getLong(properties, env, PropertyKey.HTTP_MIN_WORKER_YIELD_THRESHOLD, 10);
                 this.httpMinWorkerSleepThreshold = getLong(properties, env, PropertyKey.HTTP_MIN_WORKER_SLEEP_THRESHOLD, 10000);
 
-                // obsolete
+                // deprecated
                 String httpMinBindTo = getString(properties, env, PropertyKey.HTTP_MIN_BIND_TO, "0.0.0.0:9003");
 
                 parseBindTo(properties, env, PropertyKey.HTTP_MIN_NET_BIND_TO, httpMinBindTo, (a, p) -> {
@@ -452,22 +453,22 @@ public class PropServerConfiguration implements ServerConfiguration {
 
                 this.httpMinNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_LIMIT, 4);
 
-                // obsolete
+                // deprecated
                 this.httpMinNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_IDLE_CONNECTION_TIMEOUT, 5 * 60 * 1000L);
                 this.httpMinNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_TIMEOUT, this.httpMinNetConnectionTimeout);
 
-                // obsolete
+                // deprecated
                 this.httpMinNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_QUEUED_CONNECTION_TIMEOUT, 5 * 1000L);
                 this.httpMinNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_QUEUE_TIMEOUT, this.httpMinNetConnectionQueueTimeout);
 
-                // obsolete
+                // deprecated
                 this.httpMinNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.HTTP_MIN_NET_SND_BUF_SIZE, 1024);
                 this.httpMinNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_SNDBUF, this.httpMinNetConnectionSndBuf);
 
-                // obsolete
+                // deprecated
                 this.httpMinNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_RCV_BUF_SIZE, 1024);
                 this.httpMinNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF, this.httpMinNetConnectionRcvBuf);
-                this.httpMinNetConnectionHint = getBoolean(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_HINT, false);
+                this.httpMinNetConnectionHint = getBoolean(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF, false);
             }
 
             this.httpServerEnabled = getBoolean(properties, env, PropertyKey.HTTP_ENABLED, true);
@@ -513,23 +514,23 @@ public class PropServerConfiguration implements ServerConfiguration {
                     this.publicDirectory = new File(root, publicDirectory).getAbsolutePath();
                 }
 
-                // maintain obsolete property name for the time being
+                // maintain deprecated property name for the time being
                 this.httpNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_NET_ACTIVE_CONNECTION_LIMIT, 256);
                 this.httpNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_NET_CONNECTION_LIMIT, this.httpNetConnectionLimit);
                 this.httpNetConnectionHint = getBoolean(properties, env, PropertyKey.HTTP_NET_CONNECTION_HINT, false);
-                // obsolete
+                // deprecated
                 this.httpNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_NET_IDLE_CONNECTION_TIMEOUT, 5 * 60 * 1000L);
                 this.httpNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_NET_CONNECTION_TIMEOUT, this.httpNetConnectionTimeout);
 
-                // obsolete
+                // deprecated
                 this.httpNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.HTTP_NET_QUEUED_CONNECTION_TIMEOUT, 5 * 1000L);
                 this.httpNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.HTTP_NET_CONNECTION_QUEUE_TIMEOUT, this.httpNetConnectionQueueTimeout);
 
-                // obsolete
+                // deprecated
                 this.httpNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_SND_BUF_SIZE, 2 * 1024 * 1024);
                 this.httpNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_CONNECTION_SNDBUF, this.httpNetConnectionSndBuf);
 
-                // obsolete
+                // deprecated
                 this.httpNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_RCV_BUF_SIZE, 2 * 1024 * 1024);
                 this.httpNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.HTTP_NET_CONNECTION_RCVBUF, this.httpNetConnectionRcvBuf);
 
@@ -576,7 +577,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             this.pgEnabled = getBoolean(properties, env, PropertyKey.PG_ENABLED, true);
             if (pgEnabled) {
-                // obsolete
+                // deprecated
                 pgNetConnectionLimit = getInt(properties, env, PropertyKey.PG_NET_ACTIVE_CONNECTION_LIMIT, 10);
                 pgNetConnectionLimit = getInt(properties, env, PropertyKey.PG_NET_CONNECTION_LIMIT, pgNetConnectionLimit);
                 pgNetConnectionHint = getBoolean(properties, env, PropertyKey.PG_NET_CONNECTION_HINT, false);
@@ -585,16 +586,16 @@ public class PropServerConfiguration implements ServerConfiguration {
                     pgNetBindPort = p;
                 });
 
-                // obsolete
+                // deprecated
                 this.pgNetIdleConnectionTimeout = getLong(properties, env, PropertyKey.PG_NET_IDLE_TIMEOUT, 300_000);
                 this.pgNetIdleConnectionTimeout = getLong(properties, env, PropertyKey.PG_NET_CONNECTION_TIMEOUT, this.pgNetIdleConnectionTimeout);
                 this.pgNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.PG_NET_CONNECTION_QUEUE_TIMEOUT, 5_000);
 
-                // obsolete
+                // deprecated
                 this.pgNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.PG_NET_RECV_BUF_SIZE, -1);
                 this.pgNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.PG_NET_CONNECTION_RCVBUF, this.pgNetConnectionRcvBuf);
 
-                // obsolete
+                // deprecated
                 this.pgNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.PG_NET_SEND_BUF_SIZE, -1);
                 this.pgNetConnectionSndBuf = getIntSize(properties, env, PropertyKey.PG_NET_CONNECTION_SNDBUF, this.pgNetConnectionSndBuf);
 
@@ -806,15 +807,15 @@ public class PropServerConfiguration implements ServerConfiguration {
                     lineTcpNetBindPort = p;
                 });
 
-                // obsolete
+                // deprecated
                 this.lineTcpNetConnectionTimeout = getLong(properties, env, PropertyKey.LINE_TCP_NET_IDLE_TIMEOUT, 0);
                 this.lineTcpNetConnectionTimeout = getLong(properties, env, PropertyKey.LINE_TCP_NET_CONNECTION_TIMEOUT, this.lineTcpNetConnectionTimeout);
 
-                // obsolete
+                // deprecated
                 this.lineTcpNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.LINE_TCP_NET_QUEUED_TIMEOUT, 5_000);
                 this.lineTcpNetConnectionQueueTimeout = getLong(properties, env, PropertyKey.LINE_TCP_NET_CONNECTION_QUEUE_TIMEOUT, this.lineTcpNetConnectionQueueTimeout);
 
-                // obsolete
+                // deprecated
                 this.lineTcpNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.LINE_TCP_NET_RECV_BUF_SIZE, -1);
                 this.lineTcpNetConnectionRcvBuf = getIntSize(properties, env, PropertyKey.LINE_TCP_NET_CONNECTION_RCVBUF, this.lineTcpNetConnectionRcvBuf);
 
@@ -857,7 +858,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     this.lineTcpCommitIntervalDefault = COMMIT_INTERVAL_DEFAULT;
                 }
                 this.lineTcpAuthDbPath = getString(properties, env, PropertyKey.LINE_TCP_AUTH_DB_PATH, null);
-                // obsolete
+                // deprecated
                 String defaultTcpPartitionByProperty = getString(properties, env, PropertyKey.LINE_TCP_DEFAULT_PARTITION_BY, "DAY");
                 defaultTcpPartitionByProperty = getString(properties, env, PropertyKey.LINE_DEFAULT_PARTITION_BY, defaultTcpPartitionByProperty);
                 this.lineTcpDefaultPartitionBy = PartitionBy.fromString(defaultTcpPartitionByProperty);
@@ -3045,9 +3046,69 @@ public class PropServerConfiguration implements ServerConfiguration {
         WRITE_FO_OPTS.put("o_async", (int) CairoConfiguration.O_ASYNC);
         WRITE_FO_OPTS.put("o_none", (int) CairoConfiguration.O_NONE);
 
-        // OBSOLETE_SETTINGS;
-        // DEPRECATED_SETTINGS;
+        OBSOLETE_SETTINGS.put(
+            "line.tcp.commit.timeout",
+            "Replaced by `line.tcp.commit.interval.default` and `line.tcp.commit.interval.fraction`.");
 
+        BiConsumer<PropertyKey, PropertyKey> registerDeprecated =
+            (PropertyKey oldSetting, PropertyKey newSetting) -> {
+                DEPRECATED_SETTINGS.put(
+                    oldSetting,
+                    "Replaced by `" + newSetting.getPropertyPath() +"`.");
+            };
+
+        registerDeprecated.accept(
+            PropertyKey.HTTP_MIN_BIND_TO,
+            PropertyKey.HTTP_MIN_NET_BIND_TO);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_MIN_NET_IDLE_CONNECTION_TIMEOUT,
+            PropertyKey.HTTP_MIN_NET_CONNECTION_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_MIN_NET_QUEUED_CONNECTION_TIMEOUT,
+            PropertyKey.HTTP_MIN_NET_CONNECTION_QUEUE_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_MIN_NET_SND_BUF_SIZE,
+            PropertyKey.HTTP_MIN_NET_CONNECTION_SNDBUF);
+        DEPRECATED_SETTINGS.put(
+            PropertyKey.HTTP_NET_RCV_BUF_SIZE,
+            "Replaced by `" + PropertyKey.HTTP_MIN_NET_CONNECTION_RCVBUF.getPropertyPath() +
+            "` and `" + PropertyKey.HTTP_NET_CONNECTION_RCVBUF.getPropertyPath() + "`.");
+        registerDeprecated.accept(
+            PropertyKey.HTTP_NET_ACTIVE_CONNECTION_LIMIT,
+            PropertyKey.HTTP_NET_CONNECTION_LIMIT);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_NET_IDLE_CONNECTION_TIMEOUT,
+            PropertyKey.HTTP_NET_CONNECTION_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_NET_QUEUED_CONNECTION_TIMEOUT,
+            PropertyKey.HTTP_NET_CONNECTION_QUEUE_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.HTTP_NET_SND_BUF_SIZE,
+            PropertyKey.HTTP_NET_CONNECTION_SNDBUF);
+        registerDeprecated.accept(
+            PropertyKey.PG_NET_ACTIVE_CONNECTION_LIMIT,
+            PropertyKey.PG_NET_CONNECTION_LIMIT);
+        registerDeprecated.accept(
+            PropertyKey.PG_NET_IDLE_TIMEOUT,
+            PropertyKey.PG_NET_CONNECTION_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.PG_NET_RECV_BUF_SIZE,
+            PropertyKey.PG_NET_CONNECTION_RCVBUF);
+        registerDeprecated.accept(
+            PropertyKey.LINE_TCP_NET_ACTIVE_CONNECTION_LIMIT,
+            PropertyKey.LINE_TCP_NET_CONNECTION_LIMIT);
+        registerDeprecated.accept(
+            PropertyKey.LINE_TCP_NET_IDLE_TIMEOUT,
+            PropertyKey.LINE_TCP_NET_CONNECTION_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.LINE_TCP_NET_QUEUED_TIMEOUT,
+            PropertyKey.LINE_TCP_NET_CONNECTION_QUEUE_TIMEOUT);
+        registerDeprecated.accept(
+            PropertyKey.LINE_TCP_NET_RECV_BUF_SIZE,
+            PropertyKey.LINE_TCP_NET_CONNECTION_RCVBUF);
+        registerDeprecated.accept(
+            PropertyKey.LINE_TCP_DEFAULT_PARTITION_BY,
+            PropertyKey.LINE_DEFAULT_PARTITION_BY);
     }
 
     private static class ValidationResult {
@@ -3070,7 +3131,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         // Settings that are still valid but are now superseded by newer ones.
         Map<String, String> deprecated = new HashMap<>();
 
-        // Settings that are not valid. Either typos, or valid in future versions (in case of rollback).
+        // Settings that are not recognized.
         Set<String> incorrect = new HashSet<>();
 
         for (String propName : propertyNames) {
@@ -3097,12 +3158,12 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         boolean isError = false;
 
-        StringBuilder sb = new StringBuilder("Configuration errors:\n");
+        StringBuilder sb = new StringBuilder("Configuration issues:\n");
 
         if (!incorrect.isEmpty())
         {
             isError = true;
-            sb.append("    Incorrect settings (not recognised, probable typos):\n");
+            sb.append("    Incorrect settings (not recognized, probable typos):\n");
             for (String key : incorrect)
             {
                 sb.append("        * ");
@@ -3126,7 +3187,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         if (!deprecated.isEmpty())
         {
-            sb.append("    Deprecated settings (will be removed in future versions):\n");
+            sb.append("    Deprecated settings (superseded by newer settings):\n");
             for (Map.Entry<String, String> entry : deprecated.entrySet()) {
                 sb.append("        * ");
                 sb.append(entry.getKey());

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3120,7 +3120,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             PropertyKey.LINE_DEFAULT_PARTITION_BY);
     }
 
-    private static class ValidationResult {
+    public static class ValidationResult {
         public final boolean isError;
         public final String message;
 
@@ -3131,7 +3131,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    private static ValidationResult validate(Properties properties) {
+    public static ValidationResult validate(Properties properties) {
         Set<String> propertyNames = properties.stringPropertyNames();
 
         // Settings that used to be valid but no longer are.
@@ -3172,7 +3172,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         if (!incorrect.isEmpty())
         {
             isError = true;
-            sb.append("    Incorrect settings (not recognized, probable typos):\n");
+            sb.append("    Invalid settings (not recognized, probable typos):\n");
             for (String key : incorrect)
             {
                 sb.append("        * ");
@@ -3196,7 +3196,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         if (!deprecated.isEmpty())
         {
-            sb.append("    Deprecated settings (superseded by newer settings):\n");
+            sb.append("    Deprecated settings (recognized but superseded by newer settings):\n");
             for (Map.Entry<String, String> entry : deprecated.entrySet()) {
                 sb.append("        * ");
                 sb.append(entry.getKey());

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -149,6 +149,7 @@ public enum PropertyKey {
     CAIRO_QUERY_CACHE_EVENT_QUEUE_CAPACITY("cairo.query.cache.event.queue.capacity"),
     CIRCUIT_BREAKER_THROTTLE("circuit.breaker.throttle"),
     CIRCUIT_BREAKER_BUFFER_SIZE("circuit.breaker.buffer.size"),
+    CONFIG_VALIDATION_ENABLED("config.validation.enabled"),
     HTTP_MIN_ENABLED("http.min.enabled"),
     HTTP_MIN_WORKER_AFFINITY("http.min.worker.affinity"),
     HTTP_MIN_WORKER_YIELD_THRESHOLD("http.min.worker.yield.threshold"),

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -1,3 +1,6 @@
+# This configuration file is optionally validated. Comment or set to false to disable.
+config.validation.enabled=true
+
 # number of worker threads shared across the application. Increasing this number will increase parallelism in the application at the expense of CPU resources
 #shared.worker.count=2
 

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -137,7 +137,7 @@ query.timeout.sec=60
 ## Use this port to health check QuestDB instance when it isn't desired to log these health check requests. This is sort of /dev/null for monitoring
 
 # http.min.enabled=true
-# http.min.bind.to=0.0.0.0:9003
+# http.min.net.bind.to=0.0.0.0:9003
 
 ################ Cairo settings ##################
 
@@ -349,7 +349,6 @@ query.timeout.sec=60
 #cairo.sql.jit.debug.enabled=false
 
 #cairo.date.locale=en
-#cairo.timestamp.locale=en
 
 # Maximum number of uncommitted rows in TCP ILP
 #cairo.max.uncommitted.rows=500000
@@ -388,6 +387,9 @@ query.timeout.sec=60
 # Maximum flush query cache command queue capacity
 #cairo.query.cache.event.queue.capacity=4
 
+################ LINE settings ######################
+#line.default.partition.by=DAY
+
 ################ LINE UDP settings ##################
 
 #line.udp.bind.to=0.0.0.0:9009
@@ -400,7 +402,7 @@ query.timeout.sec=60
 #line.udp.own.thread.affinity=-1
 #line.udp.own.thread=false
 #line.udp.unicast=false
-#line.udp.commit.mode
+#line.udp.commit.mode=nosync
 #line.udp.timestamp=n
 
 ######################### LINE TCP settings ###############################
@@ -426,7 +428,6 @@ query.timeout.sec=60
 
 #line.tcp.connection.pool.capacity=64
 #line.tcp.timestamp=n
-#line.tcp.default.partition.by=DAY
 
 # TCP message buffer size
 #line.tcp.msg.buffer.size=2048

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -506,16 +506,24 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(PartitionBy.YEAR, configuration.getLineTcpReceiverConfiguration().getDefaultPartitionBy());
         Assert.assertEquals(PartitionBy.YEAR, configuration.getLineUdpReceiverConfiguration().getDefaultPartitionBy());
     }
-    @Test(expected = ServerConfigurationException.class)
-    public void testsIncorrectPropertyKeyError() throws IOException, JsonException, ServerConfigurationException {
 
-        InputStream inputStream = PropServerConfigurationTest.class.getResourceAsStream("/server.conf");
+    public void testValidationIsOffByDefault() throws IOException, JsonException, ServerConfigurationException {
         Properties properties = new Properties();
-        properties.load(inputStream);
-        properties.setProperty("this.will.throw", "Test");
-        properties.setProperty("this.will.also", "throw");
-
+        properties.setProperty("this.will.not.throw", "Test");
+        properties.setProperty("this.will.also.not", "throw");
         new PropServerConfiguration(root, properties, null, LOG, new BuildInformationHolder());
+    }
+
+    @Test(expected = ServerConfigurationException.class)
+    public void testValidation() throws IOException, JsonException, ServerConfigurationException {
+        try (InputStream inputStream = PropServerConfigurationTest.class.getResourceAsStream("/server.conf")) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            properties.setProperty("this.will.throw", "Test");
+            properties.setProperty("this.will.also", "throw");
+
+            new PropServerConfiguration(root, properties, null, LOG, new BuildInformationHolder());
+        }
     }
 
     @Test

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -557,7 +557,7 @@ public class PropServerConfigurationTest {
         Assert.assertTrue(result.isError);
         Assert.assertNotEquals(-1, result.message.indexOf("Obsolete settings"));
         Assert.assertNotEquals(-1, result.message.indexOf(
-            "Replaced by `line.tcp.commit.interval.default` and `line.tcp.commit.interval.fraction`."));
+            "Replaced by `line.tcp.commit.interval.default` and `line.tcp.commit.interval.fraction`"));
     }
 
     @Test
@@ -568,7 +568,7 @@ public class PropServerConfigurationTest {
         Assert.assertFalse(result.isError);
         Assert.assertNotEquals(-1, result.message.indexOf("Deprecated settings"));
         Assert.assertNotEquals(-1, result.message.indexOf(
-            "Replaced by `http.min.net.connection.rcvbuf` and `http.net.connection.rcvbuf`."));
+            "Replaced by `http.min.net.connection.rcvbuf` and `http.net.connection.rcvbuf`"));
     }
 
     @Test

--- a/core/src/test/resources/io/questdb/cutlass/line/tcp/LineTcpO3Test.server.conf
+++ b/core/src/test/resources/io/questdb/cutlass/line/tcp/LineTcpO3Test.server.conf
@@ -1,3 +1,5 @@
+config.validation.enabled=true
+
 shared.worker.count=2
 cairo.max.uncommitted.rows=500
 cairo.commit.lag=10000

--- a/core/src/test/resources/server-http-disabled.conf
+++ b/core/src/test/resources/server-http-disabled.conf
@@ -1,1 +1,3 @@
+config.validation.enabled=true
+
 http.enabled=false

--- a/core/src/test/resources/server-keep-alive.conf
+++ b/core/src/test/resources/server-keep-alive.conf
@@ -1,2 +1,4 @@
+config.validation.enabled=true
+
 http.keep-alive.timeout=0
 http.keep-alive.max=50000

--- a/core/src/test/resources/server-net.conf
+++ b/core/src/test/resources/server-net.conf
@@ -1,3 +1,5 @@
+config.validation.enabled=true
+
 http.net.bind.to=0.0.0.0:9020
 http.net.connection.limit=63
 http.net.connection.timeout=7000000

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -1,3 +1,5 @@
+config.validation.enabled=true
+
 http.connection.pool.initial.capacity=64
 http.connection.string.pool.capacity=512
 http.multipart.header.buffer.size=256

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -116,7 +116,7 @@ http.enabled=true
 ## Use this port to health check QuestDB instance when it isn't desired to log these health check requests. This is sort of /dev/null for monitoring
 
 # http.min.enabled=true
-# http.min.bind.to=0.0.0.0:9003
+# http.min.net.bind.to=0.0.0.0:9003
 
 ################ Cairo settings ##################
 
@@ -296,7 +296,6 @@ http.enabled=true
 # cairo.sql.sampleby.page.size=0
 
 #cairo.date.locale=en
-#cairo.timestamp.locale=en
 
 # Maximum number of uncommitted rows in TCP ILP
 #cairo.max.uncommitted.rows=500000
@@ -342,8 +341,11 @@ line.udp.enabled=true
 #line.udp.own.thread.affinity=-1
 #line.udp.own.thread=false
 #line.udp.unicast=false
-#line.udp.commit.mode
+#line.udp.commit.mode=nosync
 #line.udp.timestamp=n
+
+######################### LINE settings ###################################
+#line.default.partition.by=DAY
 
 ######################### LINE TCP settings ###############################
 line.tcp.enabled=true
@@ -360,7 +362,6 @@ line.tcp.auth.db.path=conf/auth.txt
 #line.tcp.net.recv.buf.size=-1
 #line.tcp.connection.pool.capacity=64
 #line.tcp.timestamp=n
-#line.tcp.default.partition.by=DAY
 
 # TCP message buffer size
 #line.tcp.msg.buffer.size=2048

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -1,3 +1,6 @@
+# This configuration file is optionally validated. Comment or set to false to disable.
+config.validation.enabled=true
+
 # number of worker threads shared across the application. Increasing this number will increase parallelism in the application at the expense of CPU resources
 #shared.worker.count=2
 


### PR DESCRIPTION
# Goal

* Enable validation for new installations.
* Preserve no validation for existing installations.
* Inform users how to migrate to newer setttings via deprecation logic.

# Optional Validation

New installations of QuestDB will have the following at the very top of `server.conf`:

```ini
# This configuration file is optionally validated. Comment or set to false to disable.
config.validation.enabled=true
```

Existing installations can begin validating their config by enabling the same setting, which is otherwise `false` by default.

## Naming

My rationale for calling this `config.validation.enabled` rather than `config.validation` is that the former makes it easier to introduce new config validation settings in future releases, e.g.:

```ini
config.validation.check_hostnames=true
```

That said, we could also rename this to something else. Naming suggestions welcome.

# Deprecation Logic
These changes (as per Alex's request) also log suggested config changes when:

* Obsolete settings are used: I.e. settings that existed previously, but no longer do anything. These will cause a hard fail if validation is on (just logged if validation is off).
* Deprecated settings are used: I.e. settings that are still supported, but have newer replacements. These will be logged without causing failure regardless the `config.validation.enabled` setting.

All errors are collected into a single `String` message. Depending on severity and settings, this is then either raised as an exception (causing startup to fail) or logged to an `A`dvisory log line.

Here's an example error message:

```
Configuration issues:
    Invalid settings (not recognized, probable typos):
        * telemerty.hide.tables
    Obsolete settings (no longer recognized):
        * cairo.timestamp.locale: Replaced by `cairo.date.locale`
        * pg.timestamp.locale: Replaced by `pg.date.locale`
    Deprecated settings (recognized but superseded by newer settings):
        * line.tcp.default.partition.by: Replaced by `line.default.partition.by`
        * http.min.bind.to: Replaced by `http.min.net.bind.to`
```