### PR TITLE
feat(ilp): accept double values in scientific notation

### DIFF
--- a/core/src/main/java/io/questdb/std/Numbers.java
+++ b/core/src/main/java/io/questdb/std/Numbers.java
@@ -1928,9 +1928,10 @@ public final class Numbers {
             throw NumericException.INSTANCE;
         }
 
-        boolean negative = sequence.charAt(p) == '-';
+        final char sign = sequence.charAt(p);
+        final boolean negative = sign == '-';
         int i = p;
-        if (negative) {
+        if (negative || sign == '+') {
             i++;
         }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpParser2Test.java
@@ -115,6 +115,107 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
+    public void testTrailingSpace() {
+        assertThat("measurement,a=10\n", "measurement,a=10 \n"); // Trailing space
+    }
+
+    @Test
+    public void testDoubleScientificNotation() {
+        assertThat(
+                "measurement,tag=value,tag2=value field=1.123E-03,field2=9.19097E10,field3=10.097E+3 100000\n",
+                "measurement,tag=value,tag2=value field=1.123E-03,field2=9.19097E10,field3=10.097E+3 100000\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameDot1() {
+        assertThat(
+                ".measurement,tag=value,tag2=value field=10000i\n",
+                ".measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd1() {
+        assertThat(
+                "measurement\\\\,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "measurement\\\\,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd3() {
+        assertThat(
+                "measurement/,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "measurement/,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameEnd4() {
+        assertThat(
+                "measurement\0,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "measurement\0,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid2() {
+        assertThat(
+                "mea/surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "mea/surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid3() {
+        assertThat(
+                "mea\0surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "mea\0surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNameMid4() {
+        assertThat(
+                "mea\\\\surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "mea\\\\surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix1() {
+        assertThat(
+                "../measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "../measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix2() {
+        assertThat(
+                "\0measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "\0measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testInvalidMeasurementNamePrefix3() {
+        assertThat(
+                "\\\\measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "\\\\measurement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testMangledMeasurementNameFromBothEnds() {
+        assertThat(
+                "\0\0\0,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
+                "\0\0\0,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
     public void testNoFields() {
         // Single space char between last tag and timestamp
         assertThat(
@@ -152,18 +253,11 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testTrailingSpace() {
-        assertThat("measurement,a=10\n", "measurement,a=10 \n"); // Trailing space
-    }
-
-    @Test
-    public void testTrailingSpace2() {
-        assertThat("measurement,a=10 v=11\n", "measurement,a=10 v=11 \n"); // Trailing space after fields
-    }
-
-    @Test
-    public void testTrailingSpace3() {
-        assertThat("measurement v=11\n", "measurement v=11 \n"); // Trailing space
+    public void testSpaceInMeasurementName() {
+        assertThat(
+                "tab ble,tag= 1 field=2 123\n",
+                "tab\\ ble,tag=\\ 1 field=2 123\n"
+        );
     }
 
     @Test
@@ -182,6 +276,56 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
         assertThat(
                 "table,tag=ok field=\"значение2 non ascii quoted\" 161--non ascii--\n",
                 "table,tag=ok field=\"значение2 non ascii quoted\" 161\n"
+        );
+    }
+
+    @Test
+    public void testTrailingSpace2() {
+        assertThat("measurement,a=10 v=11\n", "measurement,a=10 v=11 \n"); // Trailing space after fields
+    }
+
+    @Test
+    public void testTrailingSpace3() {
+        assertThat("measurement v=11\n", "measurement v=11 \n"); // Trailing space
+    }
+
+    @Test
+    public void testValidMeasurementNameDot2() {
+        assertThat(
+                "meas.urement,tag=value,tag2=value field=10000i\n",
+                "meas.urement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameDot3() {
+        assertThat(
+                "measurement.,tag=value,tag2=value field=10000i\n",
+                "measurement.,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameEnd2() {
+        assertThat(
+                "measurement..,tag=value,tag2=value field=10000i\n",
+                "measurement..,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNameMid1() {
+        assertThat(
+                "mea..surement,tag=value,tag2=value field=10000i\n",
+                "mea..surement,tag=value,tag2=value field=10000i\n"
+        );
+    }
+
+    @Test
+    public void testValidMeasurementNamePrefix4() {
+        assertThat(
+                "..measurement,tag=value,tag2=value field=10000i\n",
+                "..measurement,tag=value,tag2=value field=10000i\n"
         );
     }
 
@@ -248,134 +392,6 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
     }
 
     @Test
-    public void testInvalidMeasurementNamePrefix1() {
-        assertThat(
-                "../measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "../measurement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testValidMeasurementNameMid1() {
-        assertThat(
-                "mea..surement,tag=value,tag2=value field=10000i\n",
-                "mea..surement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameMid2() {
-        assertThat(
-                "mea/surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "mea/surement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameMid3() {
-        assertThat(
-                "mea\0surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "mea\0surement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameMid4() {
-        assertThat(
-                "mea\\\\surement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "mea\\\\surement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameEnd1() {
-        assertThat(
-                "measurement\\\\,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "measurement\\\\,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testValidMeasurementNameEnd2() {
-        assertThat(
-                "measurement..,tag=value,tag2=value field=10000i\n",
-                "measurement..,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameEnd3() {
-        assertThat(
-                "measurement/,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "measurement/,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameEnd4() {
-        assertThat(
-                "measurement\0,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "measurement\0,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testValidMeasurementNamePrefix4() {
-        assertThat(
-                "..measurement,tag=value,tag2=value field=10000i\n",
-                "..measurement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNameDot1() {
-        assertThat(
-                ".measurement,tag=value,tag2=value field=10000i\n",
-                ".measurement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testValidMeasurementNameDot2() {
-        assertThat(
-                "meas.urement,tag=value,tag2=value field=10000i\n",
-                "meas.urement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testValidMeasurementNameDot3() {
-        assertThat(
-                "measurement.,tag=value,tag2=value field=10000i\n",
-                "measurement.,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNamePrefix2() {
-        assertThat(
-                "\0measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "\0measurement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testInvalidMeasurementNamePrefix3() {
-        assertThat(
-                "\\\\measurement,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "\\\\measurement,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
-    public void testMangledMeasurementNameFromBothEnds() {
-        assertThat(
-                "\0\0\0,tag=value,tag2=value field=10000i--ERROR=INVALID_TABLE_NAME--",
-                "\0\0\0,tag=value,tag2=value field=10000i\n"
-        );
-    }
-
-    @Test
     public void testWithQuotedStringsWithSpaces() {
         assertThat(
                 "measurement,tag=value,tag2=value field=10000i,field2=\"longstring\",fld3=\"short string\" 100000\n",
@@ -403,14 +419,6 @@ public class LineTcpParser2Test extends LineUdpLexerTest {
                         "md_msgs ts_nsec=1634886503004129476i,pkt_size=1111i,pcap_file=\"_______________________________________________________\",raw_msg=\"__\"___________,\"________\"________\",Length=11i,first_dir=T 1634886503004129476\n",
                 "md_msgs ts_nsec=1634886503004129476i,pcap_msg=1111111i,raw_msg=\"__\\\"____\\\"___,\\\"_______\\\"___,\\\"___\\\"________,\",Length=11i,MsgSeqNum=111111i,MsgType=11i,first_dir=T 1634886503004129476\r\n" +
                         "md_msgs ts_nsec=1634886503004129476i,pkt_size=1111i,pcap_file=\"_______________________________________________________\",raw_msg=\"__\\\"___________,\\\"________\\\"________\",Length=11i,first_dir=T 1634886503004129476\r"
-        );
-    }
-
-    @Test
-    public void testSpaceInMeasurementName() {
-        assertThat(
-                "tab ble,tag= 1 field=2 123\n",
-                "tab\\ ble,tag=\\ 1 field=2 123\n"
         );
     }
 

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1107,11 +1107,11 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     @Test
     public void testWriterScientificDoubleNotation() throws Exception {
         runInContext((receiver) -> {
-            String lineData = "doubles d0=0,dm0=-0,d1=1,dE100=1E+100,dED100=0.18923E100,d0000001=1E-06,dm0001=-0.000001,dl=1234.5678,dml=-1234.5678,dvl=1.2345678901234567E+0 0\n";
+            String lineData = "doubles d0=0,d1=1.23E-10,d2=1.23E-03,d3=1.23E10,d4=1.23E01,d5=1.23E+10,d6=1.23E+01 0\n";
             send(receiver, lineData, "doubles");
 
-            String expected = "d0\tdm0\td1\tdE100\tdED100\td0000001\tdm0001\tdl\tdml\tdvl\ttimestamp\n" +
-                    "0.0\t0.0\t1.0\t1.0E100\t1.8923E99\t1.0E-6\t-1.0E-6\t1234.5678\t-1234.5678\t1.2345678901234567\t1970-01-01T00:00:00.000000Z\n";
+            String expected = "d0\td1\td2\td3\td4\td5\td6\ttimestamp\n" +
+                    "0.0\t1.23E-10\t0.00123\t1.23E10\t12.3\t1.23E10\t12.3\t1970-01-01T00:00:00.000000Z\n";
             assertTable(expected, "doubles");
         });
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -77,16 +77,6 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     private static final long TEST_TIMEOUT_IN_MS = 120000;
     private Path path;
 
-    @Before
-    public void setUpLineTcpReceiverTest() {
-        path = new Path();
-    }
-
-    @After
-    public void tearDownLineTcpReceiverTest() {
-        path.close();
-    }
-
     @Test
     public void generateKeys() throws NoSuchAlgorithmException {
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(EC_ALGORITHM);
@@ -113,6 +103,121 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         );
 
         System.out.printf("%s\tec-p-256-sha256\t%s\t%s%n", AUTH_KEY_ID1, x, y);
+    }
+
+    @Before
+    public void setUpLineTcpReceiverTest() {
+        path = new Path();
+    }
+
+    @After
+    public void tearDownLineTcpReceiverTest() {
+        path.close();
+    }
+
+    @Test
+    public void testColumnTypeStaysTheSameWhileColumnAdded() throws Exception {
+        final String tableName = "weather";
+        final int numOfRows = 2000;
+
+        try (TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY)) {
+            m.col("abcdef", ColumnType.SYMBOL).timestamp("ts");
+            CairoTestUtils.createTable(m);
+        }
+
+        final SOCountDownLatch finished = new SOCountDownLatch(1);
+        runInContext(receiver -> {
+            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                    if (name.equals(tableName)) {
+                        finished.countDown();
+                    }
+                }
+            });
+
+            new Thread(() -> {
+                try (Socket socket = getSocket()) {
+                    for (int i = 0; i < numOfRows; i++) {
+                        String value = (i % 2 == 0) ? "\"test" + i + "\"" : "" + i;
+                        sendToSocket(socket, tableName + ",abcdef=x col=" + value + "\n");
+                    }
+                } catch (Exception e) {
+                    Assert.fail("Data sending failed [e=" + e + "]");
+                    throw new RuntimeException(e);
+                }
+            }).start();
+
+            // this will wait until the writer is returned into the pool
+            finished.await();
+            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+            });
+
+            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+                final int expectedNumOfRows = numOfRows / 2;
+                // usually the data will be in the table by the time we get here but
+                // if it is not we will wait for it in a loop
+                while (reader.getTransientRowCount() < expectedNumOfRows) {
+                    Os.sleep(100);
+                }
+                Assert.assertEquals(expectedNumOfRows, reader.getTransientRowCount());
+            } catch (Exception e) {
+                Assert.fail("Reader failed [e=" + e + "]");
+                throw new RuntimeException(e);
+            }
+        }, false, 250);
+    }
+
+    @Test
+    public void testCrossingSymbolBoundary() throws Exception {
+        String tableName = "punk";
+        int count = 2100;
+        int startSymbolCount = 2040;
+        int writeIterations = 4;
+        runInContext((receiver) -> {
+            int symbolCount = startSymbolCount;
+            for (int it = 0; it < writeIterations; it++) {
+                final int iteration = it;
+                final int maxIds = symbolCount++;
+                send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
+                    try (LineTcpSender sender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                        for (int i = 0; i < count; i++) {
+                            String id = String.valueOf(i % maxIds);
+                            sender.metric(tableName)
+                                    .tag("id", id)
+                                    .$((iteration * count + i) * 10_000_000L);
+                        }
+                        sender.flush();
+                    }
+                });
+            }
+        });
+        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+            Assert.assertEquals(count * writeIterations, reader.size());
+        }
+    }
+
+    @Test
+    public void testFieldValuesHasEqualsChar() throws Exception {
+        maxMeasurementSize = 250;
+        String lineData =
+                "tab ts_nsec=1111111111111111111i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
+                        + "tab ts_nsec=2222222222222222222i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
+                        + "tab ts_nsec=3333333333333333333i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
+                        + "tab ts_nsec=4444444444444444444i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
+                        + "tab ts_nsec=5555555555555555555i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
+                        + "tab ts_nsec=6666666666666666666i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n";
+        runInContext((receiver) -> {
+            sendLinger(receiver, lineData, "tab");
+
+            String expected = "ts_nsec\traw_msg\ttimestamp\n" +
+                    "1111111111111111111\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
+                    "2222222222222222222\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
+                    "3333333333333333333\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
+                    "4444444444444444444\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
+                    "5555555555555555555\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
+                    "6666666666666666666\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n";
+            assertTable(expected, "tab");
+        });
     }
 
     @Test
@@ -182,6 +287,41 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
+    public void testFirstRowIsCancelled() throws Exception {
+        runInContext((receiver) -> {
+            send(receiver, "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag/2", "value=\2") // Invalid column name, line is not saved
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 1")
+                            .tag("tag=2", "значение 2")
+                            .field("поле=3", "{\"ключ\": \"число\"}")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 2")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag=2", "value=\\2")
+                            .$(Timestamps.DAY_MICROS * 1000L);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
+                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
+                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n" +
+                    "\tvalue=\\2\t\t1970-01-02T00:00:00.000000Z\n";
+            assertTable(expected, "table");
+        });
+    }
+
+    @Test
     public void testGoodAuthenticated() throws Exception {
         test(AUTH_KEY_ID1, AUTH_PRIVATE_KEY1, 768, 1_000, false);
     }
@@ -189,6 +329,11 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     @Test(expected = NetworkError.class)
     public void testInvalidSignature() throws Exception {
         test(AUTH_KEY_ID1, AUTH_PRIVATE_KEY2, 768, 6_000, true);
+    }
+
+    @Test(expected = NetworkError.class)
+    public void testInvalidUser() throws Exception {
+        test(AUTH_KEY_ID2, AUTH_PRIVATE_KEY2, 768, 6_000, true);
     }
 
     @Test(expected = NetworkError.class)
@@ -256,9 +401,74 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         );
     }
 
-    @Test(expected = NetworkError.class)
-    public void testInvalidUser() throws Exception {
-        test(AUTH_KEY_ID2, AUTH_PRIVATE_KEY2, 768, 6_000, true);
+    @Test
+    public void testMetaDataSizeToHitExactly16K() throws Exception {
+        final String tableName = "weather";
+        final int numOfColumns = 255;
+        final Rnd rnd = new Rnd();
+
+        final SOCountDownLatch finished = new SOCountDownLatch(1);
+        runInContext(receiver -> {
+            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                    if (name.equals(tableName)) {
+                        finished.countDown();
+                    }
+                }
+            });
+
+            try (Socket socket = getSocket()) {
+                // this loop adds columns to the table
+                // after the 252th column has been added the metadata size will be exactly 16k
+                // adding an extra 2 columns, just in case
+                for (int i = 1; i < numOfColumns; i++) {
+                    sendToSocket(socket, tableName + ",abcdefghijklmnopqrs=x, " + rnd.nextString(13 - (int) Math.log10(i)) + i + "=32 " + i + "\n");
+                }
+                finished.await(30_000_000_000L);
+            } finally {
+                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                });
+            }
+        }, false, 250);
+
+        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+            Assert.assertEquals(numOfColumns + 1, reader.getMetadata().getColumnCount());
+        }
+    }
+
+    @Test
+    public void testNewPartitionRowCancelledTwice() throws Exception {
+        runInContext((receiver) -> {
+            send(receiver, "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 1")
+                            .tag("tag=2", "значение 2")
+                            .field("поле=3", "{\"ключ\": \"число\"}")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 2")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
+                            .$(Timestamps.DAY_MICROS * 1000L);
+                    // Repeat
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
+                            .$(Timestamps.DAY_MICROS * 1000L);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
+                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
+                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, "table");
+        });
     }
 
     @Test
@@ -357,6 +567,29 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                 });
             }
+        });
+    }
+
+    @Test
+    public void testStringsWithTcpSenderWithNewLineChars() throws Exception {
+        runInContext((receiver) -> {
+            send(receiver, "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 1")
+                            .tag("tag=2", "значение 2")
+                            .field("поле=3", "{\"ключ\": \n \"число\", \r\n \"key2\": \"value2\"}\n")
+                            .$(0);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
+                    "value 1\tзначение 2\t{\"ключ\": \n" +
+                    " \"число\", \r\n" +
+                    " \"key2\": \"value2\"}\n\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, "table");
         });
     }
 
@@ -461,9 +694,148 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
+    public void testTcpSenderManyLinesToForceBufferFlush() throws Exception {
+        int rowCount = 100;
+        maxMeasurementSize = 100;
+        runInContext((receiver) -> {
+            String tableName = "table";
+            send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, 64)) {
+                    for (int i = 0; i < rowCount; i++) {
+                        lineTcpSender
+                                .metric(tableName)
+                                .tag("tag1", "value 1")
+                                .field("tag2", Chars.repeat("value 2", 10))
+                                .$(0);
+                    }
+                    lineTcpSender.flush();
+                }
+            });
+
+            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+                Assert.assertEquals(rowCount, reader.size());
+            }
+        });
+    }
+
+    @Test
+    public void testTcpSenderWithNewLineCharsInFieldName() throws Exception {
+        if (engine.getConfiguration().getFilesFacade().isRestrictedFileSystem()) {
+            // Windows (NTFS) cannot crate files with new line in file name.
+            return;
+        }
+        runInContext((receiver) -> {
+            String tableName = "table";
+            send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric(tableName)
+                            .tag("tag\n1", "value 1")
+                            .field("tag\n2", "value 2")
+                            .$(0);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag\n" +
+                    "1\ttag\n" +
+                    "2\ttimestamp\n" +
+                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, tableName);
+        });
+    }
+
+    @Test
+    public void testTcpSenderWithNewLineInTableName() throws Exception {
+        if (engine.getConfiguration().getFilesFacade().isRestrictedFileSystem()) {
+            // Windows (NTFS) cannot crate files with new line in file name.
+            return;
+        }
+        runInContext((receiver) -> {
+            String tableName = "ta\nble";
+            send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric(tableName)
+                            .tag("tag1", "value 1")
+                            .field("tag2", "value 2")
+                            .$(0);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag2\ttimestamp\n" +
+                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, tableName);
+        });
+    }
+
+    @Test
+    public void testTcpSenderWithSpaceInTableName() throws Exception {
+        runInContext((receiver) -> {
+            String tableName = "ta ble";
+            send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric(tableName)
+                            .tag("tag1", "value 1")
+                            .field("tag2", "value 2")
+                            .$(0);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag2\ttimestamp\n" +
+                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, tableName);
+        });
+    }
+
+    @Test
     // flapping test
     public void testUnauthenticated() throws Exception {
         test(null, null, 200, 1_000, false);
+    }
+
+    @Test
+    public void testUnicodeTableName() throws Exception {
+        byte[] utf8Bytes = "ल".getBytes(Files.UTF_8);
+        Assert.assertEquals(3, utf8Bytes.length);
+
+        try (TableModel m = new TableModel(configuration, "लаблअца", PartitionBy.DAY)) {
+            m.col("символ", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("поле", ColumnType.STRING)
+                    .timestamp("время");
+            CairoTestUtils.createTableWithVersion(m, ColumnType.VERSION);
+        }
+
+        runInContext((receiver) -> {
+            String lineData = "लаблअца поле=\"значение\" 1619509249714000000\n";
+            sendLinger(receiver, lineData, "लаблअца");
+
+            String lineData2 = "लаблअца,символ=значение2 поле=\"значение3\" 1619509249714000000\n";
+            sendLinger(receiver, lineData2, "लаблअца");
+
+            assertTable("символ\tполе\tвремя\n" +
+                    "\tзначение\t2021-04-27T07:40:49.714000Z\n" +
+                    "значение2\tзначение3\t2021-04-27T07:40:49.714000Z\n", "लаблअца");
+        });
+    }
+
+    @Test
+    public void testUnicodeTableNameExistingTable() throws Exception {
+        runInContext((receiver) -> {
+            String lineData = "लаблअца поле=\"значение\" 1619509249714000000\n";
+            sendLinger(receiver, lineData, "लаблअца");
+
+            String lineData2 = "लаблअца,символ=значение2 1619509249714000000\n";
+            sendLinger(receiver, lineData2, "लаблअца");
+
+            String expected = "поле\ttimestamp\tсимвол\n" +
+                    "значение\t2021-04-27T07:40:49.714000Z\t\n" +
+                    "\t2021-04-27T07:40:49.714000Z\tзначение2\n";
+            assertTable(expected, "लаблअца");
+        });
     }
 
     @Test
@@ -522,6 +894,36 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
+    public void testWithTcpSender() throws Exception {
+        runInContext((receiver) -> {
+            send(receiver, "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
+                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 1")
+                            .tag("tag=2", "значение 2")
+                            .field("поле=3", "{\"ключ\": \"число\"}")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag1", "value 2")
+                            .$(0);
+                    lineTcpSender
+                            .metric("table")
+                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
+                            .$(Timestamps.DAY_MICROS * 1000L);
+                    lineTcpSender.flush();
+                }
+            });
+
+            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
+                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
+                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, "table");
+        });
+    }
+
+    @Test
     public void testWriter17Fields() throws Exception {
         maxMeasurementSize = 1024;
         String lineData = "tableCRASH,tag_n_1=1,tag_n_2=2,tag_n_3=3,tag_n_4=4,tag_n_5=5,tag_n_6=6," +
@@ -533,71 +935,6 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             String expected = "tag_n_1\ttag_n_2\ttag_n_3\ttag_n_4\ttag_n_5\ttag_n_6\ttag_n_7\ttag_n_8\ttag_n_9\ttag_n_10\ttag_n_11\ttag_n_12\ttag_n_13\ttag_n_14\ttag_n_15\ttag_n_16\ttag_n_17\tvalue\ttimestamp\n" +
                     "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14\t15\t16\t17\t42.4\t2021-04-27T07:40:49.714000Z\n";
             assertTable(expected, "tableCRASH");
-        });
-    }
-
-    @Test
-    public void testFieldValuesHasEqualsChar() throws Exception {
-        maxMeasurementSize = 250;
-        String lineData =
-                  "tab ts_nsec=1111111111111111111i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
-                + "tab ts_nsec=2222222222222222222i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
-                + "tab ts_nsec=3333333333333333333i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
-                + "tab ts_nsec=4444444444444444444i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
-                + "tab ts_nsec=5555555555555555555i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n"
-                + "tab ts_nsec=6666666666666666666i,raw_msg=\"_________________________________________________________________________________________________________ ____________\" 1619509249714000000\n";
-        runInContext((receiver) -> {
-            sendLinger(receiver, lineData, "tab");
-
-            String expected = "ts_nsec\traw_msg\ttimestamp\n" +
-                    "1111111111111111111\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
-                    "2222222222222222222\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
-                    "3333333333333333333\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
-                    "4444444444444444444\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
-                    "5555555555555555555\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n" +
-                    "6666666666666666666\t_________________________________________________________________________________________________________ ____________\t2021-04-27T07:40:49.714000Z\n";
-            assertTable(expected, "tab");
-        });
-    }
-
-    @Test
-    public void testUnicodeTableName() throws Exception {
-        byte[] utf8Bytes = "ल".getBytes(Files.UTF_8);
-        Assert.assertEquals(3, utf8Bytes.length);
-
-        try (TableModel m = new TableModel(configuration, "लаблअца", PartitionBy.DAY)) {
-            m.col("символ", ColumnType.SYMBOL).indexed(true, 256)
-                    .col("поле", ColumnType.STRING)
-                    .timestamp("время");
-            CairoTestUtils.createTableWithVersion(m, ColumnType.VERSION);
-        }
-
-        runInContext((receiver) -> {
-            String lineData = "लаблअца поле=\"значение\" 1619509249714000000\n";
-            sendLinger(receiver, lineData, "लаблअца");
-
-            String lineData2 = "लаблअца,символ=значение2 поле=\"значение3\" 1619509249714000000\n";
-            sendLinger(receiver, lineData2, "लаблअца");
-
-            assertTable("символ\tполе\tвремя\n" +
-                    "\tзначение\t2021-04-27T07:40:49.714000Z\n" +
-                    "значение2\tзначение3\t2021-04-27T07:40:49.714000Z\n", "लаблअца");
-        });
-    }
-
-    @Test
-    public void testUnicodeTableNameExistingTable() throws Exception {
-        runInContext((receiver) -> {
-            String lineData = "लаблअца поле=\"значение\" 1619509249714000000\n";
-            sendLinger(receiver, lineData, "लаблअца");
-
-            String lineData2 = "लаблअца,символ=значение2 1619509249714000000\n";
-            sendLinger(receiver, lineData2, "लаблअца");
-
-            String expected = "поле\ttimestamp\tсимвол\n" +
-                    "значение\t2021-04-27T07:40:49.714000Z\t\n" +
-                    "\t2021-04-27T07:40:49.714000Z\tзначение2\n";
-            assertTable(expected, "लаблअца");
         });
     }
 
@@ -620,6 +957,32 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             String expected = "ts\tid\tauthor\tguild\tchannel\tflags\n" +
                     "1970-01-01T00:00:00.000001Z\t843530699759026177\t820703963477180437\t820704412095479830\t820704412095479833\t6\n";
             assertTable(expected, "messages");
+        });
+    }
+
+    @Test
+    public void testWriterCommitFails() throws Exception {
+        try (TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY)) {
+            m.timestamp("ReceiveTime")
+                    .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("Length", ColumnType.INT);
+            CairoTestUtils.createTable(m, ColumnType.VERSION);
+        }
+
+        runInContext((receiver) -> {
+            ff = new FilesFacadeImpl() {
+                @Override
+                public int rmdir(Path path) {
+                    return 5;
+                }
+            };
+
+            String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
+            sendLinger(receiver, lineData, "table_a");
+
+            String expected = "ReceiveTime\tSequenceNumber\tMessageType\tLength\n";
+            assertTable(expected, "table_a");
         });
     }
 
@@ -742,375 +1105,19 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
-    public void testWriterCommitFails() throws Exception {
-        try (TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY)) {
-            m.timestamp("ReceiveTime")
-                    .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
-                    .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
-                    .col("Length", ColumnType.INT);
-            CairoTestUtils.createTable(m, ColumnType.VERSION);
-        }
-
+    public void testWriterScientificDoubleNotation() throws Exception {
         runInContext((receiver) -> {
-            ff = new FilesFacadeImpl() {
-                @Override
-                public int rmdir(Path path) {
-                    return 5;
-                }
-            };
+            String lineData = "doubles d0=0,dm0=-0,d1=1,dE100=1E+100,dED100=0.18923E100,d0000001=1E-06,dm0001=-0.000001,dl=1234.5678,dml=-1234.5678,dvl=1.2345678901234567E+0 0\n";
+            send(receiver, lineData, "doubles");
 
-            String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
-            sendLinger(receiver, lineData, "table_a");
-
-            String expected = "ReceiveTime\tSequenceNumber\tMessageType\tLength\n";
-            assertTable(expected, "table_a");
+            String expected = "d0\tdm0\td1\tdE100\tdED100\td0000001\tdm0001\tdl\tdml\tdvl\ttimestamp\n" +
+                    "0.0\t0.0\t1.0\t1.0E100\t1.8923E99\t1.0E-6\t-1.0E-6\t1234.5678\t-1234.5678\t1.2345678901234567\t1970-01-01T00:00:00.000000Z\n";
+            assertTable(expected, "doubles");
         });
-    }
-
-    @Test
-    public void testWithTcpSender() throws Exception {
-        runInContext((receiver) -> {
-            send(receiver,  "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 1")
-                            .tag("tag=2", "значение 2")
-                            .field("поле=3", "{\"ключ\": \"число\"}")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 2")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
-                            .$(Timestamps.DAY_MICROS * 1000L);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
-                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
-                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, "table");
-        });
-    }
-
-    @Test
-    public void testStringsWithTcpSenderWithNewLineChars() throws Exception {
-        runInContext((receiver) -> {
-            send(receiver,  "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 1")
-                            .tag("tag=2", "значение 2")
-                            .field("поле=3", "{\"ключ\": \n \"число\", \r\n \"key2\": \"value2\"}\n")
-                            .$(0);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
-                    "value 1\tзначение 2\t{\"ключ\": \n" +
-                    " \"число\", \r\n" +
-                    " \"key2\": \"value2\"}\n\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, "table");
-        });
-    }
-
-    @Test
-    public void testTcpSenderWithNewLineCharsInFieldName() throws Exception {
-        if (engine.getConfiguration().getFilesFacade().isRestrictedFileSystem()) {
-            // Windows (NTFS) cannot crate files with new line in file name.
-            return;
-        }
-        runInContext((receiver) -> {
-            String tableName = "table";
-            send(receiver,  tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric(tableName)
-                            .tag("tag\n1", "value 1")
-                            .field("tag\n2", "value 2")
-                            .$(0);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag\n" +
-                    "1\ttag\n" +
-                    "2\ttimestamp\n" +
-                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, tableName);
-        });
-    }
-
-    @Test
-    public void testTcpSenderWithSpaceInTableName() throws Exception {
-        runInContext((receiver) -> {
-            String tableName = "ta ble";
-            send(receiver,  tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric(tableName)
-                            .tag("tag1", "value 1")
-                            .field("tag2", "value 2")
-                            .$(0);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag2\ttimestamp\n" +
-                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, tableName);
-        });
-    }
-
-    @Test
-    public void testTcpSenderWithNewLineInTableName() throws Exception {
-        if (engine.getConfiguration().getFilesFacade().isRestrictedFileSystem()) {
-            // Windows (NTFS) cannot crate files with new line in file name.
-            return;
-        }
-        runInContext((receiver) -> {
-            String tableName = "ta\nble";
-            send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric(tableName)
-                            .tag("tag1", "value 1")
-                            .field("tag2", "value 2")
-                            .$(0);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag2\ttimestamp\n" +
-                    "value 1\tvalue 2\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, tableName);
-        });
-    }
-
-    @Test
-    public void testTcpSenderManyLinesToForceBufferFlush() throws Exception {
-        int rowCount = 100;
-        maxMeasurementSize = 100;
-        runInContext((receiver) -> {
-            String tableName = "table";
-            send(receiver,  tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, 64)) {
-                    for(int i = 0; i < rowCount; i++) {
-                        lineTcpSender
-                                .metric(tableName)
-                                .tag("tag1", "value 1")
-                                .field("tag2", Chars.repeat("value 2", 10))
-                                .$(0);
-                    }
-                    lineTcpSender.flush();
-                }
-            });
-
-            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
-                Assert.assertEquals(rowCount, reader.size());
-            }
-        });
-    }
-
-
-    @Test
-    public void testNewPartitionRowCancelledTwice() throws Exception {
-        runInContext((receiver) -> {
-            send(receiver,  "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 1")
-                            .tag("tag=2", "значение 2")
-                            .field("поле=3", "{\"ключ\": \"число\"}")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 2")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
-                            .$(Timestamps.DAY_MICROS * 1000L);
-                    // Repeat
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag/2", "value=\2") // Invalid column name, last line is not saved
-                            .$(Timestamps.DAY_MICROS * 1000L);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
-                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
-                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n";
-            assertTable(expected, "table");
-        });
-    }
-
-    @Test
-    public void testFirstRowIsCancelled() throws Exception {
-        runInContext((receiver) -> {
-            send(receiver,  "table", WAIT_ENGINE_TABLE_RELEASE, () -> {
-                try (LineTcpSender lineTcpSender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag/2", "value=\2") // Invalid column name, line is not saved
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 1")
-                            .tag("tag=2", "значение 2")
-                            .field("поле=3", "{\"ключ\": \"число\"}")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag1", "value 2")
-                            .$(0);
-                    lineTcpSender
-                            .metric("table")
-                            .tag("tag=2", "value=\\2")
-                            .$(Timestamps.DAY_MICROS * 1000L);
-                    lineTcpSender.flush();
-                }
-            });
-
-            String expected = "tag1\ttag=2\tполе=3\ttimestamp\n" +
-                    "value 1\tзначение 2\t{\"ключ\": \"число\"}\t1970-01-01T00:00:00.000000Z\n" +
-                    "value 2\t\t\t1970-01-01T00:00:00.000000Z\n" +
-                    "\tvalue=\\2\t\t1970-01-02T00:00:00.000000Z\n";
-            assertTable(expected, "table");
-        });
-    }
-
-    @Test
-    public void testCrossingSymbolBoundary() throws Exception {
-        String tableName = "punk";
-        int count = 2100;
-        int startSymbolCount = 2040;
-        int writeIterations = 4;
-        runInContext((receiver) -> {
-            int symbolCount = startSymbolCount;
-            for(int it = 0; it < writeIterations; it++) {
-                final int iteration = it;
-                final int maxIds = symbolCount++;
-                send(receiver, tableName, WAIT_ENGINE_TABLE_RELEASE, () -> {
-                    try (LineTcpSender sender = new LineTcpSender(Net.parseIPv4("127.0.0.1"), bindPort, msgBufferSize)) {
-                        for (int i = 0; i < count; i++) {
-                            String id = String.valueOf(i % maxIds);
-                            sender.metric(tableName)
-                                    .tag("id", id)
-                                    .$((iteration * count + i) * 10_000_000L);
-                        }
-                        sender.flush();
-                    }
-                });
-            }
-        });
-        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
-            Assert.assertEquals(count * writeIterations, reader.size());
-        }
-    }
-
-    @Test
-    public void testMetaDataSizeToHitExactly16K() throws Exception {
-        final String tableName = "weather";
-        final int numOfColumns = 255;
-        final Rnd rnd = new Rnd();
-
-        final SOCountDownLatch finished = new SOCountDownLatch(1);
-        runInContext(receiver -> {
-            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
-                    if (name.equals(tableName)) {
-                        finished.countDown();
-                    }
-                }
-            });
-
-            try (Socket socket = getSocket()) {
-                // this loop adds columns to the table
-                // after the 252th column has been added the metadata size will be exactly 16k
-                // adding an extra 2 columns, just in case
-                for (int i = 1; i < numOfColumns; i++) {
-                    sendToSocket(socket, tableName + ",abcdefghijklmnopqrs=x, " + rnd.nextString(13-(int) Math.log10(i)) + i + "=32 " + i + "\n");
-                }
-                finished.await(30_000_000_000L);
-            } finally {
-                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
-                });
-            }
-        }, false, 250);
-
-        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
-            Assert.assertEquals(numOfColumns+1, reader.getMetadata().getColumnCount());
-        }
-    }
-
-    @Test
-    public void testColumnTypeStaysTheSameWhileColumnAdded() throws Exception {
-        final String tableName = "weather";
-        final int numOfRows = 2000;
-
-        try (TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-            m.col("abcdef", ColumnType.SYMBOL).timestamp("ts");
-            CairoTestUtils.createTable(m);
-        }
-
-        final SOCountDownLatch finished = new SOCountDownLatch(1);
-        runInContext(receiver -> {
-            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
-                    if (name.equals(tableName)) {
-                        finished.countDown();
-                    }
-                }
-            });
-
-            new Thread(() -> {
-                try (Socket socket = getSocket()) {
-                    for (int i = 0; i < numOfRows; i++) {
-                        String value = (i % 2 == 0) ? "\"test" + i + "\"" : "" + i;
-                        sendToSocket(socket, tableName + ",abcdef=x col=" + value + "\n");
-                    }
-                } catch (Exception e) {
-                    Assert.fail("Data sending failed [e=" + e + "]");
-                    throw new RuntimeException(e);
-                }
-            }).start();
-
-            // this will wait until the writer is returned into the pool
-            finished.await();
-            engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
-            });
-
-            try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
-                final int expectedNumOfRows = numOfRows / 2;
-                // usually the data will be in the table by the time we get here but
-                // if it is not we will wait for it in a loop
-                while (reader.getTransientRowCount() < expectedNumOfRows) {
-                    Os.sleep(100);
-                }
-                Assert.assertEquals(expectedNumOfRows, reader.getTransientRowCount());
-            } catch (Exception e) {
-                Assert.fail("Reader failed [e=" + e + "]");
-                throw new RuntimeException(e);
-            }
-        }, false, 250);
     }
 
     private void send(LineTcpReceiver receiver, String lineData, String tableName, int wait) {
         send(receiver, tableName, wait, () -> sendToSocket(lineData));
-    }
-
-    private void sendLinger(LineTcpReceiver receiver, String lineData, String tableName) {
-        send(receiver, tableName, LineTcpReceiverTest.WAIT_ENGINE_TABLE_RELEASE, () -> sendToSocket(lineData));
     }
 
     private void send(LineTcpReceiver receiver, String lineData, String tableName) {
@@ -1125,6 +1132,10 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     ) {
         send(receiver, lineData, "weather", WAIT_NO_WAIT);
         tableIndex.get("weather").await(expectedReleaseCount);
+    }
+
+    private void sendLinger(LineTcpReceiver receiver, String lineData, String tableName) {
+        send(receiver, tableName, LineTcpReceiverTest.WAIT_ENGINE_TABLE_RELEASE, () -> sendToSocket(lineData));
     }
 
     private void sendNoWait(LineTcpReceiver receiver, String threadTable, String lineDataThread) {

--- a/core/src/test/java/io/questdb/std/NumbersTest.java
+++ b/core/src/test/java/io/questdb/std/NumbersTest.java
@@ -531,6 +531,12 @@ public class NumbersTest {
         String s8 = "-Infinity";
         Assert.assertEquals(Double.parseDouble(s8), Numbers.parseDouble(s8), 0.000000001);
 
+        String s10 = "2E+2";
+        Assert.assertEquals(Double.parseDouble(s10), Numbers.parseDouble(s10), 0.000000001);
+
+        String s11 = "2E+02";
+        Assert.assertEquals(Double.parseDouble(s11), Numbers.parseDouble(s11), 0.000000001);
+
     }
 
     @Test


### PR DESCRIPTION
ILP clients written with other languages will serialize double values in scientific notation. Make sure QuestDB can parse them

- Negative exponent , example: `1.23E-10`
- Negative exponent starting with `0`, example: `1.23E-03`
- Positive exponent without sign `1.23E10`
- Positive exponent without sign starting with 0 `1.23E01`
- Positive exponent with + sign `1.23E+10`
- Positive exponent with + sign  starting with 0  `1.23E+01`