### PR TITLE
fix(core): fix results returned in wrong order from parallel filter query

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
@@ -29,7 +29,7 @@ import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.Plannable;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.mp.Sequence;
+import io.questdb.mp.SCSequence;
 import io.questdb.std.Sinkable;
 import io.questdb.std.str.CharSink;
 
@@ -65,7 +65,7 @@ public interface RecordCursorFactory extends Closeable, Sinkable, Plannable {
         return null;
     }
 
-    default PageFrameSequence<?> execute(SqlExecutionContext executionContext, Sequence collectSubSeq, int order) throws SqlException {
+    default PageFrameSequence<?> execute(SqlExecutionContext executionContext, SCSequence collectSubSeq, int order) throws SqlException {
         return null;
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -219,7 +219,7 @@ public class PageFrameReduceJob implements Job, Closeable {
         if (!circuitBreaker.checkIfTripped(frameSequence.getStartTime(), frameSequence.getCircuitBreakerFd())) {
             record.of(frameSequence.getSymbolTableSource(), frameSequence.getPageAddressCache());
             record.setFrameIndex(task.getFrameIndex());
-            assert frameSequence.doneLatch.getCount() == 0;
+            assert !frameSequence.done;
             frameSequence.getReducer().reduce(workerId, record, task, circuitBreaker, stealingFrameSequence);
         } else {
             frameSequence.cancel();

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
@@ -41,6 +41,7 @@ public class PageFrameReduceTask implements Closeable {
     private final DirectLongList rows;
     private int frameIndex = Integer.MAX_VALUE;
     private PageFrameSequence<?> frameSequence;
+    private long frameSequenceId;
 
     public PageFrameReduceTask(CairoConfiguration configuration) {
         this.rows = new DirectLongList(configuration.getPageFrameReduceRowIdListCapacity(), MemoryTag.NATIVE_OFFLOAD);
@@ -75,6 +76,10 @@ public class PageFrameReduceTask implements Closeable {
         return (PageFrameSequence<T>) frameSequence;
     }
 
+    public long getFrameSequenceId() {
+        return frameSequenceId;
+    }
+
     public PageAddressCache getPageAddressCache() {
         return frameSequence.getPageAddressCache();
     }
@@ -85,6 +90,7 @@ public class PageFrameReduceTask implements Closeable {
 
     public void of(PageFrameSequence<?> frameSequence, int frameIndex) {
         this.frameSequence = frameSequence;
+        this.frameSequenceId = frameSequence.getId();
         this.frameIndex = frameIndex;
         rows.clear();
     }

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -179,11 +179,6 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
     public void collect(long cursor, boolean forceCollect) {
         assert cursor > -1;
-        LOG.debug()
-                .$("collecting [shard=").$(shard)
-                .$(", id=").$(id)
-                .$(", cursor=").$(cursor)
-                .I$();
         if (cursor == LOCAL_TASK_CURSOR) {
             collectedFrameIndex = localTask.getFrameIndex();
             localTask.collected();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
@@ -51,12 +51,12 @@ class AsyncFilteredRecordCursor implements RecordCursor {
     private long frameRowIndex;
     private PageFrameSequence<?> frameSequence;
     private boolean isOpen;
-    // the OG rows remaining, used to reset the counter when re-running cursor from top();
+    // The OG rows remaining, used to reset the counter when re-running cursor from top().
     private long ogRowsRemaining;
     private PageAddressCacheRecord recordB;
     private DirectLongList rows;
     // Artificial limit on remaining rows to be returned from this cursor.
-    // It is typically copied from LIMIT clause on SQL statement
+    // It is typically copied from LIMIT clause on SQL statement.
     private long rowsRemaining;
 
     public AsyncFilteredRecordCursor(Function filter, boolean hasDescendingOrder) {
@@ -72,6 +72,7 @@ class AsyncFilteredRecordCursor implements RecordCursor {
                     .$("closing [shard=").$(frameSequence.getShard())
                     .$(", frameIndex=").$(frameIndex)
                     .$(", frameCount=").$(frameLimit)
+                    .$(", frameId=").$(frameSequence.getId())
                     .$(", cursor=").$(cursor)
                     .I$();
 
@@ -112,24 +113,29 @@ class AsyncFilteredRecordCursor implements RecordCursor {
 
     @Override
     public boolean hasNext() {
-        // check for the first hasNext call
+        // Check for the first hasNext call.
         if (frameIndex == -1 && frameLimit > -1) {
             fetchNextFrame();
         }
 
-        // we have rows in the current frame we still need to dispatch
+        // Check for already reached row limit.
+        if (rowsRemaining < 0) {
+            return false;
+        }
+
+        // We have rows in the current frame we still need to dispatch
         if (frameRowIndex < frameRowCount) {
             record.setRowIndex(rows.get(rowIndex()));
             frameRowIndex++;
             return checkLimit();
         }
 
-        // Release previous queue item.
+        // Release the previous queue item.
         // There is no identity check here because this check
-        // had been done when 'cursor' was assigned
+        // had been done when 'cursor' was assigned.
         collectCursor(false);
 
-        // do we have more frames?
+        // Do we have more frames?
         if (frameIndex < frameLimit) {
             fetchNextFrame();
             if (frameRowCount > 0 && frameRowIndex < frameRowCount) {
@@ -163,10 +169,11 @@ class AsyncFilteredRecordCursor implements RecordCursor {
 
     @Override
     public void toTop() {
-        // check if we at the top already and there is nothing to do
+        // Check if we at the top already and there is nothing to do.
         if (frameIndex == 0 && frameRowIndex == 0) {
             return;
         }
+        collectCursor(false);
         filter.toTop();
         frameSequence.toTop();
         rowsRemaining = ogRowsRemaining;
@@ -204,6 +211,7 @@ class AsyncFilteredRecordCursor implements RecordCursor {
                             .$("collected [shard=").$(frameSequence.getShard())
                             .$(", frameIndex=").$(task.getFrameIndex())
                             .$(", frameCount=").$(frameSequence.getFrameCount())
+                            .$(", frameId=").$(frameSequence.getId())
                             .$(", active=").$(frameSequence.isActive())
                             .$(", cursor=").$(cursor)
                             .I$();
@@ -216,7 +224,8 @@ class AsyncFilteredRecordCursor implements RecordCursor {
                         record.setFrameIndex(task.getFrameIndex());
                         break;
                     } else {
-                        this.frameRowCount = 0; // force reset frame size if frameSequence was canceled or failed
+                        // Force reset frame size if frameSequence was canceled or failed.
+                        this.frameRowCount = 0;
                         collectCursor(false);
                     }
                 } else {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
@@ -34,7 +34,6 @@ import io.questdb.cairo.sql.async.PageFrameSequence;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.mp.SCSequence;
-import io.questdb.mp.Sequence;
 import io.questdb.std.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -88,7 +87,7 @@ public class AsyncFilteredRecordCursorFactory extends AbstractRecordCursorFactor
     }
 
     @Override
-    public PageFrameSequence<AsyncFilterAtom> execute(SqlExecutionContext executionContext, Sequence collectSubSeq, int order) throws SqlException {
+    public PageFrameSequence<AsyncFilterAtom> execute(SqlExecutionContext executionContext, SCSequence collectSubSeq, int order) throws SqlException {
         return frameSequence.of(base, executionContext, collectSubSeq, filterAtom, order);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -39,7 +39,6 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.bind.CompiledFilterSymbolBindVariable;
 import io.questdb.jit.CompiledFilter;
 import io.questdb.mp.SCSequence;
-import io.questdb.mp.Sequence;
 import io.questdb.std.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -106,7 +105,7 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
     }
 
     @Override
-    public PageFrameSequence<AsyncJitFilterAtom> execute(SqlExecutionContext executionContext, Sequence collectSubSeq, int order) throws SqlException {
+    public PageFrameSequence<AsyncJitFilterAtom> execute(SqlExecutionContext executionContext, SCSequence collectSubSeq, int order) throws SqlException {
         return frameSequence.of(base, executionContext, collectSubSeq, filterAtom, order);
     }
 

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -50,7 +50,7 @@ public class LogFactory implements Closeable {
     public static final String DEFAULT_CONFIG_NAME = "log.conf";
     // placeholder that can be used in log.conf to point to $root/log/ dir
     public static final String LOG_DIR_VAR = "${log.dir}";
-    // name of default logging configuration file (in jar and in $root/conf/ dir )
+    // name of default logging configuration file (in jar and in $root/conf/ dir)
     private static final String DEFAULT_CONFIG = "/io/questdb/site/conf/" + DEFAULT_CONFIG_NAME;
     private static final int DEFAULT_LOG_LEVEL = LogLevel.INFO | LogLevel.ERROR | LogLevel.CRITICAL | LogLevel.ADVISORY;
     private static final int DEFAULT_MSG_SIZE = 4 * 1024;

--- a/core/src/main/java/io/questdb/mp/AbstractSSequence.java
+++ b/core/src/main/java/io/questdb/mp/AbstractSSequence.java
@@ -38,8 +38,8 @@ abstract class AbstractSSequence extends AbstractSequence implements Sequence {
     @Override
     public void clear() {
         setBarrier(OpenBarrier.INSTANCE);
-        value = -1;
         cache = -1;
+        value = -1;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/mp/AbstractSequence.java
+++ b/core/src/main/java/io/questdb/mp/AbstractSequence.java
@@ -52,6 +52,7 @@ class LhsPadding {
     protected long p1, p2, p3, p4, p5, p6, p7;
 }
 
+@SuppressWarnings("unused")
 class RhsPadding extends Value {
     protected long p9, p10, p11, p12, p13, p14;
 

--- a/core/src/main/java/io/questdb/mp/MCSequence.java
+++ b/core/src/main/java/io/questdb/mp/MCSequence.java
@@ -40,11 +40,6 @@ public class MCSequence extends AbstractMSequence {
         super(cycle, waitStrategy);
     }
 
-    public MCSequence(long value, int cycle) {
-        this(cycle);
-        this.value = value;
-    }
-
     public <T> void consumeAll(RingQueue<T> queue, QueueConsumer<T> consumer) {
         long cursor;
         do {

--- a/core/src/main/java/io/questdb/mp/SCSequence.java
+++ b/core/src/main/java/io/questdb/mp/SCSequence.java
@@ -88,9 +88,9 @@ public class SCSequence extends AbstractSSequence {
         return next0(next + 1);
     }
 
-    @Override
     // The method is final is because we call it from
     // the constructor.
+    @Override
     public final void setCurrent(long value) {
         this.value = value;
     }

--- a/core/src/test/java/io/questdb/mp/ConcurrentTest.java
+++ b/core/src/test/java/io/questdb/mp/ConcurrentTest.java
@@ -193,7 +193,7 @@ public class ConcurrentTest {
             }).start();
         }
 
-        if (!latch.await(TimeUnit.SECONDS.toNanos(10))) {
+        if (!latch.await(TimeUnit.SECONDS.toNanos(60))) {
             Assert.fail("Wait limit exceeded");
         }
         Assert.assertEquals(0, anomalies.get());


### PR DESCRIPTION
Fixes #2513

The problem was three-fold:
* `AsyncFilteredRecordCursor` wasn't calling `frameSequence.done()` in `topTo()`.
* Dynamic sequence addition/removal in `PubSub` could lead to out-of-sync barriers. See `testConcurrentFanOutAsyncOffloadPattern` for the reproducer.
* Our sequences (at least, the MP/MC ones) aren't sequentially consistent, so our `await()` code that was relying on the reducer counter value and the `cursor == -1` check led to unconsumed page frame tasks left in the queue.

The problem showed in this particular test since we cancel the frame sequence when the limit is reached. When we do that, reducer jobs don't run the filter, but immediately call `seq.done(cursor)`. I was able to reproduce the bug reliable with `taskset -c 0,2` to use two non-HT sibling cores. 500 iterations were enough to reproduce it reliably on Linux x86-64.

As a follow-up, we could add [jcstress-based](https://github.com/openjdk/jcstress) tests for our sequences and fix them.

As another follow-up, we could get rid of the reducer counter and reduce up to the number of not yet collected tasks in [this loop](https://github.com/questdb/questdb/blob/8ea125b88d13f006f47976d3eb2f6e452712816c/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java#L425-L433).