### PR TITLE
chore: fixed flapping logger test

### DIFF
--- a/core/src/main/java/io/questdb/log/Logger.java
+++ b/core/src/main/java/io/questdb/log/Logger.java
@@ -358,7 +358,7 @@ class Logger implements LogRecord, Log {
             return NullLogRecord.INSTANCE;
         }
 
-        final long cursor = seq.nextBully();
+        final long cursor = seq.next();
         if (cursor < 0) {
             return NullLogRecord.INSTANCE;
         }

--- a/core/src/test/java/io/questdb/log/LogFactoryTest.java
+++ b/core/src/test/java/io/questdb/log/LogFactoryTest.java
@@ -630,6 +630,21 @@ public class LogFactoryTest {
         testCustomLogIsCreated(false);
     }
 
+    private static void assertEnabled(LogRecord r) {
+        Assert.assertTrue(r.isEnabled());
+        r.$();
+    }
+
+    private static void assertDisabled(LogRecord r) {
+        Assert.assertFalse(r.isEnabled());
+        r.$();
+    }
+
+    private void assertFileLength(String file) {
+        long len = new File(file).length();
+        Assert.assertTrue("oops: " + len, len > 0L && len < 1073741824L);
+    }
+
     private void testCustomLogIsCreated(boolean isCreated) throws IOException {
         try (LogFactory factory = new LogFactory()) {
             File logConfDir = Paths.get(temp.getRoot().getPath(), "conf").toFile();
@@ -651,21 +666,6 @@ public class LogFactoryTest {
             File logFile = Paths.get(temp.getRoot().getPath(), "log\\test.log").toFile();
             MatcherAssert.assertThat(logFile.getAbsolutePath(), logFile.exists(), is(isCreated));
         }
-    }
-
-    private static void assertEnabled(LogRecord r) {
-        Assert.assertTrue(r.isEnabled());
-        r.$();
-    }
-
-    private static void assertDisabled(LogRecord r) {
-        Assert.assertFalse(r.isEnabled());
-        r.$();
-    }
-
-    private void assertFileLength(String file) {
-        long len = new File(file).length();
-        Assert.assertTrue("oops: " + len, len > 0L && len < 1073741824L);
     }
 
     private void testRollOnDate(
@@ -742,22 +742,21 @@ public class LogFactoryTest {
     }
 
     private static class TestMicrosecondClock implements MicrosecondClock {
-        private final long base;
         private final long start;
         private final long speed;
         private final long limit;
+        private long k;
 
         public TestMicrosecondClock(long start, long speed, long limit) {
-            this.base = Os.currentTimeMicros();
             this.start = start;
             this.speed = speed;
             this.limit = limit - 1;
+            this.k = 0;
         }
 
         @Override
         public long getTicks() {
-            long wall = Os.currentTimeMicros();
-            return Math.min((wall - base) * speed + start, limit);
+            return Math.min(start + (k++) * speed, limit);
         }
     }
 }


### PR DESCRIPTION
Fixed:

[https://dev.azure.com/questdb/questdb/_build/results?buildId=7788&view=logs&j=2a8db[…]-53bd-306b-3f5b3836e6eb&t=856b52a7-8d37-5a6e-f64c-b8e55c77b9fc](https://dev.azure.com/questdb/questdb/_build/results?buildId=7788&view=logs&j=2a8db746-6336-53bd-306b-3f5b3836e6eb&t=856b52a7-8d37-5a6e-f64c-b8e55c77b9fc)




```
Failed tests:
  LogFactoryTest.testRollingFileWriterByHour:311->testRollOnDate:724 ‘mylog-2015-05-04-03.log’ does not contain: mylog-2015-05-03
  LogFactoryTest.testRollingFileWriterByMonth:321->testRollOnDate:724 ‘mylog-2016-02.log’ does not contain: mylog-2015
```