### PR TITLE
fix(pgwire): revert reported pg server version back to 11.3

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3449,7 +3449,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public String getServerVersion() {
-            return "15.2";
+            return "11.3";
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -28,6 +28,7 @@ import io.questdb.*;
 import io.questdb.cairo.*;
 import io.questdb.cutlass.json.JsonException;
 import io.questdb.cutlass.line.*;
+import io.questdb.cutlass.pgwire.DefaultPGWireConfiguration;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.network.EpollFacadeImpl;
@@ -1124,6 +1125,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals("my_quest_ro", configuration.getPGWireConfiguration().getReadOnlyPassword());
             Assert.assertEquals("my_user", configuration.getPGWireConfiguration().getReadOnlyUsername());
             Assert.assertEquals(16, configuration.getPGWireConfiguration().getDispatcherConfiguration().getTestConnectionBufferSize());
+            Assert.assertEquals(new DefaultPGWireConfiguration().getServerVersion(), configuration.getPGWireConfiguration().getServerVersion());
 
             Assert.assertEquals(255, configuration.getCairoConfiguration().getMaxFileNameLength());
             Assert.assertEquals(255, configuration.getLineTcpReceiverConfiguration().getMaxFileNameLength());

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -8661,6 +8661,13 @@ create table tab as (
         });
     }
 
+    @Test
+    public void testMetadata() throws Exception {
+        assertWithPgServer(CONN_AWARE_ALL, (connection, binary) -> {
+            connection.getMetaData().getColumns("dontcare", "whatever", "x", null).close();
+        });
+    }
+
     private void assertHexScript(
             NetworkFacade clientNf,
             String script,


### PR DESCRIPTION
partially reverting the change from https://github.com/questdb/questdb/pull/3080 
#3080 changed the reported version as a side-effect, but the new version was used in PropServerConfiguration only, DefaultPGWireConfiguration stays on 11.3 The result was that most tests reported the version 11.3 to clients while production QuestDB builds reported 15.2. Some Postgres clients adjust behaviour depending on the reported server version and using different version in tests and in production builds means we could not trust tests.