### PR TITLE
fix(sql): fix potential resource leak in non-keyed sample by with filter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByNotKeyedRecordCursorFactory.java
@@ -46,10 +46,15 @@ public abstract class AbstractSampleByNotKeyedRecordCursorFactory extends Abstra
     @Override
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
         final RecordCursor baseCursor = base.getCursor(executionContext);
-        if (baseCursor.hasNext()) {
-            return initFunctionsAndCursor(executionContext, baseCursor);
+        try {
+            if (baseCursor.hasNext()) {
+                return initFunctionsAndCursor(executionContext, baseCursor);
+            }
+            Misc.free(baseCursor);
+            return EmptyTableNoSizeRecordCursor.INSTANCE;
+        } catch (Throwable ex) {
+            Misc.free(baseCursor);
+            throw ex;
         }
-        Misc.free(baseCursor);
-        return EmptyTableNoSizeRecordCursor.INSTANCE;
     }
 }


### PR DESCRIPTION
Fixes #2441

The issue was twofold. First, both AsyncFiltered* cursors could throw a filter-caused exception on `of()` call. This broke the `close()` contract in all factories dealing with a base cursor. Second, `AbstractSampleByNotKeyedRecordCursorFactory` was not closing the base cursor properly.

As a result, an exception thrown by the filter or an early client disconnection led to situation when the async filtered cursor wasn't properly closed.