### PR TITLE
fix(sql): fix COPY performance for pre-created tables with non-default symbol capacity

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/MapWriter.java
@@ -66,6 +66,8 @@ public interface MapWriter extends SymbolCountProvider {
 
     boolean getNullFlag();
 
+    int getSymbolCapacity();
+
     boolean isCached();
 
     int put(char c);
@@ -83,5 +85,4 @@ public interface MapWriter extends SymbolCountProvider {
     void updateCacheFlag(boolean flag);
 
     void updateNullFlag(boolean flag);
-
 }

--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -51,6 +51,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     private final BitmapIndexWriter indexWriter;
     private final int maxHash;
     private final MemoryMARW offsetMem;
+    private final int symbolCapacity;
     private final SymbolValueCountCollector valueCountCollector;
     private boolean nullValue = false;
     private int symbolIndexInTxWriter;
@@ -94,7 +95,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
                     configuration.getWriterFileOpenOpts()
             );
             // formula for calculating symbol capacity needs to be in agreement with symbol reader
-            final int symbolCapacity = offsetMem.getInt(HEADER_CAPACITY);
+            this.symbolCapacity = offsetMem.getInt(HEADER_CAPACITY);
             assert symbolCapacity > 0;
             final boolean useCache = offsetMem.getBool(HEADER_CACHE_ENABLED);
             this.offsetMem.jumpTo(keyToOffset(symbolCount) + Long.BYTES);
@@ -183,6 +184,11 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     @Override
     public boolean getNullFlag() {
         return offsetMem.getBool(HEADER_NULL_FLAG);
+    }
+
+    @Override
+    public int getSymbolCapacity() {
+        return symbolCapacity;
     }
 
     public int getSymbolCount() {

--- a/core/src/main/java/io/questdb/cairo/vm/NullMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/vm/NullMapWriter.java
@@ -36,6 +36,11 @@ public class NullMapWriter implements MapWriter {
     }
 
     @Override
+    public int getSymbolCapacity() {
+        return -1;
+    }
+
+    @Override
     public int getSymbolCount() {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -862,16 +862,18 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 if (unused) {
                     names.add(metadata.getColumnName(i));
                     types.add(typeManager.getTypeAdapter(metadata.getColumnType(i)));
+                    remapIndex.extendAndSet(types.size() - 1, i);
                 }
             }
         }
 
         // copy symbol capacities from the destination table to avoid
         // having default, undersized capacities in temporary tables
-        symbolCapacities.setAll(types.size(), -1);
-        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
-            if (ColumnType.isSymbol(metadata.getColumnType(i))) {
-                final int columnWriterIndex = metadata.getWriterIndex(i);
+        symbolCapacities.setAll(remapIndex.size(), -1);
+        for (int i = 0, n = remapIndex.size(); i < n; i++) {
+            final int columnIndex = remapIndex.getQuick(i);
+            if (ColumnType.isSymbol(metadata.getColumnType(columnIndex))) {
+                final int columnWriterIndex = metadata.getWriterIndex(columnIndex);
                 final MapWriter symbolWriter = writer.getSymbolMapWriter(columnWriterIndex);
                 symbolCapacities.set(i, symbolWriter.getSymbolCapacity());
             }

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -90,6 +90,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
     private final ObjList<PartitionInfo> partitions;
     private final Sequence pubSeq;
     private final RingQueue<TextImportTask> queue;
+    private final IntList symbolCapacities;
     private final TableStructureAdapter targetTableStructure;
     //stores 3 values per task : index, lo, hi (lo, hi are indexes in partitionNames)
     private final IntList taskDistribution;
@@ -190,6 +191,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         this.partitionNameSink = new StringSink();
         this.partitions = new ObjList<>();
         this.taskDistribution = new IntList();
+        this.symbolCapacities = new IntList();
     }
 
     // Load balances existing partitions between given number of workers using partition sizes.
@@ -285,6 +287,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         taskDistribution.clear();
         utf8Sink.clear();
         typeManager.clear();
+        symbolCapacities.clear();
         textMetadataDetector.clear();
         otherToTimestampAdapterPool.clear();
         partitions.clear();
@@ -838,7 +841,8 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
             }
         }
 
-        // at this point we've to use target table columns names otherwise partition attach could fail on metadata differences
+        // at this point we've to use target table columns names otherwise
+        // partition attach could fail on metadata differences
         // (if header names or synthetic names are different from table's)
         for (int i = 0, n = remapIndex.size(); i < n; i++) {
             names.set(i, metadata.getColumnName(remapIndex.get(i)));
@@ -848,7 +852,6 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         if (names.size() < metadata.getColumnCount()) {
             for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
                 boolean unused = true;
-
                 for (int r = 0, rn = remapIndex.size(); r < rn; r++) {
                     if (remapIndex.get(r) == i) {
                         unused = false;
@@ -860,6 +863,17 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                     names.add(metadata.getColumnName(i));
                     types.add(typeManager.getTypeAdapter(metadata.getColumnType(i)));
                 }
+            }
+        }
+
+        // copy symbol capacities from the destination table to avoid
+        // having default, undersized capacities in temporary tables
+        symbolCapacities.setAll(types.size(), -1);
+        for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
+            if (ColumnType.isSymbol(metadata.getColumnType(i))) {
+                final int columnWriterIndex = metadata.getWriterIndex(i);
+                final MapWriter symbolWriter = writer.getSymbolMapWriter(columnWriterIndex);
+                symbolCapacities.set(i, symbolWriter.getSymbolCapacity());
             }
         }
 
@@ -1361,7 +1375,8 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                     }
 
                     validate(names, types, null, NO_INDEX);
-                    targetTableStructure.of(tableName, names, types, timestampIndex, partitionBy);
+                    symbolCapacities.setAll(types.size(), -1);
+                    targetTableStructure.of(tableName, names, types, symbolCapacities, timestampIndex, partitionBy);
 
                     createTable(
                             ff,
@@ -1395,13 +1410,13 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                         throw TextException.$("target table is not partitioned");
                     }
                     validate(names, types, designatedTimestampColumnName, designatedTimestampIndex);
-                    targetTableStructure.of(tableName, names, types, timestampIndex, partitionBy);
+                    targetTableStructure.of(tableName, names, types, symbolCapacities, timestampIndex, partitionBy);
                     break;
                 default:
                     throw TextException.$("name is reserved [table=").put(tableName).put(']');
             }
 
-            inputFilePath.of(inputRoot).concat(inputFileName).$();//getStatus might override it
+            inputFilePath.of(inputRoot).concat(inputFileName).$(); // getStatus might override it
             targetTableStructure.setIgnoreColumnIndexedFlag(true);
 
             if (timestampAdapter == null && ColumnType.isTimestamp(types.getQuick(timestampIndex).getType())) {
@@ -1453,8 +1468,8 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         final long bytes;
         final long key;
         final CharSequence name;
-        long importedRows;//used to detect partitions that need skipping (because e.g. no data was imported for them)
-        int taskId;//assigned worker/task id
+        long importedRows; // used to detect partitions that need skipping (because e.g. no data was imported for them)
+        int taskId; // assigned worker/task id
 
         public PartitionInfo(long key, CharSequence name, long bytes) {
             this.key = key;
@@ -1495,6 +1510,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         private ObjList<CharSequence> columnNames;
         private boolean ignoreColumnIndexedFlag;
         private int partitionBy;
+        private IntList symbolCapacities;
         private CharSequence tableName;
         private int timestampColumnIndex;
 
@@ -1544,7 +1560,8 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
 
         @Override
         public int getSymbolCapacity(int columnIndex) {
-            return configuration.getDefaultSymbolCapacity();
+            final int capacity = symbolCapacities.getQuick(columnIndex);
+            return capacity != -1 ? capacity : configuration.getDefaultSymbolCapacity();
         }
 
         public int getSymbolColumnIndex(CharSequence symbolColumnName) {
@@ -1553,12 +1570,10 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 if (getColumnType(i) == ColumnType.SYMBOL) {
                     index++;
                 }
-
                 if (symbolColumnName.equals(columnNames.get(i))) {
                     return index;
                 }
             }
-
             return -1;
         }
 
@@ -1591,11 +1606,13 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 final CharSequence tableName,
                 final ObjList<CharSequence> names,
                 final ObjList<TypeAdapter> types,
+                final IntList symbolCapacities,
                 final int timestampColumnIndex,
                 final int partitionBy
         ) {
             this.tableName = tableName;
             this.columnNames = names;
+            this.symbolCapacities = symbolCapacities;
             this.ignoreColumnIndexedFlag = false;
 
             this.columnBits.clear();

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -862,7 +862,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                 if (unused) {
                     names.add(metadata.getColumnName(i));
                     types.add(typeManager.getTypeAdapter(metadata.getColumnType(i)));
-                    remapIndex.extendAndSet(types.size() - 1, i);
+                    remapIndex.add(i);
                 }
             }
         }

--- a/core/src/main/java/io/questdb/cutlass/text/types/TypeAdapter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/TypeAdapter.java
@@ -29,6 +29,7 @@ import io.questdb.std.str.DirectByteCharSequence;
 import io.questdb.std.str.DirectCharSink;
 
 public interface TypeAdapter {
+
     int getType();
 
     default boolean isIndexed() {


### PR DESCRIPTION
Refs #3269

COPY was using default symbol table capacity for temporary tables. This led to sub-optimal ingestion performance due to slow symbol lookups. With this patch, temporary tables use the same symbol capacities as the end table.

## Benchmark

Create a 100M test CSV file with this Golang program:
```go
package main

import (
	"bufio"
	"os"
	"strconv"
	"time"
)

func main() {
	f, err := os.Create("/tmp/input.csv")
	if err != nil {
		panic(err)
	}

	defer f.Close()

	_, err = f.WriteString("sym,ts\n")
	if err != nil {
		panic(err)
	}
	f.Sync()

	w := bufio.NewWriter(f)
	for i := 1; i <= 100_000_000; i++ {
		t := time.UnixMicro(int64(i) * 1_000_000)
		_, err := w.WriteString(strconv.Itoa(i%234870) + "," + t.Format("2006-01-02T15:04:05.000000Z") + "\n")
		if err != nil {
			panic(err)
		}
	}

	w.Flush()
	f.Sync()
}
```

Pre-create the table and run COPY on it:
```sql
CREATE TABLE test (sym SYMBOL CAPACITY 300000, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY YEAR;
COPY test FROM 'input.csv' WITH HEADER true;
```

Before this patch:
```
2023-05-05T08:31:18.791182Z I i.q.c.t.ParallelCsvFileImporter import complete [importId=76f11f07197e248b, file=`/tmp/input.csv`', time=1180s]
```

With this patch:
```
2023-05-05T08:10:23.145525Z I i.q.c.t.ParallelCsvFileImporter import complete [importId=76ee51f64b9008b9, file=`/tmp/input.csv`', time=16s]
```