### PR TITLE
fix(core): fix symbol index containing duplicates references

### DIFF
--- a/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
@@ -478,7 +478,7 @@ public class BitmapIndexWriter implements Closeable, Mutable {
 
     void rollbackConditionally(long row) {
         final long currentMaxRow;
-        if (row >= 0 && ((currentMaxRow = getMaxValue()) < 1 || currentMaxRow > row)) {
+        if (row >= 0 && ((currentMaxRow = getMaxValue()) < 1 || currentMaxRow >= row)) {
             rollbackValues(row - 1);
         }
     }

--- a/core/src/main/java/io/questdb/cairo/O3CopyJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3CopyJob.java
@@ -743,7 +743,7 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
         for (; row < count; row++) {
             w.add(TableUtils.toIndexKey(Unsafe.getUnsafe().getInt(dstFixAddr + row * Integer.BYTES)), row + rowAdjust);
         }
-        w.setMaxValue(count - 1);
+        w.setMaxValue(row + rowAdjust);
     }
 
     // lowest timestamp of partition where data is headed

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -483,7 +483,6 @@ public class WalWriterFuzzTest extends AbstractGriffinTest {
             if (reader.size() > 0) {
                 TableReaderMetadata metadata = reader.getMetadata();
                 for (int columnIndex = 0; columnIndex < metadata.getColumnCount(); columnIndex++) {
-                    columnIndex = columnIndex % metadata.getColumnCount();
                     if (ColumnType.isSymbol(metadata.getColumnType(columnIndex))
                             && metadata.isColumnIndexed(columnIndex)) {
                         checkIndexRandomValueScan(tableNameNoWal, tableNameWal, rnd, reader.size(), metadata.getColumnName(columnIndex));


### PR DESCRIPTION
With some commit patterns found in tests, the symbol index could contain a duplicate reference to a row. This affects WAL and non-WAL tables.