### PR TITLE
fix(core): Parse negative zero

### DIFF
--- a/core/src/main/java/io/questdb/std/Numbers.java
+++ b/core/src/main/java/io/questdb/std/Numbers.java
@@ -693,11 +693,8 @@ public final class Numbers {
             exp = -308;
         }
 
-        if (exp > -1) {
-            return (negative ? -val : val) * pow10d[exp];
-        } else {
-            return (negative ? -val : val) / pow10d[-exp];
-        }
+        double v = exp > -1 ? val * pow10d[exp] : val / pow10d[-exp];
+        return negative ? -v : v;
     }
 
     public static float parseFloat(CharSequence sequence) throws NumericException {
@@ -788,11 +785,8 @@ public final class Numbers {
             exp = -38;
         }
 
-        if (exp > 0) {
-            return (negative ? -val : val) * pow10f[exp];
-        } else {
-            return (negative ? -val : val) / pow10f[-exp];
-        }
+        float v = exp > 0 ? val * pow10f[exp] : val / pow10f[-exp];
+        return negative ? -v : v;
     }
 
     public static int parseHexInt(CharSequence sequence) throws NumericException {

--- a/core/src/test/java/io/questdb/std/NumbersTest.java
+++ b/core/src/test/java/io/questdb/std/NumbersTest.java
@@ -906,4 +906,28 @@ public class NumbersTest {
         int x = Numbers.bswap(expected);
         Assert.assertEquals(expected, Numbers.bswap(x));
     }
+
+    @Test
+    public void testParseDoubleNegativeZero() throws NumericException {
+        double actual = Numbers.parseDouble("-0.0");
+
+        //check it's zero at all
+        Assert.assertEquals(0, actual, 0.0);
+
+        //check it's *negative* zero
+        double res = 1 / actual;
+        Assert.assertEquals(Double.NEGATIVE_INFINITY, res, 0.0);
+    }
+
+    @Test
+    public void testParseFloatNegativeZero() throws NumericException {
+        float actual = Numbers.parseFloat("-0.0");
+
+        //check it's zero at all
+        Assert.assertEquals(0, actual, 0.0);
+
+        //check it's *negative* zero
+        float res = 1 / actual;
+        Assert.assertEquals(Float.NEGATIVE_INFINITY, res, 0.0);
+    }
 }


### PR DESCRIPTION
The negative sign has to be applied to a double.
The original code applied the sign to long. Which means negative zero was parsed as non-negative zero.