### PR TITLE
fix(sql): inconsistency in worker count configuration for asynchronous filters

### DIFF
--- a/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
+++ b/core/src/main/java/io/questdb/WorkerPoolAwareConfiguration.java
@@ -80,8 +80,19 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
         final T server;
         if (configuration.isEnabled()) {
             final WorkerPool localPool = configureWorkerPool(configuration, sharedWorkerPool, metrics);
+            assert localPool != null;
             final boolean local = localPool != sharedWorkerPool;
-            server = factory.create(configuration, cairoEngine, localPool, local, functionFactoryCache, snapshotAgent, metrics);
+            final int sharedWorkerCount = sharedWorkerPool == null ? localPool.getWorkerCount() : sharedWorkerPool.getWorkerCount();
+            server = factory.create(
+                    configuration,
+                    cairoEngine,
+                    localPool,
+                    local,
+                    sharedWorkerCount,
+                    functionFactoryCache,
+                    snapshotAgent,
+                    metrics
+            );
 
             if (local) {
                 localPool.assignCleaner(Path.CLEANER);
@@ -102,6 +113,7 @@ public interface WorkerPoolAwareConfiguration extends WorkerPoolConfiguration {
                 CairoEngine engine,
                 WorkerPool workerPool,
                 boolean local,
+                int sharedWorkerCount,
                 @Nullable FunctionFactoryCache functionFactoryCache,
                 @Nullable DatabaseSnapshotAgent snapshotAgent,
                 Metrics metrics

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -153,6 +153,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
     @Override
     public void close() {
+        this.clear();
         Misc.free(circuitBreaker);
         Misc.free(record);
     }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -125,6 +125,7 @@ public class HttpServer implements Closeable {
             HttpServerConfiguration configuration,
             CairoEngine cairoEngine,
             WorkerPool workerPool,
+            int sharedWorkerCount,
             HttpRequestProcessorBuilder jsonQueryProcessorBuilder,
             FunctionFactoryCache functionFactoryCache,
             DatabaseSnapshotAgent snapshotAgent
@@ -160,6 +161,7 @@ public class HttpServer implements Closeable {
                         configuration.getJsonQueryProcessorConfiguration(),
                         cairoEngine,
                         workerPool.getWorkerCount(),
+                        sharedWorkerCount,
                         functionFactoryCache,
                         snapshotAgent
                 );
@@ -295,6 +297,7 @@ public class HttpServer implements Closeable {
             CairoEngine cairoEngine,
             WorkerPool workerPool,
             boolean localPool,
+            int sharedWorkerCount,
             FunctionFactoryCache functionFactoryCache,
             DatabaseSnapshotAgent snapshotAgent,
             Metrics metrics
@@ -305,9 +308,10 @@ public class HttpServer implements Closeable {
                 configuration.getJsonQueryProcessorConfiguration(),
                 cairoEngine,
                 workerPool.getWorkerCount(),
+                sharedWorkerCount,
                 functionFactoryCache,
                 snapshotAgent);
-        addDefaultEndpoints(s, configuration, cairoEngine, workerPool, jsonQueryProcessorBuilder, functionFactoryCache, snapshotAgent);
+        addDefaultEndpoints(s, configuration, cairoEngine, workerPool, sharedWorkerCount, jsonQueryProcessorBuilder, functionFactoryCache, snapshotAgent);
         return s;
     }
 
@@ -316,6 +320,7 @@ public class HttpServer implements Closeable {
             CairoEngine cairoEngine,
             WorkerPool workerPool,
             boolean localPool,
+            int sharedWorkerCount,
             FunctionFactoryCache functionFactoryCache,
             DatabaseSnapshotAgent snapshotAgent,
             Metrics metrics

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -75,17 +75,21 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             CairoEngine engine,
             int workerCount
     ) {
-        this(configuration, engine, workerCount, null, null);
+        this(configuration, engine, workerCount, workerCount, null, null);
     }
 
     public JsonQueryProcessor(
             JsonQueryProcessorConfiguration configuration,
             CairoEngine engine,
             int workerCount,
+            int sharedWorkerCount,
             @Nullable FunctionFactoryCache functionFactoryCache,
             @Nullable DatabaseSnapshotAgent snapshotAgent
     ) {
-        this(configuration, engine, new SqlCompiler(engine, functionFactoryCache, snapshotAgent), new SqlExecutionContextImpl(engine, workerCount));
+        this(configuration,
+                engine,
+                new SqlCompiler(engine, functionFactoryCache, snapshotAgent),
+                new SqlExecutionContextImpl(engine, workerCount, sharedWorkerCount));
     }
 
     public JsonQueryProcessor(

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -73,13 +73,14 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
             CairoEngine engine,
             int workerCount
     ) {
-        this(configuration, engine, workerCount, null, null);
+        this(configuration, engine, workerCount, workerCount, null, null);
     }
 
     public TextQueryProcessor(
             JsonQueryProcessorConfiguration configuration,
             CairoEngine engine,
             int workerCount,
+            int sharedWorkerCount,
             @Nullable FunctionFactoryCache functionFactoryCache,
             @Nullable DatabaseSnapshotAgent snapshotAgent
     ) {
@@ -87,7 +88,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         this.compiler = new SqlCompiler(engine, functionFactoryCache, snapshotAgent);
         this.floatScale = configuration.getFloatScale();
         this.clock = configuration.getClock();
-        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount);
+        this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount, sharedWorkerCount);
         this.doubleScale = configuration.getDoubleScale();
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(engine.getConfiguration().getCircuitBreakerConfiguration(), MemoryTag.NATIVE_CB4);
         this.metrics = engine.getMetrics();

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1405,7 +1405,11 @@ public class PGConnectionContext implements IOContext, Mutable, WriterSource {
     private void freeUpdateCommand(UpdateOperation op) {
         // Create a copy of sqlExecutionContext here
         bindVariableService = new BindVariableServiceImpl(engine.getConfiguration());
-        SqlExecutionContextImpl newSqlExecutionContext = new SqlExecutionContextImpl(engine, sqlExecutionContext.getWorkerCount());
+        SqlExecutionContextImpl newSqlExecutionContext = new SqlExecutionContextImpl(
+                engine,
+                sqlExecutionContext.getWorkerCount(),
+                sqlExecutionContext.getSharedWorkerCount()
+        );
         newSqlExecutionContext.with(
                 sqlExecutionContext.getCairoSecurityContext(),
                 bindVariableService,

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -2621,7 +2621,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 distinctColumnMetadata,
                                 arrayColumnTypes,
                                 tempVaf,
-                                executionContext.getWorkerCount(),
+                                executionContext.getSharedWorkerCount(),
                                 tempSymbolSkewIndexes
 
                         );
@@ -2785,7 +2785,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     VectorAggregateFunctionConstructor constructor = tempVecConstructors.getQuick(i);
                     int indexInBase = tempVecConstructorArgIndexes.getQuick(i);
                     int indexInThis = tempAggIndex.getQuick(i);
-                    VectorAggregateFunction vaf = constructor.create(tempKeyKinds.size() == 0 ? 0 : tempKeyKinds.getQuick(0), indexInBase, executionContext.getWorkerCount());
+                    VectorAggregateFunction vaf = constructor.create(tempKeyKinds.size() == 0 ? 0 : tempKeyKinds.getQuick(0), indexInBase, executionContext.getSharedWorkerCount());
                     tempVaf.add(vaf);
                     meta.add(indexInThis,
                             new TableColumnMetadata(
@@ -2823,7 +2823,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             factory,
                             meta,
                             arrayColumnTypes,
-                            executionContext.getWorkerCount(),
+                            executionContext.getSharedWorkerCount(),
                             tempVaf,
                             tempKeyIndexesInBase.getQuick(0),
                             tempKeyIndex.getQuick(0),
@@ -3856,7 +3856,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     ) throws SqlException {
         if (!filterFunction.isReadThreadSafe()) {
             ObjList<Function> perWorkerFilters = new ObjList<>();
-            for (int i = 0, c = executionContext.getWorkerCount(); i < c; i++) {
+            for (int i = 0, c = executionContext.getSharedWorkerCount(); i < c; i++) {
                 final Function perWorkerFilter = compileFilter(filter, metadata, executionContext);
                 perWorkerFilters.extendAndSet(i, perWorkerFilter);
             }

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1879,10 +1879,6 @@ public class SqlCompiler implements Closeable {
     @Nullable
     private RecordCursorFactory executeCopy0(SqlExecutionContext executionContext, CopyModel model) throws SqlException {
         try {
-            int workerCount = executionContext.getWorkerCount();
-            if (workerCount < 1) {
-                throw SqlException.$(0, "Invalid worker count set [value=").put(workerCount).put("]");
-            }
             if (model.isCancel()) {
                 cancelTextImport(model);
                 return null;

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
@@ -61,6 +61,10 @@ public interface SqlExecutionContext extends Closeable {
 
     int getWorkerCount();
 
+    default int getSharedWorkerCount() {
+        return getWorkerCount();
+    }
+
     Rnd getRandom();
 
     default Rnd getAsyncRandom() {

--- a/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/DataFrameRecordCursorFactory.java
@@ -143,7 +143,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
             fwdPageFrameCursor = new FwdTableReaderPageFrameCursor(
                     columnIndexes,
                     columnSizes,
-                    executionContext.getWorkerCount(),
+                    executionContext.getSharedWorkerCount(),
                     pageFrameMinRows,
                     pageFrameMaxRows
             );
@@ -159,7 +159,7 @@ public class DataFrameRecordCursorFactory extends AbstractDataFrameRecordCursorF
             bwdPageFrameCursor = new BwdTableReaderPageFrameCursor(
                     columnIndexes,
                     columnSizes,
-                    executionContext.getWorkerCount(),
+                    executionContext.getSharedWorkerCount(),
                     pageFrameMinRows,
                     pageFrameMaxRows
             );

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByAllIndexedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByAllIndexedRecordCursor.java
@@ -93,7 +93,7 @@ class LatestByAllIndexedRecordCursor extends AbstractRecordListCursor {
         rows.setCapacity(keyCount);
         GeoHashNative.iota(rows.getAddress(), rows.getCapacity(), 0);
 
-        final int workerCount = executionContext.getWorkerCount();
+        final int workerCount = executionContext.getSharedWorkerCount();
 
         final long chunkSize = (keyCount + workerCount - 1) / workerCount;
         final int taskCount = (int) ((keyCount + chunkSize - 1) / chunkSize);

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
@@ -40,10 +40,10 @@ import org.junit.Test;
 public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
 
     private final static ReceiverFactory LINUX_FACTORY =
-            (configuration, engine, workerPool, localPool, functionFactoryCache, snapshotAgent, metrics) -> new LinuxMMLineUdpReceiver(configuration, engine, workerPool);
+            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent, metrics) -> new LinuxMMLineUdpReceiver(configuration, engine, workerPool);
 
     private final static ReceiverFactory GENERIC_FACTORY =
-            (configuration, engine, workerPool, localPool, functionFactoryCache, snapshotAgent, metrics) -> new LineUdpReceiver(configuration, engine, workerPool);
+            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent, metrics) -> new LineUdpReceiver(configuration, engine, workerPool);
 
     @Test
     public void testGenericCannotBindSocket() throws Exception {
@@ -204,7 +204,7 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
     private void assertConstructorFail(LineUdpReceiverConfiguration receiverCfg, ReceiverFactory factory) {
         try (CairoEngine engine = new CairoEngine(configuration)) {
             try {
-                factory.create(receiverCfg, engine, null, true, null, null, metrics);
+                factory.create(receiverCfg, engine, null, true,  0, null, null, metrics);
                 Assert.fail();
             } catch (NetworkError ignore) {
             }
@@ -236,7 +236,7 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
                     "blue\tx square\t3.4\t1970-01-01T00:01:40.000000Z\n";
 
             try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, null, null, metrics)) {
+                try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, 0, null, null, metrics)) {
                     // create table
                     try (TableModel model = new TableModel(configuration, "tab", PartitionBy.NONE)
                             .col("colour", ColumnType.SYMBOL)

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -6345,12 +6345,17 @@ create table tab as (
         });
     }
 
-    private PGWireServer.PGConnectionContextFactory createPGConnectionContextFactory(PGWireConfiguration conf, int workerCount,
-                                                                                     SOCountDownLatch queryStartedCount, SOCountDownLatch queryScheduledCount) {
-        return new PGWireServer.PGConnectionContextFactory(engine, conf, workerCount) {
+    private PGWireServer.PGConnectionContextFactory createPGConnectionContextFactory(
+            PGWireConfiguration conf,
+            int workerCount,
+            int sharedWorkerCount,
+            SOCountDownLatch queryStartedCount,
+            SOCountDownLatch queryScheduledCount
+    ) {
+        return new PGWireServer.PGConnectionContextFactory(engine, conf, workerCount, sharedWorkerCount) {
             @Override
-            protected SqlExecutionContextImpl getSqlExecutionContext(CairoEngine engine, int workerCount) {
-                return new SqlExecutionContextImpl(engine, workerCount) {
+            protected SqlExecutionContextImpl getSqlExecutionContext(CairoEngine engine, int workerCount, int sharedWorkerCount) {
+                return new SqlExecutionContextImpl(engine, workerCount, sharedWorkerCount) {
                     @Override
                     public QueryFutureUpdateListener getQueryFutureUpdateListener() {
                         return new QueryFutureUpdateListener() {
@@ -6402,7 +6407,7 @@ create table tab as (
                 compiler.getFunctionFactoryCache(),
                 snapshotAgent,
                 metrics,
-                createPGConnectionContextFactory(conf, workerCount, null, queryScheduledCount)
+                createPGConnectionContextFactory(conf, workerCount, workerCount, null, queryScheduledCount)
         );
     }
 
@@ -6586,7 +6591,7 @@ create table tab as (
                         compiler.getFunctionFactoryCache(),
                         snapshotAgent,
                         metrics,
-                        createPGConnectionContextFactory(conf, workerCount, queryStartedCountDownLatch, null)
+                        createPGConnectionContextFactory(conf, workerCount, workerCount, queryStartedCountDownLatch, null)
                 )
         ) {
             pool.start(LOG);


### PR DESCRIPTION
This PR fixes an inconsistency in the SqlCodeGenerator and PageFrameReduceJob worker count configuration that could lead to errors/crashes during processing.

Replaces: https://github.com/questdb/questdb/pull/2399