### PR TITLE
chore(benchmark): add j.u.HashMap for comparison in map benchmarks

### DIFF
--- a/benchmarks/src/main/java/org/questdb/QMapReadRandomKeyBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/QMapReadRandomKeyBenchmark.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Thread)
@@ -50,6 +51,7 @@ public class QMapReadRandomKeyBenchmark {
     private static final Rnd rnd = new Rnd();
     private static final CompactMap qmap = new CompactMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), N, loadFactor, 1024, Integer.MAX_VALUE);
     private static final FastMap map = new FastMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), N, loadFactor, 1024);
+    private static final HashMap<String, Long> hmap = new HashMap<>(N, (float) loadFactor);
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
@@ -68,6 +70,11 @@ public class QMapReadRandomKeyBenchmark {
     }
 
     @Benchmark
+    public CharSequence baseline() {
+        return rnd.nextChars(M);
+    }
+
+    @Benchmark
     public MapValue testDirectMap() {
         MapKey key = map.withKey();
         key.putStr(rnd.nextChars(M));
@@ -79,6 +86,11 @@ public class QMapReadRandomKeyBenchmark {
         MapKey key = qmap.withKey();
         key.putStr(rnd.nextChars(M));
         return key.findValue();
+    }
+
+    @Benchmark
+    public Long testHashMap() {
+        return hmap.get(rnd.nextChars(M).toString());
     }
 
     static {
@@ -94,6 +106,10 @@ public class QMapReadRandomKeyBenchmark {
             key.putStr(rnd.nextChars(M));
             MapValue values = key.createValue();
             values.putLong(0, i);
+        }
+
+        for (int i = 0; i < N; i++) {
+            hmap.put(rnd.nextChars(M).toString(), (long) i);
         }
     }
 }

--- a/benchmarks/src/main/java/org/questdb/QMapReadSequentialKeyBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/QMapReadSequentialKeyBenchmark.java
@@ -51,7 +51,7 @@ public class QMapReadSequentialKeyBenchmark {
     private static final Rnd rnd = new Rnd();
     private static final CompactMap qmap = new CompactMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), N, loadFactor, 1024, Integer.MAX_VALUE);
     private static final FastMap map = new FastMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), N, loadFactor, 1024);
-    private static final HashMap<String, Long> hmap = new HashMap<>();
+    private static final HashMap<String, Long> hmap = new HashMap<>(N, (float) loadFactor);
     private static final StringSink sink = new StringSink();
 
     public static void main(String[] args) throws RunnerException {
@@ -71,6 +71,11 @@ public class QMapReadSequentialKeyBenchmark {
     }
 
     @Benchmark
+    public int baseline() {
+        return rnd.nextInt(N);
+    }
+
+    @Benchmark
     public MapValue testDirectMap() {
         MapKey key = map.withKey();
         sink.clear();
@@ -80,17 +85,17 @@ public class QMapReadSequentialKeyBenchmark {
     }
 
     @Benchmark
-    public Long testHashMap() {
-        return hmap.put(String.valueOf(rnd.nextInt(N)), 100L);
-    }
-
-    @Benchmark
     public MapValue testQMap() {
         MapKey key = qmap.withKey();
         sink.clear();
         sink.put(rnd.nextInt(N));
         key.putStr(sink);
         return key.findValue();
+    }
+
+    @Benchmark
+    public Long testHashMap() {
+        return hmap.get(String.valueOf(rnd.nextInt(N)));
     }
 
     static {
@@ -106,6 +111,10 @@ public class QMapReadSequentialKeyBenchmark {
             key.putStr(String.valueOf(i));
             MapValue values = key.createValue();
             values.putLong(0, i);
+        }
+
+        for (int i = 0; i < N; i++) {
+            hmap.put(String.valueOf(i), (long) i);
         }
     }
 }

--- a/benchmarks/src/main/java/org/questdb/QMapWriteBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/QMapWriteBenchmark.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Thread)
@@ -46,17 +47,17 @@ public class QMapWriteBenchmark {
 
     private static final double loadFactor = 0.5;
     private static final int M = 25;
-    private static CompactMap qmap = new CompactMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), 64, loadFactor, 1024, Integer.MAX_VALUE);
-    private static FastMap map = new FastMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), 64, loadFactor, 1024);
-
+    private static final CompactMap qmap = new CompactMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), 64, loadFactor, 1024, Integer.MAX_VALUE);
+    private static final FastMap map = new FastMap(1024 * 1024, new SingleColumnType(ColumnType.STRING), new SingleColumnType(ColumnType.LONG), 64, loadFactor, 1024);
+    private static final HashMap<String, Long> hmap = new HashMap<>(64, (float) loadFactor);
 
     private final Rnd rnd = new Rnd();
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .include(QMapWriteBenchmark.class.getSimpleName())
-                .warmupIterations(5)
-                .measurementIterations(5)
+                .warmupIterations(3)
+                .measurementIterations(3)
                 .forks(1)
                 .build();
 
@@ -90,5 +91,10 @@ public class QMapWriteBenchmark {
         key.putStr(rnd.nextChars(M));
         MapValue value = key.createValue();
         value.putLong(0, 20);
+    }
+
+    @Benchmark
+    public void testHashMap() {
+        hmap.put(rnd.nextChars(M).toString(), 20L);
     }
 }


### PR DESCRIPTION
Ubuntu 20.04 64-bit, OpenJDK 17:
```
Benchmark                         Mode  Cnt  Score   Error  Units
QMapWriteBenchmark.baseline       avgt    3  0.277 ± 0.128  us/op
QMapWriteBenchmark.testDirectMap  avgt    3  0.735 ± 0.413  us/op
QMapWriteBenchmark.testHashMap    avgt    3  0.853 ± 0.385  us/op
QMapWriteBenchmark.testQMap       avgt    3  0.791 ± 0.843  us/op

Benchmark                                     Mode  Cnt  Score   Error  Units
QMapReadSequentialKeyBenchmark.baseline       avgt    3  0.010 ± 0.003  us/op
QMapReadSequentialKeyBenchmark.testDirectMap  avgt    3  0.324 ± 0.191  us/op
QMapReadSequentialKeyBenchmark.testHashMap    avgt    3  0.268 ± 0.091  us/op
QMapReadSequentialKeyBenchmark.testQMap       avgt    3  0.360 ± 0.042  us/op

Benchmark                                 Mode  Cnt  Score   Error  Units
QMapReadRandomKeyBenchmark.baseline       avgt    3  0.322 ± 0.113  us/op
QMapReadRandomKeyBenchmark.testDirectMap  avgt    3  0.775 ± 0.407  us/op
QMapReadRandomKeyBenchmark.testHashMap    avgt    3  0.686 ± 0.692  us/op
QMapReadRandomKeyBenchmark.testQMap       avgt    3  0.754 ± 0.289  us/op
```