### PR TITLE
feat(core): add support for `U+` - six-digit microsecond format component

### DIFF
--- a/core/src/main/java/io/questdb/cairo/PartitionBy.java
+++ b/core/src/main/java/io/questdb/cairo/PartitionBy.java
@@ -176,7 +176,7 @@ public final class PartitionBy {
                 leap = Timestamps.isLeapYear(y);
                 m = Timestamps.getMonthOfYear(timestamp, y, leap);
                 d = Timestamps.getDayOfMonth(timestamp, y, m, leap);
-                TimestampFormatUtils.append000(path, y);
+                TimestampFormatUtils.appendYear000(path, y);
                 path.put('-');
                 TimestampFormatUtils.append0(path, m);
                 path.put('-');
@@ -192,7 +192,7 @@ public final class PartitionBy {
                 y = Timestamps.getYear(timestamp);
                 leap = Timestamps.isLeapYear(y);
                 m = Timestamps.getMonthOfYear(timestamp, y, leap);
-                TimestampFormatUtils.append000(path, y);
+                TimestampFormatUtils.appendYear000(path, y);
                 path.put('-');
                 TimestampFormatUtils.append0(path, m);
 
@@ -205,7 +205,7 @@ public final class PartitionBy {
             case YEAR:
                 y = Timestamps.getYear(timestamp);
                 leap = Timestamps.isLeapYear(y);
-                TimestampFormatUtils.append000(path, y);
+                TimestampFormatUtils.appendYear000(path, y);
                 if (calculatePartitionMax) {
                     return Timestamps.addYear(Timestamps.yearMicros(y, leap), 1) - 1;
                 }
@@ -216,7 +216,7 @@ public final class PartitionBy {
                 m = Timestamps.getMonthOfYear(timestamp, y, leap);
                 d = Timestamps.getDayOfMonth(timestamp, y, m, leap);
                 int h = Timestamps.getHourOfDay(timestamp);
-                TimestampFormatUtils.append000(path, y);
+                TimestampFormatUtils.appendYear000(path, y);
                 path.put('-');
                 TimestampFormatUtils.append0(path, m);
                 path.put('-');

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/MicrosOfSecondFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/MicrosOfSecondFunctionFactory.java
@@ -66,7 +66,7 @@ public class MicrosOfSecondFunctionFactory implements FunctionFactory {
         public int getInt(Record rec) {
             final long value = arg.getTimestamp(rec);
             if (value != Numbers.LONG_NaN) {
-                return Timestamps.getMicrosOfSecond(value);
+                return Timestamps.getMicrosOfMilli(value);
             }
             return Numbers.INT_NaN;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/MonthTimestampSampler.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/MonthTimestampSampler.java
@@ -71,7 +71,7 @@ class MonthTimestampSampler implements TimestampSampler {
         this.startMin = Timestamps.getMinuteOfHour(timestamp);
         this.startSec = Timestamps.getSecondOfMinute(timestamp);
         this.startMillis = Timestamps.getMillisOfSecond(timestamp);
-        this.startMicros = Timestamps.getMicrosOfSecond(timestamp);
+        this.startMicros = Timestamps.getMicrosOfMilli(timestamp);
     }
 
     private long addMonth(long timestamp, int monthCount) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/YearTimestampSampler.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/YearTimestampSampler.java
@@ -77,7 +77,7 @@ class YearTimestampSampler implements TimestampSampler {
         this.startMin = Timestamps.getMinuteOfHour(timestamp);
         this.startSec = Timestamps.getSecondOfMinute(timestamp);
         this.startMillis = Timestamps.getMillisOfSecond(timestamp);
-        this.startMicros = Timestamps.getMicrosOfSecond(timestamp);
+        this.startMicros = Timestamps.getMicrosOfMilli(timestamp);
     }
 
     private long addYears(long timestamp, int bucket) {

--- a/core/src/main/java/io/questdb/std/Numbers.java
+++ b/core/src/main/java/io/questdb/std/Numbers.java
@@ -720,6 +720,52 @@ public final class Numbers {
         return encodeLowHighInts(negative ? val : -val, len);
     }
 
+    public static long parseInt000000Greedy(CharSequence sequence, final int p, int lim) throws NumericException {
+
+        if (lim == p) {
+            throw NumericException.INSTANCE;
+        }
+
+        boolean negative = sequence.charAt(p) == '-';
+        int i = p;
+        if (negative) {
+            i++;
+        }
+
+        if (i >= lim || notDigit(sequence.charAt(i))) {
+            throw NumericException.INSTANCE;
+        }
+
+        int val = 0;
+        for (; i < lim; i++) {
+            char c = sequence.charAt(i);
+
+            if (notDigit(c)) {
+                break;
+            }
+
+            // val * 10 + (c - '0')
+            int r = (val << 3) + (val << 1) - (c - '0');
+            if (r > val) {
+                throw NumericException.INSTANCE;
+            }
+            val = r;
+        }
+
+        final int len = i - p;
+
+        if (len > 6 || val == Integer.MIN_VALUE && !negative) {
+            throw NumericException.INSTANCE;
+        }
+
+        while (i - p < 6) {
+            val *= 10;
+            i++;
+        }
+
+        return encodeLowHighInts(negative ? val : -val, len);
+    }
+
     public static int parseIntQuiet(CharSequence sequence) {
         try {
             if (sequence == null || Chars.equals("NaN", sequence)) {

--- a/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
@@ -399,6 +399,7 @@ public class GenericTimestampFormat extends AbstractDateFormat {
         int second = 0;
         int millis = 0;
         int micros = 0;
+        int week = 0;
         int era = 1;
         int timezone = -1;
         long offset = Long.MIN_VALUE;
@@ -620,7 +621,7 @@ public class GenericTimestampFormat extends AbstractDateFormat {
                     break;
                 case TimestampFormatCompiler.OP_ISO_WEEK_OF_YEAR:
                     TimestampFormatUtils.assertRemaining(pos+1, hi);
-                    Numbers.parseInt(in, pos, pos+=2);
+                    week = Numbers.parseInt(in, pos, pos+=2);
                     break;
                 case TimestampFormatCompiler.OP_DAY_OF_WEEK:
                     TimestampFormatUtils.assertRemaining(pos, hi);
@@ -722,6 +723,6 @@ public class GenericTimestampFormat extends AbstractDateFormat {
 
         TimestampFormatUtils.assertNoTail(pos, hi);
 
-        return TimestampFormatUtils.compute(locale, era, year, month, day, hour, minute, second, millis, micros, timezone, offset, hourType);
+        return TimestampFormatUtils.compute(locale, era, year, month, week, day, hour, minute, second, millis, micros, timezone, offset, hourType);
     }
 }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
@@ -392,7 +392,6 @@ public class GenericTimestampFormat extends AbstractDateFormat {
     @Override
     public long parse(CharSequence in, int lo, int hi, DateLocale locale) throws NumericException {
         int day = 1;
-        int week = 0;
         int month = 1;
         int year = 1970;
         int hour = 0;
@@ -621,7 +620,7 @@ public class GenericTimestampFormat extends AbstractDateFormat {
                     break;
                 case TimestampFormatCompiler.OP_ISO_WEEK_OF_YEAR:
                     TimestampFormatUtils.assertRemaining(pos+1, hi);
-                    week = Numbers.parseInt(in, pos, pos+=2);
+                    Numbers.parseInt(in, pos, pos+=2);
                     break;
                 case TimestampFormatCompiler.OP_DAY_OF_WEEK:
                     TimestampFormatUtils.assertRemaining(pos, hi);
@@ -723,6 +722,6 @@ public class GenericTimestampFormat extends AbstractDateFormat {
 
         TimestampFormatUtils.assertNoTail(pos, hi);
 
-        return TimestampFormatUtils.compute(locale, era, year, month, week, day, hour, minute, second, millis, micros, timezone, offset, hourType);
+        return TimestampFormatUtils.compute(locale, era, year, month, day, hour, minute, second, millis, micros, timezone, offset, hourType);
     }
 }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/GenericTimestampFormat.java
@@ -68,16 +68,23 @@ public class GenericTimestampFormat extends AbstractDateFormat {
 
                 // MICROS
                 case TimestampFormatCompiler.OP_MICROS_ONE_DIGIT:
-                case TimestampFormatCompiler.OP_MICROS_GREEDY:
+                case TimestampFormatCompiler.OP_MICROS_GREEDY3:
                     if (micros0 == -1) {
-                        micros0 = Timestamps.getMicrosOfSecond(micros);
+                        micros0 = Timestamps.getMicrosOfMilli(micros);
                     }
                     sink.put(micros0);
                     break;
 
-                case TimestampFormatCompiler.OP_MICROS_THREE_DIGITS:
+                case TimestampFormatCompiler.OP_MICROS_GREEDY6:
                     if (micros0 == -1) {
                         micros0 = Timestamps.getMicrosOfSecond(micros);
+                    }
+                    TimestampFormatUtils.append00000(sink, micros0);
+                    break;
+
+                case TimestampFormatCompiler.OP_MICROS_THREE_DIGITS:
+                    if (micros0 == -1) {
+                        micros0 = Timestamps.getMicrosOfMilli(micros);
                     }
                     TimestampFormatUtils.append00(sink, micros0);
                     break;
@@ -423,8 +430,14 @@ public class GenericTimestampFormat extends AbstractDateFormat {
                     micros = Numbers.parseInt(in, pos, pos += 3);
                     break;
 
-                case TimestampFormatCompiler.OP_MICROS_GREEDY:
+                case TimestampFormatCompiler.OP_MICROS_GREEDY3:
                     l = Numbers.parseInt000Greedy(in, pos, hi);
+                    micros = Numbers.decodeLowInt(l);
+                    pos += Numbers.decodeHighInt(l);
+                    break;
+
+                case TimestampFormatCompiler.OP_MICROS_GREEDY6:
+                    l = Numbers.parseInt000000Greedy(in, pos, hi);
                     micros = Numbers.decodeLowInt(l);
                     pos += Numbers.decodeHighInt(l);
                     break;

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatCompiler.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatCompiler.java
@@ -1260,7 +1260,6 @@ public class TimestampFormatCompiler {
         asm.iload(LOCAL_ERA);
         asm.iload(LOCAL_YEAR);
         asm.iload(LOCAL_MONTH);
-        asm.iload(LOCAL_WEEK);
         asm.iload(LOCAL_DAY);
         asm.iload(LOCAL_HOUR);
         asm.iload(LOCAL_MINUTE);
@@ -1439,7 +1438,7 @@ public class TimestampFormatCompiler {
         int assertNoTailIndex = asm.poolMethod(TimestampFormatUtils.class, "assertNoTail", "(II)V");
         int assertStringIndex = asm.poolMethod(TimestampFormatUtils.class, "assertString", "(Ljava/lang/CharSequence;ILjava/lang/CharSequence;II)I");
         int assertCharIndex = asm.poolMethod(TimestampFormatUtils.class, "assertChar", "(CLjava/lang/CharSequence;II)V");
-        int computeMillisIndex = asm.poolMethod(TimestampFormatUtils.class, "compute", "(Lio/questdb/std/datetime/DateLocale;IIIIIIIIIIIJI)J");
+        int computeMillisIndex = asm.poolMethod(TimestampFormatUtils.class, "compute", "(Lio/questdb/std/datetime/DateLocale;IIIIIIIIIIJI)J");
         int adjustYearIndex = asm.poolMethod(TimestampFormatUtils.class, "adjustYear", "(I)I");
         int parseYearGreedyIndex = asm.poolMethod(TimestampFormatUtils.class, "parseYearGreedy", "(Ljava/lang/CharSequence;II)J");
         int appendEraIndex = asm.poolMethod(TimestampFormatUtils.class, "appendEra", "(Lio/questdb/std/str/CharSink;ILio/questdb/std/datetime/DateLocale;)V");

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatCompiler.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatCompiler.java
@@ -176,7 +176,7 @@ public class TimestampFormatCompiler {
         addOp("Z", OP_TIME_ZONE_RFC_822);
         addOp("x", OP_TIME_ZONE_ISO_8601_1);
         addOp("xx", OP_TIME_ZONE_ISO_8601_2);
-        addOp("merge_copy_var_column", OP_TIME_ZONE_ISO_8601_3);
+        addOp("xxx", OP_TIME_ZONE_ISO_8601_3);
         addOp("U", OP_MICROS_ONE_DIGIT);
         addOp("UUU", OP_MICROS_THREE_DIGITS);
         addOp("U+", OP_MICROS_GREEDY6);
@@ -739,7 +739,7 @@ public class TimestampFormatCompiler {
             int parseIntIndex,
             int assertStringIndex,
             int assertCharIndex,
-            int computeMillisIndex,
+            int computeIndex,
             int adjustYearIndex,
             int parseYearGreedyIndex,
             int parseOffsetIndex,
@@ -1260,6 +1260,7 @@ public class TimestampFormatCompiler {
         asm.iload(LOCAL_ERA);
         asm.iload(LOCAL_YEAR);
         asm.iload(LOCAL_MONTH);
+        asm.iload(LOCAL_WEEK);
         asm.iload(LOCAL_DAY);
         asm.iload(LOCAL_HOUR);
         asm.iload(LOCAL_MINUTE);
@@ -1269,7 +1270,7 @@ public class TimestampFormatCompiler {
         asm.iload(LOCAL_TIMEZONE);
         asm.lload(LOCAL_OFFSET);
         asm.iload(LOCAL_HOUR_TYPE);
-        asm.invokeStatic(computeMillisIndex);
+        asm.invokeStatic(computeIndex);
         asm.lreturn();
         asm.endMethodCode();
 
@@ -1438,7 +1439,7 @@ public class TimestampFormatCompiler {
         int assertNoTailIndex = asm.poolMethod(TimestampFormatUtils.class, "assertNoTail", "(II)V");
         int assertStringIndex = asm.poolMethod(TimestampFormatUtils.class, "assertString", "(Ljava/lang/CharSequence;ILjava/lang/CharSequence;II)I");
         int assertCharIndex = asm.poolMethod(TimestampFormatUtils.class, "assertChar", "(CLjava/lang/CharSequence;II)V");
-        int computeMillisIndex = asm.poolMethod(TimestampFormatUtils.class, "compute", "(Lio/questdb/std/datetime/DateLocale;IIIIIIIIIIJI)J");
+        int computeIndex = asm.poolMethod(TimestampFormatUtils.class, "compute", "(Lio/questdb/std/datetime/DateLocale;IIIIIIIIIIIJI)J");
         int adjustYearIndex = asm.poolMethod(TimestampFormatUtils.class, "adjustYear", "(I)I");
         int parseYearGreedyIndex = asm.poolMethod(TimestampFormatUtils.class, "parseYearGreedy", "(Ljava/lang/CharSequence;II)J");
         int appendEraIndex = asm.poolMethod(TimestampFormatUtils.class, "appendEra", "(Lio/questdb/std/str/CharSink;ILio/questdb/std/datetime/DateLocale;)V");
@@ -1529,7 +1530,7 @@ public class TimestampFormatCompiler {
                 parseIntIndex,
                 assertStringIndex,
                 assertCharIndex,
-                computeMillisIndex,
+                computeIndex,
                 adjustYearIndex,
                 parseYearGreedyIndex,
                 parseOffsetIndex,

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
@@ -29,6 +29,7 @@ import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.DateLocaleFactory;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.StringSink;
 
 import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
@@ -90,6 +91,22 @@ public class TimestampFormatUtils {
         } else if (v < 100) {
             sink.put('0').put('0');
         } else if (v < 1000) {
+            sink.put('0');
+        }
+        Numbers.append(sink, val);
+    }
+
+    public static void append00000(CharSink sink, int val) {
+        int v = Math.abs(val);
+        if (v < 10) {
+            sink.put('0').put('0').put('0').put('0').put('0');
+        } else if (v < 100) {
+            sink.put('0').put('0').put('0').put('0');
+        } else if (v < 1000) {
+            sink.put('0').put('0').put('0');
+        } else if (v < 10000) {
+            sink.put('0').put('0');
+        } else if (v < 100000) {
             sink.put('0');
         }
         Numbers.append(sink, val);
@@ -432,5 +449,15 @@ public class TimestampFormatUtils {
     }
 
     public static void init() {
+    }
+
+    public static void main(String[] args) throws NumericException {
+        TimestampFormatCompiler compiler = new TimestampFormatCompiler();
+        DateFormat f = compiler.compile("y-MM-dd HH:mm:ss.U+");
+        long t = f.parse("2022-02-02 02:02:02.1", TimestampFormatUtils.enLocale);
+        System.out.println(t);
+        StringSink sink = new StringSink();
+        f.format(t, TimestampFormatUtils.enLocale, "Z", sink);
+        System.out.println(sink);
     }
 }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
@@ -29,7 +29,6 @@ import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.DateLocaleFactory;
 import io.questdb.std.str.CharSink;
-import io.questdb.std.str.StringSink;
 
 import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
@@ -79,18 +78,6 @@ public class TimestampFormatUtils {
         if (v < 10) {
             sink.put('0').put('0');
         } else if (v < 100) {
-            sink.put('0');
-        }
-        Numbers.append(sink, val);
-    }
-
-    public static void append000(CharSink sink, int val) {
-        int v = Math.abs(val);
-        if (v < 10) {
-            sink.put('0').put('0').put('0');
-        } else if (v < 100) {
-            sink.put('0').put('0');
-        } else if (v < 1000) {
             sink.put('0');
         }
         Numbers.append(sink, val);
@@ -250,7 +237,6 @@ public class TimestampFormatUtils {
             int era,
             int year,
             int month,
-            int week,
             int day,
             int hour,
             int minute,
@@ -449,15 +435,5 @@ public class TimestampFormatUtils {
     }
 
     public static void init() {
-    }
-
-    public static void main(String[] args) throws NumericException {
-        TimestampFormatCompiler compiler = new TimestampFormatCompiler();
-        DateFormat f = compiler.compile("y-MM-dd HH:mm:ss.U+");
-        long t = f.parse("2022-02-02 02:02:02.1", TimestampFormatUtils.enLocale);
-        System.out.println(t);
-        StringSink sink = new StringSink();
-        f.format(t, TimestampFormatUtils.enLocale, "Z", sink);
-        System.out.println(sink);
     }
 }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/TimestampFormatUtils.java
@@ -302,7 +302,7 @@ public class TimestampFormatUtils {
         } else {
             long yearMicros = Timestamps.yearMicros(year, leap);
             // 4 Jan of year Y
-            // dow() is 0 based, we need to correct it to 1-based, hence + 4
+            // correction formula is taken from https://en.wikipedia.org/wiki/ISO_week_date
             final long correction = Timestamps.getDayOfWeek(yearMicros + Timestamps.monthOfYearMicros(1, leap) + 4 * Timestamps.DAY_MICROS) + 3;
             datetime = yearMicros
                     + (week * 7L + day - correction) * Timestamps.DAY_MICROS

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -454,11 +454,19 @@ final public class Timestamps {
         }
     }
 
-    public static int getMicrosOfSecond(long micros) {
+    public static int getMicrosOfMilli(long micros) {
         if (micros > -1) {
             return (int) (micros % MILLI_MICROS);
         } else {
             return (int) (MILLI_MICROS - 1 + ((micros + 1) % MILLI_MICROS));
+        }
+    }
+
+    public static int getMicrosOfSecond(long micros) {
+        if (micros > -1) {
+            return (int) (micros % SECOND_MICROS);
+        } else {
+            return (int) (SECOND_MICROS - 1 + ((micros + 1) % SECOND_MICROS));
         }
     }
 
@@ -816,7 +824,7 @@ final public class Timestamps {
 
     /**
      * Due to epoch starting on Thursday while ISO week starts on Monday, there is an offset between epoch and ISO week micros when flooring.
-     * @param micros
+     * @param micros epoch microseconds
      * @return 4 days micros offset for Monday through Wednesday and -3 days micros offset for Thursday through Sunday
      */
     public static long getIsoWeekMicrosOffset(long micros) {
@@ -825,7 +833,7 @@ final public class Timestamps {
 
     /**
      * Since ISO weeks don't always start on the first day of the year, there is an offset of days from the 1st day of the year.
-     * @param year
+     * @param year of timestamp
      * @return difference in the days from the start of the year (January 1st) and the first ISO week
      */
     public static int getIsoYearDayOffset(int year) {

--- a/core/src/main/java/io/questdb/std/datetime/millitime/DateFormatCompiler.java
+++ b/core/src/main/java/io/questdb/std/datetime/millitime/DateFormatCompiler.java
@@ -1753,6 +1753,6 @@ public class DateFormatCompiler {
         addOp("Z", OP_TIME_ZONE_RFC_822);
         addOp("x", OP_TIME_ZONE_ISO_8601_1);
         addOp("xx", OP_TIME_ZONE_ISO_8601_2);
-        addOp("merge_copy_var_column", OP_TIME_ZONE_ISO_8601_3);
+        addOp("xxx", OP_TIME_ZONE_ISO_8601_3);
     }
 }

--- a/core/src/main/java/io/questdb/std/datetime/millitime/DateFormatUtils.java
+++ b/core/src/main/java/io/questdb/std/datetime/millitime/DateFormatUtils.java
@@ -30,6 +30,7 @@ import io.questdb.std.NumericException;
 import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.DateLocaleFactory;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.CharSink;
 
 import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MILLIS;
@@ -64,18 +65,6 @@ public class DateFormatUtils {
         if (v < 10) {
             sink.put('0').put('0');
         } else if (v < 100) {
-            sink.put('0');
-        }
-        Numbers.append(sink, val);
-    }
-
-    public static void append000(CharSink sink, int val) {
-        int v = Math.abs(val);
-        if (v < 10) {
-            sink.put('0').put('0').put('0');
-        } else if (v < 100) {
-            sink.put('0').put('0');
-        } else if (v < 1000) {
             sink.put('0');
         }
         Numbers.append(sink, val);

--- a/core/src/main/java/io/questdb/std/datetime/millitime/GenericDateFormat.java
+++ b/core/src/main/java/io/questdb/std/datetime/millitime/GenericDateFormat.java
@@ -30,6 +30,7 @@ import io.questdb.std.NumericException;
 import io.questdb.std.ObjList;
 import io.questdb.std.datetime.AbstractDateFormat;
 import io.questdb.std.datetime.DateLocale;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.CharSink;
 
 public class GenericDateFormat extends AbstractDateFormat {
@@ -324,7 +325,7 @@ public class GenericDateFormat extends AbstractDateFormat {
                         year = Dates.getYear(datetime);
                         leap = Dates.isLeapYear(year);
                     }
-                    DateFormatUtils.append000(sink, year);
+                    TimestampFormatUtils.appendYear000(sink, year);
                     break;
 
                 // ERA

--- a/core/src/main/resources/text_loader.json
+++ b/core/src/main/resources/text_loader.json
@@ -19,6 +19,10 @@
     {
       "format": "yyyy-MM-ddTHH:mm:ss.SSSUUUz",
       "utf8": false
+    },
+    {
+      "format": "yyyy-MM-ddTHH:mm:ss.U+",
+      "utf8": false
     }
   ]
 }

--- a/core/src/test/java/io/questdb/griffin/engine/functions/str/ToStrDateAndTimestampTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/functions/str/ToStrDateAndTimestampTest.java
@@ -93,7 +93,7 @@ public class ToStrDateAndTimestampTest extends AbstractGriffinTest {
                 "Z",
                 "x",
                 "xx",
-                "merge_copy_var_column",
+                "xxx",
                 // "U", these also don't make sense for millis
                 // "UUU"
         };

--- a/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
@@ -106,7 +106,7 @@ public class TimestampFormatCompilerTest {
 
     @Test
     public void testIsoWeekOfYear() throws Exception {
-        assertThat("ww, YYYY", "2010-01-01T00:00:00.000Z", "06, 2010");
+        assertThat("ww, YYYY", "2010-02-08T00:00:00.000Z", "06, 2010");
     }
 
     @Test
@@ -162,6 +162,12 @@ public class TimestampFormatCompilerTest {
     @Test
     public void testFormatMicros3Micros() throws NumericException {
         assertFormat("2022-02-02 02:02:02.000 2", "y-MM-dd HH:mm:ss.SSS U", "2022-02-02T02:02:02.000002Z");
+    }
+
+    @Test
+    public void testFormatISOWeek() throws NumericException {
+        assertFormat("05", "ww", "2022-01-31T02:02:02.000012Z");
+        assertMicros("yyyy-ww HH:mm:ss.SSS U", "2022-01-31T02:02:02.001002Z", "2022-05 02:02:02.001 002");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/microtime/TimestampFormatCompilerTest.java
@@ -110,6 +110,61 @@ public class TimestampFormatCompilerTest {
     }
 
     @Test
+    public void testParseMicros6Small() throws Exception {
+        assertMicros("y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.100000Z", "2022-02-02 02:02:02.1");
+    }
+
+    @Test
+    public void testParseMicros6Mid() throws Exception {
+        assertMicros("y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.123000Z", "2022-02-02 02:02:02.123");
+    }
+
+    @Test
+    public void testParseMicros6Mid2() throws Exception {
+        assertMicros("y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.123700Z", "2022-02-02 02:02:02.1237");
+    }
+
+    @Test
+    public void testFormatMicros6Milli() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.123000", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.123000Z");
+    }
+
+    @Test
+    public void testFormatMicros6One() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.000002", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.000002Z");
+    }
+
+    @Test
+    public void testFormatMicros6Two() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.000012", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.000012Z");
+    }
+
+    @Test
+    public void testFormatMicros6Three() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.000812", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.000812Z");
+    }
+
+    @Test
+    public void testFormatMicros6Four() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.004812", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.004812Z");
+    }
+
+    @Test
+    public void testFormatMicros6Five() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.074812", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.074812Z");
+    }
+
+    @Test
+    public void testFormatMicros6Six() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.374812", "y-MM-dd HH:mm:ss.U+", "2022-02-02T02:02:02.374812Z");
+    }
+
+    @Test
+    public void testFormatMicros3Micros() throws NumericException {
+        assertFormat("2022-02-02 02:02:02.000 2", "y-MM-dd HH:mm:ss.SSS U", "2022-02-02T02:02:02.000002Z");
+    }
+
+    @Test
     public void testDayMonthYear() throws Exception {
         assertThat("dd-MM-yyyy", "2010-03-10T00:00:00.000Z", "10-03-2010");
     }

--- a/core/src/test/java/io/questdb/std/datetime/microtime/TimestampsTest.java
+++ b/core/src/test/java/io/questdb/std/datetime/microtime/TimestampsTest.java
@@ -214,14 +214,14 @@ public class TimestampsTest {
     }
 
     @Test
-    public void testGetWeeks() throws Exception {
+    public void testGetWeeks() {
         Assert.assertEquals(52, Timestamps.getWeeks(2017));
         Assert.assertEquals(52, Timestamps.getWeeks(2021));
         Assert.assertEquals(53, Timestamps.getWeeks(2020));
     }
 
     @Test
-    public void testGetDayOfTheWeekOfEndOfYear() throws Exception {
+    public void testGetDayOfTheWeekOfEndOfYear() {
         Assert.assertEquals(0, Timestamps.getDayOfTheWeekOfEndOfYear(2017));
         Assert.assertEquals(1, Timestamps.getDayOfTheWeekOfEndOfYear(1984));
         Assert.assertEquals(2, Timestamps.getDayOfTheWeekOfEndOfYear(2019));


### PR DESCRIPTION
fixes https://github.com/questdb/questdb/issues/2687

Also fixes ISO week parsing issue, introduced by https://github.com/questdb/questdb/pull/2632