### PR TITLE
chore(wal): fix truncate operation recording in WAL-E

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -360,8 +360,13 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                     processWalSql(writer, sqlInfo, operationCompiler, seqTxn);
                     break;
                 case TRUNCATE:
+                    long txn = writer.getTxn();
                     writer.setSeqTxn(seqTxn);
                     writer.removeAllPartitions();
+                    if (writer.getTxn() == txn) {
+                        // force mark the transaction as applied
+                        writer.markSeqTxnCommitted(seqTxn);
+                    }
                     break;
                 default:
                     throw new UnsupportedOperationException("Unsupported WAL txn type: " + walTxnType);

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriterEvents.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriterEvents.java
@@ -246,6 +246,7 @@ class WalWriterEvents implements Closeable {
         eventMem.putByte(WalTxnType.TRUNCATE);
         eventMem.putInt(startOffset, (int) (eventMem.getAppendOffset() - startOffset));
         eventMem.putInt(-1);
+        eventMem.putLong(WALE_SIZE_OFFSET, eventMem.getAppendOffset());
         return txn++;
     }
 }

--- a/core/src/test/java/io/questdb/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/griffin/wal/WalTableSqlTest.java
@@ -761,6 +761,24 @@ public class WalTableSqlTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testEmptyTruncate() throws Exception {
+        assertMemoryLeak(() -> {
+            String tableName = testName.getMethodName();
+            compile("create table " + tableName + " (" +
+                    "A INT," +
+                    "ts TIMESTAMP)" +
+                    " timestamp(ts) partition by DAY WAL");
+
+            compile("truncate table " + tableName);
+
+            drainWalQueue();
+
+            assertSql("wal_tables()", "name\tsuspended\twriterTxn\tsequencerTxn\n" +
+                    "testEmptyTruncate\tfalse\t1\t1\n");
+        });
+    }
+
+    @Test
     public void testInsertManyThenDrop() throws Exception {
         assertMemoryLeak(ff, () -> {
             String tableName = testName.getMethodName();


### PR DESCRIPTION
Truncate transaction in WAL-E to update the file size in the header.
Fixes #2925