### PR TITLE
fix(sql): jit to handle sql context bind vars change

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/CompiledFilterSymbolBindVariable.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/CompiledFilterSymbolBindVariable.java
@@ -24,12 +24,12 @@
 
 package io.questdb.griffin.engine.functions.bind;
 
+import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
-import io.questdb.griffin.engine.functions.constants.SymbolConstant;
 
 /**
  * String bind variable function wrapper used in SQL JIT. Also used to handle deferred
@@ -42,7 +42,7 @@ public class CompiledFilterSymbolBindVariable extends SymbolFunction implements 
     private StaticSymbolTable symbolTable;
 
     public CompiledFilterSymbolBindVariable(Function symbolFunction, int columnIndex) {
-        assert symbolFunction instanceof StrBindVariable || symbolFunction instanceof SymbolConstant;
+        assert symbolFunction.getType() == ColumnType.STRING || symbolFunction.getType() == ColumnType.SYMBOL;
         this.symbolFunction = symbolFunction;
         this.columnIndex = columnIndex;
     }
@@ -50,6 +50,7 @@ public class CompiledFilterSymbolBindVariable extends SymbolFunction implements 
     @Override
     public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
         this.symbolTable = (StaticSymbolTable) symbolTableSource.getSymbolTable(columnIndex);
+        this.symbolFunction.init(symbolTableSource, executionContext);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/CompiledFilterRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CompiledFilterRecordCursor.java
@@ -107,6 +107,7 @@ class CompiledFilterRecordCursor implements RecordCursor {
         this.bindVarMemory = bindVarMemory;
         this.bindVarCount = bindVarFunctions.size();
         colTopsFilter.init(this, executionContext);
+        Function.init(bindVarFunctions, this, executionContext);
         prepareBindVarMemory(bindVarFunctions, executionContext);
     }
 

--- a/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
+++ b/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
@@ -30,6 +30,8 @@ import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.*;
 import io.questdb.griffin.engine.functions.bind.CompiledFilterSymbolBindVariable;
+import io.questdb.griffin.engine.functions.bind.IndexedParameterLinkFunction;
+import io.questdb.griffin.engine.functions.bind.NamedParameterLinkFunction;
 import io.questdb.griffin.engine.functions.constants.ConstantFunction;
 import io.questdb.griffin.engine.functions.constants.SymbolConstant;
 import io.questdb.griffin.model.ExpressionNode;
@@ -387,7 +389,11 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
 
         if (token.charAt(0) == ':') {
             // name bind variable case
-            varFunction = getBindVariableService().getFunction(token);
+            Function bindFunction = getBindVariableService().getFunction(token);
+            if (bindFunction == null) {
+                throw SqlException.position(position).put("failed to find function for bind variable: ").put(token);
+            }
+            varFunction = new NamedParameterLinkFunction(Chars.toString(token), bindFunction.getType());
         } else {
             // indexed bind variable case
             try {
@@ -395,14 +401,18 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
                 if (variableIndex < 1) {
                     throw SqlException.$(position, "invalid bind variable index [value=").put(variableIndex).put(']');
                 }
-                varFunction = getBindVariableService().getFunction(variableIndex - 1);
+                Function bindFunction = getBindVariableService().getFunction(variableIndex - 1);
+                if (bindFunction == null) {
+                    throw SqlException.position(position).put("failed to find function for bind variable: ").put(token);
+                }
+                varFunction = new IndexedParameterLinkFunction(
+                        variableIndex - 1,
+                        bindFunction.getType(),
+                        position);
+
             } catch (NumericException e) {
                 throw SqlException.$(position, "invalid bind variable index [value=").put(token).put(']');
             }
-        }
-
-        if (varFunction == null) {
-            throw SqlException.position(position).put("failed to find function for bind variable: ").put(token);
         }
 
         return varFunction;

--- a/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
+++ b/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
@@ -26,15 +26,16 @@ package io.questdb.griffin;
 
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.SqlJitMode;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.jit.JitUtil;
 import io.questdb.std.Numbers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
+import org.junit.*;
 
 /**
  * Tests for advanced features and scenarios, such as  col tops, bind variables,
@@ -52,127 +53,9 @@ public class CompiledFilterTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testSelectAllTypesFromRecord() throws Exception {
-        final String query = "select * from x where b = true and kk < 10";
-        final String expected = "kk\ta\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tcc\tl2\thash1b\thash2b\thash3b\thash1c\thash2c\thash4c\thash8c\n" +
-                "2\t1637847416\ttrue\tV\t0.4900510449885239\t0.8258\t553\t2015-12-28T22:25:40.934Z\t\t-7611030538224290496\t1970-01-05T15:15:00.000000Z\t37\t00000000 3e e3 f1 f1 1e ca 9c 1d 06 ac\tKGHVUVSDOTSED\tY\t0x772c8b7f9505620ebbdfe8ff0cd60c64712fde5706d6ea2f545ded49c47eea61\t0\t10\t110\te\tsj\tfhcq\t35jvygt2\n" +
-                "3\t844704299\ttrue\t\t0.3456897991538844\t0.2401\t775\t2015-08-03T15:58:03.335Z\tVTJW\t-8910603140262731534\t1970-01-05T15:23:20.000000Z\t24\t00000000 ac a8 3b a6 dc 3b 7d 2b e3 92 fe 69 38 e1 77 9a\n" +
-                "00000010 e7 0c 89\tLJUMLGLHMLLEO\tY\t0xabbcbeeddca3d4fe4f25a88863fc0f467f24de22c77acf93e983e65f5551d073\t0\t01\t000\tf\t33\teusj\tb5z6npxr\n" +
-                "6\t-1501720177\ttrue\tP\t0.18158967304439033\t0.8197\t501\t2015-06-08T17:20:46.703Z\tPEHN\t-4229502740666959541\t1970-01-05T15:48:20.000000Z\t19\t\tTNLEGP\tU\t0x79423d4d320d2649767a4feda060d4fb6923c0c7d965969da1b1140a2be25241\t1\t01\t010\tr\tc0\twhjh\trcqfw2hw\n" +
-                "8\t526232578\ttrue\tE\t0.6379992093447574\t0.8515\t850\t2015-08-19T05:52:05.329Z\tPEHN\t-5157086556591926155\t1970-01-05T16:05:00.000000Z\t42\t00000000 6d 8c d8 ac c8 46 3b 47 3c e1 72 3b 9d\tJSMKIXEYVTUPD\tH\t0x2337f7e6b82ebc2405c5c1b231cffa455a6e970fb8b80abcc4129ae493cc6076\t0\t11\t000\t5\ttp\tx578\ttdnxkw6d\n";
-        final String ddl = "create table x as (select" +
-                " cast(x as int) kk," +
-                " rnd_int() a," +
-                " rnd_boolean() b," +
-                " rnd_str(1,1,2) c," +
-                " rnd_double(2) d," +
-                " rnd_float(2) e," +
-                " rnd_short(10,1024) f," +
-                " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
-                " rnd_symbol(4,4,4,2) i," +
-                " rnd_long() j," +
-                " timestamp_sequence(400000000000, 500000000) k," +
-                " rnd_byte(2,50) l," +
-                " rnd_bin(10, 20, 2) m," +
-                " rnd_str(5,16,2) n," +
-                " rnd_char() cc," +
-                " rnd_long256() l2," +
-                " rnd_geohash(1) hash1b," +
-                " rnd_geohash(2) hash2b," +
-                " rnd_geohash(3) hash3b," +
-                " rnd_geohash(5) hash1c," +
-                " rnd_geohash(10) hash2c," +
-                " rnd_geohash(20) hash4c," +
-                " rnd_geohash(40) hash8c" +
-                " from long_sequence(100)) timestamp(k)";
-
-        assertQuery(expected,
-                query,
-                ddl,
-                "k",
-                true);
-        assertSqlRunWithJit(query);
-    }
-
-    @Test
-    public void testMultiplePartitionsOrderBy() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table t1 as (select " +
-                    " x," +
-                    " timestamp_sequence(to_timestamp('1970-01-01', 'yyyy-MM-dd'), 100000L) ts " +
-                    "from long_sequence(1000)) timestamp(ts) partition by day", sqlExecutionContext);
-
-            compiler.compile("insert into t1 select " +
-                    " x," +
-                    " timestamp_sequence(to_timestamp('1970-01-02', 'yyyy-MM-dd'), 100000L) ts " +
-                    "from long_sequence(1000)", sqlExecutionContext);
-
-            final String query = "select * from t1 where x < 3 order by ts desc";
-            final String expected = "x\tts\n" +
-                    "2\t1970-01-02T00:00:00.100000Z\n" +
-                    "1\t1970-01-02T00:00:00.000000Z\n" +
-                    "2\t1970-01-01T00:00:00.100000Z\n" +
-                    "1\t1970-01-01T00:00:00.000000Z\n";
-
-            assertSql(query, expected);
-            assertSqlRunWithJit(query);
-        });
-    }
-
-    @Test
-    public void testPageFrameMaxSize() throws Exception {
-        pageFrameMaxSize = 128;
-        final long N = 8 * pageFrameMaxSize + 1;
-        assertMemoryLeak(() -> {
-            compiler.compile("create table t1 as (select " +
-                    " x," +
-                    " timestamp_sequence(to_timestamp('1970-01-01', 'yyyy-MM-dd'), 100000L) ts " +
-                    "from long_sequence(" + N + ")) timestamp(ts) partition by day", sqlExecutionContext);
-
-            final String query = "select * from t1 where x < 3";
-            final String expected = "x\tts\n" +
-                    "1\t1970-01-01T00:00:00.000000Z\n" +
-                    "2\t1970-01-01T00:00:00.100000Z\n";
-
-            assertSql(query, expected);
-            assertSqlRunWithJit(query);
-        });
-    }
-
-    @Test
-    public void testSingleBindVariableScalar() throws Exception {
-        testSingleBindVariable(SqlJitMode.JIT_MODE_FORCE_SCALAR);
-    }
-
-    @Test
-    public void testSingleBindVariableVectorized() throws Exception {
-        testSingleBindVariable(SqlJitMode.JIT_MODE_ENABLED);
-    }
-
-    private void testSingleBindVariable(int jitMode) throws Exception {
-        assertMemoryLeak(() -> {
-            sqlExecutionContext.setJitMode(jitMode);
-
-            compiler.compile("create table x as (select" +
-                    " rnd_long() l," +
-                    " timestamp_sequence(400000000000, 500000000) ts" +
-                    " from long_sequence(100)) timestamp(ts)", sqlExecutionContext);
-
-            bindVariableService.clear();
-            bindVariableService.setLong("l", 3614738589890112276L);
-
-            final String query = "select * from x where l = :l";
-            final String expected = "l\tts\n" +
-                    "3614738589890112276\t1970-01-05T16:38:20.000000Z\n";
-
-            assertSql(query, expected);
-            assertSqlRunWithJit(query);
-        });
-    }
-
-    @Test
     public void testAllBindVariableTypes() throws Exception {
         assertMemoryLeak(() -> {
+
             compiler.compile("create table x as (select" +
                     " rnd_boolean() aboolean," +
                     " rnd_byte(2,50) abyte," +
@@ -233,28 +116,6 @@ public class CompiledFilterTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testSymbolBindVariable() throws Exception {
-        assertMemoryLeak(() -> {
-            compiler.compile("create table x as (select" +
-                    " rnd_symbol('A','B','C') sym," +
-                    " timestamp_sequence(400000000000, 500000000) ts" +
-                    " from long_sequence(5)) timestamp(ts)", sqlExecutionContext);
-
-            bindVariableService.clear();
-            bindVariableService.setStr("sym", "B");
-
-            // The column order is important here, since we want
-            // query and table column indexes to be different.
-            final String query = "select ts from x where sym = :sym";
-            final String expected = "ts\n" +
-                    "1970-01-05T15:23:20.000000Z\n";
-
-            assertSql(query, expected);
-            assertSqlRunWithJit(query);
-        });
-    }
-
-    @Test
     public void testBindVariableNullCheckScalar() throws Exception {
         testBindVariableNullCheck(SqlJitMode.JIT_MODE_FORCE_SCALAR);
     }
@@ -264,22 +125,41 @@ public class CompiledFilterTest extends AbstractGriffinTest {
         testBindVariableNullCheck(SqlJitMode.JIT_MODE_ENABLED);
     }
 
-    private void testBindVariableNullCheck(int jitMode) throws Exception {
+    @Test
+    public void testIndexBindVariableReplacedContext() throws Exception {
         assertMemoryLeak(() -> {
-            sqlExecutionContext.setJitMode(jitMode);
-            final long value = 42;
             compiler.compile("create table x as (select" +
-                    " " + value + " l," +
-                    " to_timestamp('1971', 'yyyy') ts" +
-                    " from long_sequence(1)) timestamp(ts)", sqlExecutionContext);
+                    " x l," +
+                    " timestamp_sequence(400000000000, 500000000) ts" +
+                    " from long_sequence(100)) timestamp(ts)", sqlExecutionContext);
 
-            bindVariableService.clear();
-            bindVariableService.setLong("l", Numbers.LONG_NaN);
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+            indexBindVariableReplacedContext(false);
 
-            // Here we expect a NULL value on the left side of the predicate,
-            // so no rows should be returned
-            final String query = "select * from x where l + :l = " + (Numbers.LONG_NaN + value);
-            final String expected = "l\tts\n";
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            indexBindVariableReplacedContext(true);
+        });
+    }
+
+    @Test
+    public void testMultiplePartitionsOrderBy() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table t1 as (select " +
+                    " x," +
+                    " timestamp_sequence(to_timestamp('1970-01-01', 'yyyy-MM-dd'), 100000L) ts " +
+                    "from long_sequence(1000)) timestamp(ts) partition by day", sqlExecutionContext);
+
+            compiler.compile("insert into t1 select " +
+                    " x," +
+                    " timestamp_sequence(to_timestamp('1970-01-02', 'yyyy-MM-dd'), 100000L) ts " +
+                    "from long_sequence(1000)", sqlExecutionContext);
+
+            final String query = "select * from t1 where x < 3 order by ts desc";
+            final String expected = "x\tts\n" +
+                    "2\t1970-01-02T00:00:00.100000Z\n" +
+                    "1\t1970-01-02T00:00:00.000000Z\n" +
+                    "2\t1970-01-01T00:00:00.100000Z\n" +
+                    "1\t1970-01-01T00:00:00.000000Z\n";
 
             assertSql(query, expected);
             assertSqlRunWithJit(query);
@@ -337,89 +217,35 @@ public class CompiledFilterTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testSelectAllFilterWithColTopsScalar() throws Exception {
-        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
-    }
-
-    @Test
-    public void testSelectAllFilterWithColTopsVectorized() throws Exception {
-        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
-    }
-
-    private void testSelectAllFilterWithColTops(int jitMode) throws Exception {
-        final String query = "select * from t1 where j < 0";
-        final String expected = "x\tts\tj\n" +
-                "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n" +
-                "7\t1970-01-01T00:01:46.000000Z\t-7611843578141082998\n" +
-                "8\t1970-01-01T00:01:47.000000Z\t-5354193255228091881\n" +
-                "9\t1970-01-01T00:01:48.000000Z\t-2653407051020864006\n" +
-                "10\t1970-01-01T00:01:49.000000Z\t-1675638984090602536\n" +
-                "14\t1970-01-01T00:01:53.000000Z\t-7489826605295361807\n" +
-                "15\t1970-01-01T00:01:54.000000Z\t-4094902006239100839\n" +
-                "16\t1970-01-01T00:01:55.000000Z\t-4474835130332302712\n" +
-                "17\t1970-01-01T00:01:56.000000Z\t-6943924477733600060\n";
-
-        testFilterWithColTops(query, expected, jitMode);
-    }
-
-    @Test
-    public void testSelectAllBothPageFramesFilterWithColTopsScalar() throws Exception {
-        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
-    }
-
-    @Test
-    public void testSelectAllBothPageFramesFilterWithColTopsVectorized() throws Exception {
-        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
-    }
-
-    private void testSelectAllBothPageFramesFilterWithColTops(int jitMode) throws Exception {
-        final String query = "select * from t1 where x >= 3 and x <= 4";
-        final String expected = "x\tts\tj\n" +
-                "3\t1970-01-01T00:00:02.000000Z\tNaN\n" +
-                "4\t1970-01-01T00:00:03.000000Z\tNaN\n" +
-                "3\t1970-01-01T00:01:42.000000Z\t7746536061816329025\n" +
-                "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n";
-
-        testFilterWithColTops(query, expected, jitMode);
-    }
-
-    @Test
-    public void testSelectSingleColumnFilterWithColTopsScalar() throws Exception {
-        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
-    }
-
-    @Test
-    public void testSelectSingleColumnFilterWithColTopsVectorized() throws Exception {
-        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
-    }
-
-    private void testSelectSingleColumnFilterWithColTops(int jitMode) throws Exception {
-        // The column order is important here, since we want
-        // query and table column indexes to be different.
-        final String query = "select j from t1 where j <> null and x < 3";
-        final String expected = "j\n" +
-                "4689592037643856\n" +
-                "4729996258992366\n";
-
-        testFilterWithColTops(query, expected, jitMode);
-    }
-
-    private void testFilterWithColTops(String query, String expected, int jitMode) throws Exception {
+    public void testNameBindVariableReplacedContext() throws Exception {
         assertMemoryLeak(() -> {
-            sqlExecutionContext.setJitMode(jitMode);
+            compiler.compile("create table x as (select" +
+                    " x l," +
+                    " timestamp_sequence(400000000000, 500000000) ts" +
+                    " from long_sequence(100)) timestamp(ts)", sqlExecutionContext);
 
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+            namedBindVariableReplacedContext(false);
+
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            namedBindVariableReplacedContext(true);
+        });
+    }
+
+    @Test
+    public void testPageFrameMaxSize() throws Exception {
+        pageFrameMaxSize = 128;
+        final long N = 8 * pageFrameMaxSize + 1;
+        assertMemoryLeak(() -> {
             compiler.compile("create table t1 as (select " +
                     " x," +
-                    " timestamp_sequence(0, 1000000) ts " +
-                    "from long_sequence(20)) timestamp(ts)", sqlExecutionContext);
+                    " timestamp_sequence(to_timestamp('1970-01-01', 'yyyy-MM-dd'), 100000L) ts " +
+                    "from long_sequence(" + N + ")) timestamp(ts) partition by day", sqlExecutionContext);
 
-            compile("alter table t1 add column j long", sqlExecutionContext);
-
-            compiler.compile("insert into t1 select " +
-                    " x," +
-                    " timestamp_sequence(100000000, 1000000) ts," +
-                    " rnd_long() j " +
-                    "from long_sequence(20)", sqlExecutionContext);
+            final String query = "select * from t1 where x < 3";
+            final String expected = "x\tts\n" +
+                    "1\t1970-01-01T00:00:00.000000Z\n" +
+                    "2\t1970-01-01T00:00:00.100000Z\n";
 
             assertSql(query, expected);
             assertSqlRunWithJit(query);
@@ -513,6 +339,299 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                     Assert.assertFalse(cursor.hasNext());
                 }
             }
+        });
+    }
+
+    @Test
+    public void testSelectAllBothPageFramesFilterWithColTopsScalar() throws Exception {
+        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+    }
+
+    @Test
+    public void testSelectAllBothPageFramesFilterWithColTopsVectorized() throws Exception {
+        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+    }
+
+    @Test
+    public void testSelectAllFilterWithColTopsScalar() throws Exception {
+        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+    }
+
+    @Test
+    public void testSelectAllFilterWithColTopsVectorized() throws Exception {
+        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+    }
+
+    @Test
+    public void testSelectAllTypesFromRecord() throws Exception {
+        final String query = "select * from x where b = true and kk < 10";
+        final String expected = "kk\ta\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tcc\tl2\thash1b\thash2b\thash3b\thash1c\thash2c\thash4c\thash8c\n" +
+                "2\t1637847416\ttrue\tV\t0.4900510449885239\t0.8258\t553\t2015-12-28T22:25:40.934Z\t\t-7611030538224290496\t1970-01-05T15:15:00.000000Z\t37\t00000000 3e e3 f1 f1 1e ca 9c 1d 06 ac\tKGHVUVSDOTSED\tY\t0x772c8b7f9505620ebbdfe8ff0cd60c64712fde5706d6ea2f545ded49c47eea61\t0\t10\t110\te\tsj\tfhcq\t35jvygt2\n" +
+                "3\t844704299\ttrue\t\t0.3456897991538844\t0.2401\t775\t2015-08-03T15:58:03.335Z\tVTJW\t-8910603140262731534\t1970-01-05T15:23:20.000000Z\t24\t00000000 ac a8 3b a6 dc 3b 7d 2b e3 92 fe 69 38 e1 77 9a\n" +
+                "00000010 e7 0c 89\tLJUMLGLHMLLEO\tY\t0xabbcbeeddca3d4fe4f25a88863fc0f467f24de22c77acf93e983e65f5551d073\t0\t01\t000\tf\t33\teusj\tb5z6npxr\n" +
+                "6\t-1501720177\ttrue\tP\t0.18158967304439033\t0.8197\t501\t2015-06-08T17:20:46.703Z\tPEHN\t-4229502740666959541\t1970-01-05T15:48:20.000000Z\t19\t\tTNLEGP\tU\t0x79423d4d320d2649767a4feda060d4fb6923c0c7d965969da1b1140a2be25241\t1\t01\t010\tr\tc0\twhjh\trcqfw2hw\n" +
+                "8\t526232578\ttrue\tE\t0.6379992093447574\t0.8515\t850\t2015-08-19T05:52:05.329Z\tPEHN\t-5157086556591926155\t1970-01-05T16:05:00.000000Z\t42\t00000000 6d 8c d8 ac c8 46 3b 47 3c e1 72 3b 9d\tJSMKIXEYVTUPD\tH\t0x2337f7e6b82ebc2405c5c1b231cffa455a6e970fb8b80abcc4129ae493cc6076\t0\t11\t000\t5\ttp\tx578\ttdnxkw6d\n";
+        final String ddl = "create table x as (select" +
+                " cast(x as int) kk," +
+                " rnd_int() a," +
+                " rnd_boolean() b," +
+                " rnd_str(1,1,2) c," +
+                " rnd_double(2) d," +
+                " rnd_float(2) e," +
+                " rnd_short(10,1024) f," +
+                " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                " rnd_symbol(4,4,4,2) i," +
+                " rnd_long() j," +
+                " timestamp_sequence(400000000000, 500000000) k," +
+                " rnd_byte(2,50) l," +
+                " rnd_bin(10, 20, 2) m," +
+                " rnd_str(5,16,2) n," +
+                " rnd_char() cc," +
+                " rnd_long256() l2," +
+                " rnd_geohash(1) hash1b," +
+                " rnd_geohash(2) hash2b," +
+                " rnd_geohash(3) hash3b," +
+                " rnd_geohash(5) hash1c," +
+                " rnd_geohash(10) hash2c," +
+                " rnd_geohash(20) hash4c," +
+                " rnd_geohash(40) hash8c" +
+                " from long_sequence(100)) timestamp(k)";
+
+        assertQuery(expected,
+                query,
+                ddl,
+                "k",
+                true);
+        assertSqlRunWithJit(query);
+    }
+
+    @Test
+    public void testSelectSingleColumnFilterWithColTopsScalar() throws Exception {
+        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+    }
+
+    @Test
+    public void testSelectSingleColumnFilterWithColTopsVectorized() throws Exception {
+        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+    }
+
+    @Test
+    public void testSingleBindVariableScalar() throws Exception {
+        testSingleBindVariable(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+    }
+
+    @Test
+    public void testSingleBindVariableVectorized() throws Exception {
+        testSingleBindVariable(SqlJitMode.JIT_MODE_ENABLED);
+    }
+
+    @Test
+    public void testSymbolBindVariable() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table x as (select" +
+                    " rnd_symbol('A','B','C') sym," +
+                    " timestamp_sequence(400000000000, 500000000) ts" +
+                    " from long_sequence(5)) timestamp(ts)", sqlExecutionContext);
+
+            bindVariableService.clear();
+            bindVariableService.setStr("sym", "B");
+
+            // The column order is important here, since we want
+            // query and table column indexes to be different.
+            final String query = "select ts, sym from x where sym = :sym";
+
+            try (RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
+                Assert.assertTrue("JIT was not enabled for query: " + query, factory.usesCompiledFilter());
+
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+                }
+                TestUtils.assertEquals("ts\tsym\n" +
+                        "1970-01-05T15:23:20.000000Z\tB\n", sink);
+
+                BindVariableServiceImpl bindService2 = new BindVariableServiceImpl(configuration);
+                bindService2.setStr("sym", "C");
+                SqlExecutionContextImpl context2 = new SqlExecutionContextImpl(engine, 1);
+                context2.with(AllowAllCairoSecurityContext.INSTANCE, bindService2, new Rnd());
+
+                try (RecordCursor cursor = factory.getCursor(context2)) {
+                    TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+                }
+                TestUtils.assertEquals("ts\tsym\n" +
+                        "1970-01-05T15:31:40.000000Z\tC\n" +
+                        "1970-01-05T15:40:00.000000Z\tC\n", sink);
+            }
+        });
+    }
+
+    private void indexBindVariableReplacedContext(boolean jit) throws SqlException {
+
+        bindVariableService.clear();
+        bindVariableService.setInt(0, 1);
+        bindVariableService.setInt(1, 1000);
+
+        final String query = "select $2 as a, l from x where l = $1";
+
+        try (RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
+            if (jit) {
+                Assert.assertTrue("JIT was not enabled for query: " + query, factory.usesCompiledFilter());
+            }
+
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+            }
+            TestUtils.assertEquals("a\tl\n" +
+                    "1000\t1\n", sink);
+
+            BindVariableServiceImpl bindService2 = new BindVariableServiceImpl(configuration);
+            bindService2.setInt(0, 2);
+            bindService2.setInt(1, 1002);
+
+            SqlExecutionContextImpl context2 = new SqlExecutionContextImpl(engine, 1);
+            context2.with(AllowAllCairoSecurityContext.INSTANCE, bindService2, new Rnd());
+
+            try (RecordCursor cursor = factory.getCursor(context2)) {
+                TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+            }
+            TestUtils.assertEquals("a\tl\n" +
+                    "1002\t2\n", sink);
+        }
+    }
+
+    private void namedBindVariableReplacedContext(boolean jit) throws SqlException {
+
+        bindVariableService.clear();
+        bindVariableService.setInt("v1", 1);
+        bindVariableService.setInt("v2", 1000);
+
+        final String query = "select :v2 as a, l from x where l = :v1";
+
+        try (RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
+            if (jit) {
+                Assert.assertTrue("JIT was not enabled for query: " + query, factory.usesCompiledFilter());
+            }
+
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+            }
+            TestUtils.assertEquals("a\tl\n" +
+                    "1000\t1\n", sink);
+
+            BindVariableServiceImpl bindService2 = new BindVariableServiceImpl(configuration);
+            bindService2.setInt("v1", 2);
+            bindService2.setInt("v2", 1002);
+
+            SqlExecutionContextImpl context2 = new SqlExecutionContextImpl(engine, 1);
+            context2.with(AllowAllCairoSecurityContext.INSTANCE, bindService2, new Rnd());
+
+            try (RecordCursor cursor = factory.getCursor(context2)) {
+                TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+            }
+            TestUtils.assertEquals("a\tl\n" +
+                    "1002\t2\n", sink);
+        }
+    }
+
+    private void testBindVariableNullCheck(int jitMode) throws Exception {
+        assertMemoryLeak(() -> {
+            sqlExecutionContext.setJitMode(jitMode);
+            final long value = 42;
+            compiler.compile("create table x as (select" +
+                    " " + value + " l," +
+                    " to_timestamp('1971', 'yyyy') ts" +
+                    " from long_sequence(1)) timestamp(ts)", sqlExecutionContext);
+
+            bindVariableService.clear();
+            bindVariableService.setLong("l", Numbers.LONG_NaN);
+
+            // Here we expect a NULL value on the left side of the predicate,
+            // so no rows should be returned
+            final String query = "select * from x where l + :l = " + (Numbers.LONG_NaN + value);
+            final String expected = "l\tts\n";
+
+            assertSql(query, expected);
+            assertSqlRunWithJit(query);
+        });
+    }
+
+    private void testFilterWithColTops(String query, String expected, int jitMode) throws Exception {
+        assertMemoryLeak(() -> {
+            sqlExecutionContext.setJitMode(jitMode);
+
+            compiler.compile("create table t1 as (select " +
+                    " x," +
+                    " timestamp_sequence(0, 1000000) ts " +
+                    "from long_sequence(20)) timestamp(ts)", sqlExecutionContext);
+
+            compile("alter table t1 add column j long", sqlExecutionContext);
+
+            compiler.compile("insert into t1 select " +
+                    " x," +
+                    " timestamp_sequence(100000000, 1000000) ts," +
+                    " rnd_long() j " +
+                    "from long_sequence(20)", sqlExecutionContext);
+
+            assertSql(query, expected);
+            assertSqlRunWithJit(query);
+        });
+    }
+
+    private void testSelectAllBothPageFramesFilterWithColTops(int jitMode) throws Exception {
+        final String query = "select * from t1 where x >= 3 and x <= 4";
+        final String expected = "x\tts\tj\n" +
+                "3\t1970-01-01T00:00:02.000000Z\tNaN\n" +
+                "4\t1970-01-01T00:00:03.000000Z\tNaN\n" +
+                "3\t1970-01-01T00:01:42.000000Z\t7746536061816329025\n" +
+                "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n";
+
+        testFilterWithColTops(query, expected, jitMode);
+    }
+
+    private void testSelectAllFilterWithColTops(int jitMode) throws Exception {
+        final String query = "select * from t1 where j < 0";
+        final String expected = "x\tts\tj\n" +
+                "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n" +
+                "7\t1970-01-01T00:01:46.000000Z\t-7611843578141082998\n" +
+                "8\t1970-01-01T00:01:47.000000Z\t-5354193255228091881\n" +
+                "9\t1970-01-01T00:01:48.000000Z\t-2653407051020864006\n" +
+                "10\t1970-01-01T00:01:49.000000Z\t-1675638984090602536\n" +
+                "14\t1970-01-01T00:01:53.000000Z\t-7489826605295361807\n" +
+                "15\t1970-01-01T00:01:54.000000Z\t-4094902006239100839\n" +
+                "16\t1970-01-01T00:01:55.000000Z\t-4474835130332302712\n" +
+                "17\t1970-01-01T00:01:56.000000Z\t-6943924477733600060\n";
+
+        testFilterWithColTops(query, expected, jitMode);
+    }
+
+    private void testSelectSingleColumnFilterWithColTops(int jitMode) throws Exception {
+        // The column order is important here, since we want
+        // query and table column indexes to be different.
+        final String query = "select j from t1 where j <> null and x < 3";
+        final String expected = "j\n" +
+                "4689592037643856\n" +
+                "4729996258992366\n";
+
+        testFilterWithColTops(query, expected, jitMode);
+    }
+
+    private void testSingleBindVariable(int jitMode) throws Exception {
+        assertMemoryLeak(() -> {
+            sqlExecutionContext.setJitMode(jitMode);
+
+            compiler.compile("create table x as (select" +
+                    " rnd_long() l," +
+                    " timestamp_sequence(400000000000, 500000000) ts" +
+                    " from long_sequence(100)) timestamp(ts)", sqlExecutionContext);
+
+            bindVariableService.clear();
+            bindVariableService.setLong("l", 3614738589890112276L);
+
+            final String query = "select * from x where l = :l";
+            final String expected = "l\tts\n" +
+                    "3614738589890112276\t1970-01-05T16:38:20.000000Z\n";
+
+            assertSql(query, expected);
+            assertSqlRunWithJit(query);
         });
     }
 }


### PR DESCRIPTION
Jit compiled filter did not handle SqlExecutionContext change by inlining references to Bind Variable functions, instead of the indexes and names. It lead to errors that incorrect bind variables can be used in PgWire