### PR TITLE
chore(core): add GenericRecordMetadata.of

### DIFF
--- a/core/src/main/java/io/questdb/cairo/GenericRecordMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/GenericRecordMetadata.java
@@ -102,6 +102,14 @@ public class GenericRecordMetadata extends BaseRecordMetadata {
         throw CairoException.duplicateColumn(meta.getName());
     }
 
+    public static GenericRecordMetadata of(TableColumnMetadata... metadataItems) {
+        GenericRecordMetadata genericRecordMetadata = new GenericRecordMetadata();
+        for (TableColumnMetadata metadata : metadataItems) {
+            genericRecordMetadata.add(metadata);
+        }
+        return genericRecordMetadata;
+    }
+
     public void clear() {
         columnMetadata.clear();
         columnNameIndexMap.clear();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgDescriptionFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgDescriptionFunctionFactory.java
@@ -30,7 +30,14 @@ import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.RecordMetadata;
 
 public class PgDescriptionFunctionFactory extends AbstractEmptyCatalogueFunctionFactory {
-    private static final RecordMetadata METADATA;
+    private static final RecordMetadata METADATA = GenericRecordMetadata.of(
+        new TableColumnMetadata("objoid", 1, ColumnType.INT),
+        new TableColumnMetadata("classoid", 2, ColumnType.INT),
+        //TODO the below column was downgraded to short. We need to support type downgrading of compatible types when joining
+        new TableColumnMetadata("objsubid", 3, ColumnType.SHORT),
+        new TableColumnMetadata("description", 4, ColumnType.STRING)
+    );
+
 
     public PgDescriptionFunctionFactory() {
         super("pg_description()", METADATA);
@@ -39,15 +46,5 @@ public class PgDescriptionFunctionFactory extends AbstractEmptyCatalogueFunction
     @Override
     public boolean isRuntimeConstant() {
         return true;
-    }
-
-    static {
-        final GenericRecordMetadata metadata = new GenericRecordMetadata();
-        metadata.add(new TableColumnMetadata("objoid", 1, ColumnType.INT));
-        metadata.add(new TableColumnMetadata("classoid", 2, ColumnType.INT));
-        //TODO the below column was downgraded to short. We need to support type downgrading of compatible types when joining
-        metadata.add(new TableColumnMetadata("objsubid", 3, ColumnType.SHORT));
-        metadata.add(new TableColumnMetadata("description", 4, ColumnType.STRING));
-        METADATA = metadata;
     }
 }


### PR DESCRIPTION
This PR adds factory method `GenericRecordMetadata::of`, which allows getting rid of cumbersome `static`-initializers of  `METADATA` property (mostly in `io.questdb.griffin.engine.functions.catalogue` package).

In this PR only `PgDescriptionFunctionFactory ` is updated just as an example. Dear Maintainers, If you find this change useful, please let me know and I'll change other relevant occurrences and submit the PR for review. If not, please feel free to close the PR.
