### PR TITLE
chore(core): removed "cairo.detach.root" config property

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <name>QuestDB core</name>
-    <description>QuestDB is high performance SQL time series database</description>
+    <description>QuestDB a is high performance SQL time series database</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -62,7 +62,6 @@ import java.util.*;
 public class PropServerConfiguration implements ServerConfiguration {
     public static final String CONFIG_DIRECTORY = "conf";
     public static final String DB_DIRECTORY = "db";
-    public static final String DETACHED_DIRECTORY = "db";
     public static final String SNAPSHOT_DIRECTORY = "snapshot";
     public static final long COMMIT_INTERVAL_DEFAULT = 2000;
     private static final LowerCaseCharSequenceIntHashMap WRITE_FO_OPTS = new LowerCaseCharSequenceIntHashMap();
@@ -208,7 +207,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final String dbDirectory;
     private final String confRoot;
     private final String snapshotRoot;
-    private final String detachRoot;
     private final String snapshotInstanceId;
     private final boolean snapshotRecoveryEnabled;
     private final long maxRerunWaitCapMs;
@@ -432,18 +430,14 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.walEnabledDefault = getBoolean(properties, env, PropertyKey.CAIRO_WAL_ENABLED_DEFAULT, false);
 
         this.dbDirectory = getString(properties, env, PropertyKey.CAIRO_ROOT, DB_DIRECTORY);
-
-        String detachRoot = getString(properties, env, PropertyKey.CAIRO_DETACH_ROOT, DETACHED_DIRECTORY);
         if (new File(this.dbDirectory).isAbsolute()) {
             this.root = this.dbDirectory;
             this.confRoot = rootSubdir(this.root, CONFIG_DIRECTORY); // ../conf
             this.snapshotRoot = rootSubdir(this.root, SNAPSHOT_DIRECTORY); // ../snapshot
-            this.detachRoot = rootSubdir(this.root, detachRoot); // ../detached_partitions
         } else {
             this.root = new File(root, this.dbDirectory).getAbsolutePath();
             this.confRoot = new File(root, CONFIG_DIRECTORY).getAbsolutePath();
             this.snapshotRoot = new File(root, SNAPSHOT_DIRECTORY).getAbsolutePath();
-            this.detachRoot = new File(root, detachRoot).getAbsolutePath();
         }
         this.cairoAttachPartitionSuffix = getString(properties, env, PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, ".attachable");
         this.cairoAttachPartitionCopy = getBoolean(properties, env, PropertyKey.CAIRO_ATTACH_PARTITION_COPY, false);
@@ -2042,11 +2036,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getDefaultSymbolCapacity() {
             return defaultSymbolCapacity;
-        }
-
-        @Override
-        public CharSequence getDetachRoot() {
-            return detachRoot;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -134,7 +134,6 @@ public enum PropertyKey {
     CAIRO_SQL_COPY_QUEUE_CAPACITY("cairo.sql.copy.queue.capacity"),
     CAIRO_SQL_COPY_LOG_RETENTION_DAYS("cairo.sql.copy.log.retention.days"),
     CAIRO_SQL_BACKUP_ROOT("cairo.sql.backup.root"),
-    CAIRO_DETACH_ROOT("cairo.detach.root"),
     CAIRO_ATTACH_PARTITION_SUFFIX("cairo.attach.partition.suffix"),
     CAIRO_ATTACH_PARTITION_COPY("cairo.attach.partition.copy"),
     CAIRO_SQL_BACKUP_DIR_TMP_NAME("cairo.sql.backup.dir.tmp.name"),

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -158,10 +158,8 @@ public class ServerMain {
         log.advisoryW().$("available CPUs: ").$(Runtime.getRuntime().availableProcessors()).$();
         log.advisoryW().$("db root: ").$(cairoConfiguration.getRoot()).$();
         log.advisoryW().$("backup root: ").$(cairoConfiguration.getBackupRoot()).$();
-        log.advisoryW().$("partition detach root: ").$(cairoConfiguration.getDetachRoot()).$();
         try (Path path = new Path()) {
             verifyFileSystem("db", cairoConfiguration.getRoot(), path, log);
-            verifyFileSystem("partition detach", cairoConfiguration.getDetachRoot(), path, log);
             verifyFileSystem("backup", cairoConfiguration.getBackupRoot(), path, log);
             verifyFileOpts(cairoConfiguration, path);
         }

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -129,8 +129,6 @@ public interface CairoConfiguration {
 
     int getDefaultSymbolCapacity();
 
-    CharSequence getDetachRoot();
-
     int getDoubleToStrCastScale();
 
     int getFileOperationRetryCount();

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -43,7 +43,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     private final CharSequence root;
     private final CharSequence confRoot;
     private final CharSequence snapshotRoot;
-    private final CharSequence detachedRoot;
 
     private final TextConfiguration textConfiguration;
     private final DefaultTelemetryConfiguration telemetryConfiguration = new DefaultTelemetryConfiguration();
@@ -59,7 +58,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
         this.confRoot = PropServerConfiguration.rootSubdir(root, PropServerConfiguration.CONFIG_DIRECTORY);
         this.textConfiguration = new DefaultTextConfiguration(Chars.toString(confRoot));
         this.snapshotRoot = PropServerConfiguration.rootSubdir(root, PropServerConfiguration.SNAPSHOT_DIRECTORY);
-        this.detachedRoot = PropServerConfiguration.rootSubdir(root, PropServerConfiguration.DETACHED_DIRECTORY);
         Rnd rnd = new Rnd(NanosecondClockImpl.INSTANCE.getTicks(), MicrosecondClockImpl.INSTANCE.getTicks());
         this.databaseIdLo = rnd.nextLong();
         this.databaseIdHi = rnd.nextLong();
@@ -98,11 +96,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public CharSequence getBackupRoot() {
         return null;
-    }
-
-    @Override
-    public CharSequence getDetachRoot() {
-        return detachedRoot;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -628,7 +628,7 @@ public class TableWriter implements Closeable {
             return AttachDetachStatus.ATTACH_ERR_DIR_EXISTS;
         }
 
-        Path detachedPath = Path.PATH.get().of(configuration.getDetachRoot()).concat(tableName);
+        Path detachedPath = Path.PATH.get().of(configuration.getRoot()).concat(tableName);
         setPathForPartition(detachedPath, partitionBy, timestamp, false);
         detachedPath.put(configuration.getAttachPartitionSuffix()).slash$();
         int detachedRootLen = detachedPath.length();
@@ -820,7 +820,7 @@ public class TableWriter implements Closeable {
                 return AttachDetachStatus.DETACH_ERR_MISSING_PARTITION_DIR;
             }
 
-            detachedPath.of(configuration.getDetachRoot()).concat(tableName);
+            detachedPath.of(configuration.getRoot()).concat(tableName);
             int detachedRootLen = detachedPath.length();
             // detachedPath: detached partition folder
             if (!ff.exists(detachedPath.slash$())) {

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -633,7 +633,6 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 path.equals(normalize(configuration.getRoot())) ||
                 path.equals(normalize(configuration.getDbDirectory())) ||
                 path.equals(normalize(configuration.getSnapshotRoot())) ||
-                path.equals(normalize(configuration.getDetachRoot())) ||
                 path.equals(normalize(configuration.getBackupRoot()));
     }
 
@@ -656,7 +655,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 int lo = taskDistribution.getQuick(i * 3 + 1);
                 int hi = taskDistribution.getQuick(i * 3 + 2);
                 final Path srcPath = localImportJob.getTmpPath1().of(importRoot).concat(tableName).put("_").put(index);
-                final Path dstPath = localImportJob.getTmpPath2().of(configuration.getDetachRoot()).concat(tableName);
+                final Path dstPath = localImportJob.getTmpPath2().of(configuration.getRoot()).concat(tableName);
                 final int srcPlen = srcPath.length();
                 final int dstPlen = dstPath.length();
 

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -248,7 +248,6 @@ public class PropServerConfigurationTest {
         Assert.assertEquals("http-server", configuration.getHttpServerConfiguration().getDispatcherConfiguration().getDispatcherLogName());
 
         TestUtils.assertEquals(new File(root, "db").getAbsolutePath(), configuration.getCairoConfiguration().getRoot());
-        TestUtils.assertEquals(new File(root, "db").getAbsolutePath(), configuration.getCairoConfiguration().getDetachRoot());
         TestUtils.assertEquals(new File(root, "conf").getAbsolutePath(), configuration.getCairoConfiguration().getConfRoot());
         TestUtils.assertEquals(new File(root, "snapshot").getAbsolutePath(), configuration.getCairoConfiguration().getSnapshotRoot());
 

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -148,11 +148,6 @@ public class AbstractCairoTest {
             }
 
             @Override
-            public CharSequence getDetachRoot() {
-                return PropServerConfiguration.rootSubdir(getRoot(), "dbRoot_detached");
-            }
-
-            @Override
             public CharSequence getBackupRoot() {
                 if (backupDir != null) {
                     return backupDir;
@@ -250,7 +245,7 @@ public class AbstractCairoTest {
 
             @Override
             public int getPartitionPurgeListCapacity() {
-                // Bump it to high number so that test don't fail with memory leak if LongList
+                // Bump it to high number so that test doesn't fail with memory leak if LongList
                 // re-allocates
                 return 512;
             }

--- a/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
+++ b/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
@@ -78,11 +78,6 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public CharSequence getDetachRoot() {
-        return conf.getDetachRoot();
-    }
-
-    @Override
     public CharSequence getBackupTempDirName() {
         return conf.getBackupTempDirName();
     }

--- a/core/src/test/java/io/questdb/griffin/AlterTableAttachPartitionTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableAttachPartitionTest.java
@@ -1128,16 +1128,6 @@ public class AlterTableAttachPartitionTest extends AbstractGriffinTest {
             AddColumn srcTransform,
             String dstTableName,
             AddColumn dstTransform,
-            String errorMessage
-    ) throws Exception {
-        assertSchemaMismatch(srcTableName, srcTransform, dstTableName, dstTransform, null, errorMessage);
-    }
-
-    private void assertSchemaMismatch(
-            String srcTableName,
-            AddColumn srcTransform,
-            String dstTableName,
-            AddColumn dstTransform,
             AddColumn afterCreateSrc,
             String errorMessage
     ) throws Exception {
@@ -1199,7 +1189,7 @@ public class AlterTableAttachPartitionTest extends AbstractGriffinTest {
         engine.clear();
         path.of(configuration.getRoot()).concat(src.getName());
         int pathLen = path.length();
-        other.of(configuration.getDetachRoot()).concat(dst.getName());
+        other.of(configuration.getRoot()).concat(dst.getName());
         int otherLen = other.length();
         for (int i = 0; i < partitionList.length; i++) {
             String partition = partitionList[i];
@@ -1245,7 +1235,7 @@ public class AlterTableAttachPartitionTest extends AbstractGriffinTest {
                 .concat(srcTableName)
                 .concat(srcPartitionName)
                 .slash$();
-        other.of(configuration.getDetachRoot())
+        other.of(configuration.getRoot())
                 .concat(dstTableName)
                 .concat(dstPartitionName)
                 .put(configuration.getAttachPartitionSuffix())

--- a/core/src/test/java/io/questdb/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableDetachPartitionTest.java
@@ -73,7 +73,6 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
     @After
     public void tearDown() {
         super.tearDown();
-        FilesFacadeImpl.INSTANCE.rmdir(path.of(configuration.getDetachRoot()).slash$());
     }
 
     @Test
@@ -87,16 +86,19 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
 
     @Test
     public void testAlreadyDetached2() throws Exception {
-        path.of(configuration.getDetachRoot())
-                .concat("tab143")
-                .concat("2022-06-03")
-                .put(DETACHED_DIR_MARKER)
-                .slash$();
-        Assert.assertEquals(0, FilesFacadeImpl.INSTANCE.mkdirs(path, 509));
         assertFailure(
+                null,
                 "tab143",
                 "ALTER TABLE tab143 DETACH PARTITION LIST '2022-06-03'",
-                "could not detach [statusCode=" + DETACH_ERR_ALREADY_DETACHED.name() + ", table=tab143, partition='2022-06-03']"
+                "could not detach [statusCode=" + DETACH_ERR_ALREADY_DETACHED.name() + ", table=tab143, partition='2022-06-03']",
+                () -> {
+                    path.of(configuration.getRoot())
+                            .concat("tab143")
+                            .concat("2022-06-03")
+                            .put(DETACHED_DIR_MARKER)
+                            .slash$();
+                    Assert.assertEquals(0, FilesFacadeImpl.INSTANCE.mkdirs(path, 509));
+                }
         );
     }
 
@@ -479,68 +481,6 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testCannotCreateDetachedFolder() throws Exception {
-        String detachedFolderName = "d3t@ch3d";
-        FilesFacade ff2 = new FilesFacadeImpl() {
-            @Override
-            public int mkdirs(Path path, int mode) {
-                if (Chars.contains(path, detachedFolderName)) {
-                    return -1;
-                }
-                return super.mkdirs(path, mode);
-            }
-        };
-
-        assertMemoryLeak(ff2, () -> {
-            CairoConfiguration conf2 = new DefaultCairoConfiguration(root) {
-                @Override
-                public CharSequence getDetachRoot() {
-                    CharSequence r = getRoot();
-                    int idx = r.length() - 1;
-                    while (idx > 0 && r.charAt(idx) != Files.SEPARATOR) {
-                        idx--;
-                    }
-                    return r.subSequence(0, ++idx) + detachedFolderName;
-                }
-
-                public FilesFacade getFilesFacade() {
-                    return ff2;
-                }
-            };
-            CairoEngine engine2 = new CairoEngine(conf2, metrics);
-            SqlCompiler compiler2 = new SqlCompiler(engine2, null, null);
-            SqlExecutionContextImpl context2 = new SqlExecutionContextImpl(engine, 1);
-            try (TableModel tab = new TableModel(conf2, "tab42", PartitionBy.DAY)) {
-                TestUtils.createPopulateTable(
-                        compiler2,
-                        context2,
-                        tab.timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        100,
-                        "2022-06-01",
-                        5
-                );
-                try {
-                    compiler2.compile(
-                            "ALTER TABLE tab42 DETACH PARTITION LIST '2022-06-03'",
-                            context2
-                    ).execute(null).await();
-                    Assert.fail();
-                } catch (SqlException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(),
-                            "could not detach [statusCode=" + DETACH_ERR_MKDIR.name() + ", table=tab42, partition='2022-06-03']"
-                    );
-                }
-            }
-            engine2.close();
-            compiler2.close();
-        });
-    }
-
-    @Test
     public void testCannotDetachActivePartition() throws Exception {
         assertFailure(
                 "tab17",
@@ -863,8 +803,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 compile("ALTER TABLE " + brokenTableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
 
                 engine.clear();
-                path.of(configuration.getDetachRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
-                other.of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
+                path.of(configuration.getRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
+                other.of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
                 Assert.assertTrue(Files.rename(path, other) > -1);
 
                 // attempt to reattach
@@ -961,7 +901,7 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
 
                 // remove _meta.detached simply prevents metadata checking, all else is the same
-                path.of(configuration.getDetachRoot())
+                path.of(configuration.getRoot())
                         .concat(tableName)
                         .concat("2022-06-02")
                         .put(DETACHED_DIR_MARKER)
@@ -1252,8 +1192,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
                     writer.detachPartition(timestamp);
                 }
-                path.of(configuration.getDetachRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
-                other.of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
+                path.of(configuration.getRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
+                other.of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
                 Assert.assertTrue(Files.rename(path, other) > -1);
 
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
@@ -1325,8 +1265,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
                     writer.detachPartition(timestamp);
                 }
-                path.of(configuration.getDetachRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
-                other.of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
+                path.of(configuration.getRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
+                other.of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
                 Assert.assertTrue(Files.rename(path, other) > -1);
 
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
@@ -1415,8 +1355,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
                     writer.detachPartition(timestamp);
                 }
-                path.of(configuration.getDetachRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
-                other.of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
+                path.of(configuration.getRoot()).concat(brokenTableName).concat(timestampDay).put(DETACHED_DIR_MARKER).$();
+                other.of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).$();
                 Assert.assertTrue(Files.rename(path, other) > -1);
 
                 try (TableWriter writer = engine.getWriter(AllowAllCairoSecurityContext.INSTANCE, tableName, "testing")) {
@@ -1881,7 +1821,7 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "','" + timestampWrongDay2 + "'");
                 renameDetachedToAttachable(tableName, timestampDay);
 
-                Path src = Path.PATH.get().of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
+                Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
                 FilesFacade ff = FilesFacadeImpl.INSTANCE;
                 dFile(src.chop$(), "ts", -1);
                 long fd = TableUtils.openRW(ff, src.$(), LOG, configuration.getWriterFileOpenOpts());
@@ -1922,15 +1862,15 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                 String timestampWrongDay = "2021-06-01";
 
                 // Partition does not exist in copied _dtxn
-                Path src = Path.PATH.get().of(configuration.getDetachRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
-                Path dst = Path.PATH2.get().of(configuration.getDetachRoot()).concat(tableName).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
+                Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableName).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
+                Path dst = Path.PATH2.get().of(configuration.getRoot()).concat(tableName).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
 
                 FilesFacade ff = FilesFacadeImpl.INSTANCE;
                 Assert.assertEquals(0, ff.rename(src, dst));
                 assertFailure("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay + "'", "partition is not preset in detached txn file");
 
                 // Existing partition but wrong folder name
-                Path dst2 = Path.PATH.get().of(configuration.getDetachRoot()).concat(tableName).concat(timestampWrongDay2).put(configuration.getAttachPartitionSuffix()).slash$();
+                Path dst2 = Path.PATH.get().of(configuration.getRoot()).concat(tableName).concat(timestampWrongDay2).put(configuration.getAttachPartitionSuffix()).slash$();
                 Assert.assertEquals(0, ff.rename(dst, dst2));
 
                 assertFailure(
@@ -2138,14 +2078,14 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                         sqlExecutionContext
                 );
                 engine.clear();
-                path.of(configuration.getDetachRoot())
+                path.of(configuration.getRoot())
                         .concat(tableName)
                         .concat("2022-06-02")
                         .put(DETACHED_DIR_MARKER)
                         .concat(META_FILE_NAME)
                         .$();
                 Assert.assertTrue(Files.remove(path));
-                other.of(configuration.getDetachRoot())
+                other.of(configuration.getRoot())
                         .concat(brokenTableName)
                         .concat("2022-06-02")
                         .put(DETACHED_DIR_MARKER)
@@ -2169,12 +2109,28 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
     }
 
     private void assertFailure(
-            @Nullable FilesFacade withFf,
+            @Nullable FilesFacade ff,
             String tableName,
             String operation,
             String errorMsg
     ) throws Exception {
-        assertMemoryLeak(withFf, () -> {
+        assertFailure(
+                ff,
+                tableName,
+                operation,
+                errorMsg,
+                null
+        );
+    }
+
+    private void assertFailure(
+            @Nullable FilesFacade ff,
+            String tableName,
+            String operation,
+            String errorMsg,
+            @Nullable Runnable mutator
+    ) throws Exception {
+        assertMemoryLeak(ff, () -> {
             try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
                 createPopulateTable(tab
                                 .timestamp("ts")
@@ -2186,6 +2142,9 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
                         "2022-06-01",
                         5
                 );
+                if (mutator != null) {
+                    mutator.run();
+                }
                 assertFailure(operation, errorMsg);
             }
         });
@@ -2203,8 +2162,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
     private void dropCurrentVersionOfPartition(String tableName, String partitionName) throws SqlException {
         engine.clear();
         // hide the detached partition
-        path.of(configuration.getDetachRoot()).concat(tableName).concat(partitionName + ".detached").$();
-        other.of(configuration.getDetachRoot()).concat(tableName).concat(partitionName + ".detached.hide").$();
+        path.of(configuration.getRoot()).concat(tableName).concat(partitionName + ".detached").$();
+        other.of(configuration.getRoot()).concat(tableName).concat(partitionName + ".detached.hide").$();
         Assert.assertEquals(Files.FILES_RENAME_OK, Files.rename(path, other));
         // drop the latest version of the partition
         compile("ALTER TABLE " + tableName + " DROP PARTITION LIST '" + partitionName + "'", sqlExecutionContext);
@@ -2215,14 +2174,14 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
     private void renameDetachedToAttachable(String tableName, long... partitions) {
         for (long partition : partitions) {
             PartitionBy.setSinkForPartition(
-                    path.of(configuration.getDetachRoot()).concat(tableName),
+                    path.of(configuration.getRoot()).concat(tableName),
                     PartitionBy.DAY,
                     partition,
                     false
             );
             path.put(DETACHED_DIR_MARKER).$();
             PartitionBy.setSinkForPartition(
-                    other.of(configuration.getDetachRoot()).concat(tableName),
+                    other.of(configuration.getRoot()).concat(tableName),
                     PartitionBy.DAY,
                     partition,
                     false
@@ -2234,8 +2193,8 @@ public class AlterTableDetachPartitionTest extends AbstractGriffinTest {
 
     private void renameDetachedToAttachable(String tableName, String... partitions) {
         for (String partition : partitions) {
-            path.of(configuration.getDetachRoot()).concat(tableName).concat(partition).put(DETACHED_DIR_MARKER).$();
-            other.of(configuration.getDetachRoot()).concat(tableName).concat(partition).put(configuration.getAttachPartitionSuffix()).$();
+            path.of(configuration.getRoot()).concat(tableName).concat(partition).put(DETACHED_DIR_MARKER).$();
+            other.of(configuration.getRoot()).concat(tableName).concat(partition).put(configuration.getAttachPartitionSuffix()).$();
             Assert.assertTrue(Files.rename(path, other) > -1);
         }
     }


### PR DESCRIPTION
`cairo.detach.root` defaulted to `cairo.root`. So considering the dirs are the same, documenting manual partition shuffling is easy. When they are not the same - shuffling of partition becomes a mess, which is hard to document. I struggled to find a reason why anyone would want these dirs to be different. Hence why I removed the configuration.