### PR TITLE
chore(core): add WAL writer metrics

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.pool;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.TableToken;
@@ -46,7 +47,7 @@ public class WalWriterPool extends AbstractMultiTenantPool<WalWriterPool.WalWrit
 
     @Override
     protected WalWriterTenant newTenant(TableToken tableToken, Entry<WalWriterTenant> entry, int index) {
-        return new WalWriterTenant(this, entry, index, tableToken, engine.getTableSequencerAPI());
+        return new WalWriterTenant(this, entry, index, tableToken, engine.getTableSequencerAPI(), engine.getMetrics());
     }
 
     public static class WalWriterTenant extends WalWriter implements PoolTenant {
@@ -59,9 +60,10 @@ public class WalWriterPool extends AbstractMultiTenantPool<WalWriterPool.WalWrit
                 Entry<WalWriterTenant> entry,
                 int index,
                 TableToken tableToken,
-                TableSequencerAPI tableSequencerAPI
+                TableSequencerAPI tableSequencerAPI,
+                Metrics metrics
         ) {
-            super(pool.getConfiguration(), tableToken, tableSequencerAPI);
+            super(pool.getConfiguration(), tableToken, tableSequencerAPI, metrics);
             this.pool = pool;
             this.entry = entry;
             this.index = index;

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -378,12 +378,13 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                             );
 
                             if (added > -1L) {
-                                insertTimespan += microClock.getTicks() - start;
+                                long timeDelta = microClock.getTicks() - start;
+                                insertTimespan += timeDelta;
                                 rowsAdded += added;
                                 iTransaction++;
                                 long physicallyWrittenRowsSinceLastCommit = writer.getPhysicallyWrittenRowsSinceLastCommit();
                                 physicalRowsAdded += physicallyWrittenRowsSinceLastCommit;
-                                metrics.addApplyRowsWritten(added, physicallyWrittenRowsSinceLastCommit);
+                                metrics.addApplyRowsWritten(added, physicallyWrittenRowsSinceLastCommit, timeDelta);
                             }
                             if (added == -2L || isTerminating) {
                                 // transaction cursor goes beyond prepared transactionMeta or termination requested. Re-run the loop.

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -36,8 +36,8 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.AbstractQueueConsumerJob;
 import io.questdb.mp.Job;
-import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.*;
+import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.str.Path;
 import io.questdb.tasks.WalTxnNotificationTask;
 import org.jetbrains.annotations.Nullable;
@@ -384,7 +384,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                                 iTransaction++;
                                 long physicallyWrittenRowsSinceLastCommit = writer.getPhysicallyWrittenRowsSinceLastCommit();
                                 physicalRowsAdded += physicallyWrittenRowsSinceLastCommit;
-                                metrics.addRowsWritten(added, physicallyWrittenRowsSinceLastCommit, timeDelta);
+                                metrics.addApplyRowsWritten(added, physicallyWrittenRowsSinceLastCommit, timeDelta);
                             }
                             if (added == -2L || isTerminating) {
                                 // transaction cursor goes beyond prepared transactionMeta or termination requested. Re-run the loop.

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -378,13 +378,12 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                             );
 
                             if (added > -1L) {
-                                long timeDelta = microClock.getTicks() - start;
-                                insertTimespan += timeDelta;
+                                insertTimespan += microClock.getTicks() - start;
                                 rowsAdded += added;
                                 iTransaction++;
                                 long physicallyWrittenRowsSinceLastCommit = writer.getPhysicallyWrittenRowsSinceLastCommit();
                                 physicalRowsAdded += physicallyWrittenRowsSinceLastCommit;
-                                metrics.addApplyRowsWritten(added, physicallyWrittenRowsSinceLastCommit, timeDelta);
+                                metrics.addApplyRowsWritten(added, physicallyWrittenRowsSinceLastCommit);
                             }
                             if (added == -2L || isTerminating) {
                                 // transaction cursor goes beyond prepared transactionMeta or termination requested. Re-run the loop.

--- a/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
@@ -25,33 +25,25 @@
 package io.questdb.cairo.wal;
 
 import io.questdb.metrics.Counter;
-import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 public class WalMetrics {
-    private final Counter physicallyWrittenRowsCounter;
-    private final LongGauge rowsWriteRateGauge;
+    private final Counter applyPhysicallyWrittenRowsCounter;
+    private final Counter applyRowsWrittenCounter;
     private final Counter rowsWrittenCounter;
-    private final AtomicLong totalRowsWritten;
-    private final AtomicLong totalRowsWrittenTotalTime;
 
     public WalMetrics(MetricsRegistry metricsRegistry) {
-        this.physicallyWrittenRowsCounter = metricsRegistry.newCounter("wal_apply_physically_written_rows");
-        this.rowsWrittenCounter = metricsRegistry.newCounter("wal_apply_written_rows");
-        this.rowsWriteRateGauge = metricsRegistry.newLongGauge("wal_apply_rows_per_second");
-
-        this.totalRowsWrittenTotalTime = new AtomicLong();
-        this.totalRowsWritten = new AtomicLong();
+        this.applyPhysicallyWrittenRowsCounter = metricsRegistry.newCounter("wal_apply_physically_written_rows");
+        this.applyRowsWrittenCounter = metricsRegistry.newCounter("wal_apply_written_rows");
+        this.rowsWrittenCounter = metricsRegistry.newCounter("wal_written_rows");
     }
 
-    public void addRowsWritten(long rows, long physicallyWrittenRows, long timeMicros) {
-        rowsWrittenCounter.add(rows);
-        physicallyWrittenRowsCounter.add(physicallyWrittenRows);
+    public void addApplyRowsWritten(long rows, long physicallyWrittenRows) {
+        applyRowsWrittenCounter.add(rows);
+        applyPhysicallyWrittenRowsCounter.add(physicallyWrittenRows);
+    }
 
-        long totalRows = totalRowsWritten.addAndGet(rows);
-        long rowsAppendRate = totalRows * 1000_000L / Math.max(1, totalRowsWrittenTotalTime.addAndGet(timeMicros));
-        rowsWriteRateGauge.setValue(rowsAppendRate);
+    public void addRowsWritten(long rows) {
+        rowsWrittenCounter.add(rows);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
@@ -25,22 +25,33 @@
 package io.questdb.cairo.wal;
 
 import io.questdb.metrics.Counter;
+import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 public class WalMetrics {
     private final Counter applyPhysicallyWrittenRowsCounter;
+    private final LongGauge applyRowsWriteRateGauge;
     private final Counter applyRowsWrittenCounter;
     private final Counter rowsWrittenCounter;
+    private final AtomicLong totalRowsWritten = new AtomicLong();
+    private final AtomicLong totalRowsWrittenTotalTime = new AtomicLong();
 
     public WalMetrics(MetricsRegistry metricsRegistry) {
         this.applyPhysicallyWrittenRowsCounter = metricsRegistry.newCounter("wal_apply_physically_written_rows");
         this.applyRowsWrittenCounter = metricsRegistry.newCounter("wal_apply_written_rows");
+        this.applyRowsWriteRateGauge = metricsRegistry.newLongGauge("wal_apply_rows_per_second");
         this.rowsWrittenCounter = metricsRegistry.newCounter("wal_written_rows");
     }
 
-    public void addApplyRowsWritten(long rows, long physicallyWrittenRows) {
+    public void addApplyRowsWritten(long rows, long physicallyWrittenRows, long timeMicros) {
         applyRowsWrittenCounter.add(rows);
         applyPhysicallyWrittenRowsCounter.add(physicallyWrittenRows);
+
+        long totalRows = totalRowsWritten.addAndGet(rows);
+        long rowsAppendRate = totalRows * 1_000_000L / Math.max(1, totalRowsWrittenTotalTime.addAndGet(timeMicros));
+        applyRowsWriteRateGauge.setValue(rowsAppendRate);
     }
 
     public void addRowsWritten(long rows) {

--- a/core/src/main/resources/io/questdb/site/conf/log.conf
+++ b/core/src/main/resources/io/questdb/site/conf/log.conf
@@ -13,6 +13,7 @@ writers=file,stdout,http.min
 #w.file.level=INFO,ERROR
 #rollEvery accepts: day, hour, minute, month
 #w.file.rollEvery=day
+#rollSize specifies size at which to roll a new log file: a number followed by k, m, g (KB, MB, GB respectively)
 #w.file.rollSize=128m
 #lifeDuration accepts: a number followed by s, m, h, d, w, M, y for seconds, minutes, hours, etc.  
 #w.file.lifeDuration=1d


### PR DESCRIPTION
Also removes `wal_apply_rows_per_second` metric as it's trivial to configure Grafana to calculate it based on `wal_apply_written_rows`.

