### PR TITLE
feat(ui): bump web-console version to 0.2.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
         <javac.target>11</javac.target>
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
-        <web.console.version>0.1.2</web.console.version>
+        <web.console.version>0.2.0</web.console.version>
     </properties>
 
     <version>7.1.2-SNAPSHOT</version>


### PR DESCRIPTION
This PR sets version of `@questdb/web-console` dependency to 0.2.0

It includes:

* New CSV Import view by @insmac https://github.com/questdb/ui/pull/130
* Update autocomplete in editor with:
  * add keywords `snapshot`, `prepare`, `complete`, `squash`, `partitions`, `explain`
  * add function `rnd_uuid4`
  * add data type `uuid`
  * fix typo `tables_columns` -> `table_columns`
