### PR TITLE
fix(cairo): fix issue when SELECTS do not see committed data

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -408,7 +408,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         }
     }
 
-   public boolean reload() {
+    public boolean reload() {
         if (acquireTxn()) {
             return false;
         }
@@ -456,11 +456,16 @@ public class TableReader implements Closeable, SymbolTableSource {
             }
         }
 
-        // We have to be sure last txn is acquired in Scoreboard
-        // otherwise writer can delete partition version files
-        // between reading txn file and acquiring txn in the Scoreboard.
-        Unsafe.getUnsafe().loadFence();
-        return txFile.getVersion() == txFile.unsafeReadVersion();
+        // txFile can also be reloaded in goPassive->checkSchedulePurgeO3Partitions
+        // if txFile txn doesn't much reader txn, reader has to be slow reloaded
+        if (txn == txFile.getTxn()) {
+            // We have to be sure last txn is acquired in Scoreboard
+            // otherwise writer can delete partition version files
+            // between reading txn file and acquiring txn in the Scoreboard.
+            Unsafe.getUnsafe().loadFence();
+            return txFile.getVersion() == txFile.unsafeReadVersion();
+        }
+        return false;
     }
 
     private void checkSchedulePurgeO3Partitions() {

--- a/core/src/main/java/io/questdb/cairo/TxReader.java
+++ b/core/src/main/java/io/questdb/cairo/TxReader.java
@@ -362,6 +362,7 @@ public class TxReader implements Closeable, Mutable {
         attachedPartitionsSize = -1;
         attachedPartitions.clear();
         version = -1;
+        txn = -1;
     }
 
     private int findAttachedPartitionIndex(long ts) {

--- a/core/src/test/java/io/questdb/cairo/TableReadFailTest.java
+++ b/core/src/test/java/io/questdb/cairo/TableReadFailTest.java
@@ -144,8 +144,8 @@ public class TableReadFailTest extends AbstractCairoTest {
                 mem.close();
                 mem.close();
 
-                // make sure reload functions correctly
-                Assert.assertFalse(reader.reload());
+                // make sure reload functions correctly. Txn changed from 1 to 3, reload should return true
+                Assert.assertTrue(reader.reload());
 
                 try (TableWriter w = new TableWriter(configuration, "x", metrics)) {
                     // add more data


### PR DESCRIPTION
`TableReader` may miss last transaction on reload when it is taken from `ReaderPool`. This happens when the updated transaction record is read before returning to the pool at which point reader does not reload it's state according to the newly read transaction.

The outcome is that reader doesn't see the data of last transaction regardless how many time it's reloaded. For the end user adding few lines to the table using ILP these lines can be invisible until the server restart or another transaction committed.