### PR TITLE
invalid: rename danger secret key

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -19,4 +19,4 @@ jobs:
         run: yarn danger ci
         working-directory: ./ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install danger 
         run: yarn global add danger 
       - name: Danger
-        run: yarn danger ci
+        run: danger ci
         working-directory: ./ci
         env:
           GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_TOKEN }}

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -25,8 +25,9 @@ function validatePrTitle() {
 
   warn(
     [
-      "Please update the PR title. It should match this format\: \<type\>: \<description\>",
-      "Where \<type\> is one of\: " +
+      "Please update the PR title.",
+      "It should match this format: *type*: *description*",
+      "Where *type* is one of\: " +
         supportedTypes.map((type) => `"${type}"`).join(", "),
     ].join("\n"),
   )

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -25,8 +25,8 @@ function validatePrTitle() {
 
   warn(
     [
-      "Please update the PR title. It should match this format: <type>: <description>",
-      "Where <type> is one of: " +
+      "Please update the PR title. It should match this format\: \<type\>: \<description\>",
+      "Where \<type\> is one of\: " +
         supportedTypes.map((type) => `"${type}"`).join(", "),
     ].join("\n"),
   )

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -23,7 +23,7 @@ function validatePrTitle() {
     return
   }
 
-  fail(
+  warn(
     [
       "Please update the PR title. It should match this format: <type>: <description>",
       "Where <type> is one of: " +


### PR DESCRIPTION
### Context
___

Github doesn't allow secrets to start with `GITHUB_`. Renaming the key to allow it to work.