### PR TITLE
chore(build): fix javadoc warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -210,10 +210,11 @@
                 <version>3.2.0</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>compile-javadoc</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <phase>compile</phase>
                     </execution>
                 </executions>
                 <configuration>
@@ -224,6 +225,7 @@
                     <sourceFileExcludes>
                         <sourceFileExclude>${excludePattern1}</sourceFileExclude>
                     </sourceFileExcludes>
+                    <failOnWarnings>true</failOnWarnings>
                 </configuration>
             </plugin>
         </plugins>

--- a/core/src/main/java/io/questdb/cairo/ConcurrentBitmapIndexFwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/ConcurrentBitmapIndexFwdReader.java
@@ -63,6 +63,12 @@ public class ConcurrentBitmapIndexFwdReader extends AbstractIndexReader {
 
     /**
      * Allows reusing cursor objects, if that's possible.
+     *
+     * @param rowCursor the pass-through row cursor
+     * @param key symbol key
+     * @param minValue min offset, used to limit the range of the cursor
+     * @param maxValue max offset, used to limit the range of the cursor
+     * @return the same cursor where possible
      */
     public RowCursor initCursor(RowCursor rowCursor, int key, long minValue, long maxValue) {
         Cursor cursor = null;

--- a/core/src/main/java/io/questdb/cairo/sql/Function.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Function.java
@@ -151,6 +151,8 @@ public interface Function extends Closeable, StatefulAtom, Sinkable {
      * and, thus, can be called concurrently, false - otherwise. Used as a hint for
      * parallel SQL filters runtime, thus this method makes sense only for functions
      * that are allowed in a filter (WHERE clause).
+     * <p>
+     * @return true if the function and all of its children functions are thread-safe
      */
     default boolean isReadThreadSafe() {
         return false;

--- a/core/src/main/java/io/questdb/cairo/sql/RecordCursor.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RecordCursor.java
@@ -112,7 +112,7 @@ public interface RecordCursor extends Closeable, SymbolTableSource {
     }
 
     /**
-     * Returns true if the cursor is using an index, false otherwise
+     * @return true if the cursor is using an index, false otherwise
      */
     default boolean isUsingIndex() {
         return false;

--- a/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
@@ -63,7 +63,9 @@ public interface RecordCursorFactory extends Closeable, Sinkable, Plannable {
     }
 
     /**
-     * True if record cursor factory followed order by advice and doesn't require sorting .
+     * True if record cursor factory followed order by advice and doesn't require sorting.
+     *
+     * @return true if record cursor factory followed order by advice and doesn't require sorting.
      */
     default boolean followedOrderByAdvice() {
         return false;

--- a/core/src/main/java/io/questdb/cairo/sql/RowCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RowCursorFactory.java
@@ -48,7 +48,7 @@ public interface RowCursorFactory {
     boolean isEntity();
 
     /**
-     * Returns true if the returned RowCursor is using an index, false otherwise
+     * @return true if the returned RowCursor is using an index, false otherwise
      */
     default boolean isUsingIndex() {
         return false;

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryM.java
@@ -73,6 +73,7 @@ public interface MemoryM extends Closeable {
      *                          should use this parameter as the increment size
      * @param size              size of the initial mapped memory when smaller than the actual file
      * @param memoryTag         memory tag for diagnostics
+     * @param opts              file open options
      *
      */
     void of(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag, long opts);

--- a/core/src/main/java/io/questdb/griffin/CompiledQuery.java
+++ b/core/src/main/java/io/questdb/griffin/CompiledQuery.java
@@ -88,7 +88,7 @@ public interface CompiledQuery {
     <T extends AbstractOperation> T getOperation();
 
     /**
-     * Returns number of rows changed by this command. Used e.g. in pg wire protocol.
+     * @return number of rows changed by this command. Used e.g. in pg wire protocol.
      */
     long getAffectedRowsCount();
 

--- a/core/src/main/java/io/questdb/griffin/Plannable.java
+++ b/core/src/main/java/io/questdb/griffin/Plannable.java
@@ -27,7 +27,9 @@ package io.questdb.griffin;
 public interface Plannable {
 
     /**
-     * adds this object's data to plan
+     * Adds this object's data to plan
+     *
+     * @param sink to write plan data to
      */
     void toPlan(PlanSink sink);
 }

--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -112,7 +112,9 @@ public final class Files {
 
     /**
      * close(fd) should be used instead of this method in most cases
-     * unless you don't need close sys call to happen.
+     * unless you don't need to close sys call to happen.
+     * <p>
+     * @param fd the file descriptor to close
      */
     public static void decrementFileCount(long fd) {
         assert auditClose(fd);

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -82,6 +82,7 @@ public final class Hash {
      * @param p        memory pointer
      * @param len      memory length in bytes
      * @param seed     seed value
+     * @param accessor memory accessor that provides access to memory
      * @return hash code
      */
     public static long xxHash64(long p, long len, long seed, MemoryAccessor accessor) {

--- a/core/src/main/java/io/questdb/std/Numbers.java
+++ b/core/src/main/java/io/questdb/std/Numbers.java
@@ -604,6 +604,10 @@ public final class Numbers {
     /**
      * Clinger's fast path:
      * https://www.researchgate.net/publication/2295884_How_to_Read_Floating_Point_Numbers_Accurately
+     *
+     * @param sequence the sequence of bytes to parse
+     * @return double value
+     * @throws NumericException if the sequence is not a valid double
      */
     public static double parseDouble(CharSequence sequence) throws NumericException {
         int lim = sequence.length();


### PR DESCRIPTION
I really appreciate everyone adding Javadoc, the more the better. But Javadoc has to be in a correct format. From this PR onwards any Javadoc issue will fail the build