### PR TITLE
fix(core): fix rollback failure

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2003,6 +2003,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 rollbackIndexes();
                 rollbackSymbolTables();
                 columnVersionWriter.readUnsafe();
+                closeActivePartition(false);
                 purgeUnusedPartitions();
                 configureAppendPosition();
                 o3InError = false;

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.vm;
 
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.cairo.vm.api.MemoryCMARW;
@@ -73,11 +74,23 @@ public class MemoryCMARWImpl extends AbstractMemoryCR implements MemoryCMARW, Me
             if (truncate) {
                 long appendOffset = getAppendOffset();
                 truncateSize = truncateMode == Vm.TRUNCATE_TO_PAGE ? Files.ceilPageSize(appendOffset) : appendOffset;
-                // If this is lazy close of unused memory the underlying file can be already truncated using another fd
-                // and memset can lead to SIGBUS on Linux. Check the phisical file length before trying to memset to the map
-                long sz = Math.min(ff.length(fd), Math.min(size, truncateSize));
+
+                long sz = Math.min(size, truncateSize);
                 if (appendOffset < sz) {
-                    Vect.memset(pageAddress + appendOffset, sz - appendOffset, 0);
+                    try {
+                        // If this is a lazy close of unused memory the underlying file can already be truncated
+                        //  using another fd and memset can lead to SIGBUS on Linux.
+                        // Check the physical file length before trying to memset to the mapped memory.
+                        sz = Math.min(sz, ff.length(fd));
+                        if (appendOffset < sz) {
+                            Vect.memset(pageAddress + appendOffset, sz - appendOffset, 0);
+                        }
+                    } catch (CairoException e) {
+                        LOG.error().$("cannot determine file length to safely truncate [fd=").$(fd)
+                                .$(", errno=").$(e.getErrno())
+                                .$(", error=").$(e.getFlyweightMessage())
+                                .I$();
+                    }
                 }
             } else {
                 truncateSize = -1L;

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContinuousMemoryMTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContinuousMemoryMTest.java
@@ -659,6 +659,35 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTruncateSameFileWithDifferentFd() {
+        final Path path = Path.getThreadLocal(root).concat("t.d").$();
+
+        MemoryCMARW rwMem1 = Vm.getCMARWInstance(
+                TestFilesFacadeImpl.INSTANCE,
+                path,
+                Files.PAGE_SIZE,
+                (long) (Files.PAGE_SIZE * 1.5),
+                MemoryTag.MMAP_DEFAULT,
+                configuration.getWriterFileOpenOpts()
+        );
+
+        MemoryCMARW rwMem2 = Vm.getCMARWInstance(
+                TestFilesFacadeImpl.INSTANCE,
+                path,
+                Files.PAGE_SIZE,
+                (long) (Files.PAGE_SIZE * 3.5),
+                MemoryTag.MMAP_DEFAULT,
+                configuration.getWriterFileOpenOpts()
+        );
+
+        rwMem1.close();
+
+        rwMem2.jumpTo((long) (Files.PAGE_SIZE * 2.5));
+        // Assert no errors on close
+        rwMem2.close();
+    }
+
+    @Test
     public void testTruncate() {
         FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
         try (Path path = new Path().of(root).concat("tmp1").$()) {

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContinuousMemoryMTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContinuousMemoryMTest.java
@@ -41,6 +41,8 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class ContinuousMemoryMTest extends AbstractCairoTest {
 
     private static final Log LOG = LogFactory.getLog(ContinuousMemoryMTest.class);
@@ -143,6 +145,45 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
             // read these values back from
             assertRandomByte(rwMem, MAX, N);
             assertRandomByte(roMem, MAX, N);
+        });
+    }
+
+    @Test
+    public void testCMARWToleratesLengthFailureOnClose() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final Path path = Path.getThreadLocal(root).concat("t.d").$();
+            AtomicBoolean trigger = new AtomicBoolean();
+
+            FilesFacade ff = new TestFilesFacadeImpl() {
+                @Override
+                public long length(int fd) {
+                    long r = Files.length(fd);
+                    if (r < 0 || trigger.get()) {
+                        throw CairoException.critical(Os.errno()).put("Checking file size failed");
+                    }
+                    return r;
+                }
+            };
+
+            MemoryCMARW rwMem1 = Vm.getCMARWInstance(
+                    ff,
+                    path,
+                    Files.PAGE_SIZE,
+                    (long) (Files.PAGE_SIZE * 3.5),
+                    MemoryTag.MMAP_DEFAULT,
+                    configuration.getWriterFileOpenOpts()
+            );
+
+            rwMem1.jumpTo((long) (Files.PAGE_SIZE * 2.5));
+            trigger.set(true);
+            rwMem1.close();
+
+            rwMem1.of(TestFilesFacadeImpl.INSTANCE, path, Files.PAGE_SIZE,
+                    (long) (Files.PAGE_SIZE * 1.5),
+                    MemoryTag.MMAP_DEFAULT);
+            rwMem1.putLong(123);
+
+            rwMem1.close();
         });
     }
 
@@ -659,35 +700,6 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testTruncateSameFileWithDifferentFd() {
-        final Path path = Path.getThreadLocal(root).concat("t.d").$();
-
-        MemoryCMARW rwMem1 = Vm.getCMARWInstance(
-                TestFilesFacadeImpl.INSTANCE,
-                path,
-                Files.PAGE_SIZE,
-                (long) (Files.PAGE_SIZE * 1.5),
-                MemoryTag.MMAP_DEFAULT,
-                configuration.getWriterFileOpenOpts()
-        );
-
-        MemoryCMARW rwMem2 = Vm.getCMARWInstance(
-                TestFilesFacadeImpl.INSTANCE,
-                path,
-                Files.PAGE_SIZE,
-                (long) (Files.PAGE_SIZE * 3.5),
-                MemoryTag.MMAP_DEFAULT,
-                configuration.getWriterFileOpenOpts()
-        );
-
-        rwMem1.close();
-
-        rwMem2.jumpTo((long) (Files.PAGE_SIZE * 2.5));
-        // Assert no errors on close
-        rwMem2.close();
-    }
-
-    @Test
     public void testTruncate() {
         FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
         try (Path path = new Path().of(root).concat("tmp1").$()) {
@@ -776,6 +788,35 @@ public class ContinuousMemoryMTest extends AbstractCairoTest {
                 Assert.assertTrue(ff.remove(path));
             }
         }
+    }
+
+    @Test
+    public void testTruncateSameFileWithDifferentFd() {
+        final Path path = Path.getThreadLocal(root).concat("t.d").$();
+
+        MemoryCMARW rwMem1 = Vm.getCMARWInstance(
+                TestFilesFacadeImpl.INSTANCE,
+                path,
+                Files.PAGE_SIZE,
+                (long) (Files.PAGE_SIZE * 1.5),
+                MemoryTag.MMAP_DEFAULT,
+                configuration.getWriterFileOpenOpts()
+        );
+
+        MemoryCMARW rwMem2 = Vm.getCMARWInstance(
+                TestFilesFacadeImpl.INSTANCE,
+                path,
+                Files.PAGE_SIZE,
+                (long) (Files.PAGE_SIZE * 3.5),
+                MemoryTag.MMAP_DEFAULT,
+                configuration.getWriterFileOpenOpts()
+        );
+
+        rwMem1.close();
+
+        rwMem2.jumpTo((long) (Files.PAGE_SIZE * 2.5));
+        // Assert no errors on close
+        rwMem2.close();
     }
 
     private void assertBool(MemoryR rwMem, int count) {

--- a/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
@@ -75,6 +75,7 @@ public class O3FailureTest extends AbstractO3Test {
     private final static AtomicBoolean fixFailure = new AtomicBoolean(true);
     private static final FilesFacade ffAllocateFailure = new TestFilesFacadeImpl() {
         private boolean failNextAlloc = false;
+        private final AtomicInteger increment = new AtomicInteger();
 
         @Override
         public boolean allocate(int fd, long size) {
@@ -88,12 +89,19 @@ public class O3FailureTest extends AbstractO3Test {
 
         @Override
         public long length(int fd) {
-            final long remaining = counter.decrementAndGet();
-            if (!fixFailure.get() || remaining == 0) {
-                failNextAlloc = true;
-                return 0;
+            if (fd > 0) {
+                final long remaining = counter.decrementAndGet();
+                if (!fixFailure.get() || remaining == 0) {
+                    failNextAlloc = true;
+                    return 0;
+                }
+            } else {
+                // For debugging, if new call with ff.length(fd) is added, change it
+                // to ff.length(-fd) and adjust counter set by the test by the number
+                // in increment when 0 is returned
+                increment.incrementAndGet();
             }
-            return super.length(fd);
+            return super.length(Math.abs(fd));
         }
     };
     private static final FilesFacade ffFailToAllocateIndex = new TestFilesFacadeImpl() {
@@ -623,7 +631,7 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testFailOnResizingIndexContended() throws Exception {
         // this places break point on resize of key file
-        counter.set(152 + 12 + 20 + 22);
+        counter.set(152 + 12 + 20 + 19);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -933,13 +941,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTail() throws Exception {
-        counter.set(174 + 12 + 22);
+        counter.set(174 + 12 + 19);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailContended() throws Exception {
-        counter.set(174 + 12 + 22);
+        counter.set(174 + 12 + 19);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -957,25 +965,25 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailParallel() throws Exception {
-        counter.set(174 + 45 + 12 + 29);
+        counter.set(174 + 45 + 12 + 27);
         executeWithPool(2, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODatThenRegularAppend() throws Exception {
-        counter.set(165 + 45 + 12 + 24);
+        counter.set(165 + 45 + 12 + 21);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODatThenRegularAppend0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOOData() throws Exception {
-        counter.set(165 + 45 + 12 + 20);
+        counter.set(165 + 45 + 12 + 18);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataContended() throws Exception {
-        counter.set(165 + 45 + 12 + 20);
+        counter.set(165 + 45 + 12 + 21);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
@@ -1035,13 +1043,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallel() throws Exception {
-        counter.set(193 + 45 + 18 + 29);
+        counter.set(193 + 45 + 18 + 27);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallelNoReopen() throws Exception {
-        counter.set(176 + 45 + 18 + 29);
+        counter.set(176 + 45 + 18 + 26);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetryNoReopen, ffAllocateFailure);
     }
 
@@ -1116,7 +1124,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testSetAppendPositionFails() throws Exception {
-        counter.set(169 + 12 + 20 + 22);
+        counter.set(169 + 12 + 20 + 19);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
@@ -623,7 +623,7 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testFailOnResizingIndexContended() throws Exception {
         // this places break point on resize of key file
-        counter.set(152 + 12);
+        counter.set(152 + 12 + 20 + 22);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -933,13 +933,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTail() throws Exception {
-        counter.set(174 + 12);
+        counter.set(174 + 12 + 22);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailContended() throws Exception {
-        counter.set(174 + 12);
+        counter.set(174 + 12 + 22);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -957,25 +957,25 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailParallel() throws Exception {
-        counter.set(174 + 45 + 12);
+        counter.set(174 + 45 + 12 + 29);
         executeWithPool(2, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODatThenRegularAppend() throws Exception {
-        counter.set(165 + 45 + 12);
+        counter.set(165 + 45 + 12 + 24);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODatThenRegularAppend0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOOData() throws Exception {
-        counter.set(165 + 45 + 12);
+        counter.set(165 + 45 + 12 + 20);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataContended() throws Exception {
-        counter.set(165 + 45 + 12);
+        counter.set(165 + 45 + 12 + 20);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
@@ -1035,13 +1035,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallel() throws Exception {
-        counter.set(193 + 45 + 18);
+        counter.set(193 + 45 + 18 + 29);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallelNoReopen() throws Exception {
-        counter.set(176 + 45 + 18);
+        counter.set(176 + 45 + 18 + 29);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetryNoReopen, ffAllocateFailure);
     }
 
@@ -1116,7 +1116,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testSetAppendPositionFails() throws Exception {
-        counter.set(169 + 12);
+        counter.set(169 + 12 + 20 + 22);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -229,14 +229,6 @@ public class WalWriterFuzzTest extends AbstractGriffinTest {
     }
 
     @Test
-    public void testWalWriteRollbackHeavyToFix() throws Exception {
-        Rnd rnd = TestUtils.generateRandom(LOG);
-        setFuzzProbabilities(0.5, 0.5, 0.1, 0.5, 0.05, 0.05, 0.05, 1.0, 0.01, 0.01);
-        setFuzzCounts(rnd.nextBoolean(), 10_000, 300, 20, 1000, 1000, 100, 3);
-        runFuzz(rnd);
-    }
-
-    @Test
     public void testWalWriteRollbackTruncateHeavy() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setFuzzProbabilities(0.5, 0.5, 0.1, 0.5, 0.05, 0.05, 0.05, 1.0, 0.15, 0.01);


### PR DESCRIPTION
Fix rare SIGBUS which can happen after a transaction rollback on Linux.

When file is truncated it can be pad with 0 to the page size but if the file is already truncated via another file descriptor SIGBUS crash can happen on Linux.

To avoid, close active partition on rollbacks and also check file size before padding with 0 on truncate.