### PR TITLE
fix(sql): fix insert as select with group by expression and constant literals

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -3155,7 +3155,7 @@ class SqlOptimiser {
 
                     // pull literals from newly created group-by columns into both of underlying models
                     for (int j = beforeSplit, n = groupByModel.getBottomUpColumns().size(); j < n; j++) {
-                        emitLiterals(groupByModel.getBottomUpColumns().getQuick(i).getAst(), translatingModel, innerVirtualModel, baseModel, false);
+                        emitLiterals(groupByModel.getBottomUpColumns().getQuick(j).getAst(), translatingModel, innerVirtualModel, baseModel, false);
                     }
                 } else {
                     if (emitCursors(qc.getAst(), cursorModel, null, translatingModel, baseModel, sqlExecutionContext)) {

--- a/core/src/test/java/io/questdb/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/griffin/InsertTest.java
@@ -509,6 +509,50 @@ public class InsertTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testAutoIncrementUniqueId_NotFirstColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table currencies(ccy symbol, id long, ts timestamp) timestamp(ts)", sqlExecutionContext);
+
+            executeInsert("insert into currencies values ('USD', 1, '2019-03-10T00:00:00.000000Z')");
+            assertSql("currencies", "ccy\tid\tts\n" +
+                    "USD\t1\t2019-03-10T00:00:00.000000Z\n");
+
+            compiler.compile("insert into currencies select 'EUR', max(id) + 1, '2019-03-10T01:00:00.000000Z' from currencies", sqlExecutionContext);
+            assertSql("currencies", "ccy\tid\tts\n" +
+                    "USD\t1\t2019-03-10T00:00:00.000000Z\n" +
+                    "EUR\t2\t2019-03-10T01:00:00.000000Z\n");
+
+            compiler.compile("insert into currencies select 'GBP', max(id) + 1, '2019-03-10T02:00:00.000000Z' from currencies", sqlExecutionContext);
+            assertSql("currencies", "ccy\tid\tts\n" +
+                    "USD\t1\t2019-03-10T00:00:00.000000Z\n" +
+                    "EUR\t2\t2019-03-10T01:00:00.000000Z\n" +
+                    "GBP\t3\t2019-03-10T02:00:00.000000Z\n");
+        });
+    }
+
+    @Test
+    public void testAutoIncrementUniqueId_FirstColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table currencies(id long, ccy symbol, ts timestamp) timestamp(ts)", sqlExecutionContext);
+
+            executeInsert("insert into currencies values (1, 'USD', '2019-03-10T00:00:00.000000Z')");
+            assertSql("currencies", "id\tccy\tts\n" +
+                    "1\tUSD\t2019-03-10T00:00:00.000000Z\n");
+
+            compiler.compile("insert into currencies select max(id) + 1, 'EUR', '2019-03-10T01:00:00.000000Z' from currencies", sqlExecutionContext);
+            assertSql("currencies", "id\tccy\tts\n" +
+                    "1\tUSD\t2019-03-10T00:00:00.000000Z\n" +
+                    "2\tEUR\t2019-03-10T01:00:00.000000Z\n");
+
+            compiler.compile("insert into currencies select max(id) + 1, 'GBP', '2019-03-10T02:00:00.000000Z' from currencies", sqlExecutionContext);
+            assertSql("currencies", "id\tccy\tts\n" +
+                    "1\tUSD\t2019-03-10T00:00:00.000000Z\n" +
+                    "2\tEUR\t2019-03-10T01:00:00.000000Z\n" +
+                    "3\tGBP\t2019-03-10T02:00:00.000000Z\n");
+        });
+    }
+
+    @Test
     public void testInsertMultipleRows() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table trades (ts timestamp, sym symbol) timestamp(ts);", sqlExecutionContext);


### PR DESCRIPTION
Fix for indexing out of an array when `group by` is used with constant literals in `insert as select`.

Example for failing use case:
Trying to generate unique ids in insert statements by using the max() function.
```
create table currencies(ccy symbol, id long, ts timestamp) timestamp(ts);
insert into currencies values ('USD', 1, '2019-03-10T00:00:00.000000Z');
insert into currencies select 'EUR', max(id) + 1, '2019-03-10T01:00:00.000000Z' from currencies;
insert into currencies select 'GBP', max(id) + 1, '2019-03-10T02:00:00.000000Z' from currencies;
```

When running the above you get a failure on the 3rd line:
```
java.lang.AssertionError: index out of bounds, 1 >= 1
	at io.questdb/io.questdb.std.ObjList.getQuick(ObjList.java:173)
	at io.questdb/io.questdb.griffin.SqlOptimiser.rewriteSelectClause0(SqlOptimiser.java:3158)
	at io.questdb/io.questdb.griffin.SqlOptimiser.rewriteSelectClause(SqlOptimiser.java:2975)
	at io.questdb/io.questdb.griffin.SqlOptimiser.optimise(SqlOptimiser.java:3546)
	at io.questdb/io.questdb.griffin.SqlCompiler.validateAndOptimiseInsertAsSelect(SqlCompiler.java:2486)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileExecutionModel(SqlCompiler.java:1161)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileUsingModel(SqlCompiler.java:1238)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileInner(SqlCompiler.java:1191)
	at io.questdb/io.questdb.griffin.SqlCompiler.compile(SqlCompiler.java:267)
```