### PR TITLE
chore(sql): enable JIT compiler by default

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -1218,7 +1218,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         final String jitMode = overrideWithEnv(properties, env, PropertyKey.CAIRO_SQL_JIT_MODE);
 
         if (jitMode == null) {
-            return SqlJitMode.JIT_MODE_DISABLED;
+            return SqlJitMode.JIT_MODE_ENABLED;
         }
 
         if (Chars.equalsLowerCaseAscii(jitMode, "on")) {
@@ -1233,7 +1233,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             return SqlJitMode.JIT_MODE_FORCE_SCALAR;
         }
 
-        return SqlJitMode.JIT_MODE_DISABLED;
+        return SqlJitMode.JIT_MODE_ENABLED;
     }
 
     private String getString(Properties properties, @Nullable Map<String, String> env, PropertyKey key, String defaultValue) {

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -160,11 +160,9 @@ public class ServerMain {
             switch (jitMode) {
                 case SqlJitMode.JIT_MODE_ENABLED:
                     log.advisoryW().$("SQL JIT compiler mode: on").$();
-                    log.advisoryW().$("Note: JIT compiler mode is a beta feature.").$();
                     break;
                 case SqlJitMode.JIT_MODE_FORCE_SCALAR:
                     log.advisoryW().$("SQL JIT compiler mode: scalar").$();
-                    log.advisoryW().$("Note: JIT compiler mode is a beta feature.").$();
                     break;
                 case SqlJitMode.JIT_MODE_DISABLED:
                     log.advisoryW().$("SQL JIT compiler mode: off").$();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -532,7 +532,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
 
     @Override
     public int getSqlJitMode() {
-        return SqlJitMode.JIT_MODE_DISABLED;
+        return SqlJitMode.JIT_MODE_ENABLED;
     }
 
     @Override

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -331,11 +331,10 @@ query.timeout.sec=60
 #cairo.rnd.memory.max.pages=128
 
 # SQL JIT compiler mode. Options:
-# 1. on (enable JIT and use vector instructions when possible)
+# 1. on (enable JIT and use vector instructions when possible; default value)
 # 2. scalar (enable JIT and use scalar instructions only)
-# 3. off (disable JIT; default value)
-# Note: SQL JIT compiler is a beta feature.
-#cairo.sql.jit.mode=off
+# 3. off (disable JIT)
+#cairo.sql.jit.mode=on
 
 # sets the memory page size and max pages for storing IR for JIT compilation
 #cairo.sql.jit.ir.memory.page.size=8K

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -215,7 +215,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(16, configuration.getCairoConfiguration().getPageFrameReduceColumnListCapacity());
         Assert.assertEquals(4, configuration.getCairoConfiguration().getPageFrameReduceTaskPoolCapacity());
 
-        Assert.assertEquals(SqlJitMode.JIT_MODE_DISABLED, configuration.getCairoConfiguration().getSqlJitMode());
+        Assert.assertEquals(SqlJitMode.JIT_MODE_ENABLED, configuration.getCairoConfiguration().getSqlJitMode());
         Assert.assertEquals(8192, configuration.getCairoConfiguration().getSqlJitIRMemoryPageSize());
         Assert.assertEquals(8, configuration.getCairoConfiguration().getSqlJitIRMemoryMaxPages());
         Assert.assertEquals(4096, configuration.getCairoConfiguration().getSqlJitBindVarsMemoryPageSize());
@@ -886,7 +886,7 @@ public class PropServerConfigurationTest {
         Properties properties = new Properties();
         properties.setProperty("cairo.sql.jit.mode", "");
         PropServerConfiguration configuration = new PropServerConfiguration(root, properties, null, LOG, new BuildInformationHolder());
-        Assert.assertEquals(SqlJitMode.JIT_MODE_DISABLED, configuration.getCairoConfiguration().getSqlJitMode());
+        Assert.assertEquals(SqlJitMode.JIT_MODE_ENABLED, configuration.getCairoConfiguration().getSqlJitMode());
 
         properties.setProperty("cairo.sql.jit.mode", "on");
         configuration = new PropServerConfiguration(root, properties, null, LOG, new BuildInformationHolder());
@@ -902,7 +902,7 @@ public class PropServerConfigurationTest {
 
         properties.setProperty("cairo.sql.jit.mode", "foobar");
         configuration = new PropServerConfiguration(root, properties, null, LOG, new BuildInformationHolder());
-        Assert.assertEquals(SqlJitMode.JIT_MODE_DISABLED, configuration.getCairoConfiguration().getSqlJitMode());
+        Assert.assertEquals(SqlJitMode.JIT_MODE_ENABLED, configuration.getCairoConfiguration().getSqlJitMode());
     }
 
     @Test

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -204,8 +204,6 @@ public class AbstractCairoTest {
 
             @Override
             public int getSqlJitMode() {
-                // JIT compiler is a beta feature and thus is disabled by default,
-                // but we want to have it enabled in tests.
                 return jitMode;
             }
 

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -62,7 +62,7 @@ public class HttpQueryTestBuilder {
     private int workerCount = 1;
     private long startWriterWaitTimeout = 500_000;
     private long maxWriterWaitTimeout = 30_000_000L;
-    private int jitMode = SqlJitMode.JIT_MODE_DISABLED;
+    private int jitMode = SqlJitMode.JIT_MODE_ENABLED;
     private FilesFacade filesFacade = new FilesFacadeImpl();
     private QueryFutureUpdateListener queryFutureUpdateListener;
 

--- a/core/src/test/java/io/questdb/griffin/AsyncOffloadTest.java
+++ b/core/src/test/java/io/questdb/griffin/AsyncOffloadTest.java
@@ -108,7 +108,6 @@ public class AsyncOffloadTest extends AbstractGriffinTest {
         pageFrameReduceShardCount = 2;
         pageFrameReduceQueueCapacity = PAGE_FRAME_COUNT;
 
-        jitMode = SqlJitMode.JIT_MODE_DISABLED;
         AbstractGriffinTest.setUpStatic();
     }
 

--- a/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
+++ b/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
@@ -50,8 +50,7 @@ public class CompiledFilterTest extends AbstractGriffinTest {
     public void setUp() {
         // Disable the test suite on ARM64.
         Assume.assumeTrue(JitUtil.isJitSupported());
-        // Enable JIT.
-        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+
         super.setUp();
     }
 

--- a/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
@@ -61,7 +61,6 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
         // We intentionally use a small capacity for the reduce queue to exhibit various edge cases.
         pageFrameReduceQueueCapacity = QUEUE_CAPACITY;
 
-        jitMode = SqlJitMode.JIT_MODE_DISABLED;
         AbstractGriffinTest.setUpStatic();
     }
 

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -306,11 +306,10 @@ http.enabled=true
 #cairo.sql.page.frame.max.size=8M
 
 # SQL JIT compiler mode. Options:
-# 1. on (enable JIT and use vector instructions when possible)
+# 1. on (enable JIT and use vector instructions when possible; default value)
 # 2. scalar (enable JIT and use scalar instructions only)
-# 3. off (disable JIT; default value)
-# Note: SQL JIT compiler is a beta feature.
-#cairo.sql.jit.mode=off
+# 3. off (disable JIT)
+#cairo.sql.jit.mode=on
 
 # sets the memory page size and max pages for storing IR for JIT compilation
 #cairo.sql.jit.ir.memory.page.size=8K


### PR DESCRIPTION
Changes the default prop for SQL JIT compiler to "enabled", since it has proven itself to be stable. From v6.3, JIT compiler is not a beta feature anymore.

Docs PR: https://github.com/questdb/questdb.io/pull/832