### PR TITLE
fix(sql): reduce memory utilization of cursor factories

### DIFF
--- a/core/src/main/java/io/questdb/cairo/RecordChain.java
+++ b/core/src/main/java/io/questdb/cairo/RecordChain.java
@@ -35,7 +35,7 @@ import io.questdb.std.str.CharSink;
 
 import java.io.Closeable;
 
-public class RecordChain implements Closeable, RecordCursor, Mutable, RecordSinkSPI, AnalyticSPI {
+public class RecordChain implements Closeable, RecordCursor, Mutable, RecordSinkSPI, AnalyticSPI, Reallocatable {
 
     private final long[] columnOffsets;
     private final MemoryARW mem;
@@ -128,6 +128,11 @@ public class RecordChain implements Closeable, RecordCursor, Mutable, RecordSink
     @Override
     public Record getRecordB() {
         return recordB;
+    }
+
+    @Override
+    public void reallocate() {
+        //nothing to do here        
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/map/FastMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/FastMap.java
@@ -94,7 +94,7 @@ public class FastMap implements Map, Reallocatable {
             int maxResizes,
             int memoryTag
     ) {
-        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, DEFAULT_HASH, maxResizes, memoryTag);
+        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, DEFAULT_HASH, maxResizes, memoryTag, memoryTag);
     }
 
     FastMap(
@@ -106,7 +106,7 @@ public class FastMap implements Map, Reallocatable {
             HashFunction hashFunction,
             int maxResizes
     ) {
-        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, hashFunction, maxResizes, -1);
+        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, hashFunction, maxResizes, MemoryTag.NATIVE_FAST_MAP, MemoryTag.NATIVE_FAST_MAP_LONG_LIST);
     }
 
     @TestOnly
@@ -118,20 +118,21 @@ public class FastMap implements Map, Reallocatable {
             double loadFactor,
             HashFunction hashFunction,
             int maxResizes,
-            int memoryTag
+            int mapMemoryTag,
+            int listMemoryTag
     ) {
         assert pageSize > 3;
         assert loadFactor > 0 && loadFactor < 1d;
         this.initialKeyCapacity = keyCapacity;
         this.initialPageSize = pageSize;
         this.loadFactor = loadFactor;
-        this.kStart = kPos = Unsafe.malloc(this.capacity = pageSize, memoryTag > -1 ? memoryTag : MemoryTag.NATIVE_FAST_MAP);
+        this.kStart = kPos = Unsafe.malloc(this.capacity = pageSize, mapMemoryTag);
         this.kLimit = kStart + pageSize;
         this.keyCapacity = (int) (keyCapacity / loadFactor);
         this.keyCapacity = this.keyCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(this.keyCapacity);
         this.mask = this.keyCapacity - 1;
         this.free = (int) (this.keyCapacity * loadFactor);
-        this.offsets = new DirectLongList(this.keyCapacity, memoryTag > -1 ? memoryTag : MemoryTag.NATIVE_FAST_MAP_LONG_LIST);
+        this.offsets = new DirectLongList(this.keyCapacity, listMemoryTag);
         this.offsets.setPos(this.keyCapacity);
         this.offsets.zero(0);
         this.hashFunction = hashFunction;

--- a/core/src/main/java/io/questdb/cairo/map/FastMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/FastMap.java
@@ -85,7 +85,18 @@ public class FastMap implements Map, Reallocatable {
         this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, DEFAULT_HASH, maxResizes);
     }
 
-    @TestOnly
+    public FastMap(
+            int pageSize,
+            @Transient @NotNull ColumnTypes keyTypes,
+            @Transient @Nullable ColumnTypes valueTypes,
+            int keyCapacity,
+            double loadFactor,
+            int maxResizes,
+            int memoryTag
+    ) {
+        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, DEFAULT_HASH, maxResizes, memoryTag);
+    }
+
     FastMap(
             int pageSize,
             @Transient ColumnTypes keyTypes,
@@ -95,18 +106,32 @@ public class FastMap implements Map, Reallocatable {
             HashFunction hashFunction,
             int maxResizes
     ) {
+        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, hashFunction, maxResizes, -1);
+    }
+
+    @TestOnly
+    FastMap(
+            int pageSize,
+            @Transient ColumnTypes keyTypes,
+            @Transient ColumnTypes valueTypes,
+            int keyCapacity,
+            double loadFactor,
+            HashFunction hashFunction,
+            int maxResizes,
+            int memoryTag
+    ) {
         assert pageSize > 3;
         assert loadFactor > 0 && loadFactor < 1d;
         this.initialKeyCapacity = keyCapacity;
         this.initialPageSize = pageSize;
         this.loadFactor = loadFactor;
-        this.kStart = kPos = Unsafe.malloc(this.capacity = pageSize, MemoryTag.NATIVE_FAST_MAP);
+        this.kStart = kPos = Unsafe.malloc(this.capacity = pageSize, memoryTag > -1 ? memoryTag : MemoryTag.NATIVE_FAST_MAP);
         this.kLimit = kStart + pageSize;
         this.keyCapacity = (int) (keyCapacity / loadFactor);
         this.keyCapacity = this.keyCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(this.keyCapacity);
         this.mask = this.keyCapacity - 1;
         this.free = (int) (this.keyCapacity * loadFactor);
-        this.offsets = new DirectLongList(this.keyCapacity, MemoryTag.NATIVE_FAST_MAP_LONG_LIST);
+        this.offsets = new DirectLongList(this.keyCapacity, memoryTag > -1 ? memoryTag : MemoryTag.NATIVE_FAST_MAP_LONG_LIST);
         this.offsets.setPos(this.keyCapacity);
         this.offsets.zero(0);
         this.hashFunction = hashFunction;

--- a/core/src/main/java/io/questdb/griffin/engine/AbstractRedBlackTree.java
+++ b/core/src/main/java/io/questdb/griffin/engine/AbstractRedBlackTree.java
@@ -24,14 +24,13 @@
 
 package io.questdb.griffin.engine;
 
+import io.questdb.cairo.Reallocatable;
 import io.questdb.std.MemoryPages;
 import io.questdb.std.Misc;
 import io.questdb.std.Mutable;
 import io.questdb.std.Unsafe;
 
-import java.io.Closeable;
-
-public abstract class AbstractRedBlackTree implements Mutable, Closeable {
+public abstract class AbstractRedBlackTree implements Mutable, Reallocatable {
     // parent is at offset 0
     protected static final int O_LEFT = 8;
     // P(8) + L + R + C(1) + REF
@@ -60,7 +59,13 @@ public abstract class AbstractRedBlackTree implements Mutable, Closeable {
 
     @Override
     public void close() {
+        root = -1;
         Misc.free(mem);
+    }
+
+    @Override
+    public void reallocate() {
+        mem.reallocate();
     }
 
     public long size() {

--- a/core/src/main/java/io/questdb/griffin/engine/analytic/CachedAnalyticRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/analytic/CachedAnalyticRecordCursorFactory.java
@@ -170,7 +170,7 @@ public class CachedAnalyticRecordCursorFactory extends AbstractRecordCursorFacto
         }
 
         private void reallocate(ObjList list) {
-            for (int i = 0; i < list.size(); i++) {
+            for (int i = 0, n = list.size(); i < n; i++) {
                 if (list.getQuick(i) instanceof Reallocatable) {
                     ((Reallocatable) list.getQuick(i)).reallocate();
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
@@ -24,10 +24,7 @@
 
 package io.questdb.griffin.engine.functions.analytic;
 
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.RecordSink;
-import io.questdb.cairo.SingleColumnType;
+import io.questdb.cairo.*;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
@@ -94,7 +91,7 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         }
     }
 
-    private static class RowNumberFunction extends LongFunction implements ScalarFunction, AnalyticFunction, Closeable {
+    private static class RowNumberFunction extends LongFunction implements ScalarFunction, AnalyticFunction, Reallocatable {
         private final Map map;
         private final VirtualRecord partitionByRecord;
         private final RecordSink partitionBySink;
@@ -148,8 +145,13 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public void reallocate() {
+            map.reallocate();
+        }
+
+        @Override
         public void reset() {
-            map.clear();
+            map.close();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunction.java
@@ -80,6 +80,7 @@ public class AvgDoubleGroupByFunction extends DoubleFunction implements GroupByF
 
     @Override
     public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
         mapValue.putLong(valueIndex + 1, 0);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
@@ -70,7 +70,9 @@ public abstract class AbstractNoRecordSampleByCursor extends AbstractSampleByCur
 
     @Override
     public void close() {
-        base.close();
+        if (base != null) {
+            base.close();
+        }
         Misc.clearObjList(groupByFunctions);
         circuitBreaker = null;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
@@ -70,9 +70,7 @@ public abstract class AbstractNoRecordSampleByCursor extends AbstractSampleByCur
 
     @Override
     public void close() {
-        if (base != null) {
-            base.close();
-        }
+        Misc.free(base);
         Misc.clearObjList(groupByFunctions);
         circuitBreaker = null;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
@@ -73,8 +73,9 @@ public abstract class AbstractSampleByFillRecordCursorFactory extends AbstractSa
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
         final RecordCursor baseCursor = base.getCursor(executionContext);
         final SqlExecutionCircuitBreaker circuitBreaker = executionContext.getCircuitBreaker();
+        AbstractNoRecordSampleByCursor rawCursor = null;
         try {
-            AbstractNoRecordSampleByCursor rawCursor = getRawCursor();
+            rawCursor = getRawCursor();
             if (rawCursor instanceof Reallocatable) {
                 ((Reallocatable) rawCursor).reallocate();
             }
@@ -118,6 +119,9 @@ public abstract class AbstractSampleByFillRecordCursorFactory extends AbstractSa
             return initFunctionsAndCursor(executionContext, baseCursor);
         } catch (Throwable ex) {
             baseCursor.close();
+            if (rawCursor != null) {
+                rawCursor.close();
+            }
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractSampleByFillRecordCursorFactory.java
@@ -119,9 +119,7 @@ public abstract class AbstractSampleByFillRecordCursorFactory extends AbstractSa
             return initFunctionsAndCursor(executionContext, baseCursor);
         } catch (Throwable ex) {
             baseCursor.close();
-            if (rawCursor != null) {
-                rawCursor.close();
-            }
+            Misc.free(rawCursor);
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursor.java
@@ -30,6 +30,8 @@ import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.std.ObjList;
 
@@ -37,6 +39,7 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
     private final Map map;
     private final RecordSink keyMapSink;
     private final RecordCursor mapCursor;
+    private boolean isOpen;
 
     public SampleByFillNoneRecordCursor(
             Map map,
@@ -64,6 +67,16 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
         this.keyMapSink = keyMapSink;
         this.record.of(map.getRecord());
         this.mapCursor = map.getCursor();
+        this.isOpen = true;
+    }
+
+    @Override
+    public void of(RecordCursor base, SqlExecutionContext executionContext) throws SqlException {
+        super.of(base, executionContext);
+        if (!isOpen) {
+            this.map.reallocate();
+            this.isOpen = true;
+        }
     }
 
     @Override
@@ -136,5 +149,14 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
 
     private boolean mapHasNext() {
         return mapCursor.hasNext();
+    }
+
+    @Override
+    public void close() {
+        if (isOpen) {
+            map.close();
+            super.close();
+            isOpen = false;
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursorFactory.java
@@ -42,7 +42,6 @@ import io.questdb.std.Transient;
 import org.jetbrains.annotations.NotNull;
 
 public class SampleByFillNoneRecordCursorFactory extends AbstractSampleByRecordCursorFactory {
-    protected final Map map;
     private final SampleByFillNoneRecordCursor cursor;
 
     public SampleByFillNoneRecordCursorFactory(
@@ -66,9 +65,9 @@ public class SampleByFillNoneRecordCursorFactory extends AbstractSampleByRecordC
         // sink will be storing record columns to map key
         final RecordSink mapSink = RecordSinkFactory.getInstance(asm, base.getMetadata(), listColumnFilter, false);
         // this is the map itself, which we must not forget to free when factory closes
-        this.map = MapFactory.createSmallMap(configuration, keyTypes, valueTypes);
+        Map map = MapFactory.createSmallMap(configuration, keyTypes, valueTypes);
         this.cursor = new SampleByFillNoneRecordCursor(
-                this.map,
+                map,
                 mapSink,
                 groupByFunctions,
                 this.recordFunctions,
@@ -83,8 +82,8 @@ public class SampleByFillNoneRecordCursorFactory extends AbstractSampleByRecordC
 
     @Override
     protected void _close() {
+        cursor.close();
         super._close();
-        Misc.free(map);
     }
 
     @Override
@@ -97,10 +96,10 @@ public class SampleByFillNoneRecordCursorFactory extends AbstractSampleByRecordC
         final RecordCursor baseCursor = base.getCursor(executionContext);
         try {
             if (baseCursor.hasNext()) {
-                map.clear();
                 return initFunctionsAndCursor(executionContext, baseCursor);
             }
             Misc.free(baseCursor);
+            Misc.free(cursor);
             return EmptyTableNoSizeRecordCursor.INSTANCE;
         } catch (Throwable ex) {
             Misc.free(baseCursor);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursorFactory.java
@@ -103,6 +103,7 @@ public class SampleByFillNoneRecordCursorFactory extends AbstractSampleByRecordC
             return EmptyTableNoSizeRecordCursor.INSTANCE;
         } catch (Throwable ex) {
             Misc.free(baseCursor);
+            Misc.free(cursor);
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
@@ -189,6 +189,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
             // no data, nothing to do
             if (cursor.recordKeyMap.size() == 0) {
                 baseCursor.close();
+                cursor.close();
                 return EmptyTableRandomRecordCursor.INSTANCE;
             }
 
@@ -376,6 +377,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
             return cursor;
         } catch (Throwable e) {
             baseCursor.close();
+            cursor.close();
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
@@ -52,7 +52,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
     private final static Log LOG = LogFactory.getLog(GroupByRecordCursorFactory.class);
 
-    private final static int ROSTI_MINIMIZED_SIZE = 2;
+    private final static int ROSTI_MINIMIZED_SIZE = 16;//16 is the minimum size usable on arm 
 
     private final RecordCursorFactory base;
     private final ObjList<VectorAggregateFunction> vafList;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
@@ -52,6 +52,8 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
     private final static Log LOG = LogFactory.getLog(GroupByRecordCursorFactory.class);
 
+    private final static int ROSTI_MINIMIZED_SIZE = 2;
+
     private final RecordCursorFactory base;
     private final ObjList<VectorAggregateFunction> vafList;
     private final ObjectPool<VectorAggregateEntry> entryPool;
@@ -97,7 +99,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         for (int i = 0; i < workerCount; i++) {
             long ptr = raf.alloc(columnTypes, configuration.getGroupByMapCapacity());
             if (ptr == 0) {
-                for (int k = i -1; k > -1; k--) {
+                for (int k = i - 1; k > -1; k--) {
                     raf.free(pRosti[k]);
                 }
                 Misc.free(base);
@@ -177,7 +179,6 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
     @Override
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
-
         // clear maps
         for (int i = 0, n = pRosti.length; i < n; i++) {
             Rosti.clear(pRosti[i]);
@@ -327,7 +328,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                     continue;
                 }
 
-                if (!Rosti.reset(pRosti[i], configuration.getGroupByMapCapacity())) {
+                if (!Rosti.reset(pRosti[i], ROSTI_MINIMIZED_SIZE)) {
                     Misc.free(cursor);
                     throw new OutOfMemoryError();
                 }
@@ -361,7 +362,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         sink.child(base);
     }
 
-    private static class RostiRecordCursor implements RecordCursor {
+    private class RostiRecordCursor implements RecordCursor {
         private final RostiRecord record;
         private long pRosti;
         private final IntList symbolTableSkewIndex;
@@ -394,7 +395,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         @Override
         public void close() {
             Misc.free(parent);
-            Rosti.reset(pRosti, defaultMapSize);
+            Rosti.reset(pRosti, ROSTI_MINIMIZED_SIZE);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
@@ -40,7 +40,6 @@ import io.questdb.std.Misc;
 import io.questdb.std.Transient;
 
 public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
-    private final Map joinKeyMap;
     private final RecordCursorFactory masterFactory;
     private final RecordCursorFactory slaveFactory;
     private final RecordSink masterKeySink;
@@ -65,7 +64,7 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
         super(metadata);
         this.masterFactory = masterFactory;
         this.slaveFactory = slaveFactory;
-        joinKeyMap = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
+        Map joinKeyMap = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
         this.masterKeySink = masterKeySink;
         this.slaveKeySink = slaveKeySink;
         this.cursor = new AsOfJoinRecordCursor(
@@ -81,7 +80,7 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
 
     @Override
     protected void _close() {
-        joinKeyMap.close();
+        cursor.close();
         ((JoinRecordMetadata) getMetadata()).close();
         masterFactory.close();
         slaveFactory.close();
@@ -122,6 +121,7 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
         private Record slaveRecord;
         private long slaveTimestamp = Long.MIN_VALUE;
         private boolean danglingSlaveRecord = false;
+        private boolean isOpen;
 
         public AsOfJoinRecordCursor(
                 int columnSplit,
@@ -137,6 +137,7 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             this.masterTimestampIndex = masterTimestampIndex;
             this.slaveTimestampIndex = slaveTimestampIndex;
             this.valueSink = valueSink;
+            this.isOpen = true;
         }
 
         @Override
@@ -207,9 +208,12 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         private void of(RecordCursor masterCursor, RecordCursor slaveCursor) {
-            joinKeyMap.clear();
-            slaveTimestamp = Long.MIN_VALUE;
-            danglingSlaveRecord = false;
+            if (!this.isOpen) {
+                this.joinKeyMap.reallocate();
+                this.isOpen = true;
+            }
+            this.slaveTimestamp = Long.MIN_VALUE;
+            this.danglingSlaveRecord = false;
             this.masterCursor = masterCursor;
             this.slaveCursor = slaveCursor;
             this.masterRecord = masterCursor.getRecord();
@@ -217,6 +221,15 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             MapRecord mapRecord = joinKeyMap.getRecord();
             mapRecord.setSymbolTableResolver(slaveCursor, columnIndex);
             record.of(masterRecord, mapRecord);
+        }
+
+        @Override
+        public void close() {
+            if (isOpen) {
+                joinKeyMap.close();
+                isOpen = false;
+            }
+            super.close();
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsOfJoinRecordCursorFactory.java
@@ -97,6 +97,7 @@ public class AsOfJoinRecordCursorFactory extends AbstractRecordCursorFactory {
         } catch (Throwable e) {
             Misc.free(slaveCursor);
             Misc.free(masterCursor);
+            Misc.free(cursor);
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
@@ -37,7 +37,6 @@ import io.questdb.std.Misc;
 import io.questdb.std.Transient;
 
 public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
-    private final RecordChain slaveChain;
     private final RecordCursorFactory masterFactory;
     private final RecordCursorFactory slaveFactory;
     private final RecordSink masterSink;
@@ -55,13 +54,12 @@ public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             RecordSink slaveKeySink,
             RecordSink slaveChainSink,
             int columnSplit
-
     ) {
         super(metadata);
         this.masterFactory = masterFactory;
         this.slaveFactory = slaveFactory;
         Map joinKeyMap = MapFactory.createMap(configuration, joinColumnTypes, valueTypes);
-        slaveChain = new RecordChain(slaveFactory.getMetadata(), slaveChainSink, configuration.getSqlHashJoinValuePageSize(), configuration.getSqlHashJoinValueMaxPages());
+        RecordChain slaveChain = new RecordChain(slaveFactory.getMetadata(), slaveChainSink, configuration.getSqlHashJoinValuePageSize(), configuration.getSqlHashJoinValueMaxPages());
         this.masterSink = masterSink;
         this.slaveKeySink = slaveKeySink;
         this.cursor = new HashJoinRecordCursor(columnSplit, joinKeyMap, slaveChain);
@@ -69,7 +67,6 @@ public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
 
     @Override
     protected void _close() {
-        slaveChain.close();
         ((JoinRecordMetadata) getMetadata()).close();
         masterFactory.close();
         slaveFactory.close();
@@ -161,9 +158,10 @@ public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             if (!isOpen) {
                 isOpen = true;
                 joinKeyMap.reallocate();
+                slaveChain.reallocate();
             }
             HashJoinRecordCursorFactory factory = HashJoinRecordCursorFactory.this;
-            HashOuterJoinRecordCursorFactory.buildMap(slaveCursor, slaveCursor.getRecord(), joinKeyMap, factory.slaveKeySink, factory.slaveChain, circuitBreaker);
+            HashOuterJoinRecordCursorFactory.buildMap(slaveCursor, slaveCursor.getRecord(), joinKeyMap, factory.slaveKeySink, slaveChain, circuitBreaker);
         }
 
         void of(SqlExecutionContext executionContext, RecordCursor slaveCursor) throws SqlException {
@@ -187,6 +185,7 @@ public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             if (isOpen) {
                 isOpen = false;
                 joinKeyMap.close();
+                slaveChain.close();
                 super.close();
             }
         }

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashJoinRecordCursorFactory.java
@@ -81,6 +81,7 @@ public class HashJoinRecordCursorFactory extends AbstractRecordCursorFactory {
             return this.cursor;
         } catch (Throwable e) {
             Misc.free(slaveCursor);
+            Misc.free(cursor);
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
@@ -37,7 +37,6 @@ import io.questdb.std.Misc;
 import io.questdb.std.Transient;
 
 public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactory {
-    private final RecordChain slaveChain;
     private final RecordCursorFactory masterFactory;
     private final RecordCursorFactory slaveFactory;
     private final RecordSink masterSink;
@@ -60,7 +59,7 @@ public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactor
         super(metadata);
         this.masterFactory = masterFactory;
         this.slaveFactory = slaveFactory;
-        slaveChain = new RecordChain(slaveFactory.getMetadata(), slaveChainSink, configuration.getSqlHashJoinValuePageSize(), configuration.getSqlHashJoinValueMaxPages());
+        RecordChain slaveChain = new RecordChain(slaveFactory.getMetadata(), slaveChainSink, configuration.getSqlHashJoinValuePageSize(), configuration.getSqlHashJoinValueMaxPages());
         this.masterSink = masterSink;
         this.slaveKeySink = slaveKeySink;
 
@@ -100,7 +99,6 @@ public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactor
 
     @Override
     protected void _close() {
-        slaveChain.close();
         ((JoinRecordMetadata) getMetadata()).close();
         masterFactory.close();
         slaveFactory.close();
@@ -191,9 +189,10 @@ public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactor
             if (!this.isOpen) {
                 this.isOpen = true;
                 this.joinKeyMap.reallocate();
+                this.slaveChain.reallocate();
             }
             HashOuterJoinRecordCursorFactory factory = HashOuterJoinRecordCursorFactory.this;
-            buildMap(slaveCursor, slaveCursor.getRecord(), this.joinKeyMap, factory.slaveKeySink, factory.slaveChain, circuitBreaker);
+            buildMap(slaveCursor, slaveCursor.getRecord(), this.joinKeyMap, factory.slaveKeySink, this.slaveChain, circuitBreaker);
         }
 
         void of(SqlExecutionContext executionContext, RecordCursor slaveCursor) throws SqlException {
@@ -218,6 +217,7 @@ public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactor
             if (isOpen) {
                 isOpen = false;
                 joinKeyMap.close();
+                slaveChain.close();
                 super.close();
             }
         }

--- a/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinRecordCursorFactory.java
@@ -113,6 +113,7 @@ public class HashOuterJoinRecordCursorFactory extends AbstractRecordCursorFactor
             return cursor;
         } catch (Throwable e) {
             Misc.free(slaveCursor);
+            Misc.free(cursor);
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/join/JoinRecordMetadata.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/JoinRecordMetadata.java
@@ -30,10 +30,7 @@ import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.std.Chars;
-import io.questdb.std.LowerCaseCharSequenceIntHashMap;
-import io.questdb.std.Misc;
-import io.questdb.std.ObjList;
+import io.questdb.std.*;
 import io.questdb.std.str.CharSink;
 
 import java.io.Closeable;
@@ -46,7 +43,7 @@ public class JoinRecordMetadata extends BaseRecordMetadata implements Closeable 
     private int refCount;
 
     public JoinRecordMetadata(CairoConfiguration configuration, int columnCount) {
-        this.map = new FastMap(configuration.getSqlJoinMetadataPageSize(), keyTypes, valueTypes, columnCount * 2, 0.6, configuration.getSqlJoinMetadataMaxResizes());
+        this.map = new FastMap(configuration.getSqlJoinMetadataPageSize(), keyTypes, valueTypes, columnCount * 2, 0.6, configuration.getSqlJoinMetadataMaxResizes(), MemoryTag.NATIVE_JOIN_MAP);
         this.timestampIndex = -1;
         this.columnCount = 0;
         this.columnNameIndexMap = new LowerCaseCharSequenceIntHashMap(columnCount);

--- a/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
@@ -94,6 +94,7 @@ public class LtJoinLightRecordCursorFactory extends AbstractRecordCursorFactory 
         } catch (Throwable e) {
             Misc.free(slaveCursor);
             Misc.free(masterCursor);
+            Misc.free(cursor);
             throw e;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LtJoinLightRecordCursorFactory.java
@@ -220,9 +220,9 @@ public class LtJoinLightRecordCursorFactory extends AbstractRecordCursorFactory 
         @Override
         public void close() {
             if (isOpen) {
-                isOpen = false;
                 joinKeyMap.close();
                 super.close();
+                isOpen = false;
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeLongTreeChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeLongTreeChain.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin.engine.orderby;
 
+import io.questdb.cairo.Reallocatable;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.vm.Vm;
@@ -58,7 +59,7 @@ import io.questdb.std.str.CharSink;
  * but should only happen once . It's meant to limit value chain allocations on delete/insert.
  * </p>
  */
-public class LimitedSizeLongTreeChain extends AbstractRedBlackTree {
+public class LimitedSizeLongTreeChain extends AbstractRedBlackTree implements Reallocatable {
     //value marks end of value chain 
     private static final long CHAIN_END = -1;
 
@@ -109,17 +110,24 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree {
         currentValues = 0;
         freeList.clear();
         chainFreeList.clear();
+        cursor.clear();
+    }
+
+    @Override
+    public void close() {
+        clear();
+        super.close();
+        Misc.free(valueChain);
+    }
+
+    @Override
+    public void reallocate() {
+        super.reallocate();
     }
 
     @Override
     public long size() {
         return currentValues;
-    }
-
-    @Override
-    public void close() {
-        super.close();
-        Misc.free(valueChain);
     }
 
     private long appendValue(long value, long prevValueOffset) {
@@ -362,6 +370,11 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree {
             }
             treeCurrent = p;
             chainCurrent = refOf(treeCurrent);
+        }
+
+        public void clear() {
+            treeCurrent = 0;
+            chainCurrent = 0;
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursor.java
@@ -46,6 +46,7 @@ public class LimitedSizeSortedLightRecordCursor implements DelegatingRecordCurso
     private final long skipFirst; //skip first N rows
     private final long skipLast;  //skip last N rows
     private long rowsLeft;
+    private boolean isOpen;
 
     public LimitedSizeSortedLightRecordCursor(
             LimitedSizeLongTreeChain chain,
@@ -60,12 +61,16 @@ public class LimitedSizeSortedLightRecordCursor implements DelegatingRecordCurso
         this.limit = limit;
         this.skipFirst = skipFirst;
         this.skipLast = skipLast;
+        this.isOpen = true;
     }
 
     @Override
     public void close() {
-        chain.clear();
-        base.close();
+        if (isOpen) {
+            chain.close();
+            base.close();
+            isOpen = false;
+        }
     }
 
     @Override
@@ -121,6 +126,10 @@ public class LimitedSizeSortedLightRecordCursor implements DelegatingRecordCurso
 
     @Override
     public void of(RecordCursor base, SqlExecutionContext executionContext) throws SqlException {
+        if (!isOpen) {
+            chain.reallocate();
+            isOpen = true;
+        }
         this.base = base;
         this.baseRecord = base.getRecord();
         final Record placeHolderRecord = base.getRecordB();

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
@@ -29,8 +29,8 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.griffin.engine.AbstractRedBlackTree;
 import io.questdb.griffin.engine.RecordComparator;
+import io.questdb.std.Misc;
 
 /**
  * Same as SortedLightRecordCursorFactory but using LimitedSizeLongTreeChain instead.
@@ -80,9 +80,7 @@ public class LimitedSizeSortedLightRecordCursorFactory extends AbstractRecordCur
             return cursor;
         } catch (Throwable ex) {
             baseCursor.close();
-            if (cursor != null) {
-                cursor.close();
-            }
+            Misc.free(cursor);
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LongTreeChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LongTreeChain.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin.engine.orderby;
 
+import io.questdb.cairo.Reallocatable;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.vm.Vm;
@@ -33,7 +34,7 @@ import io.questdb.griffin.engine.RecordComparator;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 
-public class LongTreeChain extends AbstractRedBlackTree {
+public class LongTreeChain extends AbstractRedBlackTree implements Reallocatable {
     private final TreeCursor cursor = new TreeCursor();
     private final MemoryARW valueChain;
 
@@ -52,6 +53,12 @@ public class LongTreeChain extends AbstractRedBlackTree {
     public void close() {
         super.close();
         Misc.free(valueChain);
+        cursor.clear();
+    }
+
+    @Override
+    public void reallocate() {
+        //nothing to do here
     }
 
     private long appendValue(long value, long prevValueOffset) {
@@ -153,6 +160,11 @@ public class LongTreeChain extends AbstractRedBlackTree {
                 }
             }
             chainCurrent = refOf(treeCurrent = p);
+        }
+
+        public void clear() {
+            treeCurrent = -1;
+            chainCurrent = -1;
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/RecordTreeChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/RecordTreeChain.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.orderby;
 
 import io.questdb.cairo.ColumnTypes;
+import io.questdb.cairo.Reallocatable;
 import io.questdb.cairo.RecordChain;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.sql.Record;
@@ -38,7 +39,7 @@ import io.questdb.std.Unsafe;
 
 import java.io.Closeable;
 
-public class RecordTreeChain implements Closeable, Mutable {
+public class RecordTreeChain implements Closeable, Mutable, Reallocatable {
     // P(8) + L + R + C(1) + REF + TOP
     private static final int BLOCK_SIZE = 8 + 8 + 8 + 1 + 8 + 8;
     private static final int O_LEFT = 8;
@@ -69,6 +70,12 @@ public class RecordTreeChain implements Closeable, Mutable {
         this.mem = new MemoryPages(keyPageSize, keyMaxPages);
         this.recordChain = new RecordChain(columnTypes, recordSink, valuePageSize, valueMaxPages);
         this.recordChainRecord = this.recordChain.getRecordB();
+    }
+
+    @Override
+    public void reallocate() {
+        recordChain.reallocate();
+        mem.reallocate();
     }
 
     private static void setLeft(long blockAddress, long left) {
@@ -147,12 +154,13 @@ public class RecordTreeChain implements Closeable, Mutable {
     @Override
     public void clear() {
         root = -1;
-        this.mem.clear();
+        mem.clear();
         recordChain.clear();
     }
 
     @Override
     public void close() {
+        root = -1;
         Misc.free(recordChain);
         Misc.free(mem);
     }
@@ -308,6 +316,7 @@ public class RecordTreeChain implements Closeable, Mutable {
         @Override
         public void close() {
             base.close();
+            current = -1;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursor.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.RecordComparator;
+import io.questdb.std.Misc;
 
 class SortedLightRecordCursor implements DelegatingRecordCursor {
     private final LongTreeChain chain;
@@ -51,11 +52,8 @@ class SortedLightRecordCursor implements DelegatingRecordCursor {
             chain.close();
             isOpen = false;
         }
-        if (base != null) {
-            base.close();
-            base = null;
-            baseRecord = null;
-        }
+        base = Misc.free(base);
+        baseRecord = null;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursor.java
@@ -35,18 +35,27 @@ class SortedLightRecordCursor implements DelegatingRecordCursor {
     private final LongTreeChain.TreeCursor chainCursor;
     private RecordCursor base;
     private Record baseRecord;
+    private boolean isOpen;
 
     public SortedLightRecordCursor(LongTreeChain chain, RecordComparator comparator) {
         this.chain = chain;
         this.comparator = comparator;
         // assign it once, it's the same instance anyway
         this.chainCursor = chain.getCursor();
+        this.isOpen = true;
     }
 
     @Override
     public void close() {
-        chain.clear();
-        base.close();
+        if (isOpen) {
+            chain.close();
+            isOpen = false;
+        }
+        if (base != null) {
+            base.close();
+            base = null;
+            baseRecord = null;
+        }
     }
 
     @Override
@@ -95,12 +104,16 @@ class SortedLightRecordCursor implements DelegatingRecordCursor {
 
     @Override
     public void of(RecordCursor base, SqlExecutionContext executionContext) {
+        if (!isOpen) {
+            chain.reallocate();
+            isOpen = true;
+        }
+
         this.base = base;
         this.baseRecord = base.getRecord();
         final Record placeHolderRecord = base.getRecordB();
         final SqlExecutionCircuitBreaker circuitBreaker = executionContext.getCircuitBreaker();
 
-        chain.clear();
         while (base.hasNext()) {
             circuitBreaker.statefulThrowExceptionIfTripped();
             // Tree chain is liable to re-position record to

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
@@ -68,6 +68,7 @@ public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory 
             return cursor;
         } catch (Throwable ex) {
             baseCursor.close();
+            cursor.close();
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedLightRecordCursorFactory.java
@@ -35,7 +35,6 @@ import io.questdb.griffin.engine.RecordComparator;
 
 public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory {
     private final RecordCursorFactory base;
-    private final LongTreeChain chain;
     private final SortedLightRecordCursor cursor;
 
     public SortedLightRecordCursorFactory(
@@ -45,7 +44,7 @@ public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory 
             RecordComparator comparator
     ) {
         super(metadata);
-        this.chain = new LongTreeChain(
+        LongTreeChain chain = new LongTreeChain(
                 configuration.getSqlSortKeyPageSize(),
                 configuration.getSqlSortKeyMaxPages(),
                 configuration
@@ -58,7 +57,7 @@ public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory 
     @Override
     protected void _close() {
         base.close();
-        chain.close();
+        cursor.close();
     }
 
     @Override
@@ -69,7 +68,6 @@ public class SortedLightRecordCursorFactory extends AbstractRecordCursorFactory 
             return cursor;
         } catch (Throwable ex) {
             baseCursor.close();
-            chain.clear();
             throw ex;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedRecordCursor.java
@@ -31,15 +31,20 @@ import io.questdb.griffin.SqlExecutionContext;
 class SortedRecordCursor implements DelegatingRecordCursor {
     private final RecordTreeChain chain;
     private RecordTreeChain.TreeCursor chainCursor;
+    private boolean isOpen;
 
     public SortedRecordCursor(RecordTreeChain chain) {
         this.chain = chain;
+        this.isOpen = true;
     }
 
     @Override
     public void close() {
-        chainCursor.close();
-        chain.clear();
+        if (isOpen) {
+            chainCursor.close();
+            chain.close();
+            isOpen = false;
+        }
     }
 
     @Override
@@ -85,11 +90,14 @@ class SortedRecordCursor implements DelegatingRecordCursor {
     @Override
     public void of(RecordCursor base, SqlExecutionContext executionContext) {
         try {
+            if (!isOpen) {
+                this.chain.reallocate();
+                this.isOpen = true;
+            }
             this.chainCursor = chain.getCursor(base);
             final Record record = base.getRecord();
             final SqlExecutionCircuitBreaker circuitBreaker = executionContext.getCircuitBreaker();
 
-            chain.clear();
             while (base.hasNext()) {
                 circuitBreaker.statefulThrowExceptionIfTripped();
                 // Tree chain is liable to re-position record to

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortedRecordCursorFactory.java
@@ -36,7 +36,6 @@ import io.questdb.griffin.engine.RecordComparator;
 
 public class SortedRecordCursorFactory extends AbstractRecordCursorFactory {
     private final RecordCursorFactory base;
-    private final RecordTreeChain chain;
     private final SortedRecordCursor cursor;
 
     public SortedRecordCursorFactory(
@@ -47,7 +46,7 @@ public class SortedRecordCursorFactory extends AbstractRecordCursorFactory {
             RecordComparator comparator
     ) {
         super(metadata);
-        this.chain = new RecordTreeChain(
+        RecordTreeChain chain = new RecordTreeChain(
                 metadata,
                 recordSink,
                 comparator,
@@ -63,7 +62,7 @@ public class SortedRecordCursorFactory extends AbstractRecordCursorFactory {
     @Override
     protected void _close() {
         base.close();
-        chain.close();
+        cursor.close();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
@@ -58,6 +58,7 @@ class AsyncFilteredRecordCursor implements RecordCursor {
     // the OG rows remaining, used to reset the counter when re-running cursor from top();
     private long ogRowsRemaining;
     private boolean allFramesActive;
+    private boolean isOpen;
 
     public AsyncFilteredRecordCursor(Function filter, boolean hasDescendingOrder) {
         this.filter = filter;
@@ -67,18 +68,21 @@ class AsyncFilteredRecordCursor implements RecordCursor {
 
     @Override
     public void close() {
-        LOG.debug()
-                .$("closing [shard=").$(frameSequence.getShard())
-                .$(", frameIndex=").$(frameIndex)
-                .$(", frameCount=").$(frameLimit)
-                .$(", cursor=").$(cursor)
-                .I$();
+        if (isOpen) {
+            LOG.debug()
+                    .$("closing [shard=").$(frameSequence.getShard())
+                    .$(", frameIndex=").$(frameIndex)
+                    .$(", frameCount=").$(frameLimit)
+                    .$(", cursor=").$(cursor)
+                    .I$();
 
-        collectCursor(true);
-        if (frameLimit > -1) {
-            frameSequence.await();
+            collectCursor(true);
+            if (frameLimit > -1) {
+                frameSequence.await();
+            }
+            frameSequence.clear();
+            isOpen = false;
         }
-        frameSequence.clear();
     }
 
     public void freeRecords() {
@@ -219,6 +223,7 @@ class AsyncFilteredRecordCursor implements RecordCursor {
     }
 
     void of(PageFrameSequence<?> frameSequence, long rowsRemaining) throws SqlException {
+        this.isOpen = true;
         this.frameSequence = frameSequence;
         this.frameIndex = -1;
         this.frameLimit = frameSequence.getFrameCount() - 1;

--- a/core/src/main/java/io/questdb/std/MemoryPages.java
+++ b/core/src/main/java/io/questdb/std/MemoryPages.java
@@ -24,13 +24,14 @@
 
 package io.questdb.std;
 
+import io.questdb.cairo.Reallocatable;
 import io.questdb.griffin.engine.LimitOverflowException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 
 import java.io.Closeable;
 
-public class MemoryPages implements Closeable, Mutable {
+public class MemoryPages implements Closeable, Mutable, Reallocatable {
 
     private static final Log LOG = LogFactory.getLog(MemoryPages.class);
 
@@ -81,6 +82,13 @@ public class MemoryPages implements Closeable, Mutable {
             }
         }
         pages.clear();
+        cachePageLo = 0;
+        cachePageHi = 0;
+    }
+
+    @Override
+    public void reallocate() {
+        allocate0(0);
     }
 
     public long size() {

--- a/core/src/main/java/io/questdb/std/MemoryTag.java
+++ b/core/src/main/java/io/questdb/std/MemoryTag.java
@@ -66,7 +66,8 @@ public final class MemoryTag {
     public static final int MMAP_SEQUENCER = 38;
     public static final int MMAP_PARALLEL_IMPORT = 39;
     public static final int NATIVE_PARALLEL_IMPORT = 40;
-    public static final int SIZE = NATIVE_PARALLEL_IMPORT + 1;
+    public static final int NATIVE_JOIN_MAP = 41;
+    public static final int SIZE = NATIVE_JOIN_MAP + 1;
     private static final ObjList<String> tagNameMap = new ObjList<>(SIZE);
 
     public static String nameOf(int tag) {
@@ -115,5 +116,6 @@ public final class MemoryTag {
         tagNameMap.extendAndSet(MMAP_SEQUENCER, "MMAP_SEQUENCER");
         tagNameMap.extendAndSet(MMAP_PARALLEL_IMPORT, "MMAP_PARALLEL_IMPORT");
         tagNameMap.extendAndSet(NATIVE_PARALLEL_IMPORT, "NATIVE_PARALLEL_IMPORT");
+        tagNameMap.extendAndSet(NATIVE_JOIN_MAP, "NATIVE_JOIN_MAP");
     }
 }

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -421,11 +421,17 @@ public class AbstractCairoTest {
 
     @After
     public void tearDown() {
+        tearDown(true);
+    }
+
+    public void tearDown(boolean removeDir) {
         LOG.info().$("Tearing down test ").$(getClass().getSimpleName()).$('#').$(testName.getMethodName()).$();
         snapshotAgent.clear();
         engine.getTableIdGenerator().close();
         engine.clear();
-        TestUtils.removeTestPath(root);
+        if (removeDir) {
+            TestUtils.removeTestPath(root);
+        }
         configOverrideMaxUncommittedRows = -1;
         configOverrideCommitLagMicros = -1;
         currentMicros = -1;

--- a/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/cairo/AbstractCairoTest.java
@@ -516,7 +516,7 @@ public class AbstractCairoTest {
     protected static void assertFactoryMemoryUsage() {
         if (memoryUsage > -1) {
             long memAfterCursorClose = getMemUsedByFactories();
-            long limit = memoryUsage + 10 * 1024;
+            long limit = memoryUsage + 50 * 1024;
             if (memAfterCursorClose > limit) {
                 printFactoryMemoryUsageDiff();
                 Assert.fail("cursor memory usage should be less or equal " + limit + " but was " + memAfterCursorClose + " . Diff " + (memAfterCursorClose - memoryUsage));

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -1325,6 +1325,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             boolean checkSameStr,
             boolean expectSize
     ) throws SqlException {
+        snapshotMemoryUsage();
         try (final RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
             assertFactoryCursor(
                     expected,
@@ -1348,6 +1349,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             boolean checkSameStr,
             boolean expectSize,
             boolean sizeCanBeVariable) throws SqlException {
+        snapshotMemoryUsage();
         try (final RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
             assertFactoryCursor(
                     expected,
@@ -1373,6 +1375,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
                                        String expectedTimestamp,
                                        boolean supportsRandomAccess,
                                        boolean expectSize) throws SqlException {
+        snapshotMemoryUsage();
         try (final RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
             assertFactoryCursor(
                     expected,
@@ -1386,6 +1389,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
     }
 
     protected void assertQueryPlain(String expected, String query) throws SqlException {
+        snapshotMemoryUsage();
         try (final RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory()) {
             assertFactoryCursor(
                     expected,

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -42,13 +42,14 @@ import io.questdb.std.str.AbstractCharSequence;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+
 
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -63,8 +64,6 @@ public class AbstractGriffinTest extends AbstractCairoTest {
     protected static SqlCompiler compiler;
 
     protected final SCSequence eventSubSequence = new SCSequence();
-
-    private static final long[] SNAPSHOT = new long[MemoryTag.SIZE];
 
     public static boolean assertCursor(
             CharSequence expected,
@@ -256,6 +255,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
         } catch (SqlException e) {
             e.printStackTrace();
         }
+        assertFactoryMemoryUsage();
     }
 
     public static boolean doubleEquals(double a, double b, double epsilon) {
@@ -323,6 +323,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             if (ddl != null) {
                 compile(ddl, sqlExecutionContext);
             }
+            snapshotMemoryUsage();
             CompiledQuery cc = compiler.compile(query, sqlExecutionContext);
             RecordCursorFactory factory = cc.getRecordCursorFactory();
             try {
@@ -444,6 +445,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
         } catch (SqlException e) {
             e.printStackTrace();
         }
+        assertFactoryMemoryUsage();
     }
 
     protected static void assertCursor(
@@ -476,27 +478,32 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             boolean sizeCanBeVariable, // this means size() can either be -1 in some cases or known in others
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
+        boolean cursorAsserted;
         try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
             Assert.assertEquals("supports random access", supportsRandomAccess, factory.recordCursorSupportsRandomAccess());
-            if (
-                    assertCursor(
-                            expected,
-                            supportsRandomAccess,
-                            checkSameStr,
-                            sizeExpected,
-                            sizeCanBeVariable,
-                            cursor,
-                            factory.getMetadata(),
-                            factory.fragmentedSymbolTables()
-                    )
-            ) {
-                return;
-            }
+            cursorAsserted = assertCursor(
+                    expected,
+                    supportsRandomAccess,
+                    checkSameStr,
+                    sizeExpected,
+                    sizeCanBeVariable,
+                    cursor,
+                    factory.getMetadata(),
+                    factory.fragmentedSymbolTables()
+            );
+        }
+
+        assertFactoryMemoryUsage();
+
+        if (cursorAsserted) {
+            return;
         }
 
         try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
             testSymbolAPI(factory.getMetadata(), cursor, factory.fragmentedSymbolTables());
         }
+
+        assertFactoryMemoryUsage();
     }
 
     private static void testStringsLong256AndBinary(RecordMetadata metadata, RecordCursor cursor, boolean checkSameStr) {
@@ -734,6 +741,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
                 c++;
             }
         }
+        assertFactoryMemoryUsage();
     }
 
     protected static void printSqlResult(
@@ -784,6 +792,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
             boolean sizeCanBeVariable,
             CharSequence expectedPlan
     ) throws SqlException {
+        snapshotMemoryUsage();
         CompiledQuery cc = compiler.compile(query, sqlExecutionContext);
         RecordCursorFactory factory = cc.getRecordCursorFactory();
         if (expectedPlan != null) {
@@ -1474,65 +1483,5 @@ public class AbstractGriffinTest extends AbstractCairoTest {
 
     protected void assertPlan(CharSequence query, CharSequence expectedPlan) throws SqlException {
         TestUtils.assertEquals(expectedPlan, getPlan(query).getText());
-    }
-
-
-    @TestOnly
-    public static void printMemoryUsage() {
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            System.err.print(MemoryTag.nameOf(i));
-            System.err.print(":");
-            System.err.println(Unsafe.getMemUsedByTag(i));
-        }
-    }
-
-    @TestOnly
-    public static void snapshotMemoryUsage() {
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            SNAPSHOT[i] = Unsafe.getMemUsedByTag(i);
-        }
-    }
-
-    @TestOnly
-    public static void diffMemoryUsage() {
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            SNAPSHOT[i] = Unsafe.getMemUsedByTag(i) - SNAPSHOT[i];
-        }
-    }
-
-    @TestOnly
-    public static void printMemoryUsageDiff() {
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            if (SNAPSHOT[i] != 0L) {
-                System.err.print(MemoryTag.nameOf(i));
-                System.err.print(":");
-                System.err.println(SNAPSHOT[i]);
-            }
-        }
-    }
-
-    @TestOnly
-    public static long getMemUsedExceptMmap() {
-        long tags = 0;
-
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            if (Chars.startsWith(MemoryTag.nameOf(i), "MMAP")) {
-                tags = tags | 1L << i;
-            }
-        }
-
-        return getMemUsedExcept(tags);
-    }
-
-    @TestOnly
-    public static long getMemUsedExcept(long tagsToIgnore) {
-        long memUsed = 0;
-        for (int i = 0; i < MemoryTag.SIZE; i++) {
-            if ((tagsToIgnore & 1L << i) == 0) {
-                memUsed += Unsafe.getMemUsedByTag(i);
-            }
-        }
-
-        return memUsed;
     }
 }

--- a/core/src/test/java/io/questdb/griffin/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AsOfJoinTest.java
@@ -442,7 +442,6 @@ public class AsOfJoinTest extends AbstractGriffinTest {
     }
 
     //select a.seq hi, b.seq lo from tab a lt join b where hi > lo + 1
-
     @Test
     public void testLtJoinNoTimestamp() throws Exception {
         final String expected = "tag\thi\tlo\n" +

--- a/core/src/test/java/io/questdb/griffin/ExceptTest.java
+++ b/core/src/test/java/io/questdb/griffin/ExceptTest.java
@@ -95,7 +95,7 @@ public class ExceptTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
-
+            snapshotMemoryUsage();
             try (RecordCursorFactory rcf = compiler.compile("x", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected, rcf, true, true, true);
             }
@@ -125,6 +125,7 @@ public class ExceptTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("select * from x except y", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected2, factory, true, true, false);
             }
@@ -154,6 +155,7 @@ public class ExceptTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory rcf = compiler.compile("x", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected, rcf, true, true, true);
             }
@@ -176,6 +178,7 @@ public class ExceptTest extends AbstractGriffinTest {
                     sqlExecutionContext
             ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("select distinct t from x except y except z", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected2, factory, true, true, false);
             }

--- a/core/src/test/java/io/questdb/griffin/IntersectTest.java
+++ b/core/src/test/java/io/questdb/griffin/IntersectTest.java
@@ -97,7 +97,7 @@ public class IntersectTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
-
+            snapshotMemoryUsage();
             try (RecordCursorFactory rcf = compiler.compile("x", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected, rcf, true, true, true);
             }
@@ -126,7 +126,7 @@ public class IntersectTest extends AbstractGriffinTest {
                             " long_sequence(10))",
                     sqlExecutionContext
             );
-
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("select * from x intersect y", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected2, factory, true, true, false);
             }
@@ -155,7 +155,7 @@ public class IntersectTest extends AbstractGriffinTest {
                             " FROM long_sequence(7) x)",
                     sqlExecutionContext
             );
-
+            snapshotMemoryUsage();
             try (RecordCursorFactory rcf = compiler.compile("x", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected, rcf, true, true, true);
             }
@@ -178,6 +178,7 @@ public class IntersectTest extends AbstractGriffinTest {
                     sqlExecutionContext
             ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("select distinct t from x intersect y intersect z", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected2, factory, true, true, false);
             }
@@ -200,6 +201,7 @@ public class IntersectTest extends AbstractGriffinTest {
                     "5\tB\n" +
                     "1\tA\n";
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("(select i,s from x) intersect (select i,first(s) from y)", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor(expected, factory, true, true, false);
             }

--- a/core/src/test/java/io/questdb/griffin/KeyedAggregationTest.java
+++ b/core/src/test/java/io/questdb/griffin/KeyedAggregationTest.java
@@ -1152,6 +1152,7 @@ public class KeyedAggregationTest extends AbstractGriffinTest {
     private static void runGroupByIntWithAgg(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) throws SqlException {
         compiler.compile("create table tab as ( select cast(x as int) i, x as l, cast(x as date) dat, cast(x as timestamp) ts, cast(x as double) d, rnd_long256() l256  from long_sequence(1000));", sqlExecutionContext);
 
+        snapshotMemoryUsage();
         CompiledQuery query = compiler.compile("select count(*) cnt from " +
                 "(select i, count(*), min(i), avg(i), max(i), sum(i), " +
                 "min(l), avg(l), max(l), sum(l), " +
@@ -1189,6 +1190,7 @@ public class KeyedAggregationTest extends AbstractGriffinTest {
 
     private static void runGroupByTest(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) throws SqlException {
         compiler.compile("create table tab as  (select cast(x as int) x1, cast(x as date) dt from long_sequence(1000000))", sqlExecutionContext);
+        snapshotMemoryUsage();
         CompiledQuery query = compiler.compile("select count(*) cnt from (select x1, count(*), count(*) from tab group by x1)", sqlExecutionContext);
 
         try {

--- a/core/src/test/java/io/questdb/griffin/RecordCursorMemoryUsageTest.java
+++ b/core/src/test/java/io/questdb/griffin/RecordCursorMemoryUsageTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin;
+
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.engine.groupby.*;
+import io.questdb.std.Unsafe;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+
+public class RecordCursorMemoryUsageTest extends AbstractGriffinTest {
+
+    //HashJoinRecordCursorFactory
+
+    @Test
+    public void testAsOfJoinRecordCursorReleasesMemoryOnClose() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table tab as (select" +
+                    " rnd_symbol(20,4,4,20000) sym1," +
+                    " rnd_double(2) d," +
+                    " timestamp_sequence(0, 1000000000) ts" +
+                    " from long_sequence(1000)) timestamp(ts)");
+            try {
+                compiler.setFullFatJoins(true);
+                try (RecordCursorFactory factory = compile("select * from tab t1 asof join tab t2 ")
+                        .getRecordCursorFactory()) {
+
+                    long freeDuring;
+                    long memDuring;
+
+                    try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                        freeDuring = Unsafe.getFreeCount();
+                        memDuring = getMemUsedByFactories();
+                        while (cursor.hasNext()) ;
+                    }
+
+                    long memAfter = getMemUsedByFactories();
+                    long freeAfter = Unsafe.getFreeCount();
+
+                    assertThat(memAfter, is(lessThan(memDuring)));
+                    assertThat(freeAfter, is(greaterThan(freeDuring)));
+                }
+            } finally {
+                compiler.setFullFatJoins(false);
+            }
+        });
+    }
+
+    @Test
+    public void testSampleByFillNoneRecordCursorReleasesMemoryOnClose() throws Exception {
+        testSampleByCursorReleasesMemoryOnClose("", SampleByFillNoneRecordCursorFactory.class);
+    }
+
+    @Test
+    public void testSampleByFillNullRecordCursorReleasesMemoryOnClose() throws Exception { //prev / value
+        testSampleByCursorReleasesMemoryOnClose("FILL(null)", SampleByFillNullRecordCursorFactory.class);
+    }
+
+    @Test
+    public void testSampleByFillPrevRecordCursorReleasesMemoryOnClose() throws Exception {
+        testSampleByCursorReleasesMemoryOnClose("FILL(prev)", SampleByFillPrevRecordCursorFactory.class);
+    }
+
+    @Test
+    public void testSampleByFillValueRecordCursorReleasesMemoryOnClose() throws Exception { //prev / value
+        testSampleByCursorReleasesMemoryOnClose("FILL(10)", SampleByFillValueRecordCursorFactory.class);
+    }
+
+    private void testSampleByCursorReleasesMemoryOnClose(String fill, Class expectedFactoryClass) throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table tab as (select" +
+                    " rnd_symbol(20,4,4,20000) sym1," +
+                    " rnd_double(2) d," +
+                    " timestamp_sequence(0, 1000000000) ts" +
+                    " from long_sequence(10000)) timestamp(ts)");
+
+            try (AbstractSampleByRecordCursorFactory factory = (AbstractSampleByRecordCursorFactory) compile("select sym1, sum(d) from tab SAMPLE BY 1d " + fill)
+                    .getRecordCursorFactory()) {
+                assertThat(factory, isA(expectedFactoryClass));
+
+                long freeDuring;
+                long memDuring;
+
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    freeDuring = Unsafe.getFreeCount();
+                    memDuring = Unsafe.getMemUsed();
+
+                    while (cursor.hasNext()) ;
+                }
+
+                long memAfter = Unsafe.getMemUsed();
+                long freeAfter = Unsafe.getFreeCount();
+
+                assertThat(memAfter, is(lessThan(memDuring)));
+                assertThat(freeAfter, is(greaterThan(freeDuring)));
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/griffin/SecurityTest.java
@@ -157,6 +157,14 @@ public class SecurityTest extends AbstractGriffinTest {
         Misc.free(memoryRestrictedEngine);
     }
 
+    @After
+    public void tearDown() {
+        //we've to close id file, otherwise parent tearDown() fails on TestUtils.removeTestPath(root) in Windows 
+        memoryRestrictedEngine.getTableIdGenerator().close();
+        memoryRestrictedEngine.clear();
+        super.tearDown();
+    }
+
     @Test
     public void testAlterTableDeniedOnNoWriteAccess() throws Exception {
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -287,6 +287,8 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             ) {
                 bindVariableService.clear();
                 bindVariableService.setLong(0, 10);
+
+                snapshotMemoryUsage();
                 try (RecordCursorFactory factory = compiler.compile("select x, $1 from long_sequence(2)", sqlExecutionContext).getRecordCursorFactory()) {
                     assertCursor("x\t$1\n" +
                                     "1\t10\n" +
@@ -311,6 +313,8 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             ) {
                 bindVariableService.clear();
                 bindVariableService.setLong("y", 10);
+
+                snapshotMemoryUsage();
                 try (RecordCursorFactory factory = compiler.compile("select x, :y from long_sequence(2)", sqlExecutionContext).getRecordCursorFactory()) {
                     assertCursor("x\t:y\n" +
                                     "1\t10\n" +
@@ -336,6 +340,8 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             ) {
                 bindVariableService.clear();
                 bindVariableService.setLong(0, 10);
+
+                snapshotMemoryUsage();
                 try (RecordCursorFactory factory = compiler.compile("select x, $1 from long_sequence(2)", sqlExecutionContext).getRecordCursorFactory()) {
                     assertCursor("x\t$1\n" +
                                     "1\t10\n" +
@@ -361,6 +367,8 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
             ) {
                 bindVariableService.clear();
                 bindVariableService.setLong(0, 10);
+
+                snapshotMemoryUsage();
                 try (RecordCursorFactory factory = compiler.compile("select x from long_sequence(100) where x = $1", sqlExecutionContext).getRecordCursorFactory()) {
                     assertCursor("x\n" +
                                     "10\n",
@@ -368,7 +376,6 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                             true,
                             true,
                             false
-
                     );
                 }
             }
@@ -5213,6 +5220,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     public void testLimitOverflow() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table x as (select x from long_sequence(10))", sqlExecutionContext);
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile("x limit -9223372036854775807-1, -1", sqlExecutionContext).getRecordCursorFactory()) {
                 assertCursor("x\n" +
                                 "1\n" +
@@ -5229,7 +5237,6 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         true,
                         true,
                         true
-
                 );
             }
         });

--- a/core/src/test/java/io/questdb/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/WhereClauseParserTest.java
@@ -150,6 +150,12 @@ public class WhereClauseParserTest extends AbstractCairoTest {
         noDesignatedTimestampNorIdxReader.close();
         compiler.close();
         sqlExecutionContext.close();
+        TestUtils.removeTestPath(root);
+    }
+
+    @Override
+    public void tearDown() {
+        super.tearDown(false);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/engine/AbstractFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/AbstractFunctionFactoryTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.*;
 import io.questdb.griffin.engine.functions.cast.CastIntToByteFunctionFactory;
@@ -52,9 +53,13 @@ public abstract class AbstractFunctionFactoryTest extends BaseFunctionFactoryTes
     private static int toByteRefs = 0;
     private FunctionFactory factory;
 
-    protected void assertQuery(CharSequence expected, CharSequence sql) throws SqlException {
-        RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory();
-        assertCursor(expected, factory.getCursor(sqlExecutionContext), factory.getMetadata(), true);
+    protected void assertQuery(CharSequence expected, CharSequence sql) throws Exception {
+        assertMemoryLeak(() -> {
+            try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory();
+                 RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                assertCursor(expected, cursor, factory.getMetadata(), true);
+            }
+        });
     }
 
     protected void assertFailure(CharSequence expectedMsg, CharSequence sql) {

--- a/core/src/test/java/io/questdb/griffin/engine/functions/rnd/RndBinCCCFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/rnd/RndBinCCCFunctionFactoryTest.java
@@ -37,7 +37,7 @@ public class RndBinCCCFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testFixedLength() throws SqlException {
+    public void testFixedLength() throws Exception {
         assertQuery("x\n" +
                         "00000000 ee 41 1d 15 55 8a\n" +
                         "\n" +
@@ -53,7 +53,7 @@ public class RndBinCCCFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testFixedLengthNoNulls() throws SqlException {
+    public void testFixedLengthNoNulls() throws Exception {
         assertQuery("x\n" +
                         "00000000 ee 41 1d 15 55\n" +
                         "00000000 17 fa d8 cc 14\n" +
@@ -79,7 +79,7 @@ public class RndBinCCCFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testVarLength() throws SqlException {
+    public void testVarLength() throws Exception {
         assertQuery("x\n" +
                         "00000000 41 1d 15\n" +
                         "00000000 17 fa d8 cc 14\n" +
@@ -95,7 +95,7 @@ public class RndBinCCCFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testVarLengthNoNulls() throws SqlException {
+    public void testVarLengthNoNulls() throws Exception {
         assertQuery("x\n" +
                         "00000000 41 1d 15\n" +
                         "00000000 17 fa d8 cc 14\n" +

--- a/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/groupby/SampleByTest.java
@@ -784,6 +784,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
+            snapshotMemoryUsage();
             try (
                     RecordCursorFactory factory = compiler.compile(
                             "select k, s, first(lat) lat, last(lon) lon " +
@@ -814,6 +815,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             true
                     );
                 }
+                assertFactoryMemoryUsage();
 
                 // invalid timezone
                 sqlExecutionContext.getBindVariableService().setStr(0, "Oopsie");
@@ -825,6 +827,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     Assert.assertEquals(108, e.getPosition());
                     TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone: Oopsie");
                 }
+                assertFactoryMemoryUsage();
 
                 sqlExecutionContext.getBindVariableService().setStr(0, "Europe/Prague");
                 sqlExecutionContext.getBindVariableService().setStr(1, "uggs");
@@ -835,6 +838,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     Assert.assertEquals(123, e.getPosition());
                     TestUtils.assertContains(e.getFlyweightMessage(), "invalid offset: uggs");
                 }
+                assertFactoryMemoryUsage();
 
                 sqlExecutionContext.getBindVariableService().setStr(0, "Europe/Prague");
                 sqlExecutionContext.getBindVariableService().setStr(1, "00:10");
@@ -846,6 +850,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             true
                     );
                 }
+                assertFactoryMemoryUsage();
 
                 sqlExecutionContext.getBindVariableService().setStr(0, null);
                 sqlExecutionContext.getBindVariableService().setStr(1, "00:10");
@@ -857,6 +862,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             true
                     );
                 }
+                assertFactoryMemoryUsage();
             }
         });
     }
@@ -1190,7 +1196,7 @@ public class SampleByTest extends AbstractGriffinTest {
                         "),index(s) timestamp(k)");
     }
 
-    @Test
+    @Test//here
     public void testIndexSampleByAlignToCalendarWithTimezoneLondonShiftForward() throws Exception {
         assertSampleByIndexQuery("to_timezone\tk\ts\tlat\tlon\n" +
                         "2020-10-23T00:00:00.000000Z\t2020-10-22T23:00:00.000000Z\ta\t142.30215575416736\t2020-10-23T22:10:00.000000Z\n" +
@@ -1382,7 +1388,7 @@ public class SampleByTest extends AbstractGriffinTest {
                         "sample by 3d");
     }
 
-    @Test
+    @Test//here
     public void testIndexSampleByIndexFrameExceedsDataFrame() throws Exception {
         assertQuery("k\ts\tlat\tlon\n",
                 "select k, s, first(lat) lat, first(lon) lon " +
@@ -2885,6 +2891,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     sqlExecutionContext
             );
 
+            snapshotMemoryUsage();
             try (RecordCursorFactory factory = compiler.compile(
                     "select k, count() from x sample by 90m align to calendar time zone $1 with offset $2",
                     sqlExecutionContext
@@ -2918,6 +2925,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             true
                     );
                 }
+                assertFactoryMemoryUsage();
 
                 // invalid timezone
                 sqlExecutionContext.getBindVariableService().setStr(0, "Oopsie");
@@ -2929,6 +2937,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     Assert.assertEquals(67, e.getPosition());
                     TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone: Oopsie");
                 }
+                assertFactoryMemoryUsage();
 
                 sqlExecutionContext.getBindVariableService().setStr(0, "Europe/Prague");
                 sqlExecutionContext.getBindVariableService().setStr(1, "uggs");
@@ -2939,6 +2948,7 @@ public class SampleByTest extends AbstractGriffinTest {
                     Assert.assertEquals(82, e.getPosition());
                     TestUtils.assertContains(e.getFlyweightMessage(), "invalid offset: uggs");
                 }
+                assertFactoryMemoryUsage();
 
                 sqlExecutionContext.getBindVariableService().setStr(0, "Europe/Prague");
                 sqlExecutionContext.getBindVariableService().setStr(1, "00:10");
@@ -2950,6 +2960,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             true
                     );
                 }
+                assertFactoryMemoryUsage();
             }
         });
     }
@@ -8032,7 +8043,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             ") timestamp(k) partition by NONE",
                     sqlExecutionContext
             );
-
+            snapshotMemoryUsage();
             try (final RecordCursorFactory factory = compiler.compile("select b, sum(a), sum(c), sum(d), sum(e), sum(f), sum(g), k from x sample by 3h fill(20.56, 0, 0, 0, 0, 0)", sqlExecutionContext).getRecordCursorFactory()) {
                 assertTimestamp("k", factory);
                 String expected = "b\tsum\tsum1\tsum2\tsum3\tsum4\tsum5\tk\n" +
@@ -8357,16 +8368,16 @@ public class SampleByTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testSampleFillValueListWithNullAndPrev() throws Exception {
+    public void testSampleFillValueListWithNullAndPrev() throws Exception { //here
         assertQuery("b\tsum\tcount\tmin\tmax\tavg\tk\n" +
                         "XYZ\t28.45577791213847\t1\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T01:00:00.000000Z\n" +
-                        "ABC\t20.56\tNaN\tNaN\tNaN\tInfinity\t1970-01-03T01:00:00.000000Z\n" +
+                        "ABC\t20.56\tNaN\tNaN\tNaN\tNaN\t1970-01-03T01:00:00.000000Z\n" +
                         "XYZ\t20.56\tNaN\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T01:30:00.000000Z\n" +
-                        "ABC\t20.56\tNaN\tNaN\tNaN\tInfinity\t1970-01-03T01:30:00.000000Z\n" +
+                        "ABC\t20.56\tNaN\tNaN\tNaN\tNaN\t1970-01-03T01:30:00.000000Z\n" +
                         "XYZ\t20.56\tNaN\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T02:00:00.000000Z\n" +
-                        "ABC\t20.56\tNaN\tNaN\tNaN\tInfinity\t1970-01-03T02:00:00.000000Z\n" +
+                        "ABC\t20.56\tNaN\tNaN\tNaN\tNaN\t1970-01-03T02:00:00.000000Z\n" +
                         "XYZ\t20.56\tNaN\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T02:30:00.000000Z\n" +
-                        "ABC\t20.56\tNaN\tNaN\tNaN\tInfinity\t1970-01-03T02:30:00.000000Z\n" +
+                        "ABC\t20.56\tNaN\tNaN\tNaN\tNaN\t1970-01-03T02:30:00.000000Z\n" +
                         "XYZ\t20.56\tNaN\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T03:00:00.000000Z\n" +
                         "ABC\t79.05675319675964\t1\t79.05675319675964\t79.05675319675964\t79.05675319675964\t1970-01-03T03:00:00.000000Z\n" +
                         "XYZ\t20.56\tNaN\t28.45577791213847\t28.45577791213847\t28.45577791213847\t1970-01-03T03:30:00.000000Z\n" +

--- a/core/src/test/java/io/questdb/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/join/HashJoinTest.java
@@ -76,7 +76,7 @@ public class HashJoinTest extends AbstractGriffinTest {
             }
 
             long rssBeforeFactory = Os.getRss();
-            long tagBeforeFactory = getMemUsedExceptMmap();
+            long tagBeforeFactory = getMemUsedByFactories();
             System.gc();
 
             try (final RecordCursorFactory factory = compiler.compile("  select a1.sensor_day, \n" +
@@ -106,7 +106,7 @@ public class HashJoinTest extends AbstractGriffinTest {
                     "  left join weather_data_historical a7 on (a1.sensor_day = a7.sensor_day and max_wind_gust_overall = a7.max_wind_gust_speed)", sqlExecutionContext).getRecordCursorFactory()) {
 
                 long rssBeforeCursor = Os.getRss();
-                long virtCursorMem = getMemUsedExceptMmap() - tagBeforeFactory;
+                long virtCursorMem = getMemUsedByFactories() - tagBeforeFactory;
                 assertThat(rssBeforeCursor - rssBeforeFactory, is(lessThan(virtCursorMem)));
 
                 long freeCount;
@@ -120,7 +120,7 @@ public class HashJoinTest extends AbstractGriffinTest {
                 }
 
                 assertThat(freeCount, is(lessThan(Unsafe.getFreeCount())));
-                assertThat(getMemUsedExceptMmap(), lessThan(tagBeforeFactory + 1024 * 1024));
+                assertThat(getMemUsedByFactories(), lessThan(tagBeforeFactory + 1024 * 1024));
             }
         });
     }

--- a/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
@@ -73,6 +73,7 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
             sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
             compiler.compile("create table x as (select rnd_symbol('A','B') s, timestamp_sequence(20000000, 100000) t from long_sequence(500000)) timestamp(t) partition by hour", sqlExecutionContext);
 
+            snapshotMemoryUsage();
             final String sql = "select * from x where s in ('C','D') limit 10";
             try (final RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
                 Assert.assertEquals(AsyncFilteredRecordCursorFactory.class, factory.getClass());
@@ -523,6 +524,7 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
         sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
         compiler.compile("create table x as (select rnd_symbol('A','B') s, timestamp_sequence(20000000, 100000) t from long_sequence(500000)) timestamp(t) partition by hour", sqlExecutionContext);
 
+        snapshotMemoryUsage();
         final String sql = "select * from x where s in ('C','D') limit 10";
         try (final RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
             Assert.assertEquals(AsyncFilteredRecordCursorFactory.class, factory.getClass());

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -48,9 +48,12 @@ import io.questdb.std.str.CharSink;
 import io.questdb.std.str.MutableCharSink;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
+import org.hamcrest.MatcherAssert;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+
+import static org.hamcrest.Matchers.*;
 
 import java.io.*;
 import java.net.URISyntaxException;
@@ -1066,7 +1069,7 @@ public final class TestUtils {
 
     public static void removeTestPath(CharSequence root) {
         Path path = Path.getThreadLocal(root);
-        Files.rmdir(path.slash$());
+        MatcherAssert.assertThat("Test dir cleanup", Files.rmdir(path.slash$()), is(lessThanOrEqualTo(0)));
     }
 
     public static long toMemory(CharSequence sequence) {


### PR DESCRIPTION
This PR pushes most native memory allocations from factories to cursors .
Instead of being kept all the time (e.g. when factory is in cache), they're released on cursor.close()
and re-allocated on factory.getCursor(). 

Notes: 
1. some allocations can't be cleared completely on cursor.close() because it'd break the factory, e.g.  join metadata map  (moved to NATIVE_JOIN_MAP tag). 
2. NATIVE_OFFLOAD memory is ignored (for time being)
3. NATIVE_SAMPLE_BY_LONG_LIST is ignored because I couldn't make it grow visibly 
4. tags related to table reader and writer are ignored as well because they don't belong to cursor and are usually kept until timeout or pool closing .
