### PR TITLE
fix(sql): LatestByValueFilteredRecordCursor to initialize filter before use

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueFilteredRecordCursor.java
@@ -82,9 +82,9 @@ class LatestByValueFilteredRecordCursor extends AbstractDataFrameRecordCursor {
         this.dataFrameCursor = dataFrameCursor;
         this.recordA.of(dataFrameCursor.getTableReader());
         this.recordB.of(dataFrameCursor.getTableReader());
+        filter.init(this, executionContext);
         findRecord();
         hasNext = !empty;
-        filter.init(this, executionContext);
     }
 
     private void findRecord() {

--- a/core/src/test/java/io/questdb/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/griffin/TimestampQueryTest.java
@@ -44,6 +44,20 @@ import java.util.stream.Stream;
 
 public class TimestampQueryTest extends AbstractGriffinTest {
 
+    @Test
+    public void testSymbolInPredicate_singleElement() throws Exception {
+        assertMemoryLeak(() -> {
+            String createStmt = "CREATE table trades(symbol symbol, side symbol, timestamp timestamp) timestamp(timestamp);";
+            compiler.compile(createStmt, sqlExecutionContext);
+            executeInsert("insert into trades VALUES ('BTC', 'buy', 1609459199000000);");
+            String expected = "symbol\tside\ttimestamp\n" +
+                    "BTC\tbuy\t2020-12-31T23:59:59.000000Z\n";
+            String query = "SELECT * FROM trades\n" +
+                    "WHERE symbol in ('BTC') and side in 'buy'\n" +
+                    "LATEST ON timestamp PARTITION BY symbol;";
+            assertSql(query, expected);
+        });
+    }
 
     @Test
     public void testCast2AsValidColumnNameTouchFunction() throws Exception {

--- a/core/src/test/java/io/questdb/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/griffin/TimestampQueryTest.java
@@ -45,21 +45,6 @@ import java.util.stream.Stream;
 public class TimestampQueryTest extends AbstractGriffinTest {
 
     @Test
-    public void testSymbolInPredicate_singleElement() throws Exception {
-        assertMemoryLeak(() -> {
-            String createStmt = "CREATE table trades(symbol symbol, side symbol, timestamp timestamp) timestamp(timestamp);";
-            compiler.compile(createStmt, sqlExecutionContext);
-            executeInsert("insert into trades VALUES ('BTC', 'buy', 1609459199000000);");
-            String expected = "symbol\tside\ttimestamp\n" +
-                    "BTC\tbuy\t2020-12-31T23:59:59.000000Z\n";
-            String query = "SELECT * FROM trades\n" +
-                    "WHERE symbol in ('BTC') and side in 'buy'\n" +
-                    "LATEST ON timestamp PARTITION BY symbol;";
-            assertSql(query, expected);
-        });
-    }
-
-    @Test
     public void testCast2AsValidColumnNameTouchFunction() throws Exception {
         assertMemoryLeak(() -> {
             //create table


### PR DESCRIPTION
Otherwise, it throws a NPE:
```
java.lang.NullPointerException
	at io.questdb/io.questdb.griffin.engine.functions.bool.InSymbolFunctionFactory$Func.getBool(InSymbolFunctionFactory.java:125)
	at io.questdb/io.questdb.griffin.engine.table.LatestByValueFilteredRecordCursor.findRecord(LatestByValueFilteredRecordCursor.java:102)
	at io.questdb/io.questdb.griffin.engine.table.LatestByValueFilteredRecordCursor.of(LatestByValueFilteredRecordCursor.java:86)
	at io.questdb/io.questdb.griffin.engine.table.LatestByValueFilteredRecordCursorFactory.getCursorInstance(LatestByValueFilteredRecordCursorFactory.java:73)
	at io.questdb/io.questdb.griffin.engine.table.AbstractDataFrameRecordCursorFactory.getCursor(AbstractDataFrameRecordCursorFactory.java:54)
	at io.questdb/io.questdb.griffin.engine.table.LatestByValueFilteredRecordCursorFactory.getCursor(LatestByValueFilteredRecordCursorFactory.java:35)
	at io.questdb/io.questdb.test.tools.TestUtils.printSql(TestUtils.java:920)
```

Reported on [slack](https://questdb.slack.com/archives/C1NFJEER0/p1656704854347119?thread_ts=1656689858.836469&cid=C1NFJEER0)