### PR TITLE
chore(wal): UPDATE compilation to use TableReader metadata in apply job

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3459,7 +3459,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             supportsRandomAccess = true;
         }
 
-        if (model.isUpdate()) {
+        if (model.isUpdate() && !executionContext.isWalApplication()) {
             try (
                     TableReader reader = engine.getReader(executionContext.getCairoSecurityContext(), tab);
                     TableRecordMetadata metadata = engine.getMetadata(executionContext.getCairoSecurityContext(), tab, model.getTableVersion())

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2040,6 +2040,7 @@ class SqlOptimiser {
         }
 
         if (model.isUpdate() && !executionContext.isWalApplication()) {
+            assert lo == 0;
             try (TableRecordMetadata metadata = engine.getMetadata(executionContext.getCairoSecurityContext(), tableName)) {
                 enumerateColumns(model, metadata);
             } catch (CairoException e) {

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2039,7 +2039,7 @@ class SqlOptimiser {
             throw SqlException.$(tableNamePosition, "table directory is of unknown format");
         }
 
-        if (model.isUpdate()) {
+        if (model.isUpdate() && !executionContext.isWalApplication()) {
             try (TableRecordMetadata metadata = engine.getMetadata(executionContext.getCairoSecurityContext(), tableName)) {
                 enumerateColumns(model, metadata);
             } catch (CairoException e) {

--- a/core/src/test/java/io/questdb/cairo/wal/WalTableWriterTest.java
+++ b/core/src/test/java/io/questdb/cairo/wal/WalTableWriterTest.java
@@ -220,7 +220,7 @@ public class WalTableWriterTest extends AbstractGriffinTest {
                     int rowCount = rnd.nextInt(1000) + 2;
                     tsIncrement = rnd.nextLong(Timestamps.MINUTE_MICROS);
 
-                    LOG.infoW().$("generating wall [")
+                    LOG.infoW().$("generating wal [")
                             .$("iteration:").$(i)
                             .$(", walIndex: ").$(walIndex)
                             .$(", inOrder: ").$(inOrder)
@@ -230,7 +230,7 @@ public class WalTableWriterTest extends AbstractGriffinTest {
 
                     addRowsToWalAndApplyToTable(i, tableName, tableCopyName, rowCount, tsIncrement, start, rnd, walWriter, inOrder);
 
-                    LOG.info().$("verifying wall [").$("iteration:").$(i).I$();
+                    LOG.info().$("verifying wal [").$("iteration:").$(i).I$();
                     TestUtils.assertSqlCursors(compiler, sqlExecutionContext, tableCopyName, tableName, LOG);
 
                     start += rowCount * tsIncrement + 1;
@@ -275,7 +275,7 @@ public class WalTableWriterTest extends AbstractGriffinTest {
                     tsOffset *= sign == 0 ? -1 : 1;
                     start += tsOffset;
 
-                    LOG.infoW().$("generating wall [")
+                    LOG.infoW().$("generating wal [")
                             .$("iteration:").$(i)
                             .$(", walIndex: ").$(walIndex)
                             .$(", inOrder: ").$(inOrder)
@@ -292,7 +292,7 @@ public class WalTableWriterTest extends AbstractGriffinTest {
 
                     addRowsToWalAndApplyToTable(i, tableName, tableCopyName, rowCount, tsIncrement, start, rnd, walWriter, inOrder);
 
-                    LOG.info().$("verifying wall [").$("iteration:").$(i).I$();
+                    LOG.info().$("verifying wal [").$("iteration:").$(i).I$();
                     TestUtils.assertSqlCursors(compiler, sqlExecutionContext, tableCopyName, tableName, LOG);
 
                     start += rowCount * tsIncrement + 1;

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/AbstractLineTcpReceiverFuzzTest.java
@@ -395,25 +395,14 @@ abstract class AbstractLineTcpReceiverFuzzTest extends AbstractLineTcpReceiverTe
 
     void runTest() throws Exception {
         runTest((factoryType, thread, name, event, segment, position) -> {
-            if (walEnabled) {
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_GET) {
-                    handleWriterGetEvent(name);
-                }
-                // There is no locking as such in WAL, so we treat writer return as an unlock event.
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
-                    handleWriterUnlockEvent(name);
-                    handleWriterReturnEvent(name);
-                }
-            } else {
-                if (factoryType == PoolListener.SRC_METADATA && event == PoolListener.EV_UNLOCKED) {
-                    handleWriterUnlockEvent(name);
-                }
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_GET) {
-                    handleWriterGetEvent(name);
-                }
-                if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
-                    handleWriterReturnEvent(name);
-                }
+            if (factoryType == PoolListener.SRC_METADATA && event == PoolListener.EV_UNLOCKED) {
+                handleWriterUnlockEvent(name);
+            }
+            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_GET) {
+                handleWriterGetEvent(name);
+            }
+            if (factoryType == PoolListener.SRC_WRITER && event == PoolListener.EV_RETURN) {
+                handleWriterReturnEvent(name);
             }
         }, 250);
     }

--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverUpdateFuzzTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverUpdateFuzzTest.java
@@ -226,9 +226,10 @@ public class LineTcpReceiverUpdateFuzzTest extends AbstractLineTcpReceiverFuzzTe
         // wait for update threads to finish
         updatesDone.await();
 
-        // Repeat all updates after all lines are guaranteed to be landed in the tables
+        // wait for ingestion to finish
         super.waitDone();
 
+        // repeat all updates after all lines are guaranteed to be landed in the tables
         final SqlCompiler compiler = compilers[0];
         final SqlExecutionContext executionContext = executionContexts[0];
         for (String sql : updatesQueue) {

--- a/core/src/test/java/io/questdb/griffin/wal/WalPurgeJobTest.java
+++ b/core/src/test/java/io/questdb/griffin/wal/WalPurgeJobTest.java
@@ -491,7 +491,7 @@ public class WalPurgeJobTest extends AbstractGriffinTest {
             assertSegmentExistence(true, tableName, 1, 0);
             assertSegmentExistence(true, tableName, 1, 1);
 
-            // After draining the wall queue, all the WAL data is still there.
+            // After draining the wal queue, all the WAL data is still there.
             drainWalQueue();
             assertSql(tableName, "x\tts\tsss\n" +
                     "1\t2022-02-24T00:00:00.000000Z\t\n" +


### PR DESCRIPTION
When UPDATE is compiled in the apply job it should use TableReader's metadata and not the latest from Sequencer.
Sequencer's metadata can be ahead of the current state of the table.