### PR TITLE
Create questdb6.6.1 Change the time zone to CTS #2911

### DIFF
--- a/questdb6.6.1 Change the time zone to CTS #2911
+++ b/questdb6.6.1 Change the time zone to CTS #2911
@@ -1,0 +1,7 @@
+docker run -p 9000:9000 \
+-p 9009:9009 \
+-p 8812:8812 \
+-p 9003:9003 \
+-v "$(pwd):/var/lib/questdb" \
+-e TZ=Asia/Shanghai \
+questdb/questdb:6.6.1


### PR DESCRIPTION
Based on the information provided, it seems like the issue is that the time zone in QuestDB is not being set to the correct time zone. The expected behavior is that the time zone should be set to the local time zone of the system, which in this case is Asia/Shanghai.

One possible explanation for this issue is that QuestDB is using a default time zone of UTC, regardless of the system's time zone. To resolve this, you may need to configure QuestDB to use the system's time zone by setting the TZ environment variable to the desired time zone when starting the QuestDB container.

