### PR TITLE
fix(sql): fix DISTINCT combined with a column alias

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -67,9 +67,8 @@ import java.util.ArrayDeque;
 
 import static io.questdb.cairo.sql.DataFrameCursorFactory.ORDER_ANY;
 import static io.questdb.griffin.SqlKeywords.*;
-import static io.questdb.griffin.model.ExpressionNode.FUNCTION;
-import static io.questdb.griffin.model.ExpressionNode.LITERAL;
-import static io.questdb.griffin.model.ExpressionNode.CONSTANT;
+import static io.questdb.griffin.model.ExpressionNode.*;
+import static io.questdb.griffin.model.QueryModel.QUERY;
 import static io.questdb.griffin.model.QueryModel.*;
 
 public class SqlCodeGenerator implements Mutable, Closeable {
@@ -3031,24 +3030,27 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
     private RecordCursorFactory generateSelectDistinct(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
 
+        QueryModel nested;
         QueryModel twoDeepNested;
         ExpressionNode tableNameEn;
 
         if (
                 model.getColumns().size() == 1
-                        && model.getNestedModel() != null
+                        && (nested = model.getNestedModel()) != null
                         && model.getNestedModel().getSelectModelType() == QueryModel.SELECT_MODEL_CHOOSE
                         && (twoDeepNested = model.getNestedModel().getNestedModel()) != null
                         && twoDeepNested.getLatestBy().size() == 0
                         && (tableNameEn = twoDeepNested.getTableNameExpr()) != null
+                        && tableNameEn.type == ExpressionNode.LITERAL
                         && twoDeepNested.getWhereClause() == null
         ) {
             CharSequence tableName = tableNameEn.token;
             TableToken tableToken = executionContext.getTableToken(tableName);
             try (TableReader reader = executionContext.getReader(tableToken)) {
-                CharSequence columnName = model.getBottomUpColumnNames().get(0);
+                QueryColumn queryColumn = nested.getBottomUpColumns().get(0);
+                CharSequence physicalColumnName = queryColumn.getAst().token;
                 TableReaderMetadata readerMetadata = reader.getMetadata();
-                int columnIndex = readerMetadata.getColumnIndex(columnName);
+                int columnIndex = readerMetadata.getColumnIndex(physicalColumnName);
                 int columnType = readerMetadata.getColumnType(columnIndex);
 
                 final GenericRecordMetadata distinctColumnMetadata = new GenericRecordMetadata();

--- a/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/griffin/SqlCodeGeneratorTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.security.AllowAllCairoSecurityContext;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory;
 import io.questdb.griffin.engine.groupby.vect.GroupByJob;
 import io.questdb.mp.SOCountDownLatch;
@@ -6929,6 +6930,33 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                 true,
                 true
         );
+    }
+
+    @Test
+    public void testSelectDistinctWithColumnAlias() throws Exception {
+        assertMemoryLeak(() -> {
+            compiler.compile("create table my_table as (select x as id from long_sequence(1))", sqlExecutionContext).getType();
+            try (RecordCursorFactory factory = compiler.compile("select distinct id as foo from my_table", sqlExecutionContext).getRecordCursorFactory()) {
+                RecordMetadata metadata = factory.getMetadata();
+                Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(0));
+                assertCursor("foo\n" +
+                        "1\n", factory, true, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testSelectDistinctWithColumnAliasAndTableFunction() throws Exception {
+        assertMemoryLeak(() -> {
+            Assert.assertEquals(CREATE_TABLE, compiler.compile("create table my_table (id long)", sqlExecutionContext).getType());
+            try (RecordCursorFactory factory = compiler.compile("select distinct x as foo from long_sequence(1)", sqlExecutionContext).getRecordCursorFactory()) {
+                RecordMetadata metadata = factory.getMetadata();
+                Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(0));
+
+                assertCursor("foo\n" +
+                        "1\n", factory, true, true, false);
+            }
+        });
     }
 
     @Ignore("result order is currently dependent on stability of sorting method")


### PR DESCRIPTION
the optimized single-column happy path was overly optimistic about nested models. it was not assuming aliasing nor virtual tables.

fixes #2980