### PR TITLE
chore(pgwire): introduce PgCodec as a potential hex scripts replacement

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
@@ -31,21 +31,29 @@ import io.questdb.cutlass.pgwire.CircuitBreakerRegistry;
 import io.questdb.cutlass.pgwire.DefaultPGWireConfiguration;
 import io.questdb.cutlass.pgwire.PGWireConfiguration;
 import io.questdb.cutlass.pgwire.PGWireServer;
-import io.questdb.griffin.*;
-import io.questdb.test.mp.TestWorkerPool;
+import io.questdb.griffin.DatabaseSnapshotAgent;
+import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
+import io.questdb.griffin.FunctionFactoryCache;
+import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.Rnd;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractGriffinTest;
+import io.questdb.test.cutlass.pgwire.test.PgWireCodec;
+import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +64,23 @@ import java.util.TimeZone;
 import static io.questdb.std.Numbers.hexDigits;
 
 public abstract class BasePGTest extends AbstractGriffinTest {
+
+    protected static PgWireCodec pgCodec;
+
+    @BeforeClass
+    public static void setUpPgCodec() {
+        pgCodec = new PgWireCodec();
+    }
+
+    @AfterClass
+    public static void closePgCodec() {
+        pgCodec = Misc.freeIfCloseable(pgCodec);
+    }
+
+    @Before
+    public void clearPgCodec() {
+        pgCodec.clear();
+    }
 
     public static PGWireServer createPGWireServer(
             PGWireConfiguration configuration,

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/test/PgWireCodec.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/test/PgWireCodec.java
@@ -1,0 +1,647 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.pgwire.test;
+
+import io.questdb.std.str.StringSink;
+
+import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
+
+public class PgWireCodec implements Closeable {
+    private static final byte[] USER = "user".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DB = "database".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] CLIENT_ENCODING = "client_encoding".getBytes(StandardCharsets.UTF_8);
+    private static final int PROT_VERSION = 196608;
+
+    private final OutboundChannel out = new OutboundChannel();
+    private final InboundChannel in = new InboundChannel();
+    private final RowDescription rowDescription = new RowDescription();
+    private final RowData rowData = new RowData();
+    private final ParameterDescription parameterDescription = new ParameterDescription();
+    private final CustomStartup customStartup = new CustomStartup();
+    private final PgWireRecorder rec = new PgWireRecorder(1024 * 1024); // 1MB
+    private final Bind bind = new Bind();
+
+    public void clear() {
+        rec.clear();
+    }
+
+    @Override
+    public void close() {
+        rec.close();
+    }
+
+    public OutboundChannel out() {
+        rec.controlOut();
+        return out;
+    }
+
+    public void dumpAndClear(StringSink sink) {
+        rec.appendHexAndClear(sink);
+        rec.clear();
+    }
+
+    public class Bind {
+        public class ResultFormats {
+            private short count;
+            private long countOffset;
+
+            private ResultFormats begin() {
+                this.count = 0;
+                this.countOffset = rec.offsetAndAdvanceShort();
+                return this;
+            }
+
+            public ResultFormats add(short format) {
+                rec.appendShortBE(format);
+                count++;
+                return this;
+            }
+
+            public ResultFormats addBin() {
+                return add((short) 1);
+            }
+
+            public ResultFormats addText() {
+                return add((short) 0);
+            }
+
+            public Bind doneResultFormats() {
+                rec.setShortBE(count, countOffset);
+                return Bind.this;
+            }
+        }
+
+        public class ParameterValues {
+            private short count;
+            private long countOffset;
+
+            private ParameterValues begin() {
+                this.count = 0;
+                this.countOffset = rec.offsetAndAdvanceShort();
+                return this;
+            }
+
+            public ParameterValues addNull() {
+                rec.appendIntBE(-1);
+                count++;
+                return this;
+            }
+
+            public ParameterValues addInt4bin(int value) {
+                rec.appendIntBE(4);
+                rec.appendIntBE(value);
+                count++;
+                return this;
+            }
+
+            public Bind doneParamValues() {
+                rec.setShortBE(count, countOffset);
+                return Bind.this;
+            }
+        }
+
+        public class ParameterFormat {
+            private short count;
+            private long countOffset;
+
+            private ParameterFormat begin() {
+                this.count = 0;
+                this.countOffset = rec.offsetAndAdvanceShort();
+                return this;
+            }
+
+            public ParameterFormat add(short format) {
+                rec.appendShortBE(format);
+                count++;
+                return this;
+            }
+
+            public ParameterFormat addBin() {
+                return add((short) 1);
+            }
+
+            public ParameterFormat addText() {
+                return add((short) 0);
+            }
+
+            public Bind doneParamFormats() {
+                rec.setShortBE(count, countOffset);
+                return Bind.this;
+            }
+        }
+
+        private long startOffset;
+        private final ParameterFormat paramFormatCodes = new ParameterFormat();
+        private final ParameterValues paramValues = new ParameterValues();
+
+        private Bind begin(String portalName, String statementName) {
+            assert portalName != null;
+            assert statementName != null;
+            rec.appendByte((byte) 'B');
+            startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(portalName);
+            rec.appendAsciiZ(statementName);
+            return this;
+        }
+
+        public ParameterFormat paramFormats() {
+            return paramFormatCodes.begin();
+        }
+
+        public ParameterValues paramValues() {
+            return paramValues.begin();
+        }
+
+        public ResultFormats resultFormats() {
+            return new ResultFormats().begin();
+        }
+
+        public OutboundChannel bindDone() {
+            rec.setMsgSize(startOffset);
+            return out;
+        }
+    }
+
+    public class CustomStartup {
+        private long startOffset;
+
+        public CustomStartup begin() {
+            startOffset = rec.offsetAndAdvanceInt();
+            rec.appendIntBE(PROT_VERSION);
+            return this;
+        }
+
+        public CustomStartup addParam(String key, String value) {
+            rec.appendAsciiZ(key);
+            rec.appendAsciiZ(value);
+            return this;
+        }
+
+        public OutboundChannel startupDone() {
+            rec.appendByte((byte) 0);
+            rec.setMsgSize(startOffset);
+            return out;
+        }
+    }
+
+    public class ParameterDescription {
+        private long startOffset;
+        private long countOffset;
+        private short count;
+
+        public ParameterDescription begin() {
+            rec.appendByte((byte) 't');
+            startOffset = rec.offsetAndAdvanceInt();
+            countOffset = rec.offsetAndAdvanceShort();
+            count = 0;
+            return this;
+        }
+
+        public ParameterDescription int8Column() {
+            rec.appendIntBE(20); // int8
+            count++;
+            return this;
+        }
+
+        public ParameterDescription int4Column() {
+            rec.appendIntBE(23); // int4
+            count++;
+            return this;
+        }
+
+        public ParameterDescription varcharColumn() {
+            rec.appendIntBE(1043); // varchar
+            count++;
+            return this;
+        }
+
+        public ParameterDescription customColumn(int oid) {
+            rec.appendIntBE(oid);
+            count++;
+            return this;
+        }
+
+        public InboundChannel parameterDescriptionDone() {
+            rec.setMsgSize(startOffset);
+            rec.setShortBE(count, countOffset);
+            return in;
+        }
+    }
+
+    public class RowData {
+        private short columnCount;
+        private long startOffset;
+        private long columnCountOffset;
+
+        private RowData begin() {
+            columnCount = 0;
+            rec.appendByte((byte) 'D');
+            startOffset = rec.offsetAndAdvanceInt();
+            columnCountOffset = rec.offsetAndAdvanceShort();
+            return this;
+        }
+
+        public RowData int8ColumnText(long value) {
+            String valueString = String.valueOf(value);
+            return varcharColumn(valueString);
+        }
+
+        public RowData int4ColumnText(int value) {
+            String valueString = String.valueOf(value);
+            return varcharColumn(valueString);
+        }
+
+        public RowData boolColumnBin(boolean value) {
+            rec.appendIntBE(1);
+            rec.appendByte((byte) (value ? 1 : 0));
+            columnCount++;
+            return this;
+        }
+
+        public RowData varcharColumn(String value) {
+            if (value == null) {
+                rec.appendIntBE(-1);
+                columnCount++;
+                return this;
+            }
+            rec.appendAsciiIntSizePrefix(value);
+            columnCount++;
+            return this;
+        }
+
+        public InboundChannel rowDataDone() {
+            rec.setMsgSize(startOffset);
+            rec.setShortBE(columnCount, columnCountOffset);
+            return in;
+        }
+    }
+
+    public class RowDescription {
+        private short columnCount;
+        private long startOffset;
+        private long columnCountOffset;
+
+        private RowDescription begin() {
+            rec.appendByte((byte) 'T');
+            columnCount = 0;
+            startOffset = rec.offsetAndAdvanceInt();
+            columnCountOffset = rec.offsetAndAdvanceShort();
+            return this;
+        }
+
+        public RowDescription int8ColumnText(String name) {
+            return columnText(name, 20, (short) 8);
+        }
+
+        public RowDescription int8ColumnBin(String name) {
+            return columnBin(name, 20, (short) 8);
+        }
+
+        public RowDescription int4ColumnText(String name) {
+            return columnText(name, 23, (short) 4);
+        }
+
+        public RowDescription int4ColumnBin(String name) {
+            return columnBin(name, 23, (short) 4);
+        }
+
+        public RowDescription boolColumnText(String name) {
+            return columnText(name, 16, (short) 1);
+        }
+
+        public RowDescription boolColumnBin(String name) {
+            return columnBin(name, 16, (short) 1);
+        }
+
+        public RowDescription varcharColumnText(String name) {
+            return columnText(name, 1043, (short) -1);
+        }
+
+        public RowDescription columnText(String name, int oid, short size) {
+            return column(name, oid, size, 0, -1, (short) 0);
+        }
+
+        public RowDescription columnBin(String name, int oid, short size) {
+            return column(name, oid, size, 0, -1, (short) 1);
+        }
+
+        public RowDescription column(String name, int oid, short size, int tableId, int typeModifier, short formatCode) {
+            columnCount++;
+            rec.appendAsciiZ(name);
+            rec.appendIntBE(tableId);
+            rec.appendShortBE(columnCount);
+            rec.appendIntBE(oid);
+            rec.appendShortBE(size);
+            rec.appendIntBE(typeModifier);
+            rec.appendShortBE(formatCode);
+            return this;
+        }
+
+        public InboundChannel rowDescriptionDone() {
+            rec.setMsgSize(startOffset);
+            rec.setShortBE(columnCount, columnCountOffset);
+            return in;
+        }
+    }
+
+    public class InboundChannel {
+
+        public InboundChannel sslDeclined() {
+            rec.appendByte((byte) 'N');
+            return this;
+        }
+
+        public InboundChannel closeComplete() {
+            rec.appendByte((byte) '3');
+            rec.appendIntBE(4);
+            return this;
+        }
+
+        public InboundChannel commandCompletion(String tag) {
+            rec.appendByte((byte) 'C');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(tag);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public InboundChannel authenticationCleartextPassword() {
+            rec.appendByte((byte) 'R');
+            rec.appendIntBE(8);
+            rec.appendIntBE(3);
+            return this;
+        }
+
+        public InboundChannel authenticationOk() {
+            rec.appendByte((byte) 'R');
+            rec.appendIntBE(8);
+            rec.appendIntBE(0);
+            return this;
+        }
+
+        public InboundChannel backendKeyData(int processId, int secretKey) {
+            rec.appendByte((byte) 'K');
+            rec.appendIntBE(12);
+            rec.appendIntBE(processId);
+            rec.appendIntBE(secretKey);
+            return this;
+        }
+
+        public InboundChannel parameterStatus(String name, String value) {
+            rec.appendByte((byte) 'S');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(name);
+            rec.appendAsciiZ(value);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public InboundChannel readyForQuery_idle() {
+            rec.appendByte((byte) 'Z');
+            rec.appendIntBE(5);
+            rec.appendByte((byte) 'I');
+            return this;
+        }
+
+        public RowDescription rowDescription() {
+            return rowDescription.begin();
+        }
+
+        public RowData rowData() {
+            return rowData.begin();
+        }
+
+        public InboundChannel parseComplete() {
+            rec.appendByte((byte) '1');
+            rec.appendIntBE(4);
+            return in;
+        }
+
+        public InboundChannel bindComplete() {
+            rec.appendByte((byte) '2');
+            rec.appendIntBE(4);
+            return in;
+        }
+
+        public ParameterDescription parameterDescription() {
+            return parameterDescription.begin();
+        }
+
+        public OutboundChannel out() {
+            rec.controlOut();
+            return out;
+        }
+
+        public InboundChannel newLine() {
+            rec.controlIn();
+            return in;
+        }
+
+        public InboundChannel error(int position, String message) {
+            rec.appendByte((byte) 'E');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendByte((byte) 'C'); // SQLSTATE. QuestDB always returns 00000
+            rec.appendAsciiZ("00000");
+            rec.appendByte((byte) 'M'); // Message
+            rec.appendAsciiZ(message);
+            rec.appendByte((byte) 'S'); // Severity
+            rec.appendAsciiZ("ERROR");
+            if (position > 0) {
+                rec.appendByte((byte) 'P'); // Position
+                rec.appendAsciiZ(Integer.toString(position));
+            }
+            rec.appendByte((byte) 0); // no more fields
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public void dumpAndClear(StringSink stringSink) {
+            rec.appendHexAndClear(stringSink);
+            rec.clear();
+        }
+    }
+
+    public class OutboundChannel {
+
+        public void dumpAndClear(StringSink sink) {
+            rec.appendHexAndClear(sink);
+            rec.clear();
+        }
+
+        public OutboundChannel password(String password) {
+            rec.appendByte((byte) 'p');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(password);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel parse(String statementName, String query, int... paramTypes) {
+            rec.appendByte((byte) 'P');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(statementName);
+            rec.appendAsciiZ(query);
+            rec.appendShortBE((short) paramTypes.length);
+            for (int paramType : paramTypes) {
+                rec.appendIntBE(paramType);
+            }
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel sync() {
+            rec.appendByte((byte) 'S');
+            rec.appendIntBE(4);
+            return this;
+        }
+
+        public OutboundChannel sslRequest() {
+            rec.appendIntBE(8);
+            rec.appendIntBE(80877103);
+            return out;
+        }
+
+        public OutboundChannel execute(String portalName, int maxRows) {
+            rec.appendByte((byte) 'E');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(portalName);
+            rec.appendIntBE(maxRows);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel execute() {
+            return execute("", 0);
+        }
+
+        public OutboundChannel closePortal(String portalName) {
+            rec.appendByte((byte) 'C');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendByte((byte) 'P');
+            rec.appendAsciiZ(portalName);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel terminate() {
+            rec.appendByte((byte) 'X');
+            rec.appendIntBE(4);
+            return this;
+        }
+
+        public OutboundChannel closePortal() {
+            return closePortal("");
+        }
+
+        public OutboundChannel closeStatement(String statementName) {
+            rec.appendByte((byte) 'C');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendByte((byte) 'S');
+            rec.appendAsciiZ(statementName);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel closeStatement() {
+            return closeStatement("");
+        }
+
+        public Bind bind(String portalName, String statementName) {
+            return bind.begin(portalName, statementName);
+        }
+
+        public OutboundChannel describeStatement(String statementName) {
+            rec.appendByte((byte) 'D');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendByte((byte) 'S');
+            rec.appendAsciiZ(statementName);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel describePortal(String portalName) {
+            rec.appendByte((byte) 'D');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendByte((byte) 'P');
+            rec.appendAsciiZ(portalName);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public OutboundChannel flush() {
+            rec.appendByte((byte) 'H');
+            rec.appendIntBE(4);
+            return this;
+        }
+
+        public OutboundChannel newLine() {
+            rec.controlOut();
+            return this;
+        }
+
+        public OutboundChannel startup(String username, String database) {
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendIntBE(PROT_VERSION);
+            rec.appendBytesZ(USER);
+            rec.appendAsciiZ(username);
+            rec.appendBytesZ(DB);
+            rec.appendAsciiZ(database);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public CustomStartup startup() {
+            return customStartup.begin();
+        }
+
+        public OutboundChannel startup(String username, String database, String clientEncoding) {
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendIntBE(PROT_VERSION);
+            rec.appendBytesZ(CLIENT_ENCODING);
+            rec.appendAsciiZ(clientEncoding);
+            rec.appendBytesZ(USER);
+            rec.appendAsciiZ(username);
+            rec.appendBytesZ(DB);
+            rec.appendAsciiZ(database);
+            rec.appendByte((byte) 0);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+
+        public InboundChannel in() {
+            rec.controlIn();
+            return in;
+        }
+
+        public OutboundChannel simpleQuery(String query) {
+            rec.appendByte((byte) 'Q');
+            long startOffset = rec.offsetAndAdvanceInt();
+            rec.appendAsciiZ(query);
+            rec.setMsgSize(startOffset);
+            return this;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/test/PgWireRecorder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/test/PgWireRecorder.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.pgwire.test;
+
+import io.questdb.std.IntList;
+import io.questdb.std.LongList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.StringSink;
+
+import java.io.Closeable;
+
+public final class PgWireRecorder implements Closeable {
+    private static final char[] HEX_DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    private long ptr;
+    private long size;
+    private long offset;
+
+    private static final int IN_CONTROL = 0;
+    private static final int OUT_CONTROL = 1;
+
+    private final LongList ctrlOffsets = new LongList();
+    private final IntList ctrls = new IntList();
+
+    public PgWireRecorder(long size) {
+        ptr = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        this.size = size;
+    }
+
+    public void controlOut() {
+        ctrls.add(OUT_CONTROL);
+        ctrlOffsets.add(offset);
+    }
+
+    public void controlIn() {
+        ctrls.add(IN_CONTROL);
+        ctrlOffsets.add(offset);
+    }
+
+    @Override
+    public void close() {
+        ptr = Unsafe.free(ptr, size, MemoryTag.NATIVE_DEFAULT);
+    }
+
+    public void clear() {
+        offset = 0;
+        ctrlOffsets.clear();
+        ctrls.clear();
+    }
+
+    public long offsetAndAdvanceInt() {
+        long localOffset = offset;
+        assert offset + Integer.BYTES <= size;
+        offset += Integer.BYTES;
+        return localOffset;
+    }
+
+    public long offsetAndAdvanceShort() {
+        long localOffset = offset;
+        assert offset + Short.BYTES <= size;
+        offset += Short.BYTES;
+        return localOffset;
+    }
+
+    public int appendByte(byte b) {
+        // todo: check for overflow
+        assert offset + Byte.BYTES <= size;
+        setByte(b, offset);
+        offset++;
+        return Byte.BYTES;
+    }
+
+    public int appendBytes(byte[] bytes) {
+        int len = bytes.length;
+        for (byte b : bytes) {
+            appendByte(b);
+        }
+        return len;
+    }
+
+    public int appendBytesZ(byte[] bytes) {
+        int len = appendBytes(bytes);
+        appendByte((byte) 0);
+        return len + 1;
+    }
+
+    public void setByte(byte b, long offset) {
+        assert offset + Byte.BYTES <= size;
+        Unsafe.getUnsafe().putByte(ptr + offset, b);
+    }
+
+    public void setMsgSize(long initialOffset) {
+        long msgSize = offset - initialOffset;
+        setIntBE((int) msgSize, initialOffset);
+    }
+
+    public void setIntBE(int i, long offset) {
+        assert offset + Integer.BYTES <= size;
+        setByte((byte) (i >> 24), offset);
+        setByte((byte) (i >> 16), offset + 1);
+        setByte((byte) (i >> 8), offset + 2);
+        setByte((byte) (i), offset + 3);
+    }
+
+    public void setShortBE(short s, long offset) {
+        assert offset + Short.BYTES <= size;
+        setByte((byte) (s >> 8), offset);
+        setByte((byte) (s), offset + 1);
+    }
+
+    public int appendShortBE(short s) {
+        assert offset + Short.BYTES <= size;
+        appendByte((byte) (s >> 8));
+        appendByte((byte) (s));
+        return Short.BYTES;
+    }
+
+    public int appendIntBE(int i) {
+        appendByte((byte) (i >> 24));
+        appendByte((byte) (i >> 16));
+        appendByte((byte) (i >> 8));
+        appendByte((byte) (i));
+        return Integer.BYTES;
+    }
+
+    public int appendLongBE(long l) {
+        appendByte((byte) (l >> 56));
+        appendByte((byte) (l >> 48));
+        appendByte((byte) (l >> 40));
+        appendByte((byte) (l >> 32));
+        appendByte((byte) (l >> 24));
+        appendByte((byte) (l >> 16));
+        appendByte((byte) (l >> 8));
+        appendByte((byte) (l));
+        return Long.BYTES;
+    }
+
+    public int appendAsciiIntSizePrefix(CharSequence cs) {
+        long startOffset = offsetAndAdvanceInt();
+        int len = appendAscii(cs);
+        setIntBE(len, startOffset);
+        return len + Integer.BYTES;
+    }
+
+    public int appendAscii(CharSequence cs) {
+        int len = cs.length();
+        for (int i = 0; i < len; i++) {
+            char c = cs.charAt(i);
+            assert c < 128; // todo: support UTF-8 and rename related methods from "Ascii" to "Utf8"
+            appendByte((byte) c);
+        }
+        return len;
+    }
+
+    public int appendAsciiZ(CharSequence cs) {
+        int len = appendAscii(cs);
+        appendByte((byte) 0);
+        return len + 1;
+    }
+
+    public void appendHexAndClear(StringSink sb) {
+        assert ctrlOffsets.size() > 0;
+        assert ctrlOffsets.size() == ctrls.size();
+
+        int controlOffsetIndex = 0;
+        long nextControlOffset = ctrlOffsets.get(0);
+        for (long i = 0; i < offset; i++) {
+            if (i == nextControlOffset) {
+                if (controlOffsetIndex != 0) {
+                    // we are not at the start of the buffer
+                    // so we need to add a newline before the control
+                    sb.put('\n');
+                }
+                int control = ctrls.get(controlOffsetIndex);
+                if (control == OUT_CONTROL) {
+                    sb.put('>');
+                } else if (control == IN_CONTROL) {
+                    sb.put('<');
+                } else {
+                    throw new IllegalStateException("unknown control value at offset " + i + ": " + control);
+                }
+                if (++controlOffsetIndex < ctrlOffsets.size()) {
+                    nextControlOffset = ctrlOffsets.get(controlOffsetIndex);
+                }
+            }
+            byte b = Unsafe.getUnsafe().getByte(ptr + i);
+            sb.put(HEX_DIGITS[(b >> 4) & 0x0F]);
+            sb.put(HEX_DIGITS[b & 0x0F]);
+        }
+        clear();
+    }
+}


### PR DESCRIPTION
This is an experimental tooling which should eventually replace hex script in pgwire tests. 
# Motivation
Hex scripts are usually created by recording communication between various clients and QuestDB. They typically look like this:

```java
    public void testGolangBoolean() throws Exception {
        skipOnWalRun(); // table not created
        final String script = ">0000000804d2162f\n" +
                "<4e\n" +
                ">0000002400030000757365720078797a00646174616261736500706f7374677265730000\n" +
                "<520000000800000003\n" +
                ">70000000076f6800\n" +
                "<520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549\n" +
                ">50000000246c72757073635f315f300053454c45435420747275652c2066616c73650000004400000010536c72757073635f315f30005300000004\n" +
                "<310000000474000000060000540000003500027472756500000000000001000000100001ffffffff000066616c736500000000000002000000100001ffffffff00005a0000000549\n" +
                ">420000001a006c72757073635f315f30000000000000020001000144000000065000450000000900000000005300000004\n" +
                "<3200000004540000003500027472756500000000000001000000100001ffffffff000166616c736500000000000002000000100001ffffffff00014400000010000200000001010000000100430000000d53454c4543542031005a0000000549\n" +
                ">5800000004\n";
        assertHexScript(
                NetworkFacadeImpl.INSTANCE,
                script,
                getHexPgWireConfig()
        );
    }
```

This allows us to write Java-based regression tests for various clients. They are also relatively simple to create (as long as you know Wireshark). 

However, they come with down-sides too:
1. They are opaque and hard to troubleshoot. What if you change questdb code and a random hex test starts failing? You have to fire up Wireshark again, run the original (passing) test, then a failing test, compare communications as recorded by Wireshark, figure out the difference and reason how/if it relates to your code changes, whether it's an actual regression or a false negative and change either a test of production code. That's very tedious and error prone. Also very hard for reviewers to validate a change in a hex script is correct. 
2. It's hard to write hex scripts from scratch. While it's easy to record communication between an existing Pgwire client and QuestDB it's much harder to write your own test scenarios in hex. What if a malicious client sends an evil payload? Well, it's hard to test for this unless you build a malicious client. What if a buggy client sends an innocent yet unexpected message? Again, hard to test such scenarios unless you build/find such client. 
3. hex test disincentives changes. Imagine we change the Postgres version we report back to clients. This is sent to every client at the start of client-server communication. And if change the version string then we have to change all recorded hex scripts. That's very tedious work and chances are we avoid changing the version string so we don't have to fix all hex tests.

# PgCodec to the Rescue?
At this point it should be clear the hex scripts are far from ideal. This PR proposes a possible solution: A programmatic builder-like API to build arbitrary pgwire test scenarios. Instead of saving a hex script a test uses an API to describe a desired client-server exchange. So the example above would like like this:
```java
public void testGolangBoolean() throws Exception {
        skipOnWalRun(); // table not created
 
        pgCodec.out().sslRequest()
                .in().sslDeclined()
                .out().startup().addParam("user", "xyz").addParam("database", "postgres").startupDone()
                .in().authenticationCleartextPassword()
                .out().password("oh")
                .in().authenticationOk().parameterStatus("TimeZone", "GMT")
                .parameterStatus("application_name", "QuestDB")
                .parameterStatus("server_version", "11.3")
                .parameterStatus("integer_datetimes", "on")
                .parameterStatus("client_encoding", "UTF8")
                .backendKeyData(63, -1148479920)
                .readyForQuery_idle()
                .out()
                .parse("lrupsc_1_0", "SELECT true, false")
                .describeStatement("lrupsc_1_0")
                .sync()
                .in()
                .parseComplete()
                .parameterDescription().parameterDescriptionDone()
                .rowDescription().boolColumnText("true").boolColumnText("false").rowDescriptionDone()
                .readyForQuery_idle()
                .out()
                .bind("", "lrupsc_1_0").paramFormats().doneParamFormats().paramValues().doneParamValues().resultFormats().addBin().addBin().doneResultFormats().bindDone()
                .describePortal("")
                .execute()
                .sync()
                .in()
                .bindComplete()
                .rowDescription().boolColumnBin("true").boolColumnBin("false").rowDescriptionDone()
                .rowData().boolColumnBin(true).boolColumnBin(false).rowDataDone()
                .commandCompletion("SELECT 1")
                .readyForQuery_idle()
                .out().terminate();

        pgCodec.dumpAndClear(sink);

        String script = sink.toString();
        assertHexScript(
                NetworkFacadeImpl.INSTANCE,
                script,
                getHexPgWireConfig()
        );
```
While the test is longer than then the hex original it's way more transparent. It still requires some knowledge of the PGWire protocol, but even when you know just a little about the protocol you can have some intuition of what is the test doing. 

The PgCodec API can be seen as a very low level PgWire client API: It builds messages to be sent from a client to server and also messages we expect the server to send back to the client. The result of this is again converted to a hex script which is then executed in the same way as hard-coded hex scripts. 

This makes changes in scenarios simpler to write and review. It also makes it possible to write arbitrary scenarios without building a specialized client: think of simulating evil and buggy clients, test for protocol compliance, etc. 

# The state of this PR
The PR as it is right now allow to replace some hex scripts. It can generated most of messages. 
Not all data types are supported, but it's quite easy to extend it. 

## Improvements to be done:
1.  Simple: UTF8 support. Currently, strings are expected to be ASCII only. UTF8 support is simple to add. 
2. Hard (in terms of effort, not so much in complexity): Convert all current hex tests into PgCodec API. We do not want a mix of hex tests and PgCodec tests. This creates a mental burden for maintainers who have to learn both styles. This will require extending the API to generates malformed UTF8 strings, etc. 
3. Medium-hard: Better error messages: PgCodec test scenarios look transparent in a test source, but they are ultimately converted to hex scripts and asserts are done on hex. This was done to re-use existing infrastructure. The downside is clear: When there is a test failure then it's non-obvious what is going: Assertions compare a hex scripts with actual communication, they know nothing about how a hex script was generated. We could change the infra so assertion errors show in what message was an error, how they differ, etc.
4. Hard: Reverse engineer hex scripts into PgCode scenarios: It should be possible to write a tool to convert an arbitrary network communication (hex scripts) into a PgCode calls. The input would be a hex script and output would be a Java source code with a PgCodec-drive test. This could be done before the bullet no. 2 from this list. A possible issue. Broken messages: Imagine a hex script from a misbehaving client. If a recorded communication does not relate to any valid pgwire message then auto-transaltion from hex to PgCodec could be challenging. 