### PR TITLE
fix(core): fix intermittent errors during table reads

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -97,8 +97,6 @@ public class TableReader implements Closeable, SymbolTableSource {
         path.trimTo(rootLen);
         try {
             this.metadata = openMetaFile();
-            this.columnCount = this.metadata.getColumnCount();
-            this.columnCountShl = getColumnBits(columnCount);
             this.partitionBy = this.metadata.getPartitionBy();
             this.columnVersionReader = new ColumnVersionReader().ofRO(ff, path.trimTo(rootLen).concat(TableUtils.COLUMN_VERSION_FILE_NAME).$());
             this.txnScoreboard = new TxnScoreboard(ff, configuration.getTxnScoreboardEntryCount()).ofRW(path.trimTo(rootLen));
@@ -109,6 +107,8 @@ public class TableReader implements Closeable, SymbolTableSource {
             this.txFile = new TxReader(ff).ofRO(path.trimTo(rootLen).concat(TXN_FILE_NAME).$(), partitionBy);
             path.trimTo(rootLen);
             reloadSlow(false);
+            this.columnCount = this.metadata.getColumnCount();
+            this.columnCountShl = getColumnBits(columnCount);
             openSymbolMaps();
             partitionCount = txFile.getPartitionCount();
             partitionDirFormatMethod = PartitionBy.getPartitionDirFormatMethod(partitionBy);


### PR DESCRIPTION
fixes #2340

This was a frequently appearing issue in fuzz tests on CI. It was reproduced by adding `Os.sleep(10);` in reader reload code. The issue was to do with uncoordinated values in `columnCount` on `reader` and its `metadata`. Constructor would pick up old `columnCount` and then ask metadata to `reload` without updating `columnCount`.