### PR TITLE
chore(build): augment PR title validation rules

### DIFF
--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -1,6 +1,6 @@
-import { danger, fail } from "danger"
+import { danger, fail } from "danger";
 
-const supportedTypes = [
+const allowedTypes = [
   "feat",
   "fix",
   "chore",
@@ -13,24 +13,48 @@ const supportedTypes = [
   "ci",
   "chore",
   "revert",
-]
+];
+
+const allowedSubTypes = [
+  "build",
+  "sql",
+  "log",
+  "mig",
+  "core",
+  "ilp",
+  "pgwire",
+  "http",
+  "conf",
+];
+
+const failMessage = `
+Please update the PR title to match this format:
+\`type(subType): description\`
+
+Where \`type\` is one of:
+${allowedTypes.map((t) => `\`${t}\``).join(", ")}
+
+And: \`subType\` is one of:
+${allowedSubTypes.map((t) => `\`${t}\``).join(", ")}
+
+For Example:
+
+\`\`\`
+perf(sql): improve pattern matching performance for SELECT sub-queries
+\`\`\`
+`.trim();
 
 function validatePrTitle() {
-  const prTitleRegex = new RegExp(`^(${supportedTypes.join("|")})(\(.+\))?\:.*`)
+  const prTitleRegex = new RegExp(
+    `^(?:${allowedTypes.join("|")})\((?:${allowedSubTypes.join("|")})\): .*`
+  );
 
-  const { title } = danger.github.pr
+  const { title } = danger.github.pr;
   if (title.match(prTitleRegex)) {
-    return
+    return;
   }
 
-  fail(
-    [
-      "Please update the PR title.",
-      "It should match this format: *type*: *description*",
-      "Where *type* is one of\: " +
-        supportedTypes.map((type) => `"${type}"`).join(", "),
-    ].join("\n"),
-  )
+  fail(failMessage);
 }
 
-validatePrTitle()
+validatePrTitle();

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -46,7 +46,7 @@ perf(sql): improve pattern matching performance for SELECT sub-queries
 
 function validatePrTitle() {
   const prTitleRegex = new RegExp(
-    `^(?:${allowedTypes.join("|")})\((?:${allowedSubTypes.join("|")})\): .*`
+    `^(?:${allowedTypes.join("|")})\\((?:${allowedSubTypes.join("|")})\\): .*`
   );
 
   const { title } = danger.github.pr;


### PR DESCRIPTION
This PR adds more rules to `ci/dangerfile.js`.

If a contributor would submit a PR with a title which is considered
invalid by those rules, the CI would post a comment like this below:

---

Please update the PR title to match this format:
`type(subType): description`

Where `type` is one of:
`feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`

And `subType` is one of:
`build`, `sql`, `log`, `mig`, `core`, `ilp`, `pgwire`, `http`, `conf`

For Example:

```
perf(sql): improve pattern matching performance for SELECT sub-queries
```

---

same thing in screenshot:

![image](https://user-images.githubusercontent.com/4284659/181233639-ea1be323-de69-4c25-b950-8c3e241d5895.png)
