### PR TITLE
fix(sql): incorrect result for negative limit query with indexed symbol filter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursor.java
@@ -113,7 +113,7 @@ class DataFrameRecordCursor extends AbstractDataFrameRecordCursor {
 
     @Override
     public void skipTo(long rowCount) {
-        if (!dataFrameCursor.supportsRandomAccess() || filter != null) {
+        if (!dataFrameCursor.supportsRandomAccess() || filter != null || rowCursorFactory.isUsingIndex()) {
             super.skipTo(rowCount);
             return;
         }
@@ -121,7 +121,7 @@ class DataFrameRecordCursor extends AbstractDataFrameRecordCursor {
         DataFrame dataFrame = dataFrameCursor.skipTo(rowCount);
         if (dataFrame != null) {
             rowCursor = rowCursorFactory.getCursor(dataFrame);
-            recordA.jumpTo(dataFrame.getPartitionIndex(), dataFrame.getRowLo()); //move to partition, rowlo doesn't matter
+            recordA.jumpTo(dataFrame.getPartitionIndex(), dataFrame.getRowLo()); // move to partition, rowlo doesn't matter
             next = nextRow;
         }
     }


### PR DESCRIPTION
Closes #2308

`DataFrameRecordCursor#skipTo()` implementation was wrongly assuming same row indexes in `dataFrameCursor` and `rowCursor` while in reality the `rowCursor` might be using an index (hence, implicitly filtering the rows).

Note: there are some optimization opportunities for such limit -N + indexed filter queries we could implement. Namely, we could potentially use a backward-direction index reader.