### PR TITLE
feat(cutlass): add support for custom timestamp columns

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -156,22 +156,18 @@ public abstract class AbstractLineSender extends AbstractCharSink implements Clo
         return field(name, value);
     }
 
-    public AbstractLineSender fieldTimestamp(CharSequence name, long value) {
+    @Override
+    public final AbstractLineSender timestampColumn(CharSequence name, long value) {
         validateColumnName(name);
         field(name).put(value).put('t');
         return this;
     }
 
     @Override
-    public final AbstractLineSender timestampColumn(CharSequence name, long value) {
-        return fieldTimestamp(name, value);
-    }
-
-    @Override
     public final AbstractLineSender timestampColumn(CharSequence name, CharSequence value) throws LineSenderException {
         try {
             long value_micros = TimestampFormatUtils.parseUTCTimestamp(value);
-            return fieldTimestamp(name, value_micros);
+            return timestampColumn(name, value_micros);
         } catch (NumericException e) {
             throw new LineSenderException("could not parse timestamp in UTC ISO 8601 format.");
         }

--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -26,11 +26,9 @@ package io.questdb.cutlass.line;
 
 import io.questdb.cairo.TableUtils;
 import io.questdb.cutlass.line.tcp.AuthDb;
-import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.Chars;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
-import io.questdb.std.NumericException;
 import io.questdb.std.Unsafe;
 import io.questdb.std.Vect;
 import io.questdb.std.str.AbstractCharSink;
@@ -161,16 +159,6 @@ public abstract class AbstractLineSender extends AbstractCharSink implements Clo
         validateColumnName(name);
         field(name).put(value).put('t');
         return this;
-    }
-
-    @Override
-    public final AbstractLineSender timestampColumn(CharSequence name, CharSequence value) throws LineSenderException {
-        try {
-            long value_micros = TimestampFormatUtils.parseUTCTimestamp(value);
-            return timestampColumn(name, value_micros);
-        } catch (NumericException e) {
-            throw new LineSenderException("could not parse timestamp in UTC ISO 8601 format.");
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -173,7 +173,7 @@ public abstract class AbstractLineSender extends AbstractCharSink implements Clo
             long value_micros = TimestampFormatUtils.parseUTCTimestamp(value);
             return fieldTimestamp(name, value_micros);
         } catch (NumericException e) {
-            throw new LineSenderException("could not parse timestamp is UTC ISO 8601 format.");
+            throw new LineSenderException("could not parse timestamp in UTC ISO 8601 format.");
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/Sender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/Sender.java
@@ -48,8 +48,10 @@ import java.security.PrivateKey;
  *     <li>Obtain an instance via {@link #builder()}</li>
  *     <li>Use {@link #table(CharSequence)} to select a table</li>
  *     <li>Use {@link #symbol(CharSequence, CharSequence)} to add all symbols. You must add symbols before adding other columns.</li>
- *     <li>Use {@link #stringColumn(CharSequence, CharSequence)}, {@link #longColumn(CharSequence, long)}, {@link #doubleColumn(CharSequence, double)},
- *     {@link #boolColumn(CharSequence, boolean)}, {@link #timestampColumn(CharSequence, long)}, {@link #timestampColumn(CharSequence, CharSequence)} to add remaining columns columns</li>
+ *     <li>Use {@link #stringColumn(CharSequence, CharSequence)}, {@link #longColumn(CharSequence, long)},
+ *     {@link #doubleColumn(CharSequence, double)}, {@link #boolColumn(CharSequence, boolean)},
+ *     {@link #timestampColumn(CharSequence, long)}, {@link #timestampColumn(CharSequence, CharSequence)}
+ *     to add remaining columns columns</li>
  *     <li>Use {@link #at(long)} to finish a row with an explicit timestamp.Alternatively, you can use use
  *     {@link #atNow()} which will add a timestamp on a server.</li>
  *     <li>Optionally: You can use {@link #flush()} to send locally buffered data into a server</li>

--- a/core/src/main/java/io/questdb/cutlass/line/Sender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/Sender.java
@@ -50,8 +50,7 @@ import java.security.PrivateKey;
  *     <li>Use {@link #symbol(CharSequence, CharSequence)} to add all symbols. You must add symbols before adding other columns.</li>
  *     <li>Use {@link #stringColumn(CharSequence, CharSequence)}, {@link #longColumn(CharSequence, long)},
  *     {@link #doubleColumn(CharSequence, double)}, {@link #boolColumn(CharSequence, boolean)},
- *     {@link #timestampColumn(CharSequence, long)}, {@link #timestampColumn(CharSequence, CharSequence)}
- *     to add remaining columns columns</li>
+ *     {@link #timestampColumn(CharSequence, long)} to add remaining columns columns</li>
  *     <li>Use {@link #at(long)} to finish a row with an explicit timestamp.Alternatively, you can use use
  *     {@link #atNow()} which will add a timestamp on a server.</li>
  *     <li>Optionally: You can use {@link #flush()} to send locally buffered data into a server</li>
@@ -118,15 +117,6 @@ public interface Sender extends Closeable {
      * @return this instance for method chaining
      */
     Sender timestampColumn(CharSequence name, long value);
-
-    /**
-     * Add a column with a timestamp value
-     * @param name name of the column
-     * @param value value to add in UTC ISO 8601 format with microseconds
-     * @return this instance for method chaining
-     * @throws LineSenderException if the timestamp could not be parsed from value
-     */
-    Sender timestampColumn(CharSequence name, CharSequence value) throws LineSenderException;
 
     /**
      * Add a column with a symbol value. You must call add symbols before adding any other column types

--- a/core/src/main/java/io/questdb/cutlass/line/Sender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/Sender.java
@@ -49,7 +49,7 @@ import java.security.PrivateKey;
  *     <li>Use {@link #table(CharSequence)} to select a table</li>
  *     <li>Use {@link #symbol(CharSequence, CharSequence)} to add all symbols. You must add symbols before adding other columns.</li>
  *     <li>Use {@link #stringColumn(CharSequence, CharSequence)}, {@link #longColumn(CharSequence, long)}, {@link #doubleColumn(CharSequence, double)},
- *     {@link #boolColumn(CharSequence, boolean)} to add remaining columns columns</li>
+ *     {@link #boolColumn(CharSequence, boolean)}, {@link #timestampColumn(CharSequence, long)}, {@link #timestampColumn(CharSequence, CharSequence)} to add remaining columns columns</li>
  *     <li>Use {@link #at(long)} to finish a row with an explicit timestamp.Alternatively, you can use use
  *     {@link #atNow()} which will add a timestamp on a server.</li>
  *     <li>Optionally: You can use {@link #flush()} to send locally buffered data into a server</li>
@@ -110,8 +110,24 @@ public interface Sender extends Closeable {
     Sender boolColumn(CharSequence name, boolean value);
 
     /**
+     * Add a column with a timestamp value
+     * @param name name of the column
+     * @param value value to add (in microseconds)
+     * @return this instance for method chaining
+     */
+    Sender timestampColumn(CharSequence name, long value);
+
+    /**
+     * Add a column with a timestamp value
+     * @param name name of the column
+     * @param value value to add in UTC ISO 8601 format with microseconds
+     * @return this instance for method chaining
+     * @throws LineSenderException if the timestamp could not be parsed from value
+     */
+    Sender timestampColumn(CharSequence name, CharSequence value) throws LineSenderException;
+
+    /**
      * Add a column with a symbol value. You must call add symbols before adding any other column types
-     *
      * @param name name of the column
      * @param value value to add
      * @return this instance for method chaining

--- a/core/src/test/java/io/questdb/cutlass/line/interop/TestInterop.java
+++ b/core/src/test/java/io/questdb/cutlass/line/interop/TestInterop.java
@@ -196,6 +196,26 @@ public class TestInterop {
                                             encounteredError = true;
                                         }
                                         break;
+                                    case ColumnType.TIMESTAMP:
+                                        boolean longError = false;
+                                        boolean isoError = false;
+
+                                        try {
+                                            sender.timestampColumn(name, Numbers.parseLong(tag));
+                                        } catch (NumericException e) {
+                                            throw JsonException.$(position, "bad long");
+                                        } catch (LineSenderException e) {
+                                            longError = true;
+                                        }
+
+                                        try {
+                                            sender.timestampColumn(name, Chars.toString(tag));
+                                        } catch (LineSenderException e) {
+                                            isoError = true;
+                                        }
+
+                                        encounteredError = longError && isoError;
+                                        break;
                                     case ColumnType.STRING:
                                         try {
                                             sender.stringColumn(name, Chars.toString(tag));

--- a/core/src/test/java/io/questdb/cutlass/line/interop/TestInterop.java
+++ b/core/src/test/java/io/questdb/cutlass/line/interop/TestInterop.java
@@ -197,24 +197,13 @@ public class TestInterop {
                                         }
                                         break;
                                     case ColumnType.TIMESTAMP:
-                                        boolean longError = false;
-                                        boolean isoError = false;
-
                                         try {
                                             sender.timestampColumn(name, Numbers.parseLong(tag));
                                         } catch (NumericException e) {
                                             throw JsonException.$(position, "bad long");
                                         } catch (LineSenderException e) {
-                                            longError = true;
+                                            encounteredError = true;
                                         }
-
-                                        try {
-                                            sender.timestampColumn(name, Chars.toString(tag));
-                                        } catch (LineSenderException e) {
-                                            isoError = true;
-                                        }
-
-                                        encounteredError = longError && isoError;
                                         break;
                                     case ColumnType.STRING:
                                         try {


### PR DESCRIPTION
This PR adds support for custom timestamp columns accepting both microseconds since UNIX epoch as a long and ISO 8601 formatted UTC timestamp.