### PR TITLE
chore(ilp): make sure to reset symbol cache capacity when ILP connection is closed

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -116,10 +116,6 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
     }
 
     public void of(CairoConfiguration configuration, Path path, CharSequence columnName, long columnNameTxn, int symbolCount) {
-        of(configuration, path, columnName, columnNameTxn, symbolCount, false);
-    }
-
-    public void of(CairoConfiguration configuration, Path path, CharSequence columnName, long columnNameTxn, int symbolCount, boolean forceDisableCache) {
         FilesFacade ff = configuration.getFilesFacade();
         this.configuration = configuration;
         this.path.of(path);
@@ -152,7 +148,7 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             this.offsetMem.of(ff, path, offsetMemSize, offsetMemSize, MemoryTag.MMAP_INDEX_READER);
             this.symbolCapacity = offsetMem.getInt(SymbolMapWriter.HEADER_CAPACITY);
             assert this.symbolCapacity > 0;
-            this.cached = !forceDisableCache && offsetMem.getBool(SymbolMapWriter.HEADER_CACHE_ENABLED);
+            this.cached = offsetMem.getBool(SymbolMapWriter.HEADER_CACHE_ENABLED);
             this.nullValue = offsetMem.getBool(SymbolMapWriter.HEADER_NULL_FLAG);
 
             // index reader is used to identify attempts to store duplicate symbol value

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpNetworkIOJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpNetworkIOJob.java
@@ -54,7 +54,9 @@ class LineTcpNetworkIOJob implements NetworkIOJob, Job {
     LineTcpNetworkIOJob(
             LineTcpReceiverConfiguration configuration,
             LineTcpMeasurementScheduler scheduler,
-            IODispatcher<LineTcpConnectionContext> dispatcher, int workerId) {
+            IODispatcher<LineTcpConnectionContext> dispatcher,
+            int workerId
+    ) {
         this.millisecondClock = configuration.getMillisecondClock();
         this.maintenanceInterval = configuration.getMaintenanceInterval();
         this.scheduler = scheduler;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -57,8 +57,9 @@ class SymbolCache implements Closeable, SymbolLookup {
 
     @Override
     public void close() {
+        txReader = null;
         symbolMapReader.close();
-        symbolValueToKeyMap.clear();
+        symbolValueToKeyMap.resetCapacity();
     }
 
     @Override
@@ -92,6 +93,10 @@ class SymbolCache implements Closeable, SymbolLookup {
         return symbolValueToKeyMap.size();
     }
 
+    int getCacheCapacity() {
+        return symbolValueToKeyMap.capacity();
+    }
+
     void of(CairoConfiguration configuration,
             Path path,
             CharSequence columnName,
@@ -104,8 +109,8 @@ class SymbolCache implements Closeable, SymbolLookup {
         this.txReader = txReader;
         int symCount = safeReadUncommittedSymbolCount(symbolIndexInTxFile, false);
         path.trimTo(plen);
-        symbolMapReader.of(configuration, path, columnName, columnNameTxn, symCount);
-        symbolValueToKeyMap.clear(symCount);
+        // Make sure to forcefully disable symbolMapReader's own cache.
+        symbolMapReader.of(configuration, path, columnName, columnNameTxn, symCount, true);
     }
 
     private int safeReadUncommittedSymbolCount(int symbolIndexInTxFile, boolean initialStateOk) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -109,8 +109,7 @@ class SymbolCache implements Closeable, SymbolLookup {
         this.txReader = txReader;
         int symCount = safeReadUncommittedSymbolCount(symbolIndexInTxFile, false);
         path.trimTo(plen);
-        // Make sure to forcefully disable symbolMapReader's own cache.
-        symbolMapReader.of(configuration, path, columnName, columnNameTxn, symCount, true);
+        symbolMapReader.of(configuration, path, columnName, columnNameTxn, symCount);
     }
 
     private int safeReadUncommittedSymbolCount(int symbolIndexInTxFile, boolean initialStateOk) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -59,7 +59,7 @@ class SymbolCache implements Closeable, SymbolLookup {
     public void close() {
         txReader = null;
         symbolMapReader.close();
-        symbolValueToKeyMap.resetCapacity();
+        symbolValueToKeyMap.reset();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -110,6 +110,7 @@ class SymbolCache implements Closeable, SymbolLookup {
         int symCount = safeReadUncommittedSymbolCount(symbolIndexInTxFile, false);
         path.trimTo(plen);
         symbolMapReader.of(configuration, path, columnName, columnNameTxn, symCount);
+        symbolValueToKeyMap.clear();
     }
 
     private int safeReadUncommittedSymbolCount(int symbolIndexInTxFile, boolean initialStateOk) {

--- a/core/src/main/java/io/questdb/std/ObjIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/ObjIntHashMap.java
@@ -69,7 +69,7 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
         Arrays.fill(keys, noEntryValue);
     }
 
-    public void resetCapacity() {
+    public void reset() {
         if (capacity == initialCapacity) {
             clear();
         } else {

--- a/core/src/main/java/io/questdb/std/ObjIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/ObjIntHashMap.java
@@ -65,8 +65,10 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
 
     @Override
     public final void clear() {
-        free = capacity;
-        Arrays.fill(keys, noEntryValue);
+        if (free != capacity) {
+            free = capacity;
+            Arrays.fill(keys, noEntryValue);
+        }
     }
 
     public void reset() {

--- a/core/src/main/java/io/questdb/std/ObjIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/ObjIntHashMap.java
@@ -39,6 +39,7 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
     private K[] keys;
     private int[] values;
     private int free;
+    private final int initialCapacity;
     private int capacity;
     private int mask;
 
@@ -53,9 +54,10 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
     public ObjIntHashMap(int initialCapacity, double loadFactor, int noKeyValue) {
         assert loadFactor > 0 && loadFactor < 1.0;
         this.capacity = Math.max(initialCapacity, MIN_INITIAL_CAPACITY);
+        this.initialCapacity = capacity;
         this.loadFactor = loadFactor;
         this.noKeyValue = noKeyValue;
-        keys = getKeys();
+        keys = createKeys();
         values = new int[keys.length];
         mask = keys.length - 1;
         clear();
@@ -67,12 +69,12 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
         Arrays.fill(keys, noEntryValue);
     }
 
-    public void clear(int newCapacity) {
-        if (newCapacity <= capacity) {
+    public void resetCapacity() {
+        if (capacity == initialCapacity) {
             clear();
         } else {
-            free = capacity = Numbers.ceilPow2(newCapacity);
-            keys = getKeys();
+            free = capacity = initialCapacity;
+            keys = createKeys();
             values = new int[keys.length];
             mask = keys.length - 1;
             Arrays.fill(keys, noEntryValue);
@@ -80,7 +82,7 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
     }
 
     @SuppressWarnings("unchecked")
-    private K[] getKeys() {
+    private K[] createKeys() {
         return (K[]) new Object[Numbers.ceilPow2((int) (this.capacity / this.loadFactor))];
     }
 
@@ -135,6 +137,10 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
         return capacity - free;
     }
 
+    public int capacity() {
+        return capacity;
+    }
+
     public int valueAt(int index) {
         int index1 = -index - 1;
         return index < 0 ? values[index1] : noKeyValue;
@@ -163,7 +169,6 @@ public class ObjIntHashMap<K> implements Iterable<ObjIntHashMap.Entry<K>>, Mutab
 
     @SuppressWarnings({"unchecked"})
     private void rehash() {
-
         free = capacity = this.capacity * 2;
         int[] oldValues = values;
         K[] oldKeys = keys;

--- a/core/src/test/java/io/questdb/std/ObjIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/ObjIntHashMapTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.util.HashMap;
 
 public class ObjIntHashMapTest {
+
     @Test
     public void testAddAndIterate() {
         Rnd rnd = new Rnd();
@@ -50,6 +51,22 @@ public class ObjIntHashMapTest {
             Assert.assertNotNull(val);
             Assert.assertEquals(e.value, val.intValue());
         }
+    }
+
+    @Test
+    public void testSizeAndCapacity() {
+        ObjIntHashMap<Integer> map = new ObjIntHashMap<>();
+
+        Assert.assertEquals(0, map.size());
+        Assert.assertTrue(map.capacity() > 0);
+
+        int n = 1000;
+        for (int i = 0; i < n; i++) {
+            map.put(i, i);
+        }
+
+        Assert.assertEquals(n, map.size());
+        Assert.assertTrue(map.capacity() >= n);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/std/ObjIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/ObjIntHashMapTest.java
@@ -54,11 +54,12 @@ public class ObjIntHashMapTest {
     }
 
     @Test
-    public void testSizeAndCapacity() {
+    public void testReset() {
         ObjIntHashMap<Integer> map = new ObjIntHashMap<>();
 
+        final int initialCapacity = map.capacity();
         Assert.assertEquals(0, map.size());
-        Assert.assertTrue(map.capacity() > 0);
+        Assert.assertTrue(initialCapacity > 0);
 
         int n = 1000;
         for (int i = 0; i < n; i++) {
@@ -67,6 +68,11 @@ public class ObjIntHashMapTest {
 
         Assert.assertEquals(n, map.size());
         Assert.assertTrue(map.capacity() >= n);
+
+        map.reset();
+
+        Assert.assertEquals(0, map.size());
+        Assert.assertEquals(initialCapacity, map.capacity());
     }
 
     @Test


### PR DESCRIPTION
Symbol cache was set to the current symbol count on initialization and never shrinked back. This might lead to multiple large contiguous on-heap arrays kept in `LineTcpNetworkIOJob#unusedSymbolCaches` which may become problematic for JVM's compacting garbage collectors.