### PR TITLE
fix(sql): eliminate reduce counter race in page frame sequence used by parallel filters

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -63,8 +63,8 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     private RingQueue<PageFrameReduceTask> reduceQueue;
     private SymbolTableSource symbolTableSource;
     private T atom;
-    private PageAddressCacheRecord[] records;
-    private SqlExecutionCircuitBreaker[] circuitBreakers;
+    private PageAddressCacheRecord record;
+    private SqlExecutionCircuitBreaker circuitBreaker;
     // Local reduce task used when there is no slots in the queue to dispatch tasks.
     private PageFrameReduceTask localTask;
     private final WeakClosableObjectPool<PageFrameReduceTask> localTaskPool;
@@ -98,12 +98,9 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
         final MCSequence pageFrameReduceSubSeq = messageBus.getPageFrameReduceSubSeq(shard);
         while (doneLatch.getCount() == 0) {
-            final int workerId = getWorkerId();
-            final PageAddressCacheRecord rec = records[workerId];
-            final SqlExecutionCircuitBreaker circuitBreaker = circuitBreakers[workerId];
             final boolean allFramesReduced = reduceCounter.get() == dispatchStartFrameIndex;
             // we were asked to steal work from the reduce queue and beyond, as much as we can
-            if (PageFrameReduceJob.consumeQueue(reduceQueue, pageFrameReduceSubSeq, rec, circuitBreaker)) {
+            if (PageFrameReduceJob.consumeQueue(reduceQueue, pageFrameReduceSubSeq, record, circuitBreaker)) {
                 long cursor = collectSubSeq.next();
                 if (cursor > -1) {
                     // discard collect items
@@ -152,7 +149,8 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
     @Override
     public void close() {
-        Misc.free(circuitBreakers);
+        Misc.free(circuitBreaker);
+        Misc.free(record);
     }
 
     public PageFrameSequence<T> of(
@@ -167,11 +165,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         this.startTimeUs = microsecondClock.getTicks();
         this.circuitBreakerFd = executionContext.getCircuitBreaker().getFd();
 
-        // allow entry for 0 - main thread that is a non-worker
-        initWorkerRecords(
-                executionContext.getWorkerCount() + 1,
-                executionContext.getCircuitBreaker()
-        );
+        initRecord(executionContext.getCircuitBreaker());
 
         final Rnd rnd = executionContext.getAsyncRandom();
         try {
@@ -318,10 +312,6 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
      * @return true if at least one task was dispatched or reduced; false otherwise
      */
     private boolean dispatch() {
-        final int workerId = getWorkerId();
-        final PageAddressCacheRecord record = records[workerId];
-        final SqlExecutionCircuitBreaker circuitBreaker = circuitBreakers[workerId];
-
         boolean idle = true;
         boolean dispatched = false;
 
@@ -408,10 +398,16 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         }
         localTask.of(this, dispatchStartFrameIndex++);
 
-        final int workerId = getWorkerId();
-        final PageAddressCacheRecord record = records[workerId];
-        final SqlExecutionCircuitBreaker circuitBreaker = circuitBreakers[workerId];
-        PageFrameReduceJob.reduce(record, circuitBreaker, localTask, this);
+        try {
+            if (isActive()) {
+                PageFrameReduceJob.reduce(record, circuitBreaker, localTask, this);
+            }
+        } catch (Throwable e) {
+            cancel();
+            throw e;
+        } finally {
+            reduceCounter.incrementAndGet();
+        }
     }
 
     public PageFrameReduceTask getTask(long cursor) {
@@ -450,6 +446,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
             // done latch is reset by method call above
             doneLatch.reset();
+            id = ID_SEQ.incrementAndGet();
             dispatchStartFrameIndex = 0;
             collectedFrameIndex = -1;
             reduceCounter.set(0);
@@ -457,38 +454,18 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         }
     }
 
-    private static int getWorkerId() {
-        final Thread thread = Thread.currentThread();
-        final int workerId;
-        if (thread instanceof Worker) {
-            workerId = ((Worker) thread).getWorkerId() + 1;
-        } else {
-            workerId = 0;
-        }
-        return workerId;
-    }
-
-    private void initWorkerRecords(
-            int workerCount,
-            SqlExecutionCircuitBreaker executionContextCircuitBreaker
-    ) {
-        if (records == null || records.length < workerCount) {
+    private void initRecord(SqlExecutionCircuitBreaker executionContextCircuitBreaker) {
+        if (record == null) {
             final SqlExecutionCircuitBreakerConfiguration sqlExecutionCircuitBreakerConfiguration = executionContextCircuitBreaker.getConfiguration();
-            this.records = new PageAddressCacheRecord[workerCount];
-            this.circuitBreakers = new SqlExecutionCircuitBreaker[workerCount];
-            for (int i = 0; i < workerCount; i++) {
-                this.records[i] = new PageAddressCacheRecord();
-                if (sqlExecutionCircuitBreakerConfiguration != null) {
-                    this.circuitBreakers[i] = new NetworkSqlExecutionCircuitBreaker(sqlExecutionCircuitBreakerConfiguration);
-                } else {
-                    this.circuitBreakers[i] = NetworkSqlExecutionCircuitBreaker.NOOP_CIRCUIT_BREAKER;
-                }
+            this.record = new PageAddressCacheRecord();
+            if (sqlExecutionCircuitBreakerConfiguration != null) {
+                this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(sqlExecutionCircuitBreakerConfiguration);
+            } else {
+                this.circuitBreaker = NetworkSqlExecutionCircuitBreaker.NOOP_CIRCUIT_BREAKER;
             }
         }
 
-        for (int i = 0; i < workerCount; i++) {
-            this.circuitBreakers[i].setFd(executionContextCircuitBreaker.getFd());
-        }
+        this.circuitBreaker.setFd(executionContextCircuitBreaker.getFd());
     }
 
     private void prepareForDispatch(


### PR DESCRIPTION
Also removes redundant record and circuit breaker arrays from the page frame sequence. Only a single thread is responsible for dispatching, so it's enough to have a single object.

The race had a chance to show up for LIMIT N filters, i.e. when `await()` method had to correctly await for all dispatched tasks to be reduced and collected.