### PR TITLE
fix(core): fix stuck ingestion

### DIFF
--- a/core/src/main/java/io/questdb/mp/SOCountDownLatch.java
+++ b/core/src/main/java/io/questdb/mp/SOCountDownLatch.java
@@ -24,6 +24,7 @@
 
 package io.questdb.mp;
 
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 import java.util.concurrent.locks.LockSupport;
@@ -47,7 +48,11 @@ public class SOCountDownLatch implements CountDownLatchSPI {
     public void await() {
         this.waiter = Thread.currentThread();
         while (getCount() > 0) {
-            LockSupport.park();
+            // Don't use LockSupport.park() here.
+            // Once in a while there can be a delay between check of this.count > -count
+            // and parking and unparkWaiter() will be called before park().
+            // Limit the parking time by using Os.park() instead of LockSupport.park()
+            Os.park();
         }
     }
 

--- a/core/src/main/java/io/questdb/mp/SOUnboundedCountDownLatch.java
+++ b/core/src/main/java/io/questdb/mp/SOUnboundedCountDownLatch.java
@@ -24,6 +24,7 @@
 
 package io.questdb.mp;
 
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 
 import java.util.concurrent.locks.LockSupport;
@@ -44,7 +45,11 @@ public class SOUnboundedCountDownLatch implements CountDownLatchSPI {
         this.awaitedCount = count;
         this.waiter = Thread.currentThread();
         while (this.count > -count) {
-            LockSupport.park();
+            // Don't use LockSupport.park() here.
+            // Once in a while there can be a delay between check of this.count > -count
+            // and parking and unparkWaiter() will be called before park().
+            // Limit the parking time by using Os.park() instead of LockSupport.park()
+            Os.park();
         }
     }
 

--- a/core/src/main/java/io/questdb/std/Os.java
+++ b/core/src/main/java/io/questdb/std/Os.java
@@ -41,7 +41,7 @@ public final class Os {
     public static final int LINUX_ARM64 = 4;
     public static final int OSX_AMD64 = 1;
     public static final int OSX_ARM64 = 6;
-    public static final long PARK_NANOS_MAX = 100_000;
+    public static final long PARK_NANOS_MAX = 5 * 1_000_000_000L;
     public static final int WINDOWS = 3;
     public static final int _32Bit = -2;
     public static final int type;

--- a/core/src/main/java/io/questdb/std/Os.java
+++ b/core/src/main/java/io/questdb/std/Os.java
@@ -41,6 +41,7 @@ public final class Os {
     public static final int LINUX_ARM64 = 4;
     public static final int OSX_AMD64 = 1;
     public static final int OSX_ARM64 = 6;
+    public static final long PARK_NANOS_MAX = 100_000;
     public static final int WINDOWS = 3;
     public static final int _32Bit = -2;
     public static final int type;
@@ -141,6 +142,10 @@ public final class Os {
 
     public static boolean isWindows() {
         return type == Os.WINDOWS;
+    }
+
+    public static void park() {
+        LockSupport.parkNanos(Os.PARK_NANOS_MAX);
     }
 
     public static void pause() {

--- a/core/src/test/java/io/questdb/test/mp/SOLatchTest.java
+++ b/core/src/test/java/io/questdb/test/mp/SOLatchTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.mp;
+
+import io.questdb.mp.CountDownLatchSPI;
+import io.questdb.mp.SOCountDownLatch;
+import io.questdb.mp.SOUnboundedCountDownLatch;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class SOLatchTest {
+
+    @Test
+    public void testUnparkLatch() throws BrokenBarrierException, InterruptedException {
+        int threads = TestUtils.generateRandom(null).nextInt(30) + 1;
+        SOCountDownLatch latch = new SOCountDownLatch(threads);
+        triggerLatchAsync(threads, latch);
+        latch.await();
+    }
+
+    @Test
+    public void testUnparkUnboundedLatch() throws BrokenBarrierException, InterruptedException {
+        int threads = TestUtils.generateRandom(null).nextInt(30) + 1;
+        final SOUnboundedCountDownLatch latch = new SOUnboundedCountDownLatch();
+        triggerLatchAsync(threads, latch);
+        latch.await(threads);
+    }
+
+    private static void triggerLatchAsync(int threads, CountDownLatchSPI latch) throws InterruptedException, BrokenBarrierException {
+        CyclicBarrier startLatch = new CyclicBarrier(threads + 1);
+
+        for (int t = 0; t < threads; t++) {
+            Thread th = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    latch.countDown();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            th.start();
+        }
+        startLatch.await();
+    }
+}

--- a/core/src/test/java/io/questdb/test/mp/SOUnboundedCountDownLatchTest.java
+++ b/core/src/test/java/io/questdb/test/mp/SOUnboundedCountDownLatchTest.java
@@ -31,7 +31,6 @@ import io.questdb.mp.SOUnboundedCountDownLatch;
 import io.questdb.mp.SPSequence;
 import io.questdb.std.Os;
 import io.questdb.std.datetime.millitime.Dates;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,27 +78,6 @@ public class SOUnboundedCountDownLatchTest {
         LOG.info().$("section 2 done").$();
 
         Assert.assertEquals(count, dc.get());
-    }
-
-    @Test
-    public void testUnparked() throws BrokenBarrierException, InterruptedException {
-        final SOUnboundedCountDownLatch latch = new SOUnboundedCountDownLatch();
-        int threads = TestUtils.generateRandom(null).nextInt(30) + 1;
-        CyclicBarrier startLatch = new CyclicBarrier(threads + 1);
-
-        for (int t = 0; t < threads; t++) {
-            Thread th = new Thread(() -> {
-                try {
-                    startLatch.await();
-                    latch.countDown();
-                } catch (InterruptedException | BrokenBarrierException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            th.start();
-        }
-        startLatch.await();
-        latch.await(threads);
     }
 
     private void doTest(SPSequence pubSeq, SCSequence subSeq, SOUnboundedCountDownLatch latch, AtomicInteger dc, int count, int s) throws BrokenBarrierException, InterruptedException {

--- a/core/src/test/java/io/questdb/test/mp/SOUnboundedCountDownLatchTest.java
+++ b/core/src/test/java/io/questdb/test/mp/SOUnboundedCountDownLatchTest.java
@@ -31,6 +31,7 @@ import io.questdb.mp.SOUnboundedCountDownLatch;
 import io.questdb.mp.SPSequence;
 import io.questdb.std.Os;
 import io.questdb.std.datetime.millitime.Dates;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,6 +79,27 @@ public class SOUnboundedCountDownLatchTest {
         LOG.info().$("section 2 done").$();
 
         Assert.assertEquals(count, dc.get());
+    }
+
+    @Test
+    public void testUnparked() throws BrokenBarrierException, InterruptedException {
+        final SOUnboundedCountDownLatch latch = new SOUnboundedCountDownLatch();
+        int threads = TestUtils.generateRandom(null).nextInt(30) + 1;
+        CyclicBarrier startLatch = new CyclicBarrier(threads + 1);
+
+        for (int t = 0; t < threads; t++) {
+            Thread th = new Thread(() -> {
+                try {
+                    startLatch.await();
+                    latch.countDown();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            th.start();
+        }
+        startLatch.await();
+        latch.await(threads);
     }
 
     private void doTest(SPSequence pubSeq, SCSequence subSeq, SOUnboundedCountDownLatch latch, AtomicInteger dc, int count, int s) throws BrokenBarrierException, InterruptedException {


### PR DESCRIPTION
Fix the bug found in fuzz tests when threads suck in sorting data for many minutes and the test timeouts.

```
2023-05-13T00:32:01.6539765Z 'questdb-testing-154': WAITING
2023-05-13T00:32:01.6541095Z 		at java.base@11.0.19/jdk.internal.misc.Unsafe.park(Native Method)
2023-05-13T00:32:01.6542097Z 		at java.base@11.0.19/java.util.concurrent.locks.LockSupport.park(LockSupport.java:323)
2023-05-13T00:32:01.6545692Z 		at app//io.questdb.mp.SOUnboundedCountDownLatch.await(SOUnboundedCountDownLatch.java:47)
2023-05-13T00:32:01.6548125Z 		at app//io.questdb.cairo.TableWriter.dispatchO3CallbackQueue(TableWriter.java:3218)
2023-05-13T00:32:01.6549450Z 		at app//io.questdb.cairo.TableWriter.o3Sort(TableWriter.java:5047)
2023-05-13T00:32:01.6552080Z 		at app//io.questdb.cairo.TableWriter.o3Commit(TableWriter.java:3970)
2023-05-13T00:32:01.6554192Z 		at app//io.questdb.cairo.TableWriter.commit(TableWriter.java:2860)
2023-05-13T00:32:01.6557132Z 		at app//io.questdb.cairo.TableWriter.commit(TableWriter.java:854)
2023-05-13T00:32:01.6560112Z 		at app//io.questdb.cairo.TableWriter.commit(TableWriter.java:850)
2023-05-13T00:32:01.6562206Z 		at app//io.questdb.cutlass.line.tcp.TableUpdateDetails.releaseWriter(TableUpdateDetails.java:334)
2023-05-13T00:32:01.6564386Z 		at app//io.questdb.cutlass.line.tcp.LineTcpMeasurementEvent.releaseWriter(LineTcpMeasurementEvent.java:121)
2023-05-13T00:32:01.6567133Z 		at app//io.questdb.cutlass.line.tcp.LineTcpMeasurementScheduler.processWriterReleaseEvent(LineTcpMeasurementScheduler.java:243)
2023-05-13T00:32:01.6570549Z 		at app//io.questdb.cutlass.line.tcp.LineTcpWriterJob.drainQueue(LineTcpWriterJob.java:187)
2023-05-13T00:32:01.6572714Z 		at app//io.questdb.cutlass.line.tcp.LineTcpWriterJob.run(LineTcpWriterJob.java:92)
2023-05-13T00:32:01.6574414Z 		at app//io.questdb.mp.Worker.run(Worker.java:118)

```