### PR TITLE
chore(http): use dedicated thread for healthchecks and metrics by default

### DIFF
--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -101,6 +101,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(10, configuration.getHttpMinServerConfiguration().getYieldThreshold());
         Assert.assertEquals(100, configuration.getHttpMinServerConfiguration().getSleepThreshold());
         Assert.assertEquals(50, configuration.getHttpMinServerConfiguration().getSleepTimeout());
+        Assert.assertEquals(1, configuration.getHttpMinServerConfiguration().getWorkerCount());
 
         // this is going to need interesting validation logic
         // configuration path is expected to be relative, and we need to check if absolute path is good
@@ -896,6 +897,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(100002, configuration.getHttpMinServerConfiguration().getSleepThreshold());
             Assert.assertEquals(1002, configuration.getHttpMinServerConfiguration().getSleepTimeout());
             Assert.assertEquals(16, configuration.getHttpMinServerConfiguration().getDispatcherConfiguration().getTestConnectionBufferSize());
+            Assert.assertEquals(4, configuration.getHttpMinServerConfiguration().getWorkerCount());
 
             Assert.assertEquals(new File(root, "public_ok").getAbsolutePath(),
                     configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getPublicDirectory());

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -168,6 +168,7 @@ http.worker.yield.threshold=101
 http.worker.sleep.threshold=100001
 http.worker.sleep.timeout=1001
 
+http.min.worker.count=4
 http.min.worker.yield.threshold=102
 http.min.worker.sleep.threshold=100002
 http.min.worker.sleep.timeout=1002


### PR DESCRIPTION
This change is required to avoid having server restarts due to failed k8s liveness probes on machines with a few CPU cores. Having a dedicated thread to handle `GET /status` should guarantee the absence of false negative liveness probes.