### PR TITLE
chore(sql): fix broken test in line tcp/udp

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpPartitionReadOnlyTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpPartitionReadOnlyTest.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.line.AbstractLinePartitionReadOnlyTest;
-import io.questdb.cutlass.line.LineTcpSender;
 import io.questdb.cutlass.line.LineUdpSender;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContext;
@@ -152,7 +151,7 @@ public class LineUdpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
                 tableName,
                 () -> {
                     long[] timestampNano = {firstPartitionTs, secondPartitionTs, thirdPartitionTs, lastPartitionTs};
-                    try (LineTcpSender sender = LineTcpSender.newSender(Net.parseIPv4("127.0.0.1"), ILP_PORT, ILP_BUFFER_SIZE)) {
+                    try (LineUdpSender sender = new LineUdpSender(NetworkFacadeImpl.INSTANCE, 0, Net.parseIPv4("127.0.0.1"), ILP_PORT, 200, 1)) {
                         for (int tick = 0; tick < numEvents; tick++) {
                             int tickerId = tick % timestampNano.length;
                             timestampNano[tickerId] += lineTsStep;
@@ -185,9 +184,8 @@ public class LineUdpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
         assertMemoryLeak(() -> {
             try (
                     ServerMain qdb = new ServerMain("-d", root.toString(), Bootstrap.SWITCH_USE_DEFAULT_LOG_FACTORY_CONFIGURATION);
-                    CairoEngine engine = qdb.getCairoEngine();
-                    SqlCompiler compiler = new SqlCompiler(engine);
-                    SqlExecutionContext context = new SqlExecutionContextImpl(engine, 1).with(
+                    SqlCompiler compiler = new SqlCompiler(qdb.getCairoEngine());
+                    SqlExecutionContext context = new SqlExecutionContextImpl(qdb.getCairoEngine(), 1).with(
                             AllowAllCairoSecurityContext.INSTANCE,
                             null,
                             null,
@@ -195,6 +193,7 @@ public class LineUdpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
                             null)
             ) {
                 qdb.start();
+                CairoEngine engine = qdb.getCairoEngine();
 
                 // create a table with 4 partitions and 1111 rows
                 CairoConfiguration cairoConfig = qdb.getConfiguration().getCairoConfiguration();
@@ -214,6 +213,7 @@ public class LineUdpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
                     compiler.compile(insertFromSelectPopulateTableStmt(tableModel, 1111, firstPartitionName, 4), context);
                     engine.unlockTableName(tableToken);
                 }
+                Assert.assertNotNull(tableToken);
 
                 // set partition read-only state
                 final long[] partitionSizes = new long[partitionIsReadOnly.length];

--- a/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpPartitionReadOnlyTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/udp/LineUdpPartitionReadOnlyTest.java
@@ -208,6 +208,7 @@ public class LineUdpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
                         Path path = new Path().of(cairoConfig.getRoot())
                 ) {
                     tableToken = engine.lockTableName(tableName, 1, false);
+                    Assert.assertNotNull(tableToken);
                     engine.registerTableToken(tableToken);
                     createTable(cairoConfig, mem, path.concat(tableToken), tableModel, 1, tableToken.getDirName());
                     compiler.compile(insertFromSelectPopulateTableStmt(tableModel, 1111, firstPartitionName, 4), context);


### PR DESCRIPTION
```
2023-01-18T20:38:51.286550Z I i.q.c.TableReader open partition C:\Users\Vlad\AppData\Local\Temp\junit7611706806071924635\0e7e9312-4c08-4131-a7c2-2fd4667d336a\db\testTableIsReadOnlyTCP\2022-12-11 [rowCount=278, partitionNameTxn=-1, transientRowCount=278, partitionIndex=3, partitionCount=4]
2023-01-18T20:38:51.289596Z I i.q.c.l.t.PlainTcpLineChannel Send buffer size change from 65536 to 8192
2023-01-18T20:38:51.300230Z I tcp-line-server connected [ip=127.0.0.1, fd=2600]
2023-01-18T20:38:51.300879Z I i.q.c.p.AbstractMultiTenantPool closed 'testTableIsReadOnlyTCP' [at=0:0, reason=POOL_CLOSED]
2023-01-18T20:38:51.300978Z I i.q.c.p.AbstractMultiTenantPool open 'testTableIsReadOnlyTCP' [at=0:0]
2023-01-18T20:38:51.302760Z I i.q.g.SqlCompiler plan [q=`select-group-by min(ts) min, max(ts) max, count() count from (select [ts] from testTableIsReadOnlyTCP timestamp (ts)) sample by 1d align to calendar with offset '00:00'`, fd=-1]
2023-01-18T20:38:51.304010Z I i.q.c.TableReader open partition C:\Users\Vlad\AppData\Local\Temp\junit7611706806071924635\0e7e9312-4c08-4131-a7c2-2fd4667d336a\db\testTableIsReadOnlyTCP\2022-12-08 [rowCount=277, partitionNameTxn=-1, transientRowCount=278, partitionIndex=0, partitionCount=4]
2023-01-18T20:38:51.304492Z I i.q.c.TableReader open partition C:\Users\Vlad\AppData\Local\Temp\junit7611706806071924635\0e7e9312-4c08-4131-a7c2-2fd4667d336a\db\testTableIsReadOnlyTCP\2022-12-09 [rowCount=278, partitionNameTxn=-1, transientRowCount=278, partitionIndex=1, partitionCount=4]
2023-01-18T20:38:51.304907Z I i.q.c.TableReader open partition C:\Users\Vlad\AppData\Local\Temp\junit7611706806071924635\0e7e9312-4c08-4131-a7c2-2fd4667d336a\db\testTableIsReadOnlyTCP\2022-12-10 [rowCount=278, partitionNameTxn=-1, transientRowCount=278, partitionIndex=2, partitionCount=4]
2023-01-18T20:38:51.305263Z I i.q.c.TableReader open partition C:\Users\Vlad\AppData\Local\Temp\junit7611706806071924635\0e7e9312-4c08-4131-a7c2-2fd4667d336a\db\testTableIsReadOnlyTCP\2022-12-11 [rowCount=278, partitionNameTxn=-1, transientRowCount=278, partitionIndex=3, partitionCount=4]
2023-01-18T20:38:51.305763Z I i.q.c.p.WriterPool closed
2023-01-18T20:38:51.306354Z I i.q.c.p.AbstractMultiTenantPool closed 'testTableIsReadOnlyTCP' [at=0:0, reason=POOL_CLOSED]
2023-01-18T20:38:51.306389Z I i.q.c.p.AbstractMultiTenantPool closed
2023-01-18T20:38:51.306414Z I i.q.c.p.AbstractMultiTenantPool closed
2023-01-18T20:38:51.306432Z I i.q.c.p.AbstractMultiTenantPool closed
closed: io.questdb.cairo.CairoEngine@7c56e013
2023-01-18T20:38:51.308154Z I i.q.WorkerPoolManager closing dedicated pool [name=http, workers=1]
2023-01-18T20:38:51.309474Z I i.q.c.l.t.LineTcpMeasurementScheduler creating table [tableName=testTableIsReadOnlyTCP]
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x000001c06b153bc2, pid=18816, tid=14200
#
# JRE version: OpenJDK Runtime Environment Corretto-17.0.5.8.1 (17.0.5+8) (build 17.0.5+8-LTS)
# Java VM: OpenJDK 64-Bit Server VM Corretto-17.0.5.8.1 (17.0.5+8-LTS, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, windows-amd64)
# Problematic frame:
# J 2514 c1 sun.misc.Unsafe.getLong(J)J jdk.unsupported@17.0.5 (8 bytes) @ 0x000001c06b153bc2 [0x000001c06b153b20+0x00000000000000a2]
#
# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
#
# An error report file with more information is saved as:
# C:\Users\Vlad\dev\questdb\core\hs_err_pid18816.log
Compiled method (c1)    1653 2514       3       sun.misc.Unsafe::getLong (8 bytes)
 total in heap  [0x000001c06b153990,0x000001c06b153d28] = 920
 relocation     [0x000001c06b153ae8,0x000001c06b153b20] = 56
 main code      [0x000001c06b153b20,0x000001c06b153c60] = 320
 stub code      [0x000001c06b153c60,0x000001c06b153c98] = 56
```