### PR TITLE
fix(sql): fix NullPointerException in join query over latest on sub-queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/AbstractDeferredValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AbstractDeferredValueRecordCursorFactory.java
@@ -77,9 +77,11 @@ abstract class AbstractDeferredValueRecordCursorFactory extends AbstractDataFram
         return cursor;
     }
 
+    protected abstract StaticSymbolTable getSymbolTable(DataFrameCursor dataFrameCursor, int columnIndex);
+
     private boolean lookupDeferredSymbol(DataFrameCursor dataFrameCursor) {
         final CharSequence symbol = symbolFunc.getStr(null);
-        int symbolKey = dataFrameCursor.getSymbolTable(columnIndex).keyOf(symbol);
+        int symbolKey = getSymbolTable(dataFrameCursor, columnIndex).keyOf(symbol);
         if (symbolKey == SymbolTable.VALUE_NOT_FOUND) {
             dataFrameCursor.close();
             return true;

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredFilteredRecordCursorFactory.java
@@ -24,9 +24,7 @@
 
 package io.questdb.griffin.engine.table;
 
-import io.questdb.cairo.sql.DataFrameCursorFactory;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.*;
 import io.questdb.std.IntList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -58,5 +56,10 @@ public class LatestByValueDeferredFilteredRecordCursorFactory extends AbstractDe
             return new LatestByValueRecordCursor(columnIndex, symbolKey, columnIndexes);
         }
         return new LatestByValueFilteredRecordCursor(columnIndex, symbolKey, filter, columnIndexes);
+    }
+
+    @Override
+    protected StaticSymbolTable getSymbolTable(DataFrameCursor dataFrameCursor, int columnIndex) {
+        return dataFrameCursor.getSymbolTable(columnIndexes.getQuick(columnIndex));
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredIndexedFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredIndexedFilteredRecordCursorFactory.java
@@ -25,9 +25,7 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.TableUtils;
-import io.questdb.cairo.sql.DataFrameCursorFactory;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.*;
 import io.questdb.std.IntList;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,5 +54,10 @@ public class LatestByValueDeferredIndexedFilteredRecordCursorFactory extends Abs
     protected AbstractDataFrameRecordCursor createDataFrameCursorFor(int symbolKey) {
         assert filter != null;
         return new LatestByValueIndexedFilteredRecordCursor(columnIndex, TableUtils.toIndexKey(symbolKey), filter, columnIndexes);
+    }
+
+    @Override
+    protected StaticSymbolTable getSymbolTable(DataFrameCursor dataFrameCursor, int columnIndex) {
+        return dataFrameCursor.getSymbolTable(columnIndexes.getQuick(columnIndex));
     }
 }

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGSecurityTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGSecurityTest.java
@@ -114,7 +114,7 @@ public class PGSecurityTest extends BasePGTest {
     public void testDisallowInsertAsSelect() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table src (ts TIMESTAMP, name string) timestamp(ts) PARTITION BY DAY", sqlExecutionContext);
-            compiler.compile("insert into src values (now(), 'foo')", sqlExecutionContext);
+            TestUtils.insert(compiler, sqlExecutionContext, "insert into src values (now(), 'foo')");
             assertQueryDisallowed("insert into src select now(), name from src");
         });
     }
@@ -147,7 +147,7 @@ public class PGSecurityTest extends BasePGTest {
     public void testDisallowTruncate() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table src (ts TIMESTAMP, name string) timestamp(ts) PARTITION BY day", sqlExecutionContext);
-            compiler.compile("insert into src values (now(), 'foo')", sqlExecutionContext);
+            executeInsert("insert into src values (now(), 'foo')");
             assertQueryDisallowed("truncate table src");
         });
     }
@@ -207,7 +207,7 @@ public class PGSecurityTest extends BasePGTest {
         assertMemoryLeak(() -> {
             configureForBackups();
             compiler.compile("create table src (ts TIMESTAMP, name string) timestamp(ts) PARTITION BY day", sqlExecutionContext);
-            compiler.compile("insert into src values (now(), 'foo')", sqlExecutionContext);
+            executeInsert("insert into src values (now(), 'foo')");
             assertQueryDisallowed("backup database");
         });
     }
@@ -217,7 +217,7 @@ public class PGSecurityTest extends BasePGTest {
         assertMemoryLeak(() -> {
             configureForBackups();
             compiler.compile("create table src (ts TIMESTAMP, name string) timestamp(ts) PARTITION BY day", sqlExecutionContext);
-            compiler.compile("insert into src values (now(), 'foo')", sqlExecutionContext);
+            executeInsert("insert into src values (now(), 'foo')");
             assertQueryDisallowed("backup table src");
         });
     }
@@ -227,7 +227,7 @@ public class PGSecurityTest extends BasePGTest {
     public void testDisallowsRepairTable() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table src (ts TIMESTAMP, name string) timestamp(ts) PARTITION BY day", sqlExecutionContext);
-            compiler.compile("insert into src values (now(), 'foo')", sqlExecutionContext);
+            executeInsert("insert into src values (now(), 'foo')");
             assertQueryDisallowed("repair table src");
         });
     }

--- a/core/src/test/java/io/questdb/griffin/InsertNullGeoHashTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertNullGeoHashTest.java
@@ -73,13 +73,13 @@ public class InsertNullGeoHashTest extends AbstractGriffinTest {
     public void testInsertGeoNullByte() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table g(a geohash(4b))", sqlExecutionContext);
-            compiler.compile("insert into g values (cast(null as geohash(5b)))", sqlExecutionContext);
+            executeInsert("insert into g values (cast(null as geohash(5b)))");
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
                     "g",
                     sink,
-                    "a\n"
+                    "a\n\n"
             );
         });
     }
@@ -88,13 +88,13 @@ public class InsertNullGeoHashTest extends AbstractGriffinTest {
     public void testInsertGeoNullShort() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table g(a geohash(12b))", sqlExecutionContext);
-            compiler.compile("insert into g values (cast(null as geohash(14b)))", sqlExecutionContext);
+            executeInsert("insert into g values (cast(null as geohash(14b)))");
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
                     "g",
                     sink,
-                    "a\n"
+                    "a\n\n"
             );
         });
     }
@@ -103,13 +103,13 @@ public class InsertNullGeoHashTest extends AbstractGriffinTest {
     public void testInsertGeoNullInt() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table g(a geohash(22b))", sqlExecutionContext);
-            compiler.compile("insert into g values (cast(null as geohash(24b)))", sqlExecutionContext);
+            executeInsert("insert into g values (cast(null as geohash(24b)))");
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
                     "g",
                     sink,
-                    "a\n"
+                    "a\n\n"
             );
         });
     }
@@ -118,13 +118,13 @@ public class InsertNullGeoHashTest extends AbstractGriffinTest {
     public void testInsertGeoNullLong() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table g(a geohash(42b))", sqlExecutionContext);
-            compiler.compile("insert into g values (cast(null as geohash(44b)))", sqlExecutionContext);
+            executeInsert("insert into g values (cast(null as geohash(44b)))");
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
                     "g",
                     sink,
-                    "a\n"
+                    "a\n\n"
             );
         });
     }

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -26,8 +26,8 @@ package io.questdb.griffin;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
 import io.questdb.griffin.engine.TestBinarySequence;
 import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.std.BinarySequence;
@@ -499,6 +499,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);
             try {
                 compiler.compile("insert into balances values (1, 'USD')", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(37, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "row value count does not match column count [expected=3, actual=2, tuple=1]");
@@ -701,6 +702,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
             try {
                 compiler.compile("insert into tab select x ac  from long_sequence(10)", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(12, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "select clause must provide timestamp column");
@@ -714,6 +716,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
             try {
                 compiler.compile("insert into tab select * from (select  timestamp_sequence(0, x) ts, x ac from long_sequence(10)) timestamp(ts)", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(12, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "designated timestamp of existing table");
@@ -754,6 +757,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table tab(seq long, ts timestamp) timestamp(ts);", sqlExecutionContext);
             try {
                 compiler.compile("insert into tab select x ac, rnd_int() id from long_sequence(10)", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(12, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "expected timestamp column");
@@ -766,10 +770,11 @@ public class InsertTest extends AbstractGriffinTest {
         assertMemoryLeak(() -> {
             compiler.compile("create table test (a timestamp)", sqlExecutionContext);
             try {
-                compiler.compile("insert into test values ('2013')", sqlExecutionContext);
-            } catch (SqlException e) {
-                Assert.assertEquals(25, e.getPosition());
-                TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible types: STRING -> TIMESTAMP");
+                executeInsert("insert into test values ('foobar')");
+                Assert.fail();
+            } catch (ImplicitCastException e) {
+                Assert.assertEquals(0, e.getPosition());
+                TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible value: `foobar` [STRING -> TIMESTAMP]");
             }
         });
     }
@@ -794,6 +799,7 @@ public class InsertTest extends AbstractGriffinTest {
 
             try {
                 compiler.compile("insert into t values  (timestamp with time zone)", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(47, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "String literal expected after 'timestamp with time zone'");
@@ -847,6 +853,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table trades (sym symbol)", sqlExecutionContext);
             try {
                 compiler.compile("insert into trades VALUES ('USDJPY'), (1), ('USDFJD');", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(39, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible types: INT -> SYMBOL [from=1, to=sym]");
@@ -862,6 +869,7 @@ public class InsertTest extends AbstractGriffinTest {
             // No comma delimiter between rows
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY')(2, 'USDFJD');", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(39, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "',' expected");
@@ -870,6 +878,7 @@ public class InsertTest extends AbstractGriffinTest {
             // Empty row
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY'), ();", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(42, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "Expression expected");
@@ -878,6 +887,7 @@ public class InsertTest extends AbstractGriffinTest {
             // Empty row with comma delimiter inside
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY'), (2, 'USDFJD'), (,);", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(57, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "Expression expected");
@@ -886,6 +896,7 @@ public class InsertTest extends AbstractGriffinTest {
             // Empty row column
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY'), (2, 'USDFJD'), (3,);", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(59, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "Expression expected");
@@ -894,6 +905,7 @@ public class InsertTest extends AbstractGriffinTest {
             // Multi row insert can't end in comma token
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY'), (2, 'USDFJD'),;", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(55, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "'(' expected");
@@ -907,6 +919,7 @@ public class InsertTest extends AbstractGriffinTest {
             compiler.compile("create table trades (i int, sym symbol)", sqlExecutionContext);
             try {
                 compiler.compile("insert into trades VALUES (1, 'USDJPY'), ('USDFJD');", sqlExecutionContext);
+                Assert.fail();
             } catch (SqlException e) {
                 Assert.assertEquals(50, e.getPosition());
                 TestUtils.assertContains(e.getFlyweightMessage(), "row value count does not match column count [expected=2, actual=1, tuple=2]");

--- a/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
+++ b/core/src/test/java/io/questdb/griffin/SimulatedDeleteTest.java
@@ -24,8 +24,6 @@
 
 package io.questdb.griffin;
 
-import io.questdb.cairo.sql.InsertMethod;
-import io.questdb.cairo.sql.InsertOperation;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
 
@@ -34,11 +32,11 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
     public void testNotSelectDeleted() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table balances (cust_id int, balance_ccy symbol, balance double, inactive boolean, timestamp timestamp) timestamp(timestamp);", sqlExecutionContext);
-            execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, balance, timestamp) values (1, 'USD', 1500.00, 6000000001);", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, balance, timestamp) values (1, 'EUR', 650.50, 6000000002);", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, balance, timestamp) values (2, 'USD', 900.75, 6000000003);", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, balance, timestamp) values (2, 'EUR', 880.20, 6000000004);", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into balances (cust_id, balance_ccy, inactive, timestamp) values (1, 'USD', true, 6000000006);", sqlExecutionContext).getInsertOperation());
+            executeInsert("insert into balances (cust_id, balance_ccy, balance, timestamp) values (1, 'USD', 1500.00, 6000000001);");
+            executeInsert("insert into balances (cust_id, balance_ccy, balance, timestamp) values (1, 'EUR', 650.50, 6000000002);");
+            executeInsert("insert into balances (cust_id, balance_ccy, balance, timestamp) values (2, 'USD', 900.75, 6000000003);");
+            executeInsert("insert into balances (cust_id, balance_ccy, balance, timestamp) values (2, 'EUR', 880.20, 6000000004);");
+            executeInsert("insert into balances (cust_id, balance_ccy, inactive, timestamp) values (1, 'USD', true, 6000000006);");
 
             assertSql(
                     "(select * from balances where cust_id=1 latest on timestamp partition by balance_ccy) where not inactive;",
@@ -52,11 +50,11 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
     public void testNotSelectDeletedByLimit() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table state_table(time timestamp, id int, state symbol) timestamp(time);", sqlExecutionContext);
-            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'OFF');", sqlExecutionContext).getInsertOperation());
-            execInsert(compiler.compile("insert into state_table values(systimestamp(), 12345, 'ON');", sqlExecutionContext).getInsertOperation());
+            executeInsert("insert into state_table values(systimestamp(), 12345, 'OFF');");
+            executeInsert("insert into state_table values(systimestamp(), 12345, 'OFF');");
+            executeInsert("insert into state_table values(systimestamp(), 12345, 'OFF');");
+            executeInsert("insert into state_table values(systimestamp(), 12345, 'OFF');");
+            executeInsert("insert into state_table values(systimestamp(), 12345, 'ON');");
             TestUtils.assertSql(
                     compiler,
                     sqlExecutionContext,
@@ -66,12 +64,5 @@ public class SimulatedDeleteTest extends AbstractGriffinTest {
             );
 
         });
-    }
-
-    private static void execInsert(InsertOperation statement) throws SqlException {
-        try (InsertMethod m = statement.createMethod(sqlExecutionContext)) {
-            m.execute();
-            m.commit();
-        }
     }
 }

--- a/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCompilerTest.java
@@ -3248,8 +3248,8 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                         ") TIMESTAMP(ts) PARTITION BY DAY",
                 sqlExecutionContext
         );
-        compiler.compile("INSERT INTO t1(ts, x) VALUES (1, 1)", sqlExecutionContext);
-        compiler.compile("INSERT INTO t2(ts, x) VALUES (1, 2)", sqlExecutionContext);
+        executeInsert("INSERT INTO t1(ts, x) VALUES (1, 1)");
+        executeInsert("INSERT INTO t2(ts, x) VALUES (1, 2)");
         engine.releaseInactive();
 
         // 1.- the parser finds column t2.ts with an explicit alias TS (case does not matter - it is equiv. to ts)


### PR DESCRIPTION
Also fixes a number of issues around `INSERT INTO t VALUES()` and missing `Assert.fail()` in tests.