### PR TITLE
fix(sql): made check case-insensitive for float, month and other keywords

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -108,7 +108,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         return (tok.charAt(i++) | 32) == '/'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i)) == 'p';
+                && (tok.charAt(i) | 32) == 'p';
     }
 
     public void execute(

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -659,7 +659,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i)) == 't';
+                && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isFloat4Keyword(CharSequence tok) {
@@ -672,7 +672,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++)) == 't'
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i)) == '4';
     }
 
@@ -686,7 +686,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++)) == 't'
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i)) == '8';
     }
 
@@ -701,7 +701,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i)) == 't';
+                && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isFromKeyword(CharSequence tok) {
@@ -759,10 +759,10 @@ public class SqlKeywords {
         }
 
         int i = 0;
-        return (tok.charAt(i++)) == 'h'
-                && (tok.charAt(i++)) == 'o'
-                && (tok.charAt(i++)) == 'u'
-                && (tok.charAt(i)) == 'r';
+        return (tok.charAt(i++) | 32) == 'h'
+                && (tok.charAt(i++) | 32) == 'o'
+                && (tok.charAt(i++) | 32) == 'u'
+                && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isIfKeyword(CharSequence tok) {
@@ -1052,7 +1052,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMicrosecondsKeyword(CharSequence tok) {
@@ -1072,7 +1072,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMillenniumKeyword(CharSequence tok) {
@@ -1090,7 +1090,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i)) == 'm';
+                && (tok.charAt(i) | 32) == 'm';
     }
 
     public static boolean isMillisecondsKeyword(CharSequence tok) {
@@ -1110,7 +1110,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMinuteKeyword(CharSequence tok) {
@@ -1124,7 +1124,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == 'e';
+                && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isMonthKeyword(CharSequence tok) {
@@ -1137,7 +1137,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == 'h';
+                && (tok.charAt(i) | 32) == 'h';
     }
 
     public static boolean isNanKeyword(CharSequence tok) {

--- a/core/src/test/java/io/questdb/griffin/SqlKeywordsTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlKeywordsTest.java
@@ -27,8 +27,7 @@ package io.questdb.griffin;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.questdb.griffin.SqlKeywords.isLinearKeyword;
-import static io.questdb.griffin.SqlKeywords.isPrevKeyword;
+import static io.questdb.griffin.SqlKeywords.*;
 
 public class SqlKeywordsTest {
 
@@ -52,5 +51,112 @@ public class SqlKeywordsTest {
         Assert.assertFalse(isLinearKeyword("line12"));
         Assert.assertFalse(isLinearKeyword("linea1"));
         Assert.assertTrue(isLinearKeyword("linear"));
+    }
+
+    @Test
+    public void testIsFormatKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isFormatKeyword("format"));
+        Assert.assertTrue(isFormatKeyword("formaT"));
+        Assert.assertTrue(isFormatKeyword("FORMAT"));
+        Assert.assertTrue(isFormatKeyword("forMAT"));
+        Assert.assertFalse(isFormatKeyword("forMa"));
+    }
+
+    @Test
+    public void testIsFloatKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isFloatKeyword("float"));
+        Assert.assertTrue(isFloatKeyword("floaT"));
+        Assert.assertTrue(isFloatKeyword("FLOAT"));
+        Assert.assertTrue(isFloatKeyword("floAT"));
+        Assert.assertFalse(isFloatKeyword("flot"));
+    }
+
+    @Test
+    public void testIsFloat4KeywordIsCaseInsensitive() {
+        Assert.assertTrue(isFloat4Keyword("float4"));
+        Assert.assertTrue(isFloat4Keyword("floaT4"));
+        Assert.assertTrue(isFloat4Keyword("FLOAT4"));
+        Assert.assertTrue(isFloat4Keyword("floAT4"));
+        Assert.assertFalse(isFloat4Keyword("float"));
+    }
+
+    @Test
+    public void testIsFloat8KeywordIsCaseInsensitive() {
+        Assert.assertTrue(isFloat8Keyword("float8"));
+        Assert.assertTrue(isFloat8Keyword("floaT8"));
+        Assert.assertTrue(isFloat8Keyword("FLOAT8"));
+        Assert.assertTrue(isFloat8Keyword("floAT8"));
+        Assert.assertFalse(isFloat8Keyword("float"));
+    }
+
+    @Test
+    public void testIsHourKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isHourKeyword("hour"));
+        Assert.assertTrue(isHourKeyword("houR"));
+        Assert.assertTrue(isHourKeyword("HOUR"));
+        Assert.assertTrue(isHourKeyword("HOUr"));
+        Assert.assertTrue(isHourKeyword("hoUR"));
+        Assert.assertFalse(isHourKeyword("houra"));
+    }
+
+    @Test
+    public void testIsMaxUncommittedRowsParamIsCaseInsensitive() {
+        Assert.assertTrue(isMaxUncommittedRowsParam("MaxUncommittedRows"));
+        Assert.assertTrue(isMaxUncommittedRowsParam("maxuncommittedrows"));
+        Assert.assertTrue(isMaxUncommittedRowsParam("maxuncommittedrowS"));
+        Assert.assertTrue(isMaxUncommittedRowsParam("MAXUNCOMMITTEDROWS"));
+        Assert.assertTrue(isMaxUncommittedRowsParam("MAXUNCOMMITTEDROWs"));
+        Assert.assertTrue(isMaxUncommittedRowsParam("MaxUncommittedRowS"));
+        Assert.assertFalse(isMaxUncommittedRowsParam("MaxUncommittedRowD"));
+    }
+
+    @Test
+    public void testIsMicrosecondsKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isMicrosecondsKeyword("microseconds"));
+        Assert.assertTrue(isMicrosecondsKeyword("microsecondS"));
+        Assert.assertTrue(isMicrosecondsKeyword("MICROSECONDS"));
+        Assert.assertTrue(isMicrosecondsKeyword("MICROSECONDs"));
+        Assert.assertTrue(isMicrosecondsKeyword("MICROseconds"));
+        Assert.assertFalse(isMicrosecondsKeyword("microsecondd"));
+    }
+
+    @Test
+    public void testIsMillenniumKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isMillenniumKeyword("millennium"));
+        Assert.assertTrue(isMillenniumKeyword("millenniuM"));
+        Assert.assertTrue(isMillenniumKeyword("MILLENNIUM"));
+        Assert.assertTrue(isMillenniumKeyword("MILLENNIUm"));
+        Assert.assertTrue(isMillenniumKeyword("MILlenNIUM"));
+        Assert.assertFalse(isMillenniumKeyword("MILlenNIUn"));
+    }
+
+    @Test
+    public void testIsMillisecondsKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isMillisecondsKeyword("milliseconds"));
+        Assert.assertTrue(isMillisecondsKeyword("millisecondS"));
+        Assert.assertTrue(isMillisecondsKeyword("MILLISECONDS"));
+        Assert.assertTrue(isMillisecondsKeyword("MILLISECONDs"));
+        Assert.assertTrue(isMillisecondsKeyword("MIlliSECONDS"));
+        Assert.assertFalse(isMillisecondsKeyword("MILLISECONDD"));
+    }
+
+    @Test
+    public void testIsMinuteKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isMinuteKeyword("minute"));
+        Assert.assertTrue(isMinuteKeyword("minutE"));
+        Assert.assertTrue(isMinuteKeyword("MINUTE"));
+        Assert.assertTrue(isMinuteKeyword("MINUTe"));
+        Assert.assertTrue(isMinuteKeyword("minUTE"));
+        Assert.assertFalse(isMinuteKeyword("minutF"));
+    }
+
+    @Test
+    public void testIsMonthKeywordIsCaseInsensitive() {
+        Assert.assertTrue(isMonthKeyword("month"));
+        Assert.assertTrue(isMonthKeyword("montH"));
+        Assert.assertTrue(isMonthKeyword("MONTH"));
+        Assert.assertTrue(isMonthKeyword("MONTh"));
+        Assert.assertTrue(isMonthKeyword("MONth"));
+        Assert.assertFalse(isMonthKeyword("MONTi"));
     }
 }


### PR DESCRIPTION
This PR fixes sql keyword check accepting only lowercase letter on last position for : 
- float
- float4
- float8
- format 
- hour
- MaxUncommittedRows
- microseconds
- milliseconds
- millenium
- month

Example: 
```sql
select extract(MONTh from to_timestamp('2022-03-11T22:45:30.555555Z'))
--returns 3 

--but

select extract(MONTH from to_timestamp('2022-03-11T22:45:30.555555Z'))
--returns "unsupported part 'MONTH'"
```
