### PR TITLE
test(core): reduce the chances of fuzz test timing out

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/wal/fuzz/FuzzTransactionGenerator.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/fuzz/FuzzTransactionGenerator.java
@@ -67,6 +67,9 @@ public class FuzzTransactionGenerator {
         probabilityOfRenamingColumn = probabilityOfRenamingColumn / sumOfProbabilities;
         probabilityOfTruncate = probabilityOfTruncate / sumOfProbabilities;
 
+        // To prevent long loops of cancelling rows, limit max probability of cancelling rows
+        probabilityOfCancelRow = Math.min(probabilityOfCancelRow, 0.3);
+
         // Reduce some random parameters if there is too much data so test can finish in reasonable time
         transactionCount = Math.min(transactionCount, 1_500_000 / rowCount);
 
@@ -139,7 +142,6 @@ public class FuzzTransactionGenerator {
                         maxStrLenForStrColumns,
                         symbols,
                         rnd.nextLong(),
-                        transactionCount,
                         allRowsSameTimestamp
                 );
                 rowCount -= blockRows;
@@ -293,7 +295,6 @@ public class FuzzTransactionGenerator {
             double rollback,
             int strLen,
             String[] symbols,
-            long seed,
             long transactionCount,
             boolean allRowsSameTimestamp
     ) {
@@ -312,10 +313,8 @@ public class FuzzTransactionGenerator {
                     timestamp = timestamp + delta / rowCount;
                 }
             }
-            // Use stable random seeds which depends on the transaction index and timestamp
-            // This will generate same row for same timestamp so that tests will not fail on reordering within same timestamp
-            long seed1 = seed + timestamp;
-            long seed2 = timestamp;
+            long seed1 = rnd.nextLong();
+            long seed2 = rnd.nextLong();
             transaction.operationList.add(new FuzzInsertOperation(seed1, seed2, timestamp, notSet, nullSet, cancelRows, strLen, symbols));
         }
 


### PR DESCRIPTION
Prevent fuzz tests from generating rows with thousands of add/cancel row actions. 
Cancelling row can be an expensive operation and lead to test run timeout https://dev.azure.com/questdb/questdb/_build/results?buildId=19655&view=logs&j=85bc06a8-a627-555e-552b-b210a8c8389c&t=f747e3bf-47e7-5fc1-f444-dbfd34317c83