### PR TITLE
chore(build): Decrease Maven Wagon Connection Pool TTL

### DIFF
--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -18,7 +18,7 @@ steps:
       mavenPomFile: "pom.xml"
       mavenOptions: "$(MAVEN_OPTS)"
       options:
-        "compile $(javadoc_step) -DskipTests -P build-web-console$(javadoc_profile)  -Dhttp.keepAlive=false -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
+        "compile $(javadoc_step) -DskipTests -P build-web-console$(javadoc_profile) -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dhttp.keepAlive=false -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
       jdkVersionOption: $(jdk)
     condition:
       or(eq(variables['SOURCE_CODE_CHANGED'], 'false'), eq(variables['testset'],
@@ -32,7 +32,7 @@ steps:
       options:
         "--batch-mode --quiet -Dtest=$(includeTests)
         -Dtest.exclude=$(excludeTests)
-        -Dout=$(Build.SourcesDirectory)/ci/qlog.conf -Dhttp.keepAlive=false
+        -Dout=$(Build.SourcesDirectory)/ci/qlog.conf -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dhttp.keepAlive=false
         -DfailIfNoTests=false
         -Dsurefire.failIfNoSpecifiedTests=false
         -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
@@ -52,7 +52,7 @@ steps:
       options:
         "--batch-mode --quiet -Dtest=$(includeTests)
         -Dtest.exclude=$(excludeTests)
-        -Dout=$(Build.SourcesDirectory)/ci/qlog.conf -Dhttp.keepAlive=false -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
+        -Dout=$(Build.SourcesDirectory)/ci/qlog.conf -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dhttp.keepAlive=false -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
       jdkVersionOption: $(jdk)
       codeCoverageToolOption: "$(CODE_COVERAGE_TOOL_OPTION)"
       codeCoverageClassFilter: "$(COVERAGE_DIFF)"


### PR DESCRIPTION
This is meant to deal with the "connection reset" problem when downloading artifacts from Maven Central.

Facts:
1. Builds are running in Azure Pipelines
2. Builds have the JDK HTTP pooling disabled via  -Dhttp.keepAlive=false
3. Builds are still frequently failing with "Connection Reset"
4. The errors happen right after running Core tests

Hypothesis:
1. Maven has its own connection pooling system as documented at https://issues.apache.org/jira/browse/WAGON-545 So even when JDK pooling is disabled there is still a pool on a higher level.

2. Azure infra kills idle TCP connections while tests are running

3. When Core tests are finished Maven starts building the Benchmark module. The Benchmark module uses a different Maven Clean plugin version -> Maven wants to download this version by using a connection from its pool. When this connection happens to be killed by Azure then Maven fails to download the clean plugin -> Build Error

Assuming the hypothesis above is correct then decreasing TTL on connection in the Maven pool should eliminate the errors. In fact, it's documented at https://issues.apache.org/jira/browse/WAGON-545?focusedCommentId=16755035&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16755035
> Azure users shall set the TTL to 240 seconds or less.

If just decreasing TTL won't help then the next step is to disable the Maven pool entirely.