### PR TITLE
fix(http): fix unexpected query timeout errors in /exp endpoint

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreaker.java
@@ -86,7 +86,9 @@ public interface SqlExecutionCircuitBreaker extends ExecutionCircuitBreaker {
 
     int getFd();
 
-    /* Returns true if time was reset/powered up (for current sql command) and false otherwise . */
+    /**
+     * Returns true if time was reset/powered up (for current sql command) and false otherwise.
+     */
     boolean isTimerSet();
 
     void resetTimer();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -104,6 +104,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         try {
             boolean isExpRequest = isExpUrl(context.getRequestHeader().getUrl());
 
+            circuitBreaker.resetTimer();
             state.recordCursorFactory = QueryCache.getThreadLocalInstance().poll(state.query);
             state.setQueryCacheable(true);
             sqlExecutionContext.with(

--- a/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/cutlass/http/HttpQueryTestBuilder.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.SqlJitMode;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.cutlass.http.processors.*;
 import io.questdb.griffin.*;
@@ -98,7 +99,9 @@ public class HttpQueryTestBuilder {
                         return new DefaultSqlExecutionCircuitBreakerConfiguration() {
                             @Override
                             public long getTimeout() {
-                                return queryTimeout > 0 ? queryTimeout : super.getTimeout();
+                                return queryTimeout > 0 || queryTimeout == SqlExecutionCircuitBreaker.TIMEOUT_FAIL_ON_FIRST_CHECK
+                                        ? queryTimeout
+                                        : super.getTimeout();
                             }
                         };
                     }

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -29,6 +29,7 @@ import io.questdb.MessageBusImpl;
 import io.questdb.Metrics;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.AllowAllCairoSecurityContext;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cutlass.NetUtils;
 import io.questdb.cutlass.Services;
 import io.questdb.cutlass.http.processors.*;
@@ -77,6 +78,8 @@ public class IODispatcherTest {
     private static final RescheduleContext EmptyRescheduleContext = (retry) -> {
     };
     private static final Log LOG = LogFactory.getLog(IODispatcherTest.class);
+    private static final String QUERY_TIMEOUT_SELECT = "select i, avg(l), max(l) from t group by i order by i asc limit 3";
+    private static final String QUERY_TIMEOUT_TABLE_DDL = "create table t as (select cast(x%10 as int) as i, x as l from long_sequence(100))";
     private static final Metrics metrics = Metrics.enabled();
     private static final RecordCursorPrinter printer = new RecordCursorPrinter();
     private final String ValidImportResponse = "HTTP/1.1 200 OK\r\n" +
@@ -4389,6 +4392,64 @@ public class IODispatcherTest {
     }
 
     @Test
+    public void testJsonQueryTimeout() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(temp)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .withQueryTimeout(SqlExecutionCircuitBreaker.TIMEOUT_FAIL_ON_FIRST_CHECK)
+                .run((engine) -> {
+                    SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1);
+                    try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                        compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
+                        new SendAndReceiveRequestBuilder().executeWithStandardRequestHeaders(
+                                "GET /exec?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
+                                "HTTP/1.1 400 Bad request\r\n" +
+                                        "Server: questDB/1.0\r\n" +
+                                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                        "Transfer-Encoding: chunked\r\n" +
+                                        "Content-Type: application/json; charset=utf-8\r\n" +
+                                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                                        "\r\n" +
+                                        "83\r\n" +
+                                        "{\"query\":\"select i, avg(l), max(l) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted [fd=32]\",\"position\":0}\r\n" +
+                                        "00\r\n" +
+                                        "\r\n"
+                        );
+                    }
+                });
+    }
+
+    @Test
+    public void testJsonQueryTimeoutResetOnEachQuery() throws Exception {
+        final int timeout = 50;
+        final int iterations = 3;
+        new HttpQueryTestBuilder()
+                .withTempFolder(temp)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .withQueryTimeout(timeout)
+                .run((engine) -> {
+                    SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1);
+                    try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                        compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
+                        for (int i = 0; i < iterations; i++) {
+                            new SendAndReceiveRequestBuilder().executeWithStandardHeaders(
+                                    "GET /exec?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
+                                    "ea\r\n" +
+                                            "{\"query\":\"select i, avg(l), max(l) from t group by i order by i asc limit 3\",\"columns\":[{\"name\":\"i\",\"type\":\"INT\"},{\"name\":\"avg\",\"type\":\"DOUBLE\"},{\"name\":\"max\",\"type\":\"LONG\"}],\"dataset\":[[0,55.0,100],[1,46.0,91],[2,47.0,92]],\"count\":3}\r\n" +
+                                            "00\r\n" +
+                                            "\r\n"
+                            );
+                            Os.sleep(timeout);
+                        }
+                    }
+                });
+    }
+
+    @Test
     public void testJsonQueryTopLimit() throws Exception {
         testJsonQuery(
                 20,
@@ -7049,6 +7110,77 @@ public class IODispatcherTest {
                             false,
                             true
                     );
+                });
+    }
+
+    @Test
+    public void testTextQueryTimeout() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(temp)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .withQueryTimeout(SqlExecutionCircuitBreaker.TIMEOUT_FAIL_ON_FIRST_CHECK)
+                .run((engine) -> {
+                    SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1);
+                    try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                        compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
+                        new SendAndReceiveRequestBuilder().executeWithStandardRequestHeaders(
+                                "GET /exp?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
+                                "HTTP/1.1 400 Bad request\r\n" +
+                                        "Server: questDB/1.0\r\n" +
+                                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                        "Transfer-Encoding: chunked\r\n" +
+                                        "Content-Type: text/csv; charset=utf-8\r\n" +
+                                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                                        "\r\n" +
+                                        "88\r\n" +
+                                        "{\"query\":\"select i, avg(l), max(l) from t group by i order by i asc limit 3\",\"error\":\"[-1] timeout, query aborted [fd=32]\",\"position\":0}\r\n" +
+                                        "00\r\n" +
+                                        "\r\n"
+                        );
+                    }
+                });
+    }
+
+    @Test
+    public void testTextQueryTimeoutResetOnEachQuery() throws Exception {
+        final int timeout = 50;
+        final int iterations = 3;
+        new HttpQueryTestBuilder()
+                .withTempFolder(temp)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .withQueryTimeout(timeout)
+                .run((engine) -> {
+                    SqlExecutionContextImpl executionContext = new SqlExecutionContextImpl(engine, 1);
+                    try (SqlCompiler compiler = new SqlCompiler(engine)) {
+                        compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
+                        for (int i = 0; i < iterations; i++) {
+                            new SendAndReceiveRequestBuilder().executeWithStandardRequestHeaders(
+                                    "GET /exp?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
+                                    "HTTP/1.1 200 OK\r\n" +
+                                            "Server: questDB/1.0\r\n" +
+                                            "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                            "Transfer-Encoding: chunked\r\n" +
+                                            "Content-Type: text/csv; charset=utf-8\r\n" +
+                                            "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
+                                            "Keep-Alive: timeout=5, max=10000\r\n" +
+                                            "\r\n" +
+                                            "33\r\n" +
+                                            "\"i\",\"avg\",\"max\"\r\n" +
+                                            "0,55.0,100\r\n" +
+                                            "1,46.0,91\r\n" +
+                                            "2,47.0,92\r\n" +
+                                            "\r\n" +
+                                            "00\r\n" +
+                                            "\r\n"
+                            );
+                            Os.sleep(timeout);
+                        }
+                    }
                 });
     }
 

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -4405,17 +4405,8 @@ public class IODispatcherTest {
                         compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
                         new SendAndReceiveRequestBuilder().executeWithStandardRequestHeaders(
                                 "GET /exec?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
-                                "HTTP/1.1 400 Bad request\r\n" +
-                                        "Server: questDB/1.0\r\n" +
-                                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                                        "Transfer-Encoding: chunked\r\n" +
-                                        "Content-Type: application/json; charset=utf-8\r\n" +
-                                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                                        "\r\n" +
-                                        "83\r\n" +
-                                        "{\"query\":\"select i, avg(l), max(l) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted [fd=32]\",\"position\":0}\r\n" +
-                                        "00\r\n" +
-                                        "\r\n"
+                                336,
+                                "timeout, query aborted"
                         );
                     }
                 });
@@ -7127,18 +7118,8 @@ public class IODispatcherTest {
                         compiler.compile(QUERY_TIMEOUT_TABLE_DDL, executionContext);
                         new SendAndReceiveRequestBuilder().executeWithStandardRequestHeaders(
                                 "GET /exp?query=" + HttpUtils.urlEncodeQuery(QUERY_TIMEOUT_SELECT) + "&count=true HTTP/1.1\r\n",
-                                "HTTP/1.1 400 Bad request\r\n" +
-                                        "Server: questDB/1.0\r\n" +
-                                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                                        "Transfer-Encoding: chunked\r\n" +
-                                        "Content-Type: text/csv; charset=utf-8\r\n" +
-                                        "Content-Disposition: attachment; filename=\"questdb-query-0.csv\"\r\n" +
-                                        "Keep-Alive: timeout=5, max=10000\r\n" +
-                                        "\r\n" +
-                                        "88\r\n" +
-                                        "{\"query\":\"select i, avg(l), max(l) from t group by i order by i asc limit 3\",\"error\":\"[-1] timeout, query aborted [fd=32]\",\"position\":0}\r\n" +
-                                        "00\r\n" +
-                                        "\r\n"
+                                387,
+                                "timeout, query aborted"
                         );
                     }
                 });

--- a/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/RetryIODispatcherTest.java
@@ -37,7 +37,6 @@ import io.questdb.network.ServerDisconnectException;
 import io.questdb.std.Os;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
-import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -586,7 +585,7 @@ public class RetryIODispatcherTest {
                             int nRows = (parallelCount + 1) * validRequestRecordCount;
                             assertNRowsInserted(nRows);
                             return;
-                        } catch (ComparisonFailure e) {
+                        } catch (AssertionError e) {
                             if (i < 9) {
                                 Os.sleep(50);
                             } else {
@@ -594,7 +593,6 @@ public class RetryIODispatcherTest {
                             }
                         }
                     }
-
                 });
     }
 

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -1973,7 +1973,7 @@ if __name__ == "__main__":
                 statement.execute();
                 Assert.fail();
             } catch (SQLException e) {
-                TestUtils.assertContains(e.getMessage(), "timeout, query aborted ");
+                TestUtils.assertContains(e.getMessage(), "timeout, query aborted");
             }
         });
     }
@@ -5377,7 +5377,7 @@ nodejs code:
                         statement.execute();
                         Assert.fail();
                     } catch (SQLException e) {
-                        TestUtils.assertContains(e.getMessage(), "timeout, query aborted ");
+                        TestUtils.assertContains(e.getMessage(), "timeout, query aborted");
                     }
                 }
             }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -105,11 +105,19 @@ public final class TestUtils {
         }
     }
 
-    public static void assertContains(CharSequence _this, CharSequence that) {
-        if (Chars.contains(_this, that)) {
+    public static void assertContains(String message, CharSequence actual, CharSequence expected) {
+        // Assume that "" is contained in any string.
+        if (expected.length() == 0) {
             return;
         }
-        Assert.fail("'" + _this.toString() + "' does not contain: " + that);
+        if (Chars.contains(actual, expected)) {
+            return;
+        }
+        Assert.fail((message != null ? message + ": '" : "'") + actual.toString() + "' does not contain: " + expected);
+    }
+
+    public static void assertContains(CharSequence actual, CharSequence expected) {
+        assertContains(null, actual, expected);
     }
 
     public static void assertCursor(CharSequence expected, RecordCursor cursor, RecordMetadata metadata, boolean header, MutableCharSink sink) {


### PR DESCRIPTION
Fixes #2865

GET `/exp` endpoint wasn't resetting circuit breaker's timer.