### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.5.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -617,7 +617,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
+            <version>42.5.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
+            <version>42.5.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.4.1
- [CVE-2022-41946](https://www.oscs1024.com/hd/CVE-2022-41946)


### What did I do？
Upgrade org.postgresql:postgresql from 42.4.1 to 42.5.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS