### PR TITLE
fix(griffin): fix for mixing up TRUE and FALSE while updating BOOLEAN field

### DIFF
--- a/core/src/main/java/io/questdb/griffin/UpdateOperator.java
+++ b/core/src/main/java/io/questdb/griffin/UpdateOperator.java
@@ -377,8 +377,10 @@ public class UpdateOperator implements Closeable {
                     dstFixMem.putChar(masterRecord.getChar(i));
                     break;
                 case ColumnType.BYTE:
-                case ColumnType.BOOLEAN:
                     dstFixMem.putByte(masterRecord.getByte(i));
+                    break;
+                case ColumnType.BOOLEAN:
+                    dstFixMem.putBool(masterRecord.getBool(i));
                     break;
                 case ColumnType.GEOBYTE:
                     dstFixMem.putByte(masterRecord.getGeoByte(i));


### PR DESCRIPTION
Fixes #2173

QuestDB Record and Memory abstractions are inconsistent in how they encode/decode/cast boolean values.
Memory uses 1 to represent TRUE and 0 to FALSE, Record does the opposite.

UPDATE treated boolean values as bytes.
Basically when took a 0 value from the Record and put it into a Memory object it turned TRUE to FALSE, and the opposite for the byte value 1 where it turned FALSE to TRUE.
The fix is to not treat boolean values as bytes on the Record and Memory APIs, just use getBool() and putBool() instead which will not care about how the boolean values are represented internally.
