### PR TITLE
docs(ilp): remove license header from the auth example

### DIFF
--- a/examples/src/main/java/com/example/sender/AuthExample.java
+++ b/examples/src/main/java/com/example/sender/AuthExample.java
@@ -1,27 +1,3 @@
-/*******************************************************************************
- *     ___                  _   ____  ____
- *    / _ \ _   _  ___  ___| |_|  _ \| __ )
- *   | | | | | | |/ _ \/ __| __| | | |  _ \
- *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
- *    \__\_\\__,_|\___||___/\__|____/|____/
- *
- *  Copyright (c) 2014-2019 Appsicle
- *  Copyright (c) 2019-2022 QuestDB
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- ******************************************************************************/
-
 package com.example.sender;
 
 import io.questdb.client.Sender;


### PR DESCRIPTION
otherwise the license gets rendered in a documentation code sample

![image](https://user-images.githubusercontent.com/158619/186618278-3df0006b-4f88-47f1-af0c-ebfe71af7860.png)
