### PR TITLE
feat: add danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,22 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 16.x
+      - name: install danger 
+        run: yarn global add danger 
+      - name: Danger
+        run: yarn danger ci
+        working-directory: ./ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -1,14 +1,35 @@
-// Validate PR titles
-function validatePrTitle() {
-  const prTitleRegex = /(feat|fix|chore|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?\:.*/g
-  const prTitle = danger.github.pr.title
-  const isDraft = danger.github.pr.draft
+import { danger, fail } from "danger"
 
-  if (isDraft || prTitle.match(prTitleRegex)) {
+const supportedTypes = [
+  "feat",
+  "fix",
+  "chore",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+]
+
+function validatePrTitle() {
+  const prTitleRegex = new RegExp(`^(${supportedTypes.join("|")})(\(.+\))?\:.*`)
+
+  const { draft, title } = danger.github.pr
+  if (draft || title.match(prTitleRegex)) {
     return
   }
 
-  message('Please update the PR title. Titles need to match this format: <type>: <description>')
+  fail(
+    [
+      "Please update the PR title. It should match this format: <type>: <description>",
+      "Where <type> is one of: " +
+        supportedTypes.map((type) => `"${type}"`).join(", "),
+    ].join("\n"),
+  )
 }
 
 validatePrTitle()

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -1,0 +1,14 @@
+// Validate PR titles
+function validatePrTitle() {
+  const prTitleRegex = /(feat|fix|chore|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?\:.*/g
+  const prTitle = danger.github.pr.title
+  const isDraft = danger.github.pr.draft
+
+  if (isDraft || prTitle.match(prTitleRegex)) {
+    return
+  }
+
+  message('Please update the PR title. Titles need to match this format: <type>: <description>')
+}
+
+validatePrTitle()


### PR DESCRIPTION
### Context
___ 

Replaces #2147 

This PR adds a github action to validate PR titles using danger.

Here's an example of what it looks like if the title fails.

<img width="542" alt="Screenshot 2022-05-24 at 10 01 26 PM" src="https://user-images.githubusercontent.com/7108642/170054412-48d68133-cb4b-42a9-9347-f215f8629ba3.png">
