### PR TITLE
chore(http): unify error logging in JSON and text processors

### DIFF
--- a/core/src/main/java/io/questdb/Bootstrap.java
+++ b/core/src/main/java/io/questdb/Bootstrap.java
@@ -241,8 +241,8 @@ public class Bootstrap {
                         if (shouldRename && ff.rename(path, other) == 0) {
                             log.criticalW().$("found crash file [path=").$(other).I$();
                         } else {
-                            log.criticalW().
-                                    $("could not rename crash file [path=").$(path)
+                            log.criticalW()
+                                    .$("could not rename crash file [path=").$(path)
                                     .$(", errno=").$(ff.errno())
                                     .$(", index=").$(counter.get())
                                     .$(", max=").$(maxFiles)

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -336,26 +336,24 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
                 state.info().$("query cancelled [reason=`").$(((CairoException) e).getFlyweightMessage())
                         .$("`, q=`").utf8(state.getQuery())
                         .$("`]").$();
+            } else if (ce.isCritical()) {
+                state.critical().$("error [msg=`").$(ce.getFlyweightMessage())
+                        .$("`, errno=").$(ce.getErrno())
+                        .$(", q=`").utf8(state.getQuery())
+                        .$("`]").$();
             } else {
-                if (ce.isCritical()) {
-                    state.critical().$("error [msg=`").$(ce.getFlyweightMessage())
-                            .$("`, errno=").$(ce.getErrno())
-                            .$(", q=`").utf8(state.getQuery())
-                            .$("`]").$();
-                } else {
-                    state.error().$("error [msg=`").$(ce.getFlyweightMessage())
-                            .$("`, errno=").$(ce.getErrno())
-                            .$(", q=`").utf8(state.getQuery())
-                            .$("`]").$();
-                }
+                state.error().$("error [msg=`").$(ce.getFlyweightMessage())
+                        .$("`, errno=").$(ce.getErrno())
+                        .$(", q=`").utf8(state.getQuery())
+                        .$("`]").$();
             }
         } else if (e instanceof HttpException) {
             state.error().$("internal HTTP server error [reason=`").$(((HttpException) e).getFlyweightMessage())
-                    .$("`, q=`").utf8(state.getQuery()).$("`]").$();
+                    .$("`, q=`").utf8(state.getQuery())
+                    .$("`]").$();
         } else {
             state.critical().$("internal error [ex=").$(e)
-                    .$(", q=`")
-                    .utf8(state.getQuery())
+                    .$(", q=`").utf8(state.getQuery())
                     .$("`]").$();
             // This is a critical error, so we treat it as an unhandled one.
             metrics.health().incrementUnhandledErrors();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -391,6 +391,10 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
         readyForNextRequest(context);
     }
 
+    private LogRecord error(TextQueryProcessorState state) {
+        return LOG.error().$('[').$(state.getFd()).$("] ");
+    }
+
     private LogRecord info(TextQueryProcessorState state) {
         return LOG.info().$('[').$(state.getFd()).$("] ");
     }
@@ -411,9 +415,34 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
     }
 
     private void logInternalError(Throwable e, TextQueryProcessorState state) {
-        critical(state).$("Server error executing query ").utf8(state.query).$(e).$();
-        // This is a critical error, so we treat it as an unhandled one.
-        metrics.health().incrementUnhandledErrors();
+        if (e instanceof CairoException) {
+            CairoException ce = (CairoException) e;
+            if (ce.isInterruption()) {
+                info(state).$("query cancelled [reason=`").$(((CairoException) e).getFlyweightMessage())
+                        .$("`, q=`").utf8(state.query)
+                        .$("`]").$();
+            } else if (ce.isCritical()) {
+                critical(state).$("error [msg=`").$(ce.getFlyweightMessage())
+                        .$("`, errno=").$(ce.getErrno())
+                        .$("`, q=`").utf8(state.query)
+                        .$("`]").$();
+            } else {
+                error(state).$("error [msg=`").$(ce.getFlyweightMessage())
+                        .$("`, errno=").$(ce.getErrno())
+                        .$("`, q=`").utf8(state.query)
+                        .$("`]").$();
+            }
+        } else if (e instanceof HttpException) {
+            error(state).$("internal HTTP server error [reason=`").$(((HttpException) e).getFlyweightMessage())
+                    .$("`, q=`").utf8(state.query)
+                    .$("`]").$();
+        } else {
+            critical(state).$("internal error [ex=").$(e)
+                    .$(", q=`").utf8(state.query)
+                    .$("`]").$();
+            // This is a critical error, so we treat it as an unhandled one.
+            metrics.health().incrementUnhandledErrors();
+        }
     }
 
     private boolean parseUrl(


### PR DESCRIPTION
The purpose of this change is to avoid critical level logs for non-critical `CairoException`s.