### PR TITLE
fix(ilp): reduce ILP queue contention

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -248,8 +248,8 @@ class LineTcpMeasurementScheduler implements Closeable {
     long getNextPublisherEventSequence(int writerWorkerId) {
         assert isOpen();
         long seq;
-        //noinspection StatementWithEmptyBody
         while ((seq = pubSeq[writerWorkerId].next()) == -2) {
+            Os.pause();
         }
         return seq;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
@@ -32,6 +32,7 @@ import io.questdb.mp.RingQueue;
 import io.questdb.mp.Sequence;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.Path;
 
@@ -135,6 +136,7 @@ class LineTcpWriterJob implements Job, Closeable {
                 if (cursor == -1) {
                     return busy;
                 }
+                Os.pause();
             }
             busy = true;
             final LineTcpMeasurementEvent event = queue.get(cursor);


### PR DESCRIPTION
Removed busy spin around CAS error on ILP sequence from both ends, sender and writer.