### PR TITLE
fix(sql): fix case sensivity for certain keywords

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -346,8 +346,8 @@ public class SqlKeywords {
         }
 
         int i = 0;
-        return (tok.charAt(i++) | 32) == '|'
-                && (tok.charAt(i) | 32) == '|';
+        return tok.charAt(i++) == '|'
+                && tok.charAt(i) == '|';
     }
 
     public static boolean isCopyKeyword(CharSequence tok) {
@@ -414,8 +414,7 @@ public class SqlKeywords {
         return (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e'
-                ;
+                && (tok.charAt(i) | 32) == 'e';
     }
     
     public static boolean isDayKeyword(CharSequence tok) {
@@ -426,8 +425,7 @@ public class SqlKeywords {
         int i = 0;
         return (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'y'
-                ;
+                && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isDecadeKeyword(CharSequence tok) {
@@ -441,8 +439,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 'e'
-                ;
+                && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isDelimiterKeyword(CharSequence tok) {
@@ -659,7 +656,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i)) == 't';
+                && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isFloat4Keyword(CharSequence tok) {
@@ -672,7 +669,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++)) == 't'
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i)) == '4';
     }
 
@@ -686,7 +683,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++)) == 't'
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i)) == '8';
     }
 
@@ -701,7 +698,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i)) == 't';
+                && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isFromKeyword(CharSequence tok) {
@@ -749,8 +746,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r'
-                ;
+                && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isHourKeyword(CharSequence tok) {
@@ -759,10 +755,10 @@ public class SqlKeywords {
         }
 
         int i = 0;
-        return (tok.charAt(i++)) == 'h'
-                && (tok.charAt(i++)) == 'o'
-                && (tok.charAt(i++)) == 'u'
-                && (tok.charAt(i)) == 'r';
+        return (tok.charAt(i++) | 32) == 'h'
+                && (tok.charAt(i++) | 32) == 'o'
+                && (tok.charAt(i++) | 32) == 'u'
+                && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isIfKeyword(CharSequence tok) {
@@ -945,8 +941,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'v'
                 && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'l'
-                ;
+                && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isLimitKeyword(CharSequence tok) {
@@ -1052,7 +1047,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMicrosecondsKeyword(CharSequence tok) {
@@ -1072,7 +1067,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMillenniumKeyword(CharSequence tok) {
@@ -1090,7 +1085,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i)) == 'm';
+                && (tok.charAt(i) | 32) == 'm';
     }
 
     public static boolean isMillisecondsKeyword(CharSequence tok) {
@@ -1110,7 +1105,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i)) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMinuteKeyword(CharSequence tok) {
@@ -1124,7 +1119,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == 'e';
+                && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isMonthKeyword(CharSequence tok) {
@@ -1137,7 +1132,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == 'h';
+                && (tok.charAt(i) | 32) == 'h';
     }
 
     public static boolean isNanKeyword(CharSequence tok) {
@@ -1400,57 +1395,6 @@ public class SqlKeywords {
         return tok.length() == 1 && tok.charAt(0) == '\'';
     }
 
-    public static boolean isRegclassKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
-        int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 's';
-    }
-
-    public static boolean isRegprocKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
-        int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'c';
-    }
-
-    public static boolean isRegprocedureKeyword(CharSequence tok) {
-        if (tok.length() != 12) {
-            return false;
-        }
-
-        int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 'e';
-    }
-
     public static boolean isRenameKeyword(CharSequence tok) {
         if (tok.length() != 6) {
             return false;
@@ -1495,8 +1439,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'h'
-                ;
+                && (tok.charAt(i) | 32) == 'h';
     }
 
     public static boolean isDateStyle(CharSequence tok) {
@@ -1513,8 +1456,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e'
-                ;
+                && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isSecondKeyword(CharSequence tok) {
@@ -1528,8 +1470,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd'
-                ;
+                && (tok.charAt(i) | 32) == 'd';
     }
 
     public static boolean isSelectKeyword(CharSequence tok) {
@@ -1618,8 +1559,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'm'
-                ;
+                && (tok.charAt(i) | 32) == 'm';
     }
 
     public static boolean isTableKeyword(CharSequence tok) {

--- a/core/src/test/java/io/questdb/griffin/CopyTest.java
+++ b/core/src/test/java/io/questdb/griffin/CopyTest.java
@@ -84,23 +84,32 @@ public class CopyTest extends AbstractGriffinTest {
 
     @Test
     public void testSetAllParallelCopyOptions() throws SqlException {
+        boolean[] useUpperCase = new boolean[]{true, false};
         Object[] partitionBy = new Object[]{"HOUR", PartitionBy.HOUR, "DAY", PartitionBy.DAY, "MONTH", PartitionBy.MONTH, "YEAR", PartitionBy.YEAR};
         Object[] onError = new Object[]{"SKIP_COLUMN", Atomicity.SKIP_COL, "SKIP_ROW", Atomicity.SKIP_ROW, "ABORT", Atomicity.SKIP_ALL};
 
-        for (int p = 0; p < partitionBy.length / 2; p += 2) {
-            for (int o = 0; o < onError.length / 2; o += 2) {
+        for (boolean upperCase : useUpperCase) {
+            for (int p = 0; p < partitionBy.length / 2; p += 2) {
+                for (int o = 0; o < onError.length / 2; o += 2) {
 
-                CopyModel model = (CopyModel) compiler.testCompileModel("copy x from 'somefile.csv' with header true " +
-                        "partition by " + partitionBy[p] + " timestamp 'ts1' format 'yyyy-MM-ddTHH:mm:ss' delimiter ';' on error " + onError[o] + ";'", sqlExecutionContext);
+                    CopyModel model;
+                    if (upperCase) {
+                        model = (CopyModel) compiler.testCompileModel("COPY x FROM 'somefile.csv' WITH HEADER TRUE " +
+                                "PARTITION BY " + partitionBy[p] + " TIMESTAMP 'ts1' FORMAT 'yyyy-MM-ddTHH:mm:ss' DELIMITER ';' ON ERROR " + onError[o] + ";'", sqlExecutionContext);
+                    } else {
+                        model = (CopyModel) compiler.testCompileModel("copy x from 'somefile.csv' with header true " +
+                                "partition by " + partitionBy[p] + " timestamp 'ts1' format 'yyyy-MM-ddTHH:mm:ss' delimiter ';' on error " + onError[o] + ";'", sqlExecutionContext);
+                    }
 
-                assertEquals("x", model.getTarget().token.toString());
-                assertEquals("'somefile.csv'", model.getFileName().token.toString());
-                assertTrue(model.isHeader());
-                assertEquals(partitionBy[p + 1], model.getPartitionBy());
-                assertEquals("ts1", model.getTimestampColumnName().toString());
-                assertEquals("yyyy-MM-ddTHH:mm:ss", model.getTimestampFormat().toString());
-                assertEquals(';', model.getDelimiter());
-                assertEquals(onError[o + 1], model.getAtomicity());
+                    assertEquals("x", model.getTarget().token.toString());
+                    assertEquals("'somefile.csv'", model.getFileName().token.toString());
+                    assertTrue(model.isHeader());
+                    assertEquals(partitionBy[p + 1], model.getPartitionBy());
+                    assertEquals("ts1", model.getTimestampColumnName().toString());
+                    assertEquals("yyyy-MM-ddTHH:mm:ss", model.getTimestampFormat().toString());
+                    assertEquals(';', model.getDelimiter());
+                    assertEquals(onError[o + 1], model.getAtomicity());
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes upper case handling for the following keywords: DATE, DAY, DECADE, LEVEL, Minute, Search_Path, Second, System, DateStyle.