### PR TITLE
chore(core): allow dropping active partition concurrently with line ingress

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -242,14 +242,16 @@ public class CairoEngine implements Closeable, WriterSource, WalWriterSource {
         return metrics;
     }
 
-    public PoolListener getPoolListener() {
-        return this.writerPool.getPoolListener();
-    }
-
     public IDGenerator getTableIdGenerator() {
         return tableIdGenerator;
     }
 
+    @TestOnly
+    public PoolListener getPoolListener() {
+        return this.writerPool.getPoolListener();
+    }
+
+    @TestOnly
     public void setPoolListener(PoolListener poolListener) {
         this.writerPool.setPoolListener(poolListener);
         this.readerPool.setPoolListener(poolListener);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1455,44 +1455,47 @@ public class TableWriter implements Closeable {
             return false;
         }
 
+        final long partitionNameTxn = txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp);
+
         if (timestamp == getPartitionLo(maxTimestamp)) {
 
             // removing active partition
 
             if (index == 0) {
-                // removing the very last partition is equivalent to truncating the table
-                truncate();
-                return true;
+                // the last partition
+                columnVersionWriter.removePartition(timestamp);
+                txWriter.truncate(columnVersionWriter.getVersion());
+                closeActivePartition(true);
+                row = regularRow;
+                rowAction = ROW_ACTION_OPEN_PARTITION;
+            } else {
+                // calculate new transient row count and max timestamp
+                final int prevIndex = index - 1;
+                final long prevTimestamp = txWriter.getPartitionTimestamp(prevIndex);
+                final long newTransientRowCount = txWriter.getPartitionSize(prevIndex);
+                try {
+                    setPathForPartition(path.trimTo(rootLen), partitionBy, prevTimestamp, false);
+                    TableUtils.txnPartitionConditionally(path, txWriter.getPartitionNameTxn(prevIndex));
+                    readPartitionMinMax(ff, prevTimestamp, path, metadata.getColumnName(metadata.getTimestampIndex()), newTransientRowCount);
+                } finally {
+                    path.trimTo(rootLen);
+                }
+
+                columnVersionWriter.removePartition(timestamp);
+                txWriter.beginPartitionSizeUpdate();
+                txWriter.removeAttachedPartitions(timestamp);
+                txWriter.finishPartitionSizeUpdate(txWriter.getMinTimestamp(), attachMaxTimestamp);
+                txWriter.bumpTruncateVersion();
+
+                columnVersionWriter.commit();
+                txWriter.setColumnVersion(columnVersionWriter.getVersion());
+                txWriter.commit(defaultCommitMode, denseSymbolMapWriters);
+
+                closeActivePartition(true);
+                row = regularRow;
+                openPartition(prevTimestamp);
+                setAppendPosition(newTransientRowCount, false);
             }
-
-            // calculate new transient row count and max timestamp
-            final int prevIndex = index - 1;
-            final long prevTimestamp = txWriter.getPartitionTimestamp(prevIndex);
-            final long newTransientRowCount = txWriter.getPartitionSize(prevIndex);
-            try {
-                setPathForPartition(path.trimTo(rootLen), partitionBy, prevTimestamp, false);
-                TableUtils.txnPartitionConditionally(path, txWriter.getPartitionNameTxn(prevIndex));
-                readPartitionMinMax(ff, prevTimestamp, path, metadata.getColumnName(metadata.getTimestampIndex()), newTransientRowCount);
-            }
-            finally {
-                path.trimTo(rootLen);
-            }
-
-            columnVersionWriter.removePartition(timestamp);
-            txWriter.beginPartitionSizeUpdate();
-            txWriter.removeAttachedPartitions(timestamp);
-            // max is updated upon finishing the transaction, the value was loaded by readPartitionMinMax
-            txWriter.finishPartitionSizeUpdate(txWriter.getMinTimestamp(), attachMaxTimestamp);
-            txWriter.bumpTruncateVersion();
-
-            columnVersionWriter.commit();
-            txWriter.setColumnVersion(columnVersionWriter.getVersion());
-            txWriter.commit(defaultCommitMode, denseSymbolMapWriters);
-
-            closeActivePartition(true);
-            row = regularRow;
-            openPartition(prevTimestamp);
-            setAppendPosition(newTransientRowCount, false);
         } else {
 
             // when we want to delete first partition we must find out minTimestamp from
@@ -1508,7 +1511,6 @@ public class TableWriter implements Closeable {
                 nextMinTimestamp = readMinTimestamp(txWriter.getPartitionTimestamp(1));
             }
 
-            long partitionNameTxn = txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp);
             columnVersionWriter.removePartition(timestamp);
 
             txWriter.beginPartitionSizeUpdate();
@@ -1520,11 +1522,10 @@ public class TableWriter implements Closeable {
             columnVersionWriter.commit();
             txWriter.setColumnVersion(columnVersionWriter.getVersion());
             txWriter.commit(defaultCommitMode, denseSymbolMapWriters);
-
-            // Call O3 methods to remove check TxnScoreboard and remove partition directly
-            safeDeletePartitionDir(timestamp, partitionNameTxn);
         }
 
+        // Call O3 methods to remove check TxnScoreboard and remove partition directly
+        safeDeletePartitionDir(timestamp, partitionNameTxn);
         return true;
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1486,7 +1486,7 @@ public class TableWriter implements Closeable {
             columnVersionWriter.removePartition(timestamp);
             txWriter.beginPartitionSizeUpdate();
             txWriter.removeAttachedPartitions(timestamp);
-            txWriter.finishPartitionSizeUpdate(txWriter.getMinTimestamp(), nextMaxTimestamp);
+            txWriter.finishPartitionSizeUpdate(index == 0 ? Long.MAX_VALUE : txWriter.getMinTimestamp(), nextMaxTimestamp);
             txWriter.bumpTruncateVersion();
 
             columnVersionWriter.commit();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1461,40 +1461,46 @@ public class TableWriter implements Closeable {
 
             // removing active partition
 
+            // calculate new transient row count, min/max timestamps and find the partition to open next
+            final long nextMaxTimestamp;
+            final long newTransientRowCount;
+            final long prevTimestamp;
             if (index == 0) {
-                // the last partition
-                columnVersionWriter.removePartition(timestamp);
-                txWriter.truncate(columnVersionWriter.getVersion());
-                closeActivePartition(true);
-                row = regularRow;
-                rowAction = ROW_ACTION_OPEN_PARTITION;
+                nextMaxTimestamp = Long.MIN_VALUE;
+                newTransientRowCount = 0L;
+                prevTimestamp = 0L; // meaningless
             } else {
-                // calculate new transient row count and max timestamp
                 final int prevIndex = index - 1;
-                final long prevTimestamp = txWriter.getPartitionTimestamp(prevIndex);
-                final long newTransientRowCount = txWriter.getPartitionSize(prevIndex);
+                prevTimestamp = txWriter.getPartitionTimestamp(prevIndex);
+                newTransientRowCount = txWriter.getPartitionSize(prevIndex);
                 try {
                     setPathForPartition(path.trimTo(rootLen), partitionBy, prevTimestamp, false);
                     TableUtils.txnPartitionConditionally(path, txWriter.getPartitionNameTxn(prevIndex));
                     readPartitionMinMax(ff, prevTimestamp, path, metadata.getColumnName(metadata.getTimestampIndex()), newTransientRowCount);
+                    nextMaxTimestamp = attachMaxTimestamp;
                 } finally {
                     path.trimTo(rootLen);
                 }
+            }
 
-                columnVersionWriter.removePartition(timestamp);
-                txWriter.beginPartitionSizeUpdate();
-                txWriter.removeAttachedPartitions(timestamp);
-                txWriter.finishPartitionSizeUpdate(txWriter.getMinTimestamp(), attachMaxTimestamp);
-                txWriter.bumpTruncateVersion();
+            columnVersionWriter.removePartition(timestamp);
+            txWriter.beginPartitionSizeUpdate();
+            txWriter.removeAttachedPartitions(timestamp);
+            txWriter.finishPartitionSizeUpdate(txWriter.getMinTimestamp(), nextMaxTimestamp);
+            txWriter.bumpTruncateVersion();
 
-                columnVersionWriter.commit();
-                txWriter.setColumnVersion(columnVersionWriter.getVersion());
-                txWriter.commit(defaultCommitMode, denseSymbolMapWriters);
+            columnVersionWriter.commit();
+            txWriter.setColumnVersion(columnVersionWriter.getVersion());
+            txWriter.commit(defaultCommitMode, denseSymbolMapWriters);
 
-                closeActivePartition(true);
-                row = regularRow;
+            closeActivePartition(true);
+
+            if (index != 0) {
                 openPartition(prevTimestamp);
                 setAppendPosition(newTransientRowCount, false);
+                row = regularRow;
+            } else {
+                rowAction = ROW_ACTION_OPEN_PARTITION;
             }
         } else {
 

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -197,12 +197,12 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
 
     public void finishPartitionSizeUpdate() {
         recordStructureVersion++;
-        assert getPartitionCount() > 0;
-        this.transientRowCount = getPartitionSize(getPartitionCount() - 1);
-        this.fixedRowCount = 0;
-        this.txPartitionCount = getPartitionCount();
+        int numPartitions = getPartitionCount();
+        transientRowCount = numPartitions > 0 ? getPartitionSize(numPartitions - 1) : 0L;
+        fixedRowCount = 0L;
+        txPartitionCount = getPartitionCount();
         for (int i = 0, hi = txPartitionCount - 1; i < hi; i++) {
-            this.fixedRowCount += getPartitionSize(i);
+            fixedRowCount += getPartitionSize(i);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/pool/PoolListener.java
+++ b/core/src/main/java/io/questdb/cairo/pool/PoolListener.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.pool;
 
+@FunctionalInterface
 public interface PoolListener {
     byte SRC_WRITER = 1;
     byte SRC_READER = 2;

--- a/core/src/test/java/io/questdb/AbstractBootstrapTest.java
+++ b/core/src/test/java/io/questdb/AbstractBootstrapTest.java
@@ -48,8 +48,11 @@ public abstract class AbstractBootstrapTest {
 
     @ClassRule
     public static final TemporaryFolder temp = new TemporaryFolder();
-    static final Properties PG_CONNECTION_PROPERTIES = new Properties();
-    static final String PG_CONNECTION_URI = "jdbc:postgresql://127.0.0.1:8822/qdb";
+    protected static final Properties PG_CONNECTION_PROPERTIES = new Properties();
+    protected static final String PG_CONNECTION_URI = "jdbc:postgresql://127.0.0.1:8822/qdb";
+
+    protected static final int ILP_PORT = 9009;
+    protected static final int ILP_BUFFER_SIZE = 4 * 1024;
     private static final File siteDir = new File(ServerMain.class.getResource("/io/questdb/site/").getFile());
     protected static CharSequence root;
     private static boolean publicZipStubCreated = false;
@@ -88,7 +91,7 @@ public abstract class AbstractBootstrapTest {
         temp.delete();
     }
 
-    static void createDummyConfiguration() throws Exception {
+    protected static void createDummyConfiguration() throws Exception {
         final String confPath = root.toString() + Files.SEPARATOR + "conf";
         TestUtils.createTestPath(confPath);
         String file = confPath + Files.SEPARATOR + "server.conf";
@@ -114,9 +117,9 @@ public abstract class AbstractBootstrapTest {
             writer.println("http.bind.to=0.0.0.0:9010");
             writer.println("http.min.net.bind.to=0.0.0.0:9011");
             writer.println("pg.net.bind.to=0.0.0.0:8822");
-            writer.println("line.tcp.net.bind.to=0.0.0.0:9019");
-            writer.println("line.udp.bind.to=0.0.0.0:9019");
-            writer.println("line.udp.receive.buffer.size=" + 1024 * 4);
+            writer.println("line.tcp.net.bind.to=0.0.0.0:" + ILP_PORT);
+            writer.println("line.udp.bind.to=0.0.0.0:" + ILP_PORT);
+            writer.println("line.udp.receive.buffer.size=" + ILP_BUFFER_SIZE);
 
             // configure worker pools
             writer.println("shared.worker.count=2");

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableDropActivePartitionLineTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableDropActivePartitionLineTest.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line.tcp;
+
+import io.questdb.AbstractBootstrapTest;
+import io.questdb.Bootstrap;
+import io.questdb.ServerMain;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.pool.PoolListener;
+import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cutlass.line.LineTcpSender;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.mp.SOCountDownLatch;
+import io.questdb.network.Net;
+import io.questdb.std.Chars;
+import io.questdb.std.Misc;
+import io.questdb.std.Os;
+import io.questdb.std.Rnd;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AlterTableDropActivePartitionLineTest extends AbstractBootstrapTest {
+
+    private static final Log LOG = LogFactory.getLog(AlterTableDropActivePartitionLineTest.class);
+
+    @BeforeClass
+    public static void setUpStatic() throws Exception {
+        AbstractBootstrapTest.setUpStatic();
+        try {
+            createDummyConfiguration();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testServerMainPgWireConcurrentlyWithLineTcpSender() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (final ServerMain serverMain = new ServerMain("-d", root.toString(), Bootstrap.SWITCH_USE_DEFAULT_LOG_FACTORY_CONFIGURATION)) {
+                serverMain.start();
+
+                final CairoEngine engine = serverMain.getCairoEngine();
+
+                // create table over PGWire
+                try (
+                        Connection connection = DriverManager.getConnection(PG_CONNECTION_URI, PG_CONNECTION_PROPERTIES);
+                        PreparedStatement stmt = connection.prepareStatement(
+                                "CREATE TABLE " + tableName + "( " +
+                                        "favourite_colour SYMBOL INDEX CAPACITY 16, " +
+                                        "country SYMBOL INDEX CAPACITY 16, " +
+                                        "uniqueId LONG, " +
+                                        "quantity INT, " +
+                                        "ppu DOUBLE, " +
+                                        "addressId STRING, " +
+                                        "timestamp TIMESTAMP" +
+                                        ") TIMESTAMP(timestamp) PARTITION BY DAY " +
+                                        "WITH maxUncommittedRows=20, commitLag=200000us" // 200 millis
+                        )
+                ) {
+                    LOG.info().$("creating table: ").utf8(tableName).$();
+                    stmt.execute();
+                }
+
+                // setup a thread that will send ILP/TCP for today
+
+                // today is deterministic
+                final String activePartitionName = "2022-10-19";
+                final AtomicLong timestampNano = new AtomicLong(TimestampFormatUtils.parseTimestamp(
+                        activePartitionName + "T00:00:00.000000Z") * 1000L
+                );
+
+                final SOCountDownLatch ilpAgentHalted = new SOCountDownLatch(1);
+                final AtomicBoolean ilpAgentKeepSending = new AtomicBoolean(true);
+                final AtomicLong uniqueId = new AtomicLong(0L);
+
+                final Thread ilpAgent = new Thread(() -> {
+                    final Rnd rnd = new Rnd();
+                    try (LineTcpSender sender = LineTcpSender.newSender(Net.parseIPv4("127.0.0.1"), ILP_PORT, ILP_BUFFER_SIZE)) {
+                        while (ilpAgentKeepSending.get()) {
+                            addLine(sender, tableName, uniqueId, timestampNano, rnd).flush();
+                        }
+                        // send a few more
+                        for (int i = 0, n = 50 + rnd.nextInt(100); i < n; i++) {
+                            addLine(sender, tableName, uniqueId, timestampNano, rnd).flush();
+                        }
+                    } finally {
+                        ilpAgentHalted.countDown();
+                    }
+                });
+
+                // so that we know when the table writer is returned to the pool whence the ilpAgent is stopped
+                final SOCountDownLatch tableWriterReturnedToPool = new SOCountDownLatch(1);
+                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                    if (Chars.equalsNc(tableName, name)) {
+                        if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                            tableWriterReturnedToPool.countDown();
+                        }
+                    }
+                });
+
+                // start sending Lines
+                ilpAgent.start();
+
+                // give the ilpAgent some time
+                while (uniqueId.get() < 1_000_000L) {
+                    Os.pause();
+                }
+
+                // check table reader size
+                long beforeDropSize;
+                try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+                    beforeDropSize = reader.size();
+                    Assert.assertTrue(beforeDropSize > 0L);
+                }
+
+                // drop active partition over PGWire
+                try (
+                        Connection connection = DriverManager.getConnection(PG_CONNECTION_URI, PG_CONNECTION_PROPERTIES);
+                        PreparedStatement stmt = connection.prepareStatement("ALTER TABLE " + tableName + " DROP PARTITION LIST '" + activePartitionName + "'")
+                ) {
+                    LOG.info().$("dropping active partition").$();
+                    stmt.execute();
+                }
+
+                // tell ilpAgent to stop (it sends a few more lines after processing this signal)
+                // and wait until it has finished
+                ilpAgentKeepSending.set(false);
+                ilpAgentHalted.await();
+
+                // check size
+                try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+                    Assert.assertTrue(beforeDropSize > reader.size());
+                }
+
+                // wait for table writer to be returned to the pool
+                tableWriterReturnedToPool.await();
+
+                // drop active partition over PGWire
+                try (
+                        Connection connection = DriverManager.getConnection(PG_CONNECTION_URI, PG_CONNECTION_PROPERTIES);
+                        PreparedStatement stmt = connection.prepareStatement("ALTER TABLE " + tableName + " DROP PARTITION LIST '" + activePartitionName + "'")
+                ) {
+                    LOG.info().$("dropping active partition again").$();
+                    stmt.execute();
+                }
+
+                // check size
+                try (
+                        SqlExecutionContext context = createSqlExecutionContext(engine);
+                        SqlCompiler compiler = new SqlCompiler(engine)
+                ) {
+                    TestUtils.assertSql(
+                            compiler,
+                            context,
+                            "SELECT min(timestamp), max(timestamp), count() FROM " + tableName + " WHERE timestamp IN '" + activePartitionName + "'",
+                            Misc.getThreadLocalBuilder(),
+                            "min\tmax\tcount\n" +
+                                    "\t\t0\n"
+                    );
+                }
+            }
+        });
+    }
+
+    private static SqlExecutionContext createSqlExecutionContext(CairoEngine engine) {
+        return new SqlExecutionContextImpl(engine, 1).with(
+                AllowAllCairoSecurityContext.INSTANCE,
+                null,
+                null,
+                -1,
+                null
+        );
+    }
+
+    private LineTcpSender addLine(LineTcpSender sender, String tableName, AtomicLong uniqueId, AtomicLong timestampNano, Rnd rnd) {
+        sender.metric(tableName)
+                .tag("favourite_colour", rndOf(rnd, colour))
+                .tag("country", rndOf(rnd, country))
+                .field("uniqueId", uniqueId.getAndIncrement())
+                .field("quantity", rnd.nextPositiveInt())
+                .field("ppu", rnd.nextFloat())
+                .field("addressId", rnd.nextString(50))
+                .at(timestampNano.getAndAdd(1L + rnd.nextLong(100_000L)));
+        return sender;
+    }
+
+    private static String rndOf(Rnd rnd, String[] array) {
+        return array[rnd.nextPositiveInt() % array.length];
+    }
+
+    private final String tableName = "PurposelessTable";
+
+    private static final String[] country = {
+            "Ukraine",
+            "Poland",
+            "Lithuania",
+            "USA",
+            "Germany",
+            "Czechia",
+            "England",
+            "Spain",
+            "Singapore",
+            "Taiwan",
+            "Romania",
+    };
+    private static final String[] colour = {
+            "Yellow",
+            "Blue",
+            "Green",
+            "Red",
+            "Gray",
+            "Orange",
+            "Black",
+            "White",
+            "Pink",
+            "Brown",
+            "Purple",
+    };
+}


### PR DESCRIPTION
closes https://github.com/questdb/questdb/issues/2529

truncate cannot be used when we are dropping the very last partition because that results in the removal of index files on the spot. This action must be delayed.
