### PR TITLE
chore(core): allow implicit cast from str to long256

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -326,7 +326,8 @@ public final class ColumnType {    //@formatter:off
                 || (fromType == STRING && toTag == GEOINT)
                 || (fromType == STRING && toTag == GEOLONG)
                 || (fromType == STRING && toTag == TIMESTAMP)
-                || (fromType == SYMBOL && toTag == TIMESTAMP);
+                || (fromType == SYMBOL && toTag == TIMESTAMP)
+                || (fromType == STRING && toTag == LONG256);
     }
 
     private static boolean isNarrowingCast(int fromType, int toType) {

--- a/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
+++ b/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
@@ -113,7 +113,7 @@ public class RecordToRowCopierUtils {
         int implicitCastStrAsChar = asm.poolMethod(SqlUtil.class, "implicitCastStrAsChar", "(Ljava/lang/CharSequence;)C");
         int implicitCastStrAsInt = asm.poolMethod(SqlUtil.class, "implicitCastStrAsInt", "(Ljava/lang/CharSequence;)I");
         int implicitCastStrAsLong = asm.poolMethod(SqlUtil.class, "implicitCastStrAsLong", "(Ljava/lang/CharSequence;)J");
-        int implicitCastStrAsLong256 = asm.poolMethod(SqlUtil.class, "implicitCastStrAsLong256", "(Ljava/lang/CharSequence;)Lio/questdb/std/Long256;");
+        int implicitCastStrAsLong256 = asm.poolMethod(SqlUtil.class, "implicitCastStrAsLong256", "(Ljava/lang/CharSequence;)Lio/questdb/griffin/engine/functions/constants/Long256Constant;");
         int implicitCastStrAsDate = asm.poolMethod(SqlUtil.class, "implicitCastStrAsDate", "(Ljava/lang/CharSequence;)J");
         int implicitCastStrAsTimestamp = asm.poolMethod(SqlUtil.class, "implicitCastStrAsTimestamp", "(Ljava/lang/CharSequence;)J");
         int implicitCastDateAsTimestamp = asm.poolMethod(SqlUtil.class, "dateToTimestamp", "(J)J");

--- a/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
+++ b/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
@@ -52,6 +52,18 @@ public class RecordToRowCopierUtils {
         int thisClassIndex = asm.poolClass(asm.poolUtf8("io/questdb/griffin/rowcopier"));
         int interfaceClassIndex = asm.poolClass(RecordToRowCopier.class);
 
+        // Character        Type        Interpretation
+        // B                byte        signed byte
+        // C                char        Unicode character code point in the Basic Multilingual Plane, encoded with UTF-16
+        // D                double      double-precision floating-point value
+        // F                float       single-precision floating-point value
+        // I                int         integer
+        // J                long        long integer
+        // L ClassName ;    reference   an instance of class ClassName
+        // S                short       signed short
+        // Z                boolean     true or false
+        // [                reference   one array dimension
+
         int rGetInt = asm.poolInterfaceMethod(Record.class, "getInt", "(I)I");
         int rGetGeoInt = asm.poolInterfaceMethod(Record.class, "getGeoInt", "(I)I");
         int rGetLong = asm.poolInterfaceMethod(Record.class, "getLong", "(I)J");
@@ -101,6 +113,7 @@ public class RecordToRowCopierUtils {
         int implicitCastStrAsChar = asm.poolMethod(SqlUtil.class, "implicitCastStrAsChar", "(Ljava/lang/CharSequence;)C");
         int implicitCastStrAsInt = asm.poolMethod(SqlUtil.class, "implicitCastStrAsInt", "(Ljava/lang/CharSequence;)I");
         int implicitCastStrAsLong = asm.poolMethod(SqlUtil.class, "implicitCastStrAsLong", "(Ljava/lang/CharSequence;)J");
+        int implicitCastStrAsLong256 = asm.poolMethod(SqlUtil.class, "implicitCastStrAsLong256", "(Ljava/lang/CharSequence;)Lio/questdb/std/Long256;");
         int implicitCastStrAsDate = asm.poolMethod(SqlUtil.class, "implicitCastStrAsDate", "(Ljava/lang/CharSequence;)J");
         int implicitCastStrAsTimestamp = asm.poolMethod(SqlUtil.class, "implicitCastStrAsTimestamp", "(Ljava/lang/CharSequence;)J");
         int implicitCastDateAsTimestamp = asm.poolMethod(SqlUtil.class, "dateToTimestamp", "(J)J");
@@ -629,6 +642,10 @@ public class RecordToRowCopierUtils {
                             break;
                         case ColumnType.UUID:
                             asm.invokeInterface(wPutUuidStr, 2);
+                            break;
+                        case ColumnType.LONG256:
+                            asm.invokeStatic(implicitCastStrAsLong256);
+                            asm.invokeInterface(wPutLong256, 2);
                             break;
                         default:
                             assert false;

--- a/core/src/main/java/io/questdb/griffin/SqlUtil.java
+++ b/core/src/main/java/io/questdb/griffin/SqlUtil.java
@@ -27,7 +27,6 @@ package io.questdb.griffin;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.ImplicitCastException;
-import io.questdb.griffin.engine.functions.Long256Function;
 import io.questdb.griffin.engine.functions.constants.Long256Constant;
 import io.questdb.griffin.engine.functions.constants.Long256NullConstant;
 import io.questdb.griffin.model.ExpressionNode;
@@ -509,7 +508,7 @@ public class SqlUtil {
         return Numbers.LONG_NaN;
     }
 
-    public static Long256Function implicitCastStrAsLong256(CharSequence value) {
+    public static Long256Constant implicitCastStrAsLong256(CharSequence value) {
         if (value == null || value.length() == 0) {
             return Long256NullConstant.INSTANCE;
         }

--- a/core/src/main/java/io/questdb/griffin/SqlUtil.java
+++ b/core/src/main/java/io/questdb/griffin/SqlUtil.java
@@ -27,10 +27,14 @@ package io.questdb.griffin;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.ImplicitCastException;
+import io.questdb.griffin.engine.functions.Long256Function;
+import io.questdb.griffin.engine.functions.constants.Long256Constant;
+import io.questdb.griffin.engine.functions.constants.Long256NullConstant;
 import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.griffin.model.QueryColumn;
 import io.questdb.griffin.model.QueryModel;
+import io.questdb.std.ThreadLocal;
 import io.questdb.std.*;
 import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.microtime.Timestamps;
@@ -49,6 +53,7 @@ public class SqlUtil {
     private static final DateFormat[] DATE_FORMATS_FOR_TIMESTAMP;
     private static final int DATE_FORMATS_FOR_TIMESTAMP_SIZE;
     private static final int DATE_FORMATS_SIZE;
+    private static final ThreadLocal<Long256ConstantFactory> LONG256_FACTORY = new ThreadLocal<>(Long256ConstantFactory::new);
 
     public static void addSelectStar(
             QueryModel model,
@@ -504,18 +509,18 @@ public class SqlUtil {
         return Numbers.LONG_NaN;
     }
 
-    public static Long256 implicitCastStrAsLong256(CharSequence value) {
+    public static Long256Function implicitCastStrAsLong256(CharSequence value) {
         if (value == null || value.length() == 0) {
-            return Long256Impl.NULL_LONG256;
+            return Long256NullConstant.INSTANCE;
         }
-        Long256 long256 = new Long256Impl();
         int start = 0;
         int end = value.length();
         if (end > 2 && value.charAt(start) == '0' && (value.charAt(start + 1) | 32) == 'x') {
             start += 2;
         }
-        Long256FromCharSequenceDecoder.decode(value, start, end, long256);
-        return long256;
+        Long256ConstantFactory factory = LONG256_FACTORY.get();
+        Long256FromCharSequenceDecoder.decode(value, start, end, factory);
+        return factory.pop();
     }
 
     public static void implicitCastStrAsLong256(CharSequence value, Long256Acceptor long256Acceptor) {
@@ -670,6 +675,22 @@ public class SqlUtil {
         return pool.next().of(ExpressionNode.LITERAL, token, 0, position);
     }
 
+    private static class Long256ConstantFactory implements Long256Acceptor {
+        private Long256Constant long256;
+
+        @Override
+        public void setAll(long l0, long l1, long l2, long l3) {
+            assert long256 == null;
+            long256 = new Long256Constant(l0, l1, l2, l3);
+        }
+
+        Long256Constant pop() {
+            Long256Constant v = long256;
+            long256 = null;
+            return v;
+        }
+    }
+
     static {
         for (int i = 0, n = OperatorExpression.operators.size(); i < n; i++) {
             SqlUtil.disallowedAliases.add(OperatorExpression.operators.getQuick(i).token);
@@ -696,6 +717,5 @@ public class SqlUtil {
         };
 
         DATE_FORMATS_FOR_TIMESTAMP_SIZE = DATE_FORMATS_FOR_TIMESTAMP.length;
-
     }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlUtil.java
+++ b/core/src/main/java/io/questdb/griffin/SqlUtil.java
@@ -504,6 +504,20 @@ public class SqlUtil {
         return Numbers.LONG_NaN;
     }
 
+    public static Long256 implicitCastStrAsLong256(CharSequence value) {
+        if (value == null || value.length() == 0) {
+            return Long256Impl.NULL_LONG256;
+        }
+        Long256 long256 = new Long256Impl();
+        int start = 0;
+        int end = value.length();
+        if (end > 2 && value.charAt(start) == '0' && (value.charAt(start + 1) | 32) == 'x') {
+            start += 2;
+        }
+        Long256FromCharSequenceDecoder.decode(value, start, end, long256);
+        return long256;
+    }
+
     public static void implicitCastStrAsLong256(CharSequence value, Long256Acceptor long256Acceptor) {
         if (value != null) {
             Long256FromCharSequenceDecoder.decode(value, 0, value.length(), long256Acceptor);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256Constant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256Constant.java
@@ -31,7 +31,7 @@ import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.str.CharSink;
 
-public class Long256Constant extends Long256Function implements ConstantFunction {
+public class Long256Constant extends Long256Function implements Long256, ConstantFunction {
     private final Long256Impl value = new Long256Impl();
 
     public Long256Constant(Long256 that) {
@@ -40,6 +40,21 @@ public class Long256Constant extends Long256Function implements ConstantFunction
 
     public Long256Constant(long l0, long l1, long l2, long l3) {
         value.setAll(l0, l1, l2, l3);
+    }
+
+    @Override
+    public long getLong0() {
+        return value.getLong0();
+    }
+
+    @Override
+    public long getLong1() {
+        return value.getLong1();
+    }
+
+    @Override
+    public long getLong2() {
+        return value.getLong2();
     }
 
     @Override
@@ -55,6 +70,16 @@ public class Long256Constant extends Long256Function implements ConstantFunction
     @Override
     public Long256 getLong256B(Record rec) {
         return value;
+    }
+
+    @Override
+    public long getLong3() {
+        return value.getLong3();
+    }
+
+    @Override
+    public void setAll(long l0, long l1, long l2, long l3) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256Constant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256Constant.java
@@ -32,13 +32,18 @@ import io.questdb.std.Long256Impl;
 import io.questdb.std.str.CharSink;
 
 public class Long256Constant extends Long256Function implements Long256, ConstantFunction {
-    private final Long256Impl value = new Long256Impl();
+    protected Long256Impl value;
+
+    Long256Constant() {
+        // used by Long256NullConstant
+    }
 
     public Long256Constant(Long256 that) {
         this(that.getLong0(), that.getLong1(), that.getLong2(), that.getLong3());
     }
 
     public Long256Constant(long l0, long l1, long l2, long l3) {
+        value = new Long256Impl();
         value.setAll(l0, l1, l2, l3);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256NullConstant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256NullConstant.java
@@ -26,27 +26,19 @@ package io.questdb.griffin.engine.functions.constants;
 
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.PlanSink;
-import io.questdb.griffin.engine.functions.Long256Function;
-import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.str.CharSink;
 
-public final class Long256NullConstant extends Long256Function implements ConstantFunction {
+public final class Long256NullConstant extends Long256Constant implements ConstantFunction {
 
     public static final Long256NullConstant INSTANCE = new Long256NullConstant();
 
+    public Long256NullConstant() {
+        super(Long256Impl.NULL_LONG256);
+    }
+
     @Override
     public void getLong256(Record rec, CharSink sink) {
-    }
-
-    @Override
-    public Long256 getLong256A(Record rec) {
-        return Long256Impl.NULL_LONG256;
-    }
-
-    @Override
-    public Long256 getLong256B(Record rec) {
-        return Long256Impl.NULL_LONG256;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256NullConstant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/Long256NullConstant.java
@@ -30,11 +30,10 @@ import io.questdb.std.Long256Impl;
 import io.questdb.std.str.CharSink;
 
 public final class Long256NullConstant extends Long256Constant implements ConstantFunction {
-
     public static final Long256NullConstant INSTANCE = new Long256NullConstant();
 
     public Long256NullConstant() {
-        super(Long256Impl.NULL_LONG256);
+        value = Long256Impl.NULL_LONG256;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.pgwire.CircuitBreakerRegistry;
-import io.questdb.test.cutlass.NetUtils;
 import io.questdb.cutlass.pgwire.PGWireConfiguration;
 import io.questdb.cutlass.pgwire.PGWireServer;
 import io.questdb.griffin.QueryFutureUpdateListener;
@@ -40,7 +39,6 @@ import io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFacto
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
-import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.*;
 import io.questdb.std.*;
@@ -50,6 +48,8 @@ import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.StringSink;
+import io.questdb.test.cutlass.NetUtils;
+import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.*;
@@ -4914,7 +4914,7 @@ nodejs code:
                         final Connection connection = getConnection(server.getPort(), false, false)) {
 
                     try (PreparedStatement ps1 = connection.prepareStatement("select * from " +
-                            "(select cast(x as timestamp) ts, cast('0x05cb69971d94a00000192178ef80f0' as long256) as id, x from long_sequence(10) ) " +
+                            "(select cast(x as timestamp) ts, '0x05cb69971d94a00000192178ef80f0' as id, x from long_sequence(10) ) " +
                             "where ts between '2022-03-20' " +
                             "AND id <> '0x05ab6d9fabdabb00066a5db735d17a' " +
                             "AND id <> '0x05aba84839b9c7000006765675e630' " +
@@ -4949,7 +4949,7 @@ nodejs code:
                         final Connection connection = getConnection(server.getPort(), false, false)) {
 
                     try (PreparedStatement ps1 = connection.prepareStatement("select * from " +
-                            "(select cast(x as timestamp) ts, cast('0x05cb69971d94a00000192178ef80f0' as long256) as id, x from long_sequence(10) ) " +
+                            "(select cast(x as timestamp) ts, '0x05cb69971d94a00000192178ef80f0' as id, x from long_sequence(10) ) " +
                             "where ts between '2022-03-20' " +
                             "AND id <> '0x05ab6d9fabdabb00066a5db735d17a' " +
                             "AND id <> '0x05aba84839b9c7000006765675e630' " +
@@ -8759,7 +8759,7 @@ create table tab as (
                 int bindIdx = 1;
                 for (int p = 0; p < paramValues.length; p++) {
                     if (isBindParam[p]) {
-                        ps.setString(bindIdx++, "null" .equals(bindValues[p]) ? null : bindValues[p]);
+                        ps.setString(bindIdx++, "null".equals(bindValues[p]) ? null : bindValues[p]);
                     }
                 }
                 try (ResultSet result = ps.executeQuery()) {

--- a/core/src/test/java/io/questdb/test/griffin/FunctionParserErrorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/FunctionParserErrorTest.java
@@ -37,7 +37,7 @@ public class FunctionParserErrorTest extends AbstractGriffinTest {
         try {
             assertQuery("",
                     "select * from " +
-                            "(select cast(x as timestamp) ts, cast('0x05cb69971d94a00000192178ef80f0' as long256) as id, x from long_sequence(10) ) " +
+                            "(select cast(x as timestamp) ts, '0x05cb69971d94a00000192178ef80f0' as id, x from long_sequence(10) ) " +
                             "where ts between '2022-03-20' AND id <> '0x05ab6d9fabdabb00066a5db735d17a' AND id <> '0x05aba84839b9c7000006765675e630' AND id <> '0x05abc58d80ba1f000001ed05351873'",
                     null, null, true, true);
             Assert.fail();

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
@@ -3824,6 +3824,27 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testInsertLong256() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "long256\n",
+                "long256",
+                "create table long256 (long256 long256)",
+                null,
+                "insert into long256 values" +
+                        "('0x6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3a')," +
+                        "('0X6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3b')," +
+                        "('6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3c')",
+                "long256\n" +
+                        "0x6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3a\n" +
+                        "0x6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3b\n" +
+                        "0x6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3c\n",
+                true,
+                true,
+                false
+        ));
+    }
+
+    @Test
     public void testInsertNullSymbol() throws Exception {
         assertMemoryLeak(() -> {
             compile("CREATE TABLE symbolic_index (s SYMBOL INDEX)", sqlExecutionContext);
@@ -4633,16 +4654,16 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                     SqlCompiler compiler = new SqlCompiler(engine);
                     SqlExecutionContext sqlExecutionContext = TestUtils.createSqlExecutionCtx(engine)
             ) {
-                    compiler.compile(sql, sqlExecutionContext);
-                    Assert.assertTrue(fiddler.isHappy());
-                    try (TableReader reader = getReader(engine, "Y")) {
-                        sink.clear();
-                        reader.getMetadata().toJson(sink);
-                        TestUtils.assertEquals(expectedMetadata, sink);
-                    }
-
-                    Assert.assertEquals(0, engine.getBusyReaderCount());
+                compiler.compile(sql, sqlExecutionContext);
+                Assert.assertTrue(fiddler.isHappy());
+                try (TableReader reader = getReader(engine, "Y")) {
+                    sink.clear();
+                    reader.getMetadata().toJson(sink);
+                    TestUtils.assertEquals(expectedMetadata, sink);
                 }
+
+                Assert.assertEquals(0, engine.getBusyReaderCount());
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
@@ -35,6 +35,7 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.*;
 import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.MutableCharSink;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
@@ -3705,6 +3706,26 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testInsertFromStringToLong256() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table t as (select rnd_long256 v from long_sequence(1000))", sqlExecutionContext);
+            compile("create table l256(v long256)", sqlExecutionContext);
+            compile("insert into l256 select * from t", sqlExecutionContext);
+            if (configuration.getWalEnabledDefault()) {
+                drainWalQueue();
+            }
+            String expected = "v\n" +
+                    "0xd29b84cdf070d2247559d6d5f9ed17242a1c9ad2bbc87e8041738668eaea02fa\n" +
+                    "0xc3fd21defa26f6555ab5573037d8a34872a8be1517a17fd4e43cb3b6894fc88c\n" +
+                    "0xc78d67954cb7866695b5e08df69df8819fc909a43f149089c143a3bb982af031\n" +
+                    "0x6ddedcf7415306f799ce31489578cac77b0ec57771d6e9f27c517f53d504487d\n" +
+                    "0xa38b2ad7fbc79d366f9b5d1b162ba472613f1eb5f98a2df86a7f0ebbd1d28a95\n";
+            printSqlResult(expected, "t limit -5", null, true, false);
+            printSqlResult(expected, "l256 limit -5", null, true, false);
+        });
+    }
+
+    @Test
     public void testInsertGeoHashBitsLiteralNotBits() throws Exception {
         assertMemoryLeak(() -> {
             assertQuery(
@@ -4726,6 +4747,17 @@ public class SqlCompilerTest extends AbstractGriffinTest {
                     }
                 }
         );
+    }
+
+    private void selectAll(String tableName, boolean backup, MutableCharSink sink) throws Exception {
+
+        TestUtils.printSql(
+                compiler,
+                sqlExecutionContext,
+                "select * from " + tableName,
+                sink
+        );
+
     }
 
     private void testGeoHashWithBits(String columnSize, String geoHash, String expected) throws Exception {


### PR DESCRIPTION
This is to allow the following:

```sql
create table long256 (long256 long256);

insert into long256 values
    ('0x6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3a'),
    ('0X6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3b'),
    ('6bbf0c833a5448baa23a0366d85079afc390e9837e67ac3f653076982d02dd3c');
```

from clients through for instance pgwire.

