### PR TITLE
ci(build): add continuous fuzz test run on master

### DIFF
--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -22,8 +22,7 @@ variables:
 stages:
   - stage: HostedRunTestsBranches
     displayName: "Hosted Running tests"
-    dependsOn:
-      - CheckChanges
+
     jobs:
       - job: RunOn
         displayName: "on"

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -28,7 +28,7 @@ stages:
         displayName: "on"
         strategy:
           matrix:
-            mac-griffin:
+            ubuntu-latest:
               imageName: "ubuntu-latest"
               poolName: "Azure Pipelines"
               os: Linux
@@ -42,6 +42,7 @@ stages:
           name: $(poolName)
         timeoutInMinutes: 60
         variables:
+          SOURCE_CODE_CHANGED: true
           ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
         steps:
           - template: templates/steps.yml

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -1,0 +1,48 @@
+trigger: none
+
+schedules:
+  - cron: "*/10 * * * *"
+    displayName: Run every 15 minutes
+    branches:
+      include:
+        - master
+    always: true
+
+variables:
+  QDB_LOG_W_FILE_LOCATION: "$(Build.BinariesDirectory)/tests.log"
+  ARCHIVED_LOGS: "$(Build.ArtifactStagingDirectory)/questdb-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).zip"
+  includeTests: ""
+  excludeTests: ""
+  MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
+  MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3072m"
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
+  MAVEN_VERSION: "version"
+  MAVEN_VERSION_OPTION: "Default"
+
+stages:
+  - stage: HostedRunTestsBranches
+    displayName: "Hosted Running tests"
+    dependsOn:
+      - CheckChanges
+    jobs:
+      - job: RunOn
+        displayName: "on"
+        strategy:
+          matrix:
+            mac-griffin:
+              imageName: "ubuntu-latest"
+              poolName: "Azure Pipelines"
+              os: Linux
+              jdk: "1.8"
+              testset: "all"
+              includeTests: "**Fuzz**"
+              javadoc_step: ""
+              javadoc_profile: ""
+        pool:
+          vmImage: $(imageName)
+          name: $(poolName)
+        timeoutInMinutes: 60
+        variables:
+          ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
+        steps:
+          - template: templates/steps.yml

--- a/core/src/test/java/io/questdb/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/griffin/wal/WalWriterFuzzTest.java
@@ -103,11 +103,6 @@ public class WalWriterFuzzTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testCiFailure() throws Exception {
-        Assert.fail("testFailures");
-    }
-
-    @Test
     public void testSimpleDataTransaction() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setFuzzProbabilities(0, 0.2, 0.1, 0, 0, 0, 0, 1.0, 0.01);

--- a/core/src/test/java/io/questdb/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/griffin/wal/WalWriterFuzzTest.java
@@ -103,6 +103,11 @@ public class WalWriterFuzzTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testCiFailure() throws Exception {
+        Assert.fail("testFailures");
+    }
+
+    @Test
     public void testSimpleDataTransaction() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setFuzzProbabilities(0, 0.2, 0.1, 0, 0, 0, 0, 1.0, 0.01);


### PR DESCRIPTION
Run fuzz tests every 10 minutes in CI to increase coverage by running often with different random seeds.

https://dev.azure.com/questdb/questdb/_build?definitionId=25