### PR TITLE
fix(sql): fix slow optimisation of queries with many set operations

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -1834,14 +1834,9 @@ class SqlOptimiser {
     private QueryModel moveOrderByFunctionsIntoOuterSelect(QueryModel model) {
         // at this point order by should be on the nested model of this model :)
         QueryModel unionModel = model.getUnionModel();
-        QueryModel parent = model;
-        while (unionModel != null) {
-            parent.setUnionModel(moveOrderByFunctionsIntoOuterSelect(unionModel));
-
-            parent = unionModel;
-            unionModel = unionModel.getUnionModel();
+        if (unionModel != null) {
+            model.setUnionModel(moveOrderByFunctionsIntoOuterSelect(unionModel));
         }
-
 
         QueryModel nested = model.getNestedModel();
         if (nested != null) {

--- a/core/src/test/java/io/questdb/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/griffin/UnionTest.java
@@ -1127,4 +1127,39 @@ public class UnionTest extends AbstractGriffinTest {
             );
         });
     }
+
+    @Test
+    public void testUnionAllWithLargeNumberOfSubqueries() throws Exception {
+        testLargeNumberOfSubqueries("union all", 100);
+    }
+
+    @Test
+    public void testUnionWithLargeNumberOfSubqueries() throws Exception {
+        testLargeNumberOfSubqueries("union", 1);
+    }
+
+    @Test
+    public void testExceptWithLargeNumberOfSubqueries() throws Exception {
+        testLargeNumberOfSubqueries("except", 0);
+    }
+
+    @Test
+    public void testIntersectWithLargeNumberOfSubqueries() throws Exception {
+        testLargeNumberOfSubqueries("intersect", 1);
+    }
+
+    public void testLargeNumberOfSubqueries(String operation, int expectedCount) throws Exception {
+        assertMemoryLeak(() -> {
+            sink.clear();
+            sink.put("select count(*) cnt from ( ");
+            sink.put(" select 'a' as a, 'b' as b, 'c' as c ");
+            for (int i = 0; i < 99; i++) {
+                sink.put(operation).put(" select 'a' as a, 'b' as b, 'c' as c ");
+            }
+            sink.put(')');
+
+            assertQuery("cnt\n" + expectedCount + "\n", sink.toString(), null, false, true);
+        });
+
+    }
 }


### PR DESCRIPTION
Fixes unnecessary recursion in sql optimiser taking minutes (and more) to process queries with many set operations, e.g. 

```sql
select 1 as a, select 2 as b
union all 
select 1 as a, select 2 as b
union all 
...
```