### PR TITLE
test(pgwire): fix flaky testFetchDisconnectReleasesReaderCrossJoin

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -34,7 +34,9 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.NetUtils;
-import io.questdb.griffin.*;
+import io.questdb.griffin.QueryFutureUpdateListener;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
@@ -47,7 +49,6 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
-import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -2134,8 +2135,7 @@ if __name__ == "__main__":
                     tbl.execute();
 
                     PreparedStatement stmt = connection.prepareStatement("with crj as (select first(x) as p0 from xx) select x / p0 from xx cross join crj");
-
-                    connection.setNetworkTimeout(Runnable::run, 5);
+                    connection.setNetworkTimeout(Runnable::run, 1);
                     int testSize = 100000;
                     stmt.setFetchSize(testSize);
                     assertEquals(testSize, stmt.getFetchSize());
@@ -2148,9 +2148,7 @@ if __name__ == "__main__":
                         Assert.assertNotNull(ex);
                     }
                 }
-                Thread.sleep(100); // Give connection some time to close before closing the server.
             }
-            // Assertion that no open readers left will be performed in assertMemoryLeak
         });
     }
 


### PR DESCRIPTION
fixes flapping test

```
2022-10-09T01:13:21.7641220Z 2022-10-09T01:13:21.712177Z I i.q.c.AbstractCairoTest Tearing down test PGJobContextTest#testFetchDisconnectReleasesReaderCrossJoin
2022-10-09T01:13:21.7682280Z 2022-10-09T01:13:21.723752Z E i.q.TestListener ***** Test Failed *****io.questdb.cutlass.pgwire.PGJobContextTest.testFetchDisconnectRe
leasesReaderCrossJoin : 
2022-10-09T01:13:21.7684460Z java.lang.AssertionError
2022-10-09T01:13:21.7685660Z    at org.junit.Assert.fail(Assert.java:87)
2022-10-09T01:13:21.7686940Z    at org.junit.Assert.fail(Assert.java:96)
2022-10-09T01:13:21.7688970Z    at io.questdb.cutlass.pgwire.PGJobContextTest.lambda$testFetchDisconnectReleasesReaderCrossJoin$17(PGJobContextTest.java:2145)
2022-10-09T01:13:21.7690610Z    at io.questdb.cairo.AbstractCairoTest.lambda$assertMemoryLeak$0(AbstractCairoTest.java:488)
2022-10-09T01:13:21.7696460Z    at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:468)
2022-10-09T01:13:21.7699910Z    at io.questdb.cairo.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:485)
2022-10-09T01:13:21.7707490Z    at io.questdb.cairo.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:479)
2022-10-09T01:13:21.7710560Z    at io.questdb.cutlass.pgwire.PGJobContextTest.testFetchDisconnectReleasesReaderCrossJoin(PGJobContextTest.java:2121)
2022-10-09T01:13:21.7714830Z    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2022-10-09T01:13:21.7718850Z    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2022-10-09T01:13:21.7720550Z    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2022-10-09T01:13:21.7722120Z    at java.lang.reflect.Method.invoke(Method.java:566)
2022-10-09T01:13:21.7724690Z    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2022-10-09T01:13:21.7726450Z    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2022-10-09T01:13:21.7729240Z    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
2022-10-09T01:13:21.7730800Z    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2022-10-09T01:13:21.7732370Z    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
2022-10-09T01:13:21.7733720Z    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2022-10-09T01:13:21.7735010Z    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
2022-10-09T01:13:21.7736350Z    at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
2022-10-09T01:13:21.7737800Z    at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
2022-10-09T01:13:21.7739270Z    at java.util.concurrent.FutureTask.run(FutureTask.java:264)
2022-10-09T01:13:21.7741080Z    at java.lang.Thread.run(Thread.java:829)
```