### PR TITLE
fix(core): fix potential corrupt data produced when writing from ILP on partition boundaries

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2504,6 +2504,7 @@ public class TableWriter implements TableWriterAPI, MetadataChangeSPI, Closeable
                     if (txWriter.reconcileOptimisticPartitions()) {
                         this.lastPartitionTimestamp = txWriter.getLastPartitionTimestamp();
                         this.partitionTimestampHi = partitionCeilMethod.ceil(txWriter.getMaxTimestamp()) - 1;
+                        openLastPartition();
                     }
                 }
             }

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -564,7 +564,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
                 for (int i = maxTimestampPartitionIndex, n = getPartitionCount() - 1; i < n; i++) {
                     rowCount += getPartitionSize(i);
                 }
-                attachedPartitions.setPos(maxTimestampPartitionIndex + LONGS_PER_TX_ATTACHED_PARTITION);
+                attachedPartitions.setPos((maxTimestampPartitionIndex + 1) * LONGS_PER_TX_ATTACHED_PARTITION);
                 recordStructureVersion++;
 
                 // remove partitions

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
@@ -100,6 +100,7 @@ public interface MemoryCR extends MemoryC, MemoryR {
 
     default CharSequence getStr(long offset, CharSequenceView view) {
         long addr = addressOf(offset);
+        assert addr > 0;
         final int len = Unsafe.getUnsafe().getInt(addr);
         if (len != TableUtils.NULL_LEN) {
             if (len + 4 + offset <= size()) {


### PR DESCRIPTION
Fix bug introduced in #2759 when data is first written to future partition but not committed from the first commit because of calculated lag.