### PR TITLE
chore(sql): add config option to disable parallel SQL filter execution

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -248,6 +248,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int cairoPageFrameReduceColumnListCapacity;
     private final int cairoPageFrameReduceTaskPoolCapacity;
     private final long writerFileOpenOpts;
+    private final boolean sqlParallelFilterEnabled;
     private final int cairoPageFrameReduceShardCount;
     private int lineUdpDefaultPartitionBy;
     private int httpMinNetConnectionLimit;
@@ -696,6 +697,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.cairoPageFrameReduceQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 64));
             this.cairoPageFrameReduceRowIdListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY, 256));
             this.cairoPageFrameReduceColumnListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY, 16));
+            this.sqlParallelFilterEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FILTER_ENABLED, true);
             this.cairoPageFrameReduceShardCount = getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 4);
             this.cairoPageFrameReduceTaskPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_TASK_POOL_CAPACITY, 4);
 
@@ -2049,6 +2051,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getPageFrameReduceQueueCapacity() {
             return cairoPageFrameReduceQueueCapacity;
+        }
+
+        @Override
+        public boolean isSqlParallelFilterEnabled() {
+            return sqlParallelFilterEnabled;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -87,6 +87,7 @@ public enum PropertyKey {
     CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY("cairo.page.frame.reduce.queue.capacity"),
     CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY("cairo.page.frame.rowid.list.capacity"),
     CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY("cairo.page.frame.column.list.capacity"),
+    CAIRO_SQL_PARALLEL_FILTER_ENABLED("cairo.sql.parallel.filter.enabled"),
     CAIRO_PAGE_FRAME_SHARD_COUNT("cairo.page.frame.shard.count"),
     CAIRO_PAGE_FRAME_TASK_POOL_CAPACITY("cairo.page.frame.task.pool.capacity"),
     CAIRO_SQL_JOIN_METADATA_PAGE_SIZE("cairo.sql.join.metadata.page.size"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -186,6 +186,8 @@ public interface CairoConfiguration {
 
     int getO3PurgeDiscoveryQueueCapacity();
 
+    boolean isSqlParallelFilterEnabled();
+
     int getPageFrameReduceQueueCapacity();
 
     int getPageFrameReduceShardCount();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -354,6 +354,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean isSqlParallelFilterEnabled() {
+        return true;
+    }
+
+    @Override
     public int getPageFrameReduceQueueCapacity() {
         return 32;
     }

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -394,6 +394,9 @@ query.timeout.sec=60
 
 ################ Parallel SQL execution ################
 
+# Sets flag to enable parallel SQL filter execution.
+#cairo.sql.parallel.filter.enabled=true
+
 # Shard reduce queue contention between SQL statements that are executed concurrently.
 #cairo.page.frame.shard.count=4
 
@@ -454,7 +457,7 @@ query.timeout.sec=60
 # TCP message buffer size
 #line.tcp.msg.buffer.size=2048
 
-# Max measurement size,
+# Max measurement size
 #line.tcp.max.measurement.size=2048
 
 # Size of the queue between the IO jobs and the writer jobs, each queue entry represents a measurement

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -394,7 +394,7 @@ query.timeout.sec=60
 
 ################ Parallel SQL execution ################
 
-# Sets flag to enable parallel SQL filter execution.
+# Sets flag to enable parallel SQL filter execution. JIT compilation takes place only when this setting is enabled.
 #cairo.sql.parallel.filter.enabled=true
 
 # Shard reduce queue contention between SQL statements that are executed concurrently.

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -207,6 +207,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(-1, configuration.getLineUdpReceiverConfiguration().ownThreadAffinity());
         Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().ownThread());
 
+        Assert.assertTrue(configuration.getCairoConfiguration().isSqlParallelFilterEnabled());
         Assert.assertEquals(1_000_000, configuration.getCairoConfiguration().getSqlPageFrameMaxRows());
         Assert.assertEquals(1000, configuration.getCairoConfiguration().getSqlPageFrameMinRows());
         Assert.assertEquals(4, configuration.getCairoConfiguration().getPageFrameReduceShardCount());
@@ -739,6 +740,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(2, configuration.getLineUdpReceiverConfiguration().ownThreadAffinity());
             Assert.assertTrue(configuration.getLineUdpReceiverConfiguration().ownThread());
 
+            Assert.assertFalse(configuration.getCairoConfiguration().isSqlParallelFilterEnabled());
             Assert.assertEquals(1000, configuration.getCairoConfiguration().getSqlPageFrameMaxRows());
             Assert.assertEquals(100, configuration.getCairoConfiguration().getSqlPageFrameMinRows());
             Assert.assertEquals(128, configuration.getCairoConfiguration().getPageFrameReduceShardCount());

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -84,6 +84,7 @@ public class AbstractCairoTest {
     protected static int rndFunctionMemoryMaxPages = -1;
     protected static String snapshotInstanceId = null;
     protected static Boolean snapshotRecoveryEnabled = null;
+    protected static Boolean enableParallelFilter = null;
     protected static int queryCacheEventQueueCapacity = -1;
     protected static int pageFrameReduceShardCount = -1;
     protected static int pageFrameReduceQueueCapacity = -1;
@@ -278,6 +279,11 @@ public class AbstractCairoTest {
             public int getPageFrameReduceQueueCapacity() {
                 return pageFrameReduceQueueCapacity < 0 ? super.getPageFrameReduceQueueCapacity() : pageFrameReduceQueueCapacity;
             }
+
+            @Override
+            public boolean isSqlParallelFilterEnabled() {
+                return enableParallelFilter != null ? enableParallelFilter : super.isSqlParallelFilterEnabled();
+            }
         };
         engine = new CairoEngine(configuration, metrics);
         snapshotAgent = new DatabaseSnapshotAgent(engine);
@@ -323,6 +329,7 @@ public class AbstractCairoTest {
         spinLockTimeoutUs = -1;
         snapshotInstanceId = null;
         snapshotRecoveryEnabled = null;
+        enableParallelFilter = null;
         hideTelemetryTable = false;
         writerCommandQueueCapacity = 4;
         queryCacheEventQueueCapacity = -1;

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -113,6 +113,7 @@ cairo.sql.bind.variable.pool.size=16
 cairo.sql.sampleby.page.size=2001
 cairo.sql.page.frame.max.rows=1000
 cairo.sql.page.frame.min.rows=100
+cairo.sql.parallel.filter.enabled=false
 cairo.page.frame.shard.count=128
 cairo.page.frame.reduce.queue.capacity=1024
 cairo.page.frame.rowid.list.capacity=8

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -13,7 +13,7 @@ config.validation.strict=true
 ################ HTTP settings ##################
 
 # enable HTTP server
-#http.enabled=true
+http.enabled=true
 
 # IP address and port of HTTP server
 #http.net.bind.to=0.0.0.0:9000
@@ -423,7 +423,7 @@ query.timeout.sec=60
 #line.udp.msg.buffer.size=2048
 #line.udp.msg.count=10000
 #line.udp.receive.buffer.size=8m
-#line.udp.enabled=true
+line.udp.enabled=true
 #line.udp.own.thread.affinity=-1
 #line.udp.own.thread=false
 #line.udp.unicast=false
@@ -431,7 +431,8 @@ query.timeout.sec=60
 #line.udp.timestamp=n
 
 ######################### LINE TCP settings ###############################
-#line.tcp.enabled=true
+line.tcp.enabled=true
+line.tcp.auth.db.path=conf/auth.txt
 #line.tcp.net.bind.to=0.0.0.0:9009
 #line.tcp.net.connection.limit=10
 
@@ -493,7 +494,7 @@ query.timeout.sec=60
 
 ################ PG Wire settings ##################
 
-#pg.enabled=true
+pg.enabled=true
 #pg.net.bind.to=0.0.0.0:8812
 #pg.net.connection.limit=10
 # Windows OS might have a limit on TCP backlog size. Typically Windows 10 has max of 200. This
@@ -517,8 +518,8 @@ query.timeout.sec=60
 #pg.character.store.capacity=4096
 #pg.character.store.pool.capacity=64
 #pg.connection.pool.capacity=64
-#pg.password=quest
-#pg.user=admin
+pg.password=PG_PASSWORD_REPLACE
+pg.user=admin
 # Enables read-only mode for the pg wire protocol. In this mode data mutations queries are rejected.
 #pg.security.readonly=false
 # enables select query cache

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -394,7 +394,7 @@ query.timeout.sec=60
 
 ################ Parallel SQL execution ################
 
-# Sets flag to enable parallel SQL filter execution.
+# Sets flag to enable parallel SQL filter execution. JIT compilation takes place only when this setting is enabled.
 #cairo.sql.parallel.filter.enabled=true
 
 # Shard reduce queue contention between SQL statements that are executed concurrently.

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -13,10 +13,34 @@ config.validation.strict=true
 ################ HTTP settings ##################
 
 # enable HTTP server
-http.enabled=true
+#http.enabled=true
 
 # IP address and port of HTTP server
-#http.bind.to=0.0.0.0:9000
+#http.net.bind.to=0.0.0.0:9000
+
+#http.net.connection.limit=256
+# Windows OS might have a limit on TCP backlog size. Typically Windows 10 has max of 200. This
+# means that even if net.connection.limit is set over 200 it wont be possible to have this many
+# concurrent connections. To overcome this limitation Windows has an unreliable hack, which you can
+# exercise with this flag. Do only set it if you actively try to overcome limit you have already
+# experienced. Read more about SOMAXCONN_HINT here https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
+#http.net.connection.hint=false
+
+# idle connection timeout in millis
+#http.net.connection.timeout=300000
+
+#Amount of time in ms a connection can wait in the listen backlog queue before its refused. Connections will be aggressively removed from the backlog until the active connection limit is breached
+#http.net.connection.queue.timeout=5000
+
+
+# SO_SNDBUF value, -1 = OS default
+#http.net.connection.sndbuf=2m
+
+# SO_RCVBUF value, -1 = OS default
+#http.net.connection.rcvbuf=2m
+
+# size of receive buffer on application side
+#http.receive.buffer.size=1m
 
 # initial size of the connection pool
 #http.connection.pool.initial.capacity=16
@@ -29,9 +53,6 @@ http.enabled=true
 
 # how long code accumulates incoming data chunks for column and delimiter analysis
 #http.multipart.idle.spin.count=10000
-
-# size of receive buffer
-#http.receive.buffer.size=1m
 
 #http.request.header.buffer.size=64k
 
@@ -64,16 +85,6 @@ http.enabled=true
 #http.keep-alive.max=10000
 
 #http.static.public.directory=public
-#http.net.active.connection.limit=256
-#http.net.event.capacity=1024
-#http.net.io.queue.capacity=1024
-#http.net.idle.connection.timeout=300000
-#Amount of time in ms a connection can wait in the listen backlog queue before its refused. Connections will be aggressively removed from the backlog until the active connection limit is breached
-#http.net.queued.connection.timeout=5000
-#http.net.interest.queue.capacity=1024
-#http.net.listen.backlog=256
-#http.net.snd.buf.size=2m
-#http.net.rcv.buf.size=2m
 
 #http.text.date.adapter.pool.capacity=16
 #http.text.json.cache.limit=16384
@@ -95,21 +106,31 @@ http.enabled=true
 # enables the query cache
 #http.query.cache.enabled=true
 
-# sets the number of blocks for the query cache
+# sets the number of blocks for the query cache. Cache capacity is number_of_blocks * number_of_rows
 #http.query.cache.block.count=4
 
-# sets the number of rows for the query cache
+# sets the number of rows for the query cache. Cache capacity is number_of_blocks * number_of_rows
 #http.query.cache.row.count=16
 
 #http.security.readonly=false
 #http.security.max.response.rows=Long.MAX_VALUE
 
-# Switch to turn on terminating SQL processing if the HTTP connection is closed,
-#  the mechanism affects performance so the connection is only checked after http.security.interruptor.iterations.per.check calls are made to the check method.
-#  the mechanism also reads \r\n from the input stream and discards it since some HTTP clients send this as a keep alive in between requests, http.security.interruptor.buffer.size denotes the size of the buffer for this.
-#http.security.interrupt.on.closed.connection=true
-#http.security.interruptor.iterations.per.check=2000000
-#http.security.interruptor.buffer.size=32
+# circuit breaker is a mechanism that interrupts query execution
+# at present queries are interrupted when remote client disconnects or when execution takes too long
+# and times out
+
+# circuit breaker is designed to be invoke continuously in a tight loop
+# the throttle is a number of pin cycles before abort conditions are tested
+circuit.breaker.throttle=2000000
+
+# buffer used by the circuit breaker to check the socket state, please do not change this value
+# the reads \r\n from the input stream and discards it since some HTTP clients send this as a keep alive in between requests
+circuit.breaker.buffer.size=32
+
+# max execution time for read-only query in seconds, this can be a floating point value to specify 0.5s
+# "insert" type of queries are not aborted unless they
+# it is "insert as select", where select takes long time before producing rows for the insert
+query.timeout.sec=60
 
 ## HTTP MIN settings
 ##
@@ -209,6 +230,9 @@ http.enabled=true
 # sets the size of the QueryModel pool in the SqlCompiler
 #cairo.model.pool.capacity=1024
 
+# sets the maximum allowed negative value used in LIMIT clause in queries with filters
+#cairo.sql.max.negative.limit=10000
+
 # sets the memory page size for storing keys in LongTreeChain
 #cairo.sql.sort.key.page.size=4m
 
@@ -223,7 +247,7 @@ http.enabled=true
 #cairo.sql.hash.join.value.page.size=16777216
 #cairo.sql.hash.join.value.max.pages=2^31
 
-# sets the number of rows for latest By
+# sets the initial capacity for row id list used for latest by
 #cairo.sql.latest.by.row.count=1000
 
 # sets the memory page size and max pages of the slave chain in light hash joins
@@ -276,7 +300,7 @@ http.enabled=true
 # name of file with user's set of date and timestamp formats
 #cairo.sql.copy.formats.file=/text_loader.json
 
-# input root directory for backups
+# input root directory, where copy command reads files from
 #cairo.sql.copy.root=null
 
 # output root directory for backups
@@ -295,15 +319,16 @@ http.enabled=true
 # 0 means to use symbol block capacity
 # cairo.sql.sampleby.page.size=0
 
-#cairo.date.locale=en
+# sets the minimum number of rows in page frames used in SQL queries
+#cairo.sql.page.frame.min.rows=1000
 
-# Maximum number of uncommitted rows in TCP ILP
-#cairo.max.uncommitted.rows=500000
-# Expected maximum time lag for out-of-order rows in milliseconds
-#cairo.commit.lag=300000
+# sets the maximum number of rows in page frames used in SQL queries
+#cairo.sql.page.frame.max.rows=1000000
 
-# sets the maximum size of the page frames used in SQL queries
-#cairo.sql.page.frame.max.size=8M
+# sets the memory page size and max number of pages for memory used by rnd functions
+# currently rnd_str() and rnd_symbol(), this could extend to other rnd functions in the future
+#cairo.rnd.memory.page.size=8K
+#cairo.rnd.memory.max.pages=128
 
 # SQL JIT compiler mode. Options:
 # 1. on (enable JIT and use vector instructions when possible; default value)
@@ -328,6 +353,68 @@ http.enabled=true
 # sets debug flag for JIT compilation; when enabled, assembly will be printed into stdout
 #cairo.sql.jit.debug.enabled=false
 
+#cairo.date.locale=en
+
+# Maximum number of uncommitted rows in TCP ILP
+#cairo.max.uncommitted.rows=500000
+# Expected maximum time lag for out-of-order rows in milliseconds
+#cairo.commit.lag=300000
+
+# Memory page size per column for O3 operations. Please be aware O3 will use 2x of this RAM per column
+#cairo.o3.column.memory.size=16M
+
+# Number of partition expected on average, initial value for purge allocation job, extended in runtime automatically
+#cairo.o3.partition.purge.list.initial.capacity=1
+
+# mmap sliding page size that TableWriter uses to append data for each column
+#cairo.writer.data.append.page.size=16M
+
+# mmap page size for mapping small files, such as _txn, _todo and _meta
+# the default value is OS page size (4k Linux, 64K windows, 16k OSX M1)
+# if you override this value it will be rounded to the nearest (greater) multiple of OS page size
+#cairo.writer.misc.append.page.size=4k
+
+# mmap page size for appending index key data; key data is number of distinct symbol values times 4 bytes
+#cairo.writer.data.index.key.append.page.size=512k
+
+# mmap page size for appending value data; value data are rowids, e.g. number of rows in partition times 8 bytes
+#cairo.writer.data.index.value.append.page.size=16M
+
+# Maximum wait timeout on ALTER TABLE SQL from REST, PgWire interfaces when statement execution is ASYNCHRONOUS
+#cairo.writer.alter.busy.wait.timeout.micro=500000
+
+# Row count to check writer command queue after on busy writing (e.g. tick after X rows written)
+#cairo.writer.tick.rows.count=1024
+
+# Maximum writer ALTER TABLE and replication command capacity. Shared between all the tables
+#cairo.writer.command.queue.capacity=32
+
+# Maximum flush query cache command queue capacity
+#cairo.query.cache.event.queue.capacity=4
+
+################ Parallel SQL execution ################
+
+# Sets flag to enable parallel SQL filter execution.
+#cairo.sql.parallel.filter.enabled=true
+
+# Shard reduce queue contention between SQL statements that are executed concurrently.
+#cairo.page.frame.shard.count=4
+
+# Reduce queue is used for data processing and should be large enough to supply tasks for worker threads (shared worked pool).
+#cairo.page.frame.reduce.queue.capacity=64
+
+# Initial row ID list capacity for each slot of the "reduce" queue. Larger values reduce memory allocation rate, but increase RSS size.
+#cairo.page.frame.rowid.list.capacity=256
+
+# Initial column list capacity for each slot of the "reduce" queue. Used by JIT-compiled filters.
+#cairo.page.frame.column.list.capacity=16
+
+# Initial object pool capacity for local "reduce" tasks. These tasks are used to avoid blocking query execution when the "reduce" queue is full.
+#cairo.page.frame.task.pool.capacity=4
+
+################ LINE settings ######################
+#line.default.partition.by=DAY
+
 ################ LINE UDP settings ##################
 
 #line.udp.bind.to=0.0.0.0:9009
@@ -336,36 +423,41 @@ http.enabled=true
 #line.udp.msg.buffer.size=2048
 #line.udp.msg.count=10000
 #line.udp.receive.buffer.size=8m
-line.udp.enabled=true
+#line.udp.enabled=true
 #line.udp.own.thread.affinity=-1
 #line.udp.own.thread=false
 #line.udp.unicast=false
 #line.udp.commit.mode=nosync
 #line.udp.timestamp=n
 
-######################### LINE settings ###################################
-#line.default.partition.by=DAY
-
 ######################### LINE TCP settings ###############################
-line.tcp.enabled=true
-line.tcp.auth.db.path=conf/auth.txt
-#line.tcp.net.active.connection.limit=10
+#line.tcp.enabled=true
 #line.tcp.net.bind.to=0.0.0.0:9009
-#line.tcp.net.event.capacity=1024
-#line.tcp.net.io.queue.capacity=1024
-#line.tcp.net.idle.timeout=0
+#line.tcp.net.connection.limit=10
+
+# Windows OS might have a limit on TCP backlog size. Typically Windows 10 has max of 200. This
+# means that even if net.connection.limit is set over 200 it wont be possible to have this many
+# concurrent connections. To overcome this limitation Windows has an unreliable hack, which you can
+# exercise with this flag. Do only set it if you actively try to overcome limit you have already
+# experienced. Read more about SOMAXCONN_HINT here https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
+#line.tcp.net.connection.hint=false
+
+# idle connection timeout in millis. 0 means there is no timeout.
+#line.tcp.net.connection.timeout=0
+
 #Amount of time in ms a connection can wait in the listen backlog queue before its refused. Connections will be aggressively removed from the backlog until the active connection limit is breached
-#line.tcp.net.queued.timeout=5000
-#line.tcp.net.interest.queue.capacity=1024
-#line.tcp.net.listen.backlog=50000
-#line.tcp.net.recv.buf.size=-1
+#line.tcp.net.connection.queue.timeout=5000
+
+# SO_RCVBUF value, -1 = OS default
+#line.tcp.net.connection.rcvbuf=-1
+
 #line.tcp.connection.pool.capacity=64
 #line.tcp.timestamp=n
 
 # TCP message buffer size
 #line.tcp.msg.buffer.size=2048
 
-# Max measurement size,
+# Max measurement size
 #line.tcp.max.measurement.size=2048
 
 # Size of the queue between the IO jobs and the writer jobs, each queue entry represents a measurement
@@ -384,6 +476,9 @@ line.tcp.auth.db.path=conf/auth.txt
 #line.tcp.io.worker.sleep.threshold=10000
 #line.tcp.io.halt.on.error=false
 
+# Sets flag to disconnect TCP connection that sends malformed messages.
+#line.tcp.disconnect.on.error=true
+
 # Commit lag fraction. Used to calculate commit interval for the table according to the following formula:
 # commit_interval = commit_lag ∗ fraction
 # The calculated commit interval defines how long uncommitted data will need to remain uncommitted.
@@ -398,23 +493,34 @@ line.tcp.auth.db.path=conf/auth.txt
 
 ################ PG Wire settings ##################
 
-pg.enabled=true
-#pg.net.active.connection.limit=10
+#pg.enabled=true
 #pg.net.bind.to=0.0.0.0:8812
-#pg.net.event.capacity=1024
-#pg.net.io.queue.capacity=1024)
-#pg.net.idle.timeout=300000
+#pg.net.connection.limit=10
+# Windows OS might have a limit on TCP backlog size. Typically Windows 10 has max of 200. This
+# means that even if active.connection.limit is set over 200 it wont be possible to have this many
+# concurrent connections. To overcome this limitation Windows has an unreliable hack, which you can
+# exercise with this flag. Do only set it if you actively try to overcome limit you have already
+# experienced. Read more about SOMAXCONN_HINT here https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
+#pg.net.connection.hint=false
+
+#pg.net.connection.timeout=300000
+
 #Amount of time in ms a connection can wait in the listen backlog queue before its refused. Connections will be aggressively removed from the backlog until the active connection limit is breached
-#pg.net.queued.timeout=300000
-#pg.net.interest.queue.capacity=1024
-#pg.net.listen.backlog=50000
-#pg.net.recv.buf.size=-1
-#pg.net.send.buf.size=-1
+#pg.net.connection.queue.timeout=300000
+
+# SO_RCVBUF value, -1 = OS default
+#pg.net.connection.rcvbuf=-1
+
+# SO_SNDBUF value, -1 = OS default
+#pg.net.connection.sndbuf=-1
+
 #pg.character.store.capacity=4096
 #pg.character.store.pool.capacity=64
 #pg.connection.pool.capacity=64
-pg.password=PG_PASSWORD_REPLACE
-pg.user=admin
+#pg.password=quest
+#pg.user=admin
+# Enables read-only mode for the pg wire protocol. In this mode data mutations queries are rejected.
+#pg.security.readonly=false
 # enables select query cache
 #pg.select.cache.enabled=true
 # sets the number of blocks for the select query cache. Cache capacity is number_of_blocks * number_of_rows
@@ -435,11 +541,23 @@ pg.user=admin
 #pg.worker.affinity=-1,-1;
 #pg.halt.on.error=false
 #pg.daemon.pool=true
+#pg.binary.param.count.capacity=2
 
 ################ Telemetry settings ##################
 
+# Telemetry switch. Telemetry events are use to identify components of questdb that are being used. They never identify
+# user not data stored in questdb. All events can be viewed via `select * from telemetry`. Switching telemetry off will
+# stop all events from being collected and subsequent growth of `telemetry` table. After telemetry is switched off
+# `telemetry` table cab be dropped.
 #telemetry.enabled=true
+
+# Capacity of the internal telemetry queue, which is the gateway of all telemetry events.
+# This queue capacity does not require tweaking.
 #telemetry.queue.capacity=512
+
+# hides telemetry tables from `select * from tables()` output. As a result, telemetry tables
+# will not be visible in the Web Console table view
+#telemetry.hide.tables=true
 
 ################ Metrics settings ##################
 


### PR DESCRIPTION
JIT compiled filters are kept available only when parallel SQL filters are enabled.

Also updates AWS marketplace config artifact with the contents of the default `server.conf`. The reason for that it that they were totally out of sync.