### PR TITLE
fix(build): fixed docker entry point exiting prematurely on chown errors

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -9,7 +9,7 @@ RUN_AS_ROOT=${RUN_AS_ROOT:-"false"}
 
 find_and_own_dir() {
     if [ "$IGNORE_FIND_AND_OWN_DIR" = "false" ]; then
-        find "$1" \( ! -user questdb -o ! -group questdb \) -exec chown questdb:questdb '{}' +
+        find "$1" \( ! -user questdb -o ! -group questdb \) -exec chown questdb:questdb '{}' \;
     fi
 }
 


### PR DESCRIPTION
find command should always return 0, useful when used in kuberenetes and we mount configmaps into conf/ directory