### PR TITLE
chore(core): improve cleanup method's reliability and fix several bad calls

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -181,7 +181,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
         if (ColumnType.isSymbol(metadata.getColumnType(columnIndex))) {
             // same goes for symbol map reader - replace object with maker instance
-            Misc.free(symbolMapReaders.getAndSetQuick(columnIndex, EmptySymbolMapReader.INSTANCE));
+            Misc.freeIfCloseable(symbolMapReaders.getAndSetQuick(columnIndex, EmptySymbolMapReader.INSTANCE));
         }
     }
 
@@ -675,7 +675,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
     private void freeSymbolMapReaders() {
         for (int i = 0, n = symbolMapReaders.size(); i < n; i++) {
-            Misc.free(symbolMapReaders.getQuick(i));
+            Misc.freeIfCloseable(symbolMapReaders.getQuick(i));
         }
         symbolMapReaders.clear();
     }
@@ -1288,7 +1288,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
             if (action == -1) {
                 // deleted
-                Misc.free(symbolMapReaders.getAndSetQuick(i, null));
+                Misc.freeIfCloseable(symbolMapReaders.getAndSetQuick(i, null));
             }
 
             // don't copy entries to themselves, unless symbol map was deleted

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2751,7 +2751,7 @@ public class TableWriter implements Closeable {
         Misc.free(other);
         Misc.free(todoMem);
         Misc.free(attachMetaMem);
-        Misc.free(attachMetadata);
+        //Misc.free(attachMetadata);
         Misc.free(attachColumnVersionReader);
         Misc.free(attachIndexBuilder);
         Misc.free(columnVersionWriter);
@@ -2759,7 +2759,7 @@ public class TableWriter implements Closeable {
         Misc.free(slaveTxReader);
         Misc.free(commandQueue);
         updateOperator = Misc.free(updateOperator);
-        dropIndexOperator = Misc.free(dropIndexOperator);
+        dropIndexOperator = null; //Misc.free(dropIndexOperator);
         freeColumns(truncate & !distressed);
         try {
             releaseLock(!truncate | tx | performRecovery | distressed);
@@ -2886,7 +2886,7 @@ public class TableWriter implements Closeable {
     private void freeSymbolMapWriters() {
         if (denseSymbolMapWriters != null) {
             for (int i = 0, n = denseSymbolMapWriters.size(); i < n; i++) {
-                Misc.free(denseSymbolMapWriters.getQuick(i));
+                Misc.freeIfCloseable(denseSymbolMapWriters.getQuick(i));
             }
             denseSymbolMapWriters.clear();
         }
@@ -5337,7 +5337,7 @@ public class TableWriter implements Closeable {
                 w.setSymbolIndexInTxWriter(symColIndex);
                 symColIndex++;
             }
-            Misc.free(writer);
+            Misc.freeIfCloseable(writer);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2751,7 +2751,6 @@ public class TableWriter implements Closeable {
         Misc.free(other);
         Misc.free(todoMem);
         Misc.free(attachMetaMem);
-        //Misc.free(attachMetadata);
         Misc.free(attachColumnVersionReader);
         Misc.free(attachIndexBuilder);
         Misc.free(columnVersionWriter);
@@ -2759,7 +2758,7 @@ public class TableWriter implements Closeable {
         Misc.free(slaveTxReader);
         Misc.free(commandQueue);
         updateOperator = Misc.free(updateOperator);
-        dropIndexOperator = null; //Misc.free(dropIndexOperator);
+        dropIndexOperator = null;
         freeColumns(truncate & !distressed);
         try {
             releaseLock(!truncate | tx | performRecovery | distressed);

--- a/core/src/main/java/io/questdb/cairo/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/WalWriter.java
@@ -473,7 +473,7 @@ public class WalWriter implements Closeable {
     }
 
     private void freeSymbolMapWriters() {
-        Misc.freeObjList(symbolMapReaders);
+        Misc.freeObjListIfCloseable(symbolMapReaders);
     }
 
     private MemoryMA getPrimaryColumn(int column) {
@@ -639,7 +639,7 @@ public class WalWriter implements Closeable {
     }
 
     private void removeSymbolMapWriter(int index) {
-        Misc.free(symbolMapReaders.getAndSetQuick(index, null));
+        Misc.freeIfCloseable(symbolMapReaders.getAndSetQuick(index, null));
         initialSymbolCounts.setQuick(index, -1);
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/PageAddressCacheRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageAddressCacheRecord.java
@@ -61,7 +61,7 @@ public class PageAddressCacheRecord implements Record, Closeable {
 
     @Override
     public void close() {
-        Misc.freeObjList(symbolTableCache);
+        Misc.freeObjListIfCloseable(symbolTableCache);
     }
 
     @Override
@@ -302,7 +302,7 @@ public class PageAddressCacheRecord implements Record, Closeable {
         this.pageAddressCache = pageAddressCache;
         frameIndex = 0;
         rowIndex = 0;
-        Misc.freeObjList(symbolTableCache);
+        Misc.freeObjListIfCloseable(symbolTableCache);
         symbolTableCache.clear();
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -202,7 +202,7 @@ public class PageFrameReduceJob implements Job, Closeable {
 
     @Override
     public void close() {
-        circuitBreaker = Misc.free(circuitBreaker);
+        circuitBreaker = Misc.freeIfCloseable(circuitBreaker);
         record = Misc.free(record);
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -146,7 +146,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         dispatchStartFrameIndex = 0;
         collectedFrameIndex = -1;
         pageAddressCache.clear();
-        symbolTableSource = Misc.free(symbolTableSource);
+        symbolTableSource = Misc.freeIfCloseable(symbolTableSource);
         // collect sequence may not be set here when
         // factory is closed without using cursor
         if (collectSubSeq != null) {
@@ -164,7 +164,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     @Override
     public void close() {
         this.clear();
-        Misc.free(circuitBreaker);
+        Misc.freeIfCloseable(circuitBreaker);
         Misc.free(record);
     }
 
@@ -208,7 +208,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                         .I$();
             }
         } catch (Throwable e) {
-            this.symbolTableSource = Misc.free(this.symbolTableSource);
+            this.symbolTableSource = Misc.freeIfCloseable(this.symbolTableSource);
             throw e;
         }
         return this;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -378,10 +378,10 @@ public class HttpServer implements Closeable {
 
         @Override
         public void close() {
-            Misc.free(defaultRequestProcessor);
+            Misc.freeIfCloseable(defaultRequestProcessor);
             ObjList<CharSequence> processorKeys = processorMap.keys();
             for (int i = 0, n = processorKeys.size(); i < n; i++) {
-                Misc.free(processorMap.get(processorKeys.getQuick(i)));
+                Misc.freeIfCloseable(processorMap.get(processorKeys.getQuick(i)));
             }
         }
     }

--- a/core/src/main/java/io/questdb/cutlass/http/LocalValueMap.java
+++ b/core/src/main/java/io/questdb/cutlass/http/LocalValueMap.java
@@ -65,7 +65,7 @@ public class LocalValueMap implements Closeable, Mutable {
         for (int i = 0, n = table.length; i < n; i++) {
             Entry e = table[i];
             if (e != null) {
-                e.value = Misc.free(e.value);
+                e.value = Misc.freeIfCloseable(e.value);
                 e.k = null;
             }
             table[i] = null;
@@ -90,7 +90,7 @@ public class LocalValueMap implements Closeable, Mutable {
             LocalValue<?> k = e.k;
 
             if (k == key) {
-                Misc.free(e.value);
+                Misc.freeIfCloseable(e.value);
                 e.value = value;
                 return;
             }
@@ -139,7 +139,7 @@ public class LocalValueMap implements Closeable, Mutable {
         Entry[] tab = table;
         int len = tab.length;
 
-        tab[index].value = Misc.free(tab[index].value);
+        tab[index].value = Misc.freeIfCloseable(tab[index].value);
         tab[index] = null;
         size--;
 
@@ -148,7 +148,7 @@ public class LocalValueMap implements Closeable, Mutable {
         for (i = nextIndex(index, len); (e = tab[i]) != null; i = nextIndex(i, len)) {
             LocalValue<?> k = e.k;
             if (k == null) {
-                e.value = Misc.free(e.value);
+                e.value = Misc.freeIfCloseable(e.value);
                 tab[i] = null;
                 size--;
             } else {
@@ -209,7 +209,7 @@ public class LocalValueMap implements Closeable, Mutable {
             LocalValue<?> k = e.k;
 
             if (k == key) {
-                Misc.free(e.value);
+                Misc.freeIfCloseable(e.value);
                 e.value = value;
 
                 tab[i] = tab[index];
@@ -227,7 +227,7 @@ public class LocalValueMap implements Closeable, Mutable {
             }
         }
 
-        tab[index].value = Misc.free(tab[index].value);
+        tab[index].value = Misc.freeIfCloseable(tab[index].value);
         tab[index] = new Entry(key, value);
 
         if (slotToExpunge != index) {
@@ -247,7 +247,7 @@ public class LocalValueMap implements Closeable, Mutable {
             if (e != null) {
                 LocalValue<?> k = e.k;
                 if (k == null) {
-                    e.value = Misc.free(e.value);
+                    e.value = Misc.freeIfCloseable(e.value);
                 } else {
                     int h = k.hashCode & (newLen - 1);
                     while (newTab[h] != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/EmptyTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/EmptyTableRecordCursorFactory.java
@@ -37,7 +37,7 @@ public class EmptyTableRecordCursorFactory extends AbstractRecordCursorFactory {
 
     @Override
     protected void _close() {
-        Misc.free(getMetadata());
+        Misc.freeIfCloseable(getMetadata());
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/analytic/RowNumberFunctionFactory.java
@@ -104,7 +104,7 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         @Override
         public void close() {
             Misc.free(map);
-            Misc.free(partitionByRecord.getFunctions());
+            Misc.freeObjList(partitionByRecord.getFunctions());
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/columns/SymbolColumn.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/columns/SymbolColumn.java
@@ -65,7 +65,7 @@ public class SymbolColumn extends SymbolFunction implements ScalarFunction {
         if (executionContext.getCloneSymbolTables()) {
             if (symbolTable != null) {
                 assert ownSymbolTable;
-                symbolTable = Misc.free(symbolTable);
+                symbolTable = Misc.freeIfCloseable(symbolTable);
             }
             symbolTable = symbolTableSource.newSymbolTable(columnIndex);
             ownSymbolTable = true;
@@ -109,7 +109,7 @@ public class SymbolColumn extends SymbolFunction implements ScalarFunction {
     @Override
     public void close() {
         if (ownSymbolTable) {
-            symbolTable = Misc.free(symbolTable);
+            symbolTable = Misc.freeIfCloseable(symbolTable);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/MapSymbolColumn.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/MapSymbolColumn.java
@@ -83,7 +83,7 @@ public class MapSymbolColumn extends SymbolFunction {
         if (executionContext.getCloneSymbolTables()) {
             if (symbolTable != null) {
                 assert ownSymbolTable;
-                symbolTable = Misc.free(symbolTable);
+                symbolTable = Misc.freeIfCloseable(symbolTable);
             }
             symbolTable = symbolTableSource.newSymbolTable(cursorColumnIndex);
             ownSymbolTable = true;
@@ -108,7 +108,7 @@ public class MapSymbolColumn extends SymbolFunction {
     @Override
     public void close() {
         if (ownSymbolTable) {
-            symbolTable = Misc.free(symbolTable);
+            symbolTable = Misc.freeIfCloseable(symbolTable);
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -91,7 +91,7 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractDataFrame
     protected void _close() {
         super._close();
         Misc.free(filter);
-        Misc.free(keyExcludedValueFunctions);
+        Misc.freeObjList(keyExcludedValueFunctions);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -261,7 +261,7 @@ public class LogFactory implements Closeable {
     public void close() {
         haltThread();
         for (int i = 0, n = jobs.size(); i < n; i++) {
-            Misc.free(jobs.get(i));
+            Misc.freeIfCloseable(jobs.get(i));
         }
         for (int i = 0, n = scopeConfigs.size(); i < n; i++) {
             Misc.free(scopeConfigs.getQuick(i));
@@ -285,7 +285,7 @@ public class LogFactory implements Closeable {
                     // Exception means we cannot log anymore. Perhaps network is down or disk is full.
                     // Switch to the next job.
                 }
-                Misc.free(job);
+                Misc.freeIfCloseable(job);
             }
         }
         for (int i = 0, n = scopeConfigs.size(); i < n; i++) {

--- a/core/src/main/java/io/questdb/mp/RingQueue.java
+++ b/core/src/main/java/io/questdb/mp/RingQueue.java
@@ -74,7 +74,7 @@ public class RingQueue<T> implements Closeable {
     @Override
     public void close() {
         for (int i = 0, n = buf.length; i < n; i++) {
-            Misc.free(buf[i]);
+            Misc.freeIfCloseable(buf[i]);
         }
         if (memorySize > 0) {
             Unsafe.free(memory, memorySize, memoryTag);

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -134,7 +134,7 @@ public class WorkerPool {
             }
             halted.await();
 
-            Misc.freeObjList(workers);
+            workers.clear();//Worker is not closable  
             Misc.freeObjList(freeOnHalt);
         }
     }

--- a/core/src/main/java/io/questdb/std/AssociativeCache.java
+++ b/core/src/main/java/io/questdb/std/AssociativeCache.java
@@ -70,7 +70,7 @@ public class AssociativeCache<V> implements Closeable, Mutable {
             if (keys[i] != null) {
                 keys[i] = null;
                 if (values[i] != null) {
-                    values[i] = Misc.free(values[i]);
+                    values[i] = Misc.freeIfCloseable(values[i]);
                     freed++;
                 }
             }
@@ -117,7 +117,7 @@ public class AssociativeCache<V> implements Closeable, Mutable {
                     cachedGauge.inc();
                 } else {
                     // We're replacing the value with another one, no need to change the gauge.
-                    Misc.free(values[lo]);
+                    Misc.freeIfCloseable(values[lo]);
                 }
                 values[lo] = value;
             }
@@ -134,7 +134,7 @@ public class AssociativeCache<V> implements Closeable, Mutable {
                 cachedGauge.inc();
             } else {
                 // We're replacing the value with another one, no need to change the gauge.
-                values[idx] = Misc.free(values[idx]);
+                values[idx] = Misc.freeIfCloseable(values[idx]);
             }
         } else {
             // The block has empty entries, so we're inserting.

--- a/core/src/main/java/io/questdb/std/Misc.java
+++ b/core/src/main/java/io/questdb/std/Misc.java
@@ -39,7 +39,6 @@ public final class Misc {
     private Misc() {
     }
 
-    @SuppressWarnings("SameReturnValue")
     public static <T extends Closeable> T free(T object) {
         if (object != null) {
             try {
@@ -52,7 +51,6 @@ public final class Misc {
     }
 
     //same as free() but can be used when input object type is not guaranteed to be Closeable
-    @SuppressWarnings("SameReturnValue")
     public static <T> T freeIfCloseable(T object) {
         if (object instanceof Closeable) {
             try {

--- a/core/src/main/java/io/questdb/std/Misc.java
+++ b/core/src/main/java/io/questdb/std/Misc.java
@@ -40,7 +40,20 @@ public final class Misc {
     }
 
     @SuppressWarnings("SameReturnValue")
-    public static <T> T free(T object) {
+    public static <T extends Closeable> T free(T object) {
+        if (object != null) {
+            try {
+                object.close();
+            } catch (IOException e) {
+                throw new FatalError(e);
+            }
+        }
+        return null;
+    }
+
+    //same as free() but can be used when input object type is not guaranteed to be Closeable
+    @SuppressWarnings("SameReturnValue")
+    public static <T> T freeIfCloseable(T object) {
         if (object instanceof Closeable) {
             try {
                 ((Closeable) object).close();
@@ -57,7 +70,14 @@ public final class Misc {
         return b;
     }
 
-    public static <T> void freeObjList(ObjList<T> list) {
+    public static <T extends Closeable> void freeObjList(ObjList<T> list) {
+        if (list != null) {
+            freeObjList0(list);
+        }
+    }
+
+    //same as freeObjList() but can be used when input object type is not guaranteed to be Closeable   
+    public static <T> void freeObjListIfCloseable(ObjList<T> list) {
         if (list != null) {
             freeObjList0(list);
         }
@@ -71,11 +91,11 @@ public final class Misc {
 
     private static <T> void freeObjList0(ObjList<T> list) {
         for (int i = 0, n = list.size(); i < n; i++) {
-            list.setQuick(i, free(list.getQuick(i)));
+            list.setQuick(i, freeIfCloseable(list.getQuick(i)));
         }
     }
 
-    public static <T> void freeObjListAndClear(ObjList<T> list) {
+    public static <T extends Closeable> void freeObjListAndClear(ObjList<T> list) {
         if (list != null) {
             for (int i = 0, n = list.size(); i < n; i++) {
                 free(list.getQuick(i));
@@ -84,7 +104,7 @@ public final class Misc {
         }
     }
 
-    public static <T> void free(T[] list) {
+    public static <T extends Closeable> void free(T[] list) {
         if (list != null) {
             for (int i = 0, n = list.length; i < n; i++) {
                 list[i] = Misc.free(list[i]);
@@ -92,7 +112,7 @@ public final class Misc {
         }
     }
 
-    public static <T> void freeObjListAndKeepObjects(ObjList<T> list) {
+    public static <T extends Closeable> void freeObjListAndKeepObjects(ObjList<T> list) {
         if (list != null) {
             for (int i = 0, n = list.size(); i < n; i++) {
                 free(list.getQuick(i));

--- a/core/src/main/java/io/questdb/std/ThreadLocal.java
+++ b/core/src/main/java/io/questdb/std/ThreadLocal.java
@@ -36,7 +36,7 @@ public class ThreadLocal<T> extends java.lang.ThreadLocal<T> implements Closeabl
 
     @Override
     public void close() throws IOException {
-        Misc.free(super.get());
+        Misc.freeIfCloseable(super.get());
         remove();
     }
 

--- a/core/src/main/java/io/questdb/std/WeakMutableObjectPool.java
+++ b/core/src/main/java/io/questdb/std/WeakMutableObjectPool.java
@@ -45,7 +45,7 @@ public class WeakMutableObjectPool<T extends Mutable> extends WeakObjectPoolBase
     @Override
     public void close() {
         while (cache.size() > 0) {
-            Misc.free(cache.pop());
+            Misc.freeIfCloseable(cache.pop());
         }
     }
 
@@ -56,7 +56,7 @@ public class WeakMutableObjectPool<T extends Mutable> extends WeakObjectPoolBase
 
     @Override
     void close(T obj) {
-        Misc.free(obj);
+        Misc.freeIfCloseable(obj);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
+++ b/core/src/test/java/io/questdb/griffin/AbstractGriffinTest.java
@@ -687,7 +687,7 @@ public class AbstractGriffinTest extends AbstractCairoTest {
                     }
                 }
             } finally {
-                Misc.freeObjList(clonedSymbolTables);
+                Misc.freeObjListIfCloseable(clonedSymbolTables);
             }
         }
     }

--- a/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
@@ -663,7 +663,7 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
                     frameSequence.collect(cursor, false);
                 }
                 frameSequence.await();
-                Misc.free(frameSequence.getSymbolTableSource());
+                Misc.freeIfCloseable(frameSequence.getSymbolTableSource());
                 frameSequence.clear();
             }
         });


### PR DESCRIPTION
This PR makes Misc.free() and Misc.freeObjList() accept Closeable-derived argument only to improve type safety . 
If input type is not necessarily a Closeable then freeIfCloseable() or freeObjListIfCloseable() should be used . 
PR also contains fixes for several bad calls of aforementioned methods .