### PR TITLE
chore(wal): make WalTableListFunctionFactory reusable

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/WalTableListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/WalTableListFunctionFactory.java
@@ -117,6 +117,7 @@ public class WalTableListFunctionFactory implements FunctionFactory {
 
             @Override
             public void close() {
+                tableIndex = -1;
                 txReader.close();
             }
 


### PR DESCRIPTION
`WalTableListFunctionFactory` could be cached in QueryCache and reused.
Its state was not reset properly, adding a small fix.