### PR TITLE
chore: removed timeout from ILP test to hopefully prevent flapping tests

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -153,22 +153,10 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
     }
 
     void assertTable(TableData table) {
-        // timeout is 180 seconds
-        long timeoutMicros = 180_000_000;
-        long prev = testMicrosClock.getTicks();
         boolean checked = false;
         while (!checked) {
-            if (table.await(timeoutMicros)) {
-                checked = checkTable(table);
-                if (!checked) {
-                    long current = testMicrosClock.getTicks();
-                    timeoutMicros -= current - prev;
-                    prev = current;
-                }
-            } else {
-                Assert.fail("Timed out on waiting for the data to be ingested");
-                break;
-            }
+            table.await();
+            checked = checkTable(table);
         }
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
@@ -30,8 +30,6 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.IntLongPriorityQueue;
 import io.questdb.std.ObjList;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.questdb.cairo.ColumnType.*;
 
 public class TableData {
@@ -56,8 +54,8 @@ public class TableData {
         readyLatch.countDown();
     }
 
-    public boolean await(long micros) {
-        return readyLatch.await(TimeUnit.MICROSECONDS.toNanos(micros));
+    public void await() {
+        readyLatch.await();
     }
 
     public synchronized int size() {


### PR DESCRIPTION
check table contents without timing out