### PR TITLE
fix(http): geo types should not fall-through to the UUID adapter

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/TypeManager.java
@@ -130,6 +130,8 @@ public class TypeManager implements Mutable {
                 return nextSymbolAdapter(false);
             case ColumnType.LONG256:
                 return Long256Adapter.INSTANCE;
+            case ColumnType.UUID:
+                return UuidAdapter.INSTANCE;
             case ColumnType.GEOBYTE:
             case ColumnType.GEOSHORT:
             case ColumnType.GEOINT:
@@ -138,8 +140,6 @@ public class TypeManager implements Mutable {
                 if (adapter != null) {
                     return adapter;
                 }
-            case ColumnType.UUID:
-                return UuidAdapter.INSTANCE;
             default:
                 throw CairoException.nonCritical().put("no adapter for type [id=").put(columnType).put(", name=").put(ColumnType.nameOf(columnType)).put(']');
         }

--- a/core/src/test/java/io/questdb/test/cutlass/text/types/TypeManagerTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/types/TypeManagerTest.java
@@ -158,6 +158,11 @@ public class TypeManagerTest {
     }
 
     @Test
+    public void testIllegalMethodParameterGeoInt() {
+        testIllegalParameterForGetTypeAdapter(ColumnType.GEOINT);
+    }
+
+    @Test
     public void testNonDefaultFileName() throws JsonException, IOException {
         File configFile = temp.newFile("conf/my_awesome_text_loader.json");
         TestUtils.writeStringToFile(configFile, "{\n}\n");


### PR DESCRIPTION
I stumbled upon this certainly unintended fall-through behavior in a switch, introduced with #2769