### PR TITLE
fix(pgwire): Fix initial connection properties parser

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1979,9 +1979,9 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
 
                     final long nameLo = lo;
                     final long nameHi = getStringLength(lo, msgLimit, "malformed property name");
-                    lo = nameHi + 1;
-                    final long valueLo = lo;
+                    final long valueLo = nameHi + 1;
                     final long valueHi = getStringLength(valueLo, msgLimit, "malformed property value");
+                    lo = valueHi + 1;
 
                     // store user
                     dbcs.of(nameLo, nameHi);

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGSecurityTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGSecurityTest.java
@@ -30,11 +30,15 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.postgresql.PGProperty;
 import org.postgresql.util.PSQLException;
 
-import java.io.IOException;
 import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
+import java.util.TimeZone;
 
 import static io.questdb.test.tools.TestUtils.assertContains;
 import static org.junit.Assert.fail;
@@ -200,6 +204,46 @@ public class PGSecurityTest extends BasePGTest {
             compiler.compile("create table src (ts TIMESTAMP)", sqlExecutionContext);
             executeWithPg("select * from src");
         });
+    }
+
+    @Test
+    public void testInitialPropertiesParsedCorrectly() throws Exception {
+        // there was a bug where a value of each property was also used as a key for a property created out of thin air.
+        // so when a client sends a property with a value set to "user" then a buggy pgwire parser would create
+        // also a key "user" out of thin air with a value set as the next key. Example:
+        // 2022-05-17T16:39:18.308689Z I i.q.c.p.PGConnectionContext property [name=user, value=admin] <-- this is a legit property
+        // 2022-05-17T16:39:18.308707Z I i.q.c.p.PGConnectionContext property [name=admin, value=database] <-- this is a property "invented" by a buggy pgwire parser
+        // 2022-05-17T16:39:18.308724Z I i.q.c.p.PGConnectionContext property [name=database, value=qdb] <-- a legit property set by a client
+        // 2022-05-17T16:39:18.308789Z I i.q.c.p.PGConnectionContext property [name=qdb, value=client_encoding] <-- again, a property created out of thin air
+
+        // so this test sets a property to "user" and check authentication still succeed. it would fail on a buggy pgwire parser
+        // because the out of thin air property would overwrite the user set by the client. Example:
+        // 2022-05-17T15:58:38.973955Z I i.q.c.p.PGConnectionContext property [name=user, value=user] <-- client indicates username is "user"
+        // 2022-05-17T15:58:38.974236Z I i.q.c.p.PGConnectionContext property [name=user, value=database] <-- buggy pgwire parser overwrites username with out of thin air value
+        assertMemoryLeak(() -> {
+            try (
+                    final PGWireServer ignored = createPGServer(1);
+                    // Postgres JDBC clients ignores unknown properties and does not send them to a server
+                    // so have to use a property which actually exists
+                    final Connection connection = getConnectionWithCustomProperty(PGProperty.OPTIONS.getName(), "user");
+            ) {
+                // no need to assert anything, if we manage to create a connection then it's already a success!
+            }
+        });
+    }
+
+    protected Connection getConnectionWithCustomProperty(String key, String value) throws SQLException {
+        Properties properties = new Properties();
+        properties.setProperty("user", "admin");
+        properties.setProperty("password", "quest");
+        properties.setProperty("sslmode", "disable");
+        properties.setProperty(key, value);
+
+
+        TimeZone.setDefault(TimeZone.getTimeZone("EDT"));
+        //use this line to switch to local postgres
+        //return DriverManager.getConnection("jdbc:postgresql://127.0.0.1:5432/qdb", properties);
+        return DriverManager.getConnection("jdbc:postgresql://127.0.0.1:8812/qdb", properties);
     }
 
     private void assertQueryDisallowed(String query) throws Exception {


### PR DESCRIPTION
There was a bug where a value of each property was also used as a key for a property created out of thin air by a buggy pgwire parser.
So when a client sends a property with a value set to "user" then a buggy pgwire parser would create also a key "user" out of thin air with a value set as the next key.
Example:
```
2022-05-17T16:39:18.308689Z I i.q.c.p.PGConnectionContext property [name=user, value=admin] <-- this is a legit property
2022-05-17T16:39:18.308707Z I i.q.c.p.PGConnectionContext property [name=admin, value=database] <-- this is a property "invented" by a buggy pgwire parser
2022-05-17T16:39:18.308724Z I i.q.c.p.PGConnectionContext property [name=database, value=qdb] <-- a legit property set by a client
2022-05-17T16:39:18.308789Z I i.q.c.p.PGConnectionContext property [name=qdb, value=client_encoding] <-- again, a property created out of thin air
```
Thanks to @bziobrowski & @mariusgheorghies for help with analysis!