### PR TITLE
chore(sql): remove rank() function temporarily, it is unstable

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -655,7 +655,8 @@ open module io.questdb {
 
             // analytic functions
             io.questdb.griffin.engine.functions.analytic.RowNumberFunctionFactory,
-            io.questdb.griffin.engine.functions.analytic.RankFunctionFactory,
+            // this factory seems to corrupt memory, symptoms of which are visible on M1 CPU
+            //io.questdb.griffin.engine.functions.analytic.RankFunctionFactory,
 
             // metadata functions
             io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -643,7 +643,8 @@ io.questdb.griffin.engine.functions.str.RPadStrFunctionFactory
 
 # analytic functions
 io.questdb.griffin.engine.functions.analytic.RowNumberFunctionFactory
-io.questdb.griffin.engine.functions.analytic.RankFunctionFactory
+# this factory seems to corrupt memory, symptoms of which are visible on M1 CPU
+#io.questdb.griffin.engine.functions.analytic.RankFunctionFactory
 
 # metadata functions
 io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory

--- a/core/src/test/java/io/questdb/griffin/engine/analytic/AnalyticFunctionTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/analytic/AnalyticFunctionTest.java
@@ -28,6 +28,7 @@ import io.questdb.griffin.AbstractGriffinTest;
 import io.questdb.griffin.SqlException;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class AnalyticFunctionTest extends AbstractGriffinTest {
@@ -283,6 +284,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionAndOrderByNonSymbol() throws Exception {
         assertQuery("rank\tprice\tts\n" +
                         "1\t42\t1970-01-01T00:00:00.000000Z\n" +
@@ -312,6 +314,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionAndOrderBySymbolNoWildcard() throws Exception {
         assertQuery("rank\n" +
                         "1\n" +
@@ -341,6 +344,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionAndOrderBySymbolWildcardFirst() throws Exception {
         assertQuery("price\tsymbol\tts\trank\n" +
                         "0.8043224099968393\tCC\t1970-01-01T00:00:00.000000Z\t1\n" +
@@ -370,6 +374,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionAndOrderBySymbolWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "1\t0.8043224099968393\tCC\t1970-01-01T00:00:00.000000Z\n" +
@@ -399,6 +404,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionBySymbolAndOrderByPriceWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "2\t0.8043224099968393\tCC\t1970-01-01T00:00:00.000000Z\n" +
@@ -428,6 +434,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionBySymbolAndOrderByIntPriceWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "1\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -457,6 +464,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionBySymbolAndOrderByIntPriceDescWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "2\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -486,6 +494,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionBySymbolAndNoOrderWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "1\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -515,6 +524,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithPartitionBySymbolAndMultiOrderWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "1\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -544,6 +554,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithNoPartitionByAndOrderBySymbolWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "3\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -573,6 +584,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankWithNoPartitionByAndNoOrderByWildcardLast() throws Exception {
         assertQuery("rank\tprice\tsymbol\tts\n" +
                         "1\t1\tBB\t1970-01-01T00:00:00.000000Z\n" +
@@ -602,6 +614,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testRankFailsInNonAnalyticContext() throws Exception {
         assertFailure(
                 "select rank(), * from trades",
@@ -619,6 +632,7 @@ public class AnalyticFunctionTest extends AbstractGriffinTest {
     }
 
     @Test
+    @Ignore
     public void testAnalyticContextCleanup() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table trades as " +


### PR DESCRIPTION
current rank() implementation crashes tests on M1 CPU. It corrupts VM memory somehow. I didn't not have time to understand how.

We will do this after release