### PR TITLE
test(sql): fix flaky O3FailureTest.testOutOfFileHandles

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3957,7 +3957,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         srcDataMax,
                         partitionMutates
                 );
-
             }
         }
     }
@@ -5318,7 +5317,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         srcNameTxn = getPartitionNameTxnByIndex(partitionIndex);
                     } else {
                         srcDataMax = 0;
-                        // A version needed to housekeep dropped partitions
+                        // A version needed to housekeep dropped partitions.
                         // When partition created without O3 merge, use `txn-1` as partition version.
                         // `txn` version is used when partition is merged. Both `txn-1` and `txn` can
                         // be written within the same commit when new partition initially written in order
@@ -6114,7 +6113,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 !CairoKeywords.isDetachedDirMarker(pUtf8NameZ) &&
                 !CairoKeywords.isWal(pUtf8NameZ) &&
                 !CairoKeywords.isTxnSeq(pUtf8NameZ) &&
-                !CairoKeywords.isSeq(pUtf8NameZ)  &&
+                !CairoKeywords.isSeq(pUtf8NameZ) &&
                 !Chars.endsWith(fileNameSink, configuration.getAttachPartitionSuffix())
         ) {
             try {

--- a/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
@@ -35,13 +35,13 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
-import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
@@ -400,7 +400,7 @@ public class O3FailureTest extends AbstractO3Test {
         counter.set(1);
         executeWithoutPool(
                 O3FailureTest::testColumnTopMidAppendBlankColumnFailRetry0,
-                failOnOpeRW("v.d.1", 2)
+                failOnOpenRW("v.d.1", 2)
         );
     }
 
@@ -410,7 +410,7 @@ public class O3FailureTest extends AbstractO3Test {
         executeWithPool(
                 0,
                 O3FailureTest::testColumnTopMidAppendBlankColumnFailRetry0,
-                failOnOpeRW("v.d.1", 2)
+                failOnOpenRW("v.d.1", 2)
         );
     }
 
@@ -431,13 +431,13 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testColumnTopMidDataMergeDataFailRetryReadTop() throws Exception {
         counter.set(13);
-        executeWithoutPool(O3FailureTest::testColumnTopMidDataMergeDataFailRetry0, failOnOpeRW("v2.d.3", 3));
+        executeWithoutPool(O3FailureTest::testColumnTopMidDataMergeDataFailRetry0, failOnOpenRW("v2.d.3", 3));
     }
 
     @Test
     public void testColumnTopMidDataMergeDataFailRetryReadTopContended() throws Exception {
         counter.set(13);
-        executeWithPool(0, O3FailureTest::testColumnTopMidDataMergeDataFailRetry0, failOnOpeRW("v2.d.3", 3));
+        executeWithPool(0, O3FailureTest::testColumnTopMidDataMergeDataFailRetry0, failOnOpenRW("v2.d.3", 3));
     }
 
     @Test
@@ -789,7 +789,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testOutOfFileHandles() throws Exception {
-        counter.set(1536);
+        counter.set(1195); // 995 files are opened when provisioning tables
         executeWithPool(4, O3FailureTest::testOutOfFileHandles0, new TestFilesFacadeImpl() {
             @Override
             public boolean close(int fd) {
@@ -1273,7 +1273,7 @@ public class O3FailureTest extends AbstractO3Test {
         assertMaxTimestamp(compiler.getEngine(), expectedMaxTimestamp);
     }
 
-    private static FilesFacade failOnOpeRW(String fileName, int count) {
+    private static FilesFacade failOnOpenRW(String fileName, int count) {
         AtomicInteger counter = new AtomicInteger(count);
         return new TestFilesFacadeImpl() {
             @Override
@@ -3302,21 +3302,16 @@ public class O3FailureTest extends AbstractO3Test {
                 executionContext
         );
 
-        compiler.compile("create table y1 as (y)", executionContext);
-
-        // create expected result sets
-        compiler.compile("create table z as (x union all y)", executionContext);
+        compiler.compile("create table y1 as (y) timestamp(ts) partition by DAY", executionContext);
 
         // create another compiler to be used by second pool
         try (SqlCompiler compiler2 = new SqlCompiler(engine)) {
-
             final CyclicBarrier barrier = new CyclicBarrier(2);
             final SOCountDownLatch haltLatch = new SOCountDownLatch(2);
             final AtomicInteger errorCount = new AtomicInteger();
 
             // we have two pairs of tables (x,y) and (x1,y1)
             WorkerPool pool1 = new WorkerPool(() -> 1);
-
             pool1.assign(new Job() {
                 private boolean toRun = true;
 
@@ -3339,7 +3334,6 @@ public class O3FailureTest extends AbstractO3Test {
             });
 
             final WorkerPool pool2 = new TestWorkerPool(1);
-
             pool2.assign(new Job() {
                 private boolean toRun = true;
 
@@ -3368,6 +3362,7 @@ public class O3FailureTest extends AbstractO3Test {
 
             pool1.halt();
             pool2.halt();
+
             Assert.assertTrue(errorCount.get() > 0);
         }
     }


### PR DESCRIPTION
Initial atomic counter value set in the test was too high leading to occasional failures.