### PR TITLE
chore(core): fix flaky IODispatcher test

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -6745,7 +6745,12 @@ public class IODispatcherTest {
             final AtomicBoolean finished = new AtomicBoolean(false);
             final SOCountDownLatch senderHalt = new SOCountDownLatch(senderCount);
             try (IODispatcher<HttpConnectionContext> dispatcher = IODispatchers.create(
-                    new DefaultIODispatcherConfiguration(),
+                    new DefaultIODispatcherConfiguration() {
+                        @Override
+                        public boolean getPeerNoLinger() {
+                            return true;
+                        }
+                    },
                     (fd, dispatcher1) -> new HttpConnectionContext(httpServerConfiguration.getHttpContextConfiguration(), metrics).of(fd, dispatcher1)
             )) {
 


### PR DESCRIPTION
Fix for occasional CI failure.
IODispatcherTest produced the below error:
```
Exception in thread "Thread-327" java.lang.AssertionError: could not connect, errno=49
	at org.junit.Assert.fail(Assert.java:89)
	at io.questdb/io.questdb.test.tools.TestUtils.assertConnect(TestUtils.java:89)

java.lang.AssertionError: Not all requests successful, test failed, see previous failures
	at org.junit.Assert.fail(Assert.java:89)
	at io.questdb/io.questdb.cutlass.http.IODispatcherTest.lambda$testTwoThreadsSendTwoThreadsRead$56(IODispatcherTest.java:6873)
```
```
EADDRNOTAVAIL   49              /* Can't assign requested address */
```

The problem seems to be that sometimes the connection lingers around for some time after it is closed and trying to open a new connection results in EADDRNOTAVAIL (49).
Setting NO_LINGER option for the server socket helps.