### PR TITLE
feat(core): use critical level to log all unhandled errors

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -255,7 +255,7 @@ public class CairoEngine implements Closeable, WriterSource {
             return getReader(executionContext.getCairoSecurityContext(), tableName);
         } catch (CairoException ex) {
             // Cannot open reader on existing table is pretty bad.
-            LOG.error().$("error opening reader for ").$(statement)
+            LOG.critical().$("error opening reader for ").$(statement)
                     .$(" statement [table=").$(tableName)
                     .$(",errno=").$(ex.getErrno())
                     .$(",error=").$(ex.getMessage()).I$();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -5002,8 +5002,8 @@ public class TableWriter implements Closeable {
         }
     }
 
-    private void throwDistressException(Throwable cause) {
-        LOG.critical().$("writer error [table=").$(tableName).$(", ex=").$(cause).I$();
+    private void throwDistressException(CairoException cause) {
+        LOG.critical().$("writer error [table=").$(tableName).$(", e=").$((Sinkable) cause).I$();
         this.distressed = true;
         throw new CairoError(cause);
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -469,7 +469,6 @@ public class TableWriter implements Closeable {
 
             // remove _todo
             clearTodoLog();
-
         } catch (CairoException err) {
             throwDistressException(err);
         }
@@ -5004,6 +5003,7 @@ public class TableWriter implements Closeable {
     }
 
     private void throwDistressException(Throwable cause) {
+        LOG.critical().$("writer error [table=").$(tableName).$(", ex=").$(cause).I$();
         this.distressed = true;
         throw new CairoError(cause);
     }
@@ -5110,7 +5110,6 @@ public class TableWriter implements Closeable {
                 denseIndexers.getQuick(i).refreshSourceAndIndex(lo, hi);
             } catch (CairoException e) {
                 // this is pretty severe, we hit some sort of limit
-                LOG.critical().$("index error {").$((Sinkable) e).$('}').$();
                 throwDistressException(e);
             }
         }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2238,7 +2238,7 @@ public class TableWriter implements Closeable {
                         .$(", errno=").$(e.getErrno())
                         .$(']').$();
                 if (!ff.remove(path)) {
-                    LOG.error()
+                    LOG.critical()
                             .$("could not remove '").utf8(path).$("'. Please remove MANUALLY.")
                             .$("[errno=").$(ff.errno())
                             .$(']').$();

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -423,7 +423,7 @@ public class WriterPool extends AbstractPool {
             e.ownershipReason = lockReason;
             return logAndReturn(e, PoolListener.EV_CREATE);
         } catch (CairoException ex) {
-            LOG.error()
+            LOG.critical()
                     .$("could not open [table=`").utf8(name)
                     .$("`, thread=").$(e.owner)
                     .$(", ex=").$(ex.getFlyweightMessage())
@@ -578,7 +578,7 @@ public class WriterPool extends AbstractPool {
 
             notifyListener(thread, name, PoolListener.EV_RETURN);
         } else {
-            LOG.error().$("orphaned [table=`").utf8(name).$("`]").$();
+            LOG.critical().$("orphaned [table=`").utf8(name).$("`]").$();
             notifyListener(thread, name, PoolListener.EV_UNEXPECTED_CLOSE);
         }
         return true;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -539,7 +539,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         } else if (e instanceof HttpException) {
             state.error().$("internal HTTP server error [q=`").utf8(state.getQuery()).$("`, reason=`").$(((HttpException) e).getFlyweightMessage()).$("`]").$();
         } else {
-            state.error().$("internal error [q=`").utf8(state.getQuery()).$("`, ex=").$(e).$(']').$();
+            state.critical().$("internal error [q=`").utf8(state.getQuery()).$("`, ex=").$(e).$(']').$();
             // This is a critical error, so we treat it as an unhandled one.
             metrics.healthCheck().incrementUnhandledErrors();
         }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -183,6 +183,10 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
         return LOG.error().$('[').$(getFd()).$("] ");
     }
 
+    public LogRecord critical() {
+        return LOG.critical().$('[').$(getFd()).$("] ");
+    }
+
     public void freeAsyncOperation() {
         asyncOperation = Misc.free(asyncOperation);
         operationFuture = Misc.free(operationFuture);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -335,10 +335,6 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
                 .$(", totalBytesSent=").$(context.getTotalBytesSent()).$(']').$();
     }
 
-    private LogRecord error(TextQueryProcessorState state) {
-        return LOG.error().$('[').$(state.getFd()).$("] ");
-    }
-
     private LogRecord critical(TextQueryProcessorState state) {
         return LOG.critical().$('[').$(state.getFd()).$("] ");
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -339,6 +339,10 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         return LOG.error().$('[').$(state.getFd()).$("] ");
     }
 
+    private LogRecord critical(TextQueryProcessorState state) {
+        return LOG.critical().$('[').$(state.getFd()).$("] ");
+    }
+
     protected void header(HttpChunkedResponseSocket socket, TextQueryProcessorState state, int status_code) throws PeerDisconnectedException, PeerIsSlowToReadException {
         socket.status(status_code, "text/csv; charset=utf-8");
         if (state.fileName != null && state.fileName.length() > 0) {
@@ -366,7 +370,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
             Throwable e,
             TextQueryProcessorState state
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        error(state).$("Server error executing query ").utf8(state.query).$(e).$();
+        critical(state).$("Server error executing query ").utf8(state.query).$(e).$();
         // This is a critical error, so we treat it as an unhandled one.
         metrics.healthCheck().incrementUnhandledErrors();
         sendException(socket, 0, e.getMessage(), state);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -229,8 +229,8 @@ class LineTcpConnectionContext implements IOContext, Mutable {
                     }
                 }
             } catch (CairoException ex) {
-                LOG.error().
-                        $('[').$(fd).$("] could not process line data [table=").$(parser.getMeasurementName())
+                LOG.error()
+                        .$('[').$(fd).$("] could not process line data [table=").$(parser.getMeasurementName())
                         .$(", msg=").$(ex.getFlyweightMessage())
                         .$(", errno=").$(ex.getErrno())
                         .I$();
@@ -240,9 +240,9 @@ class LineTcpConnectionContext implements IOContext, Mutable {
                 }
                 goodMeasurement = false;
             } catch (Throwable ex) {
-                LOG.error().
-                        $('[').$(fd).$("] could not process line data [table=").$(parser.getMeasurementName()).
-                        $(", ex=").$(ex)
+                LOG.critical()
+                        .$('[').$(fd).$("] could not process line data [table=").$(parser.getMeasurementName())
+                        .$(", ex=").$(ex)
                         .I$();
                 // This is a critical error, so we treat it as an unhandled one.
                 metrics.healthCheck().incrementUnhandledErrors();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -32,12 +32,7 @@ import io.questdb.log.LogFactory;
 import io.questdb.network.IOContext;
 import io.questdb.network.IODispatcher;
 import io.questdb.network.NetworkFacade;
-import io.questdb.std.Chars;
-import io.questdb.std.DirectBinarySequence;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.Mutable;
-import io.questdb.std.Unsafe;
-import io.questdb.std.Vect;
+import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.DirectByteCharSequence;
 import io.questdb.std.str.StringSink;
@@ -254,9 +249,13 @@ class LineTcpConnectionContext implements IOContext, Mutable {
     private void logParseError() {
         int position = (int) (parser.getBufferAddress() - recvBufStartOfMeasurement);
         assert position >= 0;
-        LOG.error().$('[').$(fd).$("] could not parse measurement, ").$(parser.getErrorCode()).$(" at ").$(position)
+        LOG.error()
+                .$('[').$(fd)
+                .$("] could not parse measurement, ").$(parser.getErrorCode())
+                .$(" at ").$(position)
                 .$(", line (may be mangled due to partial parsing): '")
-                .$(byteCharSequence.of(recvBufStartOfMeasurement, parser.getBufferAddress())).$("'").$();
+                .$(byteCharSequence.of(recvBufStartOfMeasurement, parser.getBufferAddress())).$("'")
+                .$();
     }
 
     private void startNewMeasurement() {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
@@ -114,7 +114,11 @@ class LineTcpWriterJob implements Job, Closeable {
                         // taking the earliest commit time
                         minTableNextCommitTime = tableNextCommitTime;
                     }
-                } catch (Throwable th) {
+                } catch (Throwable ex) {
+                    LOG.critical()
+                            .$("commit failed [table=").$(assignedTables.getQuick(n).getTableNameUtf16())
+                            .$(",ex=").$(ex)
+                            .I$();
                     metrics.healthCheck().incrementUnhandledErrors();
                 }
             }
@@ -159,11 +163,11 @@ class LineTcpWriterJob implements Job, Closeable {
                         }
                     } catch (Throwable ex) {
                         tab.setWriterInError();
-                        metrics.healthCheck().incrementUnhandledErrors();
-                        LOG.error()
+                        LOG.critical()
                                 .$("closing writer because of error [table=").$(tab.getTableNameUtf16())
                                 .$(",ex=").$(ex)
                                 .I$();
+                        metrics.healthCheck().incrementUnhandledErrors();
                         closeWriter = true;
                         event.createWriterReleaseEvent(tab, false);
                         // This is a critical error, so we treat it as an unhandled one.

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -2774,7 +2774,7 @@ public class SqlCompiler implements Closeable {
                             throw SqlException.$(0, "there is an active query against '").put(writer.getTableName()).put("'. Try again.");
                         }
                     } catch (CairoException | CairoError e) {
-                        LOG.error().$("could truncate [table=").$(writer.getTableName()).$(", e=").$((Sinkable) e).$(']').$();
+                        LOG.error().$("could not truncate [table=").$(writer.getTableName()).$(", e=").$((Sinkable) e).$(']').$();
                         throw e;
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
@@ -336,7 +336,7 @@ public class SampleByFirstLastRecordCursorFactory extends AbstractRecordCursorFa
             for (int i = 0; i < maxSamplePeriodSize && currentTs <= lastInDataTimestamp; i++) {
                 currentTs = nextTs;
                 nextTs = getNextTimestamp();
-                assert nextTs != currentTs;
+                assert nextTs != currentTs : "uh-oh, we may have got into an infinite loop with ts " + nextTs;
                 samplePeriodAddress.add(currentTs);
             }
             return (int) samplePeriodAddress.size();

--- a/core/src/main/java/io/questdb/log/Log.java
+++ b/core/src/main/java/io/questdb/log/Log.java
@@ -45,8 +45,6 @@ public interface Log {
 
     LogRecord advisoryW();
 
-    boolean isDebugEnabled();
-
     LogRecord xerror();
 
     LogRecord xcritical();

--- a/core/src/main/java/io/questdb/log/Logger.java
+++ b/core/src/main/java/io/questdb/log/Logger.java
@@ -296,11 +296,6 @@ class Logger implements LogRecord, Log {
         return addTimestamp(xadvisory(), LogLevel.ADVISORY_HEADER);
     }
 
-    @Override
-    public boolean isDebugEnabled() {
-        return debugSeq != null;
-    }
-
     public LogRecord xerror() {
         return next(errorSeq, errorRing, LogLevel.ERROR);
     }

--- a/core/src/main/java/io/questdb/log/SyncLogger.java
+++ b/core/src/main/java/io/questdb/log/SyncLogger.java
@@ -268,11 +268,6 @@ public class SyncLogger implements LogRecord, Log {
         return addTimestamp(xAdvisoryW(), LogLevel.ADVISORY_HEADER);
     }
 
-    @Override
-    public boolean isDebugEnabled() {
-        return debugSeq != null;
-    }
-
     public LogRecord xerror() {
         return next(errorSeq, errorRing, LogLevel.ERROR);
     }

--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -157,9 +157,9 @@ public class Worker extends Thread {
 
     private void onError(int i, Throwable e) throws Throwable {
         metrics.healthCheck().incrementUnhandledErrors();
-        // Log error even when halt on error is set
+        // Log error even then halt if halt error setting is on.
         if (log != null) {
-            log.error().$("unhandled error [job=").$(jobs.get(i).toString()).$(", ex=").$(e).$(']').$();
+            log.critical().$("unhandled error [job=").$(jobs.get(i).toString()).$(", ex=").$(e).$(']').$();
         } else {
             e.printStackTrace();
         }

--- a/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/log/LogAlertSocketTest.java
@@ -502,11 +502,6 @@ public class LogAlertSocketTest {
         }
 
         @Override
-        public boolean isDebugEnabled() {
-            return false;
-        }
-
-        @Override
         public LogRecord xerror() {
             throw new UnsupportedOperationException();
         }

--- a/core/src/test/java/io/questdb/network/NetTest.java
+++ b/core/src/test/java/io/questdb/network/NetTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.network;
 
-import io.questdb.cairo.AbstractCairoTest;
 import io.questdb.std.Chars;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Os;
@@ -80,7 +79,7 @@ public class NetTest {
     public void testLeakyAddrInfo() throws Exception {
         NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
         boolean leakDetected = false;
-        long addrInfo[] = new long[1];
+        long[] addrInfo = new long[1];
         try {
             TestUtils.assertMemoryLeak(() -> addrInfo[0] = nf.getAddrInfo("localhost", 443));
         } catch (AssertionError e) {
@@ -90,7 +89,7 @@ public class NetTest {
         } finally {
             long ptr = addrInfo[0];
             if (ptr == -1) {
-                fail("localhost could not be resolved. something is wrong.");
+                fail("localhost could not be resolved. Something is wrong.");
             }
             nf.freeAddrInfo(ptr);
             if (!leakDetected) {
@@ -103,7 +102,7 @@ public class NetTest {
     public void testLeakySockAddr() throws Exception {
         NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
         boolean leakDetected = false;
-        long sockAddr[] = new long[1];
+        long[] sockAddr = new long[1];
         try {
             TestUtils.assertMemoryLeak(() -> sockAddr[0] = nf.sockaddr("127.0.0.1", 443));
         } catch (AssertionError e) {
@@ -113,7 +112,7 @@ public class NetTest {
         } finally {
             long ptr = sockAddr[0];
             if (ptr == 0) {
-                fail("SockAddr could no be allocated. something is wrong.");
+                fail("SockAddr could no be allocated. Something is wrong.");
             }
             nf.freeSockAddr(ptr);
             if (!leakDetected) {

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -482,13 +482,13 @@ public final class TestUtils {
         int addrInfoCountAfter = Net.getAllocatedAddrInfoCount();
         Assert.assertTrue(addrInfoCountAfter > -1);
         if (addrInfoCount != addrInfoCountAfter) {
-            Assert.fail("AddrInfo allocation count before the test: " + addrInfoCount +", after the test: " + addrInfoCountAfter);
+            Assert.fail("AddrInfo allocation count before the test: " + addrInfoCount + ", after the test: " + addrInfoCountAfter);
         }
 
         int sockAddrCountAfter = Net.getAllocatedSockAddrCount();
         Assert.assertTrue(sockAddrCountAfter > -1);
         if (sockAddrCount != sockAddrCountAfter) {
-            Assert.fail("SockAddr allocation count before the test: " + sockAddrCount +", after the test: " + sockAddrCountAfter);
+            Assert.fail("SockAddr allocation count before the test: " + sockAddrCount + ", after the test: " + sockAddrCountAfter);
         }
     }
 


### PR DESCRIPTION
With this change, instance log alerting can be based on ` C ` (critical log level) entries instead of ` E ` (error level) which produces lots of false positives.

cc @mariusgheorghies 

Also removes unused `Log#isDebugEnabled()` method and improves code style slightly.