### PR TITLE
feat(sql): added syntax for symbol typed column declaration (#1514)

### DIFF
--- a/core/src/test/java/io/questdb/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlParserTest.java
@@ -1449,6 +1449,52 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testCreateTableSymbolParenthesesParams() throws SqlException {
+        assertCreateTable("create table x (" +
+                        "x SYMBOL capacity 128 nocache index capacity 256)",
+                "create table x (" +
+                        "x SYMBOL (128, false, true, 256))");
+    }
+
+    @Test
+    public void testCreateTableSymbolParenthesesParamsIgnoreIndexCapacity() throws SqlException {
+        assertCreateTable("create table x (" +
+                        "t TIMESTAMP," +
+                        " x SYMBOL capacity 128 nocache index capacity 256)" +
+                        " timestamp(t)" +
+                        " partition by YEAR",
+                "create table x (" +
+                        "t TIMESTAMP, " +
+                        "x SYMBOL (128, false, true)) " +
+                        "timestamp(t) " +
+                        "partition by YEAR");
+    }
+
+    @Test
+    public void testCreateTableSymbolParenthesesParamsIgnoreIndexAndIndexCapacity() throws SqlException {
+        assertCreateTable("create table x (" +
+                        "x SYMBOL capacity 128 nocache)",
+                "create table x (" +
+                        "x SYMBOL (128, false))");
+    }
+
+    @Test
+    public void testCreateTableSymbolParenthesesParamsSymbolCapacity() throws SqlException {
+        assertCreateTable("create table x (" +
+                        "x SYMBOL capacity 256 cache)",
+                "create table x (" +
+                        "x SYMBOL(158))");
+    }
+
+    @Test
+    public void testCreateTableSymbolParenthesesParamsDefault() throws SqlException {
+        assertCreateTable("create table x (" +
+                        "x SYMBOL capacity 128 cache)",
+                "create table x (" +
+                        "x SYMBOL())");
+    }
+
+    @Test
     public void testCreateTableNoCache() throws SqlException {
         assertCreateTable("create table x (" +
                         "a INT," +


### PR DESCRIPTION
This pull request contains added new feature mentioned in issue (#1514) https://github.com/questdb/questdb/issues/1514 to support new syntax for symbol typed column declaration.

In the issue, the feature is proposed to support syntax in format:
```
CREATE TABLE tab (
    id SYMBOL(100, 4, true, true),
    ts timestamp
)
```
to have the same effect as 
```
CREATE TABLE tab (
    id SYMBOL capacity 100 cache index capacity 4,
    ts timestamp
)
```
In which the parameters in parentheses are in order of (symbol capacity, index capacity, cached/noncached, indexed/non-indexed). However, in consideration of consistancy with the original syntax, I decided to implement it in order of (symbol capacity, cached/noncached, indexed/non-indexed, index capacity). 

Please check out examples below to understand: 
```
id SYMBOL() // symbol capacity, cached/noncached & index/nonindexed & index capacity: by default;
id SYMBOL(100, true) // symbol capacity: 100, cached, index/nonindexed & index capacity: by default; 
id SYMBOL(100, true, false) // symbol capacity: 100, cached, nonindexed, index capacity: by default;
id SYMBOL(100, true, true, 100) // symbol capacity: 100, cached, indexed, index capacity: 100;
```

Since I'm not so sure whether this implementation of mine is appropriate, please let me know if modifications are needed. 

In this commit, I edited only the SqlParser.java file and updated four relavant JUnit tests.