### PR TITLE
fix(sql): fix symbol column initialization in latest by cursors

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByAllFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByAllFilteredRecordCursor.java
@@ -71,8 +71,8 @@ class LatestByAllFilteredRecordCursor extends AbstractDescendingRecordListCursor
         if (!isOpen()) {
             map.reopen();
         }
-        filter.init(this, executionContext);
         super.of(dataFrameCursor, executionContext);
+        filter.init(this, executionContext);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValuesFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValuesFilteredRecordCursor.java
@@ -62,9 +62,9 @@ class LatestByValuesFilteredRecordCursor extends AbstractDescendingRecordListCur
 
     @Override
     public void of(DataFrameCursor dataFrameCursor, SqlExecutionContext executionContext) throws SqlException {
-        filter.init(this, executionContext);
         isMapPrepared = false;
         super.of(dataFrameCursor, executionContext);
+        filter.init(this, executionContext);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/griffin/LatestByTest.java
+++ b/core/src/test/java/io/questdb/griffin/LatestByTest.java
@@ -36,6 +36,23 @@ import org.junit.Test;
 public class LatestByTest extends AbstractGriffinTest {
 
     @Test
+    public void testLatestByAllFilteredResolvesSymbol() throws Exception {
+        assertQuery("devid\taddress\tvalue\tvalue_decimal\tcreated_at\tts\n",
+                "SELECT * FROM history_P4v\n" +
+                        "WHERE\n" +
+                        "  devid = 'LLLAHFZHYA'\n" +
+                        "LATEST ON ts PARTITION BY address",
+                "CREATE TABLE history_P4v (\n" +
+                        "  devid SYMBOL,\n" +
+                        "  address SHORT,\n" +
+                        "  value SHORT,\n" +
+                        "  value_decimal BYTE,\n" +
+                        "  created_at DATE,\n" +
+                        "  ts TIMESTAMP\n" +
+                        ") timestamp(ts) PARTITION BY DAY;", "ts", true, false, false);
+    }
+
+    @Test
     public void testLatestByAllIndexedIndexReaderGetsReloaded() throws Exception {
         final int iterations = 100;
         assertMemoryLeak(() -> {
@@ -486,6 +503,17 @@ public class LatestByTest extends AbstractGriffinTest {
                     true,
                     true);
         });
+    }
+
+    @Test
+    public void testLatestByValuesFilteredResolvesSymbol() throws Exception {
+        assertQuery("s\ti\tts\n",
+                "select s, i, ts " +
+                        "from a " +
+                        "where s in (select distinct s from a) " +
+                        "and s = 'ABC' " +
+                        "latest on ts partition by s",
+                "create table a ( i int, s symbol, ts timestamp ) timestamp(ts)", "ts", true, false, false);
     }
 
     @Test


### PR DESCRIPTION
Fixes #3026  

Fixes symbol filter initialization order in query mentioned in isssue and : 
```sql
create table a ( i int, s symbol, ts timestamp ) timestamp(ts);

select s, i, ts 
from a 
where s in (select distinct s from a) 
and s = 'ABC' <-- fixed filter 
latest on ts partition by s;
```