### PR TITLE
chore(sql): added test with asymmetric pools

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/PageAddressCacheRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageAddressCacheRecord.java
@@ -42,7 +42,7 @@ public class PageAddressCacheRecord implements Record, Closeable {
     private final Long256Impl long256A = new Long256Impl();
     private final Long256Impl long256B = new Long256Impl();
 
-    private PageFrameCursor cursor; // Makes it possible to determine real row id, not one relative to page.
+    // Makes it possible to determine real row id, not one relative to page.
     private SymbolTableSource symbolTableSource;
     private final ObjList<SymbolTable> symbolTableCache = new ObjList<>();
     private PageAddressCache pageAddressCache;
@@ -54,12 +54,6 @@ public class PageAddressCacheRecord implements Record, Closeable {
         this.pageAddressCache = other.pageAddressCache;
         this.frameIndex = other.frameIndex;
         this.rowIndex = other.rowIndex;
-
-        if (symbolTableSource instanceof PageFrameCursor) {
-            this.cursor = (PageFrameCursor) symbolTableSource;
-        } else {
-            this.cursor = null;
-        }
     }
 
     public PageAddressCacheRecord() {
@@ -287,11 +281,6 @@ public class PageAddressCacheRecord implements Record, Closeable {
 
     public void of(SymbolTableSource symbolTableSource, PageAddressCache pageAddressCache) {
         this.symbolTableSource = symbolTableSource;
-        if (symbolTableSource instanceof PageFrameCursor) {
-            cursor = (PageFrameCursor) symbolTableSource;
-        } else {
-            cursor = null;
-        }
         this.pageAddressCache = pageAddressCache;
         frameIndex = 0;
         rowIndex = 0;

--- a/core/src/test/java/io/questdb/EmbeddedApiTest.java
+++ b/core/src/test/java/io/questdb/EmbeddedApiTest.java
@@ -36,8 +36,8 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.griffin.engine.groupby.vect.GroupByJob;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.test.tools.TestUtils;
@@ -59,24 +59,8 @@ public class EmbeddedApiTest {
         final CairoConfiguration configuration = new DefaultCairoConfiguration(temp.getRoot().getAbsolutePath());
         final Log log = LogFactory.getLog("testConcurrentSQLExec");
 
-        int workerCount = 2;
         TestUtils.assertMemoryLeak(() -> {
-            WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(workerCount);
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return workerCount;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool workerPool = new TestWorkerPool(2);
 
             Rnd rnd = new Rnd();
             try (

--- a/core/src/test/java/io/questdb/EmbeddedApiTest.java
+++ b/core/src/test/java/io/questdb/EmbeddedApiTest.java
@@ -59,18 +59,17 @@ public class EmbeddedApiTest {
         final CairoConfiguration configuration = new DefaultCairoConfiguration(temp.getRoot().getAbsolutePath());
         final Log log = LogFactory.getLog("testConcurrentSQLExec");
 
+        int workerCount = 2;
         TestUtils.assertMemoryLeak(() -> {
             WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{
-                            -1, -1
-                    };
+                    return TestUtils.getWorkerAffinity(workerCount);
                 }
 
                 @Override
                 public int getWorkerCount() {
-                    return 2;
+                    return workerCount;
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -1382,26 +1382,10 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 }
             };
 
-            final int workerCount = 2;
             try (MyWorkScheduler workScheduler = new MyWorkScheduler(pubSeq, subSeq)) {
                 final WorkerPool workerPool;
                 if (subSeq != null) {
-                    workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                        @Override
-                        public int[] getWorkerAffinity() {
-                            return TestUtils.getWorkerAffinity(workerCount);
-                        }
-
-                        @Override
-                        public int getWorkerCount() {
-                            return workerCount;
-                        }
-
-                        @Override
-                        public boolean haltOnError() {
-                            return false;
-                        }
-                    }, metrics);
+                    workerPool = new TestWorkerPool(2, metrics);
                     workerPool.assign(new ColumnIndexerJob(workScheduler));
                     workerPool.start(LOG);
                 } else {
@@ -1523,24 +1507,8 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 timestamp = sg.appendABC(AbstractCairoTest.configuration, rnd, N, timestamp, increment);
             }
 
-            final int workerCount = 2;
             try (final MyWorkScheduler workScheduler = new MyWorkScheduler()) {
-                final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public int[] getWorkerAffinity() {
-                        return TestUtils.getWorkerAffinity(workerCount);
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount;
-                    }
-
-                    @Override
-                    public boolean haltOnError() {
-                        return false;
-                    }
-                }, metrics);
+                WorkerPool workerPool = new TestWorkerPool(2, metrics);
                 workerPool.assign(new ColumnIndexerJob(workScheduler));
 
                 try (TableWriter writer = new TableWriter(configuration, "ABC", workScheduler, metrics)) {

--- a/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/cairo/FullFwdDataFrameCursorTest.java
@@ -1382,18 +1382,19 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 }
             };
 
+            final int workerCount = 2;
             try (MyWorkScheduler workScheduler = new MyWorkScheduler(pubSeq, subSeq)) {
                 final WorkerPool workerPool;
                 if (subSeq != null) {
                     workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                         @Override
                         public int[] getWorkerAffinity() {
-                            return new int[]{-1, -1};
+                            return TestUtils.getWorkerAffinity(workerCount);
                         }
 
                         @Override
                         public int getWorkerCount() {
-                            return 2;
+                            return workerCount;
                         }
 
                         @Override
@@ -1522,16 +1523,17 @@ public class FullFwdDataFrameCursorTest extends AbstractCairoTest {
                 timestamp = sg.appendABC(AbstractCairoTest.configuration, rnd, N, timestamp, increment);
             }
 
+            final int workerCount = 2;
             try (final MyWorkScheduler workScheduler = new MyWorkScheduler()) {
                 final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                     @Override
                     public int[] getWorkerAffinity() {
-                        return new int[]{-1, -1};
+                        return TestUtils.getWorkerAffinity(workerCount);
                     }
 
                     @Override
                     public int getWorkerCount() {
-                        return 2;
+                        return workerCount;
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -31,6 +31,7 @@ import io.questdb.cutlass.http.processors.QueryCache;
 import io.questdb.griffin.SqlException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Os;
@@ -51,8 +52,6 @@ public class HttpHealthCheckTestBuilder {
     private boolean injectUnhandledError;
 
     public void run(HttpClientCode code) throws Exception {
-        final int workerCount = 1;
-
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
@@ -64,22 +63,7 @@ public class HttpHealthCheckTestBuilder {
                 metrics = Metrics.enabled();
             }
 
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return workerCount;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, metrics);
+            WorkerPool workerPool = new TestWorkerPool(1, metrics);
 
             if (injectUnhandledError) {
                 final AtomicBoolean alreadyErrored = new AtomicBoolean();

--- a/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -34,9 +34,9 @@ import io.questdb.log.LogFactory;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Os;
+import io.questdb.test.tools.TestUtils;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.Arrays;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,8 +52,6 @@ public class HttpHealthCheckTestBuilder {
 
     public void run(HttpClientCode code) throws Exception {
         final int workerCount = 1;
-        final int[] workerAffinity = new int[workerCount];
-        Arrays.fill(workerAffinity, -1);
 
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
@@ -69,7 +67,7 @@ public class HttpHealthCheckTestBuilder {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return workerAffinity;
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
@@ -32,9 +32,8 @@ import io.questdb.cutlass.http.processors.QueryCache;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.metrics.Scrapable;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
-import io.questdb.test.tools.TestUtils;
 import org.junit.rules.TemporaryFolder;
 
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
@@ -62,22 +61,7 @@ public class HttpMinTestBuilder {
                     .withBaseDir(temp.getRoot().getAbsolutePath())
                     .build();
 
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool workerPool = new TestWorkerPool(1);
 
             DefaultCairoConfiguration cairoConfiguration = new DefaultCairoConfiguration(baseDir);
 

--- a/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
@@ -34,9 +34,8 @@ import io.questdb.log.LogFactory;
 import io.questdb.metrics.Scrapable;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.test.tools.TestUtils;
 import org.junit.rules.TemporaryFolder;
-
-import java.util.Arrays;
 
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
 
@@ -57,9 +56,6 @@ public class HttpMinTestBuilder {
     }
 
     public void run(HttpQueryTestBuilder.HttpClientCode code) throws Exception {
-        final int[] workerAffinity = new int[1];
-        Arrays.fill(workerAffinity, -1);
-
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
@@ -69,12 +65,12 @@ public class HttpMinTestBuilder {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return workerAffinity;
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
                 public int getWorkerCount() {
-                    return workerAffinity.length;
+                    return 1;
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -37,13 +37,12 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.Misc;
 import io.questdb.std.str.Path;
-import io.questdb.test.tools.TestUtils;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -84,22 +83,8 @@ public class HttpQueryTestBuilder {
                 metrics = Metrics.enabled();
             }
 
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
+            final WorkerPool workerPool = new TestWorkerPool(workerCount, metrics);
 
-                @Override
-                public int getWorkerCount() {
-                    return workerCount;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, metrics);
             if (workerCount > 1) {
                 workerPool.assignCleaner(Path.CLEANER);
             }

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -43,9 +43,9 @@ import io.questdb.std.FilesFacade;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.Misc;
 import io.questdb.std.str.Path;
+import io.questdb.test.tools.TestUtils;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.Arrays;
 import java.util.concurrent.BrokenBarrierException;
 
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
@@ -75,9 +75,6 @@ public class HttpQueryTestBuilder {
     }
 
     public void run(CairoConfiguration configuration, HttpClientCode code) throws Exception {
-        final int[] workerAffinity = new int[workerCount];
-        Arrays.fill(workerAffinity, -1);
-
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = serverConfigBuilder
@@ -90,7 +87,7 @@ public class HttpQueryTestBuilder {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return workerAffinity;
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -1719,22 +1719,7 @@ public class IODispatcherTest {
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 3;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool workerPool = new TestWorkerPool(3, metrics);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)
@@ -2193,22 +2178,7 @@ public class IODispatcherTest {
             final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(nf, baseDir, 256, false, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)
@@ -2815,23 +2785,7 @@ public class IODispatcherTest {
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
-
+            WorkerPool workerPool = new TestWorkerPool(1);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)
@@ -3972,23 +3926,7 @@ public class IODispatcherTest {
         assertMemoryLeak(() -> {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
-
+            WorkerPool workerPool = new TestWorkerPool(1);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)
@@ -4179,22 +4117,7 @@ public class IODispatcherTest {
             final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(nf, baseDir, 256, false, true);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)) {
@@ -4269,22 +4192,7 @@ public class IODispatcherTest {
             final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(nf, baseDir, 4096, false, true);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir), metrics);
                     HttpServer httpServer = new HttpServer(httpConfiguration, engine.getMessageBus(), metrics, workerPool, false)
@@ -4376,22 +4284,7 @@ public class IODispatcherTest {
                     .build();
             QueryCache.configure(httpConfiguration);
 
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(1);
 
             try (CairoEngine engine = new CairoEngine(new DefaultCairoConfiguration(baseDir) {
                 @Override
@@ -5263,22 +5156,7 @@ public class IODispatcherTest {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultCairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     MessageBus messageBus = new MessageBusImpl(configuration);
                     HttpServer httpServer = new HttpServer(httpConfiguration, messageBus, metrics, workerPool, false)
@@ -5433,22 +5311,7 @@ public class IODispatcherTest {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultCairoConfiguration configuration = new DefaultCairoConfiguration(baseDir);
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration(baseDir, false);
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     MessageBus messageBus = new MessageBusImpl(configuration);
                     HttpServer httpServer = new HttpServer(httpConfiguration, messageBus, metrics, workerPool, false)
@@ -5601,22 +5464,7 @@ public class IODispatcherTest {
                     false,
                     "HTTP/1.0 "
             );
-            final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            WorkerPool workerPool = new TestWorkerPool(2);
             try (
                     MessageBus messageBus = new MessageBusImpl(configuration);
                     HttpServer httpServer = new HttpServer(httpConfiguration, messageBus, metrics, workerPool, false)

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -1722,7 +1722,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -2196,7 +2196,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -2818,7 +2818,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -3975,7 +3975,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -4182,7 +4182,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -4272,7 +4272,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -4379,7 +4379,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -5266,7 +5266,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -5436,7 +5436,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -5604,7 +5604,7 @@ public class IODispatcherTest {
             final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -33,12 +33,10 @@ import io.questdb.cutlass.line.tcp.load.LineData;
 import io.questdb.cutlass.line.tcp.load.TableData;
 import io.questdb.log.Log;
 import io.questdb.mp.SOCountDownLatch;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.ConcurrentHashMap;
 import io.questdb.std.LowerCaseCharSequenceObjHashMap;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -301,23 +299,8 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
     }
 
     @Override
-    protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
-        return new WorkerPoolConfiguration() {
-            @Override
-            public int[] getWorkerAffinity() {
-                return TestUtils.getWorkerAffinity(getWorkerCount());
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-
-            @Override
-            public boolean haltOnError() {
-                return true;
-            }
-        };
+    protected int getWorkerCount() {
+        return 4;
     }
 
     void initFuzzParameters(int duplicatesFactor, int columnReorderingFactor, int columnSkipFactor, int newColumnFactor, int nonAsciiValueFactor,

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -38,6 +38,7 @@ import io.questdb.std.ConcurrentHashMap;
 import io.questdb.std.LowerCaseCharSequenceObjHashMap;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -302,11 +303,9 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
     @Override
     protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
         return new WorkerPoolConfiguration() {
-            private final int[] affinity = {-1, -1, -1, -1};
-
             @Override
             public int[] getWorkerAffinity() {
-                return affinity;
+                return TestUtils.getWorkerAffinity(getWorkerCount());
             }
 
             @Override

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -32,8 +32,8 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.network.Net;
@@ -54,7 +54,7 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
     protected static final int WAIT_ILP_TABLE_RELEASE = 0x2;
     protected static final int WAIT_ALTER_TABLE_RELEASE = 0x4;
     private final static Log LOG = LogFactory.getLog(AbstractLineTcpReceiverTest.class);
-    protected final WorkerPool sharedWorkerPool = new WorkerPool(getWorkerPoolConfiguration(), metrics);
+    protected final WorkerPool sharedWorkerPool = new TestWorkerPool(getWorkerCount(), metrics);
     protected final int bindPort = 9002; // Don't clash with other tests since they may run in parallel
     private final ThreadLocal<Socket> tlSocket = new ThreadLocal<>();
     private final IODispatcherConfiguration ioDispatcherConfiguration = new DefaultIODispatcherConfiguration() {
@@ -174,23 +174,8 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
         return socket;
     }
 
-    protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
-        return new WorkerPoolConfiguration() {
-            @Override
-            public int[] getWorkerAffinity() {
-                return TestUtils.getWorkerAffinity(getWorkerCount());
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 1;
-            }
-
-            @Override
-            public boolean haltOnError() {
-                return true;
-            }
-        };
+    protected int getWorkerCount() {
+        return 1;
     }
 
     protected void runInContext(LineTcpServerAwareContext r) throws Exception {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -176,11 +176,9 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
 
     protected WorkerPoolConfiguration getWorkerPoolConfiguration() {
         return new WorkerPoolConfiguration() {
-            private final int[] affinity = {-1};
-
             @Override
             public int[] getWorkerAffinity() {
-                return affinity;
+                return TestUtils.getWorkerAffinity(getWorkerCount());
             }
 
             @Override

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -37,12 +37,12 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.str.FloatingDirectCharSink;
 import io.questdb.std.str.Path;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
@@ -118,11 +118,9 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
 
     private static WorkerPool createWorkerPool(final int workerCount, final boolean haltOnError) {
         return new WorkerPool(new WorkerPoolConfiguration() {
-            private final int[] affinityByThread;
-
             @Override
             public int[] getWorkerAffinity() {
-                return affinityByThread;
+                return TestUtils.getWorkerAffinity(workerCount);
             }
 
             @Override
@@ -133,11 +131,6 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
             @Override
             public boolean haltOnError() {
                 return haltOnError;
-            }
-
-            {
-                affinityByThread = new int[workerCount];
-                Arrays.fill(affinityByThread, -1);
             }
         }, metrics);
     }

--- a/core/src/test/java/io/questdb/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/BasePGTest.java
@@ -32,10 +32,10 @@ import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.*;
-import java.util.Arrays;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -59,9 +59,6 @@ public class BasePGTest extends AbstractGriffinTest {
 
     protected PGWireServer createPGServer(int workerCount, long maxQueryTime) {
 
-        final int[] affinity = new int[workerCount];
-        Arrays.fill(affinity, -1);
-
         final SqlExecutionCircuitBreakerConfiguration circuitBreakerConfiguration = new DefaultSqlExecutionCircuitBreakerConfiguration() {
             @Override
             public long getMaxTime() {
@@ -77,7 +74,7 @@ public class BasePGTest extends AbstractGriffinTest {
 
             @Override
             public int[] getWorkerAffinity() {
-                return affinity;
+                return TestUtils.getWorkerAffinity(workerCount);
             }
 
             @Override

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -26,11 +26,11 @@ package io.questdb.cutlass.pgwire;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.NetUtils;
-import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.griffin.QueryFutureUpdateListener;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContextImpl;
@@ -62,10 +62,12 @@ import org.postgresql.util.PSQLException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.Date;
 import java.sql.*;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -4054,7 +4056,7 @@ nodejs code:
             try (
                     final PGWireServer ignored = createPGServer(2);
                     final Connection connection = getConnection(false, false);
-                    final Statement statement = connection.createStatement();
+                    final Statement statement = connection.createStatement()
             ) {
                 statement.execute("create table tab(ts timestamp, value double)");
                 try (PreparedStatement insert = connection.prepareStatement("insert into tab(ts, value) values(?, ?)")) {
@@ -4151,7 +4153,7 @@ nodejs code:
             final PGWireConfiguration conf = new DefaultPGWireConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1, -1, -1, -1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -6182,8 +6184,6 @@ create table tab as (
     }
 
     private PGWireServer createPGServer(SOCountDownLatch queryScheduledCount) {
-        final int[] affinity = new int[2];
-        Arrays.fill(affinity, -1);
         int workerCount = 2;
 
         final PGWireConfiguration conf = new DefaultPGWireConfiguration() {
@@ -6194,7 +6194,7 @@ create table tab as (
 
             @Override
             public int[] getWorkerAffinity() {
-                return affinity;
+                return TestUtils.getWorkerAffinity(getWorkerCount());
             }
 
             @Override
@@ -6710,8 +6710,6 @@ create table tab as (
 
     private void testAddColumnBusyWriter(boolean alterRequestReturnSuccess, SOCountDownLatch queryStartedCountDownLatch) throws SQLException, InterruptedException, BrokenBarrierException, SqlException {
         AtomicLong errors = new AtomicLong();
-        final int[] affinity = new int[2];
-        Arrays.fill(affinity, -1);
         int workerCount = 2;
 
         final PGWireConfiguration conf = new DefaultPGWireConfiguration() {
@@ -6722,7 +6720,7 @@ create table tab as (
 
             @Override
             public int[] getWorkerAffinity() {
-                return affinity;
+                return TestUtils.getWorkerAffinity(getWorkerCount());
             }
 
             @Override

--- a/core/src/test/java/io/questdb/griffin/AbstractO3Test.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractO3Test.java
@@ -239,16 +239,11 @@ public class AbstractO3Test {
     ) throws Exception {
         executeVanilla(() -> {
             if (workerCount > 0) {
-                int[] affinity = new int[workerCount];
-                for (int i = 0; i < workerCount; i++) {
-                    affinity[i] = -1;
-                }
-
                 WorkerPool pool = new WorkerPool(
                         new WorkerPoolAwareConfiguration() {
                             @Override
                             public int[] getWorkerAffinity() {
-                                return affinity;
+                                return TestUtils.getWorkerAffinity(getWorkerCount());
                             }
 
                             @Override

--- a/core/src/test/java/io/questdb/griffin/AsyncOffloadTest.java
+++ b/core/src/test/java/io/questdb/griffin/AsyncOffloadTest.java
@@ -203,16 +203,11 @@ public class AsyncOffloadTest extends AbstractGriffinTest {
     private void testParallelStress(String query, String expected, int workerCount, int threadCount, int jitMode) throws Exception {
         AbstractCairoTest.jitMode = jitMode;
 
-        final int[] affinity = new int[workerCount];
-        for (int i = 0; i < workerCount; i++) {
-            affinity[i] = -1;
-        }
-
         WorkerPool pool = new WorkerPool(
                 new WorkerPoolAwareConfiguration() {
                     @Override
                     public int[] getWorkerAffinity() {
-                        return affinity;
+                        return TestUtils.getWorkerAffinity(getWorkerCount());
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
+++ b/core/src/test/java/io/questdb/griffin/LatestByParallelTest.java
@@ -250,16 +250,11 @@ public class LatestByParallelTest {
         executeVanilla(() -> {
             if (workerCount > 0) {
 
-                int[] affinity = new int[workerCount];
-                for (int i = 0; i < workerCount; i++) {
-                    affinity[i] = -1;
-                }
-
                 WorkerPool pool = new WorkerPool(
                         new WorkerPoolAwareConfiguration() {
                             @Override
                             public int[] getWorkerAffinity() {
-                                return affinity;
+                                return TestUtils.getWorkerAffinity(getWorkerCount());
                             }
 
                             @Override

--- a/core/src/test/java/io/questdb/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3FailureTest.java
@@ -31,8 +31,8 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
+import io.questdb.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.*;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -3614,22 +3614,7 @@ public class O3FailureTest extends AbstractO3Test {
             });
             pool1.assignCleaner(Path.CLEANER);
 
-            final WorkerPool pool2 = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool pool2 = new TestWorkerPool(1);
 
             pool2.assign(new Job() {
                 private boolean toRun = true;

--- a/core/src/test/java/io/questdb/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3FailureTest.java
@@ -3573,7 +3573,7 @@ public class O3FailureTest extends AbstractO3Test {
             WorkerPool pool1 = new WorkerPool(new WorkerPoolAwareConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -3617,7 +3617,7 @@ public class O3FailureTest extends AbstractO3Test {
             final WorkerPool pool2 = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -34,10 +34,7 @@ import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.mp.Job;
-import io.questdb.mp.SOCountDownLatch;
-import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.mp.*;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
@@ -1072,22 +1069,7 @@ public class O3Test extends AbstractO3Test {
             });
             pool1.assignCleaner(Path.CLEANER);
 
-            final WorkerPool pool2 = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public int[] getWorkerAffinity() {
-                    return TestUtils.getWorkerAffinity(getWorkerCount());
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-
-                @Override
-                public boolean haltOnError() {
-                    return false;
-                }
-            }, Metrics.disabled());
+            final WorkerPool pool2 = new TestWorkerPool(1);
 
             pool2.assign(new Job() {
                 private boolean toRun = true;

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -1031,7 +1031,7 @@ public class O3Test extends AbstractO3Test {
             WorkerPool pool1 = new WorkerPool(new WorkerPoolAwareConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override
@@ -1075,7 +1075,7 @@ public class O3Test extends AbstractO3Test {
             final WorkerPool pool2 = new WorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public int[] getWorkerAffinity() {
-                    return new int[]{-1};
+                    return TestUtils.getWorkerAffinity(getWorkerCount());
                 }
 
                 @Override

--- a/core/src/test/java/io/questdb/mp/TestWorkerPool.java
+++ b/core/src/test/java/io/questdb/mp/TestWorkerPool.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.mp;
+
+import io.questdb.Metrics;
+import io.questdb.test.tools.TestUtils;
+
+public class TestWorkerPool extends WorkerPool {
+
+    public TestWorkerPool(int workerCount) {
+        this(workerCount, Metrics.disabled());
+    }
+
+    public TestWorkerPool(int workerCount, Metrics metrics) {
+        super(new WorkerPoolConfiguration() {
+            @Override
+            public int[] getWorkerAffinity() {
+                return TestUtils.getWorkerAffinity(workerCount);
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return workerCount;
+            }
+
+            @Override
+            public boolean haltOnError() {
+                return false;
+            }
+        }, metrics);
+    }
+}

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -25,8 +25,8 @@
 package io.questdb.test.tools;
 
 import io.questdb.cairo.*;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
 import io.questdb.griffin.*;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.log.Log;
@@ -49,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -369,6 +370,29 @@ public final class TestUtils {
             if (Character.toLowerCase(expected.charAt(i)) != Character.toLowerCase(actual.charAt(i))) {
                 Assert.assertEquals(message, expected, actual);
             }
+        }
+    }
+
+    public static void assertEventually(Runnable assertion) {
+        assertEventually(assertion, 30);
+    }
+
+    public static void assertEventually(Runnable assertion, int timeoutSeconds) {
+        long maxSleepingTimeMillis = 1000;
+        long nextSleepingTimeMillis = 10;
+        long startTime = System.nanoTime();
+        long deadline = startTime + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        for (; ; ) {
+            try {
+                assertion.run();
+                return;
+            } catch (AssertionError error) {
+                if (System.nanoTime() >= deadline) {
+                    throw error;
+                }
+            }
+            Os.sleep(nextSleepingTimeMillis);
+            nextSleepingTimeMillis = Math.min(maxSleepingTimeMillis, nextSleepingTimeMillis << 1);
         }
     }
 
@@ -744,6 +768,12 @@ public final class TestUtils {
         };
     }
 
+    public static int[] getWorkerAffinity(int workerCount) {
+        int[] res = new int[workerCount];
+        Arrays.fill(res, -1);
+        return res;
+    }
+
     public static void insert(SqlCompiler compiler, SqlExecutionContext sqlExecutionContext, CharSequence insertSql) throws SqlException {
         CompiledQuery compiledQuery = compiler.compile(insertSql, sqlExecutionContext);
         Assert.assertNotNull(compiledQuery.getInsertOperation());
@@ -751,37 +781,6 @@ public final class TestUtils {
         try (InsertMethod insertMethod = insertOperation.createMethod(sqlExecutionContext)) {
             insertMethod.execute();
             insertMethod.commit();
-        }
-    }
-
-    public static void printCursor(RecordCursor cursor, RecordMetadata metadata, boolean header, MutableCharSink sink, RecordCursorPrinter printer) {
-        sink.clear();
-        printer.print(cursor, metadata, header, sink);
-    }
-
-    public static void printSql(
-            SqlCompiler compiler,
-            SqlExecutionContext sqlExecutionContext,
-            CharSequence sql,
-            MutableCharSink sink
-    ) throws SqlException {
-        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
-            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                printCursor(cursor, factory.getMetadata(), true, sink, printer);
-            }
-        }
-    }
-
-    public static void printSqlWithTypes(
-            SqlCompiler compiler,
-            SqlExecutionContext sqlExecutionContext,
-            CharSequence sql,
-            MutableCharSink sink
-    ) throws SqlException {
-        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
-            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                printCursor(cursor, factory.getMetadata(), true, sink, printerWithTypes);
-            }
         }
     }
 
@@ -860,14 +859,34 @@ public final class TestUtils {
         }
     }
 
-    private static void putGeoHash(long hash, int bits, CharSink sink) {
-        if (hash == GeoHashes.NULL) {
-            return;
+    public static void printCursor(RecordCursor cursor, RecordMetadata metadata, boolean header, MutableCharSink sink, RecordCursorPrinter printer) {
+        sink.clear();
+        printer.print(cursor, metadata, header, sink);
+    }
+
+    public static void printSql(
+            SqlCompiler compiler,
+            SqlExecutionContext sqlExecutionContext,
+            CharSequence sql,
+            MutableCharSink sink
+    ) throws SqlException {
+        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                printCursor(cursor, factory.getMetadata(), true, sink, printer);
+            }
         }
-        if (bits % 5 == 0) {
-            GeoHashes.appendCharsUnsafe(hash, bits / 5, sink);
-        } else {
-            GeoHashes.appendBinaryStringUnsafe(hash, bits, sink);
+    }
+
+    public static void printSqlWithTypes(
+            SqlCompiler compiler,
+            SqlExecutionContext sqlExecutionContext,
+            CharSequence sql,
+            MutableCharSink sink
+    ) throws SqlException {
+        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                printCursor(cursor, factory.getMetadata(), true, sink, printerWithTypes);
+            }
         }
     }
 
@@ -907,6 +926,17 @@ public final class TestUtils {
         }
     }
 
+    private static void putGeoHash(long hash, int bits, CharSink sink) {
+        if (hash == GeoHashes.NULL) {
+            return;
+        }
+        if (bits % 5 == 0) {
+            GeoHashes.appendCharsUnsafe(hash, bits / 5, sink);
+        } else {
+            GeoHashes.appendBinaryStringUnsafe(hash, bits, sink);
+        }
+    }
+
     private static void assertEquals(Long256 expected, Long256 actual) {
         if (expected == actual) return;
         if (actual == null) {
@@ -933,29 +963,6 @@ public final class TestUtils {
         for (int i = 0, n = metadataExpected.getColumnCount(); i < n; i++) {
             Assert.assertEquals("Column name " + i, metadataExpected.getColumnName(i), metadataActual.getColumnName(i));
             Assert.assertEquals("Column type " + i, metadataExpected.getColumnType(i), metadataActual.getColumnType(i));
-        }
-    }
-
-    public static void assertEventually(Runnable assertion) {
-        assertEventually(assertion, 30);
-    }
-
-    public static void assertEventually(Runnable assertion, int timeoutSeconds) {
-        long maxSleepingTimeMillis = 1000;
-        long nextSleepingTimeMillis = 10;
-        long startTime = System.nanoTime();
-        long deadline = startTime + TimeUnit.SECONDS.toNanos(timeoutSeconds);
-        for (;;) {
-            try {
-                assertion.run();
-                return;
-            } catch (AssertionError error) {
-                if (System.nanoTime() >= deadline) {
-                    throw error;
-                }
-            }
-            Os.sleep(nextSleepingTimeMillis);
-            nextSleepingTimeMillis = Math.min(maxSleepingTimeMillis, nextSleepingTimeMillis << 1);
         }
     }
 


### PR DESCRIPTION
I wanted to verify that if we use multiple pools we don't share object instances between them