### PR TITLE
feat(sql): allow list of timestamps of higher precision than required int alter table attach/detach/drop partition 

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1016,7 +1016,6 @@ public class SqlCompiler implements Closeable {
             // reader == null means it's compilation for WAL table
             // before applying to WAL writer
             if (reader != null) {
-                final long timestamp;
                 try {
                     // rtrim partition name to appropriate size
                     int partitionBy = reader.getPartitionedBy();
@@ -1027,7 +1026,7 @@ public class SqlCompiler implements Closeable {
                         throw SqlException.position(lexer.lastTokenPosition())
                                 .put("timestamp has too low resolution to determine partition [ts=").put(partitionName).put(']');
                     }
-                    timestamp = PartitionBy.parsePartitionDirName(partitionName, 0, len, partitionBy);
+                    long timestamp = PartitionBy.parsePartitionDirName(partitionName, 0, len, partitionBy);
                     alterOperationBuilder.addPartitionToList(timestamp, partitionNamePosition);
                 } catch (CairoException e) {
                     throw SqlException.$(lexer.lastTokenPosition(), e.getFlyweightMessage())
@@ -1046,7 +1045,7 @@ public class SqlCompiler implements Closeable {
             }
         } while (true);
 
-        return compiledQuery.ofAlter(this.alterOperationBuilder.build());
+        return compiledQuery.ofAlter(alterOperationBuilder.build());
     }
 
     private CompiledQuery alterTableRenameColumn(int tableNamePosition, TableToken tableToken, TableRecordMetadata metadata) throws SqlException {

--- a/core/src/test/java/io/questdb/cairo/PartitionByTest.java
+++ b/core/src/test/java/io/questdb/cairo/PartitionByTest.java
@@ -188,27 +188,27 @@ public class PartitionByTest {
 
     @Test
     public void testDirectoryParseFailureByDay() {
-        assertParseFailure("'YYYY-MM-DD' expected", "2013-03", PartitionBy.DAY);
+        assertParseFailure("'yyyy-MM-dd' expected", "2013-03", PartitionBy.DAY);
     }
 
     @Test
     public void testDirectoryParseFailureByHour() {
-        assertParseFailure("'YYYY-MM-DDTHH' expected", "2013-03-12", PartitionBy.HOUR);
+        assertParseFailure("'yyyy-MM-ddTHH' expected", "2013-03-12", PartitionBy.HOUR);
     }
 
     @Test
     public void testDirectoryParseFailureByMonth() {
-        assertParseFailure("'YYYY-MM' expected", "2013-03-02", PartitionBy.MONTH);
+        assertParseFailure("'yyyy-MM' expected", "2013-03-02", PartitionBy.MONTH);
     }
 
     @Test
     public void testDirectoryParseFailureByWeek() {
-        assertParseFailure("'YYYYWww' expected", "2013-03-12", PartitionBy.WEEK);
+        assertParseFailure("'YYYY-Www' expected", "2013-03-12", PartitionBy.WEEK);
     }
 
     @Test
     public void testDirectoryParseFailureByYear() {
-        assertParseFailure("'YYYY' expected", "2013-03-12", PartitionBy.YEAR);
+        assertParseFailure("'yyyy' expected", "2013-03-12", PartitionBy.YEAR);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/cutlass/pgwire/PGJobContextTest.java
@@ -1444,8 +1444,8 @@ if __name__ == "__main__":
     }
 
     @Test
-    public void testBindVariableDropLastPartition() throws Exception {
-        assertWithPgServer(CONN_AWARE_SIMPLE_TEXT & CONN_AWARE_SIMPLE_BINARY & CONN_AWARE_EXTENDED_PREPARED_TEXT, (connection, binary) -> {
+    public void testBindVariableDropLastPartitionList() throws Exception {
+        ConnectionAwareRunnable runnable = (connection, binary) -> {
             connection.setAutoCommit(false);
             connection.prepareStatement("create table x (l long, ts timestamp) timestamp(ts) partition by month").execute();
             connection.prepareStatement("insert into x values (12, '2023-02-11T11:12:22.116234Z')").execute();
@@ -1473,7 +1473,12 @@ if __name__ == "__main__":
                         rs
                 );
             }
-        });
+        };
+
+        assertWithPgServer(Mode.SIMPLE, true, runnable, -2, Long.MAX_VALUE);
+        assertWithPgServer(Mode.SIMPLE, true, runnable, -1, Long.MAX_VALUE);
+        assertWithPgServer(Mode.SIMPLE, false, runnable, -2, Long.MAX_VALUE);
+        assertWithPgServer(Mode.SIMPLE, false, runnable, -1, Long.MAX_VALUE);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/AlterTableDropActivePartitionTest.java
+++ b/core/src/test/java/io/questdb/griffin/AlterTableDropActivePartitionTest.java
@@ -203,6 +203,147 @@ public class AlterTableDropActivePartitionTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testDetachPartitionsLongerPartitionName() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+                    final String tableName = testName.getMethodName();
+
+                    createTableX(tableName,
+                            TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n" +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            "insert into " + tableName + " values(1, '2023-10-10T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(2, '2023-10-11T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(3, '2023-10-12T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(4, '2023-10-12T00:00:01.000000Z')",
+                            "insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(6, '2023-10-12T00:00:02.000000Z')");
+
+                    detachPartition(tableName, "2023-10-12T23:59:59.999999Z");
+                    detachPartition(tableName, "2023-10-11T23:59:59.999999Z");
+                    detachPartition(tableName, "2023-10-10T23:59:59.999999Z");
+
+                    assertTableX(tableName, TableHeader +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            MinMaxCountHeader +
+                                    "2023-10-15T00:00:00.000000Z\t2023-10-15T00:00:00.000000Z\t1\n");
+                }
+        );
+    }
+
+    @Test
+    public void testDropPartitionsLongerPartitionName() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+                    final String tableName = testName.getMethodName();
+
+                    createTableX(tableName,
+                            TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n" +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            "insert into " + tableName + " values(1, '2023-10-10T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(2, '2023-10-11T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(3, '2023-10-12T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(4, '2023-10-12T00:00:01.000000Z')",
+                            "insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(6, '2023-10-12T00:00:02.000000Z')");
+
+                    dropPartition(tableName, "2023-10-12T23:59:59.999999Z");
+                    dropPartition(tableName, "2023-10-11T23:59:59.999999Z");
+                    dropPartition(tableName, "2023-10-10T23:59:59.999999Z");
+
+                    assertTableX(tableName, TableHeader +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            MinMaxCountHeader +
+                                    "2023-10-15T00:00:00.000000Z\t2023-10-15T00:00:00.000000Z\t1\n");
+                }
+        );
+    }
+
+    @Test
+    public void testDropActivePartitionDetachHigherResolutionTimestamp() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+                    final String tableName = testName.getMethodName();
+
+                    createTableX(tableName,
+                            TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n" +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            "insert into " + tableName + " values(1, '2023-10-10T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(2, '2023-10-11T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(3, '2023-10-12T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(4, '2023-10-12T00:00:01.000000Z')",
+                            "insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(6, '2023-10-12T00:00:02.000000Z')");
+
+                    String activePartitionTs = "2023-10-15T00:00:00.000000Z";
+
+                    dropPartition(tableName, activePartitionTs); // drop active partition
+                    insert("insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')"); // recreate it
+                    dropPartition(tableName, activePartitionTs); // drop active partition
+
+                    assertTableX(tableName, TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n",
+                            MinMaxCountHeader +
+                                    "2023-10-10T00:00:00.000000Z\t2023-10-12T00:00:02.000000Z\t5\n");
+                }
+        );
+    }
+
+    @Test
+    public void testDropActivePartitionDetachLowerResolutionTimestamp() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+                    final String tableName = testName.getMethodName();
+
+                    createTableX(tableName,
+                            TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n" +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            "insert into " + tableName + " values(1, '2023-10-10T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(2, '2023-10-11T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(3, '2023-10-12T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(4, '2023-10-12T00:00:01.000000Z')",
+                            "insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')",
+                            "insert into " + tableName + " values(6, '2023-10-12T00:00:02.000000Z')");
+
+                    String activePartitionTs = "2023-10";
+                    try {
+                        dropPartition(tableName, activePartitionTs); // drop active partition
+                    } catch (SqlException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "timestamp has too low resolution to determine partition [ts=" + activePartitionTs + ']');
+                    }
+                    assertTableX(tableName, TableHeader +
+                                    "1\t2023-10-10T00:00:00.000000Z\n" +
+                                    "2\t2023-10-11T00:00:00.000000Z\n" +
+                                    "3\t2023-10-12T00:00:00.000000Z\n" +
+                                    "4\t2023-10-12T00:00:01.000000Z\n" +
+                                    "6\t2023-10-12T00:00:02.000000Z\n" +
+                                    "5\t2023-10-15T00:00:00.000000Z\n",
+                            MinMaxCountHeader +
+                                    "2023-10-10T00:00:00.000000Z\t2023-10-15T00:00:00.000000Z\t6\n");
+                }
+        );
+    }
+
+    @Test
     public void testDropActivePartitionFailsBecausePrevMaxPartitionIsIncorrect() throws Exception {
         FilesFacade myFf = new TestFilesFacadeImpl() {
             @Override


### PR DESCRIPTION
Solves https://github.com/questdb/questdb/issues/2879

The approach is to let the compiler only process the chars required to understand a partition dir name, while ignoring the rest, for each of the items in the comma separated list following the `LIST` token. 

Example, for a table partitioned by month:

```
alter table x drop partition list '2023-03-29T23', ... ;
```

`2023-03-29T23` is a valid partition name now for month granularity because the compiler knows that the patter for partition by month is `yyyy-MM`, which means it can parse a date up to month, thus `-29T23` is ignored. Incidentally, this would work too `alter table x drop partition list '2023-03-a-banana' ;`. We are trying to make life easier for users who might use a full timestamp (`select max(ts) from table`)  to drop a partition (the last one in this example).

`WHERE is not supported`, no value, and harder a problem to **solve.**
