### PR TITLE
feat(sql): add gauge metrics for current cached query count

### DIFF
--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -27,6 +27,7 @@ package io.questdb;
 import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cutlass.http.processors.HealthCheckMetrics;
 import io.questdb.cutlass.http.processors.JsonQueryMetrics;
+import io.questdb.cutlass.pgwire.PGWireMetrics;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.metrics.MetricsRegistryImpl;
 import io.questdb.metrics.NullMetricsRegistry;
@@ -38,6 +39,7 @@ import io.questdb.std.str.CharSink;
 public class Metrics implements Scrapable {
     private final boolean enabled;
     private final JsonQueryMetrics jsonQuery;
+    private final PGWireMetrics pgWire;
     private final HealthCheckMetrics healthCheck;
     private final TableWriterMetrics tableWriter;
     private final MetricsRegistry metricsRegistry;
@@ -45,6 +47,7 @@ public class Metrics implements Scrapable {
     Metrics(boolean enabled, MetricsRegistry metricsRegistry) {
         this.enabled = enabled;
         this.jsonQuery = new JsonQueryMetrics(metricsRegistry);
+        this.pgWire = new PGWireMetrics(metricsRegistry);
         this.healthCheck = new HealthCheckMetrics(metricsRegistry);
         this.tableWriter = new TableWriterMetrics(metricsRegistry);
         createMemoryGauges(metricsRegistry);
@@ -76,6 +79,10 @@ public class Metrics implements Scrapable {
 
     public JsonQueryMetrics jsonQuery() {
         return jsonQuery;
+    }
+
+    public PGWireMetrics pgWire() {
+        return pgWire;
     }
 
     public HealthCheckMetrics healthCheck() {

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
@@ -55,23 +55,23 @@ public class TableWriterMetrics {
     }
 
     public long getCommitCount() {
-        return commitCounter.get();
+        return commitCounter.getValue();
     }
 
     public long getO3CommitCount() {
-        return o3CommitCounter.get();
+        return o3CommitCounter.getValue();
     }
 
     public long getCommittedRows() {
-        return committedRowCounter.get();
+        return committedRowCounter.getValue();
     }
 
     public long getRollbackCount() {
-        return rollbackCounter.get();
+        return rollbackCounter.getValue();
     }
 
     public long getPhysicallyWrittenRows() {
-        return physicallyWrittenRowCounter.get();
+        return physicallyWrittenRowCounter.getValue();
     }
 
     public void incrementCommits() {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -303,7 +303,7 @@ public class HttpServer implements Closeable {
             Metrics metrics
     ) {
         final HttpServer s = new HttpServer(configuration, cairoEngine.getMessageBus(), metrics, workerPool, localPool);
-        QueryCache.configure(configuration);
+        QueryCache.configure(configuration, metrics);
         HttpRequestProcessorBuilder jsonQueryProcessorBuilder = () -> new JsonQueryProcessor(
                 configuration.getJsonQueryProcessorConfiguration(),
                 cairoEngine,

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckMetrics.java
@@ -40,6 +40,6 @@ public class HealthCheckMetrics {
     }
 
     public long unhandledErrorsCount() {
-        return unhandledErrorCounter.get();
+        return unhandledErrorCounter.getValue();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
@@ -25,6 +25,7 @@
 package io.questdb.cutlass.http.processors;
 
 import io.questdb.metrics.Counter;
+import io.questdb.metrics.Gauge;
 import io.questdb.metrics.MetricsRegistry;
 import org.jetbrains.annotations.TestOnly;
 
@@ -32,10 +33,12 @@ public class JsonQueryMetrics {
 
     private final Counter startedQueriesCounter;
     private final Counter completedQueriesCounter;
+    private final Gauge cachedQueriesGauge;
 
     public JsonQueryMetrics(MetricsRegistry metricsRegistry) {
         this.startedQueriesCounter = metricsRegistry.newCounter("json_queries");
         this.completedQueriesCounter = metricsRegistry.newCounter("json_queries_completed");
+        this.cachedQueriesGauge = metricsRegistry.newGauge("json_queries_cached");
     }
 
     public void markStart() {
@@ -46,13 +49,17 @@ public class JsonQueryMetrics {
         completedQueriesCounter.inc();
     }
 
+    public Gauge cachedQueriesGauge() {
+        return cachedQueriesGauge;
+    }
+
     @TestOnly
     public long startedQueriesCount() {
-        return startedQueriesCounter.get();
+        return startedQueriesCounter.getValue();
     }
 
     @TestOnly
     public long completedQueriesCount() {
-        return completedQueriesCounter.get();
+        return completedQueriesCounter.getValue();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/QueryCache.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/QueryCache.java
@@ -24,10 +24,12 @@
 
 package io.questdb.cutlass.http.processors;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.metrics.Gauge;
 import io.questdb.std.AssociativeCache;
 import io.questdb.std.ThreadLocal;
 
@@ -39,15 +41,17 @@ public final class QueryCache implements Closeable {
     private static ThreadLocal<QueryCache> TL_QUERY_CACHE;
     private final AssociativeCache<RecordCursorFactory> cache;
 
-    public QueryCache(int blocks, int rows) {
-        this.cache = new AssociativeCache<>(blocks, rows);
+    public QueryCache(int blocks, int rows, Gauge cachedQueriesGauge) {
+        this.cache = new AssociativeCache<>(blocks, rows, cachedQueriesGauge);
     }
 
-    public static void configure(HttpServerConfiguration configuration) {
+    public static void configure(HttpServerConfiguration configuration, Metrics metrics) {
         final boolean enableQueryCache = configuration.isQueryCacheEnabled();
         final int blockCount = enableQueryCache ? configuration.getQueryCacheBlockCount() : 1;
         final int rowCount = enableQueryCache ? configuration.getQueryCacheRowCount() : 1;
-        TL_QUERY_CACHE = new ThreadLocal<>(() -> new QueryCache(blockCount, rowCount));
+        TL_QUERY_CACHE = new ThreadLocal<>(
+                () -> new QueryCache(blockCount, rowCount, metrics.jsonQuery().cachedQueriesGauge())
+        );
     }
 
     public static QueryCache getInstance() {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
@@ -22,37 +22,26 @@
  *
  ******************************************************************************/
 
+package io.questdb.cutlass.pgwire;
 
-package io.questdb.metrics;
+import io.questdb.metrics.Gauge;
+import io.questdb.metrics.MetricsRegistry;
 
-import io.questdb.std.str.CharSink;
+public class PGWireMetrics {
 
-import java.util.concurrent.atomic.LongAdder;
+    private final Gauge cachedSelectsGauge;
+    private final Gauge cachedUpdatesGauge;
 
-class CounterImpl implements Counter {
-    private final CharSequence name;
-    private final LongAdder counter;
-
-    CounterImpl(CharSequence name) {
-        this.name = name;
-        this.counter = new LongAdder();
+    public PGWireMetrics(MetricsRegistry metricsRegistry) {
+        this.cachedSelectsGauge = metricsRegistry.newGauge("pg_wire_select_queries_cached");
+        this.cachedUpdatesGauge = metricsRegistry.newGauge("pg_wire_update_queries_cached");
     }
 
-    @Override
-    public void add(long value) {
-        counter.add(value);
+    public Gauge cachedSelectsGauge() {
+        return cachedSelectsGauge;
     }
 
-    @Override
-    public long getValue() {
-        return counter.sum();
-    }
-
-    @Override
-    public void scrapeIntoPrometheus(CharSink sink) {
-        PrometheusFormatUtils.appendCounterType(name, sink);
-        PrometheusFormatUtils.appendCounterNamePrefix(name, sink);
-        PrometheusFormatUtils.appendSampleLineSuffix(sink, counter.longValue());
-        PrometheusFormatUtils.appendNewLine(sink);
+    public Gauge cachedUpdatesGauge() {
+        return cachedUpdatesGauge;
     }
 }

--- a/core/src/main/java/io/questdb/metrics/Counter.java
+++ b/core/src/main/java/io/questdb/metrics/Counter.java
@@ -24,8 +24,6 @@
 
 package io.questdb.metrics;
 
-import org.jetbrains.annotations.TestOnly;
-
 public interface Counter extends Scrapable {
 
     default void inc() {
@@ -34,5 +32,5 @@ public interface Counter extends Scrapable {
 
     void add(long value);
 
-    long get();
+    long getValue();
 }

--- a/core/src/main/java/io/questdb/metrics/Gauge.java
+++ b/core/src/main/java/io/questdb/metrics/Gauge.java
@@ -29,4 +29,8 @@ public interface Gauge extends Scrapable {
     void inc();
 
     void dec();
+
+    void add(long value);
+
+    long getValue();
 }

--- a/core/src/main/java/io/questdb/metrics/GaugeImpl.java
+++ b/core/src/main/java/io/questdb/metrics/GaugeImpl.java
@@ -28,11 +28,11 @@ import io.questdb.std.str.CharSink;
 
 import java.util.concurrent.atomic.LongAdder;
 
-class GaugeImpl implements Gauge {
+public class GaugeImpl implements Gauge {
     private final LongAdder counter;
     private final CharSequence name;
 
-    GaugeImpl(CharSequence name) {
+    public GaugeImpl(CharSequence name) {
         this.name = name;
         this.counter = new LongAdder();
     }
@@ -45,6 +45,16 @@ class GaugeImpl implements Gauge {
     @Override
     public void dec() {
         counter.decrement();
+    }
+
+    @Override
+    public void add(long value) {
+        counter.add(value);
+    }
+
+    @Override
+    public long getValue() {
+        return counter.sum();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/metrics/MemoryTagGauge.java
+++ b/core/src/main/java/io/questdb/metrics/MemoryTagGauge.java
@@ -20,20 +20,26 @@ public class MemoryTagGauge implements Gauge {
 
     @Override
     public void inc() {
-        //do nothing as this gauge is RO view of memory tag stats  
+        // do nothing as this gauge is RO view of memory tag stats
     }
 
     @Override
     public void dec() {
-        //do nothing as this gauge is RO view of memory tag stats
+        // do nothing as this gauge is RO view of memory tag stats
+    }
+
+    @Override
+    public void add(long value) {
+        // do nothing as this gauge is RO view of memory tag stats
+    }
+
+    @Override
+    public long getValue() {
+        return Unsafe.getMemUsedByTag(memoryTag);
     }
 
     public String getName() {
         return MemoryTag.nameOf(memoryTag);
-    }
-
-    private long getValue() {
-        return Unsafe.getMemUsedByTag(memoryTag);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/metrics/NullCounter.java
+++ b/core/src/main/java/io/questdb/metrics/NullCounter.java
@@ -41,7 +41,7 @@ class NullCounter implements Counter, CounterWithOneLabel, CounterWithTwoLabels 
     }
 
     @Override
-    public long get() {
+    public long getValue() {
         return 0;
     }
 

--- a/core/src/main/java/io/questdb/metrics/NullGauge.java
+++ b/core/src/main/java/io/questdb/metrics/NullGauge.java
@@ -26,7 +26,7 @@ package io.questdb.metrics;
 
 import io.questdb.std.str.CharSink;
 
-class NullGauge implements Gauge {
+public class NullGauge implements Gauge {
     public static final NullGauge INSTANCE = new NullGauge();
 
     private NullGauge() {
@@ -38,6 +38,15 @@ class NullGauge implements Gauge {
 
     @Override
     public void dec() {
+    }
+
+    @Override
+    public void add(long value) {
+    }
+
+    @Override
+    public long getValue() {
+        return 0;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/metrics/VirtualGauge.java
+++ b/core/src/main/java/io/questdb/metrics/VirtualGauge.java
@@ -15,18 +15,24 @@ public class VirtualGauge implements Gauge {
         this.provider = statProvider;
     }
 
-    public long getValue() {
-        return provider.getValue();
-    }
-
     @Override
     public void inc() {
-        //do nothing as this gauge is RO view of some stat
+        // do nothing as this gauge is RO view of some stat
     }
 
     @Override
     public void dec() {
-        //do nothing as this gauge is RO view of some stat
+        // do nothing as this gauge is RO view of some stat
+    }
+
+    @Override
+    public void add(long value) {
+        // do nothing as this gauge is RO view of some stat
+    }
+
+    @Override
+    public long getValue() {
+        return provider.getValue();
     }
 
     private CharSequence getName() {

--- a/core/src/main/java/io/questdb/std/AssociativeCache.java
+++ b/core/src/main/java/io/questdb/std/AssociativeCache.java
@@ -69,8 +69,10 @@ public class AssociativeCache<V> implements Closeable, Mutable {
         for (int i = 0, n = keys.length; i < n; i++) {
             if (keys[i] != null) {
                 keys[i] = null;
-                free(i);
-                freed++;
+                if (values[i] != null) {
+                    values[i] = Misc.free(values[i]);
+                    freed++;
+                }
             }
         }
         cachedGauge.add(-freed);
@@ -118,10 +120,11 @@ public class AssociativeCache<V> implements Closeable, Mutable {
 
         final CharSequence outgoingKey = keys[lo + bmask];
         if (outgoingKey != null) {
-            if (values[lo + bmask] == null) {
+            int idx = lo + bmask;
+            if (values[idx] == null) {
                 cachedGauge.inc();
             } else {
-                free(lo + bmask);
+                values[idx] = Misc.free(values[idx]);
             }
         } else {
             cachedGauge.inc();
@@ -137,10 +140,6 @@ public class AssociativeCache<V> implements Closeable, Mutable {
         values[lo] = value;
 
         return outgoingKey;
-    }
-
-    private void free(int lo) {
-        values[lo] = Misc.free(values[lo]);
     }
 
     private int getIndex(CharSequence key) {

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -24,7 +24,10 @@
 
 package io.questdb.cairo;
 
-import io.questdb.*;
+import io.questdb.DefaultTelemetryConfiguration;
+import io.questdb.MessageBus;
+import io.questdb.Metrics;
+import io.questdb.TelemetryConfiguration;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.DatabaseSnapshotAgent;
@@ -77,7 +80,7 @@ public class AbstractCairoTest {
     protected static DateFormat backupDirTimestampFormat;
     protected static long configOverrideCommitLagMicros = -1;
     protected static int configOverrideMaxUncommittedRows = -1;
-    protected static Metrics metrics = Metrics.enabled();
+    protected static Metrics metrics;
     protected static int capacity = -1;
     protected static int sampleByIndexSearchPageSize;
     protected static int binaryEncodingMaxLength = -1;
@@ -365,6 +368,7 @@ public class AbstractCairoTest {
                 return attachableDirSuffix == null ? super.getAttachPartitionSuffix() : attachableDirSuffix;
             }
         };
+        metrics = Metrics.enabled();
         engine = new CairoEngine(configuration, metrics);
         snapshotAgent = new DatabaseSnapshotAgent(engine);
         messageBus = engine.getMessageBus();

--- a/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -57,11 +57,11 @@ public class HttpHealthCheckTestBuilder {
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
                     .withBaseDir(baseDir)
                     .build();
-            QueryCache.configure(httpConfiguration);
-
             if (metrics == null) {
                 metrics = Metrics.enabled();
             }
+
+            QueryCache.configure(httpConfiguration, metrics);
 
             WorkerPool workerPool = new TestWorkerPool(1, metrics);
 

--- a/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpMinTestBuilder.java
@@ -81,7 +81,7 @@ public class HttpMinTestBuilder {
                     }
                 });
 
-                QueryCache.configure(httpConfiguration);
+                QueryCache.configure(httpConfiguration, Metrics.disabled());
 
                 workerPool.start(LOG);
 

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -222,7 +222,7 @@ public class HttpQueryTestBuilder {
                     }
                 });
 
-                QueryCache.configure(httpConfiguration);
+                QueryCache.configure(httpConfiguration, metrics);
 
                 workerPool.start(LOG);
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -4346,7 +4346,7 @@ public class IODispatcherTest {
                     .withHttpProtocolVersion("HTTP/1.1 ")
                     .withOnPeerDisconnect(peerDisconnectLatch::countDown)
                     .build();
-            QueryCache.configure(httpConfiguration);
+            QueryCache.configure(httpConfiguration, metrics);
 
             WorkerPool workerPool = new TestWorkerPool(1);
 
@@ -7067,7 +7067,7 @@ public class IODispatcherTest {
                 .withServerKeepAlive(serverKeepAlive)
                 .withHttpProtocolVersion(httpProtocolVersion)
                 .build();
-        QueryCache.configure(httpConfiguration);
+        QueryCache.configure(httpConfiguration, metrics);
         return httpConfiguration;
     }
 

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -24,19 +24,18 @@
 
 package io.questdb.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.griffin.engine.ops.AbstractOperation;
 import io.questdb.griffin.engine.ops.OperationDispatcher;
+import io.questdb.griffin.engine.ops.UpdateOperation;
 import io.questdb.mp.SCSequence;
 import io.questdb.mp.SOCountDownLatch;
-import io.questdb.griffin.engine.ops.UpdateOperation;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.AbstractCharSequence;
@@ -47,7 +46,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 import org.junit.AfterClass;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,7 +61,6 @@ public class AbstractGriffinTest extends AbstractCairoTest {
     protected static BindVariableService bindVariableService;
     protected static SqlExecutionContext sqlExecutionContext;
     protected static SqlCompiler compiler;
-    protected static Metrics metrics = Metrics.enabled();
 
     protected final SCSequence eventSubSequence = new SCSequence();
 

--- a/core/src/test/java/io/questdb/std/AssociativeCacheTest.java
+++ b/core/src/test/java/io/questdb/std/AssociativeCacheTest.java
@@ -58,10 +58,16 @@ public class AssociativeCacheTest {
             cache.put(Integer.toString(i), Integer.toString(i));
             Assert.assertEquals(i + 1, gauge.getValue());
         }
+
         cache.poll("0");
         Assert.assertEquals(9, gauge.getValue());
+        // Second poll() on the same key should be ignored.
+        cache.poll("0");
+        Assert.assertEquals(9, gauge.getValue());
+        // put() should insert value for key-value pair cleared by poll().
         cache.put("0", "42");
         Assert.assertEquals(10, gauge.getValue());
+
         cache.clear();
         Assert.assertEquals(0, gauge.getValue());
     }

--- a/core/src/test/java/io/questdb/std/AssociativeCacheTest.java
+++ b/core/src/test/java/io/questdb/std/AssociativeCacheTest.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import io.questdb.metrics.Gauge;
+import io.questdb.metrics.GaugeImpl;
 import io.questdb.std.str.DirectByteCharSequence;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,6 +41,29 @@ public class AssociativeCacheTest {
         Assert.assertEquals("1", cache.peek("X"));
         Assert.assertEquals("2", cache.peek("Y"));
         Assert.assertEquals("3", cache.peek("Z"));
+        Assert.assertEquals("1", cache.poll("X"));
+        Assert.assertEquals("2", cache.poll("Y"));
+        Assert.assertEquals("3", cache.poll("Z"));
+        Assert.assertNull(cache.poll("X"));
+        Assert.assertNull(cache.poll("Y"));
+        Assert.assertNull(cache.poll("Z"));
+    }
+
+    @Test
+    public void testGaugeUpdates() {
+        Gauge gauge = new GaugeImpl("foobar");
+        AssociativeCache<String> cache = new AssociativeCache<>(8, 64, gauge);
+        Assert.assertEquals(0, gauge.getValue());
+        for (int i = 0; i < 10; i++) {
+            cache.put(Integer.toString(i), Integer.toString(i));
+            Assert.assertEquals(i + 1, gauge.getValue());
+        }
+        cache.poll("0");
+        Assert.assertEquals(9, gauge.getValue());
+        cache.put("0", "42");
+        Assert.assertEquals(10, gauge.getValue());
+        cache.clear();
+        Assert.assertEquals(0, gauge.getValue());
     }
 
     @Test


### PR DESCRIPTION
Fixes #2286
Fixes #2349

Fixes `flush_query_cache()` function tests flakiness. The tests no longer rely on memory consumption, but instead check the new metric values.