### PR TITLE
chore(build): allow `build:` without `()` and `ui` subtype in PR titles

### DIFF
--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -47,7 +47,7 @@ perf(sql): improve pattern matching performance for SELECT sub-queries
 
 function validatePrTitle() {
   const prTitleRegex = new RegExp(
-    `^((?:${allowedTypes.join("|")})\\((?:${allowedSubTypes.join("|")})\\) | "build"): .*`
+    `^(((?:${allowedTypes.join("|")})\\((?:${allowedSubTypes.join("|")})\\))|build): .*`
   );
 
   const { title } = danger.github.pr;

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -15,6 +15,7 @@ const allowedTypes = [
 ];
 
 const allowedSubTypes = [
+  "build",
   "sql",
   "log",
   "mig",

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -25,6 +25,7 @@ const allowedSubTypes = [
   "pgwire",
   "http",
   "conf",
+  "ui",
 ];
 
 const failMessage = `
@@ -46,7 +47,7 @@ perf(sql): improve pattern matching performance for SELECT sub-queries
 
 function validatePrTitle() {
   const prTitleRegex = new RegExp(
-    `^(?:${allowedTypes.join("|")})\\((?:${allowedSubTypes.join("|")})\\): .*`
+    `^((?:${allowedTypes.join("|")})\\((?:${allowedSubTypes.join("|")})\\) | "build"): .*`
   );
 
   const { title } = danger.github.pr;

--- a/ci/dangerfile.js
+++ b/ci/dangerfile.js
@@ -9,14 +9,12 @@ const allowedTypes = [
   "refactor",
   "perf",
   "test",
-  "build",
   "ci",
   "chore",
   "revert",
 ];
 
 const allowedSubTypes = [
-  "build",
   "sql",
   "log",
   "mig",


### PR DESCRIPTION
### Allows the following PR titles:

```
feat(ui): hello world
chore(ui): hellow world
build: 6.6
```

new sub-type "ui", can be used with any type

### Disallows the following:

```
build(sql): hello
build(core): hello
build(anything): hello
```
no brackets after "build" type.