### PR TITLE
ci(build): fix snapshot pipeline

### DIFF
--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -26,8 +26,9 @@ stages:
             displayName: "Build binaries with Maven"
             inputs:
               mavenPomFile: "core/pom.xml"
+              goals: "package"
               options:
-                "clean package --batch-mode --quiet -DskipTests -P build-web-console,build-binaries -Dhttp.keepAlive=false"
+                "--batch-mode --quiet -DskipTests -P build-web-console,build-binaries -Dhttp.keepAlive=false"
               jdkVersionOption: 1.11
           - bash: |
               cd "$(Build.SourcesDirectory)"/core

--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -26,7 +26,7 @@ stages:
             lfs: false
             submodules: false
           - bash: |
-              /tmp/docker exec -t -u 0 ci-container sh -c "yum -y install git"
+              yum -y install git
 
               cd /tmp
               curl -q -O https://mirrors.ukfast.co.uk/sites/ftp.apache.org/maven/maven-3/"$MVN_VERSION"/binaries/"$MVN"-bin.tar.gz

--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -25,7 +25,7 @@ stages:
           - task: Maven@3
             displayName: "Build binaries with Maven"
             inputs:
-              mavenPomFile: "pom.xml"
+              mavenPomFile: "core/pom.xml"
               options:
                 "clean package --batch-mode --quiet -DskipTests -P build-web-console,build-binaries -Dhttp.keepAlive=false"
               jdkVersionOption: 1.11

--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -15,9 +15,6 @@ stages:
     jobs:
       - job: BuildOnLinux
         displayName: "Build on Linux"
-        container:
-          image: adoptopenjdk/openjdk11:centos
-          options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
         pool:
           vmImage: "ubuntu-latest"
         steps:
@@ -25,18 +22,15 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
+          - task: Maven@3
+            displayName: "Build binaries with Maven"
+            inputs:
+              mavenPomFile: "pom.xml"
+              options:
+                "clean package --batch-mode --quiet -DskipTests -P build-web-console,build-binaries -Dhttp.keepAlive=false"
+              jdkVersionOption: 1.11
           - bash: |
-              yum -y install git
-
-              cd /tmp
-              curl -q -O https://mirrors.ukfast.co.uk/sites/ftp.apache.org/maven/maven-3/"$MVN_VERSION"/binaries/"$MVN"-bin.tar.gz
-              tar xf "$MVN"-bin.tar.gz
-
-              cd "$HOME"
-
               cd "$(Build.SourcesDirectory)"/core
-              /tmp/"$MVN"/bin/mvn clean package --batch-mode --quiet -DskipTests -P build-web-console,build-binaries
-
               find target \( -name "*rt-linux*.tar.gz" -o -name "*no-jre*.tar.gz" \) -exec mv '{}' "$(Build.BinariesDirectory)"/ \;
             displayName: "Build snapshot"
           - task: PublishBuildArtifacts@1
@@ -44,6 +38,7 @@ stages:
             inputs:
               artifactName: Snapshot
               pathtoPublish: $(Build.BinariesDirectory)
+
       - job: UploadToS3
         dependsOn: BuildOnLinux
         condition: succeeded()

--- a/ci/templates/hosted-cover-jobs.yml
+++ b/ci/templates/hosted-cover-jobs.yml
@@ -10,6 +10,8 @@ jobs:
           jdk: "1.11"
           testset: "coverage"
           includeTests: "griffin.**.*?"
+          javadoc_step: ""
+          javadoc_profile: ""
         linux-cairo:
           imageName: "ubuntu-latest"
           poolName: "Azure Pipelines"
@@ -17,6 +19,8 @@ jobs:
           jdk: "1.11"
           testset: "coverage"
           includeTests: "cairo.**.*?"
+          javadoc_step: ""
+          javadoc_profile: ""
         linux-other:
           imageName: "ubuntu-latest"
           poolName: "Azure Pipelines"
@@ -24,6 +28,8 @@ jobs:
           jdk: "1.11"
           testset: "coverage"
           excludeTests: "**/griffin/**,**/cairo/**"
+          javadoc_step: ""
+          javadoc_profile: ""
     pool:
       vmImage: $(imageName)
       name: $(poolName)

--- a/ci/templates/self-hosted-jobs.yml
+++ b/ci/templates/self-hosted-jobs.yml
@@ -19,5 +19,7 @@ jobs:
       ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
       os: Linux
       jdk: "1.11"
+      javadoc_step: ""
+      javadoc_profile: ""
     steps:
       - template: steps.yml


### PR DESCRIPTION
Fixes pipeline `snaphost-pipeline.yml` which is triggered on master commit to produce snapshot binaries.

Fixed run https://dev.azure.com/questdb/questdb/_build/results?buildId=13879&view=results