### PR TITLE
Updated a minor change of swag => 'swags'

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ with contributing:
 - [Create a fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)
   of QuestDB and submit a pull request with your proposed changes.
 
-✨ As a sign of our gratitude, we also send **QuestDB swag** to our
+✨ As a sign of our gratitude, we also send **QuestDB swags** to our
 contributors. [Claim your swag here.](https://questdb.io/community)
 
 A big thanks goes to the following wonderful people who have contributed to


### PR DESCRIPTION
I think QuestDB is giving Swags like not in count of 1 but many swags they gives so thats why we can say it 'Swags' instead of swag.