### PR TITLE
chore(core): marginally reduce time it takes to build Docker imeage (DL3015)

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -2,12 +2,12 @@ FROM debian:bullseye
 ARG tag_name
 
 RUN apt-get update \
-  && apt-get install git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip -y
+  && apt-get install --no-install-recommends git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip -y
 
 RUN wget -O- https://apt.corretto.aws/corretto.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/winehq.gpg >/dev/null && \
     add-apt-repository 'deb https://apt.corretto.aws stable main' && \
     apt-get update && \
-    apt-get install -y java-17-amazon-corretto-jdk=1:17.0.3.6-1
+    apt-get install --no-install-recommends -y java-17-amazon-corretto-jdk=1:17.0.3.6-1
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto
 WORKDIR /build


### PR DESCRIPTION
Hi!
The Dockerfile placed at "core/Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance