### PR TITLE
feat(sql): added support for standard deviation (sample) aggregate function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleDoubleGroupByFunction.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Standard deviation is calculated using an algorithm first proposed by B. P. Welford.
+ * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm">Welford's algorithm</a>
+ */
+public class StdDevSampleDoubleGroupByFunction extends DoubleFunction implements GroupByFunction, UnaryFunction {
+    private final Function arg;
+    private int valueIndex;
+
+    public StdDevSampleDoubleGroupByFunction(@NotNull Function arg) {
+        this.arg = arg;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record) {
+        final double d = arg.getDouble(record);
+        if (Numbers.isFinite(d)) {
+            double mean = 0;
+            double sum = 0;
+            long count = 1;
+            double oldMean = mean;
+            mean += (d-mean)/count;
+            sum += (d-mean)*(d-oldMean);
+            mapValue.putDouble(valueIndex, mean);
+            mapValue.putDouble(valueIndex + 1 , sum);
+            mapValue.putLong(valueIndex + 2, 1L);
+        } else {
+            mapValue.putDouble(valueIndex, 0);
+            mapValue.putDouble(valueIndex + 1, 0);
+            mapValue.putLong(valueIndex + 2, 0);
+        }
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record) {
+        final double d = arg.getDouble(record);
+        if (Numbers.isFinite(d)) {
+            double mean = mapValue.getDouble(valueIndex);
+            double sum = mapValue.getDouble(valueIndex + 1);
+            long count = mapValue.getLong(valueIndex + 2) + 1;
+            double oldMean = mean;
+            mean += (d-mean)/count;
+            sum += (d-mean)*(d-oldMean);
+            mapValue.putDouble(valueIndex, mean);
+            mapValue.putDouble(valueIndex + 1, sum);
+            mapValue.addLong(valueIndex + 2, 1L);
+        }
+    }
+
+    @Override
+    public void pushValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.LONG);
+    }
+
+    @Override
+    public void setDouble(MapValue mapValue, double value) {
+        mapValue.putDouble(valueIndex, value);
+        mapValue.putLong(valueIndex + 2, 1L);
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
+        mapValue.putDouble(valueIndex + 1, Double.NaN);
+        mapValue.putLong(valueIndex + 2, 0);
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public double getDouble(Record rec) {
+        long count = rec.getLong(valueIndex + 2);
+        if (count - 1 > 0) {
+            double sum = rec.getDouble(valueIndex + 1);
+            double variance = sum / (count - 1);
+            return Math.sqrt(variance);
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleDoubleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleDoubleGroupByFunctionFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class StdDevSampleDoubleGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "stddev_samp(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new StdDevSampleDoubleGroupByFunction(args.getQuick(0));
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -576,6 +576,8 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.ReplaceStrFunctionFactory,
 //                  avg()
             io.questdb.griffin.engine.functions.groupby.AvgDoubleGroupByFunctionFactory,
+//                 stddev_samp()
+            io.questdb.griffin.engine.functions.groupby.StdDevSampleDoubleGroupByFunctionFactory,
 //                  ^
             io.questdb.griffin.engine.functions.math.PowDoubleFunctionFactory,
             io.questdb.griffin.engine.functions.table.AllTablesFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -559,6 +559,9 @@ io.questdb.griffin.engine.functions.str.RightFunctionFactory
 # avg()
 io.questdb.griffin.engine.functions.groupby.AvgDoubleGroupByFunctionFactory
 
+# stddev_samp()
+io.questdb.griffin.engine.functions.groupby.StdDevSampleDoubleGroupByFunctionFactory
+
 # strpos()
 io.questdb.griffin.engine.functions.str.StrPosFunctionFactory
 io.questdb.griffin.engine.functions.str.StrPosCharFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunctionFactoryTest.java
@@ -32,9 +32,9 @@ public class AvgDoubleGroupByFunctionFactoryTest extends AbstractGriffinTest {
     @Test
     public void testAll() throws Exception {
         assertMemoryLeak(() -> assertSql(
-                "select max(x), avg(x), sum(x) from long_sequence(10)",
-                "max\tavg\tsum\n" +
-                        "10\t5.5\t55\n"
+                "select max(x), avg(x), sum(x), stddev_samp(x) from long_sequence(10)",
+                "max\tavg\tsum\tstddev_samp\n" +
+                        "10\t5.5\t55\t3.0276503540974917\n"
         ));
     }
 
@@ -43,9 +43,9 @@ public class AvgDoubleGroupByFunctionFactoryTest extends AbstractGriffinTest {
         assertMemoryLeak(() -> {
             compiler.compile("create table test2 as(select case  when rnd_double() > 0.6 then 1.0   else 0.0  end val from long_sequence(100));", sqlExecutionContext);
             assertSql(
-                    "select sum(1/val) , avg(1/val), max(1/val), min(1/val), ksum(1/val), nsum(1/val) from test2",
-                    "sum\tavg\tmax\tmin\tksum\tnsum\n" +
-                            "44.0\t1.0\tInfinity\t1.0\t44.0\t44.0\n"
+                    "select sum(1/val) , avg(1/val), max(1/val), min(1/val), ksum(1/val), nsum(1/val), stddev_samp(1/val) from test2",
+                    "sum\tavg\tmax\tmin\tksum\tnsum\tstddev_samp\n" +
+                            "44.0\t1.0\tInfinity\t1.0\t44.0\t44.0\t0.0\n"
             );
         });
     }
@@ -70,13 +70,13 @@ public class AvgDoubleGroupByFunctionFactoryTest extends AbstractGriffinTest {
             executeInsert("insert into fill_options values(to_timestamp('2020-01-01:12:00:00', 'yyyy-MM-dd:HH:mm:ss'), 3);");
             executeInsert("insert into fill_options values(to_timestamp('2020-01-01:14:00:00', 'yyyy-MM-dd:HH:mm:ss'), 5);");
 
-            assertQuery("ts\tmin\tmax\tavg\n" +
-                    "2020-01-01T10:00:00.000000Z\t1\t1\t1.0\n" +
-                    "2020-01-01T11:00:00.000000Z\t2\t2\t2.0\n" +
-                    "2020-01-01T12:00:00.000000Z\t3\t3\t3.0\n" +
-                    "2020-01-01T13:00:00.000000Z\t4\t4\t4.0\n" +
-                    "2020-01-01T14:00:00.000000Z\t5\t5\t5.0\n",
-                    "select ts, min(price) min, max(price) max, avg(price) avg\n" +
+            assertQuery("ts\tmin\tmax\tavg\tstddev_samp\n" +
+                            "2020-01-01T10:00:00.000000Z\t1\t1\t1.0\tNaN\n" +
+                            "2020-01-01T11:00:00.000000Z\t2\t2\t2.0\tNaN\n" +
+                            "2020-01-01T12:00:00.000000Z\t3\t3\t3.0\tNaN\n" +
+                            "2020-01-01T13:00:00.000000Z\t4\t4\t4.0\tNaN\n" +
+                            "2020-01-01T14:00:00.000000Z\t5\t5\t5.0\tNaN\n",
+                    "select ts, min(price) min, max(price) max, avg(price) avg, stddev_samp(price) stddev_samp\n" +
                             "from fill_options\n" +
                             "sample by 1h\n" +
                             "fill(linear);",

--- a/core/src/test/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/groupby/StdDevSampleGroupByFunctionFactoryTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.SqlException;
+import org.junit.Test;
+
+public class StdDevSampleGroupByFunctionFactoryTest extends AbstractGriffinTest {
+
+    @Test
+    public void testStddevSampAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "select stddev_samp(x) from (select cast(null as double) x from long_sequence(100))",
+                "stddev_samp\nNaN\n"));
+    }
+
+    @Test
+    public void testStddevSampSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select cast(x as double) x from long_sequence(100))", sqlExecutionContext);
+            executeInsert("insert into 'tbl1' VALUES (null)");
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1(x double)", sqlExecutionContext);
+            executeInsert("insert into 'tbl1' VALUES (null)");
+            executeInsert("insert into 'tbl1' select x from long_sequence(100)");
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select cast(x as double) x from long_sequence(100))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampLong256Values() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select x cast(x as long256) from long_sequence(100))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select cast(x as float) x from long_sequence(100))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select cast(x as int) x from long_sequence(100))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n29.011491975882016\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select 17.2151921 x from long_sequence(100))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n0.0\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1(x int)", sqlExecutionContext);
+            executeInsert("insert into 'tbl1' VALUES " +
+                    "(17.2151920)");
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\nNaN\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1(x int)", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\nNaN\n"
+            );
+        });
+    }
+
+    @Test
+    public void testStddevSampOverflow() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table tbl1 as (select 100000000 x from long_sequence(1000000))", sqlExecutionContext);
+            assertSql(
+                    "select stddev_samp(x) from tbl1",
+                    "stddev_samp\n0.0\n"
+            );
+        });
+    }
+}


### PR DESCRIPTION
 Add support for standard deviation (sample) aggregate function. Fixes #1809 

The signature of the function is `stddev_samp` as used in [Postgres](https://www.postgresql.org/docs/9.1/functions-aggregate.html).

The current implementation follows the avg group by aggregate function and returns always a double value or null.
Tests have been added in a new file: `StddevSampleGroupByFunctionFactoryTest` and `sttdev_samp` check is added along other aggregate function inside `AvgDoubleGroupByFunctionFactoryTest` following the pattern there!