### PR TITLE
chore: Our own ThreadLocal does not allocate new instance when closing

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -625,7 +625,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 this.pgCharacterStoreCapacity = getInt(properties, env, PropertyKey.PG_CHARACTER_STORE_CAPACITY, 4096);
                 this.pgBinaryParamsCapacity = getInt(properties, env, PropertyKey.PG_BINARY_PARAM_COUNT_CAPACITY, 2);
                 this.pgCharacterStorePoolCapacity = getInt(properties, env, PropertyKey.PG_CHARACTER_STORE_POOL_CAPACITY, 64);
-                this.pgConnectionPoolInitialCapacity = getInt(properties, env, PropertyKey.PG_CONNECTION_POOL_CAPACITY, 64);
+                this.pgConnectionPoolInitialCapacity = getInt(properties, env, PropertyKey.PG_CONNECTION_POOL_CAPACITY, 4);
                 this.pgPassword = getString(properties, env, PropertyKey.PG_PASSWORD, "quest");
                 this.pgUsername = getString(properties, env, PropertyKey.PG_USER, "admin");
                 this.pgReadOnlySecurityContext = getBoolean(properties, env, PropertyKey.PG_SECURITY_READONLY, false);

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -413,7 +413,7 @@ public class HttpServer implements Closeable {
         }
 
         private void closeContextPool() {
-            Misc.free(this.contextPool.get());
+            Misc.free(this.contextPool);
             LOG.info().$("closed").$();
         }
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
@@ -175,7 +175,7 @@ public class LineTcpReceiver implements Closeable {
         }
 
         private void closeContextPool() {
-            Misc.free(this.contextPool.get());
+            Misc.free(this.contextPool);
             LOG.info().$("closed").$();
         }
     }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
@@ -68,7 +68,7 @@ public class DefaultPGWireConfiguration implements PGWireConfiguration {
 
     @Override
     public int getConnectionPoolInitialCapacity() {
-        return 64;
+        return 4;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
@@ -81,8 +81,11 @@ public class LimitedSizeSortedLightRecordCursorFactory extends AbstractRecordCur
 
             cursor.of(baseCursor, executionContext);
             return cursor;
-        } catch (RuntimeException ex) {
+        } catch (Throwable ex) {
             baseCursor.close();
+            if (chain != null) {
+                chain.clear();
+            }
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
@@ -67,8 +67,9 @@ public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory 
         try {
             cursor.of(baseCursor, executionContext);
             return cursor;
-        } catch (RuntimeException ex) {
+        } catch (Throwable ex) {
             baseCursor.close();
+            chain.clear();
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/std/ThreadLocal.java
+++ b/core/src/main/java/io/questdb/std/ThreadLocal.java
@@ -24,7 +24,10 @@
 
 package io.questdb.std;
 
-public class ThreadLocal<T> extends java.lang.ThreadLocal<T> {
+import java.io.Closeable;
+import java.io.IOException;
+
+public class ThreadLocal<T> extends java.lang.ThreadLocal<T> implements Closeable {
     private final ObjectFactory<T> fact;
 
     public ThreadLocal(ObjectFactory<T> fact) {
@@ -32,7 +35,18 @@ public class ThreadLocal<T> extends java.lang.ThreadLocal<T> {
     }
 
     @Override
-    protected T initialValue() {
-        return fact.newInstance();
+    public void close() throws IOException {
+        Misc.free(super.get());
+        remove();
+    }
+
+    @Override
+    public T get() {
+        T val = super.get();
+        if (val == null) {
+            val = fact.newInstance();
+            set(val);
+        }
+        return val;
     }
 }

--- a/core/src/main/java/io/questdb/std/str/Path.java
+++ b/core/src/main/java/io/questdb/std/str/Path.java
@@ -59,11 +59,8 @@ public class Path extends AbstractCharSink implements Closeable, LPSZ {
     }
 
     public static void clearThreadLocals() {
-        Misc.free(PATH.get());
-        PATH.remove();
-
-        Misc.free(PATH2.get());
-        PATH2.remove();
+        Misc.free(PATH);
+        Misc.free(PATH2);
     }
 
     public static Path getThreadLocal(CharSequence root) {


### PR DESCRIPTION
`Path.clearThreadLocals()` did not guarantee that it will not call `malloc()`, which usually happened where thread local was `null` in the first place.

Calling `malloc` on shutdown could be troublesome, because system could be shutting down because of `malloc()` failure in the first place. Shutdown code path should be free of `malloc()` calls.


Additionally:

- reduced default PG context pool size from 64 to 4. 
- replaced `RuntimeException` handling with `Throwable` and reducing size of `RecordChain` when exception occurs