### PR TITLE
test(core): get rid of O(n^2) check in WAL writer fuzz tests

### DIFF
--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -59,6 +59,8 @@ import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -139,128 +141,92 @@ public final class TestUtils {
         final int timestampIndex = metadataActual.getTimestampIndex();
 
         long timestampValue = -1;
-        BytecodeAssembler asm = null;
         EntityColumnFilter entityColumnFilter;
         RecordSink recordSink;
-        long chainLO = -1;
-        long chainRO = -1;
-        RecordChain chainL = null;
-        RecordChain chainR = null;
+        HashMap<String, Integer> mapL = null;
+        HashMap<String, Integer> mapR = null;
         AssertionError deferred = null;
-        RecordMetadata symAsStrTypes = null;
 
-        try {
-            long rowIndex = 0;
-            while (cursorExpected.hasNext()) {
-                if (!cursorActual.hasNext()) {
-                    Assert.fail("Actual cursor does not have record at " + rowIndex);
+        long rowIndex = 0;
+        while (cursorExpected.hasNext()) {
+            if (!cursorActual.hasNext()) {
+                Assert.fail("Actual cursor does not have record at " + rowIndex);
+            }
+            rowIndex++;
+            if (timestampValue != -1) {
+                // we are or were stashing record with the same timestamp
+                long tsL = l.getTimestamp(timestampIndex);
+                long tsR = r.getTimestamp(timestampIndex);
+
+                if (tsL == timestampValue && tsR == timestampValue) {
+                    // store both records
+                    addRecordToMap(l, metadataExpected, mapL);
+                    addRecordToMap(r, metadataActual, mapR);
+                    continue;
                 }
-                rowIndex++;
-                if (timestampValue != -1) {
-                    // we are or were stashing record with the same timestamp
+
+                // check if we can bail out early because current record timestamps do not match
+                if (tsL != tsR) {
+                    throw new AssertionError(
+                            String.format(
+                                    "Row %d column %s[%s] %s",
+                                    rowIndex,
+                                    metadataActual.getColumnName(timestampIndex),
+                                    ColumnType.TIMESTAMP,
+                                    "timestamp mismatch"
+                            )
+                    );
+                }
+
+                // compare accumulated records
+                try {
+                    Assert.assertEquals(mapL, mapR);
+                } catch (AssertionError ignore) {
+                    throw deferred;
+                }
+
+                // something changed, reset the store
+                timestampValue = -1;
+
+                mapL.clear();
+                mapR.clear();
+            }
+            try {
+                assertColumnValues(metadataExpected, metadataActual, l, r, rowIndex, symbolsAsStrings);
+            } catch (AssertionError e) {
+                // Assertion error could be to do with unstable sort order,
+                // lets try to eliminate this.
+                if (timestampIndex == -1) {
+                    // cannot do anything with tables without timestamp
+                    throw e;
+                } else {
                     long tsL = l.getTimestamp(timestampIndex);
                     long tsR = r.getTimestamp(timestampIndex);
-
-                    if (tsL == timestampValue && tsR == timestampValue) {
-                        // store both records
-                        chainLO = chainL.put(l, chainLO);
-                        chainRO = chainR.put(r, chainRO);
-                        continue;
-                    }
-
-                    // check if we can bail out early because current record timestamps do not match
                     if (tsL != tsR) {
-                        throw new AssertionError(
-                                String.format(
-                                        "Row %d column %s[%s] %s",
-                                        rowIndex,
-                                        metadataActual.getColumnName(timestampIndex),
-                                        ColumnType.TIMESTAMP,
-                                        "timestamp mismatch"
-                                )
-                        );
-                    }
-
-                    // compare chains
-                    chainL.toTop();
-                    Record chainLR = chainL.getRecord();
-                    Record chainRR = chainR.getRecord();
-                    long recordsScanned = 0;
-                    long recordsMatched = 0;
-                    while (chainL.hasNext()) {
-                        recordsScanned++;
-                        chainR.toTop();
-                        while (chainR.hasNext()) {
-                            try {
-                                assertColumnValues(symAsStrTypes, symAsStrTypes, chainLR, chainRR, 0, false);
-                                recordsMatched++;
-                                break;
-                            } catch (AssertionError ignore) {
-                                // ignore
-                            }
-                        }
-                    }
-
-                    if (recordsMatched < recordsScanned) {
-                        throw deferred;
-                    }
-
-                    // something changed, reset the store
-                    timestampValue = -1;
-                    // reset chain offsets
-                    chainLO = -1;
-                    chainRO = -1;
-
-                    chainL.clear();
-                    chainR.clear();
-                }
-                try {
-                    assertColumnValues(metadataExpected, metadataActual, l, r, rowIndex, symbolsAsStrings);
-                } catch (AssertionError e) {
-                    // Assertion error could be to do with unstable sort order,
-                    // lets try to eliminate this.
-                    if (timestampIndex == -1) {
-                        // cannot do anything with tables without timestamp
+                        // timestamps are not matching, bail out
                         throw e;
-                    } else {
-                        long tsL = l.getTimestamp(timestampIndex);
-                        long tsR = r.getTimestamp(timestampIndex);
-                        if (tsL != tsR) {
-                            // timestamps are not matching, bail out
-                            throw e;
-                        }
-
-                        // will throw this later if our reordering doesn't work
-
-                        deferred = e;
-
-                        // this is first time we experienced this error
-                        // do we have chains ?
-
-                        timestampValue = tsL;
-
-                        if (asm == null) {
-                            asm = new BytecodeAssembler();
-                            entityColumnFilter = new EntityColumnFilter();
-                            entityColumnFilter.of(metadataActual.getColumnCount());
-                            recordSink = RecordSinkFactory.getInstance(asm, metadataActual, entityColumnFilter, true);
-                            symAsStrTypes = copySymAstStr(metadataActual);
-                            chainL = new RecordChain(symAsStrTypes, recordSink, 1024 * 1024, Integer.MAX_VALUE);
-                            chainR = new RecordChain(symAsStrTypes, recordSink, 1024 * 1024, Integer.MAX_VALUE);
-                        }
-
-                        // store both records
-                        chainLO = chainL.put(l, chainLO);
-                        chainRO = chainR.put(r, chainRO);
                     }
+
+                    // will throw this later if our reordering doesn't work
+                    deferred = e;
+
+                    // this is first time we experienced this error
+                    // do we have maps?
+                    timestampValue = tsL;
+
+                    if (mapL == null) {
+                        mapL = new HashMap<>();
+                        mapR = new HashMap<>();
+                    }
+
+                    // store both records
+                    addRecordToMap(l, metadataExpected, mapL);
+                    addRecordToMap(r, metadataActual, mapR);
                 }
             }
-
-            Assert.assertFalse("Expected cursor misses record " + rowIndex, cursorActual.hasNext());
-        } finally {
-            Misc.free(chainL);
-            Misc.free(chainR);
         }
+
+        Assert.assertFalse("Expected cursor misses record " + rowIndex, cursorActual.hasNext());
     }
 
     public static void assertEquals(File a, File b) {
@@ -1382,6 +1348,20 @@ public final class TestUtils {
         }
     }
 
+    private static void addRecordToMap(Record record, RecordMetadata metadata, Map<String, Integer> map) {
+        sink.clear();
+        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
+            printColumn(record, metadata, i, sink, true);
+        }
+        String printed = sink.toString();
+        map.compute(printed, (s, i) -> {
+            if (i == null) {
+                return 0;
+            }
+            return i + 1;
+        });
+    }
+
     private static void assertColumnValues(
             RecordMetadata metadataExpected,
             RecordMetadata metadataActual,
@@ -1472,6 +1452,18 @@ public final class TestUtils {
         }
     }
 
+    private static void assertEquals(RecordMetadata metadataExpected, RecordMetadata metadataActual, boolean symbolsAsStrings) {
+        Assert.assertEquals("Column count must be same", metadataExpected.getColumnCount(), metadataActual.getColumnCount());
+        for (int i = 0, n = metadataExpected.getColumnCount(); i < n; i++) {
+            Assert.assertEquals("Column name " + i, metadataExpected.getColumnName(i), metadataActual.getColumnName(i));
+            int columnType1 = metadataExpected.getColumnType(i);
+            columnType1 = symbolsAsStrings && ColumnType.isSymbol(columnType1) ? ColumnType.STRING : columnType1;
+            int columnType2 = metadataActual.getColumnType(i);
+            columnType2 = symbolsAsStrings && ColumnType.isSymbol(columnType2) ? ColumnType.STRING : columnType2;
+            Assert.assertEquals("Column type " + i, columnType1, columnType2);
+        }
+    }
+
     private static void assertEquals(Long256 expected, Long256 actual) {
         if (expected == actual) return;
         if (actual == null) {
@@ -1483,18 +1475,6 @@ public final class TestUtils {
                 || expected.getLong2() != actual.getLong2()
                 || expected.getLong3() != actual.getLong3()) {
             Assert.assertEquals(toHexString(expected), toHexString(actual));
-        }
-    }
-
-    private static void assertEquals(RecordMetadata metadataExpected, RecordMetadata metadataActual, boolean symbolsAsStrings) {
-        Assert.assertEquals("Column count must be same", metadataExpected.getColumnCount(), metadataActual.getColumnCount());
-        for (int i = 0, n = metadataExpected.getColumnCount(); i < n; i++) {
-            Assert.assertEquals("Column name " + i, metadataExpected.getColumnName(i), metadataActual.getColumnName(i));
-            int columnType1 = metadataExpected.getColumnType(i);
-            columnType1 = symbolsAsStrings && ColumnType.isSymbol(columnType1) ? ColumnType.STRING : columnType1;
-            int columnType2 = metadataActual.getColumnType(i);
-            columnType2 = symbolsAsStrings && ColumnType.isSymbol(columnType2) ? ColumnType.STRING : columnType2;
-            Assert.assertEquals("Column type " + i, columnType1, columnType2);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1346,20 +1346,6 @@ public final class TestUtils {
         }
     }
 
-    private static void addRecordToMap(Record record, RecordMetadata metadata, Map<String, Integer> map) {
-        sink.clear();
-        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
-            printColumn(record, metadata, i, sink, true);
-        }
-        String printed = sink.toString();
-        map.compute(printed, (s, i) -> {
-            if (i == null) {
-                return 0;
-            }
-            return i + 1;
-        });
-    }
-
     private static void assertColumnValues(
             RecordMetadata metadataExpected,
             RecordMetadata metadataActual,
@@ -1517,6 +1503,28 @@ public final class TestUtils {
                 Long.toHexString(expected.getLong1()) + " " +
                 Long.toHexString(expected.getLong2()) + " " +
                 Long.toHexString(expected.getLong3());
+    }
+
+    static void addAllRecordsToMap(RecordCursor cursor, RecordMetadata metadata, Map<String, Integer> map) {
+        cursor.toTop();
+        Record record = cursor.getRecord();
+        while (cursor.hasNext()) {
+            addRecordToMap(record, metadata, map);
+        }
+    }
+
+    static void addRecordToMap(Record record, RecordMetadata metadata, Map<String, Integer> map) {
+        sink.clear();
+        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
+            printColumn(record, metadata, i, sink, true);
+        }
+        String printed = sink.toString();
+        map.compute(printed, (s, i) -> {
+            if (i == null) {
+                return 1;
+            }
+            return i + 1;
+        });
     }
 
     @FunctionalInterface

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -141,8 +141,6 @@ public final class TestUtils {
         final int timestampIndex = metadataActual.getTimestampIndex();
 
         long timestampValue = -1;
-        EntityColumnFilter entityColumnFilter;
-        RecordSink recordSink;
         HashMap<String, Integer> mapL = null;
         HashMap<String, Integer> mapR = null;
         AssertionError deferred = null;

--- a/core/src/test/java/io/questdb/test/tools/TestUtilsTest.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtilsTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.tools;
+
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractGriffinTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class TestUtilsTest extends AbstractGriffinTest {
+
+    @Test
+    public void testOrderTolerantRecordComparison() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table x (x long, ts timestamp) timestamp(ts) partition by day");
+            compile("create table y (x long, ts timestamp) timestamp(ts) partition by day");
+
+            compile("insert into x values (1, '2022-02-24T00:00:01.000000Z')");
+            compile("insert into x values (2, '2022-02-24T00:00:01.000000Z')");
+            compile("insert into x values (3, '2022-02-24T00:00:02.000000Z')");
+
+            compile("insert into y values (2, '2022-02-24T00:00:01.000000Z')");
+            compile("insert into y values (1, '2022-02-24T00:00:01.000000Z')");
+            compile("insert into y values (3, '2022-02-24T00:00:02.000000Z')");
+
+            HashMap<String, Integer> mapX = new HashMap<>();
+            HashMap<String, Integer> mapY = new HashMap<>();
+
+            addAllRecordsToMap("x", mapX);
+            addAllRecordsToMap("y", mapY);
+
+            Assert.assertEquals(mapX, mapY);
+
+            compile("insert into y values (2, '2022-02-24T00:00:01.000000Z')");
+
+            // now the maps should be different since we've added an extra record
+
+            mapY.clear();
+            addAllRecordsToMap("y", mapY);
+
+            Assert.assertNotEquals(mapX, mapY);
+        });
+    }
+
+    private static void addAllRecordsToMap(String query, Map<String, Integer> map) throws SqlException {
+        try (
+                RecordCursorFactory factory = compiler.compile(query, sqlExecutionContext).getRecordCursorFactory();
+                RecordCursor cursor = factory.getCursor(sqlExecutionContext)
+        ) {
+            TestUtils.addAllRecordsToMap(cursor, factory.getMetadata(), map);
+        }
+    }
+}


### PR DESCRIPTION
Prevents WAL writer fuzz tests from timing out due to O(n^2) comparison of rows with duplicate timestamps.