### PR TITLE
fix(sql): fix the comparison refer to 'infinity'

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -150,6 +150,10 @@ public final class ColumnType {
         return columnType == DOUBLE;
     }
 
+    public static boolean isFloat(int columnType) {
+        return columnType == FLOAT;
+    }
+
     public static boolean isGeoHash(int columnType) {
         return (columnType & TYPE_FLAG_GEO_HASH) != 0;
     }

--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -150,10 +150,6 @@ public final class ColumnType {
         return columnType == DOUBLE;
     }
 
-    public static boolean isFloat(int columnType) {
-        return columnType == FLOAT;
-    }
-
     public static boolean isGeoHash(int columnType) {
         return (columnType & TYPE_FLAG_GEO_HASH) != 0;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -65,8 +65,14 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
         if (isNullConstant(left, leftType)) {
             return dispatchUnaryFunc(right, rightType);
         }
+        if (isInfiniteConstant(left, leftType)) {
+            return dispatchUnaryFuncInfinite(right, rightType, left.getDouble(null) > 0);
+        }
         if (isNullConstant(right, rightType)) {
             return dispatchUnaryFunc(left, leftType);
+        }
+        if (isInfiniteConstant(right, rightType)) {
+            return dispatchUnaryFuncInfinite(left, leftType, right.getDouble(null) > 0);
         }
         return new Func(args.getQuick(0), args.getQuick(1));
     }
@@ -76,6 +82,11 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
                 (ColumnType.isDouble(operandType) && Double.isNaN(operand.getDouble(null))
                         ||
                         operandType == ColumnType.NULL);
+    }
+
+    private static boolean isInfiniteConstant(Function operand, int operandType) {
+        return operand.isConstant() &&
+                (ColumnType.isDouble(operandType) && Double.isInfinite(operand.getDouble(null)));
     }
 
     private static Function dispatchUnaryFunc(Function operand, int operandType) {
@@ -93,6 +104,16 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
             default:
                 // double
                 return new FuncDoubleIsNaN(operand);
+        }
+    }
+
+    private static Function dispatchUnaryFuncInfinite(Function operand, int operandType, boolean isPos) {
+        switch (ColumnType.tagOf(operandType)) {
+            case ColumnType.FLOAT:
+                return isPos? new FuncFloatIsInfinite(operand) : new FuncFloatIsNegInfinite(operand);
+            default:
+                // double
+                return isPos? new FuncDoubleIsInfinite(operand) :new FuncDoubleIsNegInfinite(operand);
         }
     }
 
@@ -223,6 +244,78 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
         @Override
         public boolean getBool(Record rec) {
             return negated != (Double.isNaN(arg.getDouble(rec)));
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+    }
+
+    protected static class FuncFloatIsInfinite extends NegatableBooleanFunction implements UnaryFunction {
+        protected final Function arg;
+
+        public FuncFloatIsInfinite(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated != (arg.getFloat(rec) == Float.POSITIVE_INFINITY);
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+    }
+
+    protected static class FuncFloatIsNegInfinite extends NegatableBooleanFunction implements UnaryFunction {
+        protected final Function arg;
+
+        public FuncFloatIsNegInfinite(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated != (arg.getFloat(rec) == Float.NEGATIVE_INFINITY);
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+    }
+
+    protected static class FuncDoubleIsInfinite extends NegatableBooleanFunction implements UnaryFunction {
+        protected final Function arg;
+
+        public FuncDoubleIsInfinite(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated != (arg.getDouble(rec) == Double.POSITIVE_INFINITY);
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+    }
+
+    protected static class FuncDoubleIsNegInfinite extends NegatableBooleanFunction implements UnaryFunction {
+        protected final Function arg;
+
+        public FuncDoubleIsNegInfinite(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            return negated != (arg.getDouble(rec) == Double.NEGATIVE_INFINITY);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -55,6 +55,8 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
         // to NaN route to this factory. Obviously comparing naively will not work
         // We have to check arg types and when NaN is present we would generate special case
         // functions for NaN checks.
+        // As for Infinity, Infinity could be double or float, and the special judgment is
+        // only between Infinity and Infinity.
 
         Function left = args.getQuick(0);
         Function right = args.getQuick(1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -97,6 +97,12 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
     }
 
     protected static class Func extends NegatableBooleanFunction implements BinaryFunction {
+        // This function uses both subtraction and equality to judge whether two parameters
+        // are equal because subtraction is to prevent the judging mistakes with different
+        // precision, and equality is for the comparison of Infinity. In java,
+        // Infinity - Infinity = NaN, so it won't satisfy the subtraction situation. But
+        // Infinity = Infinity, so use equality could solve this problem.
+
         protected final Function left;
         protected final Function right;
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -86,7 +86,7 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
 
     private static boolean isInfiniteConstant(Function operand, int operandType) {
         return operand.isConstant() &&
-                (ColumnType.isDouble(operandType) && Double.isInfinite(operand.getDouble(null)));
+                ((ColumnType.isDouble(operandType) || ColumnType.isFloat(operandType)) && Double.isInfinite(operand.getDouble(null)));
     }
 
     private static Function dispatchUnaryFunc(Function operand, int operandType) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -86,7 +86,7 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
 
     private static boolean isInfiniteConstant(Function operand, int operandType) {
         return operand.isConstant() &&
-                ((ColumnType.isDouble(operandType) || ColumnType.isFloat(operandType)) && Double.isInfinite(operand.getDouble(null)));
+                ((ColumnType.isDouble(operandType) && Double.isInfinite(operand.getDouble(null))) || (ColumnType.isFloat(operandType) && Float.isInfinite(operand.getFloat(null))) );
     }
 
     private static Function dispatchUnaryFunc(Function operand, int operandType) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactory.java
@@ -97,7 +97,7 @@ public class EqDoubleFunctionFactory implements FunctionFactory {
     }
 
     protected static class Func extends NegatableBooleanFunction implements BinaryFunction {
-        // This function uses both subtraction and equality to judge whether two parameters
+        // This function class uses both subtraction and equality to judge whether two parameters
         // are equal because subtraction is to prevent the judging mistakes with different
         // precision, and equality is for the comparison of Infinity. In java,
         // Infinity - Infinity = NaN, so it won't satisfy the subtraction situation. But

--- a/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
@@ -80,6 +80,37 @@ public class CastTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testInfinity() throws Exception {
+        assertQuery(
+                "a\n",
+                "select a from tab",
+                "create table tab (a boolean)",
+                null,
+                "insert into tab select cast('Infinity' as double) = cast('Infinity' as double)," +
+                        "cast('Infinity' as float) = cast('Infinity' as double)," +
+                        "cast('Infinity' as float) = cast('Infinity' as float)," +
+                        "cast('-Infinity' as double) = cast('-Infinity' as double)," +
+                        "cast('-Infinity' as double) = cast('-Infinity' as float)," +
+                        "cast('-Infinity' as float) = cast('-Infinity' as float)," +
+                        "cast('Infinity' as double) != cast('-Infinity' as double)," +
+                        "cast('Infinity' as float) > 1 " +
+                        "from long_sequence(8)",
+                "a\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n" +
+                        "true\n",
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testBooleanToByte() throws Exception {
         assertQuery(
                 "a\n",

--- a/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/cast/CastTest.java
@@ -111,6 +111,22 @@ public class CastTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testInfinityNonConstant() throws Exception {
+        assertQuery(
+                "column\n",
+                "select a = b from tab ",
+                "create table tab (a double, b float)",
+                null,
+                "insert into tab values (cast('Infinity' as double), cast('Infinity' as float))",
+                "column\n" +
+                        "true\n",
+                true,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testBooleanToByte() throws Exception {
         assertQuery(
                 "a\n",

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
@@ -336,6 +336,22 @@ public class EqDoubleFunctionFactoryTest extends AbstractFunctionFactoryTest {
         Assert.assertTrue(function.isConstant());
     }
 
+    @Test
+    public void testNegInfFloatEqualsNegInfFloat() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new FloatConstant(Float.NEGATIVE_INFINITY));
+        args.add(new FloatConstant(Float.NEGATIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertTrue(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
     @Override
     protected FunctionFactory getFunctionFactory() {
         return new EqDoubleFunctionFactory();

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
@@ -320,6 +320,22 @@ public class EqDoubleFunctionFactoryTest extends AbstractFunctionFactoryTest {
         Assert.assertTrue(function.isConstant());
     }
 
+    @Test
+    public void testInfFloatEqualsInfFloat() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new FloatConstant(Float.POSITIVE_INFINITY));
+        args.add(new DoubleConstant(Float.POSITIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertTrue(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
     @Override
     protected FunctionFactory getFunctionFactory() {
         return new EqDoubleFunctionFactory();

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
@@ -256,6 +256,70 @@ public class EqDoubleFunctionFactoryTest extends AbstractFunctionFactoryTest {
         Assert.assertFalse(function.isConstant());
     }
 
+    @Test
+    public void testInfDoubleEqualsInfDouble() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new DoubleConstant(Double.POSITIVE_INFINITY));
+        args.add(new DoubleConstant(Double.POSITIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertTrue(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
+    @Test
+    public void testNegInfDoubleEqualsNegInfDouble() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new DoubleConstant(Double.NEGATIVE_INFINITY));
+        args.add(new DoubleConstant(Double.NEGATIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertTrue(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
+    @Test
+    public void testInfDoubleEqualsNegInfDouble() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new DoubleConstant(Double.POSITIVE_INFINITY));
+        args.add(new DoubleConstant(Double.NEGATIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertFalse(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
+    @Test
+    public void testInfFloatEqualsInfDouble() throws SqlException {
+        FunctionFactory factory = getFunctionFactory();
+        ObjList<Function> args = new ObjList<>();
+        args.add(new FloatConstant(Float.POSITIVE_INFINITY));
+        args.add(new DoubleConstant(Double.POSITIVE_INFINITY));
+
+        IntList argPositions = new IntList();
+        argPositions.add(2);
+        argPositions.add(1);
+
+        Function function = factory.newInstance(4, args, argPositions, configuration, sqlExecutionContext);
+        Assert.assertTrue(function.getBool(null));
+        Assert.assertTrue(function.isConstant());
+    }
+
     @Override
     protected FunctionFactory getFunctionFactory() {
         return new EqDoubleFunctionFactory();

--- a/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/eq/EqDoubleFunctionFactoryTest.java
@@ -325,7 +325,7 @@ public class EqDoubleFunctionFactoryTest extends AbstractFunctionFactoryTest {
         FunctionFactory factory = getFunctionFactory();
         ObjList<Function> args = new ObjList<>();
         args.add(new FloatConstant(Float.POSITIVE_INFINITY));
-        args.add(new DoubleConstant(Float.POSITIVE_INFINITY));
+        args.add(new FloatConstant(Float.POSITIVE_INFINITY));
 
         IntList argPositions = new IntList();
         argPositions.add(2);


### PR DESCRIPTION
Fixes #2112
Adding special judgment of 'infinity' in SQL commands to make `Infinity = Infinity` and `-Infinity = -Infinity`, no matter in float or in double.

Updated changed files:
- `EqDoubleFunctionFactory.java`: adding judgment using equality besides using subtraction
- `EqDoubleFunctionFactoryTest.java`: adding tests for direct equal operation
- `CastTest.java`: adding tests for using infinity in SQL commands
