### PR TITLE
fix(core): fix default geohash value to be NULL instead of 0 for existing rows when column added

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -1086,6 +1086,9 @@ public class TableReader implements Closeable, SymbolTableSource {
                 // these indexes have state and may not be always required
                 Misc.free(indexReaders.getAndSetQuick(primaryIndex, null));
                 Misc.free(indexReaders.getAndSetQuick(secondaryIndex, null));
+
+                // Column to present in the partition. Set column top to be the size of the partition.
+                columnTops.setQuick(columnBase / 2 + columnIndex, columnRowCount);
             }
         } finally {
             path.trimTo(plen);

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -848,17 +848,23 @@ public final class TableUtils {
         switch (ColumnType.tagOf(columnType)) {
             case ColumnType.BOOLEAN:
             case ColumnType.BYTE:
-            case ColumnType.GEOBYTE:
                 Vect.memset(addr, count, 0);
+                break;
+            case ColumnType.GEOBYTE:
+                Vect.memset(addr, count, GeoHashes.BYTE_NULL);
                 break;
             case ColumnType.CHAR:
             case ColumnType.SHORT:
-            case ColumnType.GEOSHORT:
                 Vect.setMemoryShort(addr, (short) 0, count);
                 break;
+            case ColumnType.GEOSHORT:
+                Vect.setMemoryShort(addr, GeoHashes.SHORT_NULL, count);
+                break;
             case ColumnType.INT:
-            case ColumnType.GEOINT:
                 Vect.setMemoryInt(addr, Numbers.INT_NaN, count);
+                break;
+            case ColumnType.GEOINT:
+                Vect.setMemoryInt(addr, GeoHashes.INT_NULL, count);
                 break;
             case ColumnType.FLOAT:
                 Vect.setMemoryFloat(addr, Float.NaN, count);
@@ -869,8 +875,10 @@ public final class TableUtils {
             case ColumnType.LONG:
             case ColumnType.DATE:
             case ColumnType.TIMESTAMP:
-            case ColumnType.GEOLONG:
                 Vect.setMemoryLong(addr, Numbers.LONG_NaN, count);
+                break;
+            case ColumnType.GEOLONG:
+                Vect.setMemoryLong(addr, GeoHashes.NULL, count);
                 break;
             case ColumnType.DOUBLE:
                 Vect.setMemoryDouble(addr, Double.NaN, count);

--- a/core/src/main/java/io/questdb/griffin/UpdateOperator.java
+++ b/core/src/main/java/io/questdb/griffin/UpdateOperator.java
@@ -142,15 +142,16 @@ public class UpdateOperator extends PurgingOperator implements QuietClosable {
                     final long currentRow = Rows.toLocalRowID(rowId);
 
                     if (rowPartitionIndex != partitionIndex) {
-                        LOG.info()
-                                .$("updating partition [partitionIndex=").$(partitionIndex)
-                                .$(", rowPartitionIndex=").$(rowPartitionIndex)
-                                .$(", rowPartitionTs=").$ts(tableWriter.getPartitionTimestamp(rowPartitionIndex))
-                                .$(", affectedColumnCount=").$(affectedColumnCount)
-                                .$(", prevRow=").$(prevRow)
-                                .$(", minRow=").$(minRow)
-                                .I$();
                         if (partitionIndex > -1) {
+                            LOG.info()
+                                    .$("updating partition [partitionIndex=").$(partitionIndex)
+                                    .$(", rowPartitionIndex=").$(rowPartitionIndex)
+                                    .$(", rowPartitionTs=").$ts(tableWriter.getPartitionTimestamp(rowPartitionIndex))
+                                    .$(", affectedColumnCount=").$(affectedColumnCount)
+                                    .$(", prevRow=").$(prevRow)
+                                    .$(", minRow=").$(minRow)
+                                    .I$();
+
                             copyColumns(
                                     partitionIndex,
                                     affectedColumnCount,

--- a/core/src/test/java/io/questdb/griffin/UpdateTest.java
+++ b/core/src/test/java/io/questdb/griffin/UpdateTest.java
@@ -27,9 +27,15 @@ package io.questdb.griffin;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.security.CairoSecurityContextImpl;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.OperationFuture;
+import io.questdb.cairo.sql.ReaderOutOfDateException;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.engine.ops.UpdateOperation;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.Rnd;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -1411,6 +1417,52 @@ public class UpdateTest extends AbstractGriffinTest {
                     "1970-01-08T10:40:00.000000Z\t\t13\t15\n" +
                     "1970-01-08T16:40:00.000000Z\tquestdb1\t14\tquestdb2\n" +
                     "1970-01-08T22:40:00.000000Z\trdgb\t15\t\n");
+        });
+    }
+
+    @Test
+    public void testUpdateGeohashColumnWithColumnTop() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table up as" +
+                    " (select timestamp_sequence(0, 6 * 60 * 60 * 1000000L) ts," +
+                    " rnd_str('15', null, '190232', 'rdgb', '', '1') as str1," +
+                    " x as lng2" +
+                    " from long_sequence(10)" +
+                    " )" +
+                    " timestamp(ts) partition by DAY", sqlExecutionContext);
+
+            compile("alter table up add column geo1 geohash(1c)", sqlExecutionContext);
+            compile("alter table up add column geo2 geohash(2c)", sqlExecutionContext);
+            compile("alter table up add column geo4 geohash(5c)", sqlExecutionContext);
+            compile("alter table up add column geo8 geohash(8c)", sqlExecutionContext);
+            compile("insert into up select * from " +
+                    " (select timestamp_sequence(6*100000000000L, 6 * 60 * 60 * 1000000L) ts," +
+                    " rnd_str('15', null, '190232', 'rdgb', '', '1') as str1," +
+                    " x + 10 as lng2," +
+                    " rnd_geohash(5) as geo1," +
+                    " rnd_geohash(10) as geo2," +
+                    " rnd_geohash(25) as geo4," +
+                    " rnd_geohash(40) as geo8" +
+                    " from long_sequence(5))", sqlExecutionContext);
+
+            executeUpdate("UPDATE up SET geo1 = cast('q' as geohash(1c)), geo2 = 'qu', geo4='quest', geo8='questdb0' WHERE lng2 in (6, 8, 10, 12, 14)");
+
+            assertSql("up", "ts\tstr1\tlng2\tgeo1\tgeo2\tgeo4\tgeo8\n" +
+                    "1970-01-01T00:00:00.000000Z\t15\t1\t\t\t\t\n" +
+                    "1970-01-01T06:00:00.000000Z\t15\t2\t\t\t\t\n" +
+                    "1970-01-01T12:00:00.000000Z\t\t3\t\t\t\t\n" +
+                    "1970-01-01T18:00:00.000000Z\t1\t4\t\t\t\t\n" +
+                    "1970-01-02T00:00:00.000000Z\t1\t5\t\t\t\t\n" +
+                    "1970-01-02T06:00:00.000000Z\t1\t6\tq\tqu\tquest\tquestdb0\n" +
+                    "1970-01-02T12:00:00.000000Z\t190232\t7\t\t\t\t\n" +
+                    "1970-01-02T18:00:00.000000Z\t\t8\tq\tqu\tquest\tquestdb0\n" +
+                    "1970-01-03T00:00:00.000000Z\t15\t9\t\t\t\t\n" +
+                    "1970-01-03T06:00:00.000000Z\t\t10\tq\tqu\tquest\tquestdb0\n" +
+                    "1970-01-07T22:40:00.000000Z\t\t11\tn\tpn\t2gjm2\t7qgcr0y6\n" +
+                    "1970-01-08T04:40:00.000000Z\t\t12\tq\tqu\tquest\tquestdb0\n" +
+                    "1970-01-08T10:40:00.000000Z\t\t13\t8\t1y\tcd0fj\t5h18p8vz\n" +
+                    "1970-01-08T16:40:00.000000Z\t\t14\tq\tqu\tquest\tquestdb0\n" +
+                    "1970-01-08T22:40:00.000000Z\t\t15\t1\trc\t5vm2w\tz22qdyty\n");
         });
     }
 


### PR DESCRIPTION
`TableUtils.setNull` did not respect geohash null value to be -1 instead of 0 as for other column types.

Also `TableReader` when reading partition with missing column did not set the column to have column top but instead relied on `NullMemoryMR.Instance` to return null values which are different for `Short` and `GeoShort` types.