### PR TITLE
chore(core): fix error in partition squashing on indexed columns

### DIFF
--- a/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
@@ -81,6 +81,19 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
         super.close();
     }
 
+    public void ofRW(
+            Path partitionPath,
+            CharSequence columnName,
+            long columnTxn,
+            int columnType,
+            int indexBlockCapacity,
+            long columnTop,
+            int columnIndex
+    ) {
+        super.ofRW(partitionPath, columnName, columnTxn, columnType, columnTop, columnIndex);
+        indexWriter.of(partitionPath, columnName, columnTxn, columnTop < 0 ? indexBlockCapacity : 0);
+    }
+
     @Override
     public void ofRW(
             Path partitionPath,
@@ -93,16 +106,15 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
         throw new UnsupportedOperationException();
     }
 
-    public void ofRW(
-            Path partitionPath,
-            CharSequence columnName,
-            long columnTxn,
-            int columnType,
-            int indexBlockCapacity,
-            long columnTop,
-            int columnIndex
-    ) {
-        super.ofRW(partitionPath, columnName, columnTxn, columnType, columnTop, columnIndex);
-        indexWriter.of(partitionPath, columnName, columnTxn, columnTop < 0 ? indexBlockCapacity : 0);
+    // Useful for debugging
+    @SuppressWarnings("unused")
+    private int keyCount(int key, long size, long mappedAddress) {
+        int count = 0;
+        for (long i = 0; i < size; i++) {
+            if (TableUtils.toIndexKey(Unsafe.getUnsafe().getInt(mappedAddress + (i << 2))) == key) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -338,10 +338,9 @@ public final class Files {
     }
 
     public static long mremap(int fd, long address, long previousSize, long newSize, long offset, int flags, int memoryTag) {
-        Unsafe.recordMemAlloc(-previousSize, memoryTag);
         address = mremap0(fd, address, previousSize, newSize, offset, flags);
         if (address != -1) {
-            Unsafe.recordMemAlloc(newSize, memoryTag);
+            Unsafe.recordMemAlloc(newSize - previousSize, memoryTag);
         }
         return address;
     }

--- a/core/src/main/java/io/questdb/std/LongList.java
+++ b/core/src/main/java/io/questdb/std/LongList.java
@@ -354,6 +354,15 @@ public class LongList implements Mutable, LongVec, Sinkable {
         Arrays.fill(data, pos, pos + slotSize, noEntryValue);
     }
 
+    public void reverse() {
+        int n = size();
+        for (int i = 0, m = n / 2; i < m; i++) {
+            long tmp = data[i];
+            data[i] = data[n - i - 1];
+            data[n - i - 1] = tmp;
+        }
+    }
+
     public void seed(int capacity, long value) {
         ensureCapacity(capacity);
         pos = capacity;

--- a/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
@@ -685,7 +685,7 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testFailOnResizingIndexContended() throws Exception {
         // this places break point on resize of key file
-        counter.set(152 + 12 + 20 + 19);
+        counter.set(152 + 12 + 20 + 19 + 8);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -1011,13 +1011,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTail() throws Exception {
-        counter.set(174 + 12 + 19);
+        counter.set(174 + 12 + 19 + 8);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailContended() throws Exception {
-        counter.set(174 + 12 + 19);
+        counter.set(174 + 12 + 19 + 8);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -1035,25 +1035,25 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailParallel() throws Exception {
-        counter.set(174 + 45 + 12 + 27);
+        counter.set(174 + 45 + 12 + 27 + 12);
         executeWithPool(2, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODatThenRegularAppend() throws Exception {
-        counter.set(165 + 45 + 12 + 21);
+        counter.set(165 + 45 + 12 + 21 + 9);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODatThenRegularAppend0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOOData() throws Exception {
-        counter.set(165 + 45 + 12 + 18);
+        counter.set(165 + 45 + 12 + 18 + 8);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataContended() throws Exception {
-        counter.set(165 + 45 + 12 + 21);
+        counter.set(165 + 45 + 12 + 21 + 9);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
@@ -1129,13 +1129,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallel() throws Exception {
-        counter.set(193 + 45 + 18 + 27);
+        counter.set(193 + 45 + 18 + 27 + 12);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallelNoReopen() throws Exception {
-        counter.set(176 + 45 + 18 + 26);
+        counter.set(176 + 45 + 18 + 26 + 12);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetryNoReopen, ffAllocateFailure);
     }
 
@@ -1210,7 +1210,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testSetAppendPositionFails() throws Exception {
-        counter.set(169 + 12 + 20 + 19);
+        counter.set(169 + 12 + 20 + 19 + 8);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 


### PR DESCRIPTION
Fixes error found in fuzz test. The problem occurs when an indexed column could have garbage left in the key file after the key file is re-created (truncated).

```
2023-05-15T13:02:07.9451609Z java.lang.AssertionError
2023-05-15T13:02:07.9451965Z 	at io.questdb.cairo.BitmapIndexWriter.add(BitmapIndexWriter.java:126)
2023-05-15T13:02:07.9452411Z 	at io.questdb.cairo.frm.file.ContiguousFileIndexedFrameColumn.append(ContiguousFileIndexedFrameColumn.java:59)
2023-05-15T13:02:07.9452854Z 	at io.questdb.cairo.frm.FrameAlgebra.append(FrameAlgebra.java:63)
2023-05-15T13:02:07.9453229Z 	at io.questdb.cairo.frm.FrameAlgebra.append(FrameAlgebra.java:37)
2023-05-15T13:02:07.9453628Z 	at io.questdb.cairo.TableWriter.squashSplitPartitions(TableWriter.java:6851)
2023-05-15T13:02:07.9454053Z 	at io.questdb.cairo.TableWriter.squashPartitionRange(TableWriter.java:6743)
2023-05-15T13:02:07.9454466Z 	at io.questdb.cairo.TableWriter.squashSplitPartitions(TableWriter.java:6784)
2023-05-15T13:02:07.9454851Z 	at io.questdb.cairo.TableWriter.processWalData(TableWriter.java:1698)
2023-05-15T13:02:07.9455276Z 	at io.questdb.cairo.wal.ApplyWal2TableJob.processWalCommit(ApplyWal2TableJob.java:467)
2023-05-15T13:02:07.9455731Z 	at io.questdb.cairo.wal.ApplyWal2TableJob.applyOutstandingWalTransactions(ApplyWal2TableJob.java:392)
2023-05-15T13:02:07.9456178Z 	at io.questdb.cairo.wal.ApplyWal2TableJob.applyWAL(ApplyWal2TableJob.java:119)
2023-05-15T13:02:07.9456581Z 	at io.questdb.cairo.wal.ApplyWal2TableJob.doRun(ApplyWal2TableJob.java:573)
2023-05-15T13:02:07.9456998Z 	at io.questdb.mp.AbstractQueueConsumerJob.run(AbstractQueueConsumerJob.java:41)
2023-05-15T13:02:07.9457375Z 	at io.questdb.mp.Job.run(Job.java:57)
2023-05-15T13:02:07.9457963Z 	at io.questdb.test.griffin.wal.WalWriterFuzzTest.runApplyThread(WalWriterFuzzTest.java:566)
2023-05-15T13:02:07.9458424Z 	at io.questdb.test.griffin.wal.WalWriterFuzzTest.lambda$applyManyWalParallel$1(WalWriterFuzzTest.java:360)
2023-05-15T13:02:07.9458838Z 	at java.lang.Thread.run(Thread.java:829)
2023-05-15T13:02:07.9459140Z ]
```