### PR TITLE
feat(core): add rss memory metric

### DIFF
--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -29,6 +29,7 @@ import io.questdb.cutlass.http.processors.JsonQueryMetrics;
 import io.questdb.cutlass.pgwire.PGWireMetrics;
 import io.questdb.metrics.*;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.CharSink;
 
@@ -101,6 +102,7 @@ public class Metrics implements Scrapable {
         metricsRegistry.newVirtualGauge("memory_mem_used", Unsafe::getMemUsed);
         metricsRegistry.newVirtualGauge("memory_malloc_count", Unsafe::getMallocCount);
         metricsRegistry.newVirtualGauge("memory_realloc_count", Unsafe::getReallocCount);
+        metricsRegistry.newVirtualGauge("memory_rss", Os::getRss);
         metricsRegistry.newVirtualGauge("memory_jvm_free", jvmFreeMemRef);
         metricsRegistry.newVirtualGauge("memory_jvm_total", jvmTotalMemRef);
         metricsRegistry.newVirtualGauge("memory_jvm_max", jvmMaxMemRef);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/DumpMemoryUsageFunctionFactory.java
@@ -33,10 +33,7 @@ import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.log.LogRecord;
-import io.questdb.std.IntList;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.ObjList;
-import io.questdb.std.Unsafe;
+import io.questdb.std.*;
 
 public class DumpMemoryUsageFunctionFactory implements FunctionFactory {
 
@@ -63,6 +60,7 @@ public class DumpMemoryUsageFunctionFactory implements FunctionFactory {
             final LogRecord record = LOG.advisory();
 
             record.$("\n\tTOTAL: ").$(Unsafe.getMemUsed());
+            record.$("\n\tRSS: ").$(Os.getRss());
             record.$("\n\tMALLOC_COUNT: ").$(Unsafe.getMallocCount());
             record.$("\n\tREALLOC_COUNT: ").$(Unsafe.getReallocCount());
             record.$("\n\tFREE_COUNT: ").$(Unsafe.getFreeCount());

--- a/core/src/main/java/io/questdb/griffin/engine/table/MemoryMetricsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/MemoryMetricsRecordCursorFactory.java
@@ -32,11 +32,12 @@ import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 public final class MemoryMetricsRecordCursorFactory extends AbstractRecordCursorFactory {
     private static final RecordMetadata METADATA;
-    private static final int METRIC_COUNT = MemoryTag.SIZE + 1; // 1 per each tag + 1 extra for total memory
+    private static final int METRIC_COUNT = MemoryTag.SIZE + 2; // 1 per each tag + 2 extra for total memory and rss 
     private static final String[] KEYS = new String[METRIC_COUNT];
     private final StringLongTuplesRecordCursor cursor = new StringLongTuplesRecordCursor();
     private final long[] values = new long[METRIC_COUNT];
@@ -61,8 +62,9 @@ public final class MemoryMetricsRecordCursorFactory extends AbstractRecordCursor
         assert collector.length == METRIC_COUNT;
 
         collector[0] = Unsafe.getMemUsed();
+        collector[1] = Os.getRss();
         for (int i = 0; i < MemoryTag.SIZE; i++) {
-            collector[i + 1] = Unsafe.getMemUsedByTag(i);
+            collector[i + 2] = Unsafe.getMemUsedByTag(i);
         }
     }
 
@@ -73,8 +75,9 @@ public final class MemoryMetricsRecordCursorFactory extends AbstractRecordCursor
         METADATA = metadata;
 
         KEYS[0] = "TOTAL_USED";
+        KEYS[1] = "RSS";
         for (int i = 0; i < MemoryTag.SIZE; i++) {
-            KEYS[i + 1] = MemoryTag.nameOf(i);
+            KEYS[i + 2] = MemoryTag.nameOf(i);
         }
     }
 }

--- a/core/src/test/java/io/questdb/griffin/engine/table/MemoryMetricsRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/griffin/engine/table/MemoryMetricsRecordCursorFactoryTest.java
@@ -27,10 +27,14 @@ package io.questdb.griffin.engine.table;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.AbstractGriffinTest;
+import io.questdb.griffin.CompiledQuery;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
 import io.questdb.std.Unsafe;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -46,11 +50,22 @@ public class MemoryMetricsRecordCursorFactoryTest extends AbstractGriffinTest {
 
     @Test
     public void testSql() throws Exception {
-        printSqlResult(MemoryMetricsRecordCursorFactoryTest::expectedTableContent, "select * from memory_metrics()", null, null, null, false, true, true, false, null);
+        CompiledQuery cc = compiler.compile("select * from memory_metrics()", sqlExecutionContext);
+        RecordCursorFactory factory = cc.getRecordCursorFactory();
+        try {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                TestUtils.printCursor(cursor, factory.getMetadata(), true, sink, printer);
+
+                String expected = expectedTableContent();
+                assertTrue(sink.toString().matches(expected));
+            }
+        } finally {
+            Misc.free(factory);
+        }
     }
 
     @Test
-    public void testValues() throws Exception {
+    public void testValues() {
         try (MemoryMetricsRecordCursorFactory factory = new MemoryMetricsRecordCursorFactory();
              RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
             assertCursor(cursor);
@@ -63,6 +78,9 @@ public class MemoryMetricsRecordCursorFactoryTest extends AbstractGriffinTest {
 
         assertEquals("TOTAL_USED", record.getStr(0));
         assertEquals(Unsafe.getMemUsed(), record.getLong(1));
+        cursor.hasNext();
+        assertEquals("RSS", record.getStr(0));
+        assertTrue(record.getLong(1) > 0);
         for (int i = 0; i < MemoryTag.SIZE; i++) {
             assertTrue(cursor.hasNext());
             assertEquals(MemoryTag.nameOf(i), record.getStr(0));
@@ -84,6 +102,7 @@ public class MemoryMetricsRecordCursorFactoryTest extends AbstractGriffinTest {
     private static String expectedTableContent() {
         StringBuilder sb = new StringBuilder("memory_tag").append('\t').append("bytes").append('\n');
         sb.append("TOTAL_USED").append('\t').append(Unsafe.getMemUsed()).append('\n');
+        sb.append("RSS").append("\t[0-9]+\n");//asserting exact value is not practical
         for (int i = 0; i < MemoryTag.SIZE; i++) {
             sb.append(MemoryTag.nameOf(i)).append('\t').append(Unsafe.getMemUsedByTag(i)).append('\n');
         }


### PR DESCRIPTION
Adds Resident Set Size / Working Set Size to memory metrics list in : 
- /metrics endpoint 
- memory_metrics() & dump_memory_usage() functions 

It's not a 100% accurate metric but should be better than existing ones . 
There are differences between OSes though, for example Linux doesn't include MMAPed pages while Windows does (but only once they've been touched). 