### PR TITLE
test(core): send-receive test did not account for multi-byte characters, which causes flapping tests

### DIFF
--- a/core/src/main/java/io/questdb/Bootstrap.java
+++ b/core/src/main/java/io/questdb/Bootstrap.java
@@ -156,7 +156,7 @@ public class Bootstrap {
                             bootstrapConfiguration.getEnv(),
                             log,
                             buildInformation,
-                            bootstrapConfiguration.getFactoriesFactory()
+                            bootstrapConfiguration.getFactoryProvider()
                     );
                 } else {
                     config = new PropServerConfiguration(
@@ -165,7 +165,7 @@ public class Bootstrap {
                             bootstrapConfiguration.getEnv(),
                             log,
                             buildInformation,
-                            bootstrapConfiguration.getFactoriesFactory()
+                            bootstrapConfiguration.getFactoryProvider()
                     ) {
                         private CairoConfiguration cairoConf;
 

--- a/core/src/main/java/io/questdb/BootstrapConfiguration.java
+++ b/core/src/main/java/io/questdb/BootstrapConfiguration.java
@@ -33,7 +33,7 @@ public interface BootstrapConfiguration {
 
     Map<String, String> getEnv();
 
-    FactoryProvider getFactoriesFactory();
+    FactoryProvider getFactoryProvider();
 
     FilesFacade getFilesFacade();
 

--- a/core/src/main/java/io/questdb/DefaultBootstrapConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultBootstrapConfiguration.java
@@ -47,7 +47,7 @@ public class DefaultBootstrapConfiguration implements BootstrapConfiguration {
     }
 
     @Override
-    public FactoryProvider getFactoriesFactory() {
+    public FactoryProvider getFactoryProvider() {
         return DefaultFactoryProvider.INSTANCE;
     }
 

--- a/core/src/main/java/io/questdb/DefaultFactoryProvider.java
+++ b/core/src/main/java/io/questdb/DefaultFactoryProvider.java
@@ -26,6 +26,8 @@ package io.questdb;
 
 import io.questdb.cairo.security.AllowAllSecurityContextFactory;
 import io.questdb.cairo.security.SecurityContextFactory;
+import io.questdb.cutlass.auth.DefaultPublicKeyRepoFactory;
+import io.questdb.cutlass.auth.PublicKeyRepoFactory;
 import io.questdb.cutlass.pgwire.PGAuthenticatorFactory;
 import io.questdb.cutlass.pgwire.PGBasicAuthenticatorFactory;
 import io.questdb.griffin.SqlParserFactory;
@@ -47,5 +49,10 @@ public class DefaultFactoryProvider implements FactoryProvider {
     @Override
     public SqlParserFactory getSqlParserFactory() {
         return SqlParserFactoryImpl.INSTANCE;
+    }
+
+    @Override
+    public PublicKeyRepoFactory getPublicKeyRepoFactory() {
+        return DefaultPublicKeyRepoFactory.INSTANCE;
     }
 }

--- a/core/src/main/java/io/questdb/FactoryProvider.java
+++ b/core/src/main/java/io/questdb/FactoryProvider.java
@@ -25,6 +25,7 @@
 package io.questdb;
 
 import io.questdb.cairo.security.SecurityContextFactory;
+import io.questdb.cutlass.auth.PublicKeyRepoFactory;
 import io.questdb.cutlass.pgwire.PGAuthenticatorFactory;
 import io.questdb.griffin.SqlParserFactory;
 
@@ -36,4 +37,6 @@ public interface FactoryProvider {
     SecurityContextFactory getSecurityContextFactory();
 
     SqlParserFactory getSqlParserFactory();
+
+    PublicKeyRepoFactory getPublicKeyRepoFactory();
 }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -27,8 +27,8 @@ package io.questdb;
 import io.questdb.cairo.*;
 import io.questdb.cairo.security.SecurityContextFactory;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
-import io.questdb.cutlass.auth.DefaultPublicKeyRepoFactory;
 import io.questdb.cutlass.auth.PublicKeyRepoFactory;
+import io.questdb.cutlass.auth.StaticPublicKeyRepoFactory;
 import io.questdb.cutlass.http.*;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
@@ -443,6 +443,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private long pgWorkerSleepThreshold;
     private long pgWorkerYieldThreshold;
     private String publicDirectory;
+    private PublicKeyRepoFactory publicKeyRepoFactory;
     private int recvBufferSize;
     private int requestHeaderBufferSize;
     private int rollBufferLimit;
@@ -1065,6 +1066,9 @@ public class PropServerConfiguration implements ServerConfiguration {
                 }
                 if (null != lineTcpAuthDbPath) {
                     this.lineTcpAuthDbPath = new File(root, this.lineTcpAuthDbPath).getAbsolutePath();
+                    this.publicKeyRepoFactory = new StaticPublicKeyRepoFactory(lineTcpAuthDbPath);
+                } else {
+                    this.publicKeyRepoFactory = factoryProvider.getPublicKeyRepoFactory();
                 }
                 this.minIdleMsBeforeWriterRelease = getLong(properties, env, PropertyKey.LINE_TCP_MIN_IDLE_MS_BEFORE_WRITER_RELEASE, 500);
                 this.lineTcpDisconnectOnError = getBoolean(properties, env, PropertyKey.LINE_TCP_DISCONNECT_ON_ERROR, true);
@@ -1606,11 +1610,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public SecurityContextFactory getSecurityContextFactory() {
-            return securityContextFactory;
-        }
-
-        @Override
         public SqlExecutionCircuitBreakerConfiguration getCircuitBreakerConfiguration() {
             return circuitBreakerConfiguration;
         }
@@ -1963,6 +1962,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getSampleByIndexSearchPageSize() {
             return sampleByIndexSearchPageSize;
+        }
+
+        @Override
+        public SecurityContextFactory getSecurityContextFactory() {
+            return securityContextFactory;
         }
 
         @Override
@@ -2914,8 +2918,6 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     private class PropLineTcpReceiverConfiguration implements LineTcpReceiverConfiguration {
 
-        private PublicKeyRepoFactory publicKeyRepoFactory;
-
         @Override
         public String getAuthDbPath() {
             return lineTcpAuthDbPath;
@@ -3026,11 +3028,6 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public PublicKeyRepoFactory getPublicKeyRepoFactory() {
-            if (publicKeyRepoFactory == null) {
-                if (getAuthDbPath() != null) {
-                    publicKeyRepoFactory = new DefaultPublicKeyRepoFactory(getAuthDbPath());
-                }
-            }
             return publicKeyRepoFactory;
         }
 

--- a/core/src/main/java/io/questdb/cutlass/auth/StaticPublicKeyRepoFactory.java
+++ b/core/src/main/java/io/questdb/cutlass/auth/StaticPublicKeyRepoFactory.java
@@ -24,11 +24,17 @@
 
 package io.questdb.cutlass.auth;
 
-public class DefaultPublicKeyRepoFactory implements PublicKeyRepoFactory {
-    public static final PublicKeyRepoFactory INSTANCE = new DefaultPublicKeyRepoFactory();
+import io.questdb.cutlass.line.tcp.StaticPublicKeyRepo;
+
+public class StaticPublicKeyRepoFactory implements PublicKeyRepoFactory {
+    private final StaticPublicKeyRepo publicKeyRepo;
+
+    public StaticPublicKeyRepoFactory(String authDbPath) {
+        publicKeyRepo = new StaticPublicKeyRepo(authDbPath);
+    }
 
     @Override
     public PublicKeyRepo getInstance() {
-        return null;
+        return publicKeyRepo;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -57,8 +57,6 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
         }
     };
     private final IODispatcherConfiguration ioDispatcherConfiguration = new DefaultIODispatcherConfiguration();
-    private PublicKeyRepoFactory publicKeyRepoFactory;
-
     @Override
     public String getAuthDbPath() {
         return null;
@@ -170,12 +168,7 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
 
     @Override
     public PublicKeyRepoFactory getPublicKeyRepoFactory() {
-        if (publicKeyRepoFactory == null) {
-            if (getAuthDbPath() != null) {
-                publicKeyRepoFactory = new DefaultPublicKeyRepoFactory(getAuthDbPath());
-            }
-        }
-        return publicKeyRepoFactory;
+        return DefaultPublicKeyRepoFactory.INSTANCE;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/AbstractTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractTest.java
@@ -57,8 +57,7 @@ public class AbstractTest {
                         0,
                         0,
                         0,
-                        factoryProvider.getSecurityContextFactory(),
-                        factoryProvider.getPGAuthenticatorFactory()
+                        factoryProvider
                 );
             }
         }, TestUtils.getServerMainArgs(root)));

--- a/core/src/test/java/io/questdb/test/TestServerConfiguration.java
+++ b/core/src/test/java/io/questdb/test/TestServerConfiguration.java
@@ -25,6 +25,7 @@
 package io.questdb.test;
 
 import io.questdb.DefaultServerConfiguration;
+import io.questdb.FactoryProvider;
 import io.questdb.cairo.security.SecurityContextFactory;
 import io.questdb.cutlass.http.DefaultHttpContextConfiguration;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
@@ -59,17 +60,16 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
     private final boolean enableHttp;
     private final boolean enableLineTcp;
     private final boolean enablePgWire;
-    private final PGAuthenticatorFactory pgAuthenticatorFactory;
-    private final SecurityContextFactory securityContextFactory;
+    private final FactoryProvider factoryProvider;
     private final PGWireConfiguration confPgWire = new DefaultPGWireConfiguration() {
         @Override
         public PGAuthenticatorFactory getAuthenticatorFactory() {
-            return pgAuthenticatorFactory;
+            return factoryProvider.getPGAuthenticatorFactory();
         }
 
         @Override
         public SecurityContextFactory getSecurityContextFactory() {
-            return securityContextFactory;
+            return factoryProvider.getSecurityContextFactory();
         }
 
         @Override
@@ -86,7 +86,7 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
 
         @Override
         public SecurityContextFactory getSecurityContextFactory() {
-            return securityContextFactory;
+            return factoryProvider.getSecurityContextFactory();
         }
     }) {
         @Override
@@ -126,7 +126,7 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
 
         @Override
         public SecurityContextFactory getSecurityContextFactory() {
-            return securityContextFactory;
+            return factoryProvider.getSecurityContextFactory();
         }
 
         @Override
@@ -146,8 +146,7 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
             int workerCountHttp,
             int workerCountLineTcpIO,
             int workerCountLineTcpWriter,
-            SecurityContextFactory securityContextFactory,
-            PGAuthenticatorFactory pgAuthenticatorFactory
+            FactoryProvider factoryProvider
     ) {
         super(root);
         this.workerCountHttp = workerCountHttp;
@@ -157,8 +156,7 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
         this.enablePgWire = enablePgWire;
         this.workerCountLineTcpIO = workerCountLineTcpIO;
         this.workerCountLineTcpWriter = workerCountLineTcpWriter;
-        this.securityContextFactory = securityContextFactory;
-        this.pgAuthenticatorFactory = pgAuthenticatorFactory;
+        this.factoryProvider = factoryProvider;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/SendAndReceiveRequestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/SendAndReceiveRequestBuilder.java
@@ -138,7 +138,7 @@ public class SendAndReceiveRequestBuilder {
             Os.sleep(pauseBetweenSendAndReceive);
         }
         // receive response
-        final int expectedToReceive = expectedResponse.length();
+        final int expectedToReceive = (expectedResponse instanceof String) ? ((String) expectedResponse).getBytes().length : expectedResponse.length();
         int received = 0;
         if (printOnly) {
             System.out.println("expected");
@@ -172,8 +172,9 @@ public class SendAndReceiveRequestBuilder {
             }
         }
 
-        byte[] receivedBytes = new byte[receivedByteList.size()];
-        for (int i = 0; i < receivedByteList.size(); i++) {
+        int lim = Math.min(expectedToReceive, receivedByteList.size());
+        byte[] receivedBytes = new byte[lim];
+        for (int i = 0; i < lim; i++) {
             receivedBytes[i] = (byte) receivedByteList.getQuick(i);
         }
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -28,7 +28,12 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cairo.pool.ex.EntryLockedException;
 import io.questdb.cutlass.auth.AuthUtils;
-import io.questdb.cutlass.line.tcp.*;
+import io.questdb.cutlass.auth.PublicKeyRepoFactory;
+import io.questdb.cutlass.auth.StaticPublicKeyRepoFactory;
+import io.questdb.cutlass.line.tcp.DefaultLineTcpReceiverConfiguration;
+import io.questdb.cutlass.line.tcp.LineTcpReceiver;
+import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
+import io.questdb.cutlass.line.tcp.LineTcpReceiverConfigurationHelper;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
@@ -185,6 +190,15 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
         @Override
         public boolean isSymbolAsFieldSupported() {
             return symbolAsFieldSupported;
+        }
+
+        @Override
+        public PublicKeyRepoFactory getPublicKeyRepoFactory() {
+            if (authKeyId == null) {
+                return super.getPublicKeyRepoFactory();
+            }
+
+            return new StaticPublicKeyRepoFactory(getAuthDbPath());
         }
     };
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -29,6 +29,8 @@ import io.questdb.cairo.SecurityContext;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.security.AllowAllSecurityContextFactory;
 import io.questdb.cairo.security.SecurityContextFactory;
+import io.questdb.cutlass.auth.PublicKeyRepoFactory;
+import io.questdb.cutlass.auth.StaticPublicKeyRepoFactory;
 import io.questdb.cutlass.line.tcp.*;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -206,6 +208,14 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
             @Override
             public long getWriterIdleTimeout() {
                 return 150;
+            }
+
+            @Override
+            public PublicKeyRepoFactory getPublicKeyRepoFactory() {
+                if (withAuth) {
+                    return new StaticPublicKeyRepoFactory(getAuthDbPath());
+                }
+                return super.getPublicKeyRepoFactory();
             }
 
             @Override


### PR DESCRIPTION
It is now possible to use partial response matching in HTTP tests, which deals with cases where some error responses contain variable file names