### PR TITLE
fix(ilp): fix occasionally damaged metadata in implicitly created tables

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -266,7 +266,9 @@ public final class TableUtils {
             path.trimTo(rootLen);
             mem.putInt(count);
             mem.putInt(structure.getPartitionBy());
-            mem.putInt(structure.getTimestampIndex());
+            int timestampIndex = structure.getTimestampIndex();
+            assert timestampIndex >= 0 && timestampIndex < count && structure.getColumnType(timestampIndex) == ColumnType.TIMESTAMP;
+            mem.putInt(timestampIndex);
             mem.putInt(tableVersion);
             mem.putInt(tableId);
             mem.putInt(structure.getMaxUncommittedRows());
@@ -274,8 +276,6 @@ public final class TableUtils {
             mem.putLong(0); // Structure version.
             mem.putInt(structure.isWalEnabled() ? 1 : 0);
             mem.jumpTo(TableUtils.META_OFFSET_COLUMN_TYPES);
-
-            assert count > 0;
 
             for (int i = 0; i < count; i++) {
                 mem.putInt(structure.getColumnType(i));

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableStructureAdapter.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableStructureAdapter.java
@@ -137,6 +137,7 @@ class TableStructureAdapter implements TableStructure {
         this.tableName = tableName;
         entityNamesUtf16.clear();
         entities.clear();
+        timestampIndex = -1;
         final boolean hasNonAsciiChars = parser.hasNonAsciiChars();
         for (int i = 0; i < parser.getEntityCount(); i++) {
             final LineTcpParser.ProtoEntity entity = parser.getEntity(i);


### PR DESCRIPTION
Consider this scenario:
1. Ingest a row to a non-existing table. The row has an explicit timestamp column. This set the `timestampIndex` inside TableStructureAdapter to a non-default value.

2. Ingest another row to a different non-existing table. TableStructureAdapter still has the `timestampIndex` field sets from the previous row. So the 2nd table will have the timestamp index pointing to a random column, even to a column which does not exist at all.