### PR TITLE
fix(ilp): fix degradation of row-by-row commit when commit operation takes longer than commit lag

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -186,7 +186,10 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
             retryQueue.add(purgeTaskRun);
             useful = true;
         }
-        commit();
+
+        if (useful) {
+            commit();
+        }
         return useful;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
@@ -102,7 +102,7 @@ class LineTcpWriterJob implements Job, Closeable {
     }
 
     private void commitTables() {
-        final long wallClockMillis = millisecondClock.getTicks();
+        long wallClockMillis = millisecondClock.getTicks();
         if (wallClockMillis > nextCommitTime) {
             long minTableNextCommitTime = Long.MAX_VALUE;
             for (int n = 0, sz = assignedTables.size(); n < sz; n++) {
@@ -111,6 +111,8 @@ class LineTcpWriterJob implements Job, Closeable {
                 // time greater than millis and that will be our nextCommitTime
                 try {
                     long tableNextCommitTime = assignedTables.getQuick(n).commitIfIntervalElapsed(wallClockMillis);
+                    // get current time again, commit is not instant and take quite some time.
+                    wallClockMillis = millisecondClock.getTicks();
                     if (tableNextCommitTime < minTableNextCommitTime) {
                         // taking the earliest commit time
                         minTableNextCommitTime = tableNextCommitTime;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -219,8 +219,11 @@ public class TableUpdateDetails implements Closeable {
         }
         if (writer != null) {
             final long commitInterval = writer.getCommitInterval();
+            long start = millisecondClock.getTicks();
             commit(wallClockMillis - lastMeasurementMillis < commitInterval);
-            nextCommitTime += commitInterval;
+            // Do not commit row by row if the commit takes longer than commitInterval.
+            // Exclude time to commit from the commit interval.
+            nextCommitTime += commitInterval + millisecondClock.getTicks() - start;
         }
         return nextCommitTime;
     }


### PR DESCRIPTION
Reducing default `commitLag` to 1 second uncovered issue that if the commit itself takes longer than 1 second ILP degrades to row by row commit.

This fix accounts to the fact that commits are not instant in the calculations of the next commit time.