### PR TITLE
chore(ilp): fix for race condition in ILP shutdown test

### DIFF
--- a/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1693,13 +1693,16 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                 }
             }, "shutdown thread").start();
 
-            for (int i = 1000; i < 1000000; i++) {
+            int i = 1000;
+            // run until throws exception or will be killed by CI
+            while (true) {
                 sender.metric(tableName)
                         .field("id", i)
                         .$(i * 1_000_000L);
                 sender.flush();
+                i++;
+                Os.sleep(100);
             }
-            Assert.fail("Expected LineSenderException");
         } catch (LineSenderException lse) {
             //expected
         } finally {


### PR DESCRIPTION
If unlucky the ingestion could have finished earlier than the shutdown happened on the other thread.
Now the test ingests until shutdown happens eventually