### PR TITLE
feat: when PR title validation fails, display what types are available

### DIFF
--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -1,14 +1,35 @@
-// Validate PR titles
-function validatePrTitle() {
-  const prTitleRegex = /(feat|fix|chore|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?\:.*/g
-  const prTitle = danger.github.pr.title
-  const isDraft = danger.github.pr.draft
+import { danger, fail } from "danger"
 
-  if (isDraft || prTitle.match(prTitleRegex)) {
+const supportedTypes = [
+  "feat",
+  "fix",
+  "chore",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+]
+
+function validatePrTitle() {
+  const prTitleRegex = new RegExp(`^(${supportedTypes.join("|")})(\(.+\))?\:.*`)
+
+  const { draft, title } = danger.github.pr
+  if (draft || title.match(prTitleRegex)) {
     return
   }
 
-  message('Please update the PR title. Titles need to match this format: <type>: <description>')
+  fail(
+    [
+      "Please update the PR title. It should match this format: <type>: <description>",
+      "Where <type> is one of: " +
+        supportedTypes.map((type) => `"${type}"`).join(", "),
+    ].join("\n"),
+  )
 }
 
 validatePrTitle()


### PR DESCRIPTION
Originally wanted to create this PR for #2147 but at the time of `git push` noticed that it's a fork, so can't use it as a base branch.

Aaaanyway

#2147 adds a new check for PRs which validates PR title.

If PR title does not adhere to a specific format, then a comment appears
on the PR with text like this:

> Please update the PR title. Titles need to match this format: <type>: <description>

However, at that point PR can be green and contributor might not know
what exactly goes into `<type>`.

Thus, this PR:

1. makes PR validation failure message more clear, looks like this:
> Please update the PR title. It should match this format: <type>: <description>
> Where <type> is one of: "feat", "fix", "chore", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"

2. uses `fail` instead of `message`. This way, given invalid PR title, the PR
   will fail and contributor is forced to provide a valid PR title
   (can't ignore the message).
