### PR TITLE
fix(sql): fix order by removal in subquery with explicit timestamp

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2395,6 +2395,10 @@ class SqlOptimiser {
         if (model.getLimitLo() != null) {
             topLevelOrderByMnemonic = OrderByMnemonic.ORDER_BY_UNKNOWN;
         }
+        //if model has explicit timestamp then we should detect and preserve actual order because it might be used for asof/lt/splice join 
+        if (model.getTimestamp() != null) {
+            topLevelOrderByMnemonic = OrderByMnemonic.ORDER_BY_REQUIRED;
+        }
 
         // determine if ordering is required
         switch (topLevelOrderByMnemonic) {

--- a/core/src/main/java/io/questdb/griffin/engine/join/SpliceJoinLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SpliceJoinLightRecordCursorFactory.java
@@ -129,7 +129,9 @@ public class SpliceJoinLightRecordCursorFactory extends AbstractRecordCursorFact
     @Override
     public void toPlan(PlanSink sink) {
         sink.type("Splice Join");
-        sink.optAttr("condition", joinContext);
+        if (joinContext != null && !joinContext.isEmpty()) {
+            sink.optAttr("condition", joinContext);
+        }
         sink.child(masterFactory);
         sink.child(slaveFactory);
     }

--- a/core/src/main/java/io/questdb/griffin/model/JoinContext.java
+++ b/core/src/main/java/io/questdb/griffin/model/JoinContext.java
@@ -59,6 +59,10 @@ public class JoinContext implements Mutable, Plannable {
         parents.clear();
     }
 
+    public boolean isEmpty() {
+        return aNodes.size() == 0 && bNodes.size() == 0;
+    }
+
     @Override
     public void toPlan(PlanSink sink) {
         for (int i = 0, n = aNodes.size(); i < n; i++) {

--- a/core/src/test/java/io/questdb/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/griffin/ExplainPlanTest.java
@@ -57,6 +57,8 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class ExplainPlanTest extends AbstractGriffinTest {
 
     protected final static Log LOG = LogFactory.getLog(ExplainPlanTest.class);
@@ -3561,6 +3563,117 @@ public class ExplainPlanTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testOrderByIsMaintainedInLtAndAsofSubqueries() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("CREATE TABLE gas_prices (timestamp TIMESTAMP, galon_price DOUBLE ) timestamp (timestamp);");
+
+            for (String joinType : Arrays.asList("AsOf", "Lt")) {
+                String query = "with gp as \n" +
+                        "(\n" +
+                        "selecT * from (\n" +
+                        "selecT * from gas_prices order by timestamp asc, galon_price desc\n" +
+                        ") timestamp(timestamp))\n" +
+                        "selecT * from gp gp1 \n" +
+                        joinType + " join gp gp2 \n" +
+                        "order by gp1.timestamp; ";
+
+                String expectedPlan = "SelectedRecord\n" +
+                        "    " + joinType + " Join\n" +
+                        "        SelectedRecord\n" +
+                        "            Sort light\n" +
+                        "              keys: [timestamp, galon_price desc]\n" +
+                        "                DataFrame\n" +
+                        "                    Row forward scan\n" +
+                        "                    Frame forward scan on: gas_prices\n" +
+                        "        SelectedRecord\n" +
+                        "            Sort light\n" +
+                        "              keys: [timestamp, galon_price desc]\n" +
+                        "                DataFrame\n" +
+                        "                    Row forward scan\n" +
+                        "                    Frame forward scan on: gas_prices\n";
+
+                assertPlan(query, expectedPlan);
+            }
+        });
+    }
+
+    @Test
+    public void testOrderByIsMaintainedInSpliceSubqueries() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("CREATE TABLE gas_prices (timestamp TIMESTAMP, galon_price DOUBLE ) timestamp (timestamp);");
+
+            String query = "with gp as (\n" +
+                    "selecT * from (\n" +
+                    "selecT * from gas_prices order by timestamp asc, galon_price desc\n" +
+                    ") timestamp(timestamp))\n" +
+                    "selecT * from gp gp1 \n" +
+                    "splice join gp gp2 \n" +
+                    "order by gp1.timestamp; ";
+
+            String expectedPlan = "Sort\n" +
+                    "  keys: [timestamp]\n" +
+                    "    SelectedRecord\n" +
+                    "        Splice Join\n" +
+                    "            SelectedRecord\n" +
+                    "                Sort light\n" +
+                    "                  keys: [timestamp, galon_price desc]\n" +
+                    "                    DataFrame\n" +
+                    "                        Row forward scan\n" +
+                    "                        Frame forward scan on: gas_prices\n" +
+                    "            SelectedRecord\n" +
+                    "                Sort light\n" +
+                    "                  keys: [timestamp, galon_price desc]\n" +
+                    "                    DataFrame\n" +
+                    "                        Row forward scan\n" +
+                    "                        Frame forward scan on: gas_prices\n";
+
+            assertPlan(query, expectedPlan);
+        });
+    }
+
+    @Test
+    public void testOrderByIsMaintainedInSubquery() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("CREATE TABLE gas_prices " +
+                    "(timestamp TIMESTAMP, " +
+                    "galon_price DOUBLE) " +
+                    "timestamp (timestamp);");
+
+            String query = "WITH full_range AS (  \n" +
+                    "  SELECT timestamp, galon_price FROM (\n" +
+                    "    SELECT * FROM (\n" +
+                    "      SELECT * FROM gas_prices\n" +
+                    "      UNION\n" +
+                    "      SELECT to_timestamp('1999-01-01', 'yyyy-MM-dd'), NULL as galon_price -- First Date\n" +
+                    "      UNION \n" +
+                    "      SELECT to_timestamp('2023-02-20', 'yyyy-MM-dd'), NULL  as galon_price -- Last Date\n" +
+                    "    ) AS unordered_data \n" +
+                    "    order by timestamp\n" +
+                    "  ) TIMESTAMP(timestamp)\n" +
+                    ") \n" +
+                    "select * " +
+                    "from full_range";
+
+            String expectedPlan = "SelectedRecord\n" +
+                    "    Sort\n" +
+                    "      keys: [timestamp]\n" +
+                    "        Union\n" +
+                    "            Union\n" +
+                    "                DataFrame\n" +
+                    "                    Row forward scan\n" +
+                    "                    Frame forward scan on: gas_prices\n" +
+                    "                VirtualRecord\n" +
+                    "                  functions: [915148800000000,null]\n" +
+                    "                    long_sequence count: 1\n" +
+                    "            VirtualRecord\n" +
+                    "              functions: [1676851200000000,null]\n" +
+                    "                long_sequence count: 1\n";
+            assertPlan(query, expectedPlan);
+            assertPlan(query + " order by timestamp", expectedPlan);
+        });
+    }
+
+    @Test
     public void testRewriteAggregateWithAddition() throws Exception {
         assertMemoryLeak(() -> {
             compile("  CREATE TABLE tab ( x int );");
@@ -6108,7 +6221,6 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                     "SelectedRecord\n" +
                             "    Filter filter: a.i=b.i\n" +
                             "        Splice Join\n" +
-                            "          condition: \n" +
                             "            DataFrame\n" +
                             "                Row forward scan\n" +
                             "                Frame forward scan on: a\n" +


### PR DESCRIPTION
Fixes #3010 
Even if order by is defined in outer query, order by in nested query should not be ignored if it's marked with explicit timestamp.
Timestamp(ts) is often used to make query pass validation of time-based joins (AsOf, Lt and Splice) so nested order by clause can't be removed. 

Example : 
```sql
CREATE TABLE gas_prices (timestamp TIMESTAMP, galon_price DOUBLE ) timestamp (timestamp);

with gp as 
(
  select * from (
     select * from gas_prices order by timestamp asc, galon_price desc
  ) timestamp(timestamp)
)
select * from gp gp1 
asof join gp gp2 
order by gp1.timestamp;
```
produces following plan in branch : 
```
SelectedRecord
    AsOf Join
        SelectedRecord
            Sort light
              keys: [timestamp, galon_price desc]
                DataFrame
                    Row forward scan
                    Frame forward scan on: gas_prices
        SelectedRecord
            Sort light
              keys: [timestamp, galon_price desc]
                DataFrame
                    Row forward scan
                    Frame forward scan on: gas_prices
```
VS
```
SelectedRecord
    AsOf Join
        SelectedRecord
                DataFrame
                    Row forward scan
                    Frame forward scan on: gas_prices
        SelectedRecord
                DataFrame
                    Row forward scan
                    Frame forward scan on: gas_prices
```
in master.



