### PR TITLE
test(ilp): fix flaky test

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
@@ -436,7 +436,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n" +
                     "Power\t6A\t1\t1970-01-01T00:43:51.819999Z\n";
             assertTable(expected);
-        });
+        }, false, 1000);
     }
 
     @Test


### PR DESCRIPTION
fixes #2350
There is a race between returning an idle TableWriter into a pool and ALTER execution. If a TableWriter is returned before ALTER is executed then the ALTER succeeds and the test fails.

There is a tension between idleWriterTimeout and test duration: The smaller the timeout the greater likelihood of a test failure, but a long timeout increases test duration. So I'm increasing it from 250ms to 1000ms. It should help. If it does not then perhaps the test should be redesigned entirely.