### PR TITLE
feat(ilp): make ILP implicit schema optional

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -395,6 +395,8 @@ public class PropServerConfiguration implements ServerConfiguration {
     private short integerDefaultColumnType;
     private final int columnPurgeTaskPoolCapacity;
     private final int maxFileNameLength;
+    private final boolean ilpAutoCreateNewColumns;
+    private final boolean ilpAutoCreateNewTables;
 
     public PropServerConfiguration(
             String root,
@@ -924,6 +926,8 @@ public class PropServerConfiguration implements ServerConfiguration {
                     this.integerDefaultColumnType = ColumnType.LONG;
                 }
             }
+            this.ilpAutoCreateNewColumns = getBoolean(properties, env, PropertyKey.LINE_AUTO_CREATE_NEW_COLUMNS, true);
+            this.ilpAutoCreateNewTables = getBoolean(properties, env, PropertyKey.LINE_AUTO_CREATE_NEW_TABLES, true);
 
             this.sharedWorkerCount = getInt(properties, env, PropertyKey.SHARED_WORKER_COUNT, Math.max(1, cpuAvailable / 2 - 1 - cpuUsed));
             this.sharedWorkerAffinity = getAffinity(properties, env, PropertyKey.SHARED_WORKER_AFFINITY, sharedWorkerCount);
@@ -2492,6 +2496,16 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     private class PropLineUdpReceiverConfiguration implements LineUdpReceiverConfiguration {
         @Override
+        public boolean getAutoCreateNewColumns() {
+            return ilpAutoCreateNewColumns;
+        }
+
+        @Override
+        public boolean getAutoCreateNewTables() {
+            return ilpAutoCreateNewTables;
+        }
+
+        @Override
         public int getCommitMode() {
             return lineUdpCommitMode;
         }
@@ -2738,6 +2752,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public String getAuthDbPath() {
             return lineTcpAuthDbPath;
+        }
+
+        @Override
+        public boolean getAutoCreateNewColumns() {
+            return ilpAutoCreateNewColumns;
+        }
+
+        @Override
+        public boolean getAutoCreateNewTables() {
+            return ilpAutoCreateNewTables;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -352,7 +352,9 @@ public enum PropertyKey {
     CAIRO_SQL_COLUMN_PURGE_RETRY_DELAY_MULTIPLIER("cairo.sql.column.purge.retry.delay.multiplier"),
     CAIRO_SQL_COLUMN_PURGE_RETRY_LIMIT_DAYS("cairo.sql.column.purge.retry.limit.days"),
     CAIRO_SQL_SYSTEM_TABLE_PREFIX("cairo.system.table.prefix"),
-    CAIRO_MAX_FILE_NAME_LENGTH("cairo.max.file.name.length");
+    CAIRO_MAX_FILE_NAME_LENGTH("cairo.max.file.name.length"),
+    LINE_AUTO_CREATE_NEW_COLUMNS("line.auto.create.new.columns"),
+    LINE_AUTO_CREATE_NEW_TABLES("line.auto.create.new.tables");
 
     private static final Map<String, PropertyKey> nameMapping;
     private final String propertyPath;

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -772,8 +772,12 @@ public class TableReader implements Closeable, SymbolTableSource {
                 try {
                     return metadata.of(path, ColumnType.VERSION);
                 } catch (CairoException ex) {
-                    if (!existanceChecked && !ff.exists(path.put(Files.SEPARATOR).$())) {
-                        throw CairoException.instance(2).put("table does not exist [table=").put(tableName).put(']');
+                    if (!existanceChecked) {
+                        path.trimTo(rootLen).put(Files.SEPARATOR).$();
+                        if (!ff.exists(path)) {
+                            throw CairoException.instance(2).put("table does not exist [table=").put(tableName).put(']');
+                        }
+                        path.trimTo(rootLen).concat(TableUtils.META_FILE_NAME).$();
                     }
                     existanceChecked = true;
                     handleMetadataLoadException(deadline, ex);

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -89,9 +89,6 @@ public class TableReader implements Closeable, SymbolTableSource {
         this.path = new Path();
         this.path.of(configuration.getRoot()).concat(this.tableName);
         this.rootLen = path.length();
-        if (!ff.exists(path.put(Files.SEPARATOR).$())) {
-            throw CairoException.instance(2).put("table does not exist [table=").put(tableName).put(']');
-        }
         path.trimTo(rootLen);
         try {
             this.metadata = openMetaFile();
@@ -770,10 +767,15 @@ public class TableReader implements Closeable, SymbolTableSource {
         TableReaderMetadata metadata = new TableReaderMetadata(ff);
         path.concat(TableUtils.META_FILE_NAME).$();
         try {
+            boolean existanceChecked = false;
             while (true) {
                 try {
                     return metadata.of(path, ColumnType.VERSION);
                 } catch (CairoException ex) {
+                    if (!existanceChecked && !ff.exists(path.put(Files.SEPARATOR).$())) {
+                        throw CairoException.instance(2).put("table does not exist [table=").put(tableName).put(']');
+                    }
+                    existanceChecked = true;
                     handleMetadataLoadException(deadline, ex);
                 }
             }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -89,6 +89,10 @@ public class TableReader implements Closeable, SymbolTableSource {
         this.path = new Path();
         this.path.of(configuration.getRoot()).concat(this.tableName);
         this.rootLen = path.length();
+        if (!ff.exists(path.put(Files.SEPARATOR).$())) {
+            throw CairoException.instance(2).put("table does not exist [table=").put(tableName).put(']');
+        }
+        path.trimTo(rootLen);
         try {
             this.metadata = openMetaFile();
             this.columnCount = this.metadata.getColumnCount();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -139,6 +139,16 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
     }
 
     @Override
+    public boolean getAutoCreateNewColumns() {
+        return true;
+    }
+
+    @Override
+    public boolean getAutoCreateNewTables() {
+        return true;
+    }
+
+    @Override
     public int getDefaultPartitionBy() {
         return PartitionBy.DAY;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -47,6 +47,7 @@ class LineTcpMeasurementEvent implements Closeable {
     private final boolean stringToCharCastAllowed;
     private final boolean symbolAsFieldSupported;
     private final int maxColumnNameLength;
+    private final boolean autoCreateNewColumns;
     private int writerWorkerId;
     private TableUpdateDetails tableUpdateDetails;
     private boolean commitOnWriterClose;
@@ -59,9 +60,11 @@ class LineTcpMeasurementEvent implements Closeable {
             DefaultColumnTypes defaultColumnTypes,
             boolean stringToCharCastAllowed,
             boolean symbolAsFieldSupported,
-            int maxColumnNameLength
+            int maxColumnNameLength,
+            boolean autoCreateNewColumns
     ) {
         this.maxColumnNameLength = maxColumnNameLength;
+        this.autoCreateNewColumns = autoCreateNewColumns;
         this.buffer = new LineTcpEventBuffer(bufLo, bufSize);
         this.clock = clock;
         this.timestampAdapter = timestampAdapter;
@@ -275,9 +278,11 @@ class LineTcpMeasurementEvent implements Closeable {
             } else if (columnWriterIndex == COLUMN_NOT_FOUND) {
                 // send column by name
                 final String columnName = localDetails.getColName();
-                if (TableUtils.isValidColumnName(columnName, maxColumnNameLength)) {
+                if (autoCreateNewColumns && TableUtils.isValidColumnName(columnName, maxColumnNameLength)) {
                     offset = buffer.addColumnName(offset, columnName);
                     colType = localDetails.getColumnType(columnName, entityType);
+                } else if (!autoCreateNewColumns) {
+                    throw newColumnsNotAllowed(columnName);
                 } else {
                     throw invalidColNameError(columnName);
                 }
@@ -497,6 +502,13 @@ class LineTcpMeasurementEvent implements Closeable {
         buffer.addDesignatedTimestamp(buffer.getAddress(), timestamp);
         buffer.addNumOfColumns(buffer.getAddress() + Long.BYTES, entitiesWritten);
         writerWorkerId = tableUpdateDetails.getWriterThreadId();
+    }
+
+    private CairoException newColumnsNotAllowed(String colName) {
+        return CairoException.instance(0)
+                .put("column does not exist, creating new columns is disabled [table=").put(tableUpdateDetails.getTableNameUtf16())
+                .put(", columnName=").put(colName)
+                .put(']');
     }
 
     void createWriterReleaseEvent(TableUpdateDetails tableUpdateDetails, boolean commitOnWriterClose) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -64,6 +64,8 @@ class LineTcpMeasurementScheduler implements Closeable {
     private final MemoryMARW ddlMem = Vm.getMARWInstance();
     private final LineTcpReceiverConfiguration configuration;
     private final MPSequence[] pubSeq;
+    private final boolean autoCreateNewTables;
+    private final boolean autoCreateNewColumns;
     private LineTcpReceiver.SchedulerListener listener;
 
     LineTcpMeasurementScheduler(
@@ -95,6 +97,8 @@ class LineTcpMeasurementScheduler implements Closeable {
         tableUpdateDetailsUtf16 = new LowerCaseCharSequenceObjHashMap<>();
         idleTableUpdateDetailsUtf16 = new LowerCaseCharSequenceObjHashMap<>();
         loadByWriterThread = new long[writerWorkerPool.getWorkerCount()];
+        autoCreateNewTables = lineConfiguration.getAutoCreateNewTables();
+        autoCreateNewColumns = lineConfiguration.getAutoCreateNewColumns();
         int maxMeasurementSize = lineConfiguration.getMaxMeasurementSize();
         int queueSize = lineConfiguration.getWriterQueueCapacity();
         long commitIntervalDefault = configuration.getCommitIntervalDefault();
@@ -115,7 +119,9 @@ class LineTcpMeasurementScheduler implements Closeable {
                             defaultColumnTypes,
                             lineConfiguration.isStringToCharCastAllowed(),
                             lineConfiguration.isSymbolAsFieldSupported(),
-                            lineConfiguration.getMaxFileNameLength()),
+                            lineConfiguration.getMaxFileNameLength(),
+                            lineConfiguration.getAutoCreateNewColumns()
+                    ),
                     getEventSlotSize(maxMeasurementSize),
                     queueSize,
                     MemoryTag.NATIVE_DEFAULT
@@ -264,6 +270,16 @@ class LineTcpMeasurementScheduler implements Closeable {
             } else {
                 int status = engine.getStatus(securityContext, path, tableNameUtf16, 0, tableNameUtf16.length());
                 if (status != TableUtils.TABLE_EXISTS) {
+                    if (!autoCreateNewTables) {
+                        throw CairoException.instance(0)
+                                .put("table does not exist, creating new tables is disabled [table=").put(tableNameUtf16)
+                                .put(']');
+                    }
+                    if (!autoCreateNewColumns) {
+                        throw CairoException.instance(0)
+                                .put("table does not exist, cannot create table, creating new columns is disabled [table=").put(tableNameUtf16)
+                                .put(']');
+                    }
                     // validate that parser entities do not contain NULLs
                     TableStructureAdapter tsa = tableStructureAdapter.of(tableNameUtf16, parser);
                     for (int i = 0, n = tsa.getColumnCount(); i < n; i++) {
@@ -325,12 +341,11 @@ class LineTcpMeasurementScheduler implements Closeable {
             return true;
         } catch (CairoException ex) {
             // Table could not be created
-            LOG.info()
-                    .$("could not create table [tableName=").$(parser.getMeasurementName())
-                    .$(", ex=`").$(ex.getFlyweightMessage())
-                    .$("`, errno=").$(ex.getErrno())
+            LOG.error().$("could not create table [tableName=").$(parser.getMeasurementName())
+                    .$(", errno=").$(ex.getErrno())
                     .I$();
-            return false;
+            // More details will be logged by catching thread
+            throw ex;
         }
 
         final int writerThreadId = tab.getWriterThreadId();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
@@ -36,6 +36,10 @@ public interface LineTcpReceiverConfiguration {
 
     String getAuthDbPath();
 
+    boolean getAutoCreateNewColumns();
+
+    boolean getAutoCreateNewTables();
+
     CairoSecurityContext getCairoSecurityContext();
 
     int getConnectionPoolInitialCapacity();

--- a/core/src/main/java/io/questdb/cutlass/line/udp/DefaultLineUdpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/DefaultLineUdpReceiverConfiguration.java
@@ -118,6 +118,16 @@ public class DefaultLineUdpReceiverConfiguration implements LineUdpReceiverConfi
     }
 
     @Override
+    public boolean getAutoCreateNewColumns() {
+        return true;
+    }
+
+    @Override
+    public boolean getAutoCreateNewTables() {
+        return true;
+    }
+
+    @Override
     public int getCommitMode() {
         return CommitMode.NOSYNC;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpLexer.java
@@ -60,6 +60,7 @@ public class LineUdpLexer implements Mutable, Closeable {
             floatingCharSequence.hi = buffer + Numbers.decodeLowInt(address) - 2;
             assert floatingCharSequence.hi < bufferHi;
             assert floatingCharSequence.lo >= buffer;
+            assert floatingCharSequence.lo <= floatingCharSequence.hi;
             return floatingCharSequence;
         };
         clear();

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -76,7 +76,6 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private TableWriter writer;
     private final LineEndParser MY_LINE_END = this::appendRow;
     private RecordMetadata metadata;
-    private int columnCount;
     private int columnIndex;
     private long columnName;
     private int columnType;
@@ -90,6 +89,8 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private final FieldValueParser MY_TAG_VALUE = this::parseTagValue;
     private final FieldValueParser MY_FIELD_VALUE = this::parseFieldValue;
     private final FieldValueParser MY_NEW_FIELD_VALUE = this::parseFieldValueNewTable;
+    private final boolean autoCreateNewTables;
+    private final boolean autoCreateNewColumns;
 
     public LineUdpParserImpl(
             CairoEngine engine,
@@ -104,6 +105,8 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
 
         defaultFloatColumnType = udpConfiguration.getDefaultColumnTypeForFloat();
         defaultIntegerColumnType = udpConfiguration.getDefaultColumnTypeForInteger();
+        this.autoCreateNewTables = udpConfiguration.getAutoCreateNewTables();
+        this.autoCreateNewColumns = udpConfiguration.getAutoCreateNewColumns();
     }
 
     @Override
@@ -183,7 +186,6 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
         TableWriter writer = engine.getWriter(cairoSecurityContext, cache.get(tableName), WRITER_LOCK_REASON);
         this.writer = writer;
         this.metadata = writer.getMetadata();
-        this.columnCount = metadata.getColumnCount();
         writerCache.valueAtQuick(cacheEntryIndex).writer = writer;
 
         final int columnCount = columnNameType.size() / 2;
@@ -268,7 +270,6 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private void createState(CacheEntry entry) {
         writer = entry.writer;
         metadata = writer.getMetadata();
-        columnCount = metadata.getColumnCount();
         switchModeToAppend();
     }
 
@@ -292,6 +293,16 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                         cacheWriter(entry, token);
                         break;
                     case TABLE_DOES_NOT_EXIST:
+                        if (!autoCreateNewTables) {
+                            throw CairoException.instance(0)
+                                    .put("table does not exist, creating new tables is disabled [table=").put(token)
+                                    .put(']');
+                        }
+                        if (!autoCreateNewColumns) {
+                            throw CairoException.instance(0)
+                                    .put("table does not exist, cannot create table, creating new columns is disabled [table=").put(token)
+                                    .put(']');
+                        }
                         tableName = token.getCacheAddress();
                         if (onLineEnd != MY_NEW_LINE_END) {
                             onLineEnd = MY_NEW_LINE_END;
@@ -319,7 +330,9 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
         columnIndex = metadata.getColumnIndexQuiet(token);
         if (columnIndex > -1) {
             columnType = metadata.getColumnType(columnIndex);
-        } else {
+        }
+
+        if (columnIndex < 0 || columnType < 0) {
             prepareNewColumn(token);
         }
     }
@@ -429,11 +442,18 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
             }
         } else {
             CharSequence colNameAsChars = cache.get(columnName);
-            if (TableUtils.isValidColumnName(colNameAsChars, udpConfiguration.getMaxFileNameLength())) {
+            if (autoCreateNewColumns && TableUtils.isValidColumnName(colNameAsChars, udpConfiguration.getMaxFileNameLength())) {
                 writer.addColumn(colNameAsChars, valueType);
-                columnIndexAndType.add(Numbers.encodeLowHighInts(columnCount++, valueType));
+                // Writer index can be different from column count, it keeps deleted columns in metadata
+                int columnIndex = writer.getColumnIndex(colNameAsChars);
+                columnIndexAndType.add(Numbers.encodeLowHighInts(columnIndex, valueType));
                 columnValues.add(value.getCacheAddress());
                 geoHashBitsSizeByColIdx.add(0);
+            } else if (!autoCreateNewColumns) {
+                throw CairoException.instance(0)
+                        .put("column does not exist, creating new columns is disabled [table=").put(writer.getTableName())
+                        .put(", columnName=").put(colNameAsChars)
+                        .put(']');
             } else {
                 LOG.error().$("invalid column name [table=").$(writer.getTableName())
                         .$(", columnName=").$(colNameAsChars)

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -338,6 +338,11 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     }
 
     private void parseFieldNameNewTable(CachedCharSequence token) {
+        if (!TableUtils.isValidColumnName(token, udpConfiguration.getMaxFileNameLength())) {
+            LOG.error().$("invalid column name [columnName=").$(token).I$();
+            switchModeToSkipLine();
+            return;
+        }
         columnNameType.add(token.getCacheAddress());
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpReceiverConfiguration.java
@@ -30,6 +30,10 @@ import io.questdb.network.NetworkFacade;
 
 public interface LineUdpReceiverConfiguration {
 
+    boolean getAutoCreateNewColumns();
+
+    boolean getAutoCreateNewTables();
+
     int getCommitMode();
 
     int getBindIPv4Address();

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -418,6 +418,12 @@ query.timeout.sec=60
 ################ LINE settings ######################
 #line.default.partition.by=DAY
 
+# Enable / Disable  automatic creation of new columns in existing tables via ILP. When set to false overrides value of line.auto.create.new.tables to false
+#line.auto.create.new.columns=true
+
+# Enable / Disable automatic creation of new tables via ILP.
+#line.auto.create.new.tables=true
+
 ################ LINE UDP settings ##################
 
 #line.udp.bind.to=0.0.0.0:9009

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -332,6 +332,11 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(127, configuration.getCairoConfiguration().getMaxFileNameLength());
         Assert.assertEquals(127, configuration.getLineTcpReceiverConfiguration().getMaxFileNameLength());
         Assert.assertEquals(127, configuration.getLineUdpReceiverConfiguration().getMaxFileNameLength());
+
+        Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().getAutoCreateNewColumns());
+        Assert.assertTrue(configuration.getLineUdpReceiverConfiguration().getAutoCreateNewColumns());
+        Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().getAutoCreateNewTables());
+        Assert.assertTrue(configuration.getLineUdpReceiverConfiguration().getAutoCreateNewTables());
     }
 
     @Test
@@ -846,6 +851,11 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(255, configuration.getCairoConfiguration().getMaxFileNameLength());
             Assert.assertEquals(255, configuration.getLineTcpReceiverConfiguration().getMaxFileNameLength());
             Assert.assertEquals(255, configuration.getLineUdpReceiverConfiguration().getMaxFileNameLength());
+
+            Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().getAutoCreateNewColumns());
+            Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().getAutoCreateNewColumns());
+            Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().getAutoCreateNewTables());
+            Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().getAutoCreateNewTables());
         }
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -98,6 +98,8 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
     protected boolean symbolAsFieldSupported;
     protected short floatDefaultColumnType;
     protected short integerDefaultColumnType;
+    protected boolean autoCreateNewColumns = true;
+    protected boolean autoCreateNewTables = true;
 
     @Before
     public void before() {
@@ -109,6 +111,8 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
         disconnectOnError = false;
         floatDefaultColumnType = ColumnType.DOUBLE;
         integerDefaultColumnType = ColumnType.LONG;
+        autoCreateNewColumns = true;
+        autoCreateNewTables = true;
         lineTcpConfiguration = createNoAuthReceiverConfiguration(provideLineTcpNetworkFacade());
     }
 
@@ -161,6 +165,16 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
 
     protected LineTcpReceiverConfiguration createReceiverConfiguration(final boolean withAuth, final NetworkFacade nf) {
         return new DefaultLineTcpReceiverConfiguration() {
+            @Override
+            public boolean getAutoCreateNewColumns() {
+                return autoCreateNewColumns;
+            }
+
+            @Override
+            public boolean getAutoCreateNewTables() {
+                return autoCreateNewTables;
+            }
+
             @Override
             public int getNetMsgBufferSize() {
                 return netMsgBufferSize.get();

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -224,3 +224,6 @@ metrics.enabled=true
 
 cairo.o3.partition.purge.list.initial.capacity=16
 cairo.max.file.name.length=255
+
+line.auto.create.new.columns=false
+line.auto.create.new.tables=false


### PR DESCRIPTION
Adds 2 configuration options:

```
# Enable / Disable  automatic creation of new columns in existing tables via ILP. When set to false overrides value of line.auto.create.new.tables to false
#line.auto.create.new.columns=true

# Enable / Disable automatic creation of new tables via ILP.
#line.auto.create.new.tables=true
```

Done for production hardening where new tables should not be created dynamically when a client sends bad formatted data to ILP socket.

As a side enhancement `TableReader` when created will check that table folder exists on first failure opening metadata. This is to fix retrying to open metadata file and timing out on deleted / non existing tables