### PR TITLE
fix(sql): fix TableReader metadata open when columns are added frequently

### DIFF
--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.vm;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.vm.api.MemoryCMR;
@@ -67,15 +68,15 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
     }
 
     @Override
-    public boolean isMapped(long offset, long len) {
-        return offset + len <= size();
-    }
-
-    @Override
     public void extend(long newSize) {
         if (newSize > size) {
             setSize0(newSize);
         }
+    }
+
+    @Override
+    public boolean isMapped(long offset, long len) {
+        return offset + len <= size();
     }
 
     @Override
@@ -91,6 +92,12 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
             }
         }
         map(ff, name, size);
+    }
+
+    @Override
+    public void smallFile(FilesFacade ff, LPSZ name, int memoryTag) {
+        // Override default implementation to defer ff.length() call to use fd instead of path
+        of(ff, name, ff.getPageSize(), -1, memoryTag, CairoConfiguration.O_NONE);
     }
 
     protected void map(FilesFacade ff, LPSZ name, final long size) {

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -97,7 +97,13 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
     @Override
     public void smallFile(FilesFacade ff, LPSZ name, int memoryTag) {
         // Override default implementation to defer ff.length() call to use fd instead of path
-        of(ff, name, ff.getPageSize(), -1, memoryTag, CairoConfiguration.O_NONE);
+        of(ff, name, ff.getPageSize(), -1, memoryTag, CairoConfiguration.O_NONE, -1);
+    }
+
+    @Override
+    public void wholeFile(FilesFacade ff, LPSZ name, int memoryTag) {
+        // Override default implementation to defer ff.length() call to use fd instead of path
+        of(ff, name, ff.getMapPageSize(), -1, memoryTag, CairoConfiguration.O_NONE, -1);
     }
 
     protected void map(FilesFacade ff, LPSZ name, final long size) {

--- a/core/src/test/java/io/questdb/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/griffin/O3FailureTest.java
@@ -28,7 +28,10 @@ import io.questdb.cairo.*;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.mp.*;
+import io.questdb.mp.Job;
+import io.questdb.mp.SOCountDownLatch;
+import io.questdb.mp.TestWorkerPool;
+import io.questdb.mp.WorkerPool;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
@@ -225,7 +228,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testAllocateFailsAtO3OpenColumn() throws Exception {
-        counter.set(50);
+        counter.set(50 + 5);
         executeWithPool(0, O3FailureTest::testAllocateFailsAtO3OpenColumn0, new FilesFacadeImpl() {
             private boolean failNextAlloc = false;
 
@@ -252,7 +255,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testAllocateToResizeLastPartition() throws Exception {
-        counter.set(48);
+        counter.set(51 + 3);
         executeWithPool(0, O3FailureTest::testAllocateToResizeLastPartition0, new FilesFacadeImpl() {
             private boolean failNextAlloc = false;
 
@@ -554,7 +557,7 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testFailOnResizingIndexContended() throws Exception {
         // this places break point on resize of key file
-        counter.set(152);
+        counter.set(152 + 12);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -868,13 +871,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTail() throws Exception {
-        counter.set(174);
+        counter.set(174 + 12);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailContended() throws Exception {
-        counter.set(174);
+        counter.set(174 + 12);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -892,25 +895,25 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailParallel() throws Exception {
-        counter.set(174 + 45);
+        counter.set(174 + 45 + 12);
         executeWithPool(2, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODatThenRegularAppend() throws Exception {
-        counter.set(165 + 45);
+        counter.set(165 + 45 + 12);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODatThenRegularAppend0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOOData() throws Exception {
-        counter.set(165 + 45);
+        counter.set(165 + 45 + 12);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataContended() throws Exception {
-        counter.set(165 + 45);
+        counter.set(165 + 45 + 12);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
@@ -972,13 +975,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallel() throws Exception {
-        counter.set(193 + 45);
+        counter.set(193 + 45 + 18);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallelNoReopen() throws Exception {
-        counter.set(176 + 45);
+        counter.set(176 + 45 + 18);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetryNoReopen, ffAllocateFailure);
     }
 
@@ -1053,7 +1056,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testSetAppendPositionFails() throws Exception {
-        counter.set(169);
+        counter.set(169 + 12);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 


### PR DESCRIPTION
Fixes this error from CI

```
2022-10-06T10:18:42.7683627Z 2022-10-06T10:18:42.719293Z I i.q.c.TableWriter ADDED column 'col428[SYMBOL], name txn 639 to /tmp/junit4122981112622880555/dbRoot/tbl_meta_test
2022-10-06T10:18:42.7684649Z 2022-10-06T10:18:42.720608Z E i.q.c.AbstractCairoTest 
2022-10-06T10:18:42.7685393Z io.questdb.cairo.CairoException: [0] File is too small, size=20480, required=20490
2022-10-06T10:18:42.7686143Z 	at io.questdb.cairo.CairoException.critical(CairoException.java:89)
2022-10-06T10:18:42.7686904Z 	at io.questdb.cairo.TableUtils.getCharSequence(TableUtils.java:1194)
2022-10-06T10:18:42.7687656Z 	at io.questdb.cairo.TableUtils.getColumnName(TableUtils.java:1177)
2022-10-06T10:18:42.7688394Z 	at io.questdb.cairo.TableUtils.validateMeta(TableUtils.java:1032)
2022-10-06T10:18:42.7689159Z 	at io.questdb.cairo.TableReaderMetadata.deferredInit(TableReaderMetadata.java:178)
2022-10-06T10:18:42.7689937Z 	at io.questdb.cairo.TableReader.openMetaFile(TableReader.java:758)
2022-10-06T10:18:42.7690925Z 	at io.questdb.cairo.TableReader.<init>(TableReader.java:99)
2022-10-06T10:18:42.7691715Z 	at io.questdb.cairo.pool.ReaderPool$R.<init>(ReaderPool.java:383)
2022-10-06T10:18:42.7692576Z 	at io.questdb.cairo.pool.ReaderPool.get(ReaderPool.java:93)
2022-10-06T10:18:42.7693302Z 	at io.questdb.cairo.CairoEngine.getReader(CairoEngine.java:272)
2022-10-06T10:18:42.7694038Z 	at io.questdb.cairo.CairoEngine.getReader(CairoEngine.java:262)
2022-10-06T10:18:42.7694892Z 	at io.questdb.cairo.TableReaderTest.lambda$testAddColumnPartitionConcurrentCreateReader$46(TableReaderTest.java:1628)
2022-10-06T10:18:42.7695701Z 	at java.lang.Thread.run(Thread.java:829)
2022-10-06T10:18:43.3785985Z 2022-10-06T10:18:43.360687Z I i.q.c.TableWriter adding column 'col429[SYMBOL], name txn 641 to 
```

by reading file length by file descriptor after opening the file.

When table metadata file is frequently updated, a new file is created and swap-renamed to the name _meta. When TableReader opens metadata file it could read file length of the different version of metadata resulting to the above error