### PR TITLE
chore: do not fail on read-only mime.types when public does not exist

### DIFF
--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -553,7 +553,15 @@ public class ServerMain {
         }
         setPublicVersion(publicDir, thisVersion);
         copyConfResource(dir, false, buffer, "conf/date.formats", log);
-        copyConfResource(dir, true, buffer, "conf/mime.types", log);
+        try {
+            copyConfResource(dir, true, buffer, "conf/mime.types", log);
+        } catch (IOException exception) {
+            // conf can be read-only, this is not critical
+            if (exception.getMessage() == null ||
+                    (!exception.getMessage().contains("Read-only file system") && !exception.getMessage().contains("Permission denied"))) {
+                throw exception;
+            }
+        }
         copyConfResource(dir, false, buffer, "conf/server.conf", log);
         copyConfResource(dir, false, buffer, "conf/log.conf", log);
     }


### PR DESCRIPTION
`conf` directory can be mounted as read-only for security reasons. Do not fail if `mime.types` cannot be overwritten