### PR TITLE
fix(cairo): fix meta data validation to avoid occasional error while adding new column

### DIFF
--- a/core/src/test/java/io/questdb/cairo/TableReaderMetadataCorruptionTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReaderMetadataCorruptionTest.java
@@ -39,22 +39,6 @@ import org.junit.Test;
 public class TableReaderMetadataCorruptionTest extends AbstractCairoTest {
 
     @Test
-    public void testColumnNameInvalid() throws Exception {
-        final String[] names = new String[]{"a", "b", "c", "d", "e", "f"};
-        final int[] types = new int[]{ColumnType.INT, ColumnType.INT, ColumnType.STRING, ColumnType.LONG, ColumnType.DATE, ColumnType.TIMESTAMP};
-
-        assertMetaConstructorFailure(
-                names,
-                types,
-                names.length,
-                5,
-                "File is too small, column names are missing 356",
-                4906,
-                356
-        );
-    }
-
-    @Test
     public void testColumnNameMissing() throws Exception {
         final String[] names = new String[]{"a", "b", "c", "d", "b", "f"};
         final int[] types = new int[]{ColumnType.INT, ColumnType.INT, ColumnType.STRING, ColumnType.LONG, ColumnType.DATE, ColumnType.TIMESTAMP};
@@ -126,7 +110,7 @@ public class TableReaderMetadataCorruptionTest extends AbstractCairoTest {
                 5,
                 "File is too small, column length for column 3 is missing",
                 4906,
-                342
+                341
         );
     }
 


### PR DESCRIPTION
Fix in table meta data validation.
Offset was not checked properly against the size of the meta data.
Offset can be equal to the mem size as after reading the last column name the offset will be pointing just after the last byte of the meta data.
Depending on the column names, this offset could be exactly the size of the allocated meta data mem.

