### PR TITLE
fix(core): fix O3 merge corrupt string column on merge temporarily

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
@@ -1827,7 +1827,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 final long srcDataMaxBytes = srcDataMax * Long.BYTES;
                 if (srcDataTop > prefixHi || prefixType == O3_BLOCK_O3) {
                     // extend the existing column down, we will be discarding it anyway
-                    srcDataFixSize = srcDataActualBytes + srcDataMaxBytes + Long.BYTES;
+                    srcDataFixSize = srcDataActualBytes + Long.BYTES + srcDataMaxBytes + Long.BYTES;
                     srcDataFixAddr = mapRW(ff, srcFixFd, srcDataFixSize, MemoryTag.MMAP_O3);
                     ff.madvise(srcDataFixAddr, srcDataFixSize, Files.POSIX_MADV_SEQUENTIAL);
 
@@ -1867,14 +1867,14 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                                 srcDataFixAddr,
                                 0,
                                 hiInclusive,
-                                srcDataFixAddr + srcDataMaxBytes
+                                srcDataFixAddr + srcDataMaxBytes + Long.BYTES
                         );
 
                         // now set the "empty" bit of fixed size column with references to those
                         // null strings we just added
                         // Call to setVarColumnRefs32Bit must be after shiftCopyFixedSizeColumnData
                         // because data first have to be shifted before overwritten
-                        Vect.setVarColumnRefs32Bit(srcDataFixAddr + srcDataActualBytes, 0, srcDataTop);
+                        Vect.setVarColumnRefs32Bit(srcDataFixAddr + srcDataActualBytes + Long.BYTES, 0, srcDataTop);
                     } else {
                         // We need to reserve null values for every column top value
                         // in the variable len file. Each null value takes 8 bytes for binary
@@ -1903,15 +1903,15 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                                 srcDataFixAddr,
                                 0,
                                 hiInclusive,
-                                srcDataFixAddr + srcDataMaxBytes
+                                srcDataFixAddr + srcDataMaxBytes + Long.BYTES
                         );
 
                         // now set the "empty" bit of fixed size column with references to those
                         // null strings we just added
-                        Vect.setVarColumnRefs64Bit(srcDataFixAddr + srcDataActualBytes, 0, srcDataTop);
+                        Vect.setVarColumnRefs64Bit(srcDataFixAddr + srcDataActualBytes + Long.BYTES, 0, srcDataTop);
                     }
                     srcDataTop = 0;
-                    srcDataFixOffset = srcDataActualBytes;
+                    srcDataFixOffset = srcDataActualBytes + Long.BYTES;
                 } else {
                     // when we are shuffling "empty" space we can just reduce column top instead
                     // of moving data

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -1022,7 +1022,10 @@ public class TableReader implements Closeable, SymbolTableSource {
                     TableUtils.iFile(path.trimTo(plen), name, columnTxn);
                     mem2 = openOrCreateMemory(path, columns, secondaryIndex, mem2, columnSize);
                     long column2Size = mem2.getLong(columnRowCount * 8L);
-                    assert column2Size > 0 && column2Size <= (1L << 40); // 1TB, e.g. reasonable size, not garbage
+                    if (column2Size <= 0 || column2Size >= (1L << 40)) {
+                        LOG.critical().$("Invalid var len column size [column=").$(name).$(", size=").$(column2Size).$(", path=").$(path).I$();
+                        throw CairoException.critical(0).put("Invalid column size [column=").put(path).put(", size=").put(column2Size).put(']');
+                    }
                     TableUtils.dFile(path.trimTo(plen), name, columnTxn);
                     openOrCreateMemory(path, columns, primaryIndex, mem1, column2Size);
                 } else {

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -50,6 +50,7 @@ import org.junit.rules.TestName;
 import java.net.URISyntaxException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -836,11 +837,12 @@ public class O3Test extends AbstractO3Test {
     public void testReadPartitionWhileMergingVarColumnWithColumnTop() throws Exception {
         AtomicReference<SqlCompiler> compilerRef = new AtomicReference<>();
         AtomicReference<SqlExecutionContext> executionContextRef = new AtomicReference<>();
+        AtomicBoolean compared = new AtomicBoolean(false);
 
         FilesFacade ff = new TestFilesFacadeImpl() {
             @Override
             public int openRW(LPSZ name, long opts) {
-                if (Chars.contains(name, "2020-02-05.5" + Files.SEPARATOR + "ks.")) {
+                if (Chars.contains(name, "2020-02-05.") && Chars.contains(name, Files.SEPARATOR + "ks.")) {
                     try {
                         TestUtils.assertSqlCursors(
                                 compilerRef.get(),
@@ -849,6 +851,7 @@ public class O3Test extends AbstractO3Test {
                                 "x",
                                 LOG
                         );
+                        compared.set(true);
                     } catch (SqlException e) {
                         throw new RuntimeException(e);
                     }
@@ -924,6 +927,8 @@ public class O3Test extends AbstractO3Test {
                 },
                 ff
         );
+
+        Assert.assertTrue("comparison did not happen", compared.get());
     }
 
     @Test

--- a/core/src/test/java/io/questdb/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/griffin/O3Test.java
@@ -38,6 +38,7 @@ import io.questdb.mp.WorkerPool;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.test.tools.TestUtils;
 import org.hamcrest.MatcherAssert;
@@ -50,6 +51,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.questdb.cairo.vm.Vm.getStorageLength;
 
@@ -828,6 +830,100 @@ public class O3Test extends AbstractO3Test {
     @Test
     public void testPartitionedOOTopAndBottomParallel() throws Exception {
         executeWithPool(4, O3Test::testPartitionedOOTopAndBottom0);
+    }
+
+    @Test
+    public void testReadPartitionWhileMergingVarColumnWithColumnTop() throws Exception {
+        AtomicReference<SqlCompiler> compilerRef = new AtomicReference<>();
+        AtomicReference<SqlExecutionContext> executionContextRef = new AtomicReference<>();
+
+        FilesFacade ff = new TestFilesFacadeImpl() {
+            @Override
+            public int openRW(LPSZ name, long opts) {
+                if (Chars.contains(name, "2020-02-05.5" + Files.SEPARATOR + "ks.")) {
+                    try {
+                        TestUtils.assertSqlCursors(
+                                compilerRef.get(),
+                                executionContextRef.get(),
+                                "zz order by ts",
+                                "x",
+                                LOG
+                        );
+                    } catch (SqlException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return super.openRW(name, opts);
+            }
+        };
+
+        executeWithPool(
+                0,
+                (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext executionContext) -> {
+                    compilerRef.set(compiler);
+                    executionContextRef.set(executionContext);
+
+                    compiler.compile(
+                            "create table x as (" +
+                                    "select" +
+                                    " cast(x as int) i," +
+                                    " -x j," +
+                                    " timestamp_sequence('2020-02-03T13', 60*1000000L) ts" +
+                                    " from long_sequence(60*24*2+300)" +
+                                    ") timestamp (ts) partition by DAY",
+                            executionContext
+                    );
+
+                    compiler.compile("alter table x add column k uuid", executionContext).execute(null).await();
+                    compiler.compile("alter table x add column kb binary", executionContext).execute(null).await();
+                    compiler.compile("alter table x add column ks string", executionContext).execute(null).await();
+
+                    compiler.compile(
+                            "create table y as (" +
+                                    "select" +
+                                    " cast(x as int) * 1000000 i," +
+                                    " -x - 1000000L as j," +
+                                    " timestamp_sequence('2020-02-05T20:01:05', 60*1000000L) ts," +
+                                    " rnd_uuid4() as k," +
+                                    " rnd_bin() as kb," +
+                                    " rnd_str(5,16,2) as ks" +
+                                    " from long_sequence(10))",
+                            executionContext
+                    );
+
+                    compiler.compile(
+                            "create table z as (" +
+                                    "select" +
+                                    " cast(x as int) * 1000000 i," +
+                                    " -x - 1000000L as j," +
+                                    " timestamp_sequence('2020-02-05T17:01:05', 60*1000000L) ts," +
+                                    " rnd_uuid4() as k," +
+                                    " rnd_bin() as kb," +
+                                    " rnd_str(5,16,2) as ks" +
+                                    " from long_sequence(100))",
+                            executionContext
+                    );
+
+                    compiler.compile(
+                            "create table zz as (select * from x union all select * from y)",
+                            executionContext
+                    );
+
+                    compiler.compile("insert into x select * from y", executionContext);
+                    compiler.compile("insert into x select * from z", executionContext);
+
+                    compiler.compile("insert into zz select * from z", executionContext);
+
+                    TestUtils.assertSqlCursors(
+                            compiler,
+                            executionContext,
+                            "zz order by ts",
+                            "x",
+                            LOG
+                    );
+                },
+                ff
+        );
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug in STRING / BINARY column writes in certain Out of Order scenarios found in CI 

```
2023-03-23T16:24:21.609243Z I i.q.c.TableReader open partition /var/folders/qn/549sb2396ks05yjdft2m4vr40000gn/T/junit4732718961811833104/dbRoot/weather2~/2016-06-13.12 [rowCount=10, partitionNameTxn=12, transientRowCount=10, partitionIndex=0, partitionCount=1]
Exception in thread "Thread-5382" java.lang.AssertionError: /var/folders/qn/549sb2396ks05yjdft2m4vr40000gn/T/junit4732718961811833104/dbRoot/weather2~/2016-06-13.12/terület1.i.13
	at io.questdb/io.questdb.cairo.TableReader.reloadColumnAt(TableReader.java:1025)
	at io.questdb/io.questdb.cairo.TableReader.openPartitionColumns(TableReader.java:848)
	at io.questdb/io.questdb.cairo.TableReader.openPartition0(TableReader.java:815)
	at io.questdb/io.questdb.cairo.TableReader.reOpenPartition(TableReader.java:880)
	at io.questdb/io.questdb.cairo.TableReader.reconcileOpenPartitionsFrom(TableReader.java:413)
	at io.questdb/io.questdb.cairo.TableReader.reconcileOpenPartitions(TableReader.java:954)
	at io.questdb/io.questdb.cairo.TableReader.reload(TableReader.java:453)
	at io.questdb/io.questdb.cairo.TableReader.goActive(TableReader.java:338)
	at io.questdb/io.questdb.cairo.pool.ReaderPool$R.refresh(ReaderPool.java:126)
```