### PR TITLE
fix(core): consistent segment rollover in WalWriter

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1069,10 +1069,11 @@ public class WalWriter implements TableWriterAPI {
 
     private void openNewSegment() {
         try {
-            segmentId++;
+            final int newSegmentId = segmentId + 1;
             currentTxnStartRowNum = 0;
             rowValueIsNotNull.fill(0, columnCount, -1);
-            final int segmentPathLen = createSegmentDir(segmentId);
+            final int segmentPathLen = createSegmentDir(newSegmentId);
+            segmentId = newSegmentId;
 
             for (int i = 0; i < columnCount; i++) {
                 int type = metadata.getColumnType(i);


### PR DESCRIPTION
During a WAL segment roll-over we:
  1. Start writing to a new segment.
  2. Clean up the old segment.

In that order.

This PR is to ensure that we maintain the lock to the old segment until we're done cleaning it up.

This is necessary because cleaning up requires truncating files which makes modifications to the filesystem and thus still requires a lock.