### PR TITLE
chore(core): fix fuzzy test in line protocol (#2340)

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -355,6 +355,9 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
             if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_UNLOCKED) {
                 handleWriterUnlockEvent(name);
             }
+            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_GET) {
+                handleWriterGetEvent(name);
+            }
             if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
                 handleWriterReturnEvent(name);
             }
@@ -366,13 +369,19 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         tableNames.putIfAbsent(tableName.toLowerCase(), tableName);
     }
 
+    void handleWriterGetEvent(CharSequence name) {
+        final TableData table = tables.get(name);
+        table.obtainPermit();
+    }
+
     void handleWriterReturnEvent(CharSequence name) {
         final TableData table = tables.get(name);
-        table.ready();
+        table.returnPermit();
     }
 
     void runTest(PoolListener listener, long minIdleMsBeforeWriterRelease) throws Exception {
         runInContext(receiver -> {
+            Assert.assertEquals(0, tables.size());
             for (int i = 0; i < numOfTables; i++) {
                 final CharSequence tableName = getTableName(i);
                 tables.put(tableName, new TableData(tableName));

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpCommitTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpCommitTest.java
@@ -138,14 +138,14 @@ public class LineTcpCommitTest extends AbstractLineTcpReceiverFuzzTest {
         }, minIdleMsBeforeWriterRelease);
     }
 
+    @Override
     void handleWriterUnlockEvent(CharSequence name) {
-        final String tableName = name.toString();
-        tableNames.putIfAbsent(tableName.toLowerCase(), tableName);
+        super.handleWriterUnlockEvent(name);
 
         // set the table ready right after created
         // instead of the 'ready' latch we will rely on the timeout in assertTable(table)
         final TableData table = tables.get(name);
-        table.ready();
+        table.returnPermit();
     }
 
     void handleWriterReturnEvent(CharSequence name) {


### PR DESCRIPTION
The problem is that return was being called many times, so the first time did unlock the wait, and broke the test, in a non deterministic manner.

Closes https://github.com/questdb/questdb/issues/2340