### PR TITLE
fix(ui): fix sql statement slicing when the cursor is at the end position

### DIFF
--- a/ui/src/scenes/Editor/Monaco/utils.ts
+++ b/ui/src/scenes/Editor/Monaco/utils.ts
@@ -62,6 +62,10 @@ export const getQueryFromCursor = (
   if (!position) return
 
   for (let i = 0; i < text.length; i++) {
+    if (sql !== null) {
+      break
+    }
+
     const char = text[i]
 
     switch (char) {
@@ -73,7 +77,7 @@ export const getQueryFromCursor = (
 
         if (
           row < position.lineNumber - 1 ||
-          (row === position.lineNumber - 1 && column < position.column)
+          (row === position.lineNumber - 1 && column < position.column - 1)
         ) {
           sqlTextStack.push({
             row: startRow,
@@ -86,6 +90,7 @@ export const getQueryFromCursor = (
           startPos = i + 1
           column++
         } else {
+          // empty queries, aka ;; , make sql.length === 0
           sql = text.substring(startPos === -1 ? 0 : startPos, i)
         }
         break
@@ -127,13 +132,9 @@ export const getQueryFromCursor = (
         break
       }
     }
-
-    if (sql) {
-      break
-    }
   }
 
-  if (!sql) {
+  if (sql === null) {
     sql = startPos === -1 ? text : text.substring(startPos)
   }
 


### PR DESCRIPTION
Fixes #2151

Note that to correct the slicing, we only need to change one line (L80 in the modified file), but previously web console behaves kind of strange when meeting multiple semicolons, the other changes are for that.

For example, the following query may include `;` as the beginning of a sql statement, or splitting out a single `;` as a statement. With the modifications in this PR, when a cursor is in the middle of semicolons, the nearest valid statement before the cursor will be executed.

```sql
;;select 1;;;;;
select 2;   ;

select 3;;select
4


```