### PR TITLE
chore(ilp): symbol cache fix

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/SymbolLookup.java
+++ b/core/src/main/java/io/questdb/cairo/sql/SymbolLookup.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.sql;
 
+@FunctionalInterface
 public interface SymbolLookup {
     int keyOf(CharSequence value);
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -40,7 +40,7 @@ import io.questdb.std.str.StringSink;
 
 import java.io.Closeable;
 
-import static io.questdb.cairo.TableUtils.TXN_FILE_NAME;
+import static io.questdb.cairo.TableUtils.*;
 import static io.questdb.cutlass.line.tcp.LineTcpUtils.utf8BytesToString;
 import static io.questdb.cutlass.line.tcp.LineTcpUtils.utf8ToUtf16;
 
@@ -369,19 +369,15 @@ public class TableUpdateDetails implements Closeable {
             latestKnownMetadata = Misc.free(latestKnownMetadata);
         }
 
-        private SymbolCache addSymbolCache(int colWriterIndex) {
+        private SymbolLookup addSymbolCache(int colWriterIndex) {
             try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableNameUtf16)) {
-                int symIndex = resolveSymbolIndexAndName(reader.getMetadata(), colWriterIndex);
+                final int symIndex = resolveSymbolIndexAndName(reader.getMetadata(), colWriterIndex);
                 if (symbolNameTemp == null || symIndex < 0) {
-                    if (writerSPI == null) {
-                        // In case of a WAL table, the change may be not yet applied to the end table - it's fine.
-                        return null;
-                    } else {
-                        throw CairoException.critical(0).put(reader.getMetadata().getColumnName(colWriterIndex)).put(" cannot find symbol column name by writer index ").put(colWriterIndex);
-                    }
+                    return NOT_FOUND_LOOKUP;
                 }
-                path.of(engine.getConfiguration().getRoot()).concat(tableNameUtf16);
-                SymbolCache symCache;
+                final CairoConfiguration cairoConfiguration = engine.getConfiguration();
+                path.of(cairoConfiguration.getRoot()).concat(tableNameUtf16);
+                final SymbolCache symCache;
                 final int lastUnusedSymbolCacheIndex = unusedSymbolCaches.size() - 1;
                 if (lastUnusedSymbolCacheIndex > -1) {
                     symCache = unusedSymbolCaches.get(lastUnusedSymbolCacheIndex);
@@ -389,11 +385,10 @@ public class TableUpdateDetails implements Closeable {
                 } else {
                     symCache = new SymbolCache(configuration);
                 }
-                FilesFacade filesFacade = engine.getConfiguration().getFilesFacade();
 
                 if (this.clean) {
                     if (this.txReader == null) {
-                        this.txReader = new TxReader(filesFacade);
+                        this.txReader = new TxReader(cairoConfiguration.getFilesFacade());
                     }
                     int pathLen = path.length();
                     this.txReader.ofRO(path.concat(TXN_FILE_NAME).$(), reader.getPartitionedBy());
@@ -404,7 +399,7 @@ public class TableUpdateDetails implements Closeable {
                 long columnNameTxn = reader.getColumnVersionReader().getDefaultColumnNameTxn(colWriterIndex);
                 assert symIndex <= colWriterIndex;
                 symCache.of(
-                        engine.getConfiguration(),
+                        cairoConfiguration,
                         writerAPI,
                         colWriterIndex,
                         path,
@@ -429,7 +424,7 @@ public class TableUpdateDetails implements Closeable {
             return writerColIndex;
         }
 
-        private int resolveSymbolIndexAndName(TableReaderMetadata metadata, int colWriterIndex) {
+        private int resolveSymbolIndexAndName(TableRecordMetadata metadata, int colWriterIndex) {
             symbolNameTemp = null;
             int symIndex = -1;
             for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
@@ -544,7 +539,7 @@ public class TableUpdateDetails implements Closeable {
             if (latestKnownMetadata != null) {
                 return latestKnownMetadata.getStructureVersion();
             }
-            return -1;
+            return ANY_TABLE_VERSION;
         }
 
         SymbolLookup getSymbolLookup(int columnIndex) {
@@ -553,10 +548,7 @@ public class TableUpdateDetails implements Closeable {
                 if (symCache != null) {
                     return symCache;
                 }
-                SymbolLookup lookup = addSymbolCache(columnIndex);
-                if (lookup != null) {
-                    return lookup;
-                }
+                return addSymbolCache(columnIndex);
             }
             return NOT_FOUND_LOOKUP;
         }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -40,7 +40,8 @@ import io.questdb.std.str.StringSink;
 
 import java.io.Closeable;
 
-import static io.questdb.cairo.TableUtils.*;
+import static io.questdb.cairo.TableUtils.ANY_TABLE_VERSION;
+import static io.questdb.cairo.TableUtils.TXN_FILE_NAME;
 import static io.questdb.cutlass.line.tcp.LineTcpUtils.utf8BytesToString;
 import static io.questdb.cutlass.line.tcp.LineTcpUtils.utf8ToUtf16;
 
@@ -373,6 +374,9 @@ public class TableUpdateDetails implements Closeable {
             try (TableReader reader = engine.getReader(AllowAllCairoSecurityContext.INSTANCE, tableNameUtf16)) {
                 final int symIndex = resolveSymbolIndexAndName(reader.getMetadata(), colWriterIndex);
                 if (symbolNameTemp == null || symIndex < 0) {
+                    // looks like the column has just been added to the table, and
+                    // the reader is a bit behind and cannot see the column yet
+                    // we will pass the symbol as string
                     return NOT_FOUND_LOOKUP;
                 }
                 final CairoConfiguration cairoConfiguration = engine.getConfiguration();


### PR DESCRIPTION
If new symbol columns are added during heavy ILP ingestion it can happen that the new symbol field appears on more ILP lines before the column gets added to the table.
This means that while processing the second, third... lines `TableReader` could be _behind_, meaning it cannot see the new column yet for some time.
The same can happen to the metadata requested from the pool but that seems to reload faster, refresh is called on every get().

These are the different phases:
1. Pooled metadata and the reader are both behind, they are sync, no problem.
2. Pooled metadata has been refreshed but the reader is still behind, this is the window when we can see errors.
3. Pooled metadata and the reader are both refreshed, they are sync, no problem.

Solution is to treat the second phase the same way as the first one: do not try to resolve symbols, just pass them as strings.
When we reach the 3rd phase we can add the symbol cache.