### PR TITLE
fix(sql): fix crash in hash outer join with filter factory

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinFilteredLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/HashOuterJoinFilteredLightRecordCursorFactory.java
@@ -181,8 +181,6 @@ public class HashOuterJoinFilteredLightRecordCursorFactory extends AbstractRecor
                     slaveCursor.recordAt(slaveRecord, slaveChainCursor.next());
                     if (filter.getBool(record)) {
                         return true;
-                    } else {
-                        slaveChainCursor.next();
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3289 

Fix unsafe TreeCursor.next() call without a prior TreeCursor.hasNext() that can lead to EXCEPTION_ACCESS_VIOLATION . 