### PR TITLE
fix(core): fix server start failure with sql syntax error in logs

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -41,7 +41,9 @@ import io.questdb.cutlass.text.TextImportExecutionContext;
 import io.questdb.griffin.DatabaseSnapshotAgent;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.mp.*;
+import io.questdb.mp.Job;
+import io.questdb.mp.Sequence;
+import io.questdb.mp.SynchronizedJob;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.str.Path;
@@ -96,8 +98,8 @@ public class CairoEngine implements Closeable, WriterSource {
         this.metadataPool = new MetadataPool(configuration, this);
         this.walWriterPool = new WalWriterPool(configuration, this);
         this.engineMaintenanceJob = new EngineMaintenanceJob(configuration);
-        this.telemetry = new Telemetry<>(TelemetryTask.TYPE, configuration);
-        this.telemetryWal = new Telemetry<>(TelemetryWalTask.TYPE, configuration);
+        this.telemetry = new Telemetry<>(TelemetryTask.TELEMETERY, configuration);
+        this.telemetryWal = new Telemetry<>(TelemetryWalTask.WAL_TELEMTRY, configuration);
         this.tableIdGenerator = new IDGenerator(configuration, TableUtils.TAB_INDEX_FILE_NAME);
         try {
             this.tableIdGenerator.open();

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -98,8 +98,8 @@ public class CairoEngine implements Closeable, WriterSource {
         this.metadataPool = new MetadataPool(configuration, this);
         this.walWriterPool = new WalWriterPool(configuration, this);
         this.engineMaintenanceJob = new EngineMaintenanceJob(configuration);
-        this.telemetry = new Telemetry<>(TelemetryTask.TELEMETERY, configuration);
-        this.telemetryWal = new Telemetry<>(TelemetryWalTask.WAL_TELEMTRY, configuration);
+        this.telemetry = new Telemetry<>(TelemetryTask.TELEMETRY, configuration);
+        this.telemetryWal = new Telemetry<>(TelemetryWalTask.WAL_TELEMETRY, configuration);
         this.tableIdGenerator = new IDGenerator(configuration, TableUtils.TAB_INDEX_FILE_NAME);
         try {
             this.tableIdGenerator.open();

--- a/core/src/main/java/io/questdb/tasks/TelemetryTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryTask.java
@@ -40,7 +40,7 @@ public class TelemetryTask implements AbstractTelemetryTask {
     public static final Telemetry.TelemetryTypeBuilder<TelemetryTask> TELEMETRY = new Telemetry.TelemetryTypeBuilder<TelemetryTask>() {
         @Override
         public Telemetry.TelemetryType<TelemetryTask> build(CairoConfiguration configuration) {
-            return new Telemetry.TelemetryType<>() {
+            return new Telemetry.TelemetryType<TelemetryTask>() {
                 private final TelemetryTask systemStatusTask = new TelemetryTask();
 
                 @Override

--- a/core/src/main/java/io/questdb/tasks/TelemetryTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryTask.java
@@ -26,6 +26,7 @@ package io.questdb.tasks;
 
 import io.questdb.Telemetry;
 import io.questdb.TelemetryOrigin;
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableWriter;
 import io.questdb.log.Log;
@@ -36,9 +37,44 @@ public class TelemetryTask implements AbstractTelemetryTask {
     public static final String TABLE_NAME = "telemetry";
 
     private static final Log LOG = LogFactory.getLog(TelemetryTask.class);
+    public static final Telemetry.TelemetryTypeBuilder<TelemetryTask> TELEMETRY = new Telemetry.TelemetryTypeBuilder<TelemetryTask>() {
+        @Override
+        public Telemetry.TelemetryType<TelemetryTask> build(CairoConfiguration configuration) {
+            return new Telemetry.TelemetryType<>() {
+                private final TelemetryTask systemStatusTask = new TelemetryTask();
 
-    private short origin;
+                @Override
+                public String getCreateSql() {
+                    // Telemetry table will not have sys. prefix for compatibility.
+                    return "CREATE TABLE IF NOT EXISTS \"" + TABLE_NAME + "\" (" +
+                            "created timestamp, " +
+                            "event short, " +
+                            "origin short" +
+                            ") timestamp(created)";
+                }
+
+                @Override
+                public String getTableName() {
+                    return TABLE_NAME;
+                }
+
+                @Override
+                public ObjectFactory<TelemetryTask> getTaskFactory() {
+                    return TelemetryTask::new;
+                }
+
+                @Override
+                public void logStatus(TableWriter writer, short systemStatus, long micros) {
+                    systemStatusTask.origin = TelemetryOrigin.INTERNAL;
+                    systemStatusTask.event = systemStatus;
+                    systemStatusTask.writeTo(writer, micros);
+                    writer.commit();
+                }
+            };
+        }
+    };
     private short event;
+    private short origin;
 
     private TelemetryTask() {
     }
@@ -65,36 +101,4 @@ public class TelemetryTask implements AbstractTelemetryTask {
                     .$(']').$();
         }
     }
-
-    public static final Telemetry.TelemetryTypeBuilder<TelemetryTask> TELEMETERY = configuration -> new Telemetry.TelemetryType<>() {
-        private final TelemetryTask systemStatusTask = new TelemetryTask();
-
-        @Override
-        public String getCreateSql() {
-            // Telemetry table will not have sys. prefix for compatibility.
-            return "CREATE TABLE IF NOT EXISTS \"" + TABLE_NAME + "\" (" +
-                    "created timestamp, " +
-                    "event short, " +
-                    "origin short" +
-                    ") timestamp(created)";
-        }
-
-        @Override
-        public String getTableName() {
-            return TABLE_NAME;
-        }
-
-        @Override
-        public ObjectFactory<TelemetryTask> getTaskFactory() {
-            return TelemetryTask::new;
-        }
-
-        @Override
-        public void logStatus(TableWriter writer, short systemStatus, long micros) {
-            systemStatusTask.origin = TelemetryOrigin.INTERNAL;
-            systemStatusTask.event = systemStatus;
-            systemStatusTask.writeTo(writer, micros);
-            writer.commit();
-        }
-    };
 }

--- a/core/src/main/java/io/questdb/tasks/TelemetryTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryTask.java
@@ -66,21 +66,22 @@ public class TelemetryTask implements AbstractTelemetryTask {
         }
     }
 
-    public static final Telemetry.TelemetryType<TelemetryTask> TYPE = new Telemetry.TelemetryType<TelemetryTask>() {
+    public static final Telemetry.TelemetryTypeBuilder<TelemetryTask> TELEMETERY = configuration -> new Telemetry.TelemetryType<>() {
         private final TelemetryTask systemStatusTask = new TelemetryTask();
 
         @Override
-        public String getTableName() {
-            return TABLE_NAME;
-        }
-
-        @Override
-        public String getCreateSql(CharSequence prefix) {
-            return "CREATE TABLE IF NOT EXISTS " + prefix + TABLE_NAME + " (" +
+        public String getCreateSql() {
+            // Telemetry table will not have sys. prefix for compatibility.
+            return "CREATE TABLE IF NOT EXISTS \"" + TABLE_NAME + "\" (" +
                     "created timestamp, " +
                     "event short, " +
                     "origin short" +
                     ") timestamp(created)";
+        }
+
+        @Override
+        public String getTableName() {
+            return TABLE_NAME;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
@@ -39,7 +39,7 @@ public class TelemetryWalTask implements AbstractTelemetryTask {
         @Override
         public Telemetry.TelemetryType<TelemetryWalTask> build(CairoConfiguration configuration) {
             String tableName = configuration.getSystemTableNamePrefix() + TABLE_NAME;
-            return new Telemetry.TelemetryType<>() {
+            return new Telemetry.TelemetryType<TelemetryWalTask>() {
                 @Override
                 public String getCreateSql() {
                     return "CREATE TABLE IF NOT EXISTS \"" + tableName + "\" (" +

--- a/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
@@ -34,16 +34,42 @@ import org.jetbrains.annotations.NotNull;
 
 public class TelemetryWalTask implements AbstractTelemetryTask {
     public static final String TABLE_NAME = "telemetry_wal";
+    public static final Telemetry.TelemetryTypeBuilder<TelemetryWalTask> WAL_TELEMTRY = configuration -> {
+        String tableName = configuration.getSystemTableNamePrefix() + TABLE_NAME;
+        return new Telemetry.TelemetryType<>() {
+            @Override
+            public String getCreateSql() {
+                return "CREATE TABLE IF NOT EXISTS \"" + tableName + "\" (" +
+                        "created timestamp, " +
+                        "event short, " +
+                        "tableId int, " +
+                        "walId int, " +
+                        "seqTxn long, " +
+                        "rowCount long," +
+                        "physicalRowCount long," +
+                        "latency float" +
+                        ") timestamp(created) partition by MONTH BYPASS WAL";
+            }
 
+            @Override
+            public String getTableName() {
+                return tableName;
+            }
+
+            @Override
+            public ObjectFactory<TelemetryWalTask> getTaskFactory() {
+                return TelemetryWalTask::new;
+            }
+        };
+    };
     private static final Log LOG = LogFactory.getLog(TelemetryWalTask.class);
-
     private short event;
+    private float latency; // millis
+    private long physicalRowCount;
+    private long rowCount;
+    private long seqTxn;
     private int tableId;
     private int walId;
-    private long seqTxn;
-    private long rowCount;
-    private long physicalRowCount;
-    private float latency; // millis
 
     private TelemetryWalTask() {
     }
@@ -80,30 +106,4 @@ public class TelemetryWalTask implements AbstractTelemetryTask {
                     .$(']').$();
         }
     }
-
-    public static final Telemetry.TelemetryType<TelemetryWalTask> TYPE = new Telemetry.TelemetryType<TelemetryWalTask>() {
-        @Override
-        public String getTableName() {
-            return TABLE_NAME;
-        }
-
-        @Override
-        public String getCreateSql(CharSequence prefix) {
-            return "CREATE TABLE IF NOT EXISTS " + prefix + TABLE_NAME + " (" +
-                    "created timestamp, " +
-                    "event short, " +
-                    "tableId int, " +
-                    "walId int, " +
-                    "seqTxn long, " +
-                    "rowCount long," +
-                    "physicalRowCount long," +
-                    "latency float" +
-                    ") timestamp(created) partition by MONTH BYPASS WAL";
-        }
-
-        @Override
-        public ObjectFactory<TelemetryWalTask> getTaskFactory() {
-            return TelemetryWalTask::new;
-        }
-    };
 }

--- a/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
+++ b/core/src/main/java/io/questdb/tasks/TelemetryWalTask.java
@@ -25,6 +25,7 @@
 package io.questdb.tasks;
 
 import io.questdb.Telemetry;
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableWriter;
 import io.questdb.log.Log;
@@ -34,33 +35,36 @@ import org.jetbrains.annotations.NotNull;
 
 public class TelemetryWalTask implements AbstractTelemetryTask {
     public static final String TABLE_NAME = "telemetry_wal";
-    public static final Telemetry.TelemetryTypeBuilder<TelemetryWalTask> WAL_TELEMTRY = configuration -> {
-        String tableName = configuration.getSystemTableNamePrefix() + TABLE_NAME;
-        return new Telemetry.TelemetryType<>() {
-            @Override
-            public String getCreateSql() {
-                return "CREATE TABLE IF NOT EXISTS \"" + tableName + "\" (" +
-                        "created timestamp, " +
-                        "event short, " +
-                        "tableId int, " +
-                        "walId int, " +
-                        "seqTxn long, " +
-                        "rowCount long," +
-                        "physicalRowCount long," +
-                        "latency float" +
-                        ") timestamp(created) partition by MONTH BYPASS WAL";
-            }
+    public static final Telemetry.TelemetryTypeBuilder<TelemetryWalTask> WAL_TELEMETRY = new Telemetry.TelemetryTypeBuilder<TelemetryWalTask>() {
+        @Override
+        public Telemetry.TelemetryType<TelemetryWalTask> build(CairoConfiguration configuration) {
+            String tableName = configuration.getSystemTableNamePrefix() + TABLE_NAME;
+            return new Telemetry.TelemetryType<>() {
+                @Override
+                public String getCreateSql() {
+                    return "CREATE TABLE IF NOT EXISTS \"" + tableName + "\" (" +
+                            "created timestamp, " +
+                            "event short, " +
+                            "tableId int, " +
+                            "walId int, " +
+                            "seqTxn long, " +
+                            "rowCount long," +
+                            "physicalRowCount long," +
+                            "latency float" +
+                            ") timestamp(created) partition by MONTH BYPASS WAL";
+                }
 
-            @Override
-            public String getTableName() {
-                return tableName;
-            }
+                @Override
+                public String getTableName() {
+                    return tableName;
+                }
 
-            @Override
-            public ObjectFactory<TelemetryWalTask> getTaskFactory() {
-                return TelemetryWalTask::new;
-            }
-        };
+                @Override
+                public ObjectFactory<TelemetryWalTask> getTaskFactory() {
+                    return TelemetryWalTask::new;
+                }
+            };
+        }
     };
     private static final Log LOG = LogFactory.getLog(TelemetryWalTask.class);
     private short event;

--- a/core/src/test/java/io/questdb/TelemetryTest.java
+++ b/core/src/test/java/io/questdb/TelemetryTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class TelemetryTest extends AbstractCairoTest {
     private final static FilesFacade FF = TestFilesFacadeImpl.INSTANCE;
-    private final static String TELEMETRY = configuration.getSystemTableNamePrefix() + TelemetryTask.TABLE_NAME;
+    private final static String TELEMETRY = TelemetryTask.TABLE_NAME;
 
     @Test
     public void testTelemetryCanDeleteTableWhenDisabled() throws Exception {

--- a/core/src/test/java/io/questdb/cairo/DefaultTestCairoConfiguration.java
+++ b/core/src/test/java/io/questdb/cairo/DefaultTestCairoConfiguration.java
@@ -57,4 +57,9 @@ public class DefaultTestCairoConfiguration extends DefaultCairoConfiguration {
     public boolean mangleTableDirNames() {
         return true;
     }
+
+    @Override
+    public CharSequence getSystemTableNamePrefix() {
+        return "sys.";
+    }
 }

--- a/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/cutlass/http/IODispatcherTest.java
@@ -7689,9 +7689,9 @@ public class IODispatcherTest {
         final String baseDir = temp.getRoot().getAbsolutePath();
         DefaultCairoConfiguration configuration = new DefaultTestCairoConfiguration(baseDir);
 
-        String telemetry = configuration.getSystemTableNamePrefix() + TelemetryTask.TABLE_NAME;
-        TableToken tememetryTableName = new TableToken(telemetry, telemetry, 0, false);
-        try (TableReader reader = new TableReader(configuration, tememetryTableName)) {
+        String telemetry = TelemetryTask.TABLE_NAME;
+        TableToken telemetryTableName = new TableToken(telemetry, telemetry, 0, false);
+        try (TableReader reader = new TableReader(configuration, telemetryTableName)) {
             final StringSink sink = new StringSink();
             sink.clear();
             printer.printFullColumn(reader.getCursor(), reader.getMetadata(), index, false, sink);

--- a/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/cutlass/text/ParallelCsvFileImporterTest.java
@@ -2717,7 +2717,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
 
     private void testStatusLogCleanup(int daysToKeep) throws SqlException {
         String backlogTableName = configuration.getSystemTableNamePrefix() + "text_import_log";
-        compiler.compile("create table " + backlogTableName + " as " +
+        compiler.compile("create table \"" + backlogTableName + "\" as " +
                 "(" +
                 "select" +
                 " timestamp_sequence(0, 100000000000) ts," +
@@ -2741,7 +2741,7 @@ public class ParallelCsvFileImporterTest extends AbstractGriffinTest {
                 false,
                 true
         );
-        compiler.compile("drop table " + backlogTableName, sqlExecutionContext);
+        compiler.compile("drop table \"" + backlogTableName + "\"", sqlExecutionContext);
     }
 
     static IndexChunk chunk(String path, long... data) {

--- a/core/src/test/java/io/questdb/griffin/CopyTest.java
+++ b/core/src/test/java/io/questdb/griffin/CopyTest.java
@@ -1122,7 +1122,7 @@ public class CopyTest extends AbstractGriffinTest {
         assertMemoryLeak(() -> {
             CountDownLatch processed = new CountDownLatch(1);
 
-            compiler.compile("drop table if exists " + configuration.getSystemTableNamePrefix() + "text_import_log", sqlExecutionContext);
+            compiler.compile("drop table if exists \"" + configuration.getSystemTableNamePrefix() + "text_import_log\"", sqlExecutionContext);
             try (TextImportRequestJob processingJob = new TextImportRequestJob(engine, 1, null)) {
 
                 Thread processingThread = createJobThread(processingJob, processed);

--- a/core/src/test/java/io/questdb/griffin/wal/WalTelemetryTest.java
+++ b/core/src/test/java/io/questdb/griffin/wal/WalTelemetryTest.java
@@ -79,7 +79,7 @@ public class WalTelemetryTest extends AbstractGriffinTest {
                     "1970-01-01T00:00:00.004000Z\t103\t4\t1\t2\t-1\t-1\t1.0000\n" +
                     "1970-01-01T00:00:00.004000Z\t105\t4\t1\t2\t6\t6\t0.0000\n");
 
-            assertSql(sysPrefix + TelemetryTask.TABLE_NAME, "created\tevent\torigin\n" +
+            assertSql(TelemetryTask.TABLE_NAME, "created\tevent\torigin\n" +
                     "1970-01-01T00:00:00.001000Z\t100\t1\n" +
                     "1970-01-01T00:00:00.004000Z\t101\t1\n");
         });


### PR DESCRIPTION
Fix bug introduced in #2930

Because of system table prefix is `sys.` the table name must be quoted. Without quotes `.` creates invalid syntax and server fails to start.

```
io.questdb.Bootstrap$BootstrapException: io.questdb.griffin.SqlException: [30] unexpected token: .
	at io.questdb/io.questdb.ServerMain$1.configureSharedPool(ServerMain.java:149)
	at io.questdb/io.questdb.WorkerPoolManager.<init>(WorkerPoolManager.java:48)
	at io.questdb/io.questdb.ServerMain$1.<init>(ServerMain.java:93)
	at io.questdb/io.questdb.ServerMain.<init>(ServerMain.java:93)
	at io.questdb/io.questdb.ServerMain.<init>(ServerMain.java:69)
	at io.questdb/io.questdb.ServerMain.<init>(ServerMain.java:65)
	at io.questdb/io.questdb.ServerMain.main(ServerMain.java:214)
Caused by: io.questdb.griffin.SqlException: [30] unexpected token: .
	at io.questdb/io.questdb.std.ThreadLocal.get(ThreadLocal.java:46)
	at io.questdb/io.questdb.griffin.SqlException.position(SqlException.java:101)
	at io.questdb/io.questdb.griffin.SqlException.unexpectedToken(SqlException.java:110)
	at io.questdb/io.questdb.griffin.SqlParser.errUnexpected(SqlParser.java:111)
	at io.questdb/io.questdb.griffin.SqlParser.parseCreateTable(SqlParser.java:481)
	at io.questdb/io.questdb.griffin.SqlParser.parseCreateStatement(SqlParser.java:447)
	at io.questdb/io.questdb.griffin.SqlParser.parse(SqlParser.java:2164)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileExecutionModel(SqlCompiler.java:1161)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileUsingModel(SqlCompiler.java:1253)
	at io.questdb/io.questdb.griffin.SqlCompiler.compileInner(SqlCompiler.java:1206)
	at io.questdb/io.questdb.griffin.SqlCompiler.compile(SqlCompiler.java:266)
	at io.questdb/io.questdb.Telemetry.init(Telemetry.java:102)
	at io.questdb/io.questdb.TelemetryJob.<init>(TelemetryJob.java:61)
	at io.questdb/io.questdb.ServerMain$1.configureSharedPool(ServerMain.java:142)
	... 6 more
```

Also this PR reverts renaming of `telemetry` table to `sys.telemetry` which introduced in the link PR. Name should be `telemetry` and not `sys.telemetry` for compatibility.