### PR TITLE
feat(sql): support `insert into table with ...` syntax

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -1409,7 +1409,7 @@ public final class SqlParser {
             throw SqlException.$(lexer.getPosition(), "'select' or 'values' expected");
         }
 
-        if (isSelectKeyword(tok)) {
+        if (isSelectKeyword(tok) || isWithKeyword(tok)) {
             model.setSelectKeywordPosition(lexer.lastTokenPosition());
             lexer.unparseLast();
             final QueryModel queryModel = parseDml(lexer, null, lexer.lastTokenPosition());

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -256,6 +256,17 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testInsertAsWith() throws Exception {
+        assertInsertTimestamp(
+                "seq\tts\n" +
+                        "1\t1970-01-01T00:00:00.123456Z\n",
+                "insert into tab with x as (select 1, '123456') select * from x",
+                null,
+                false
+        );
+    }
+
+    @Test
     public void testInsertContextSwitch() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table balances(cust_id int, ccy symbol, balance double)", sqlExecutionContext);


### PR DESCRIPTION
Closes #2719

The execution algorithm is the same as for `insert into table select ...`