### PR TITLE
fix(core): fix index miss values or contain duplicates in certain commit patterns

### DIFF
--- a/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
@@ -478,7 +478,7 @@ public class BitmapIndexWriter implements Closeable, Mutable {
 
     void rollbackConditionally(long row) {
         final long currentMaxRow;
-        if (row > 0 && ((currentMaxRow = getMaxValue()) < 1 || currentMaxRow > row)) {
+        if (row >= 0 && ((currentMaxRow = getMaxValue()) < 1 || currentMaxRow > row)) {
             rollbackValues(row - 1);
         }
     }

--- a/core/src/test/java/io/questdb/test/griffin/O3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3MaxLagTest.java
@@ -487,8 +487,9 @@ public class O3MaxLagTest extends AbstractO3Test {
                             if (longColIndex > -1) {
                                 row.putLong(longColIndex, timestamp);
                             }
+                            float rndFloat = rnd.nextFloat();
                             if (floatColIndex > -1) {
-                                row.putFloat(floatColIndex, rnd.nextFloat());
+                                row.putFloat(floatColIndex, rndFloat);
                             }
                             if (strColIndex > -1) {
                                 row.putStr(strColIndex, varCol[id % varCol.length]);
@@ -501,7 +502,7 @@ public class O3MaxLagTest extends AbstractO3Test {
                                 row.putLong(longColIndex, timestamp);
                             }
                             if (floatColIndex > -1) {
-                                row.putFloat(floatColIndex, rnd.nextFloat());
+                                row.putFloat(floatColIndex, rndFloat);
                             }
                             if (strColIndex > -1) {
                                 row.putStr(strColIndex, varCol[id % varCol.length]);
@@ -514,9 +515,9 @@ public class O3MaxLagTest extends AbstractO3Test {
                     ordered.commit();
                 }
             }
-            TestUtils.assertEquals(compiler, sqlExecutionContext, "ordered", "o3");
+            TestUtils.assertSqlCursors(compiler, sqlExecutionContext, "ordered", "o3", LOG);
             engine.releaseAllWriters();
-            TestUtils.assertEquals(compiler, sqlExecutionContext, "ordered", "o3");
+            TestUtils.assertSqlCursors(compiler, sqlExecutionContext, "ordered", "o3", LOG);
 
             engine.releaseAllReaders();
             try (TableWriter o3 = TestUtils.getWriter(engine, "o3")) {

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -493,7 +493,7 @@ public class WalWriterFuzzTest extends AbstractGriffinTest {
                 String randomValue = sink.length() > prefix.length() + 2 ? sink.subSequence(prefix.length(), sink.length() - 1).toString() : null;
                 String indexedWhereClause = " where \"" + columnName + "\" = " + (randomValue == null ? "null" : "'" + randomValue + "'");
                 LOG.info().$("checking random index with filter: ").$(indexedWhereClause).I$();
-                String limit = " limit 8970, 9100";
+                String limit = ""; // For debugging
                 TestUtils.assertSqlCursors(compiler, sqlExecutionContext, tableNameNoWal + indexedWhereClause + limit, tableNameWal + indexedWhereClause + limit, LOG);
             }
         }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1407,10 +1407,10 @@ public final class TestUtils {
                         }
                         break;
                     case ColumnType.DOUBLE:
-                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), Numbers.MAX_SCALE);
+                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), 1E-6);
                         break;
                     case ColumnType.FLOAT:
-                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 4);
+                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 1E-4);
                         break;
                     case ColumnType.INT:
                         Assert.assertEquals(rr.getInt(i), lr.getInt(i));
@@ -1497,20 +1497,6 @@ public final class TestUtils {
                 || expected.getLong3() != actual.getLong3()) {
             Assert.assertEquals(toHexString(expected), toHexString(actual));
         }
-    }
-
-    private static RecordMetadata copySymAstStr(RecordMetadata src) {
-        final GenericRecordMetadata metadata = new GenericRecordMetadata();
-        for (int i = 0, n = src.getColumnCount(); i < n; i++) {
-            metadata.add(
-                    new TableColumnMetadata(
-                            src.getColumnName(i),
-                            src.getColumnType(i) != ColumnType.SYMBOL ? src.getColumnType(i) : ColumnType.STRING
-                    )
-            );
-        }
-        metadata.setTimestampIndex(src.getTimestampIndex());
-        return metadata;
     }
 
     private static long partitionIncrement(int partitionBy, long fromTimestamp, int totalRows, int partitionCount) {

--- a/utils/src/test/java/io/questdb/cliutil/TestUtils.java
+++ b/utils/src/test/java/io/questdb/cliutil/TestUtils.java
@@ -97,10 +97,10 @@ public class TestUtils {
                         Assert.assertEquals(rr.getTimestamp(i), lr.getTimestamp(i));
                         break;
                     case ColumnType.DOUBLE:
-                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), 1E-19);
+                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), 1E-6);
                         break;
                     case ColumnType.FLOAT:
-                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 1E-4);
+                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 1E-3);
                         break;
                     case ColumnType.INT:
                         Assert.assertEquals(rr.getInt(i), lr.getInt(i));

--- a/utils/src/test/java/io/questdb/cliutil/TestUtils.java
+++ b/utils/src/test/java/io/questdb/cliutil/TestUtils.java
@@ -33,7 +33,6 @@ import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Chars;
-import io.questdb.std.Numbers;
 import org.junit.Assert;
 
 public class TestUtils {
@@ -98,10 +97,10 @@ public class TestUtils {
                         Assert.assertEquals(rr.getTimestamp(i), lr.getTimestamp(i));
                         break;
                     case ColumnType.DOUBLE:
-                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), Numbers.MAX_SCALE);
+                        Assert.assertEquals(rr.getDouble(i), lr.getDouble(i), 1E-19);
                         break;
                     case ColumnType.FLOAT:
-                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 4);
+                        Assert.assertEquals(rr.getFloat(i), lr.getFloat(i), 1E-4);
                         break;
                     case ColumnType.INT:
                         Assert.assertEquals(rr.getInt(i), lr.getInt(i));


### PR DESCRIPTION
After adding index testing to fuzz tests few issues were found and fixed
- WAL tables can miss a range of rows in the index. When rows were applied from lag, indexes were not incrementally built.
- Non-WAL tables can have duplicated index entries when a row cancel happens on the edge of a partition. 