### PR TITLE
feat: run as questdb user in docker

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -25,22 +25,37 @@ RUN tar xvfz questdb-*-rt-*.tar.gz
 
 RUN rm questdb-*-rt-*.tar.gz
 
+ENV GOSU_VERSION 1.14
+RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" && \
+    wget -O gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    gpg --batch --verify gosu.asc gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" gosu.asc && \
+    chmod +x gosu && \
+    ./gosu --version && \
+    ./gosu nobody true
+
 FROM debian:bullseye-slim
 
 WORKDIR /app
 
 COPY --from=0 /build/questdb/core/target/questdb-*-rt-* .
+COPY --from=0 /build/questdb/core/target/gosu /usr/local/bin/gosu
 
-WORKDIR /app/bin
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
-# QuestDB root directory
-RUN mkdir -p /root/.questdb
+# Create questdb user and group
+RUN groupadd -g 10001 questdb && \
+    useradd -u 10001 -g 10001 -d /var/lib/questdb -M -s /sbin/nologin questdb && \
+    mkdir -p /var/lib/questdb && \
+    chown -R questdb:questdb /var/lib/questdb
 
 # Make working folder the quest db folder
-WORKDIR /root/.questdb
-
-# bash prompt
-RUN echo "PS1='🐳  \[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'" > /root/.bashrc
+WORKDIR /var/lib/questdb
 
 # Make port 9000 available to the world outside this container
 EXPOSE 9000/tcp
@@ -54,8 +69,8 @@ EXPOSE 9009/tcp
 # which make logger use default configuration. However, when user configures
 # a volume with something like:
 #
-# docker run -v "$(pwd):/root/.questdb/"  questdb/questdb
+# docker run -v "$(pwd):/var/lib/questdb/"  questdb/questdb
 #
 # then one can create 'log.conf' in the 'conf' dir and override logger fully
 #
-CMD ["/usr/bin/env", "QDB_PACKAGE=docker", "/app/bin/java", "-Dout=conf/log.conf", "-m", "io.questdb/io.questdb.ServerMain", "-d", "/root/.questdb", "-f"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+export QDB_PACKAGE=${QDB_PACKAGE:-docker}
+
+QUESTDB_DATA_DIR=${QUESTDB_DATA_DIR:-"/var/lib/questdb"}
+IGNORE_DATA_ROOT_MOUNT_CHECK=${IGNORE_DATA_ROOT_MOUNT_CHECK:-"false"}
+IGNORE_FIND_AND_OWN_DIR=${IGNORE_FIND_AND_OWN_DIR:-"false"}
+RUN_AS_ROOT=${RUN_AS_ROOT:-"false"}
+
+find_and_own_dir() {
+    if [ "$IGNORE_FIND_AND_OWN_DIR" = "false" ]; then
+        find "$1" \( ! -user questdb -o ! -group questdb \) -exec chown questdb:questdb '{}' +
+    fi
+}
+
+# Temporary only
+# Most of the users will have the data mounted under /root/.questdb as default
+# we will run as root for them until they change the mount to /var/lib/questdb or someting else
+if [ "$IGNORE_DATA_ROOT_MOUNT_CHECK" = "false" ] && mount | grep "/root/.questdb" -q; then
+    echo "Found /root/.questdb mount, overwriting QUESTDB_DATA_DIR"
+    QUESTDB_DATA_DIR="/root/.questdb"
+fi
+
+if [ $# -eq 0 ]; then
+    echo "No arguments found, start with default arguments"
+    set -- /app/bin/java -Dout=conf/log.conf -m io.questdb/io.questdb.ServerMain -d ${QUESTDB_DATA_DIR} -f
+else
+    if [ "${1:0:1}" = '-' ]; then
+        echo "Found config arguments $@"
+        set -- /app/bin/java "$@"
+    elif [ "$1" = "/app/bin/java" ]; then
+        echo "Java binary arguments found, Non default arguments config run"
+        set -- "$@"
+    fi
+fi
+
+if [ "$(id -u)" = '0' ] && [ "${QUESTDB_DATA_DIR%/}" != "/root/.questdb" ] && [ "$RUN_AS_ROOT" = "false" ] ; then
+    echo "Running as questdb user"
+    find_and_own_dir ${QUESTDB_DATA_DIR}
+    exec gosu questdb "$@"
+fi
+
+echo "Running as $(id -un) user"
+exec "$@"

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -398,7 +398,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int maxFileNameLength;
     private final boolean ilpAutoCreateNewColumns;
     private final boolean ilpAutoCreateNewTables;
-    private boolean simulateCrashEnabled;
+    private final boolean simulateCrashEnabled;
 
     public PropServerConfiguration(
             String root,

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -398,6 +398,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int maxFileNameLength;
     private final boolean ilpAutoCreateNewColumns;
     private final boolean ilpAutoCreateNewTables;
+    private boolean simulateCrashEnabled;
 
     public PropServerConfiguration(
             String root,
@@ -428,6 +429,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         this.snapshotInstanceId = getString(properties, env, PropertyKey.CAIRO_SNAPSHOT_INSTANCE_ID, "");
         this.snapshotRecoveryEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SNAPSHOT_RECOVERY_ENABLED, true);
+        this.simulateCrashEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SIMULATE_CRASH_ENABLED, false);
 
         int cpuAvailable = Runtime.getRuntime().availableProcessors();
         int cpuUsed = 0;
@@ -2154,6 +2156,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getSampleByIndexSearchPageSize() {
             return sampleByIndexSearchPageSize;
+        }
+
+        @Override
+        public boolean getSimulateCrashEnabled() {
+            return simulateCrashEnabled;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -355,7 +355,8 @@ public enum PropertyKey {
     CAIRO_SQL_SYSTEM_TABLE_PREFIX("cairo.system.table.prefix"),
     CAIRO_MAX_FILE_NAME_LENGTH("cairo.max.file.name.length"),
     LINE_AUTO_CREATE_NEW_COLUMNS("line.auto.create.new.columns"),
-    LINE_AUTO_CREATE_NEW_TABLES("line.auto.create.new.tables");
+    LINE_AUTO_CREATE_NEW_TABLES("line.auto.create.new.tables"),
+    CAIRO_SIMULATE_CRASH_ENABLED("cairo.enable.crash.simulation");
 
     private static final Map<String, PropertyKey> nameMapping;
     private final String propertyPath;

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -224,6 +224,8 @@ public interface CairoConfiguration {
 
     int getSampleByIndexSearchPageSize();
 
+    boolean getSimulateCrashEnabled();
+
     /**
      * Returns database instance id. The instance id is used by the snapshot recovery mechanism:
      * on database start the id is compared with the id stored in a snapshot, if any. If the ids

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -439,6 +439,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean getSimulateCrashEnabled() {
+        return false;
+    }
+
+    @Override
     public int getRndFunctionMemoryPageSize() {
         return 8192;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/SimulateCrashFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/SimulateCrashFunctionFactory.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+
+public class SimulateCrashFunctionFactory implements FunctionFactory {
+
+    private static final SimulateCrashFunction CrashInstance = new SimulateCrashFunction();
+    private static final DoNothingInstance Dummy = new DoNothingInstance();
+
+    @Override
+    public String getSignature() {
+        return "simulate_crash()";
+    }
+
+    @Override
+    public Function newInstance(int position,
+                                ObjList<Function> args,
+                                IntList argPositions,
+                                CairoConfiguration configuration,
+                                SqlExecutionContext sqlExecutionContext
+    ) {
+        if (configuration.getSimulateCrashEnabled())  {
+            return CrashInstance;
+        }
+        return Dummy;
+    }
+
+    private static class SimulateCrashFunction extends BooleanFunction {
+        @Override
+        public boolean getBool(Record rec) {
+            Unsafe.getUnsafe().getLong(0L);
+            return true;
+        }
+    }
+
+    private static class DoNothingInstance extends BooleanFunction {
+        @Override
+        public boolean getBool(Record rec) {
+            return false;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/SimulateCrashFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/SimulateCrashFunctionFactory.java
@@ -38,10 +38,11 @@ public class SimulateCrashFunctionFactory implements FunctionFactory {
 
     private static final SimulateCrashFunction CrashInstance = new SimulateCrashFunction();
     private static final DoNothingInstance Dummy = new DoNothingInstance();
+    private static final OutOfMemoryFunction OutOfMemoryInstance = new OutOfMemoryFunction();
 
     @Override
     public String getSignature() {
-        return "simulate_crash()";
+        return "simulate_crash(a)";
     }
 
     @Override
@@ -51,8 +52,15 @@ public class SimulateCrashFunctionFactory implements FunctionFactory {
                                 CairoConfiguration configuration,
                                 SqlExecutionContext sqlExecutionContext
     ) {
+
         if (configuration.getSimulateCrashEnabled())  {
-            return CrashInstance;
+            char killType = args.get(0).getChar(null);
+            switch (killType) {
+                case '0':
+                    return CrashInstance;
+                case 'M':
+                    return OutOfMemoryInstance;
+            }
         }
         return Dummy;
     }
@@ -62,6 +70,13 @@ public class SimulateCrashFunctionFactory implements FunctionFactory {
         public boolean getBool(Record rec) {
             Unsafe.getUnsafe().getLong(0L);
             return true;
+        }
+    }
+
+    private static class OutOfMemoryFunction extends BooleanFunction {
+        @Override
+        public boolean getBool(Record rec) {
+            throw new OutOfMemoryError("simulate_crash('M')");
         }
     }
 

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -569,6 +569,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.FlushQueryCacheFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.SimulateCrashFunctionFactory,
 
 //            PostgreSQL advisory locks functions
             io.questdb.griffin.engine.functions.lock.AdvisoryUnlockAll,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -543,6 +543,7 @@ io.questdb.griffin.engine.functions.catalogue.TableListFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.FlushQueryCacheFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.SimulateCrashFunctionFactory
 
 # PostgreSQL advisory locks functions
 io.questdb.griffin.engine.functions.lock.AdvisoryUnlockAll

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/SimlateCrashFunctionTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/SimlateCrashFunctionTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.std.Os;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+public class SimlateCrashFunctionTest extends AbstractGriffinTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                "select simulate_crash()",
+                sink,
+                "simulate_crash\n" +
+                        "false\n"
+        ));
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/SimlateCrashFunctionTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/catalogue/SimlateCrashFunctionTest.java
@@ -36,7 +36,16 @@ public class SimlateCrashFunctionTest extends AbstractGriffinTest {
         assertMemoryLeak(() -> TestUtils.assertSql(
                 compiler,
                 sqlExecutionContext,
-                "select simulate_crash()",
+                "select simulate_crash('0')",
+                sink,
+                "simulate_crash\n" +
+                        "false\n"
+        ));
+
+        assertMemoryLeak(() -> TestUtils.assertSql(
+                compiler,
+                sqlExecutionContext,
+                "select simulate_crash('M')",
                 sink,
                 "simulate_crash\n" +
                         "false\n"


### PR DESCRIPTION
Tested with:
- legacy questdb root folder on /root/.questdb
  - questdb will run as root
  - if there are problems with `/root/.questdb` mount detection there is a environment variable flag that will disable the check: `IGNORE_DATA_ROOT_MOUNT_CHECK`
    - in this case setting `IGNORE_DATA_ROOT_MOUNT_CHECK` to true, `QUESTDB_DATA_DIR` to `/root/.questdb` and `RUN_AS_ROOT` to true should have the same effect
- new questdb root folder on /var/lib/questdb
- if data in /var/lib/questdb is own by other than questdb:questdb it will change ownership to questdb:questdb, this should help with migration
- different entrypoint overwrite (docker-entrypoint.sh is bypassed)
- different arguments to /app/bin/java
- different commands that start with /app/bin/java
- with other user than questdb, works but should files in questdb data should be own by that user id

Added the following environment variable:
- `IGNORE_FIND_AND_OWN_DIR` set to `false` by default
  - there is a function that will find all the files owned by other users/group than questdb/questdb and it will change the ownership to questdb/questdb
  - this flag will disable the change of ownership
- `IGNORE_DATA_ROOT_MOUNT_CHECK` set to `false` by default
  - this will disable the `/root/.questdb` check if that creates problems
- `RUN_AS_ROOT` default set to `false`
  - it will run questdb as root if set to true
- `QUESTDB_DATA_DIR` default to `/var/lib/questdb`
  - set this if you are mount quesdb data to another path
