### PR TITLE
feat(core): add external configuration for lag calculation window size

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -162,6 +162,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int o3CallbackQueueCapacity;
     private final int o3ColumnMemorySize;
     private final int o3CopyQueueCapacity;
+    private final int o3LagCalculationWindowsSize;
     private final long o3MaxLag;
     private final long o3MinLagUs;
     private final int o3OpenColumnQueueCapacity;
@@ -897,6 +898,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.o3PartitionQueueCapacity = getQueueCapacity(properties, env, PropertyKey.CAIRO_O3_PARTITION_QUEUE_CAPACITY, 128);
             this.o3OpenColumnQueueCapacity = getQueueCapacity(properties, env, PropertyKey.CAIRO_O3_OPEN_COLUMN_QUEUE_CAPACITY, 128);
             this.o3CopyQueueCapacity = getQueueCapacity(properties, env, PropertyKey.CAIRO_O3_COPY_QUEUE_CAPACITY, 128);
+            this.o3LagCalculationWindowsSize = getIntSize(properties, env, PropertyKey.CAIRO_O3_LAG_CALCULATION_WINDOW_SIZE, 4);
             this.o3PurgeDiscoveryQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_O3_PURGE_DISCOVERY_QUEUE_CAPACITY, 128));
             this.o3ColumnMemorySize = (int) Files.ceilPageSize(getIntSize(properties, env, PropertyKey.CAIRO_O3_COLUMN_MEMORY_SIZE, 8 * Numbers.SIZE_1MB));
             this.maxUncommittedRows = getInt(properties, env, PropertyKey.CAIRO_MAX_UNCOMMITTED_ROWS, 500_000);
@@ -1502,6 +1504,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean attachPartitionCopy() {
             return cairoAttachPartitionCopy;
+        }
+
+        @Override
+        public int getO3LagCalculationWindowsSize() {
+            return o3LagCalculationWindowsSize;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -146,6 +146,7 @@ public enum PropertyKey {
     CAIRO_O3_PARTITION_QUEUE_CAPACITY("cairo.o3.partition.queue.capacity"),
     CAIRO_O3_OPEN_COLUMN_QUEUE_CAPACITY("cairo.o3.open.column.queue.capacity"),
     CAIRO_O3_COPY_QUEUE_CAPACITY("cairo.o3.copy.queue.capacity"),
+    CAIRO_O3_LAG_CALCULATION_WINDOW_SIZE("cairo.o3.lag.calculation.windows.size"),
     CAIRO_O3_UPD_PARTITION_SIZE_QUEUE_CAPACITY("cairo.o3.upd.partition.size.queue.capacity"),
     CAIRO_O3_PURGE_DISCOVERY_QUEUE_CAPACITY("cairo.o3.purge.discovery.queue.capacity"),
     CAIRO_O3_COLUMN_MEMORY_SIZE("cairo.o3.column.memory.size"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -24,9 +24,9 @@
 
 package io.questdb.cairo;
 
-import io.questdb.VolumeDefinitions;
 import io.questdb.BuildInformation;
 import io.questdb.TelemetryConfiguration;
+import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.std.*;
@@ -210,6 +210,8 @@ public interface CairoConfiguration {
     long getO3MaxLag();
 
     long getO3MinLag();
+
+    int getO3LagCalculationWindowsSize();
 
     int getO3OpenColumnQueueCapacity();
 

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -64,6 +64,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getO3LagCalculationWindowsSize() {
+        return 4;
+    }
+
+    @Override
     public boolean enableTestFactories() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -89,7 +89,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private static final int ROW_ACTION_O3 = 3;
     private static final int ROW_ACTION_OPEN_PARTITION = 0;
     private static final int ROW_ACTION_SWITCH_PARTITION = 4;
-    private static final int WINDOW_SIZE = 4;
     final ObjList<MemoryMA> columns;
     // Latest command sequence per command source.
     // Publisher source is identified by a long value
@@ -131,7 +130,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final ObjList<MemoryCR> o3ColumnOverrides;
     private final SOUnboundedCountDownLatch o3DoneLatch = new SOUnboundedCountDownLatch();
     private final AtomicInteger o3ErrorCount = new AtomicInteger();
-    private final long[] o3LastTimestampSpreads = new long[WINDOW_SIZE];
+    private final long[] o3LastTimestampSpreads;
     private final AtomicLong o3PartitionUpdRemaining = new AtomicLong();
     private final ObjList<O3CallbackTask> o3PendingCallbackTasks = new ObjList<>();
     private final boolean o3QuickSortEnabled;
@@ -335,6 +334,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             commandPubSeq = new MPSequence(commandQueue.getCycle());
             commandPubSeq.then(commandSubSeq).then(commandPubSeq);
             walColumnMemoryPool = new WeakClosableObjectPool<>(GET_MEMORY_CMOR, columnCount);
+            o3LastTimestampSpreads = new long[configuration.getO3LagCalculationWindowsSize()];
             Arrays.fill(o3LastTimestampSpreads, 0);
         } catch (Throwable e) {
             doClose(false);
@@ -3421,7 +3421,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                     lagError = getMaxTimestamp() - o3CommitBatchTimestampMin;
 
-                    int n = WINDOW_SIZE - 1;
+                    int n = o3LastTimestampSpreads.length - 1;
 
                     if (lagError > 0) {
                         o3EffectiveLag += lagError * configuration.getO3LagIncreaseFactor();

--- a/core/src/test/java/io/questdb/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/PropServerConfigurationTest.java
@@ -386,6 +386,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(10_000, configuration.getWalApplyPoolConfiguration().getSleepThreshold());
         Assert.assertEquals(10, configuration.getWalApplyPoolConfiguration().getYieldThreshold());
         Assert.assertEquals(20, configuration.getCairoConfiguration().getWalApplyLookAheadTransactionCount());
+        Assert.assertEquals(4, configuration.getCairoConfiguration().getO3LagCalculationWindowsSize());
         Assert.assertTrue(configuration.getCairoConfiguration().isTableTypeConversionEnabled());
     }
 
@@ -1147,6 +1148,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(33033, configuration.getWalApplyPoolConfiguration().getYieldThreshold());
             Assert.assertEquals(23, configuration.getCairoConfiguration().getWalApplyLookAheadTransactionCount());
             Assert.assertFalse(configuration.getCairoConfiguration().isTableTypeConversionEnabled());
+            Assert.assertEquals(120, configuration.getCairoConfiguration().getO3LagCalculationWindowsSize());
         }
     }
 

--- a/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
+++ b/core/src/test/java/io/questdb/cutlass/text/CairoConfigurationWrapper.java
@@ -24,9 +24,9 @@
 
 package io.questdb.cutlass.text;
 
-import io.questdb.VolumeDefinitions;
 import io.questdb.BuildInformation;
 import io.questdb.TelemetryConfiguration;
+import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.std.FilesFacade;
@@ -81,6 +81,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     @Override
     public CharSequence getBackupRoot() {
         return conf.getBackupRoot();
+    }
+
+    @Override
+    public int getO3LagCalculationWindowsSize() {
+        return conf.getO3LagCalculationWindowsSize();
     }
 
     @Override

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -273,3 +273,4 @@ cairo.wal.inactive.writer.ttl=333303
 cairo.wal.apply.look.ahead.txn.count=23
 
 table.type.conversion.enabled=false
+cairo.o3.lag.calculation.windows.size=120


### PR DESCRIPTION
Ability to set size of the window, which is used by O3 automatic lag algo to maintain correct lag size. Before this lag window was hardcoded to have 4 entries, which may be insufficient for some ingestion data patterns.

The new option can be set via:

```
cairo.o3.lag.calculation.windows.size=128
```