### PR TITLE
fix(sql): fix order in over clause not accepting direction

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -1664,11 +1664,11 @@ public final class SqlParser {
 
                         if (isDescKeyword(tok)) {
                             ((AnalyticColumn) col).addOrderBy(orderByExpr, QueryModel.ORDER_DIRECTION_DESCENDING);
-                            tok = tok(lexer, "',' or ')'");
+                            tok = tokIncludingLocalBrace(lexer, "',' or ')'");
                         } else {
                             ((AnalyticColumn) col).addOrderBy(orderByExpr, QueryModel.ORDER_DIRECTION_ASCENDING);
                             if (isAscKeyword(tok)) {
-                                tok = tok(lexer, "',' or ')'");
+                                tok = tokIncludingLocalBrace(lexer, "',' or ')'");
                             }
                         }
                     } while (Chars.equals(tok, ','));


### PR DESCRIPTION
Fixes parser not accepting ASC or DESC for last order by column in over clause .

Example: 

```sql
create table weather
(
 timestamp timestamp,
 temperature float
) timestamp(timestamp) partition by year;

select timestamp, temperature from 
( 
  Select temperature, timestamp, 
         row_number() over (partition by timestamp_floor('y', timestamp) order by temperature desc )  rid 
  from weather2 
) inq 
where rid = 0 
order by timestamp
```

returns 
_',' or ')' expected_ 
error 