### PR TITLE
fix(sql): fix infinite loop in SAMPLE BY month over first or last values and indexed column filter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/MonthTimestampSampler.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/MonthTimestampSampler.java
@@ -58,7 +58,8 @@ class MonthTimestampSampler implements TimestampSampler {
         int m = Timestamps.getMonthOfYear(value, y, leap);
         // target month
         int nextMonth = ((m - 1) / monthCount) * monthCount + 1;
-        return toMicros(y, leap, startDay, nextMonth, startHour, startMin, startSec, startMillis, startMicros);
+        int d = startDay > 0 ? startDay : 1;
+        return toMicros(y, leap, d, nextMonth, startHour, startMin, startSec, startMillis, startMicros);
     }
 
     @Override
@@ -95,12 +96,16 @@ class MonthTimestampSampler implements TimestampSampler {
             }
         }
         int _d = startDay;
-        int maxDay = Timestamps.getDaysPerMonth(_m, Timestamps.isLeapYear(_y));
-        if (_d > maxDay) {
-            _d = maxDay;
+        if (startDay == 0) {
+            _d = 1;
+        } else {
+            int maxDay = Timestamps.getDaysPerMonth(_m, Timestamps.isLeapYear(_y));
+            if (_d > maxDay) {
+                _d = maxDay;
+            }
         }
-        return Timestamps.toMicros(_y, _m, _d) +
-                startHour * Timestamps.HOUR_MICROS
+        return Timestamps.toMicros(_y, _m, _d)
+                + startHour * Timestamps.HOUR_MICROS
                 + startMin * Timestamps.MINUTE_MICROS
                 + startSec * Timestamps.SECOND_MICROS
                 + startMillis * Timestamps.MILLI_MICROS

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
@@ -336,6 +336,7 @@ public class SampleByFirstLastRecordCursorFactory extends AbstractRecordCursorFa
             for (int i = 0; i < maxSamplePeriodSize && currentTs <= lastInDataTimestamp; i++) {
                 currentTs = nextTs;
                 nextTs = getNextTimestamp();
+                assert nextTs != currentTs;
                 samplePeriodAddress.add(currentTs);
             }
             return (int) samplePeriodAddress.size();

--- a/core/src/test/java/io/questdb/griffin/engine/groupby/MonthTimestampSamplerTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/groupby/MonthTimestampSamplerTest.java
@@ -71,4 +71,73 @@ public class MonthTimestampSamplerTest {
                 sink
         );
     }
+
+    @Test
+    public void testNextTimestamp() throws NumericException {
+        MonthTimestampSampler sampler = new MonthTimestampSampler(1);
+
+        final String[] src = new String[] {
+                "2013-12-31T00:00:00.000000Z",
+                "2014-01-01T00:00:00.000000Z",
+                "2020-01-01T12:12:12.123456Z",
+        };
+        final String[] next = new String[] {
+                "2014-01-01T00:00:00.000000Z",
+                "2014-02-01T00:00:00.000000Z",
+                "2020-02-01T00:00:00.000000Z",
+        };
+        Assert.assertEquals(src.length, next.length);
+
+        for (int i = 0; i < src.length; i++) {
+            long ts = TimestampFormatUtils.parseUTCTimestamp(src[i]);
+            long nextTs = sampler.nextTimestamp(ts);
+            Assert.assertEquals(TimestampFormatUtils.parseUTCTimestamp(next[i]), nextTs);
+        }
+    }
+
+    @Test
+    public void testPreviousTimestamp() throws NumericException {
+        MonthTimestampSampler sampler = new MonthTimestampSampler(1);
+
+        final String[] src = new String[] {
+                "2013-12-31T00:00:00.000000Z",
+                "2014-01-01T00:00:00.000000Z",
+                "2020-02-01T12:12:12.123456Z",
+        };
+        final String[] prev = new String[] {
+                "2013-11-01T00:00:00.000000Z",
+                "2013-12-01T00:00:00.000000Z",
+                "2020-01-01T00:00:00.000000Z",
+        };
+        Assert.assertEquals(src.length, prev.length);
+
+        for (int i = 0; i < src.length; i++) {
+            long ts = TimestampFormatUtils.parseUTCTimestamp(src[i]);
+            long prevTs = sampler.previousTimestamp(ts);
+            Assert.assertEquals(TimestampFormatUtils.parseUTCTimestamp(prev[i]), prevTs);
+        }
+    }
+
+    @Test
+    public void testRound() throws NumericException {
+        MonthTimestampSampler sampler = new MonthTimestampSampler(1);
+
+        final String[] src = new String[] {
+                "2013-12-31T00:00:00.000000Z",
+                "2014-01-01T00:00:00.000000Z",
+                "2014-02-12T12:12:12.123456Z",
+        };
+        final String[] rounded = new String[] {
+                "2013-12-01T00:00:00.000000Z",
+                "2014-01-01T00:00:00.000000Z",
+                "2014-02-01T00:00:00.000000Z",
+        };
+        Assert.assertEquals(src.length, rounded.length);
+
+        for (int i = 0; i < src.length; i++) {
+            long ts = TimestampFormatUtils.parseUTCTimestamp(src[i]);
+            long roundedTs = sampler.round(ts);
+            Assert.assertEquals(TimestampFormatUtils.parseUTCTimestamp(rounded[i]), roundedTs);
+        }
+    }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
@@ -1596,6 +1596,38 @@ public class SampleByTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testIndexSampleByMonth() throws Exception {
+        assertQuery("k\ts\tlat\tlon\n",
+                "select k, s, last(lat) lat, last(lon) lon " +
+                        "from xx " +
+                        "where s = 'b' " +
+                        "  and k >= cast(1388534400 * 1000000L as timestamp) " +
+                        "  and k <= cast(1655742718 * 1000000L as timestamp)" +
+                        "sample by 1M",
+                "create table xx (k timestamp, s symbol, lat double, lon double)" +
+                        ", index(s capacity 10) timestamp(k) partition by DAY",
+                "k",
+                false,
+                false,
+                true);
+
+        assertSampleByIndexQuery("k\ts\tlat\tlon\n" +
+                        "2014-01-01T00:00:00.000000Z\tb\t248.0\t123.7\n",
+                "select k, s, last(lat) lat, last(lon) lon " +
+                        "from xx " +
+                        "where s = 'b' " +
+                        "  and k >= cast(1388534400 * 1000000L as timestamp) " +
+                        "  and k <= cast(1655742718 * 1000000L as timestamp)" +
+                        "sample by 1M",
+                "insert into xx " +
+                        "values " +
+                        "    ('2014-01-01T00:00:00.000000Z', 'b', 245, 123.4)," +
+                        "    ('2014-01-01T00:05:00.000000Z', 'b', 246, 123.5)," +
+                        "    ('2014-01-01T00:10:00.000000Z', 'b', 247, 123.6)," +
+                        "    ('2014-01-01T00:15:00.000000Z', 'b', 248, 123.7);");
+    }
+
+    @Test
     public void testIndexSampleByMicro() throws Exception {
         sampleByIndexSearchPageSize = 256;
         assertSampleByIndexQuery(


### PR DESCRIPTION
For certain timestamps, `MonthTimestampSampler#nextTimestamp()` was returning the provided timestamp instead of the timestamp larger by N months. Apart from that, `MonthTimestampSampler#round()` could also return incorrect values. See the added tests for more details.

All of the above issues led to an infinite loop in `SampleByFirstLastRecordCursor#getNextState()`.