### PR TITLE
fix(core): fix race in WAL table transaction log

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -332,7 +332,7 @@ public class TableSequencerAPI implements QuietCloseable {
                 entry.writeLock();
             }
 
-            if (!entry.isDistressed()) {
+            if (!entry.isDistressed() && !entry.isClosed()) {
                 return entry;
             } else {
                 if (lock == SequencerLockType.READ) {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -182,6 +182,7 @@ public class TableSequencerImpl implements TableSequencer {
     @Override
     public long nextStructureTxn(long expectedStructureVersion, TableMetadataChange change) {
         // Writing to TableSequencer can happen from multiple threads, so we need to protect against concurrent writes.
+        assert !closed;
         long txn;
         try {
             if (metadata.getStructureVersion() == expectedStructureVersion) {
@@ -216,6 +217,7 @@ public class TableSequencerImpl implements TableSequencer {
     @Override
     public long nextTxn(long expectedSchemaVersion, int walId, int segmentId, long segmentTxn) {
         // Writing to TableSequencer can happen from multiple threads, so we need to protect against concurrent writes.
+        assert !closed;
         long txn;
         try {
             if (metadata.getStructureVersion() == expectedSchemaVersion) {

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -34,6 +34,7 @@ import io.questdb.cutlass.line.tcp.load.TableData;
 import io.questdb.log.Log;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.*;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -47,13 +48,12 @@ import static io.questdb.cairo.ColumnType.*;
 @RunWith(Parameterized.class)
 abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTest {
 
+    static final int UPPERCASE_TABLE_RANDOMIZE_FACTOR = 2;
     private static final int MAX_NUM_OF_SKIPPED_COLS = 2;
     private static final int NEW_COLUMN_RANDOMIZE_FACTOR = 2;
-    static final int UPPERCASE_TABLE_RANDOMIZE_FACTOR = 2;
     private static final int SEND_SYMBOLS_WITH_SPACE_RANDOMIZE_FACTOR = 2;
     protected final short[] colTypes = new short[]{STRING, DOUBLE, DOUBLE, DOUBLE, STRING, DOUBLE};
-    private final AtomicLong timestampMillis = new AtomicLong(1465839830102300L);
-    protected Rnd random;
+    protected final boolean walEnabled;
     private final String[][] colNameBases = new String[][]{
             {"terület", "TERÜLet", "tERülET", "TERÜLET"},
             {"temperature", "TEMPERATURE", "Temperature", "TempeRaTuRe"},
@@ -63,44 +63,42 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
             {"ветер", "Ветер", "ВЕТЕР", "вЕТЕр", "ВетЕР"}
     };
     private final String[] colValueBases = new String[]{"europe", "8", "2", "1", "note", "6"};
+    private final char[] nonAsciiChars = {'ó', 'í', 'Á', 'ч', 'Ъ', 'Ж', 'ю', 0x3000, 0x3080, 0x3a55};
     private final String[][] tagNameBases = new String[][]{
             {"location", "Location", "LOCATION", "loCATion", "LocATioN"},
             {"city", "ciTY", "CITY"}
     };
     private final String[] tagValueBases = new String[]{"us-midwest", "London"};
-    private final char[] nonAsciiChars = {'ó', 'í', 'Á', 'ч', 'Ъ', 'Ж', 'ю', 0x3000, 0x3080, 0x3a55};
-    protected int numOfLines;
+    private final AtomicLong timestampMillis = new AtomicLong(1465839830102300L);
     protected int numOfIterations;
-    protected int numOfThreads;
+    protected int numOfLines;
     protected int numOfTables;
-    protected long waitBetweenIterationsMillis;
+    protected int numOfThreads;
     protected boolean pinTablesToThreads;
-
-    private SOCountDownLatch threadPushFinished;
-    protected LowerCaseCharSequenceObjHashMap<TableData> tables;
+    protected Rnd random;
     protected ConcurrentHashMap<CharSequence> tableNames;
-
-    private int duplicatesFactor = -1;
+    protected LowerCaseCharSequenceObjHashMap<TableData> tables;
+    protected long waitBetweenIterationsMillis;
     private int columnReorderingFactor = -1;
     private int columnSkipFactor = -1;
-    private int nonAsciiValueFactor = -1;
-    private int newColumnFactor = -1;
     private boolean diffCasesInColNames = false;
+    private int duplicatesFactor = -1;
+    private volatile String errorMsg = null;
     private boolean exerciseTags = true;
+    private int newColumnFactor = -1;
+    private int nonAsciiValueFactor = -1;
     private boolean sendStringsAsSymbols = false;
     private boolean sendSymbolsWithSpace = false;
-
-    private volatile String errorMsg = null;
-    protected final boolean walEnabled;
+    private SOCountDownLatch threadPushFinished;
 
     public AbstractLineTcpReceiverFuzzTest(WalMode walMode) {
         this.walEnabled = (walMode == WalMode.WITH_WAL);
     }
 
-    @Parameterized.Parameters(name="{0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                { WalMode.WITH_WAL }, { WalMode.NO_WAL }
+        return Arrays.asList(new Object[][]{
+                {WalMode.WITH_WAL}, {WalMode.NO_WAL}
         });
     }
 
@@ -112,25 +110,7 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
 
     @Before
     public void setUp2() {
-        long s0 = System.currentTimeMillis();
-        long s1 = System.nanoTime();
-        random = new Rnd(s0, s1);
-        getLog().info().$("random seed : ").$(s0).$(", ").$(s1).$();
-    }
-
-    protected abstract Log getLog();
-
-    protected void mayDrainWalQueue() {
-        if (walEnabled) {
-            drainWalQueue();
-        }
-    }
-
-    private CharSequence addTag(LineData line, int tagIndex) {
-        final CharSequence tagName = generateTagName(tagIndex, false);
-        final CharSequence tagValue = generateTagValue(tagIndex);
-        line.addTag(tagName, tagValue);
-        return tagName;
+        random = TestUtils.generateRandom(getLog());
     }
 
     private CharSequence addColumn(LineData line, int colIndex) {
@@ -140,13 +120,6 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         return colName;
     }
 
-    private void addDuplicateTag(LineData line, int tagIndex, CharSequence tagName) {
-        if (shouldFuzz(duplicatesFactor)) {
-            final CharSequence tagValueDupe = generateTagValue(tagIndex);
-            line.addTag(tagName, tagValueDupe);
-        }
-    }
-
     private void addDuplicateColumn(LineData line, int colIndex, CharSequence colName) {
         if (shouldFuzz(duplicatesFactor)) {
             final CharSequence colValueDupe = generateColumnValue(colIndex);
@@ -154,12 +127,10 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         }
     }
 
-    private void addNewTag(LineData line) {
-        if (shouldFuzz(newColumnFactor)) {
-            final int extraTagIndex = random.nextInt(tagNameBases.length);
-            final CharSequence tagNameNew = generateTagName(extraTagIndex, true);
-            final CharSequence tagValueNew = generateTagValue(extraTagIndex);
-            line.addTag(tagNameNew, tagValueNew);
+    private void addDuplicateTag(LineData line, int tagIndex, CharSequence tagName) {
+        if (shouldFuzz(duplicatesFactor)) {
+            final CharSequence tagValueDupe = generateTagValue(tagIndex);
+            line.addTag(tagName, tagValueDupe);
         }
     }
 
@@ -172,34 +143,20 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         }
     }
 
-    void waitForTable(TableData table) {
-        // if CI is very slow the table could be released before ingestion stops
-        // then acquired again for further data ingestion
-        // because of the above we will wait in a loop with a timeout for the data to appear in the table
-        // in most cases we should not hit the sleep() below
-        table.await();
-        for (int i = 0; i < 180; i++) {
-            mayDrainWalQueue();
-            if (checkTable(table)) {
-                return;
-            }
-            Os.sleep(1000);
+    private void addNewTag(LineData line) {
+        if (shouldFuzz(newColumnFactor)) {
+            final int extraTagIndex = random.nextInt(tagNameBases.length);
+            final CharSequence tagNameNew = generateTagName(extraTagIndex, true);
+            final CharSequence tagValueNew = generateTagValue(extraTagIndex);
+            line.addTag(tagNameNew, tagValueNew);
         }
-        throw new RuntimeException("Timed out on waiting for the data, table=" + table.getName());
     }
 
-    // return false means data is not in the table yet and should be called again
-    boolean checkTable(TableData table) {
-        final CharSequence tableName = tableNames.get(table.getName());
-        if (tableName == null) {
-            getLog().info().$(table.getName()).$(" has not been created yet").$();
-            return false;
-        }
-        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
-            getLog().info().$("table.getName(): ").$(table.getName()).$(", tableName: ").$(tableName)
-                    .$(", table.size(): ").$(table.size()).$(", reader.size(): ").$(reader.size()).$();
-            return table.size() <= reader.size();
-        }
+    private CharSequence addTag(LineData line, int tagIndex) {
+        final CharSequence tagName = generateTagName(tagIndex, false);
+        final CharSequence tagValue = generateTagValue(tagIndex);
+        line.addTag(tagName, tagValue);
+        return tagName;
     }
 
     private void assertTable(TableData table) {
@@ -228,6 +185,20 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         }
     }
 
+    private String generateColumnName(int index, boolean randomize) {
+        return generateName(colNameBases[index], randomize);
+    }
+
+    private String generateColumnValue(int index) {
+        return generateValue(colTypes[index], colValueBases[index]);
+    }
+
+    private String generateName(String[] names, boolean randomize) {
+        final int caseIndex = diffCasesInColNames ? random.nextInt(names.length) : 0;
+        final String postfix = randomize ? Integer.toString(random.nextInt(NEW_COLUMN_RANDOMIZE_FACTOR)) : "";
+        return names[caseIndex] + postfix;
+    }
+
     private int[] generateOrdering(int numOfCols) {
         final int[] columnOrdering = new int[numOfCols];
         if (shouldFuzz(columnReorderingFactor)) {
@@ -245,6 +216,86 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
             }
         }
         return columnOrdering;
+    }
+
+    private String generateTagName(int index, boolean randomize) {
+        return generateName(tagNameBases[index], randomize);
+    }
+
+    private String generateTagValue(int index) {
+        return generateValue(SYMBOL, tagValueBases[index]);
+    }
+
+    private String generateValue(short type, String valueBase) {
+        final String postfix;
+        switch (type) {
+            case DOUBLE:
+                postfix = random.nextInt(9) + ".0";
+                return valueBase + postfix;
+            case SYMBOL:
+                postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
+                if (sendSymbolsWithSpace && random.nextInt(SEND_SYMBOLS_WITH_SPACE_RANDOMIZE_FACTOR) == 0) {
+                    final int spaceIndex = random.nextInt(valueBase.length() - 1);
+                    valueBase = valueBase.substring(0, spaceIndex) + "  " + valueBase.substring(spaceIndex);
+                }
+                return valueBase + postfix;
+            case STRING:
+                postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
+                return sendStringsAsSymbols ? valueBase + postfix : "\"" + valueBase + postfix + "\"";
+            default:
+                return valueBase;
+        }
+    }
+
+    private int[] getColumnIndexes() {
+        return skipColumns(generateOrdering(colNameBases.length));
+    }
+
+    private CharSequence getTableName(int tableIndex) {
+        return getTableName(tableIndex, false);
+    }
+
+    private int[] getTagIndexes() {
+        return skipColumns(generateOrdering(tagNameBases.length));
+    }
+
+    private boolean shouldFuzz(int fuzzFactor) {
+        return fuzzFactor > 0 && random.nextInt(fuzzFactor) == 0;
+    }
+
+    private int[] skipColumns(int[] originalColumnIndexes) {
+        if (shouldFuzz(columnSkipFactor)) {
+            // avoid list here and just copy slices of the original array into the new one
+            final List<Integer> indexes = new ArrayList<>();
+            for (int originalColumnIndex : originalColumnIndexes) {
+                indexes.add(originalColumnIndex);
+            }
+            final int numOfSkippedCols = random.nextInt(MAX_NUM_OF_SKIPPED_COLS) + 1;
+            for (int i = 0; i < numOfSkippedCols; i++) {
+                final int skipIndex = random.nextInt(indexes.size());
+                indexes.remove(skipIndex);
+            }
+            final int[] columnIndexes = new int[indexes.size()];
+            for (int i = 0; i < columnIndexes.length; i++) {
+                columnIndexes[i] = indexes.get(i);
+            }
+            return columnIndexes;
+        }
+        return originalColumnIndexes;
+    }
+
+    // return false means data is not in the table yet and should be called again
+    boolean checkTable(TableData table) {
+        final CharSequence tableName = tableNames.get(table.getName());
+        if (tableName == null) {
+            getLog().info().$(table.getName()).$(" has not been created yet").$();
+            return false;
+        }
+        try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableName)) {
+            getLog().info().$("table.getName(): ").$(table.getName()).$(", tableName: ").$(tableName)
+                    .$(", table.size(): ").$(table.size()).$(", reader.size(): ").$(reader.size()).$();
+            return table.size() <= reader.size();
+        }
     }
 
     protected LineData generateLine() {
@@ -266,60 +317,7 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         return line;
     }
 
-    private String generateTagName(int index, boolean randomize) {
-        return generateName(tagNameBases[index], randomize);
-    }
-
-    private String generateColumnName(int index, boolean randomize) {
-        return generateName(colNameBases[index], randomize);
-    }
-
-    private String generateName(String[] names, boolean randomize) {
-        final int caseIndex = diffCasesInColNames ? random.nextInt(names.length) : 0;
-        final String postfix = randomize ? Integer.toString(random.nextInt(NEW_COLUMN_RANDOMIZE_FACTOR)) : "";
-        return names[caseIndex] + postfix;
-    }
-
-    private String generateTagValue(int index) {
-        return generateValue(SYMBOL, tagValueBases[index]);
-    }
-
-    private String generateColumnValue(int index) {
-        return generateValue(colTypes[index], colValueBases[index]);
-    }
-
-    private String generateValue(short type, String valueBase) {
-        final String postfix;
-        switch (type) {
-            case DOUBLE:
-                postfix = random.nextInt(9) + ".0";
-                return valueBase + postfix;
-            case SYMBOL:
-                postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
-                if (sendSymbolsWithSpace && random.nextInt(SEND_SYMBOLS_WITH_SPACE_RANDOMIZE_FACTOR) == 0) {
-                    final int spaceIndex = random.nextInt(valueBase.length()-1);
-                    valueBase = valueBase.substring(0, spaceIndex) + "  " + valueBase.substring(spaceIndex);
-                }
-                return valueBase + postfix;
-            case STRING:
-                postfix = Character.toString(shouldFuzz(nonAsciiValueFactor) ? nonAsciiChars[random.nextInt(nonAsciiChars.length)] : random.nextChar());
-                return sendStringsAsSymbols ? valueBase + postfix : "\"" + valueBase + postfix + "\"";
-            default:
-                return valueBase;
-        }
-    }
-
-    private int[] getTagIndexes() {
-        return skipColumns(generateOrdering(tagNameBases.length));
-    }
-
-    private int[] getColumnIndexes() {
-        return skipColumns(generateOrdering(colNameBases.length));
-    }
-
-    private CharSequence getTableName(int tableIndex) {
-        return getTableName(tableIndex, false);
-    }
+    protected abstract Log getLog();
 
     protected CharSequence getTableName(int tableIndex, boolean randomCase) {
         final String tableName;
@@ -334,6 +332,21 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
     @Override
     protected int getWorkerCount() {
         return 4;
+    }
+
+    void handleWriterGetEvent(CharSequence name) {
+        final TableData table = tables.get(name);
+        table.obtainPermit();
+    }
+
+    void handleWriterReturnEvent(CharSequence name) {
+        final TableData table = tables.get(name);
+        table.returnPermit();
+    }
+
+    void handleWriterUnlockEvent(CharSequence name) {
+        final String tableName = name.toString();
+        tableNames.putIfAbsent(tableName.toLowerCase(), tableName);
     }
 
     void initFuzzParameters(int duplicatesFactor, int columnReorderingFactor, int columnSkipFactor, int newColumnFactor, int nonAsciiValueFactor,
@@ -370,6 +383,12 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         tableNames = new ConcurrentHashMap<>();
     }
 
+    protected void mayDrainWalQueue() {
+        if (walEnabled) {
+            drainWalQueue();
+        }
+    }
+
     protected CharSequence pickTableName(int threadId) {
         return getTableName(pinTablesToThreads ? threadId : random.nextInt(numOfTables), true);
     }
@@ -377,6 +396,9 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
     void runTest() throws Exception {
         runTest((factoryType, thread, name, event, segment, position) -> {
             if (walEnabled) {
+                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_GET) {
+                    handleWriterGetEvent(name);
+                }
                 // There is no locking as such in WAL, so we treat writer return as an unlock event.
                 if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
                     handleWriterUnlockEvent(name);
@@ -394,21 +416,6 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
                 }
             }
         }, 250);
-    }
-
-    void handleWriterUnlockEvent(CharSequence name) {
-        final String tableName = name.toString();
-        tableNames.putIfAbsent(tableName.toLowerCase(), tableName);
-    }
-
-    void handleWriterGetEvent(CharSequence name) {
-        final TableData table = tables.get(name);
-        table.obtainPermit();
-    }
-
-    void handleWriterReturnEvent(CharSequence name) {
-        final TableData table = tables.get(name);
-        table.returnPermit();
     }
 
     void runTest(PoolListener listener, long minIdleMsBeforeWriterRelease) throws Exception {
@@ -444,13 +451,18 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
                     final Socket socket = sockets.get(i);
                     socket.close();
                 }
-                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {});
+                engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
+                });
             }
         }, false, minIdleMsBeforeWriterRelease);
 
         if (errorMsg != null) {
             Assert.fail(errorMsg);
         }
+    }
+
+    void setError(String errorMsg) {
+        this.errorMsg = errorMsg;
     }
 
     protected void startThread(int threadId, Socket socket, SOCountDownLatch threadPushFinished) {
@@ -483,32 +495,19 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
         }
     }
 
-    void setError(String errorMsg) {
-        this.errorMsg = errorMsg;
-    }
-
-    private boolean shouldFuzz(int fuzzFactor) {
-        return fuzzFactor > 0 && random.nextInt(fuzzFactor) == 0;
-    }
-
-    private int[] skipColumns(int[] originalColumnIndexes) {
-        if (shouldFuzz(columnSkipFactor)) {
-            // avoid list here and just copy slices of the original array into the new one
-            final List<Integer> indexes = new ArrayList<>();
-            for (int originalColumnIndex : originalColumnIndexes) {
-                indexes.add(originalColumnIndex);
+    void waitForTable(TableData table) {
+        // if CI is very slow the table could be released before ingestion stops
+        // then acquired again for further data ingestion
+        // because of the above we will wait in a loop with a timeout for the data to appear in the table
+        // in most cases we should not hit the sleep() below
+        table.await();
+        for (int i = 0; i < 180; i++) {
+            mayDrainWalQueue();
+            if (checkTable(table)) {
+                return;
             }
-            final int numOfSkippedCols = random.nextInt(MAX_NUM_OF_SKIPPED_COLS) + 1;
-            for (int i = 0; i < numOfSkippedCols; i++) {
-                final int skipIndex = random.nextInt(indexes.size());
-                indexes.remove(skipIndex);
-            }
-            final int[] columnIndexes = new int[indexes.size()];
-            for (int i = 0; i < columnIndexes.length; i++) {
-                columnIndexes[i] = indexes.get(i);
-            }
-            return columnIndexes;
+            Os.sleep(1000);
         }
-        return originalColumnIndexes;
+        throw new RuntimeException("Timed out on waiting for the data, table=" + table.getName());
     }
 }

--- a/core/src/test/java/io/questdb/std/DirectLongListTest.java
+++ b/core/src/test/java/io/questdb/std/DirectLongListTest.java
@@ -59,10 +59,7 @@ public class DirectLongListTest {
 
     @Test
     public void test128BitSortFuzzTest() throws Exception {
-        long s0 = System.currentTimeMillis();
-        long s1 = System.nanoTime();
-        Rnd rnd = new Rnd(s0, s1);
-        LOG.info().$("random seed : ").$(s0).$(", ").$(s1).$();
+        Rnd rnd = TestUtils.generateRandom(LOG);
 
         int size = 1024 * 1024;
         int range = Integer.MAX_VALUE - 1;

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -66,16 +66,10 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public final class TestUtils {
 
     public static final RecordCursorPrinter printer = new RecordCursorPrinter();
-
+    private static final RecordCursorPrinter printerWithTypes = new RecordCursorPrinter().withTypes(true);
     private static final StringSink sink = new StringSink();
 
-    private static final RecordCursorPrinter printerWithTypes = new RecordCursorPrinter().withTypes(true);
-
     private TestUtils() {
-    }
-
-    public static double getZeroToOneDouble(Rnd rnd) {
-        return rnd.nextPositiveLong() / (double) Long.MAX_VALUE;
     }
 
     public static boolean areEqual(BinarySequence a, BinarySequence b) {
@@ -808,10 +802,6 @@ public final class TestUtils {
         }
     }
 
-    public static void setupWorkerPool(WorkerPool workerPool, CairoEngine cairoEngine) throws SqlException {
-        O3Utils.setupWorkerPool(workerPool, cairoEngine, null, null);
-    }
-
     public static void execute(
             @Nullable WorkerPool pool,
             CustomisableRunnable runner,
@@ -885,6 +875,10 @@ public final class TestUtils {
                 return 0;
             }
         };
+    }
+
+    public static double getZeroToOneDouble(Rnd rnd) {
+        return rnd.nextPositiveLong() / (double) Long.MAX_VALUE;
     }
 
     public static void insert(SqlCompiler compiler, SqlExecutionContext sqlExecutionContext, CharSequence insertSql) throws SqlException {
@@ -1128,6 +1122,10 @@ public final class TestUtils {
         }
     }
 
+    public static void setupWorkerPool(WorkerPool workerPool, CairoEngine cairoEngine) throws SqlException {
+        O3Utils.setupWorkerPool(workerPool, cairoEngine, null, null);
+    }
+
     public static long toMemory(CharSequence sequence) {
         long ptr = Unsafe.malloc(sequence.length(), MemoryTag.NATIVE_DEFAULT);
         Chars.asciiStrCpy(sequence, sequence.length(), ptr);
@@ -1138,6 +1136,32 @@ public final class TestUtils {
     public static void writeStringToFile(File file, String s) throws IOException {
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(s.getBytes(Files.UTF_8));
+        }
+    }
+
+    private static void assertEquals(Long256 expected, Long256 actual) {
+        if (expected == actual) return;
+        if (actual == null) {
+            Assert.fail("Expected " + toHexString(expected) + ", but was: null");
+        }
+
+        if (expected.getLong0() != actual.getLong0()
+                || expected.getLong1() != actual.getLong1()
+                || expected.getLong2() != actual.getLong2()
+                || expected.getLong3() != actual.getLong3()) {
+            Assert.assertEquals(toHexString(expected), toHexString(actual));
+        }
+    }
+
+    private static void assertEquals(RecordMetadata metadataExpected, RecordMetadata metadataActual, boolean symbolsAsStrings) {
+        Assert.assertEquals("Column count must be same", metadataExpected.getColumnCount(), metadataActual.getColumnCount());
+        for (int i = 0, n = metadataExpected.getColumnCount(); i < n; i++) {
+            Assert.assertEquals("Column name " + i, metadataExpected.getColumnName(i), metadataActual.getColumnName(i));
+            int columnType1 = metadataExpected.getColumnType(i);
+            columnType1 = symbolsAsStrings && ColumnType.isSymbol(columnType1) ? ColumnType.STRING : columnType1;
+            int columnType2 = metadataActual.getColumnType(i);
+            columnType2 = symbolsAsStrings && ColumnType.isSymbol(columnType2) ? ColumnType.STRING : columnType2;
+            Assert.assertEquals("Column type " + i, columnType1, columnType2);
         }
     }
 
@@ -1163,37 +1187,11 @@ public final class TestUtils {
         }
     }
 
-    private static void assertEquals(Long256 expected, Long256 actual) {
-        if (expected == actual) return;
-        if (actual == null) {
-            Assert.fail("Expected " + toHexString(expected) + ", but was: null");
-        }
-
-        if (expected.getLong0() != actual.getLong0()
-                || expected.getLong1() != actual.getLong1()
-                || expected.getLong2() != actual.getLong2()
-                || expected.getLong3() != actual.getLong3()) {
-            Assert.assertEquals(toHexString(expected), toHexString(actual));
-        }
-    }
-
     private static String toHexString(Long256 expected) {
         return Long.toHexString(expected.getLong0()) + " " +
                 Long.toHexString(expected.getLong1()) + " " +
                 Long.toHexString(expected.getLong2()) + " " +
                 Long.toHexString(expected.getLong3());
-    }
-
-    private static void assertEquals(RecordMetadata metadataExpected, RecordMetadata metadataActual, boolean symbolsAsStrings) {
-        Assert.assertEquals("Column count must be same", metadataExpected.getColumnCount(), metadataActual.getColumnCount());
-        for (int i = 0, n = metadataExpected.getColumnCount(); i < n; i++) {
-            Assert.assertEquals("Column name " + i, metadataExpected.getColumnName(i), metadataActual.getColumnName(i));
-            int columnType1 = metadataExpected.getColumnType(i);
-            columnType1 = symbolsAsStrings && ColumnType.isSymbol(columnType1) ? ColumnType.STRING : columnType1;
-            int columnType2 = metadataActual.getColumnType(i);
-            columnType2 = symbolsAsStrings && ColumnType.isSymbol(columnType2) ? ColumnType.STRING : columnType2;
-            Assert.assertEquals("Column type " + i, columnType1, columnType2);
-        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
The change is in `TableSequencerAPI`:
```
-            if (!entry.isDistressed()) {
+            if (!entry.isDistressed() && !entry.isClosed()) {
```