### PR TITLE
fix(sql): fix infinite loop in count_distinct on UUID column

### DIFF
--- a/core/src/main/java/io/questdb/std/LongLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/LongLongHashSet.java
@@ -108,11 +108,7 @@ public final class LongLongHashSet implements Mutable, Sinkable {
         if (slot < 0) {
             return false;
         }
-
         addAt(slot, key1, key2);
-        if (size == capacity) {
-            rehash();
-        }
         return true;
     }
 
@@ -125,7 +121,9 @@ public final class LongLongHashSet implements Mutable, Sinkable {
      */
     public void addAt(int slot, long key1, long key2) {
         set(slot, key1, key2);
-        size++;
+        if (++size == capacity) {
+            rehash();
+        }
     }
 
     /**
@@ -237,7 +235,7 @@ public final class LongLongHashSet implements Mutable, Sinkable {
         values[slot * 2 + 1] = key2;
     }
 
-    interface SinkStrategy {
+    public interface SinkStrategy {
         void put(long key1, long key2, CharSink sink);
     }
 }

--- a/core/src/test/java/io/questdb/test/std/LongLongHashSetTest.java
+++ b/core/src/test/java/io/questdb/test/std/LongLongHashSetTest.java
@@ -40,7 +40,7 @@ public class LongLongHashSetTest {
     private final static Rnd rnd = new Rnd();
 
     @Test
-    public void testInsertDupsKeys() {
+    public void testInsertDuplicateKeys() {
         LongLongHashSet longSet = new LongLongHashSet(10, 0.5f, Long.MIN_VALUE, LongLongHashSet.LONG_LONG_STRATEGY);
         Set<TwoLongs> jdkSet = new HashSet<>();
         for (int i = 0; i < 10_000; i++) {
@@ -60,6 +60,24 @@ public class LongLongHashSetTest {
             long key1 = rnd.nextLong();
             long key2 = rnd.nextLong();
             assertEquals(jdkSet.add(new TwoLongs(key1, key2)), longSet.add(key1, key2));
+            maybeAssertContainsSameKeysAndSize(longSet, jdkSet);
+        }
+        assertContainsSameKeysAndSize(longSet, jdkSet);
+    }
+
+    @Test
+    public void testInsertRandomKeysViaAddAt() {
+        LongLongHashSet longSet = new LongLongHashSet(10, 0.5f, Long.MIN_VALUE, LongLongHashSet.LONG_LONG_STRATEGY);
+        Set<TwoLongs> jdkSet = new HashSet<>();
+        for (int i = 0; i < 10_000; i++) {
+            long key1 = rnd.nextLong();
+            long key2 = rnd.nextLong();
+            final int index = longSet.keySlot(key1, key2);
+            if (index < 0) {
+                continue;
+            }
+            longSet.addAt(index, key1, key2);
+            jdkSet.add(new TwoLongs(key1, key2));
             maybeAssertContainsSameKeysAndSize(longSet, jdkSet);
         }
         assertContainsSameKeysAndSize(longSet, jdkSet);


### PR DESCRIPTION
`size` wasn't incremented in `addAt()` method leading to an infinite loop when `probe()` is called. As a result, `count_distinct()` on UUID column could lead to a never-ending query.