### PR TITLE
feat(sql): fix display of interval scans in EXPLAIN's output

### DIFF
--- a/core/src/main/java/io/questdb/griffin/BasePlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/BasePlanSink.java
@@ -163,6 +163,12 @@ public abstract class BasePlanSink implements PlanSink {
         return this;
     }
 
+    @Override
+    public PlanSink valISODate(long l) {
+        sink.putISODate(l);
+        return this;
+    }
+
     static class EscapingStringSink extends StringSink {
         @Override
         public CharSink put(CharSequence cs) {

--- a/core/src/main/java/io/questdb/griffin/PlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/PlanSink.java
@@ -108,6 +108,7 @@ public interface PlanSink {
 
     PlanSink val(long hash, int geoHashBits);
 
-    PlanSink valUuid(long lo, long hi);
+    PlanSink valISODate(long l);
 
+    PlanSink valUuid(long lo, long hi);
 }

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -55,7 +55,9 @@ import io.questdb.log.LogFactory;
 import io.questdb.std.*;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractGriffinTest;
+import io.questdb.test.tools.StationaryMicrosClock;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -64,6 +66,12 @@ import java.util.Arrays;
 public class ExplainPlanTest extends AbstractGriffinTest {
 
     protected final static Log LOG = LogFactory.getLog(ExplainPlanTest.class);
+
+    @BeforeClass
+    public static void setUpStatic() {
+        testMicrosClock = StationaryMicrosClock.INSTANCE;
+        AbstractGriffinTest.setUpStatic();
+    }
 
     @Test
     public void test2686LeftJoinDoesntMoveOtherInnerJoinPredicate() throws Exception {
@@ -1233,7 +1241,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
     public void testExplainUpdateWithFilter() throws Exception {
         assertPlan("create table a ( l long, d double, ts timestamp) timestamp(ts)",
                 "update a set l = 20, d = d+rnd_double() " +
-                        "where d < 100.0d and ts > dateadd('d', -1, now());",
+                        "where d < 100.0d and ts > dateadd('d', 1, now()  );",
                 "Update table: a\n" +
                         "    VirtualRecord\n" +
                         "      functions: [20,d+rnd_double()]\n" +
@@ -1243,7 +1251,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "            DataFrame\n" +
                         "                Row forward scan\n" +
                         "                Interval forward scan on: a\n" +
-                        "                  intervals: [static=[0,9223372036854775807,281481419161601,4294967296] dynamic=[dateadd('d',-1,now())]]\n");
+                        "                  intervals: [(\"1970-01-02T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -1475,7 +1483,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "            DataFrame\n" +
                         "                Row forward scan\n" +
                         "                Interval forward scan on: trades\n" +
-                        "                  intervals: [static=[0,9223372036854775807,281481419161601,4294967296] dynamic=[dateadd('m',-30,now())]]\n");
+                        "                  intervals: [(\"1969-12-31T23:30:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -2736,7 +2744,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "    Row backward scan\n" +
                         "      expectedSymbolsCount: 2147483647\n" +
                         "    Interval backward scan on: a\n" +
-                        "      intervals: [static=[1,9223372036854775807]\n");
+                        "      intervals: [(\"1970-01-01T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -4197,7 +4205,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "        Index forward scan on: sym deferred: true\n" +
                         "          filter: sym='S'\n" +
                         "        Interval forward scan on: a\n" +
-                        "          intervals: [static=[1,99]\n");
+                        "          intervals: [(\"1970-01-01T00:00:00.000001Z\",\"1970-01-01T00:00:00.000099Z\")]\n");
     }
 
     @Test
@@ -4648,7 +4656,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[0,9223372036854775807,281481419161601,4294967296] dynamic=[now()]]\n");
+                        "      intervals: [(\"1970-01-01T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -4658,7 +4666,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[NaN,0,844422782648321,4294967296,0,9223372036854775807,281481419161601,4294967296] dynamic=[now(),dateadd('d',-1,now())]]\n");
+                        "      intervals: [(\"1969-12-31T00:00:00.000001Z\",\"1969-12-31T23:59:59.999999Z\")]\n");
     }
 
     @Test
@@ -4668,7 +4676,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[0,9223372036854775807,281481419161601,4294967296,1640995200000001,9223372036854775807,2147483649,4294967296] dynamic=[now(),null]]\n");
+                        "      intervals: [(\"2022-01-01T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -4678,7 +4686,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row backward scan\n" +
                         "    Interval backward scan on: tab\n" +
-                        "      intervals: [static=[0,9223372036854775807,281481419161601,4294967296,1640995200000001,9223372036854775807,2147483649,4294967296] dynamic=[now(),null]]\n");
+                        "      intervals: [(\"2022-01-01T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -4792,7 +4800,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                     "            Index forward scan on: s deferred: true\n" +
                     "              filter: s=:s2::string\n" +
                     "        Interval forward scan on: a\n" +
-                    "          intervals: [static=[0,86399999999]\n";
+                    "          intervals: [(\"1970-01-01T00:00:00.000000Z\",\"1970-01-01T23:59:59.999999Z\")]\n";
 
             assertPlan(queryDesc, expectedPlan.replace("#ORDER#", " desc"));
             assertQuery("s\tts\n" +
@@ -4947,7 +4955,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                     "  filter: length(s)=2\n" +
                     "    Cursor-order scan\n" +
                     "    Interval forward scan on: a\n" +
-                    "      intervals: [static=[1678838400000000,1678924799999999]\n";
+                    "      intervals: [(\"2023-03-15T00:00:00.000000Z\",\"2023-03-15T23:59:59.999999Z\")]\n";
 
             assertPlan(query.replace("#ORDER#", "asc"),
                     expectedPlan.replace("#ORDER#", "asc"));
@@ -5010,7 +5018,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "    Index forward scan on: s\n" +
                         "      symbolOrder: asc\n" +
                         "    Interval forward scan on: a\n" +
-                        "      intervals: [static=[0,99]\n");
+                        "      intervals: [(\"1970-01-01T00:00:00.000000Z\",\"1970-01-01T00:00:00.000099Z\")]\n");
     }
 
     @Test
@@ -5104,7 +5112,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                             "    Index backward scan on: s1\n" +
                             "      filter: s1=1\n" +
                             "    Interval forward scan on: a\n" +
-                            "      intervals: [static=[1,8]\n");
+                            "      intervals: [(\"1970-01-01T00:00:00.000001Z\",\"1970-01-01T00:00:00.000008Z\")]\n");
         });
     }
 
@@ -5124,7 +5132,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                             "        Index backward scan on: s1\n" +
                             "          filter: s1=2\n" +
                             "    Interval forward scan on: a\n" +
-                            "      intervals: [static=[1,8]\n");
+                            "      intervals: [(\"1970-01-01T00:00:00.000001Z\",\"1970-01-01T00:00:00.000008Z\")]\n");
         });
     }
 
@@ -5145,7 +5153,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                             "        DataFrame\n" +
                             "            Row forward scan\n" +
                             "            Interval forward scan on: a\n" +
-                            "              intervals: [static=[1,8]\n");
+                            "              intervals: [(\"1970-01-01T00:00:00.000001Z\",\"1970-01-01T00:00:00.000008Z\")]\n");
         });
     }
 
@@ -5332,7 +5340,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[1583020800000001,9223372036854775807]\n");
+                        "      intervals: [(\"2020-03-01T00:00:00.000001Z\",\"MAX\")]\n");
     }
 
     @Test
@@ -5344,7 +5352,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Interval forward scan on: tab\n" +
-                        "          intervals: [static=[1577847600000000,1577851200999999,1577934000000000,1577937600999999,1578020400000000,1578024000999999]\n");
+                        "          intervals: [(\"2020-01-01T03:00:00.000000Z\",\"2020-01-01T04:00:00.999999Z\"),(\"2020-01-02T03:00:00.000000Z\",\"2020-01-02T04:00:00.999999Z\"),(\"2020-01-03T03:00:00.000000Z\",\"2020-01-03T04:00:00.999999Z\")]\n");
     }
 
     @Test
@@ -5356,7 +5364,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Interval forward scan on: tab\n" +
-                        "          intervals: [static=[1577847600000000,1577851200999999,1577934000000000,1577937600999999,1578020400000000,1578024000999999]\n");
+                        "          intervals: [(\"2020-01-01T03:00:00.000000Z\",\"2020-01-01T04:00:00.999999Z\"),(\"2020-01-02T03:00:00.000000Z\",\"2020-01-02T04:00:00.999999Z\"),(\"2020-01-03T03:00:00.000000Z\",\"2020-01-03T04:00:00.999999Z\")]\n");
     }
 
     @Test
@@ -5366,7 +5374,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[1583020800000000,1583107199999999]\n");
+                        "      intervals: [(\"2020-03-01T00:00:00.000000Z\",\"2020-03-01T23:59:59.999999Z\")]\n");
     }
 
     @Test // TODO: this should use interval scan with two ranges !
@@ -5395,7 +5403,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[1583798400000001,1585699199999999]\n");
+                        "      intervals: [(\"2020-03-10T00:00:00.000001Z\",\"2020-03-31T23:59:59.999999Z\")]\n");
     }
 
     @Test // TODO: this should use interval scan with two ranges !
@@ -5429,7 +5437,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row forward scan\n" +
                         "    Interval forward scan on: tab\n" +
-                        "      intervals: [static=[1577847600000000,1577851200999999,1577934000000000,1577937600999999,1578020400000000,1578024000999999]\n");
+                        "      intervals: [(\"2020-01-01T03:00:00.000000Z\",\"2020-01-01T04:00:00.999999Z\"),(\"2020-01-02T03:00:00.000000Z\",\"2020-01-02T04:00:00.999999Z\"),(\"2020-01-03T03:00:00.000000Z\",\"2020-01-03T04:00:00.999999Z\")]\n");
     }
 
     @Test
@@ -5439,7 +5447,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                 "DataFrame\n" +
                         "    Row backward scan\n" +
                         "    Interval backward scan on: tab\n" +
-                        "      intervals: [static=[1577847600000000,1577851200999999,1577934000000000,1577937600999999,1578020400000000,1578024000999999]\n");
+                        "      intervals: [(\"2020-01-01T03:00:00.000000Z\",\"2020-01-01T04:00:00.999999Z\"),(\"2020-01-02T03:00:00.000000Z\",\"2020-01-02T04:00:00.999999Z\"),(\"2020-01-03T03:00:00.000000Z\",\"2020-01-03T04:00:00.999999Z\")]\n");
     }
 
     @Test
@@ -5836,7 +5844,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Interval forward scan on: tab\n" +
-                        "          intervals: [static=[1609459200000000,1609545599999999]\n");
+                        "          intervals: [(\"2021-01-01T00:00:00.000000Z\",\"2021-01-01T23:59:59.999999Z\")]\n");
     }
 
     @Test // TODO: this one should use jit
@@ -6921,7 +6929,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                             "            Index forward scan on: s deferred: true\n" +
                             "              filter: s=:s2::string\n" +
                             "        Interval forward scan on: a\n" +
-                            "          intervals: [static=[0,86399999999]\n");
+                            "          intervals: [(\"1970-01-01T00:00:00.000000Z\",\"1970-01-01T23:59:59.999999Z\")]\n");
 
             assertQuery("s\tts\n" +
                     "S2\t1970-01-01T00:00:00.000000Z\n" +
@@ -6940,7 +6948,7 @@ public class ExplainPlanTest extends AbstractGriffinTest {
                             "            Index forward scan on: s deferred: true\n" +
                             "              filter: s=:s2::string\n" +
                             "        Interval forward scan on: a\n" +
-                            "          intervals: [static=[0,86399999999]\n");
+                            "          intervals: [(\"1970-01-01T00:00:00.000000Z\",\"1970-01-01T23:59:59.999999Z\")]\n");
 
             assertQuery("s\tts\n" +
                     "S1\t1970-01-01T00:00:00.000001Z\n" +

--- a/core/src/test/java/io/questdb/test/griffin/KeyedAggregationTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/KeyedAggregationTest.java
@@ -198,7 +198,7 @@ public class KeyedAggregationTest extends AbstractGriffinTest {
                             "            Index forward scan on: account_uuid\n" +
                             "              symbolOrder: asc\n" +
                             "            Interval forward scan on: records\n" +
-                            "              intervals: [static=[1675209600000001,1675295999999999]\n");
+                            "              intervals: [(\"2023-02-01T00:00:00.000001Z\",\"2023-02-01T23:59:59.999999Z\")]\n");
 
             assertQuery("account_uuid\trequest_count\n" +
                     "s0\t0\n" +

--- a/core/src/test/java/io/questdb/test/griffin/LatestByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/LatestByTest.java
@@ -136,7 +136,7 @@ public class LatestByTest extends AbstractGriffinTest {
                             "    Index backward scan on: device_id parallel: true\n" +
                             "      filter: g8c within(\"0010000110110001110001111100010000100000\")\n" +
                             "    Interval backward scan on: pos_test\n" +
-                            "      intervals: [static=[1630540800000000,1630627199999999]\n");
+                            "      intervals: [(\"2021-09-02T00:00:00.000000Z\",\"2021-09-02T23:59:59.999999Z\")]\n");
 
             //prefix filter is applied AFTER latest on 
             assertQuery("ts\tdevice_id\tg8c\n" +

--- a/core/src/test/java/io/questdb/test/griffin/LimitTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/LimitTest.java
@@ -456,7 +456,7 @@ public class LimitTest extends AbstractGriffinTest {
                     "    DataFrame\n" +
                     "        Row backward scan\n" +
                     "        Interval backward scan on: intervaltest\n" +
-                    "          intervals: [static=[1680739799000001,9223372036854775807]\n");
+                    "          intervals: [(\"2023-04-06T00:09:59.000001Z\",\"MAX\")]\n");
 
             assertQuery("id\tts\n" +
                             "600000\t2023-04-06T00:10:00.000000Z\n" +

--- a/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
@@ -427,7 +427,7 @@ public class OrderByWithFilterTest extends AbstractGriffinTest {
                     "                DataFrame\n" +
                     "                    Row forward scan\n" +
                     "                    Interval forward scan on: trips\n" +
-                    "                      intervals: [static=[1561852800000000,9223372036854775807]\n");
+                    "                      intervals: [(\"2019-06-30T00:00:00.000000Z\",\"MAX\")]\n");
 
             assertQuery("vendor_id\n" +
                     "A1\n" +
@@ -471,7 +471,7 @@ public class OrderByWithFilterTest extends AbstractGriffinTest {
                     "                DataFrame\n" +
                     "                    Row forward scan\n" +
                     "                    Interval forward scan on: t1\n" +
-                    "                      intervals: [static=[1561852800000000,9223372036854775807]\n" +
+                    "                      intervals: [(\"2019-06-30T00:00:00.000000Z\",\"MAX\")]\n" +
                     "                Hash\n" +
                     "                    Async Filter\n" +
                     "                      filter: vendor_id in [A1,A2]\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionCaseTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionCaseTest.java
@@ -225,7 +225,7 @@ public class GroupByFunctionCaseTest extends AbstractGriffinTest {
                             "                DataFrame\n" +
                             "                    Row forward scan\n" +
                             "                    Interval forward scan on: spot_trades\n" +
-                            "                      intervals: [static=[1640995200000000,9223372036854775807]\n");
+                            "                      intervals: [(\"2022-01-01T00:00:00.000000Z\",\"MAX\")]\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -3561,7 +3561,7 @@ public class SampleByTest extends AbstractGriffinTest {
                             "        DataFrame\n" +
                             "            Row forward scan\n" +
                             "            Interval forward scan on: tab\n" +
-                            "              intervals: [static=[1669852800000001,9223372036854775807]\n");
+                            "              intervals: [(\"2022-12-01T00:00:00.000001Z\",\"MAX\")]\n");
 
             assertQuery("ts\ts\tfirst\n" +
                             "2022-12-01T01:33:00.000000Z\tB\t3\n" +


### PR DESCRIPTION
Changes : 
- fix display for interval scans with dynamic intervals 
- show iso-formatted timestamps instead of raw long values 
