### PR TITLE
chore(sql): test speedup

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
@@ -1478,10 +1478,13 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
     @Test
     public void testImportWithSkipRowAtomicityImportsNoRowsWhenNonTimestampColumnCantBeParsed() throws Exception {
         executeWithPool(4, 8, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            compiler.compile("create table tab ( ts timestamp, line symbol, description double, d double, s symbol) timestamp(ts) partition by MONTH;", sqlExecutionContext);
+            // the StrSym should be 'symbol' and DoubleCol should be 'double'
+            // we intentionally create these columns with a wrong type so the ParallelCsvFileImporter fails to parse these columns
+            // the subsequent assert checks no row was imported - as the atomicity level is set to SKIP_ROW
+            compiler.compile("create table tab (StrSym int, Int symbol,Int_Col int, DoubleCol int,IsoDate timestamp,Fmt1Date timestamp,Fmt2Date date,Phone string,boolean boolean,long long) timestamp(IsoDate) partition by MONTH;", sqlExecutionContext);
 
             try (ParallelCsvFileImporter importer = new ParallelCsvFileImporter(engine, sqlExecutionContext.getWorkerCount())) {
-                importer.of("tab", "test-quotes-big.csv", PartitionBy.MONTH, (byte) ',', "ts", "yyyy-MM-ddTHH:mm:ss.SSSSSSZ", true, null, Atomicity.SKIP_ROW);
+                importer.of("tab", "test-import.csv", PartitionBy.MONTH, (byte) ',', "IsoDate", "yyyy-MM-ddTHH:mm:ss.SSSZ", false, null, Atomicity.SKIP_ROW);
                 importer.process();
             }
 


### PR DESCRIPTION
testImportWithSkipRowAtomicityImportsNoRowsWhenNonTimestampColumnCantBeParsed() was running 20-30s on M1. Now it's <5s.
This slowness caused a timeout on CI: we were unlucky and the test was running on a cloud box with super slow I/O.