### PR TITLE
docs(ilp): add an example with auth, but without TLS

### DIFF
--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -44,9 +44,9 @@
   addr:
     host: clever-black-363-c1213c97.ilp.b04c.questdb.net
     port: 32074
-- name: ilp-auth-annotated
+- name: ilp-auth
   lang: java
-  path: examples/src/main/java/com/example/sender/AuthExampleAnnotated.java
+  path: examples/src/main/java/com/example/sender/AuthExample.java
   header: |-
     Java client library [docs](https://questdb.io/docs/reference/clients/java_ilp)
     and [Maven artifact](https://search.maven.org/artifact/org.questdb/questdb).

--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -10,13 +10,13 @@
     <dependency>
         <groupId>org.questdb</groupId>
         <artifactId>questdb</artifactId>
-        <version>6.4.3</version>
+        <version>6.5</version>
     </dependency>
     ```
 
     Gradle
     ```
-    compile group: 'org.questdb', name: 'questdb', version: '6.4.3'
+    compile group: 'org.questdb', name: 'questdb', version: '6.5'
     ```
 - name: ilp-auth-tls
   lang: java
@@ -30,13 +30,13 @@
     <dependency>
         <groupId>org.questdb</groupId>
         <artifactId>questdb</artifactId>
-        <version>6.4.3</version>
+        <version>6.5</version>
     </dependency>
     ```
 
     Gradle
     ```
-    compile group: 'org.questdb', name: 'questdb', version: '6.4.3'
+    compile group: 'org.questdb', name: 'questdb', version: '6.5'
     ```
   auth:
     kid: admin
@@ -44,3 +44,29 @@
   addr:
     host: clever-black-363-c1213c97.ilp.b04c.questdb.net
     port: 32074
+- name: ilp-auth-annotated
+  lang: java
+  path: examples/src/main/java/com/example/sender/AuthExampleAnnotated.java
+  header: |-
+    Java client library [docs](https://questdb.io/docs/reference/clients/java_ilp)
+    and [Maven artifact](https://search.maven.org/artifact/org.questdb/questdb).
+
+    Maven
+    ```
+    <dependency>
+        <groupId>org.questdb</groupId>
+        <artifactId>questdb</artifactId>
+        <version>6.5</version>
+    </dependency>
+    ```
+
+    Gradle
+    ```
+    compile group: 'org.questdb', name: 'questdb', version: '6.5'
+    ```
+  auth:
+    kid: testUser1
+    d: GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0
+  addr:
+    host: localhost
+    port: 9009

--- a/examples/src/main/java/com/example/sender/AuthExample.java
+++ b/examples/src/main/java/com/example/sender/AuthExample.java
@@ -26,7 +26,7 @@ package com.example.sender;
 
 import io.questdb.client.Sender;
 
-public class AuthExampleAnnotated {
+public class AuthExample {
     public static void main(String[] args) {
         // Replace:
         // 1. "localhost:9000" with a host and port of your QuestDB server

--- a/examples/src/main/java/com/example/sender/AuthExampleAnnotated.java
+++ b/examples/src/main/java/com/example/sender/AuthExampleAnnotated.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.example.sender;
+
+import io.questdb.client.Sender;
+
+public class AuthExampleAnnotated {
+    public static void main(String[] args) {
+        // Replace:
+        // 1. "localhost:9000" with a host and port of your QuestDB server
+        // 2. "testUser1" with KID portion from your JSON Web Key
+        // 3. token with the D portion of your JSON Web Key
+        try (Sender sender = Sender.builder()
+                .address("localhost:9009")
+                .enableAuth("testUser1").authToken("GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0")
+                .build()) {
+            sender.table("inventors")
+                    .symbol("born", "Austrian Empire")
+                    .longColumn("id", 0)
+                    .stringColumn("name", "Nicola Tesla")
+                    .atNow();
+            sender.table("inventors")
+                    .symbol("born", "USA")
+                    .longColumn("id", 1)
+                    .stringColumn("name", "Thomas Alva Edison")
+                    .atNow();
+        }
+    }
+}


### PR DESCRIPTION
to be used in documentation

also updated questdb (client) library versions