### PR TITLE
feat(http): introduce configuration for health check pessimism

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -348,6 +348,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private int httpNetConnectionRcvBuf;
     private int httpNetConnectionSndBuf;
     private long httpNetConnectionTimeout;
+    private boolean httpPessimisticHealthCheckEnabled;
     private boolean httpReadOnlySecurityContext;
     private boolean httpServerKeepAlive;
     private String httpVersion;
@@ -667,6 +668,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 this.jsonQueryConnectionCheckFrequency = getInt(properties, env, PropertyKey.HTTP_JSON_QUERY_CONNECTION_CHECK_FREQUENCY, 1_000_000);
                 this.jsonQueryFloatScale = getInt(properties, env, PropertyKey.HTTP_JSON_QUERY_FLOAT_SCALE, 4);
                 this.jsonQueryDoubleScale = getInt(properties, env, PropertyKey.HTTP_JSON_QUERY_DOUBLE_SCALE, 12);
+                this.httpPessimisticHealthCheckEnabled = getBoolean(properties, env, PropertyKey.HTTP_PESSIMISTIC_HEALTH_CHECK, false);
                 this.httpReadOnlySecurityContext = getBoolean(properties, env, PropertyKey.HTTP_SECURITY_READONLY, false);
                 this.maxHttpQueryResponseRowLimit = getLong(properties, env, PropertyKey.HTTP_SECURITY_MAX_RESPONSE_ROWS, Long.MAX_VALUE);
                 this.interruptOnClosedConnection = getBoolean(properties, env, PropertyKey.HTTP_SECURITY_INTERRUPT_ON_CLOSED_CONNECTION, true);
@@ -2777,6 +2779,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         public boolean isEnabled() {
             return httpMinServerEnabled;
         }
+
+        @Override
+        public boolean isPessimisticHealthCheckEnabled() {
+            return httpPessimisticHealthCheckEnabled;
+        }
     }
 
     private class PropHttpServerConfiguration implements HttpServerConfiguration {
@@ -2854,6 +2861,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isEnabled() {
             return httpServerEnabled;
+        }
+
+        @Override
+        public boolean isPessimisticHealthCheckEnabled() {
+            return httpPessimisticHealthCheckEnabled;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -224,6 +224,7 @@ public enum PropertyKey {
     HTTP_TEXT_ROLL_BUFFER_LIMIT("http.text.roll.buffer.limit"),
     HTTP_TEXT_ROLL_BUFFER_SIZE("http.text.roll.buffer.size"),
     HTTP_TEXT_UTF8_SINK_SIZE("http.text.utf8.sink.size"),
+    HTTP_PESSIMISTIC_HEALTH_CHECK("http.pessimistic.health.check.enabled"),
     HTTP_SECURITY_READONLY("http.security.readonly"),
     HTTP_SECURITY_MAX_RESPONSE_ROWS("http.security.max.response.rows"),
     HTTP_SECURITY_INTERRUPT_ON_CLOSED_CONNECTION("http.security.interrupt.on.closed.connection"),

--- a/core/src/main/java/io/questdb/cutlass/Services.java
+++ b/core/src/main/java/io/questdb/cutlass/Services.java
@@ -46,7 +46,7 @@ import io.questdb.griffin.DatabaseSnapshotAgent;
 import io.questdb.griffin.FunctionFactoryCache;
 import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.WorkerPool;
-import io.questdb.std.*;
+import io.questdb.std.Os;
 import org.jetbrains.annotations.Nullable;
 
 public final class Services {
@@ -215,7 +215,7 @@ public final class Services {
 
             @Override
             public HttpRequestProcessor newInstance() {
-                return new HealthCheckProcessor();
+                return new HealthCheckProcessor(configuration.isPessimisticHealthCheckEnabled());
             }
         }, true);
         if (metrics.isEnabled()) {

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
@@ -89,6 +89,11 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     }
 
     @Override
+    public SecurityContextFactory getSecurityContextFactory() {
+        return AllowAllSecurityContextFactory.INSTANCE;
+    }
+
+    @Override
     public int getSendBufferSize() {
         return 1024 * 1024;
     }
@@ -101,10 +106,5 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     @Override
     public boolean readOnlySecurityContext() {
         return false;
-    }
-
-    @Override
-    public SecurityContextFactory getSecurityContextFactory() {
-        return AllowAllSecurityContextFactory.INSTANCE;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -203,6 +203,11 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     @Override
+    public boolean isPessimisticHealthCheckEnabled() {
+        return false;
+    }
+
+    @Override
     public boolean isQueryCacheEnabled() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
@@ -52,11 +52,11 @@ public interface HttpContextConfiguration {
 
     int getRequestHeaderBufferSize();
 
+    SecurityContextFactory getSecurityContextFactory();
+
     int getSendBufferSize();
 
     boolean getServerKeepAlive();
 
     boolean readOnlySecurityContext();
-
-    SecurityContextFactory getSecurityContextFactory();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfiguration.java
@@ -34,4 +34,6 @@ public interface HttpMinServerConfiguration extends WorkerPoolConfiguration {
     HttpContextConfiguration getHttpContextConfiguration();
 
     WaitProcessorConfiguration getWaitProcessorConfiguration();
+
+    boolean isPessimisticHealthCheckEnabled();
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/StrArrayFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/StrArrayFunction.java
@@ -145,26 +145,6 @@ public abstract class StrArrayFunction implements Function {
     }
 
     @Override
-    public CharSequence getStr(Record rec) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void getStr(Record rec, CharSink sink) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public CharSequence getStrB(Record rec) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int getStrLen(Record rec) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public final CharSequence getSymbol(Record rec) {
         return getStr(rec);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentSchemasFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentSchemasFunctionFactory.java
@@ -55,6 +55,16 @@ public class CurrentSchemasFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public CharSequence getStr(Record rec) {
+            return "{public}";
+        }
+
+        @Override
+        public void getStr(Record rec, CharSink sink) {
+            sink.put(getStr(rec));
+        }
+
+        @Override
         public CharSequence getStr(Record rec, int arrayIndex) {
             return "public";
         }
@@ -65,8 +75,18 @@ public class CurrentSchemasFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public CharSequence getStrB(Record rec) {
+            return getStr(rec);
+        }
+
+        @Override
         public CharSequence getStrB(Record rec, int arrayIndex) {
             return getStr(rec, arrayIndex);
+        }
+
+        @Override
+        public int getStrLen(Record rec) {
+            return getStr(rec).length();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/StringToStringArrayFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/StringToStringArrayFunction.java
@@ -43,6 +43,7 @@ public class StringToStringArrayFunction extends StrArrayFunction {
     private static final int BRANCH_DOUBLE_QUOTE = 4;
     private static final int BRANCH_ITEM = 1;
     private final ObjList<CharSequence> items = new ObjList<>();
+    private final StringSink sink = new StringSink();
 
     public StringToStringArrayFunction(int position, CharSequence type) throws SqlException {
         if (type == null) {
@@ -151,8 +152,18 @@ public class StringToStringArrayFunction extends StrArrayFunction {
     }
 
     @Override
+    public CharSequence getStr(Record rec) {
+        return initSink();
+    }
+
+    @Override
     public CharSequence getStr(Record rec, int arrayIndex) {
         return items.getQuick(arrayIndex);
+    }
+
+    @Override
+    public void getStr(Record rec, CharSink sink) {
+        sink.put(initSink());
     }
 
     @Override
@@ -161,8 +172,18 @@ public class StringToStringArrayFunction extends StrArrayFunction {
     }
 
     @Override
+    public CharSequence getStrB(Record rec) {
+        return initSink();
+    }
+
+    @Override
     public CharSequence getStrB(Record rec, int arrayIndex) {
         return getStr(rec, arrayIndex);
+    }
+
+    @Override
+    public int getStrLen(Record rec) {
+        return initSink().length();
     }
 
     @Override
@@ -203,5 +224,20 @@ public class StringToStringArrayFunction extends StrArrayFunction {
             }
         }
         throw SqlException.$(position, "array must start with '{'");
+    }
+
+    private StringSink initSink() {
+        if (sink.length() > 0) {
+            return sink;
+        }
+        sink.put('{');
+        for (int i = 0, n = items.size(); i < n; i++) {
+            sink.put(items.getQuick(i));
+            if (i != n - 1) {
+                sink.put(',');
+            }
+        }
+        sink.put('}');
+        return sink;
     }
 }

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -142,6 +142,9 @@ query.timeout.sec=60
 #http.min.enabled=true
 #http.min.net.bind.to=0.0.0.0:9003
 
+# When enabled, health check will return HTTP 500 if there were any unhandled errors since QuestDB instance start.
+#http.pessimistic.health.check.enabled=false
+
 ################ Cairo settings ##################
 
 # directory for storing db tables and metadata. this directory is inside the server root directory provided at startup

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -141,6 +141,9 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(12, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getDoubleScale());
         Assert.assertEquals("Keep-Alive: timeout=5, max=10000" + Misc.EOL, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getKeepAliveHeader());
 
+        Assert.assertFalse(configuration.getHttpMinServerConfiguration().isPessimisticHealthCheckEnabled());
+        Assert.assertFalse(configuration.getHttpServerConfiguration().isPessimisticHealthCheckEnabled());
+
         Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
         Assert.assertEquals(Long.MAX_VALUE, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());
         Assert.assertTrue(configuration.getCairoConfiguration().getCircuitBreakerConfiguration().isEnabled());
@@ -878,6 +881,9 @@ public class PropServerConfigurationTest {
             Assert.assertFalse(configuration.getHttpServerConfiguration().isQueryCacheEnabled());
             Assert.assertEquals(32, configuration.getHttpServerConfiguration().getQueryCacheBlockCount());
             Assert.assertEquals(16, configuration.getHttpServerConfiguration().getQueryCacheRowCount());
+
+            Assert.assertTrue(configuration.getHttpMinServerConfiguration().isPessimisticHealthCheckEnabled());
+            Assert.assertTrue(configuration.getHttpServerConfiguration().isPessimisticHealthCheckEnabled());
 
             Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().readOnlySecurityContext());
             Assert.assertEquals(50000, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getMaxQueryResponseRowLimit());

--- a/core/src/test/java/io/questdb/test/cutlass/http/HealthCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HealthCheckTest.java
@@ -75,10 +75,11 @@ public class HealthCheckTest {
         testHealthy(Metrics.enabled(), healthCheckRequest);
     }
 
-    public void testUnhealthy(Metrics metrics, String expectedResponse) throws Exception {
+    public void testUnhealthy(Metrics metrics, boolean pessimisticHealthCheck, String expectedResponse) throws Exception {
         new HttpHealthCheckTestBuilder()
                 .withTempFolder(temp)
                 .withMetrics(metrics)
+                .withPessimisticHealthCheck(pessimisticHealthCheck)
                 .withInjectedUnhandledError()
                 .run(engine -> new SendAndReceiveRequestBuilder()
                         .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
@@ -86,24 +87,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void testUnhealthyWhenMetricsDisabled() throws Exception {
-        // Unhandled error detection is based on metrics,
-        // so we expect the health check to return HTTP 200.
-        final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
-                "Server: questDB/1.0\r\n" +
-                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
-                "Transfer-Encoding: chunked\r\n" +
-                "Content-Type: text/plain\r\n" +
-                "\r\n" +
-                "0f\r\n" +
-                "Status: Healthy\r\n" +
-                "00\r\n" +
-                "\r\n";
-        testUnhealthy(Metrics.disabled(), expectedResponse);
-    }
-
-    @Test
-    public void testUnhealthyWhenMetricsEnabled() throws Exception {
+    public void testUnhealthyWhenMetricsAndPessimisticHealthCheckEnabled() throws Exception {
         final String expectedResponse = "HTTP/1.1 500 Internal server error\r\n" +
                 "Server: questDB/1.0\r\n" +
                 "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
@@ -115,7 +99,39 @@ public class HealthCheckTest {
                 "Unhandled errors: 1\r\n" +
                 "00\r\n" +
                 "\r\n";
-        testUnhealthy(Metrics.enabled(), expectedResponse);
+        testUnhealthy(Metrics.enabled(), true, expectedResponse);
+    }
+
+    @Test
+    public void testUnhealthyWhenMetricsDisabled() throws Exception {
+        // Unhandled error detection is based on metrics, so we expect the health check to return HTTP 200.
+        final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                "Server: questDB/1.0\r\n" +
+                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "0f\r\n" +
+                "Status: Healthy\r\n" +
+                "00\r\n" +
+                "\r\n";
+        testUnhealthy(Metrics.disabled(), true, expectedResponse);
+    }
+
+    @Test
+    public void testUnhealthyWhenMetricsEnabledAndPessimisticHealthCheckDisabled() throws Exception {
+        // We expect the health check to ignore unhandled errors counter and return HTTP 200.
+        final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                "Server: questDB/1.0\r\n" +
+                "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "0f\r\n" +
+                "Status: Healthy\r\n" +
+                "00\r\n" +
+                "\r\n";
+        testUnhealthy(Metrics.enabled(), false, expectedResponse);
     }
 
     private void testHealthy(Metrics metrics, String request) throws Exception {
@@ -123,7 +139,7 @@ public class HealthCheckTest {
                 .withTempFolder(temp)
                 .withMetrics(metrics)
                 .run(engine -> {
-                    String expectedResponse = "HTTP/1.1 200 OK\r\n" +
+                    final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
                             "Server: questDB/1.0\r\n" +
                             "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
                             "Transfer-Encoding: chunked\r\n" +
@@ -133,7 +149,6 @@ public class HealthCheckTest {
                             "Status: Healthy\r\n" +
                             "00\r\n" +
                             "\r\n";
-
                     new SendAndReceiveRequestBuilder()
                             .withNetworkFacade(NetworkFacadeImpl.INSTANCE)
                             .execute(request, expectedResponse);

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -26,17 +26,17 @@ package io.questdb.test.cutlass.http;
 
 import io.questdb.Metrics;
 import io.questdb.cairo.CairoEngine;
+import io.questdb.cutlass.Services;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
 import io.questdb.cutlass.http.HttpServer;
-import io.questdb.test.cairo.DefaultTestCairoConfiguration;
-import io.questdb.cutlass.Services;
 import io.questdb.cutlass.http.processors.QueryCache;
 import io.questdb.griffin.SqlException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.mp.WorkerPool;
 import io.questdb.std.Os;
+import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import io.questdb.test.mp.TestWorkerPool;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -49,6 +49,7 @@ public class HttpHealthCheckTestBuilder {
     private static final Log LOG = LogFactory.getLog(HttpHealthCheckTestBuilder.class);
     private boolean injectUnhandledError;
     private Metrics metrics;
+    private boolean pessimisticHealthCheck = false;
     private TemporaryFolder temp;
 
     public void run(HttpClientCode code) throws Exception {
@@ -56,6 +57,7 @@ public class HttpHealthCheckTestBuilder {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
                     .withBaseDir(baseDir)
+                    .withPessimisticHealthCheck(pessimisticHealthCheck)
                     .build();
             if (metrics == null) {
                 metrics = Metrics.enabled();
@@ -107,6 +109,11 @@ public class HttpHealthCheckTestBuilder {
 
     public HttpHealthCheckTestBuilder withMetrics(Metrics metrics) {
         this.metrics = metrics;
+        return this;
+    }
+
+    public HttpHealthCheckTestBuilder withPessimisticHealthCheck(boolean pessimisticHealthCheck) {
+        this.pessimisticHealthCheck = pessimisticHealthCheck;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
@@ -47,6 +47,7 @@ public class HttpServerConfigurationBuilder {
     private String httpProtocolVersion = "HTTP/1.1 ";
     private long multipartIdleSpinCount = -1;
     private NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
+    private boolean pessimisticHealthCheck = false;
     private int receiveBufferSize = 1024 * 1024;
     private int rerunProcessingQueueSize = 4096;
     private int sendBufferSize = 1024 * 1024;
@@ -225,6 +226,11 @@ public class HttpServerConfigurationBuilder {
                     }
                 };
             }
+
+            @Override
+            public boolean isPessimisticHealthCheckEnabled() {
+                return pessimisticHealthCheck;
+            }
         };
     }
 
@@ -260,6 +266,11 @@ public class HttpServerConfigurationBuilder {
 
     public HttpServerConfigurationBuilder withNetwork(NetworkFacade nf) {
         this.nf = nf;
+        return this;
+    }
+
+    public HttpServerConfigurationBuilder withPessimisticHealthCheck(boolean pessimisticHealthCheck) {
+        this.pessimisticHealthCheck = pessimisticHealthCheck;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -5378,7 +5378,7 @@ public class IODispatcherTest extends AbstractTest {
 
                             @Override
                             public HttpRequestProcessor getDefaultProcessor() {
-                                return new HealthCheckProcessor();
+                                return new HealthCheckProcessor(false);
                             }
 
                             @Override

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/StrArrayFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/StrArrayFunctionTest.java
@@ -140,36 +140,6 @@ public class StrArrayFunctionTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testGetStr() {
-        function.getStr(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetStr2() {
-        function.getStr(null, null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetStrB() {
-        function.getStrB(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetStrLen() {
-        function.getStrLen(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetSym() {
-        function.getSymbol(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetSymbolB() {
-        function.getSymbolB(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
     public void testGetTimestamp() {
         function.getTimestamp(null);
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/StrArrayFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/StrArrayFunctionTest.java
@@ -39,8 +39,18 @@ public class StrArrayFunctionTest {
         }
 
         @Override
+        public CharSequence getStr(Record rec) {
+            return "{hello}";
+        }
+
+        @Override
         public CharSequence getStr(Record rec, int arrayIndex) {
             return "hello";
+        }
+
+        @Override
+        public void getStr(Record rec, CharSink sink) {
+            sink.put(getStr(rec));
         }
 
         @Override
@@ -49,8 +59,18 @@ public class StrArrayFunctionTest {
         }
 
         @Override
+        public CharSequence getStrB(Record rec) {
+            return getStr(rec);
+        }
+
+        @Override
         public CharSequence getStrB(Record rec, int arrayIndex) {
             return getStr(rec, arrayIndex);
+        }
+
+        @Override
+        public int getStrLen(Record rec) {
+            return getStr(rec).length();
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/CurrentSchemasFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/CurrentSchemasFunctionFactoryTest.java
@@ -43,6 +43,19 @@ public class CurrentSchemasFunctionFactoryTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testCurrentSchemasFuncInSelect() throws Exception {
+        assertQuery(
+                "s\n" +
+                        "{public}\n",
+                "select current_schemas(true) s from long_sequence(1)",
+                "create table x as (select x from long_sequence(1))",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testPrefixedCurrentSchemasFunc() throws Exception {
         assertQuery(
                 "x\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/StringToStringArrayFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/StringToStringArrayFunctionTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin.engine.functions.catalogue;
 
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.engine.functions.catalogue.StringToStringArrayFunction;
+import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -76,6 +77,30 @@ public class StringToStringArrayFunctionTest {
         Assert.assertThrows(UnsupportedOperationException.class, () -> f.getGeoLong(null));
         Assert.assertThrows(UnsupportedOperationException.class, () -> f.getGeoShort(null));
         Assert.assertThrows(UnsupportedOperationException.class, () -> f.getGeoByte(null));
+    }
+
+    @Test
+    public void testGetStrEmpty() throws SqlException {
+        StringToStringArrayFunction function = new StringToStringArrayFunction(42, "{}");
+        TestUtils.assertEquals("{}", function.getStr(null));
+        TestUtils.assertEquals("{}", function.getStrB(null));
+        Assert.assertEquals(2, function.getStrLen(null));
+
+        StringSink sink = new StringSink();
+        function.getStr(null, sink);
+        TestUtils.assertEquals("{}", sink);
+    }
+
+    @Test
+    public void testGetStrSimple() throws SqlException {
+        StringToStringArrayFunction function = new StringToStringArrayFunction(42, "{ab, 3,true,1.26,test 1}");
+        TestUtils.assertEquals("{ab,3,true,1.26,test 1}", function.getStr(null));
+        TestUtils.assertEquals("{ab,3,true,1.26,test 1}", function.getStrB(null));
+        Assert.assertEquals(23, function.getStrLen(null));
+
+        StringSink sink = new StringSink();
+        function.getStr(null, sink);
+        TestUtils.assertEquals("{ab,3,true,1.26,test 1}", sink);
     }
 
     @Test

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -47,6 +47,8 @@ http.query.cache.enabled=false
 http.query.cache.block.count=32
 http.query.cache.row.count=16
 
+http.pessimistic.health.check.enabled=true
+
 http.security.readonly=true
 http.security.max.response.rows=50000
 

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -138,6 +138,9 @@ query.timeout.sec=60
 #http.min.enabled=true
 #http.min.net.bind.to=0.0.0.0:9003
 
+# When enabled, health check will return HTTP 500 if there were any unhandled errors since QuestDB instance start.
+#http.pessimistic.health.check.enabled=false
+
 ################ Cairo settings ##################
 
 # directory for storing db tables and metadata. this directory is inside the server root directory provided at startup


### PR DESCRIPTION
Fixes #3288

Introduces `http.pessimistic.health.check.enabled` property (`false` by default) to configure health check endpoint pessimism. When enabled, the health check will return HTTP 500 if there were any unhandled errors since server start. This is a potentially breaking change as previously the behavior was always the same as with `http.pessimistic.health.check.enabled=true`.

Also, fixes `select current_schemas(true) from long_sequence(1)` query handling, so that it no longer leads to `UnsupportedOperationException`.