### PR TITLE
fix(sql): fix potential stack overflow in PG Wire select and insert cache pooling

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -67,7 +67,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     private SqlExecutionCircuitBreaker[] circuitBreakers;
     // Local reduce task used when there is no slots in the queue to dispatch tasks.
     private PageFrameReduceTask localTask;
-    private final WeakAutoClosableObjectPool<PageFrameReduceTask> localTaskPool;
+    private final WeakClosableObjectPool<PageFrameReduceTask> localTaskPool;
     private long startTimeUs;
     private long circuitBreakerFd;
     private SqlExecutionContext sqlExecutionContext;
@@ -76,7 +76,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
             CairoConfiguration configuration,
             MessageBus messageBus,
             PageFrameReducer reducer,
-            WeakAutoClosableObjectPool<PageFrameReduceTask> localTaskPool
+            WeakClosableObjectPool<PageFrameReduceTask> localTaskPool
     ) {
         this.pageAddressCache = new PageAddressCache(configuration);
         this.messageBus = messageBus;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -386,11 +386,11 @@ public class HttpServer implements Closeable {
     }
 
     private static class HttpContextFactory implements IOContextFactory<HttpConnectionContext>, Closeable, EagerThreadSetup {
-        private final ThreadLocal<WeakObjectPool<HttpConnectionContext>> contextPool;
+        private final ThreadLocal<WeakMutableObjectPool<HttpConnectionContext>> contextPool;
         private boolean closed = false;
 
         public HttpContextFactory(HttpContextConfiguration configuration, Metrics metrics) {
-            this.contextPool = new ThreadLocal<>(() -> new WeakObjectPool<>(() ->
+            this.contextPool = new ThreadLocal<>(() -> new WeakMutableObjectPool<>(() ->
                     new HttpConnectionContext(configuration, metrics), configuration.getConnectionPoolInitialCapacity()));
         }
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
@@ -131,7 +131,7 @@ public class LineTcpReceiver implements Closeable {
     }
 
     private class LineTcpConnectionContextFactory implements IOContextFactory<LineTcpConnectionContext>, Closeable, EagerThreadSetup {
-        private final ThreadLocal<WeakObjectPool<LineTcpConnectionContext>> contextPool;
+        private final ThreadLocal<WeakMutableObjectPool<LineTcpConnectionContext>> contextPool;
         private boolean closed = false;
 
         public LineTcpConnectionContextFactory(LineTcpReceiverConfiguration configuration) {
@@ -145,7 +145,7 @@ public class LineTcpReceiver implements Closeable {
                 factory = () -> new LineTcpAuthConnectionContext(configuration, authDb, scheduler, metrics);
             }
 
-            this.contextPool = new ThreadLocal<>(() -> new WeakObjectPool<>(factory, configuration.getConnectionPoolInitialCapacity()));
+            this.contextPool = new ThreadLocal<>(() -> new WeakMutableObjectPool<>(factory, configuration.getConnectionPoolInitialCapacity()));
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/AbstractTypeContainer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/AbstractTypeContainer.java
@@ -26,24 +26,21 @@ package io.questdb.cutlass.pgwire;
 
 import io.questdb.cairo.sql.BindVariableService;
 import io.questdb.griffin.SqlException;
+import io.questdb.std.AbstractSelfReturningObject;
 import io.questdb.std.IntList;
-import io.questdb.std.WeakAutoClosableObjectPool;
+import io.questdb.std.WeakSelfReturningObjectPool;
 
-import java.io.Closeable;
-
-abstract class AbstractTypeContainer<T extends Closeable> implements Closeable {
+public abstract class AbstractTypeContainer<T extends AbstractTypeContainer<?>> extends AbstractSelfReturningObject<T> {
     private final IntList types = new IntList();
-    private final WeakAutoClosableObjectPool<T> parentPool;
 
-    public AbstractTypeContainer(WeakAutoClosableObjectPool<T> parentPool) {
-        this.parentPool = parentPool;
+    public AbstractTypeContainer(WeakSelfReturningObjectPool<T> parentPool) {
+        super(parentPool);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void close() {
+        super.close();
         types.clear();
-        this.parentPool.push((T) this);
     }
 
     public void defineBindVariables(BindVariableService bindVariableService) throws SqlException {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -124,9 +124,9 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     private final Path path = new Path();
     private final IntList bindVariableTypes = new IntList();
     private final IntList selectColumnTypes = new IntList();
-    private final WeakObjectPool<NamedStatementWrapper> namedStatementWrapperPool;
-    private final WeakObjectPool<Portal> namedPortalPool;
-    private final WeakAutoClosableObjectPool<TypesAndInsert> typesAndInsertPool;
+    private final WeakMutableObjectPool<NamedStatementWrapper> namedStatementWrapperPool;
+    private final WeakMutableObjectPool<Portal> namedPortalPool;
+    private final WeakSelfReturningObjectPool<TypesAndInsert> typesAndInsertPool;
     private final DateLocale locale;
     private final CharSequenceObjHashMap<TableWriter> pendingWriters;
     private final DirectCharSink utf8Sink;
@@ -180,7 +180,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     private final PGResumeProcessor resumeQueryCompleteRef = this::resumeQueryComplete;
     private NamedStatementWrapper wrapper;
     private AssociativeCache<TypesAndSelect> typesAndSelectCache;
-    private WeakAutoClosableObjectPool<TypesAndSelect> typesAndSelectPool;
+    private WeakSelfReturningObjectPool<TypesAndSelect> typesAndSelectPool;
     // this is a reference to types either from the context or named statement, where it is provided
     private IntList activeBindVariableTypes;
     private boolean sendParameterDescription;
@@ -212,14 +212,14 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
         this.locale = configuration.getDefaultDateLocale();
         this.sqlExecutionContext = sqlExecutionContext;
         this.sqlExecutionContext.setRandom(this.rnd = configuration.getRandom());
-        this.namedStatementWrapperPool = new WeakObjectPool<>(NamedStatementWrapper::new, configuration.getNamesStatementPoolCapacity()); // 16
-        this.namedPortalPool = new WeakObjectPool<>(Portal::new, configuration.getNamesStatementPoolCapacity()); // 16
+        this.namedStatementWrapperPool = new WeakMutableObjectPool<>(NamedStatementWrapper::new, configuration.getNamesStatementPoolCapacity()); // 32
+        this.namedPortalPool = new WeakMutableObjectPool<>(Portal::new, configuration.getNamesStatementPoolCapacity()); // 32
         this.namedStatementMap = new CharSequenceObjHashMap<>(configuration.getNamedStatementCacheCapacity());
         this.pendingWriters = new CharSequenceObjHashMap<>(configuration.getPendingWritersCacheSize());
         this.namedPortalMap = new CharSequenceObjHashMap<>(configuration.getNamedStatementCacheCapacity());
         this.binarySequenceParamsPool = new ObjectPool<>(DirectBinarySequence::new, configuration.getBinParamCountCapacity());
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(configuration.getCircuitBreakerConfiguration());
-        this.typesAndInsertPool = new WeakAutoClosableObjectPool<>(TypesAndInsert::new, configuration.getInsertPoolCapacity()); // 32
+        this.typesAndInsertPool = new WeakSelfReturningObjectPool<>(TypesAndInsert::new, configuration.getInsertPoolCapacity()); // 64
         final boolean enableInsertCache = configuration.isInsertCacheEnabled();
         final int blockCount = enableInsertCache ? configuration.getInsertCacheBlockCount() : 1; // 8
         final int rowCount = enableInsertCache ? configuration.getInsertCacheRowCount() : 1; // 8
@@ -360,7 +360,7 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     public void handleClientOperation(
             @Transient SqlCompiler compiler,
             @Transient AssociativeCache<TypesAndSelect> selectAndTypesCache,
-            @Transient WeakAutoClosableObjectPool<TypesAndSelect> selectAndTypesPool,
+            @Transient WeakSelfReturningObjectPool<TypesAndSelect> selectAndTypesPool,
             int operation
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, PeerIsSlowToWriteException, BadProtocolException {
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGJobContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGJobContext.java
@@ -33,7 +33,7 @@ import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.network.PeerIsSlowToWriteException;
 import io.questdb.std.AssociativeCache;
 import io.questdb.std.Misc;
-import io.questdb.std.WeakAutoClosableObjectPool;
+import io.questdb.std.WeakSelfReturningObjectPool;
 
 import java.io.Closeable;
 
@@ -41,7 +41,7 @@ public class PGJobContext implements Closeable {
 
     private final SqlCompiler compiler;
     private final AssociativeCache<TypesAndSelect> selectAndTypesCache;
-    private final WeakAutoClosableObjectPool<TypesAndSelect> selectAndTypesPool;
+    private final WeakSelfReturningObjectPool<TypesAndSelect> selectAndTypesPool;
 
     public PGJobContext(
             PGWireConfiguration configuration,
@@ -54,7 +54,7 @@ public class PGJobContext implements Closeable {
         final int blockCount = enableSelectCache ? configuration.getSelectCacheBlockCount() : 1;
         final int rowCount = enableSelectCache ? configuration.getSelectCacheRowCount() : 1;
         this.selectAndTypesCache = new AssociativeCache<>(blockCount, rowCount);
-        this.selectAndTypesPool = new WeakAutoClosableObjectPool<>(TypesAndSelect::new, blockCount * rowCount);
+        this.selectAndTypesPool = new WeakSelfReturningObjectPool<>(TypesAndSelect::new, blockCount * rowCount);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -36,7 +36,7 @@ import io.questdb.mp.*;
 import io.questdb.network.*;
 import io.questdb.std.Misc;
 import io.questdb.std.ThreadLocal;
-import io.questdb.std.WeakObjectPool;
+import io.questdb.std.WeakMutableObjectPool;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
@@ -185,11 +185,11 @@ public class PGWireServer implements Closeable {
     }
 
     public static class PGConnectionContextFactory implements IOContextFactory<PGConnectionContext>, Closeable, EagerThreadSetup {
-        private final ThreadLocal<WeakObjectPool<PGConnectionContext>> contextPool;
+        private final ThreadLocal<WeakMutableObjectPool<PGConnectionContext>> contextPool;
         private boolean closed = false;
 
         public PGConnectionContextFactory(CairoEngine engine, PGWireConfiguration configuration, int workerCount) {
-            this.contextPool = new ThreadLocal<>(() -> new WeakObjectPool<>(() ->
+            this.contextPool = new ThreadLocal<>(() -> new WeakMutableObjectPool<>(() ->
                     new PGConnectionContext(engine, configuration, getSqlExecutionContext(engine, workerCount)), configuration.getConnectionPoolInitialCapacity()));
         }
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
@@ -27,12 +27,12 @@ package io.questdb.cutlass.pgwire;
 import io.questdb.cairo.sql.BindVariableService;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.std.Misc;
-import io.questdb.std.WeakAutoClosableObjectPool;
+import io.questdb.std.WeakSelfReturningObjectPool;
 
 public class TypesAndSelect extends AbstractTypeContainer<TypesAndSelect> {
     private RecordCursorFactory factory;
 
-    public TypesAndSelect(WeakAutoClosableObjectPool<TypesAndSelect> parentPool) {
+    public TypesAndSelect(WeakSelfReturningObjectPool<TypesAndSelect> parentPool) {
         super(parentPool);
     }
 

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -122,7 +122,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final IntList groupByFunctionPositions = new IntList();
     private final LongList prefixes = new LongList();
     private final ObjectPool<ExpressionNode> expressionNodePool;
-    private final WeakAutoClosableObjectPool<PageFrameReduceTask> reduceTaskPool;
+    private final WeakClosableObjectPool<PageFrameReduceTask> reduceTaskPool;
     private boolean enableJitNullChecks = true;
     private boolean fullFatJoins = false;
 
@@ -143,8 +143,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         jitIRMem.putByte((byte) 0);
         jitIRMem.truncate();
         this.expressionNodePool = expressionNodePool;
-        this.reduceTaskPool = new WeakAutoClosableObjectPool<>(
-                (p) -> new PageFrameReduceTask(configuration),
+        this.reduceTaskPool = new WeakClosableObjectPool<>(
+                () -> new PageFrameReduceTask(configuration),
                 configuration.getPageFrameReduceTaskPoolCapacity()
         );
     }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
@@ -60,7 +60,7 @@ public class AsyncFilteredRecordCursorFactory implements RecordCursorFactory {
             @NotNull MessageBus messageBus,
             @NotNull RecordCursorFactory base,
             @NotNull Function filter,
-            @NotNull @Transient WeakAutoClosableObjectPool<PageFrameReduceTask> localTaskPool,
+            @NotNull @Transient WeakClosableObjectPool<PageFrameReduceTask> localTaskPool,
             @Nullable Function limitLoFunction,
             int limitLoPos
     ) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -70,7 +70,7 @@ public class AsyncJitFilteredRecordCursorFactory implements RecordCursorFactory 
             @NotNull ObjList<Function> bindVarFunctions,
             @NotNull Function filter,
             @NotNull CompiledFilter compiledFilter,
-            @NotNull @Transient WeakAutoClosableObjectPool<PageFrameReduceTask> localTaskPool,
+            @NotNull @Transient WeakClosableObjectPool<PageFrameReduceTask> localTaskPool,
             @Nullable Function limitLoFunction,
             int limitLoPos
     ) {

--- a/core/src/main/java/io/questdb/std/AbstractSelfReturningObject.java
+++ b/core/src/main/java/io/questdb/std/AbstractSelfReturningObject.java
@@ -24,21 +24,18 @@
 
 package io.questdb.std;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.io.Closeable;
 
-public class WeakAutoClosableObjectPool<T extends Closeable> extends WeakObjectPoolBase<T> {
-    private final AutoClosableObjectFactory<T> factory;
+public abstract class AbstractSelfReturningObject<T extends AbstractSelfReturningObject<?>> implements Closeable {
+    private final WeakSelfReturningObjectPool<T> parentPool;
 
-    public WeakAutoClosableObjectPool(@NotNull AutoClosableObjectFactory<T> factory, int initSize) {
-        super(initSize);
-        this.factory = factory;
-        fill();
+    public AbstractSelfReturningObject(WeakSelfReturningObjectPool<T> parentPool) {
+        this.parentPool = parentPool;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    T newInstance() {
-        return factory.newInstance(this);
+    public void close() {
+        parentPool.push((T) this);
     }
 }

--- a/core/src/main/java/io/questdb/std/SelfReturningObjectFactory.java
+++ b/core/src/main/java/io/questdb/std/SelfReturningObjectFactory.java
@@ -24,9 +24,7 @@
 
 package io.questdb.std;
 
-import java.io.Closeable;
-
 @FunctionalInterface
-public interface AutoClosableObjectFactory<T extends Closeable> {
-    T newInstance(WeakAutoClosableObjectPool<T> parent);
+public interface SelfReturningObjectFactory<T extends AbstractSelfReturningObject<?>> {
+    T newInstance(WeakSelfReturningObjectPool<T> parent);
 }

--- a/core/src/main/java/io/questdb/std/WeakClosableObjectPool.java
+++ b/core/src/main/java/io/questdb/std/WeakClosableObjectPool.java
@@ -26,20 +26,35 @@ package io.questdb.std;
 
 import org.jetbrains.annotations.NotNull;
 
-public class WeakObjectPool<T extends Mutable> extends WeakObjectPoolBase<T> {
+import java.io.Closeable;
+
+public class WeakClosableObjectPool<T extends Closeable> extends WeakObjectPoolBase<T> implements Closeable {
     private final ObjectFactory<T> factory;
 
-    public WeakObjectPool(@NotNull ObjectFactory<T> factory, int initSize) {
+    public WeakClosableObjectPool(@NotNull ObjectFactory<T> factory, int initSize) {
         super(initSize);
         this.factory = factory;
         fill();
     }
 
     @Override
-    void clear(T obj) {
-        obj.clear();
+    public boolean push(T obj) {
+        return super.push(obj);
     }
 
+    @Override
+    public void close() {
+        while (cache.size() > 0) {
+            Misc.free(cache.pop());
+        }
+    }
+
+    @Override
+    void close(T obj) {
+        Misc.free(obj);
+    }
+
+    @Override
     T newInstance() {
         return factory.newInstance();
     }

--- a/core/src/main/java/io/questdb/std/WeakMutableObjectPool.java
+++ b/core/src/main/java/io/questdb/std/WeakMutableObjectPool.java
@@ -22,25 +22,45 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.pgwire;
+package io.questdb.std;
 
-import io.questdb.cairo.sql.BindVariableService;
-import io.questdb.cairo.sql.InsertStatement;
-import io.questdb.std.WeakSelfReturningObjectPool;
+import org.jetbrains.annotations.NotNull;
 
-public class TypesAndInsert extends AbstractTypeContainer<TypesAndInsert> {
-    private InsertStatement insert;
+import java.io.Closeable;
 
-    public TypesAndInsert(WeakSelfReturningObjectPool<TypesAndInsert> parentPool) {
-        super(parentPool);
+public class WeakMutableObjectPool<T extends Mutable> extends WeakObjectPoolBase<T> implements Closeable {
+    private final ObjectFactory<T> factory;
+
+    public WeakMutableObjectPool(@NotNull ObjectFactory<T> factory, int initSize) {
+        super(initSize);
+        this.factory = factory;
+        fill();
     }
 
-    public InsertStatement getInsert() {
-        return insert;
+    @Override
+    public boolean push(T obj) {
+        return super.push(obj);
     }
 
-    public void of(InsertStatement insert, BindVariableService bindVariableService) {
-        this.insert = insert;
-        copyTypesFrom(bindVariableService);
+    @Override
+    public void close() {
+        while (cache.size() > 0) {
+            Misc.free(cache.pop());
+        }
+    }
+
+    @Override
+    void clear(T obj) {
+        obj.clear();
+    }
+
+    @Override
+    void close(T obj) {
+        Misc.free(obj);
+    }
+
+    @Override
+    T newInstance() {
+        return factory.newInstance();
     }
 }

--- a/core/src/main/java/io/questdb/std/WeakObjectPoolBase.java
+++ b/core/src/main/java/io/questdb/std/WeakObjectPoolBase.java
@@ -24,7 +24,6 @@
 
 package io.questdb.std;
 
-import java.io.Closeable;
 import java.util.ArrayDeque;
 
 /**
@@ -41,7 +40,7 @@ import java.util.ArrayDeque;
  * pools until we run out of memory. Hence we limit the maximum number of
  * objects a pool can hold.
  */
-abstract class WeakObjectPoolBase<T> implements Closeable {
+abstract class WeakObjectPoolBase<T> {
     // package private for testing
     final ArrayDeque<T> cache = new ArrayDeque<>();
 
@@ -53,31 +52,27 @@ abstract class WeakObjectPoolBase<T> implements Closeable {
         this.maxSize = 2 * initSize;
     }
 
-    @Override
-    public void close() {
-        while (cache.size() > 0) {
-            Misc.free(cache.pop());
-        }
-    }
-
     public T pop() {
         final T obj = cache.poll();
         return obj == null ? newInstance() : obj;
     }
 
-    public boolean push(T obj) {
+    boolean push(T obj) {
         assert obj != null;
         if (cache.size() < maxSize) {
             clear(obj);
             cache.push(obj);
             return true;
         } else {
-            Misc.free(obj);
+            close(obj);
             return false;
         }
     }
 
     void clear(T obj) {
+    }
+
+    void close(T obj) {
     }
 
     final void fill() {

--- a/core/src/main/java/io/questdb/std/WeakSelfReturningObjectPool.java
+++ b/core/src/main/java/io/questdb/std/WeakSelfReturningObjectPool.java
@@ -22,25 +22,27 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.pgwire;
+package io.questdb.std;
 
-import io.questdb.cairo.sql.BindVariableService;
-import io.questdb.cairo.sql.InsertStatement;
-import io.questdb.std.WeakSelfReturningObjectPool;
+import org.jetbrains.annotations.NotNull;
 
-public class TypesAndInsert extends AbstractTypeContainer<TypesAndInsert> {
-    private InsertStatement insert;
+/**
+ * This object pool does not attempt to close pooled objects and instead assumes that
+ * objects return themselves to the pool on close() method call. Note that the push()
+ * method is not exposed by this class - the only way an object returns to the pool is
+ * a close() call.
+ */
+public class WeakSelfReturningObjectPool<T extends AbstractSelfReturningObject<?>> extends WeakObjectPoolBase<T> {
+    private final SelfReturningObjectFactory<T> factory;
 
-    public TypesAndInsert(WeakSelfReturningObjectPool<TypesAndInsert> parentPool) {
-        super(parentPool);
+    public WeakSelfReturningObjectPool(@NotNull SelfReturningObjectFactory<T> factory, int initSize) {
+        super(initSize);
+        this.factory = factory;
+        fill();
     }
 
-    public InsertStatement getInsert() {
-        return insert;
-    }
-
-    public void of(InsertStatement insert, BindVariableService bindVariableService) {
-        this.insert = insert;
-        copyTypesFrom(bindVariableService);
+    @Override
+    T newInstance() {
+        return factory.newInstance(this);
     }
 }

--- a/core/src/test/java/io/questdb/std/WeakSelfReturningObjectPoolTest.java
+++ b/core/src/test/java/io/questdb/std/WeakSelfReturningObjectPoolTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class WeakSelfReturningObjectPoolTest {
+    private static final int initSize = 12;
+
+    @Test
+    public void testSelfReturnOnClose() {
+        final int elementCount = 10 * initSize;
+
+        final List<SelfReturningPoolElement> tmp = new ArrayList<>();
+        final WeakSelfReturningObjectPool<SelfReturningPoolElement> pool = new WeakSelfReturningObjectPool<>(SelfReturningPoolElement::new, initSize);
+
+        for (int i = 0; i < elementCount; i++) {
+            SelfReturningPoolElement element = pool.pop();
+            assertFalse(element.closed);
+            tmp.add(element);
+        }
+
+        assertEquals(0, pool.cache.size());
+        for (int i = 0; i < elementCount; i++) {
+            SelfReturningPoolElement element = tmp.get(i);
+            element.close();
+            assertTrue(element.closed);
+        }
+
+        assertEquals(2 * initSize, pool.cache.size());
+    }
+
+    @Test
+    public void testPopPush() {
+        final int elementCount = 10 * initSize;
+
+        final WeakSelfReturningObjectPool<SelfReturningPoolElement> pool = new WeakSelfReturningObjectPool<>(SelfReturningPoolElement::new, initSize);
+
+        assertEquals(initSize, pool.cache.size());
+
+        final List<SelfReturningPoolElement> tmp = new ArrayList<>();
+        for (int i = 0; i < elementCount; i++) {
+            SelfReturningPoolElement element = pool.pop();
+            assertFalse(element.closed);
+            tmp.add(element);
+        }
+        assertEquals(0, pool.cache.size());
+
+        for (int i = 0; i < elementCount; i++) {
+            SelfReturningPoolElement element = tmp.get(i);
+            pool.push(element);
+            // The pool should not attempt to close objects.
+            assertFalse(element.closed);
+        }
+        assertEquals(2 * initSize, pool.cache.size());
+    }
+
+    private static class SelfReturningPoolElement extends AbstractSelfReturningObject<SelfReturningPoolElement> {
+        boolean closed;
+
+        public SelfReturningPoolElement(WeakSelfReturningObjectPool<SelfReturningPoolElement> parentPool) {
+            super(parentPool);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
A stack overflow could occur in situation when a cached SELECT or INSERT query container object gets returned to a pool. Luckily, such error would only happen with non-default settings for the pool capacities.

The issue is fixed by splitting `WeakAutoCloseableObjectPool` class into two separate classes with clear purposes: `WeakSelfReturningObjectPool` and `WeakCloseableObjectPool`. The first class is the one that is used in PG Wire caches. It doesn't expose `push()` method and instead assumes that the pooled objects return themselves to the pool as a part of the `close()` method call.