### PR TITLE
chore(ilp): fuzz test refactoring

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -266,9 +266,19 @@ class AbstractLineTcpReceiverTest extends AbstractCairoTest {
             while (sent != lineDataBytes.length) {
                 int rc = Net.send(socket.fd, bufaddr + sent, lineDataBytes.length - sent);
                 if (rc < 0) {
+                    LOG.error().$("Data sending failed [rc=").$(rc)
+                            .$(", sent=").$(sent)
+                            .$(", bufferSize=").$(lineDataBytes.length)
+                            .I$();
                     throw new RuntimeException("Data sending failed [rc=" + rc + "]");
                 }
                 sent += rc;
+                if (sent != lineDataBytes.length) {
+                    LOG.info().$("Data sending is in progress [rc=").$(rc)
+                            .$(", sent=").$(sent)
+                            .$(", bufferSize=").$(lineDataBytes.length)
+                            .I$();
+                }
             }
         } finally {
             Unsafe.free(bufaddr, lineDataBytes.length, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/LineData.java
@@ -67,16 +67,16 @@ public class LineData {
         add(tagName, tagValue, true);
     }
 
-    public synchronized String generateRandomUpdate(CharSequence tableName, List<ColumnNameType> metadata, Rnd rnd) {
+    public synchronized String generateRandomUpdate(CharSequence tableName, List<ColumnNameType> columns, Rnd rnd) {
         int columnType = -1;
-        CharSequence name;
         int fieldIndex = -1;
 
         OUT:
-        for (int i = 0; i < metadata.size(); i++) {
-            name = metadata.get(i).columnName;
+        for (int i = 0; i < columns.size(); i++) {
+            final ColumnNameType column = columns.get(i);
+            final CharSequence name = column.columnName;
             if (!updated.contains(name)) {
-                columnType = metadata.get(i).columnType;
+                columnType = column.columnType;
 
                 for (int j = 0; j < names.size(); j++) {
                     if (Chars.equals(name, names.getQuick(j))) {
@@ -88,8 +88,8 @@ public class LineData {
             }
         }
         if (fieldIndex == -1) {
-            // Nothing to update anymore on this like. Update field to the value of the self.
-            return String.format("update \"%s\" set %s=%s where 1 != 1", tableName, metadata.get(0), metadata.get(0));
+            // Nothing to update anymore on this line. Update field to the value of the self.
+            return String.format("update \"%s\" set %s=%s where 1 != 1", tableName, columns.get(0).columnName, columns.get(0).columnName);
         }
 
         double value = 5000.0 + rnd.nextInt(1000);

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/load/TableData.java
@@ -47,10 +47,6 @@ public class TableData {
         return tableName;
     }
 
-    public void notReady() {
-        readyLatch.setCount(1);
-    }
-
     public void ready() {
         readyLatch.countDown();
     }


### PR DESCRIPTION
- separated the 'waiting for the data to appear in the table' and the 'asserting on the table' phases, this suits better for the UPDATE fuzz test
- tables cannot be marked as 'not ready for assertion yet' anymore, this was a potential source of race conditions

hopefully this change will help to get rid of the occasional CI failures
