### PR TITLE
Update Dockerfile: the wrong GPG key is used

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -4,7 +4,9 @@ ARG tag_name
 RUN apt-get update \
   && apt-get install --no-install-recommends git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip -y
 
-RUN wget -O- https://apt.corretto.aws/corretto.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/winehq.gpg >/dev/null && \
+# RUN wget -O- https://apt.corretto.aws/corretto.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/winehq.gpg >/dev/null && \
+RUN wget -O- https://apt.corretto.aws/gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/corretto.gpg >/dev/null && \ 
+
     add-apt-repository 'deb https://apt.corretto.aws stable main' && \
     apt-get update && \
     apt-get install --no-install-recommends -y java-17-amazon-corretto-jdk=1:17.0.3.6-1


### PR DESCRIPTION
The container is built from two different base images, which is unnecessary. You can combine the two FROM instructions into one and remove the second FROM statement. Finally, make sure that the "**docker-entrypoint.sh**" file is present in the build context when running the docker build command.