### PR TITLE
fix(wal): remove unnecessary critical error about unsolicited table lock

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -125,7 +125,9 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                     applyOutstandingWalTransactions(tableToken, writer, engine, operationCompiler, tempPath, runStatus);
                     lastWriterTxn = writer.getSeqTxn();
                 } catch (EntryUnavailableException tableBusy) {
-                    if (!WAL_2_TABLE_WRITE_REASON.equals(tableBusy.getReason()) && !WAL_2_TABLE_RESUME_REASON.equals(tableBusy.getReason())) {
+                    if (tableBusy.getReason() != null // only pool release action does not have lock reason
+                            && !WAL_2_TABLE_WRITE_REASON.equals(tableBusy.getReason())
+                            && !WAL_2_TABLE_RESUME_REASON.equals(tableBusy.getReason())) {
                         LOG.critical().$("unsolicited table lock [table=").utf8(tableToken.getDirName()).$(", lock_reason=").$(tableBusy.getReason()).I$();
                     }
                     // Don't suspend table. Perhaps writer will be unlocked with no transaction applied.


### PR DESCRIPTION
Remove unnecessary critical error message from logs about `unsolicited table lock` when `ApplyWal2TableJob` races with engine releasing inactive writers.