### PR TITLE
chore(ilp): removing dumpBuffer()

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -422,7 +422,7 @@ public final class ColumnType {
         TYPE_SIZE_POW2[INT] = 2;
         TYPE_SIZE_POW2[SYMBOL] = 2;
         TYPE_SIZE_POW2[DOUBLE] = 3;
-        TYPE_SIZE[STRING] = -1;
+        TYPE_SIZE_POW2[STRING] = -1;
         TYPE_SIZE_POW2[LONG] = 3;
         TYPE_SIZE_POW2[DATE] = 3;
         TYPE_SIZE_POW2[TIMESTAMP] = 3;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -35,7 +35,6 @@ import io.questdb.network.NetworkFacade;
 import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.DirectByteCharSequence;
-import io.questdb.std.str.StringSink;
 
 class LineTcpConnectionContext implements IOContext, Mutable {
     private static final Log LOG = LogFactory.getLog(LineTcpConnectionContext.class);
@@ -46,8 +45,6 @@ class LineTcpConnectionContext implements IOContext, Mutable {
     private final MillisecondClock milliClock;
     private final DirectByteCharSequence byteCharSequence = new DirectByteCharSequence();
     private final LineTcpParser parser;
-    private final DirectBinarySequence binarySequence = new DirectBinarySequence();
-    private final StringSink stringSink = new StringSink();
     private final boolean disconnectOnError;
     protected long fd;
     protected IODispatcher<LineTcpConnectionContext> dispatcher;
@@ -93,15 +90,6 @@ class LineTcpConnectionContext implements IOContext, Mutable {
     @Override
     public boolean invalid() {
         return fd == -1;
-    }
-
-    @Override
-    public void dumpBuffer() {
-        if (recvBufPos > recvBufStart) {
-            stringSink.clear();
-            Chars.toSink(binarySequence.of(recvBufStart, recvBufPos - recvBufStart), stringSink);
-            LOG.error().$('[').$(fd).$("] data remained in buffer: [").$(stringSink).$(']').$();
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -263,7 +263,6 @@ public abstract class AbstractIODispatcher<C extends IOContext> extends Synchron
         if (context == null || context.invalid()) {
             return;
         }
-        context.dumpBuffer();
 
         final long fd = context.getFd();
         LOG.info()

--- a/core/src/main/java/io/questdb/network/IOContext.java
+++ b/core/src/main/java/io/questdb/network/IOContext.java
@@ -34,8 +34,5 @@ public interface IOContext extends Closeable {
 
     boolean invalid();
 
-    default void dumpBuffer() {
-    }
-
     IODispatcher<?> getDispatcher();
 }


### PR DESCRIPTION
Removing the piece of code checking if anything left in the buffer unprocessed when ILP disconnect happens.
This check was put in place hoping it will help to find the root cause of ILP fuzz test timeouts but it did not help.
Instead now it is causing trouble because when ILP authentication fails the buffer is not compacted.
We can see a misleading error on the log after every ILP auth failure.

