### PR TITLE
fix(ui): Fix `select build()` being called repeatedly

### DIFF
--- a/ui/src/scenes/Footer/BuildVersion/services.ts
+++ b/ui/src/scenes/Footer/BuildVersion/services.ts
@@ -24,8 +24,16 @@
 
 const buildVersionRegex = /Build Information: (QuestDB [0-9A-Za-z.]*),/
 
+const commitHashRegex = /Commit Hash ([0-9A-Za-z]*)/
+
 export const formatVersion = (value: string | number | boolean) => {
   const matches = buildVersionRegex.exec(value.toString())
+
+  return matches ? matches[1].replace("QuestDB ", "") : ""
+}
+
+export const formatCommitHash = (value: string | number | boolean) => {
+  const matches = commitHashRegex.exec(value.toString())
 
   return matches ? matches[1] : ""
 }


### PR DESCRIPTION
### The fix
The main purpose of this PR is to fix an issue wherein `select build()` is fired repeatedly upon resizing panels (caused by the side effect hook being called on each re-render).

### Side changes
Instead of copying to clipboard, the button now links to either release notes (when using a ready-made version) or commit hash (i.e. on a custom local build). 

Release info:
<img width="298" alt="CleanShot 2022-06-13 at 17 00 26@2x" src="https://user-images.githubusercontent.com/1871646/173386470-3ffbfe88-2b9f-4ad5-8f0e-8cb4eddfd5a7.png">

Custom build info:
<img width="1063" alt="CleanShot 2022-06-13 at 17 06 55@2x" src="https://user-images.githubusercontent.com/1871646/173386573-30c26743-d5fc-4e96-a196-232db5a8397d.png">

