### PR TITLE
fix(ilp): fix variability in ILP performance

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpUtils.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpUtils.java
@@ -46,7 +46,7 @@ final class LineTcpUtils {
         return utf8CharSeq;
     }
 
-    static CharSequence utf8BytesToString(DirectByteCharSequence utf8CharSeq, MutableCharSink tempSink) {
+    static String utf8BytesToString(DirectByteCharSequence utf8CharSeq, MutableCharSink tempSink) {
         tempSink.clear();
         for (int i = 0, n = utf8CharSeq.length(); i < n; i++) {
             tempSink.put(utf8CharSeq.charAt(i));

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -292,10 +292,10 @@ public class TableUpdateDetails implements Closeable {
         private final Path path = new Path();
         // maps column names to their indexes
         // keys are mangled strings created from the utf-8 encoded byte representations of the column names
-        private final CharSequenceIntHashMap columnIndexByNameUtf8 = new CharSequenceIntHashMap();
+        private final DirectByteCharSequenceIntHashMap columnIndexByNameUtf8 = new DirectByteCharSequenceIntHashMap();
         // maps column names to their types
         // will be populated for dynamically added columns only
-        private final CharSequenceIntHashMap columnTypeByNameUtf8 = new CharSequenceIntHashMap();
+        private final DirectByteCharSequenceIntHashMap columnTypeByNameUtf8 = new DirectByteCharSequenceIntHashMap();
         private final ObjList<SymbolCache> symbolCacheByColumnIndex = new ObjList<>();
         private final ObjList<SymbolCache> unusedSymbolCaches;
         // indexed by colIdx + 1, first value accounts for spurious, new cols (index -1)

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -27,6 +27,7 @@ package io.questdb.std;
 import io.questdb.griffin.engine.functions.constants.CharConstant;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.CharSinkBase;
+import io.questdb.std.str.DirectByteCharSequence;
 import io.questdb.std.str.Path;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -346,6 +347,23 @@ public final class Chars {
             return value.hashCode();
         }
 
+        int len = value.length();
+        if (len == 0) {
+            return 0;
+        }
+
+        int h = 0;
+        for (int p = 0; p < len; p++) {
+            h = 31 * h + value.charAt(p);
+        }
+        return h;
+    }
+
+    public static int hashCode(String value) {
+        return value.hashCode();
+    }
+
+    public static int hashCode(DirectByteCharSequence value) {
         int len = value.length();
         if (len == 0) {
             return 0;

--- a/core/src/main/java/io/questdb/std/DirectByteCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/DirectByteCharSequenceIntHashMap.java
@@ -1,0 +1,279 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import io.questdb.std.str.DirectByteCharSequence;
+
+import java.util.Arrays;
+
+
+public class DirectByteCharSequenceIntHashMap implements Mutable {
+    public static final int NO_ENTRY_VALUE = -1;
+    protected static final int MIN_INITIAL_CAPACITY = 16;
+    protected final double loadFactor;
+    private final int noEntryValue;
+    private final ObjList<String> list;
+    protected String[] keys;
+    protected int mask;
+    protected int free;
+    protected int capacity;
+    private int[] values;
+
+    public DirectByteCharSequenceIntHashMap() {
+        this(8);
+    }
+
+    public DirectByteCharSequenceIntHashMap(int initialCapacity) {
+        this(initialCapacity, 0.5, NO_ENTRY_VALUE);
+    }
+
+    public DirectByteCharSequenceIntHashMap(int initialCapacity, double loadFactor, int noEntryValue) {
+        if (loadFactor <= 0d || loadFactor >= 1d) {
+            throw new IllegalArgumentException("0 < loadFactor < 1");
+        }
+
+        this.free = this.capacity = initialCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(initialCapacity);
+        this.loadFactor = loadFactor;
+        int len = Numbers.ceilPow2((int) (this.capacity / loadFactor));
+        this.keys = new String[len];
+        DirectByteCharSequenceIntHashMap.this.mask = len - 1;
+        this.noEntryValue = noEntryValue;
+        this.list = new ObjList<>(capacity);
+        values = new int[keys.length];
+        clear();
+    }
+
+    @Override
+    public final void clear() {
+        Arrays.fill(keys, null);
+        free = this.capacity;
+        list.clear();
+        Arrays.fill(values, noEntryValue);
+    }
+
+    public boolean contains(DirectByteCharSequence key) {
+        return keyIndex(key) < 0;
+    }
+
+    public boolean excludes(DirectByteCharSequence key) {
+        return keyIndex(key) > -1;
+    }
+
+    public boolean excludes(DirectByteCharSequence key, int lo, int hi) {
+        return keyIndex(key, lo, hi) > -1;
+    }
+
+    public int get(DirectByteCharSequence key) {
+        return valueAt(keyIndex(key));
+    }
+
+    public int get(String key) {
+        return valueAt(keyIndex(key));
+    }
+
+    public int keyIndex(DirectByteCharSequence key) {
+        int index = Hash.spread(Chars.hashCode(key)) & mask;
+
+        if (keys[index] == null) {
+            return index;
+        }
+
+        if (Chars.equals(key, keys[index])) {
+            return -index - 1;
+        }
+
+        return probe(key, index);
+    }
+
+    public int keyIndex(String key) {
+        int index = Hash.spread(Chars.hashCode(key)) & mask;
+
+        if (keys[index] == null) {
+            return index;
+        }
+
+        if (Chars.equals(key, keys[index])) {
+            return -index - 1;
+        }
+
+        return probe(key, index);
+    }
+
+    public int keyIndex(DirectByteCharSequence key, int lo, int hi) {
+        int index = Hash.spread(Chars.hashCode(key, lo, hi)) & mask;
+
+        if (keys[index] == null) {
+            return index;
+        }
+        CharSequence cs = keys[index];
+        if (Chars.equals(key, lo, hi, cs, 0, cs.length())) {
+            return -index - 1;
+        }
+        return probe(key, lo, hi, index);
+    }
+
+    public int remove(DirectByteCharSequence key) {
+        int index = keyIndex(key);
+        if (index < 0) {
+            removeAt(index);
+            return -index - 1;
+        }
+        return -1;
+    }
+
+    public void removeAt(int index) {
+        if (index < 0) {
+            int index1 = -index - 1;
+            CharSequence key = keys[index1];
+            int from = -index - 1;
+            erase(from);
+            free++;
+
+            // after we have freed up a slot
+            // consider non-empty keys directly below
+            // they may have been a direct hit but because
+            // directly hit slot wasn't empty these keys would
+            // have moved.
+            //
+            // After slot if freed these keys require re-hash
+            from = (from + 1) & mask;
+            for (
+                    CharSequence k = keys[from];
+                    k != null;
+                    from = (from + 1) & mask, k = keys[from]
+            ) {
+                int idealHit = Hash.spread(Chars.hashCode(k)) & mask;
+                if (idealHit != from) {
+                    int to;
+                    if (keys[idealHit] != null) {
+                        to = probe(k, idealHit);
+                    } else {
+                        to = idealHit;
+                    }
+
+                    if (to > -1) {
+                        move(from, to);
+                    }
+                }
+            }
+            list.remove(key);
+        }
+    }
+
+    public int size() {
+        return capacity - free;
+    }
+
+    private void erase(int index) {
+        keys[index] = null;
+        values[index] = noEntryValue;
+    }
+
+    private void move(int from, int to) {
+        keys[to] = keys[from];
+        values[to] = values[from];
+        erase(from);
+    }
+
+    public ObjList<String> keys() {
+        return list;
+    }
+
+    public boolean put(String key, int value) {
+        return putAt(keyIndex(key), key, value);
+    }
+
+    public boolean putAt(int index, String key, int value) {
+        if (index < 0) {
+            values[-index - 1] = value;
+            return false;
+        }
+
+        putAt0(index, key, value);
+        list.add(key);
+        return true;
+    }
+
+    public int valueAt(int index) {
+        int index1 = -index - 1;
+        return index < 0 ? values[index1] : noEntryValue;
+    }
+
+    public int valueQuick(int index) {
+        return valueAt(keyIndex(list.getQuick(index)));
+    }
+
+    private int probe(CharSequence key, int index) {
+        do {
+            index = (index + 1) & mask;
+            if (keys[index] == null) {
+                return index;
+            }
+            if (Chars.equals(key, keys[index])) {
+                return -index - 1;
+            }
+        } while (true);
+    }
+
+    private int probe(CharSequence key, int lo, int hi, int index) {
+        do {
+            index = (index + 1) & mask;
+            if (keys[index] == null) {
+                return index;
+            }
+            CharSequence cs = keys[index];
+            if (Chars.equals(key, lo, hi, cs, 0, cs.length())) {
+                return -index - 1;
+            }
+        } while (true);
+    }
+
+    private void putAt0(int index, String key, int value) {
+        keys[index] = key;
+        values[index] = value;
+        if (--free == 0) {
+            rehash();
+        }
+    }
+
+    private void rehash() {
+        int[] oldValues = values;
+        String[] oldKeys = keys;
+        int size = capacity - free;
+        capacity = capacity * 2;
+        free = capacity - size;
+        mask = Numbers.ceilPow2((int) (capacity / loadFactor)) - 1;
+        this.keys = new String[mask + 1];
+        this.values = new int[mask + 1];
+        for (int i = oldKeys.length - 1; i > -1; i--) {
+            String key = oldKeys[i];
+            if (key != null) {
+                final int index = keyIndex(key);
+                keys[index] = key;
+                values[index] = oldValues[i];
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/std/CharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/CharSequenceIntHashMapTest.java
@@ -237,6 +237,4 @@ public class CharSequenceIntHashMapTest {
             Assert.assertFalse(map.excludes(cs, 1, 9));
         }
     }
-
-
 }

--- a/core/src/test/java/io/questdb/std/DirectByteCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/DirectByteCharSequenceIntHashMapTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2022 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import io.questdb.std.str.DirectByteCharSequence;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class DirectByteCharSequenceIntHashMapTest {
+    @Test
+    public void testHashMapCompatibility() {
+        final Rnd rnd = new Rnd();
+        int N = 100_000;
+        int memSize = 8 * 1024 * 1024;
+        long mem = Unsafe.malloc(memSize, MemoryTag.NATIVE_DEFAULT);
+        HashMap<String, Integer> hashMap = new HashMap<>();
+        ArrayList<String> list = new ArrayList<>();
+        final DirectByteCharSequence dbcs = new DirectByteCharSequence();
+        DirectByteCharSequenceIntHashMap ourMap = new DirectByteCharSequenceIntHashMap();
+        try {
+            // generate random strings and randomly add some of them to the HashMap
+            long p = mem;
+            for (int i = 0; i < N; i++) {
+                String s = rnd.nextString(rnd.nextInt(10));
+                list.add(s);
+                if (rnd.nextBoolean()) {
+                    Object v = hashMap.put(s, i);
+                    boolean added = ourMap.put(s, i);
+
+                    // if we can add string to HashMap, we must be able to add it to our map too.
+                    // Opposite is true also. Both maps must behave the same
+                    if (v == null) {
+                        Assert.assertTrue(added);
+                    } else {
+                        Assert.assertFalse(added);
+                    }
+                }
+                // copy each string to the memory
+                int len = s.length();
+                Unsafe.getUnsafe().putInt(p, len);
+                Chars.asciiStrCpy(s, len, p + 4);
+                p += 4 + len;
+            }
+
+            Assert.assertEquals(hashMap.size(), ourMap.size());
+
+            // verify contains(), excludes() and get()
+            // sequential access to our memory
+            p = mem;
+            for (int i = 0; i < N; i++) {
+                String s = list.get(i);
+                int len = s.length();
+                p += 4;
+                dbcs.of(p, p + len);
+                Assert.assertEquals(hashMap.containsKey(s), ourMap.contains(dbcs));
+                Assert.assertNotEquals(hashMap.containsKey(s), ourMap.excludes(dbcs));
+                Assert.assertNotEquals(hashMap.containsKey(s), ourMap.excludes(dbcs, 0, len));
+
+                Object v = hashMap.get(s);
+                int k = ourMap.get(dbcs);
+
+                if (v == null) {
+                    Assert.assertEquals(-1, k);
+                    Assert.assertTrue(ourMap.keyIndex(dbcs, 0, len) > -1);
+                } else {
+                    Assert.assertEquals(v, k);
+                    int keyIndex = ourMap.keyIndex(dbcs, 0, len);
+                    Assert.assertTrue(keyIndex < 0);
+                    Assert.assertEquals(k, ourMap.valueAt(keyIndex));
+                }
+                p += len;
+            }
+
+            // verify iteration of keys
+            for (int i = 0, n = ourMap.size(); i < n; i++) {
+                int k = ourMap.valueQuick(i);
+                Object v = hashMap.get(ourMap.keys().getQuick(i));
+                Assert.assertNotNull(v);
+                Assert.assertEquals((int) v, k);
+            }
+
+            // verify remove()
+            p = mem;
+            for (int i = 0; i < N; i++) {
+                String s = list.get(i);
+                int len = s.length();
+                p += 4;
+                dbcs.of(p, p + len);
+                if (hashMap.containsKey(s)) {
+                    if (rnd.nextBoolean()) {
+                        Object v = hashMap.remove(s);
+                        Assert.assertNotNull(v);
+                        ourMap.remove(dbcs);
+                    }
+                } else {
+                    Assert.assertEquals(-1, ourMap.remove(dbcs));
+                }
+                p+=len;
+            }
+
+            // compare HashMap to our map after random removal
+            p = mem;
+            for (int i = 0; i < N; i++) {
+                String s = list.get(i);
+                int len = s.length();
+                p += 4;
+                dbcs.of(p, p + len);
+                Object v = hashMap.get(s);
+                if (v != null) {
+                    Assert.assertEquals(v, ourMap.get(dbcs));
+                } else {
+                    Assert.assertEquals(-1, ourMap.get(dbcs));
+                }
+                p+=len;
+            }
+
+        } finally {
+            Unsafe.free(mem, memSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/std/DirectByteCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/std/DirectByteCharSequenceIntHashMapTest.java
@@ -83,6 +83,7 @@ public class DirectByteCharSequenceIntHashMapTest {
 
                 Object v = hashMap.get(s);
                 int k = ourMap.get(dbcs);
+                Assert.assertEquals(k, ourMap.get(s));
 
                 if (v == null) {
                     Assert.assertEquals(-1, k);


### PR DESCRIPTION
Together with https://github.com/questdb/questdb/pull/2635 this PR stabilized performance of ILP ingestion by eliminating 
[megamorphic virtual calls](https://shipilev.net/jvm/anatomy-quarks/16-megamorphic-virtual-calls/). Specifically `charAt()` calls on `CharSequence` implementations.

On my desktop I get very stable TSBS performance of 1.2+M rows/s. Never below (notwithstanding short default lag, which could send TSBS into O3)