### PR TITLE
Non-blocking interactive mode for parallel imports

### DIFF
--- a/core/src/main/java/io/questdb/MessageBus.java
+++ b/core/src/main/java/io/questdb/MessageBus.java
@@ -26,6 +26,7 @@ package io.questdb;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
+import io.questdb.cutlass.text.TextImportRequestTask;
 import io.questdb.cutlass.text.TextImportTask;
 import io.questdb.mp.*;
 import io.questdb.tasks.*;
@@ -119,5 +120,17 @@ public interface MessageBus extends Closeable {
 
     SCSequence getTextImportColSeq();
 
-    Lock getTextImportQueueLock();
+    RingQueue<TextImportRequestTask> getTextImportRequestCollectingQueue();
+
+    Sequence getTextImportRequestCollectingPubSeq();
+
+    Sequence getTextImportRequestCollectingSubSeq();
+
+    RingQueue<TextImportRequestTask> getTextImportRequestProcessingQueue();
+
+    Sequence getTextImportRequestProcessingPubSeq();
+
+    Sequence getTextImportRequestProcessingSubSeq();
+
+    Sequence getTextImportRequestProcessingStatusSeq();
 }

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -32,6 +32,8 @@ import io.questdb.cutlass.line.udp.LineUdpReceiver;
 import io.questdb.cutlass.line.udp.LinuxMMLineUdpReceiver;
 import io.questdb.cutlass.pgwire.PGWireServer;
 import io.questdb.cutlass.text.TextImportJob;
+import io.questdb.cutlass.text.TextImportRequestCollectingJob;
+import io.questdb.cutlass.text.TextImportRequestProcessingJob;
 import io.questdb.griffin.DatabaseSnapshotAgent;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.FunctionFactoryCache;
@@ -227,6 +229,12 @@ public class ServerMain {
             workerPool.assign(new GroupByJob(cairoEngine.getMessageBus()));
             workerPool.assign(new LatestByAllIndexedJob(cairoEngine.getMessageBus()));
             workerPool.assign(new TextImportJob(cairoEngine.getMessageBus()));
+
+            TextImportRequestCollectingJob textImportRequestJob = new TextImportRequestCollectingJob(cairoEngine, functionFactoryCache);
+            TextImportRequestProcessingJob textImportRequestProcessJob = new TextImportRequestProcessingJob(cairoEngine, configuration.getWorkerPoolConfiguration().getWorkerCount() - 4);
+            workerPool.assign(textImportRequestJob);
+            workerPool.assign(textImportRequestProcessJob);
+            workerPool.freeOnHalt(textImportRequestJob);
 
             instancesToClean.add(createHttpServer(workerPool, log, cairoEngine, functionFactoryCache, snapshotAgent, metrics));
             instancesToClean.add(createMinHttpServer(workerPool, log, cairoEngine, functionFactoryCache, snapshotAgent, metrics));

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -562,6 +562,7 @@ public class ServerMain {
     }
 
     protected static void shutdownQuestDb(final WorkerPool workerPool, final ObjList<? extends Closeable> instancesToClean) {
+        ShutdownFlag.INSTANCE.shutdown();
         workerPool.halt();
         Misc.freeObjList(instancesToClean);
     }

--- a/core/src/main/java/io/questdb/ShutdownFlag.java
+++ b/core/src/main/java/io/questdb/ShutdownFlag.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public enum ShutdownFlag {
+    INSTANCE;
+    private final AtomicBoolean flag = new AtomicBoolean(false);
+    public void shutdown() { flag.set(true); }
+    public boolean isShutdown() { return  flag.get(); }
+}

--- a/core/src/main/java/io/questdb/cutlass/text/CancellationToken.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CancellationToken.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.text;
+
+import io.questdb.ShutdownFlag;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CancellationToken {
+    private final AtomicBoolean canceledFlag = new AtomicBoolean(false);
+
+    public boolean isCanceled() {
+        return canceledFlag.get() || ShutdownFlag.INSTANCE.isShutdown();
+    }
+
+    public void reset() {
+        canceledFlag.set(false);
+    }
+
+    public void cancel() {
+        canceledFlag.set(true);
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/text/TextImportRequestCollectingJob.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextImportRequestCollectingJob.java
@@ -1,0 +1,321 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.text;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.*;
+import io.questdb.griffin.engine.ops.UpdateOperation;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.mp.RingQueue;
+import io.questdb.mp.SCSequence;
+import io.questdb.mp.Sequence;
+import io.questdb.mp.SynchronizedJob;
+import io.questdb.std.*;
+import io.questdb.std.datetime.microtime.MicrosecondClock;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.*;
+
+public class TextImportRequestCollectingJob extends SynchronizedJob implements Closeable {
+    private static final Log LOG = LogFactory.getLog(TextImportRequestCollectingJob.class);
+    private static final int TIMESTAMP_COLUMN = 0;
+    private static final int TABLE_NAME_COLUMN = 1;
+    private static final int FILE_NAME_COLUMN = 2;
+    private static final int HEADER_COLUMN = 3;
+    private static final int TIMESTAMP_COLUMN_NAME_COLUMN = 4;
+    private static final int FIELD_DELIMITER_COLUMN = 5;
+    private static final int TIMESTAMP_FORMAT_COLUMN = 6;
+    private static final int TABLE_PARTITION_BY_COLUMN = 7;
+    private static final int STATUS_COLUMN = 8;
+    private static final int COMPLETED_COLUMN = 9;
+
+    private final String backlogTableName;
+    private final RingQueue<TextImportRequestTask> requestCollectingQueue;
+    private final Sequence requestCollectingSubSeq;
+    private final Sequence requestProcessingStatusSeq;
+    private final RingQueue<TextImportRequestTask> requestProcessingQueue;
+    private final Sequence requestProcessingPubSeq;
+
+    private final MicrosecondClock clock;
+    private SqlCompiler sqlCompiler;
+    private TableWriter writer;
+    private SqlExecutionContextImpl sqlExecutionContext;
+    private final ArrayDeque<TextImportRequestTask> pendingRequests;
+
+    private final WeakMutableObjectPool<TextImportRequestTask> taskPool;
+    private final SCSequence eventSubSequence = new SCSequence();
+
+    private final CharSequenceObjHashMap<CancellationToken> inProgressRequests;
+    private final CharSequenceHashSet cancelledRequests;
+
+    public TextImportRequestCollectingJob(final CairoEngine engine, @Nullable FunctionFactoryCache functionFactoryCache) throws SqlException {
+        CairoConfiguration configuration = engine.getConfiguration();
+        this.clock = configuration.getMicrosecondClock();
+        this.backlogTableName = configuration.getSystemTableNamePrefix() + "parallel_text_import_log";
+
+        this.requestCollectingQueue = engine.getMessageBus().getTextImportRequestCollectingQueue();
+        this.requestCollectingSubSeq = engine.getMessageBus().getTextImportRequestCollectingSubSeq();
+
+        this.requestProcessingQueue = engine.getMessageBus().getTextImportRequestProcessingQueue();
+        this.requestProcessingPubSeq = engine.getMessageBus().getTextImportRequestProcessingPubSeq();
+        this.requestProcessingStatusSeq = engine.getMessageBus().getTextImportRequestProcessingStatusSeq();
+
+        this.sqlCompiler = new SqlCompiler(engine, functionFactoryCache, null);
+        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, 1);
+        this.sqlExecutionContext.with(AllowAllCairoSecurityContext.INSTANCE, null, null);
+        this.sqlCompiler.compile(
+                "CREATE TABLE IF NOT EXISTS \"" + backlogTableName + "\" (" +
+                        "ts timestamp, " + // 0
+                        "table_name symbol, " + // 1
+                        "file_name symbol, " + // 2
+                        "header boolean, " + // 3
+                        "timestamp_column_name symbol, " + // 4
+                        "field_delimiter byte, " + // 5
+                        "timestamp_format symbol, " + // 6
+                        "table_partition_by int, " + // 7
+                        "status symbol, " + // 8
+                        "completed timestamp" + // 9
+                        ") timestamp(ts) partition by MONTH",
+                sqlExecutionContext
+        );
+        this.writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, backlogTableName, "QuestDB system");
+        final int requestCapacity = requestCollectingQueue.getCycle() * 2;
+        this.pendingRequests = new ArrayDeque<>(requestCapacity);
+        this.taskPool = new WeakMutableObjectPool<>(TextImportRequestTask::new, requestCapacity);
+        this.inProgressRequests = new CharSequenceObjHashMap<>(requestCapacity);
+        this.cancelledRequests = new CharSequenceHashSet();
+        loadRequestsBacklog();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.writer = Misc.free(this.writer);
+        this.sqlCompiler = Misc.free(sqlCompiler);
+        this.sqlExecutionContext = Misc.free(sqlExecutionContext);
+    }
+
+    @Override
+    protected boolean runSerially() {
+        try {
+            boolean requestUseful = processIncomingRequestsQueue();
+            boolean dispatchUseful = dispatchPendingRequests();
+            boolean statusUseful = processStatus();
+            return statusUseful || dispatchUseful || requestUseful;
+        } catch (Throwable th) {
+            return false;
+        }
+    }
+
+    private boolean processIncomingRequestsQueue() {
+        boolean useful = false;
+        while (true) {
+            long cursor = requestCollectingSubSeq.next();
+
+            if (cursor < 0) {
+                break;
+            }
+
+            TextImportRequestTask task = requestCollectingQueue.get(cursor);
+            String tableName = task.getTableName();
+            if (task.getStatus() == TextImportTask.STATUS_CANCEL) {
+                if (pendingRequests.contains(task)) {
+                    cancelledRequests.add(tableName);
+                } else {
+                    CancellationToken token = inProgressRequests.get(tableName);
+                    if (token != null) {
+                        token.cancel();
+                        inProgressRequests.remove(tableName);
+                    } else {
+                        LOG.error().$("cannot cancel import request for table[").$(tableName).$("]").$();
+                    }
+                }
+            } else {
+                if (!(pendingRequests.contains(task) || inProgressRequests.contains(tableName))) {
+                    TextImportRequestTask newTask = taskPool.pop();
+                    newTask.copyFrom(task);
+                    appendToTableBacklog(newTask);
+                    pendingRequests.add(newTask);
+                }
+            }
+
+            requestCollectingSubSeq.done(cursor);
+            useful = true;
+        }
+
+        commit();
+        return useful;
+    }
+
+    private void commit() {
+        try {
+            if (writer != null) {
+                writer.commit();
+            }
+        } catch (Throwable th) {
+            LOG.error().$("error saving to parallel import house keeping log, cannot commit")
+                    .$(", releasing writer and stop updating log [table=").$(backlogTableName)
+                    .$(", error=").$(th)
+                    .I$();
+            writer = Misc.free(writer);
+        }
+    }
+
+    private boolean dispatchPendingRequests() {
+        boolean useful = false;
+        while (pendingRequests.size() > 0) {
+            TextImportRequestTask pendingTask = pendingRequests.peek();
+            String tableName = pendingTask.getTableName();
+            // do not dispatch cancelled requests
+            if (cancelledRequests.contains(tableName)) {
+                cancelledRequests.remove(tableName);
+                pendingRequests.poll();
+                taskPool.push(pendingTask);
+                String statusName = TextImportTask.getStatusName(TextImportTask.STATUS_CANCEL);
+                updateRequestStatus(tableName, statusName);
+                continue;
+            }
+            long cursor = requestProcessingPubSeq.next();
+            if (cursor > -1) {
+                TextImportRequestTask task = requestProcessingQueue.get(cursor);
+                task.copyFrom(pendingTask);
+                task.setStatus(TextImportTask.STATUS_OK);
+                CancellationToken token = task.getCancellationToken();
+                token.reset();
+                inProgressRequests.put(tableName, token);
+                requestProcessingPubSeq.done(cursor);
+                pendingRequests.poll();
+                taskPool.push(pendingTask);
+                useful = true;
+            } else {
+                break;
+            }
+        }
+        return useful;
+    }
+
+    private boolean processStatus() {
+        boolean useful = false;
+        while (true) {
+            long cursor = requestProcessingStatusSeq.next();
+            if (cursor > -1) {
+                TextImportRequestTask finishedTask = requestProcessingQueue.get(cursor);
+                String tableName = finishedTask.getTableName();
+                updateRequestStatus(tableName, TextImportTask.getStatusName(finishedTask.getStatus()));
+                inProgressRequests.remove(tableName);
+                if (finishedTask.getStatus() == TextImportTask.STATUS_CANCEL) {
+                    cancelledRequests.remove(tableName);
+                }
+                requestProcessingStatusSeq.done(cursor);
+                useful = true;
+            } else {
+                break;
+            }
+        }
+        return useful;
+    }
+
+    private void updateRequestStatus(final CharSequence tableName, final CharSequence status) {
+        CharSequence query = "UPDATE \"" + backlogTableName + "\" SET completed = now(), status = '" + status + "' WHERE table_name = '" + tableName + "' and completed = null";
+        try {
+            CompiledQuery cq = sqlCompiler.compile(query, sqlExecutionContext);
+            try (UpdateOperation op = cq.getUpdateOperation();
+                 OperationFuture fut = cq.getDispatcher().execute(op, sqlExecutionContext, eventSubSequence)
+            ) {
+                writer.tick();
+                fut.await();
+            }
+        } catch (SqlException e) {
+            LOG.error().$("failed to update parallel import log table").$((Throwable)e).$();
+        }
+    }
+
+    private void loadRequestsBacklog() {
+        try {
+            CompiledQuery reloadQuery = sqlCompiler.compile(
+                    "SELECT * FROM \"" + backlogTableName + "\" WHERE completed = null",
+                    sqlExecutionContext
+            );
+
+            try (RecordCursorFactory recordCursorFactory = reloadQuery.getRecordCursorFactory()) {
+                assert recordCursorFactory.supportsUpdateRowId(backlogTableName);
+                try (RecordCursor records = recordCursorFactory.getCursor(sqlExecutionContext)) {
+                    Record rec = records.getRecord();
+                    while (records.hasNext()) {
+                        String tableName = Chars.toString(rec.getSym(TABLE_NAME_COLUMN));
+                        String fileName = Chars.toString(rec.getSym(FILE_NAME_COLUMN));
+                        boolean headerFlag = rec.getBool(HEADER_COLUMN);
+                        String timestampColumnName = Chars.toString(rec.getSym(TIMESTAMP_COLUMN_NAME_COLUMN));
+                        byte delimiter = rec.getByte(FIELD_DELIMITER_COLUMN);
+                        String timestampFormat = Chars.toString(rec.getSym(TIMESTAMP_FORMAT_COLUMN));
+                        int partition_by = rec.getInt(TABLE_PARTITION_BY_COLUMN);
+
+                        TextImportRequestTask task = taskPool.pop();
+                        task.of(tableName, fileName, headerFlag, timestampColumnName, delimiter, timestampFormat, partition_by);
+                        pendingRequests.add(task);
+                    }
+                }
+            }
+            if ( pendingRequests.size() == 0 && writer != null) {
+                // No tasks to do. Cleanup the log table
+                try {
+                    writer.truncate();
+                } catch (Throwable th) {
+                    LOG.error().$("failed to truncate parallel import log table").$(th).$();
+                }
+            }
+        } catch (SqlException e) {
+            LOG.error().$("failed to reload parallel import tasks").$((Throwable) e).$();
+        }
+    }
+
+    private void appendToTableBacklog(final TextImportRequestTask task) {
+        if (writer != null) {
+            try {
+                TableWriter.Row row = writer.newRow(clock.getTicks());
+                row.putSym(TABLE_NAME_COLUMN, task.getTableName());
+                row.putSym(FILE_NAME_COLUMN, task.getFileName());
+                row.putBool(HEADER_COLUMN, task.isHeaderFlag());
+                row.putSym(TIMESTAMP_COLUMN_NAME_COLUMN, task.getTimestampColumnName());
+                row.putByte(FIELD_DELIMITER_COLUMN, task.getDelimiter());
+                row.putSym(TIMESTAMP_FORMAT_COLUMN, task.getTimestampFormat());
+                row.putInt(TABLE_PARTITION_BY_COLUMN, task.getPartitionBy());
+                row.append();
+            } catch (Throwable th) {
+                LOG.error().$("error saving to parallel import house keeping log, unable to insert")
+                        .$(", releasing writer and stop updating log [table=").$(backlogTableName)
+                        .$(", error=").$(th)
+                        .I$();
+                writer = Misc.free(writer);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/text/TextImportRequestProcessingJob.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextImportRequestProcessingJob.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.text;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.mp.RingQueue;
+import io.questdb.mp.Sequence;
+import io.questdb.mp.SynchronizedJob;
+
+public class TextImportRequestProcessingJob extends SynchronizedJob {
+    private static final Log LOG = LogFactory.getLog(TextImportRequestProcessingJob.class);
+
+    private final RingQueue<TextImportRequestTask> requestProcessQueue;
+    private final Sequence requestProcessSubSeq;
+    private final CairoEngine engine;
+    private final int workerCount;
+
+    public TextImportRequestProcessingJob(final CairoEngine engine, int workerCount) {
+        this.engine = engine;
+        this.workerCount = workerCount;
+        this.requestProcessQueue = engine.getMessageBus().getTextImportRequestProcessingQueue();
+        this.requestProcessSubSeq = engine.getMessageBus().getTextImportRequestProcessingSubSeq();
+    }
+
+    @Override
+    protected boolean runSerially() {
+        long cursor = requestProcessSubSeq.next();
+        if (cursor > -1) {
+            TextImportRequestTask task = requestProcessQueue.get(cursor);
+            ParallelCsvFileImporter loader = new ParallelCsvFileImporter(engine, workerCount, task.getCancellationToken());
+            try {
+                loader.of(
+                        task.getTableName(),
+                        task.getFileName(),
+                        task.getPartitionBy(),
+                        task.getDelimiter(),
+                        task.getTimestampColumnName(),
+                        task.getTimestampFormat(),
+                        task.isHeaderFlag()
+                );
+                loader.process();
+            } catch (TextException e) {
+                LOG.error().$((Throwable)e).$();
+            } finally {
+                task.setStatus(loader.getStatus());
+                requestProcessSubSeq.done(cursor);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/text/TextImportRequestTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextImportRequestTask.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.text;
+
+import io.questdb.std.Mutable;
+
+public class TextImportRequestTask implements Mutable {
+    private byte status = TextImportTask.STATUS_OK;
+    private final CancellationToken cancellationToken = new CancellationToken();
+
+    private String tableName;
+    private String fileName;
+    private boolean headerFlag;
+    private String timestampColumnName;
+    private byte delimiter;
+    private String timestampFormat;
+    private int partitionBy;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TextImportRequestTask task = (TextImportRequestTask) o;
+
+        return tableName.equals(task.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return tableName.hashCode();
+    }
+
+    public byte getStatus() {
+        return status;
+    }
+
+    public void setStatus(byte status) {
+        this.status = status;
+    }
+
+    public CancellationToken getCancellationToken() {
+        return cancellationToken;
+    }
+
+    public void of(String tableName) {
+        this.clear();
+        this.tableName = tableName;
+        this.setStatus(TextImportTask.STATUS_CANCEL);
+    }
+
+    public void of(String tableName,
+                   String fileName,
+                   boolean headerFlag,
+                   String timestampColumnName,
+                   byte delimiter,
+                   String timestampFormat,
+                   int partition_by
+    ) {
+        this.clear();
+        this.tableName = tableName;
+        this.fileName = fileName;
+        this.headerFlag = headerFlag;
+        this.timestampColumnName = timestampColumnName;
+        this.delimiter = delimiter;
+        this.timestampFormat = timestampFormat;
+        this.partitionBy = partition_by;
+    }
+
+    public void copyFrom(final TextImportRequestTask other) {
+        this.tableName = other.tableName;
+        this.fileName = other.fileName;
+        this.headerFlag = other.headerFlag;
+        this.timestampColumnName = other.timestampColumnName;
+        this.delimiter = other.delimiter;
+        this.timestampFormat = other.timestampFormat;
+        this.partitionBy = other.partitionBy;
+    }
+
+    @Override
+    public void clear() {
+        this.tableName = null;
+        this.fileName = null;
+        this.headerFlag = false;
+        this.timestampColumnName = null;
+        this.delimiter = 0;
+        this.timestampFormat = null;
+        this.partitionBy = -1;
+        this.status = TextImportTask.STATUS_OK;
+    }
+
+    public byte getDelimiter() {
+        return delimiter;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getPartitionBy() {
+        return partitionBy;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getTimestampColumnName() {
+        return timestampColumnName;
+    }
+
+    public String getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    public boolean isHeaderFlag() {
+        return headerFlag;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -32,10 +32,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
-import io.questdb.cutlass.text.Atomicity;
-import io.questdb.cutlass.text.ParallelCsvFileImporter;
-import io.questdb.cutlass.text.TextException;
-import io.questdb.cutlass.text.TextLoader;
+import io.questdb.cutlass.text.*;
 import io.questdb.griffin.engine.functions.cast.CastCharToStrFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastStrToGeoHashFunctionFactory;
 import io.questdb.griffin.engine.functions.catalogue.*;
@@ -47,6 +44,8 @@ import io.questdb.griffin.engine.table.TableListRecordCursorFactory;
 import io.questdb.griffin.model.*;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.mp.RingQueue;
+import io.questdb.mp.Sequence;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.std.*;
@@ -1858,28 +1857,38 @@ public class SqlCompiler implements Closeable {
 
     private void copyTable(SqlExecutionContext executionContext, CopyModel model) throws SqlException {
         try {
+            int workerCount = executionContext.getWorkerCount();
+            if (workerCount > 1 && model.isCancel()) {
+                addTextImportRequest(model, null);
+                return;
+            }
+
             int len = configuration.getSqlCopyBufferSize();
             long buf = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);
             try {
-                final CharSequence name = GenericLexer.assertNoDots(GenericLexer.unquote(model.getFileName().token), model.getFileName().position);
+                final CharSequence fileName = GenericLexer.assertNoDots(GenericLexer.unquote(model.getFileName().token), model.getFileName().position);
 
-                if (model.isParalell()) {
+                setupTextLoaderFromModel(model);
+                if (model.isParallel()) {
                     if (model.getTimestampFormat() == null) {
                         model.setTimestampFormat("yyyy-MM-ddTHH:mm:ss.SSSUUUZ");
                     }
                     if (model.getDelimiter() < 0) {
                         model.setDelimiter((byte) ',');
                     }
-
-                    try (ParallelCsvFileImporter loader = new ParallelCsvFileImporter(executionContext)) {
-                        loader.of(model.getTableName().token, name, model.getPartitionBy(), model.getDelimiter(), model.getTimestampColumnName(), model.getTimestampFormat(), model.isHeader(), model.getAtomicity());
-                        loader.process();
+                    //todo: how to make this interactive with the only one thread available?
+                    if (workerCount > 1) {
+                        addTextImportRequest(model, fileName);
+                    } else {
+                        try (ParallelCsvFileImporter loader = new ParallelCsvFileImporter(executionContext.getCairoEngine(), workerCount, null)) {
+                            loader.of(model.getTableName().token, fileName, model.getPartitionBy(), model.getDelimiter(), model.getTimestampColumnName(), model.getTimestampFormat(), model.isHeader(), model.getAtomicity());
+                            loader.process();
+                        }
                     }
-
                     return;
                 }
 
-                path.of(configuration.getInputRoot()).concat(name).$();
+                path.of(configuration.getInputRoot()).concat(fileName).$();
                 long fd = ff.openRO(path);
                 try {
                     if (fd == -1) {
@@ -1916,6 +1925,42 @@ public class SqlCompiler implements Closeable {
         } catch (TextException e) {
             LOG.error().$((Throwable) e).$();
             throw SqlException.$(0, e.getMessage());
+        }
+    }
+
+    private void addTextImportRequest(CopyModel model, @Nullable CharSequence fileName) {
+        Sequence textImportPubSeq = messageBus.getTextImportRequestCollectingPubSeq();
+        RingQueue<TextImportRequestTask> textImportRequestQueue = messageBus.getTextImportRequestCollectingQueue();
+        while (true) {
+            long cursor = textImportPubSeq.next();
+
+            if (cursor < -1) {
+                Os.pause();
+                continue;
+            }
+
+            if (cursor < 0) {
+                LOG.error().$("Text import request queue is full.").$();
+                return;
+            }
+
+            TextImportRequestTask task = textImportRequestQueue.get(cursor);
+            CharSequence tableName = GenericLexer.unquote(model.getTableName().token);
+            if (model.isCancel()) {
+                task.of(tableName.toString());
+            } else {
+                assert fileName != null;
+                task.of(tableName.toString(),
+                        fileName.toString(),
+                        model.isHeader(),
+                        model.getTimestampColumnName().toString(),
+                        model.getDelimiter(),
+                        model.getTimestampFormat().toString(),
+                        model.getPartitionBy());
+            }
+
+            textImportPubSeq.done(cursor);
+            return;
         }
     }
 
@@ -2106,8 +2151,8 @@ public class SqlCompiler implements Closeable {
 
     @NotNull
     private CompiledQuery executeCopy(SqlExecutionContext executionContext, CopyModel executionModel) throws SqlException {
-        setupTextLoaderFromModel(executionModel);
-        if (Chars.equalsLowerCaseAscii(executionModel.getFileName().token, "stdin")) {
+        if (!executionModel.isCancel() && Chars.equalsLowerCaseAscii(executionModel.getFileName().token, "stdin")) {
+            setupTextLoaderFromModel(executionModel);
             return compiledQuery.ofCopyRemote(textLoader);
         }
         copyTable(executionContext, executionModel);

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -1893,6 +1893,20 @@ public class SqlKeywords {
                 && (tok.charAt(i) | 32) == 'h';
     }
 
+    public static boolean isCancelKeyword(CharSequence tok) {
+        if (tok.length() != 6) {
+            return false;
+        }
+
+        int i = 0;
+        return (tok.charAt(i++) | 32) == 'c'
+                && (tok.charAt(i++) | 32) == 'a'
+                && (tok.charAt(i++) | 32) == 'n'
+                && (tok.charAt(i++) | 32) == 'c'
+                && (tok.charAt(i++) | 32) == 'e'
+                && (tok.charAt(i) | 32) == 'l';
+    }
+
     static {
         TIMESTAMP_PART_SET.add("microseconds");
         TIMESTAMP_PART_SET.add("milliseconds");

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -31,6 +31,7 @@ import io.questdb.cairo.TableUtils;
 import io.questdb.cutlass.text.Atomicity;
 import io.questdb.griffin.model.*;
 import io.questdb.std.*;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -430,7 +431,14 @@ public final class SqlParser {
             throw SqlException.$(lexer.lastTokenPosition(), "COPY is disabled ['cairo.sql.copy.root' is not set?]");
         }
         ExpressionNode tableName = expectExpr(lexer);
-        CharSequence tok = tok(lexer, "'from' or 'to'");
+        CharSequence tok = tok(lexer, "'from' or 'to' or 'cancel'");
+
+        if (isCancelKeyword(tok)) {
+            CopyModel model = copyModelPool.next();
+            model.setCancel(true);
+            model.setTableName(tableName);
+            return model;
+        }
 
         if (isFromKeyword(tok)) {
             final ExpressionNode fileName = expectExpr(lexer);

--- a/core/src/main/java/io/questdb/griffin/model/CopyModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/CopyModel.java
@@ -36,6 +36,7 @@ public class CopyModel implements ExecutionModel, Mutable, Sinkable {
     private boolean header;
 
     private boolean parallel;
+    private boolean cancel;
     private CharSequence timestampFormat;
     private CharSequence timestampColumnName;
     private int partitionBy;
@@ -51,6 +52,7 @@ public class CopyModel implements ExecutionModel, Mutable, Sinkable {
         fileName = null;
         header = false;
         parallel = false;
+        cancel = false;
         timestampFormat = null;
         timestampColumnName = null;
         partitionBy = -1;
@@ -123,6 +125,10 @@ public class CopyModel implements ExecutionModel, Mutable, Sinkable {
         this.parallel = parallel;
     }
 
+    public void setCancel(boolean cancel) {
+        this.cancel = cancel;
+    }
+
     public void setTimestampColumnName(CharSequence timestampColumn) {
         this.timestampColumnName = timestampColumn;
     }
@@ -137,5 +143,9 @@ public class CopyModel implements ExecutionModel, Mutable, Sinkable {
 
     public boolean isParallel() {
         return parallel;
+    }
+
+    public boolean isCancel() {
+        return cancel;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/model/CopyModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/CopyModel.java
@@ -135,7 +135,7 @@ public class CopyModel implements ExecutionModel, Mutable, Sinkable {
     public void toSink(CharSink sink) {
     }
 
-    public boolean isParalell() {
+    public boolean isParallel() {
         return parallel;
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.CoreMatchers.*;
 
@@ -744,7 +743,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportEmptyCsv() throws Exception {
         executeWithPool(4, 16, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of("t", "test-quotes-empty.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -759,7 +758,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(16, 16, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( ts timestamp, line string, description string, d double ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -799,7 +798,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                     "  l256 long256," +
                     "  ge geohash(20b)" +
                     ") timestamp(tstmp) partition by DAY;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("alltypes", "test-alltypes-with-gaps.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
             }
@@ -838,7 +837,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                     "  l256 long256," +
                     "  ge geohash(20b)" +
                     ") timestamp(tstmp) partition by DAY;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("alltypes", "test-alltypes-with-gaps.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
             }
@@ -863,7 +862,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(8, 4, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab ( line symbol, ts timestamp, d double, description string) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -889,7 +888,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(8, 4, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab (other symbol, txt symbol, line symbol, ts timestamp, d symbol) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-small.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSZ", true);
                 indexer.process();
@@ -906,7 +905,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test//all rows in the file fail on timestamp parsing so indexing phase will return empty result
     public void testImportCsvWithTimestampNotMatchingInputFormatFails() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss", true);
                 indexer.process();
                 Assert.fail();
@@ -926,7 +925,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, ff, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -951,7 +950,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -976,7 +975,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1000,7 +999,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1029,7 +1028,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1059,7 +1058,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         };
 
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1096,7 +1095,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab ( line symbol, ts timestamp, d double, description string) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1124,7 +1123,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 8, brokenFf, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab ( line symbol, ts timestamp, d double, description string) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(1);
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1140,7 +1139,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportWithSkipAllAtomicityFailsWhenTimestampCantBeParsedAtIndexingPhase() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss", true, Atomicity.SKIP_ALL);
                 indexer.process();
                 Assert.fail();
@@ -1155,7 +1154,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab ( ts timestamp, line symbol, description double, d double ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true, Atomicity.SKIP_ROW);
                 indexer.process();
             }
@@ -1184,7 +1183,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                     "  ge geohash(20b)" +
                     ") timestamp(tstmp) partition by DAY;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("alltypes", "test-errors.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true, Atomicity.SKIP_ROW);
                 indexer.process();
             }
@@ -1220,7 +1219,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                     "  ge geohash(20b)" +
                     ") timestamp(tstmp) partition by DAY;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("alltypes", "test-errors.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true, Atomicity.SKIP_COL);
                 indexer.process();
             }
@@ -1233,7 +1232,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportCsvFromFileWithBadColumnNamesInHeaderIntoNewTableFiltersOutBadCharacters() throws Exception {
         executeWithPool(4, 16, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of("t", "test-badheadernames.csv", PartitionBy.MONTH, (byte) ',', "Ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1249,7 +1248,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportCsvIntoNewTable() throws Exception {
         executeWithPool(16, 16, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             final String tableName = "tableName";
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of(tableName, "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1276,7 +1275,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         inputRoot = new File("./src/test/resources/csv/").getAbsolutePath();
 
         try (Path path = new Path().of(inputRoot).slash().concat(fileName).$();
-             ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+             ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
             indexer.setMinChunkSize(1);
             if (bufferLen > 0) {
                 indexer.setBufferLength(bufferLen);
@@ -1380,7 +1379,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                 compiler.compile(ddl, sqlExecutionContext);
             }
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tableName", fileName, partitionBy, (byte) ',', tsCol, tsFormat, true);
                 indexer.process();
                 Assert.fail("exception expected");
@@ -1394,7 +1393,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithHeaderButInputPartitionByNotMatchingTargetTables() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table someTable ( ts timestamp, s string, d double, i int ) timestamp(ts) partition by DAY;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("someTable", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail();
@@ -1408,7 +1407,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithHeaderButPartitionByNotSpecifiedAndTargetTableIsNotPartitioned() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table someTable ( ts timestamp, s string, d double, i int ) timestamp(ts);", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("someTable", "test-quotes-big.csv", -1, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail();
@@ -1422,7 +1421,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithHeaderButTargetTableIsNotPartitioned2() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table someTable ( ts timestamp, s string, d double, i int ) timestamp(ts);", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("someTable", "test-quotes-big.csv", -1, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail();
@@ -1435,7 +1434,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportFileWithHeaderButPartitionBySetToNone() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tableName", "test-quotes-big.csv", PartitionBy.NONE, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail();
@@ -1448,7 +1447,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportFileWithHeaderButPartitionByNotSpecifiedAndTargetTableDoesntExist() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tableName", "test-quotes-big.csv", -1, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail();
@@ -1461,7 +1460,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportFileWithHeaderWhenTargetTableDoesntExistSuccess() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
 
@@ -1476,7 +1475,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( ts timestamp, line string, d double, description string ) timestamp(ts) partition by month;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", null, true);
                 indexer.process();
             }
@@ -1492,7 +1491,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
             compiler.compile("create table t ( ts timestamp, s string, d double, i int ) timestamp(ts) partition by day;", sqlExecutionContext);
             compiler.compile("insert into t select cast(x as timestamp), 'a', x, x from long_sequence(10);", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.DAY, (byte) ',', "ts", null, true);
                 indexer.process();
                 Assert.fail();
@@ -1509,7 +1508,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithNoHeaderIntoExistingTableFailsBecauseTsPositionInTableIsDifferentFromFile() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( ts timestamp, s string, d double, i int ) timestamp(ts) partition by day;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-noheader.csv", PartitionBy.DAY, (byte) ',', null, null, false);
                 indexer.process();
                 Assert.fail();
@@ -1522,7 +1521,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportFileWithNoHeaderIntoNewTableFailsBecauseTsColCantBeFoundInFileHeader() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-noheader.csv", PartitionBy.DAY, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", false);
                 indexer.process();
                 Assert.fail();
@@ -1536,7 +1535,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     //when there is no header and header is not forced then target tabel columns get following names : f0, f1, ..., fN 
     public void testImportFileWithNoHeaderIntoNewTableSucceedsBecauseSyntheticColumnNameIsUsed() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-noheader.csv", PartitionBy.DAY, (byte) ',', "f1", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", false);
                 indexer.process();
             }
@@ -1547,7 +1546,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test//it fails even though ts column name and format are specified
     public void testImportFileWithHeaderIntoNewTableFailsBecauseTsColCantBeFoundInFileHeader() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-quotes-oneline.csv", PartitionBy.DAY, (byte) ',', "ts2", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", false);
                 indexer.process();
                 Assert.fail();
@@ -1561,7 +1560,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithNoHeaderIntoExistingTableSucceedsBecauseTsPositionInTableIsSameAsInFile() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( s string, ts timestamp, d double, s2 string ) timestamp(ts) partition by day;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-noheader.csv", PartitionBy.DAY, (byte) ',', null, null, false);
                 indexer.process();
             }
@@ -1573,7 +1572,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithHeaderIntoExistingTableWhenInputColumnCountIsSmallerThanTablesSucceedsAndInsertsNullIntoMissingColumns() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( line string, ts timestamp, d double, description string, i int, l long ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
             }
@@ -1587,7 +1586,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     public void testImportFileWithHeaderIntoExistingTableFailsBecauseInputColumnCountIsLargerThanTables() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table someTable ( line string, ts timestamp, d double ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("someTable", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
                 indexer.process();
                 Assert.fail("exception expected");
@@ -1614,7 +1613,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     }
 
     private void importAllIntoNew(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) throws SqlException, TextException {
-        try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+        try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
             indexer.of("alltypes", "test-alltypes.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
             indexer.process();
         }
@@ -1682,7 +1681,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                 "  l256 long256," +
                 "  ge geohash(20b)" +
                 ") timestamp(tstmp) partition by DAY;", sqlExecutionContext);
-        try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+        try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
             indexer.of("alltypes", "test-alltypes.csv", PartitionBy.DAY, (byte) ',', "tstmp", "yyyy-MM-ddTHH:mm:ss.SSSUUUZ", true);
             indexer.process();
         }
@@ -1706,7 +1705,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 16, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table t ( ts timestamp, line string, description string, d double ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of("t", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1726,7 +1725,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
             compiler.compile("create table tab ( ts timestamp, line string, description double, d double ) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true, Atomicity.SKIP_ALL);
                 indexer.process();
                 Assert.fail();
@@ -1743,7 +1742,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
             final String tableName = "tableName";
             compiler.compile("create table " + tableName + " ( ts timestamp, line symbol, d double, description symbol) timestamp(ts) partition by MONTH;", sqlExecutionContext);
 
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+            try (ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
                 indexer.setMinChunkSize(10);
                 indexer.of(tableName, "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
                 indexer.process();
@@ -1761,41 +1760,6 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                             "line1000\t1972-09-27T00:00:00.000000Z\t0.918270255022\tdesc 1000\n",
                     "select line, ts, d, description from " + tableName + " limit -10",
                     "ts", true, false, true);
-        });
-    }
-
-    @Test
-    public void testImportOnlyOneActiveImport() throws Exception {
-        executeWithPool(8, 2, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            final String tableName = "tableName";
-            compiler.compile("create table " + tableName + " ( ts timestamp, line symbol, d double, description symbol) timestamp(ts) partition by MONTH;", sqlExecutionContext);
-            CountDownLatch latch = new CountDownLatch(1);
-            Thread importer = new Thread(() -> {
-                try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
-                    indexer.setMinChunkSize(10);
-                    indexer.of(tableName, "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
-                    indexer.processTest(latch::countDown);
-                } catch (SqlException e) {
-                    e.printStackTrace();
-                }
-                Path.clearThreadLocals();
-            });
-
-            importer.start();
-            latch.await();
-
-            try (ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
-                indexer.setMinChunkSize(10);
-                indexer.of(tableName, "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true);
-                try {
-                    indexer.process();
-                    Assert.fail();
-                } catch (SqlException e) {
-                    MatcherAssert.assertThat(e.getMessage(), containsString("Another parallel copy command in progress"));
-                }
-            }
-
-            importer.join();
         });
     }
 
@@ -1832,7 +1796,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
         inputRoot = new File("./src/test/resources/csv/").getAbsolutePath();
 
         try (Path path = new Path().of(inputRoot).slash().concat(fileName).$();
-             ParallelCsvFileImporter indexer = new ParallelCsvFileImporter(sqlExecutionContext)) {
+             ParallelCsvFileImporter indexer = new  ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount(), null)) {
             indexer.setMinChunkSize(1);
             indexer.of("table", fileName, PartitionBy.DAY, (byte) ',', "unknown", null, false);
 

--- a/core/src/test/java/io/questdb/griffin/CopyTest.java
+++ b/core/src/test/java/io/questdb/griffin/CopyTest.java
@@ -69,7 +69,7 @@ public class CopyTest extends AbstractGriffinTest {
         assertEquals("y", model.getTableName().token.toString());
         assertEquals("'somefile.csv'", model.getFileName().token.toString());
         assertFalse(model.isHeader());
-        assertTrue(model.isParalell());
+        assertTrue(model.isParallel());
         assertEquals(-1, model.getPartitionBy());
         assertNull(model.getTimestampColumnName());
         assertNull(model.getTimestampFormat());
@@ -90,7 +90,7 @@ public class CopyTest extends AbstractGriffinTest {
                 assertEquals("x", model.getTableName().token.toString());
                 assertEquals("'somefile.csv'", model.getFileName().token.toString());
                 assertTrue(model.isHeader());
-                assertTrue(model.isParalell());
+                assertTrue(model.isParallel());
                 assertEquals(partitionBy[p + 1], model.getPartitionBy());
                 assertEquals("ts1", model.getTimestampColumnName().toString());
                 assertEquals("yyyy-MM-ddTHH:mm:ss", model.getTimestampFormat().toString());


### PR DESCRIPTION
The current implementation of parallel import has several problems:

Import request blocks the web console.
Import request can be unintentionally cancelled by network circuit breaker on a broken connection or a poorly configured timeout event.
This PR introduces a non-blocking interactive mode for parallel imports.

Two queues and processing jobs were added, as well as a persistent backlog of requests.

MPSC import requests accepting queue.
SPSC import requests processing queue.
sys.parallel_text_import_log as a pending imports backlog
A pending import request can be cancelled with a custom copy tableName cancel; command using tableName as a request ID.
A new import request for tableName is simply ignored if there is another pending request in the backlog for tableName.