### PR TITLE
fix(sql): fix error when resolving symbol value

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/EmptyTableRandomRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/EmptyTableRandomRecordCursor.java
@@ -24,10 +24,9 @@
 
 package io.questdb.griffin.engine;
 
-import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.EmptySymbolMapReader;
+import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.RecordCursor;
-import io.questdb.cairo.sql.VirtualRecordNoRowid;
 import io.questdb.std.ObjList;
 
 final public class EmptyTableRandomRecordCursor implements RecordCursor {
@@ -54,6 +53,11 @@ final public class EmptyTableRandomRecordCursor implements RecordCursor {
     @Override
     public Record getRecordB() {
         return recordB;
+    }
+
+    @Override
+    public SymbolTable getSymbolTable(int columnIndex) {
+        return EmptySymbolMapReader.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
Fixes UnsupportedOperationException when resolving symbol value and : 
- table is empty  or 
- value doesn't exist in symbol map 