### PR TITLE
fix(core): fix partition does not exist error after partition drop

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -76,6 +76,9 @@ public class TableReader implements Closeable, SymbolTableSource {
     private LongList columnTops;
     private ObjList<MemoryMR> columns;
     private int partitionCount;
+    private long txColumnVersion = -1;
+    private long txPartitionVersion = -1;
+    private long txTruncateVersion = -1;
     private long rowCount;
     private long tempMem8b = Unsafe.malloc(8, MemoryTag.NATIVE_TABLE_READER);
     private long txn = TableUtils.INITIAL_TXN;
@@ -420,14 +423,17 @@ public class TableReader implements Closeable, SymbolTableSource {
         if (acquireTxn()) {
             return false;
         }
-        final long prevPartitionVersion = this.txFile.getPartitionTableVersion();
-        final long prevColumnVersion = this.txFile.getColumnVersion();
-        final long prevTruncateVersion = this.txFile.getTruncateVersion();
         try {
             reloadSlow(true);
             // partition reload will apply truncate if necessary
             // applyTruncate for non-partitioned tables only
-            reconcileOpenPartitions(prevPartitionVersion, prevColumnVersion, prevTruncateVersion);
+            reconcileOpenPartitions(txPartitionVersion, txColumnVersion, txTruncateVersion);
+
+            // Save transaction details which impact the reloading. Do not rely on txReader, it can be reloaded outside this method.
+            txPartitionVersion = this.txFile.getPartitionTableVersion();
+            txColumnVersion = this.txFile.getColumnVersion();
+            txTruncateVersion = this.txFile.getTruncateVersion();
+
             return true;
         } catch (Throwable e) {
             releaseTxn();


### PR DESCRIPTION
Fixes underlying reason for #2619 e.g. when reader is pooled and a partition is dropped TableReader does not correctly reload the partitions and produces `Partition 'XXX' does not exist in table 'test_table' directory`
