### PR TITLE
feat(sql): add column pre-touch for parallel filter

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -260,6 +260,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int columnPurgeRetryLimitDays;
     private final long columnPurgeRetryDelay;
     private final boolean sqlParallelFilterEnabled;
+    private final boolean sqlParallelFilterPreTouchEnabled;
     private final int cairoPageFrameReduceShardCount;
     private final int replaceFunctionBufferMaxSize;
     private final int cairoSqlCopyQueueCapacity;
@@ -747,6 +748,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.cairoPageFrameReduceRowIdListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY, 256));
             this.cairoPageFrameReduceColumnListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY, 16));
             this.sqlParallelFilterEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FILTER_ENABLED, true);
+            this.sqlParallelFilterPreTouchEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED, false);
             this.cairoPageFrameReduceShardCount = getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 4);
             this.cairoPageFrameReduceTaskPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_TASK_POOL_CAPACITY, 4);
 
@@ -2625,6 +2627,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isSqlParallelFilterEnabled() {
             return sqlParallelFilterEnabled;
+        }
+
+        @Override
+        public boolean isSqlParallelFilterPreTouchEnabled() {
+            return sqlParallelFilterPreTouchEnabled;
         }
     }
 

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -89,6 +89,7 @@ public enum PropertyKey {
     CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY("cairo.page.frame.rowid.list.capacity"),
     CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY("cairo.page.frame.column.list.capacity"),
     CAIRO_SQL_PARALLEL_FILTER_ENABLED("cairo.sql.parallel.filter.enabled"),
+    CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED("cairo.sql.parallel.filter.pretouch.enabled"),
     CAIRO_PAGE_FRAME_SHARD_COUNT("cairo.page.frame.shard.count"),
     CAIRO_PAGE_FRAME_TASK_POOL_CAPACITY("cairo.page.frame.task.pool.capacity"),
     CAIRO_SQL_JOIN_METADATA_PAGE_SIZE("cairo.sql.join.metadata.page.size"),

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -37,6 +37,7 @@ import io.questdb.griffin.DatabaseSnapshotAgent;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.FunctionFactoryCache;
 import io.questdb.griffin.engine.groupby.vect.GroupByJob;
+import io.questdb.griffin.engine.table.AsyncFilterAtom;
 import io.questdb.griffin.engine.table.LatestByAllIndexedJob;
 import io.questdb.jit.JitUtil;
 import io.questdb.log.Log;
@@ -298,6 +299,7 @@ public class ServerMain {
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 System.err.println(new Date() + " QuestDB is shutting down");
+                System.err.println("Pre-touch magic number: " + AsyncFilterAtom.PRE_TOUCH_BLACKHOLE.sum());
                 shutdownQuestDb(workerPool, instancesToClean);
                 System.err.println(new Date() + " QuestDB is down");
                 LogFactory.INSTANCE.flushJobsAndClose();

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -410,4 +410,6 @@ public interface CairoConfiguration {
     boolean isSqlJitDebugEnabled();
 
     boolean isSqlParallelFilterEnabled();
+
+    boolean isSqlParallelFilterPreTouchEnabled();
 }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -424,6 +424,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean isSqlParallelFilterPreTouchEnabled() {
+        return false;
+    }
+
+    @Override
     public int getSqlCopyLogRetentionDays() {
         return 3;
     }

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -34,6 +34,7 @@ import io.questdb.log.LogFactory;
 import io.questdb.mp.*;
 import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -1125,6 +1125,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
 
         final boolean enableParallelFilter = configuration.isSqlParallelFilterEnabled();
+        final boolean preTouchColumns = configuration.isSqlParallelFilterPreTouchEnabled();
         if (enableParallelFilter && factory.supportPageFrameCursor()) {
 
             final boolean useJit = executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED;
@@ -1165,7 +1166,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             jitFilter,
                             reduceTaskPool,
                             limitLoFunction,
-                            limitLoPos
+                            limitLoPos,
+                            preTouchColumns
                     );
                 } catch (SqlException | LimitOverflowException ex) {
                     Misc.free(jitFilter);
@@ -1203,7 +1205,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             executionContext
                     ),
                     limitLoFunction,
-                    limitLoPos
+                    limitLoPos,
+                    preTouchColumns
             );
         }
         return new FilteredRecordCursorFactory(factory, filter);
@@ -1451,7 +1454,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                         executionContext
                                 ),
                                 null,
-                                0
+                                0,
+                                false
                         );
                     } else {
                         master = new FilteredRecordCursorFactory(

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -432,6 +432,9 @@ query.timeout.sec=60
 # Sets flag to enable parallel SQL filter execution. JIT compilation takes place only when this setting is enabled.
 #cairo.sql.parallel.filter.enabled=true
 
+# Sets flag to enable column pre-touch as a part of the parallel SQL filter execution. Enabling this setting may improve query performance in case of large tables.
+#cairo.sql.parallel.filter.pretouch.enabled=false
+
 # Shard reduce queue contention between SQL statements that are executed concurrently.
 #cairo.page.frame.shard.count=4
 

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -214,6 +214,7 @@ public class PropServerConfigurationTest {
         Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().ownThread());
 
         Assert.assertTrue(configuration.getCairoConfiguration().isSqlParallelFilterEnabled());
+        Assert.assertFalse(configuration.getCairoConfiguration().isSqlParallelFilterPreTouchEnabled());
         Assert.assertEquals(1_000_000, configuration.getCairoConfiguration().getSqlPageFrameMaxRows());
         Assert.assertEquals(1000, configuration.getCairoConfiguration().getSqlPageFrameMinRows());
         Assert.assertEquals(4, configuration.getCairoConfiguration().getPageFrameReduceShardCount());
@@ -772,6 +773,7 @@ public class PropServerConfigurationTest {
             Assert.assertTrue(configuration.getLineUdpReceiverConfiguration().ownThread());
 
             Assert.assertFalse(configuration.getCairoConfiguration().isSqlParallelFilterEnabled());
+            Assert.assertTrue(configuration.getCairoConfiguration().isSqlParallelFilterPreTouchEnabled());
             Assert.assertEquals(1000, configuration.getCairoConfiguration().getSqlPageFrameMaxRows());
             Assert.assertEquals(100, configuration.getCairoConfiguration().getSqlPageFrameMinRows());
             Assert.assertEquals(128, configuration.getCairoConfiguration().getPageFrameReduceShardCount());

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -92,6 +92,7 @@ public class AbstractCairoTest {
     protected static String snapshotInstanceId = null;
     protected static Boolean snapshotRecoveryEnabled = null;
     protected static Boolean enableParallelFilter = null;
+    protected static Boolean enableColumnPreTouch = null;
     protected static int queryCacheEventQueueCapacity = -1;
     protected static int pageFrameReduceShardCount = -1;
     protected static int pageFrameReduceQueueCapacity = -1;
@@ -112,7 +113,6 @@ public class AbstractCairoTest {
     protected static int defaultTableWriteMode = -1;
     protected static Boolean copyPartitionOnAttach = null;
     protected static String attachableDirSuffix = null;
-
 
     private static TelemetryConfiguration telemetryConfiguration;
     @Rule
@@ -329,6 +329,11 @@ public class AbstractCairoTest {
             }
 
             @Override
+            public boolean isSqlParallelFilterPreTouchEnabled() {
+                return enableColumnPreTouch != null ? enableColumnPreTouch : super.isSqlParallelFilterPreTouchEnabled();
+            }
+
+            @Override
             public int getColumnPurgeTaskPoolCapacity() {
                 return columnVersionTaskPoolCapacity >= 0 ? columnVersionTaskPoolCapacity : super.getColumnPurgeTaskPoolCapacity();
             }
@@ -416,6 +421,7 @@ public class AbstractCairoTest {
         snapshotInstanceId = null;
         snapshotRecoveryEnabled = null;
         enableParallelFilter = null;
+        enableColumnPreTouch = null;
         hideTelemetryTable = false;
         writerCommandQueueCapacity = 4;
         queryCacheEventQueueCapacity = -1;

--- a/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
+++ b/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
@@ -798,6 +798,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public boolean isSqlParallelFilterPreTouchEnabled() {
+        return conf.isSqlParallelFilterPreTouchEnabled();
+    }
+
+    @Override
     public int getSqlCopyLogRetentionDays() {
         return conf.getSqlCopyLogRetentionDays();
     }

--- a/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
+++ b/core/src/test/java/io/questdb/griffin/CompiledFilterTest.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Tests for advanced features and scenarios, such as  col tops, bind variables,
+ * Tests for advanced features and scenarios, such as col tops, bind variables,
  * random access, record behavior, and so on.
  */
 public class CompiledFilterTest extends AbstractGriffinTest {
@@ -179,7 +179,7 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                     "3\t1970-01-01T00:00:02.000000Z\tNaN\n" +
                     "3\t1970-01-01T00:01:42.000000Z\t7746536061816329025\n";
 
-            testFilterWithColTops(query, expected, SqlJitMode.JIT_MODE_ENABLED);
+            testFilterWithColTops(query, expected, SqlJitMode.JIT_MODE_ENABLED, false);
         });
     }
 
@@ -346,75 +346,103 @@ public class CompiledFilterTest extends AbstractGriffinTest {
 
     @Test
     public void testSelectAllBothPageFramesFilterWithColTopsScalar() throws Exception {
-        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR, false);
     }
 
     @Test
     public void testSelectAllBothPageFramesFilterWithColTopsVectorized() throws Exception {
-        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, false);
+    }
+
+    @Test
+    public void testSelectAllBothPageFramesFilterWithColTopsPreTouchEnabled() throws Exception {
+        testSelectAllBothPageFramesFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, true);
     }
 
     @Test
     public void testSelectAllFilterWithColTopsScalar() throws Exception {
-        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR, false);
     }
 
     @Test
     public void testSelectAllFilterWithColTopsVectorized() throws Exception {
-        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, false);
     }
 
     @Test
-    public void testSelectAllTypesFromRecord() throws Exception {
-        final String query = "select * from x where b = true and kk < 10";
-        final String expected = "kk\ta\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tcc\tl2\thash1b\thash2b\thash3b\thash1c\thash2c\thash4c\thash8c\n" +
-                "2\t1637847416\ttrue\tV\t0.4900510449885239\t0.8258\t553\t2015-12-28T22:25:40.934Z\t\t-7611030538224290496\t1970-01-05T15:15:00.000000Z\t37\t00000000 3e e3 f1 f1 1e ca 9c 1d 06 ac\tKGHVUVSDOTSED\tY\t0x772c8b7f9505620ebbdfe8ff0cd60c64712fde5706d6ea2f545ded49c47eea61\t0\t10\t110\te\tsj\tfhcq\t35jvygt2\n" +
-                "3\t844704299\ttrue\t\t0.3456897991538844\t0.2401\t775\t2015-08-03T15:58:03.335Z\tVTJW\t-8910603140262731534\t1970-01-05T15:23:20.000000Z\t24\t00000000 ac a8 3b a6 dc 3b 7d 2b e3 92 fe 69 38 e1 77 9a\n" +
-                "00000010 e7 0c 89\tLJUMLGLHMLLEO\tY\t0xabbcbeeddca3d4fe4f25a88863fc0f467f24de22c77acf93e983e65f5551d073\t0\t01\t000\tf\t33\teusj\tb5z6npxr\n" +
-                "6\t-1501720177\ttrue\tP\t0.18158967304439033\t0.8197\t501\t2015-06-08T17:20:46.703Z\tPEHN\t-4229502740666959541\t1970-01-05T15:48:20.000000Z\t19\t\tTNLEGP\tU\t0x79423d4d320d2649767a4feda060d4fb6923c0c7d965969da1b1140a2be25241\t1\t01\t010\tr\tc0\twhjh\trcqfw2hw\n" +
-                "8\t526232578\ttrue\tE\t0.6379992093447574\t0.8515\t850\t2015-08-19T05:52:05.329Z\tPEHN\t-5157086556591926155\t1970-01-05T16:05:00.000000Z\t42\t00000000 6d 8c d8 ac c8 46 3b 47 3c e1 72 3b 9d\tJSMKIXEYVTUPD\tH\t0x2337f7e6b82ebc2405c5c1b231cffa455a6e970fb8b80abcc4129ae493cc6076\t0\t11\t000\t5\ttp\tx578\ttdnxkw6d\n";
-        final String ddl = "create table x as (select" +
-                " cast(x as int) kk," +
-                " rnd_int() a," +
-                " rnd_boolean() b," +
-                " rnd_str(1,1,2) c," +
-                " rnd_double(2) d," +
-                " rnd_float(2) e," +
-                " rnd_short(10,1024) f," +
-                " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
-                " rnd_symbol(4,4,4,2) i," +
-                " rnd_long() j," +
-                " timestamp_sequence(400000000000, 500000000) k," +
-                " rnd_byte(2,50) l," +
-                " rnd_bin(10, 20, 2) m," +
-                " rnd_str(5,16,2) n," +
-                " rnd_char() cc," +
-                " rnd_long256() l2," +
-                " rnd_geohash(1) hash1b," +
-                " rnd_geohash(2) hash2b," +
-                " rnd_geohash(3) hash3b," +
-                " rnd_geohash(5) hash1c," +
-                " rnd_geohash(10) hash2c," +
-                " rnd_geohash(20) hash4c," +
-                " rnd_geohash(40) hash8c" +
-                " from long_sequence(100)) timestamp(k)";
+    public void testSelectAllFilterWithColTopsPreTouchEnabled() throws Exception {
+        testSelectAllFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, true);
+    }
 
-        assertQuery(expected,
-                query,
-                ddl,
-                "k",
-                true);
-        assertSqlRunWithJit(query);
+    @Test
+    public void testSelectAllTypesFromRecordPreTouchDisabled() throws Exception {
+        testSelectAllTypesFromRecord(false);
+    }
+
+    @Test
+    public void testSelectAllTypesFromRecordPreTouchEnabled() throws Exception {
+        testSelectAllTypesFromRecord(true);
+    }
+
+    private void testSelectAllTypesFromRecord(boolean preTouch) throws Exception {
+        assertMemoryLeak(() -> {
+            enableColumnPreTouch = preTouch;
+
+            final String query = "select * from x where b = true and kk < 10";
+            final String expected = "kk\ta\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tcc\tl2\thash1b\thash2b\thash3b\thash1c\thash2c\thash4c\thash8c\n" +
+                    "2\t1637847416\ttrue\tV\t0.4900510449885239\t0.8258\t553\t2015-12-28T22:25:40.934Z\t\t-7611030538224290496\t1970-01-05T15:15:00.000000Z\t37\t00000000 3e e3 f1 f1 1e ca 9c 1d 06 ac\tKGHVUVSDOTSED\tY\t0x772c8b7f9505620ebbdfe8ff0cd60c64712fde5706d6ea2f545ded49c47eea61\t0\t10\t110\te\tsj\tfhcq\t35jvygt2\n" +
+                    "3\t844704299\ttrue\t\t0.3456897991538844\t0.2401\t775\t2015-08-03T15:58:03.335Z\tVTJW\t-8910603140262731534\t1970-01-05T15:23:20.000000Z\t24\t00000000 ac a8 3b a6 dc 3b 7d 2b e3 92 fe 69 38 e1 77 9a\n" +
+                    "00000010 e7 0c 89\tLJUMLGLHMLLEO\tY\t0xabbcbeeddca3d4fe4f25a88863fc0f467f24de22c77acf93e983e65f5551d073\t0\t01\t000\tf\t33\teusj\tb5z6npxr\n" +
+                    "6\t-1501720177\ttrue\tP\t0.18158967304439033\t0.8197\t501\t2015-06-08T17:20:46.703Z\tPEHN\t-4229502740666959541\t1970-01-05T15:48:20.000000Z\t19\t\tTNLEGP\tU\t0x79423d4d320d2649767a4feda060d4fb6923c0c7d965969da1b1140a2be25241\t1\t01\t010\tr\tc0\twhjh\trcqfw2hw\n" +
+                    "8\t526232578\ttrue\tE\t0.6379992093447574\t0.8515\t850\t2015-08-19T05:52:05.329Z\tPEHN\t-5157086556591926155\t1970-01-05T16:05:00.000000Z\t42\t00000000 6d 8c d8 ac c8 46 3b 47 3c e1 72 3b 9d\tJSMKIXEYVTUPD\tH\t0x2337f7e6b82ebc2405c5c1b231cffa455a6e970fb8b80abcc4129ae493cc6076\t0\t11\t000\t5\ttp\tx578\ttdnxkw6d\n";
+            final String ddl = "create table x as (select" +
+                    " cast(x as int) kk," +
+                    " rnd_int() a," +
+                    " rnd_boolean() b," +
+                    " rnd_str(1,1,2) c," +
+                    " rnd_double(2) d," +
+                    " rnd_float(2) e," +
+                    " rnd_short(10,1024) f," +
+                    " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                    " rnd_symbol(4,4,4,2) i," +
+                    " rnd_long() j," +
+                    " timestamp_sequence(400000000000, 500000000) k," +
+                    " rnd_byte(2,50) l," +
+                    " rnd_bin(10, 20, 2) m," +
+                    " rnd_str(5,16,2) n," +
+                    " rnd_char() cc," +
+                    " rnd_long256() l2," +
+                    " rnd_geohash(1) hash1b," +
+                    " rnd_geohash(2) hash2b," +
+                    " rnd_geohash(3) hash3b," +
+                    " rnd_geohash(5) hash1c," +
+                    " rnd_geohash(10) hash2c," +
+                    " rnd_geohash(20) hash4c," +
+                    " rnd_geohash(40) hash8c" +
+                    " from long_sequence(100)) timestamp(k)";
+
+            assertQuery(expected,
+                    query,
+                    ddl,
+                    "k",
+                    true);
+            assertSqlRunWithJit(query);
+        });
     }
 
     @Test
     public void testSelectSingleColumnFilterWithColTopsScalar() throws Exception {
-        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_FORCE_SCALAR, false);
     }
 
     @Test
     public void testSelectSingleColumnFilterWithColTopsVectorized() throws Exception {
-        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED);
+        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, false);
+    }
+
+    @Test
+    public void testSelectSingleColumnFilterWithColTopsPreTouchEnabled() throws Exception {
+        testSelectSingleColumnFilterWithColTops(SqlJitMode.JIT_MODE_ENABLED, true);
     }
 
     @Test
@@ -463,6 +491,33 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                         "1970-01-05T15:31:40.000000Z\tC\n" +
                         "1970-01-05T15:40:00.000000Z\tC\n", sink);
             }
+        });
+    }
+
+    @Test
+    public void testMixedSelectPreTouchEnabled() throws Exception {
+        assertMemoryLeak(() -> {
+            enableColumnPreTouch = true;
+
+            compiler.compile("create table t1 as (select " +
+                    " x," +
+                    " timestamp_sequence(to_timestamp('1970-01-01', 'yyyy-MM-dd'), 100000L) ts " +
+                    "from long_sequence(10)) timestamp(ts) partition by day", sqlExecutionContext);
+
+            final String query = "select 1 as one, (4 + 2) as the_answer, ts as col_ts, x as col_x, sqrt(x) as root_x from t1 where x > 1";
+            final String expected = "one\tthe_answer\tcol_ts\tcol_x\troot_x\n" +
+                    "1\t6\t1970-01-01T00:00:00.100000Z\t2\t1.4142135623730951\n" +
+                    "1\t6\t1970-01-01T00:00:00.200000Z\t3\t1.7320508075688772\n" +
+                    "1\t6\t1970-01-01T00:00:00.300000Z\t4\t2.0\n" +
+                    "1\t6\t1970-01-01T00:00:00.400000Z\t5\t2.23606797749979\n" +
+                    "1\t6\t1970-01-01T00:00:00.500000Z\t6\t2.449489742783178\n" +
+                    "1\t6\t1970-01-01T00:00:00.600000Z\t7\t2.6457513110645907\n" +
+                    "1\t6\t1970-01-01T00:00:00.700000Z\t8\t2.8284271247461903\n" +
+                    "1\t6\t1970-01-01T00:00:00.800000Z\t9\t3.0\n" +
+                    "1\t6\t1970-01-01T00:00:00.900000Z\t10\t3.1622776601683795\n";
+
+            assertSql(query, expected);
+            assertSqlRunWithJit(query);
         });
     }
 
@@ -556,9 +611,10 @@ public class CompiledFilterTest extends AbstractGriffinTest {
         });
     }
 
-    private void testFilterWithColTops(String query, String expected, int jitMode) throws Exception {
+    private void testFilterWithColTops(String query, String expected, int jitMode, boolean preTouch) throws Exception {
         assertMemoryLeak(() -> {
             sqlExecutionContext.setJitMode(jitMode);
+            enableColumnPreTouch = preTouch;
 
             compiler.compile("create table t1 as (select " +
                     " x," +
@@ -578,7 +634,7 @@ public class CompiledFilterTest extends AbstractGriffinTest {
         });
     }
 
-    private void testSelectAllBothPageFramesFilterWithColTops(int jitMode) throws Exception {
+    private void testSelectAllBothPageFramesFilterWithColTops(int jitMode, boolean preTouch) throws Exception {
         final String query = "select * from t1 where x >= 3 and x <= 4";
         final String expected = "x\tts\tj\n" +
                 "3\t1970-01-01T00:00:02.000000Z\tNaN\n" +
@@ -586,10 +642,10 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                 "3\t1970-01-01T00:01:42.000000Z\t7746536061816329025\n" +
                 "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n";
 
-        testFilterWithColTops(query, expected, jitMode);
+        testFilterWithColTops(query, expected, jitMode, preTouch);
     }
 
-    private void testSelectAllFilterWithColTops(int jitMode) throws Exception {
+    private void testSelectAllFilterWithColTops(int jitMode, boolean preTouch) throws Exception {
         final String query = "select * from t1 where j < 0";
         final String expected = "x\tts\tj\n" +
                 "4\t1970-01-01T00:01:43.000000Z\t-6945921502384501475\n" +
@@ -602,10 +658,10 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                 "16\t1970-01-01T00:01:55.000000Z\t-4474835130332302712\n" +
                 "17\t1970-01-01T00:01:56.000000Z\t-6943924477733600060\n";
 
-        testFilterWithColTops(query, expected, jitMode);
+        testFilterWithColTops(query, expected, jitMode, preTouch);
     }
 
-    private void testSelectSingleColumnFilterWithColTops(int jitMode) throws Exception {
+    private void testSelectSingleColumnFilterWithColTops(int jitMode, boolean preTouch) throws Exception {
         // The column order is important here, since we want
         // query and table column indexes to be different.
         final String query = "select j from t1 where j <> null and x < 3";
@@ -613,7 +669,7 @@ public class CompiledFilterTest extends AbstractGriffinTest {
                 "4689592037643856\n" +
                 "4729996258992366\n";
 
-        testFilterWithColTops(query, expected, jitMode);
+        testFilterWithColTops(query, expected, jitMode, preTouch);
     }
 
     private void testSingleBindVariable(int jitMode) throws Exception {

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -115,6 +115,7 @@ cairo.sql.sampleby.page.size=2001
 cairo.sql.page.frame.max.rows=1000
 cairo.sql.page.frame.min.rows=100
 cairo.sql.parallel.filter.enabled=false
+cairo.sql.parallel.filter.pretouch.enabled=true
 cairo.page.frame.shard.count=128
 cairo.page.frame.reduce.queue.capacity=1024
 cairo.page.frame.rowid.list.capacity=8

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -418,6 +418,9 @@ query.timeout.sec=60
 # Sets flag to enable parallel SQL filter execution. JIT compilation takes place only when this setting is enabled.
 #cairo.sql.parallel.filter.enabled=true
 
+# Sets flag to enable column pre-touch as a part of the parallel SQL filter execution. Enabling this setting may improve query performance in case of large tables.
+#cairo.sql.parallel.filter.pretouch.enabled=false
+
 # Shard reduce queue contention between SQL statements that are executed concurrently.
 #cairo.page.frame.shard.count=4
 


### PR DESCRIPTION
In case of a large table that doesn't fit to OS page cache (think, free RAM), performance of queries that use parallel filter may be limited with the capabilities of the single ("query owner") thread.

Here is an example scenario:

```sql
SELECT col_a, col_b, ..., col_N
FROM tab
WHERE ts in '2016-02-10' and col_a = 'foobar';
```

Here the filter only touches col_a which has all chances to fit to page cache, so filtering itself may be fast. Yet, the owner thread would have to accumulate all selected column values into the send buffer which may lead to page faults on almost each mmapped memory access, especially if filtered rows aren't located in the same pages (think, they're spread in terms of time).

When `cairo.sql.parallel.filter.pretouch.enabled=true`, all threads that participate in filtering will touch all selected columns helping the owner thread to avoid major page faults later on.

### Benchmarking

Test stand: m6a.4xlarge (16 vCPU, 64GB RAM) + gp3 300GB with 16K IOPS and 1K MB/s; Ubuntu 22.04; two tables occupying 137GB of disk space; queries involve filter on a single column (8GB in size for each table)

* Pre-touch disabled: hot execution is bottlenecked with around 100MB/s rate of disk reads done by a single thread
* Pre-touch enabled: hot execution varies in the 800-1000MB/s interval and read operations are issued by all shared worker threads