### PR TITLE
chore(docs): improve github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,7 +7,7 @@ body:
       value: |
         Thank you for reporting the bug.  
         Please provide all the required information to receive faster responses from the maintainers. 
-  - type: textarean
+  - type: textarea
     attributes:
       label: Describe the bug
       description: A concise description of what you're experiencing.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Thank you for reporting the bug.  
-        Please provide all the required information to receive faster responses from the maintainers. 
+        ❗ Please provide all the required information to receive faster responses from the maintainers. 
   - type: textarea
     attributes:
       label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -5,8 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out a bug report!
-  - type: textarea
+        Thank you for reporting the bug.  
+        Please provide all the required information to receive faster responses from the maintainers. 
+  - type: textarean
     attributes:
       label: Describe the bug
       description: A concise description of what you're experiencing.
@@ -49,7 +50,7 @@ body:
     attributes:
       label: Additional context
       description: |
-        Add screenshots, links, or details that provide context about the issue.
+        Please add screenshots, logs files, links, or details that provide context about the issue.
 
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,8 @@
+blank_issues_enabled: false
 contact_links:
   - name: Stack Overflow Community
     url: https://stackoverflow.com/questions/tagged/questdb
-    about:
-      Ask generic questions or find popular solutions suggested by the QuestDB
-      community
+    about: Ask Stack Overflow community or search for popular solutions.
+  - name: Community on Slack
+    url: https://slack.questdb.io
+    about: Ask generic questions or meet other developers who are building with QuestDB.


### PR DESCRIPTION
- add notes in the template to facilitate higher-quality github bug reports
- disable blank github issues to reduce the chance of receiving freestyle github issues from the users
- add a link to our slack community for users who have generic questions, increasing the slack visibility 