### PR TITLE
fix(core): allow server to perform graceful shutdown under heavy ILP load

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3CopyJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3CopyJob.java
@@ -499,15 +499,15 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
             final int commitMode = tableWriter.getConfiguration().getCommitMode();
             if (commitMode != CommitMode.NOSYNC) {
                 boolean async = commitMode == CommitMode.ASYNC;
-                if (dstFixAddr != 0) {
-                    ff.msync(dstFixAddr, Math.abs(dstFixSize), async);
+                if (dstFixAddr != 0 && dstFixSize > 0) {
+                    ff.msync(dstFixAddr, dstFixSize, async);
                     // sync FD in case we wrote data not via mmap
                     if (dstFixFd != -1 && dstFixFd != 0) {
                         ff.fsync(Math.abs(dstFixFd));
                     }
                 }
-                if (dstVarAddr != 0) {
-                    ff.msync(dstVarAddr, Math.abs(dstVarSize), async);
+                if (dstVarAddr != 0 && dstVarSize > 0) {
+                    ff.msync(dstVarAddr, dstVarSize, async);
                     if (dstVarFd != -1 && dstVarFd != 0) {
                         ff.fsync(Math.abs(dstVarFd));
                     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -46,6 +46,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
     private static final Log LOG = LogFactory.getLog(LineTcpConnectionContext.class);
     private static final long QUEUE_FULL_LOG_HYSTERESIS_IN_MS = 10_000;
     protected final NetworkFacade nf;
+    private final Authenticator authenticator;
     private final DirectByteCharSequence byteCharSequence = new DirectByteCharSequence();
     private final long checkIdleInterval;
     private final long commitInterval;
@@ -67,7 +68,6 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
     private long lastQueueFullLogMillis = 0;
     private long nextCheckIdleTime;
     private long nextCommitTime;
-    private final Authenticator authenticator;
 
     public LineTcpConnectionContext(LineTcpReceiverConfiguration configuration, LineTcpMeasurementScheduler scheduler, Metrics metrics) {
         this.configuration = configuration;
@@ -333,13 +333,10 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
                             return IOContextResult.NEEDS_DISCONNECT;
                         }
 
-                        if (!read()) {
-                            if (peerDisconnected) {
-                                return IOContextResult.NEEDS_DISCONNECT;
-                            }
-                            return IOContextResult.NEEDS_READ;
+                        if (peerDisconnected) {
+                            return IOContextResult.NEEDS_DISCONNECT;
                         }
-                        break;
+                        return IOContextResult.NEEDS_READ;
                     }
                 }
             } catch (CairoException ex) {

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -233,7 +233,7 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
         };
     }
 
-    protected boolean handleContextIO() {
+    protected boolean handleContextIO0() {
         switch (context.handleIO(noNetworkIOJob)) {
             case NEEDS_READ:
                 context.getDispatcher().registerChannel(context, IOOperation.READ);
@@ -368,7 +368,7 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
         // Guard against slow writers on disconnect
         int maxIterations = 2000;
         while (maxIterations-- > 0) {
-            if (!handleContextIO()) {
+            if (!handleContextIO0()) {
                 break;
             }
             LockSupport.parkNanos(1_000_000);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpInsertGeoHashTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpInsertGeoHashTest.java
@@ -108,7 +108,7 @@ abstract class BaseLineTcpInsertGeoHashTest extends BaseLineTcpContextTest {
                 Assert.assertTrue(isWalTable(tableName));
             }
             recvBuffer = inboundLines;
-            handleContextIO();
+            handleContextIO0();
             waitForIOCompletion();
             closeContext();
             mayDrainWalQueue();

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/EllipticCurveAuthConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/EllipticCurveAuthConnectionContextTest.java
@@ -106,16 +106,16 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
         runInAuthContext(() -> {
             maxSendBytes = 0;
             recvBuffer = AUTH_KEY_ID1 + "\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             Assert.assertNull(sentBytes);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             Assert.assertNull(sentBytes);
             maxSendBytes = -1;
-            handleContextIO();
+            handleContextIO0();
             Assert.assertNull(sentBytes);
             Assert.assertTrue(disconnected);
         });
@@ -126,18 +126,18 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
         runInAuthContext(() -> {
             maxSendBytes = 5;
             recvBuffer = AUTH_KEY_ID1 + "\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertEquals(maxSendBytes, sentBytes.length);
             sentBytes = null;
             Assert.assertFalse(disconnected);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertEquals(maxSendBytes, sentBytes.length);
             sentBytes = null;
             Assert.assertFalse(disconnected);
             maxSendBytes = -1;
-            handleContextIO();
+            handleContextIO0();
             Assert.assertNull(sentBytes);
             Assert.assertTrue(disconnected);
         });
@@ -158,7 +158,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             }
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -175,7 +175,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -192,7 +192,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -209,7 +209,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -226,7 +226,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us\\ midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -243,7 +243,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us\\ midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -260,7 +260,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             Assert.assertTrue(authSequenceCompleted);
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us\\ midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -286,7 +286,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
 
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us\\ midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -316,7 +316,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             }
             Assert.assertFalse(disconnected);
             recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             waitForIOCompletion();
             closeContext();
@@ -354,7 +354,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
         try {
             runInAuthContext(() -> {
                 recvBuffer = "weather,location=us-midwest temperature=82 1465839830100400200\n";
-                handleContextIO();
+                handleContextIO0();
                 Assert.assertFalse(disconnected);
                 waitForIOCompletion();
                 closeContext();
@@ -397,13 +397,13 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
     public void testTruncatedKeyId() throws Exception {
         runInAuthContext(() -> {
             recvBuffer = "test";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             recvBuffer = "Key";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             recvBuffer = null;
-            handleContextIO();
+            handleContextIO0();
             Assert.assertTrue(disconnected);
         });
     }
@@ -458,7 +458,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             }
             byte[] signature = Base64.getEncoder().encode(rawSignature);
             send(new String(signature, Files.UTF_8) + "\n" + extraData, fragmentSignature);
-            handleContextIO();
+            handleContextIO0();
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -476,7 +476,7 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
             if (fragment) {
                 maxSendBytes = rnd.nextInt(10) + 1;
             }
-            handleContextIO();
+            handleContextIO0();
             if (null != sentBytes) {
                 if (null == challengeBytes) {
                     challengeBytes = sentBytes;
@@ -511,11 +511,11 @@ public class EllipticCurveAuthConnectionContextTest extends BaseLineTcpContextTe
                     recvBuffer = sendStr.substring(nSent, nSent + n);
                 }
                 nSent += n;
-                handleContextIO();
+                handleContextIO0();
             } while (nSent < sendStr.length());
         } else {
             recvBuffer = sendStr;
-            handleContextIO();
+            handleContextIO0();
         }
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextBrokenUTF8Test.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextBrokenUTF8Test.java
@@ -59,7 +59,7 @@ public class LineTcpConnectionContextBrokenUTF8Test extends BaseLineTcpContextTe
                             table + ",location=us-eastcoast temperature=80,hőmérséklet=25" + nonPrintable + ",hőmérséklet=23 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
 
-            handleContextIO();
+            handleContextIO0();
             Assert.assertEquals(disconnectOnError, disconnected);
             closeContext();
         });

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextInvalidSymbolTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextInvalidSymbolTest.java
@@ -52,7 +52,7 @@ public class LineTcpConnectionContextInvalidSymbolTest extends BaseLineTcpContex
                             table + ",ip_address=Invalid IP address. cpu=13 1465839830101400200\n" +
                             table + ",ip_address=192.168.0.1 cpu=42 1465839830100500200\n";
 
-            handleContextIO();
+            handleContextIO0();
             Assert.assertEquals(disconnectOnError, disconnected);
             closeContext();
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -79,10 +79,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         runInContext(() -> {
             recvBuffer = tableName + ",location=us-midwest temperature=82 1465839830100400200\n" +
                     tableName + ",location=us-eastcoast cast=cast,temperature=81,humidity=23 1465839830101400200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             drainWalQueue();
             String expected = "location\ttemperature\ttimestamp\tcast\thumidity\n" +
@@ -113,10 +110,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thumidity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
@@ -178,10 +172,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tcity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
@@ -201,10 +192,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         addTable(table);
         runInContext(() -> {
             recvBuffer = makeMessages(table);
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -231,10 +219,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -259,10 +244,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 a=146583983102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
 
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -288,7 +270,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast,broken temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -314,7 +296,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast broken=23 temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -340,10 +322,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast broken.col=aString,temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
 
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -369,10 +348,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast,broken.col=aString temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -398,10 +374,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast,broken.col=aString temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -426,7 +399,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 146583983x102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -452,10 +425,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast raining=T 1465839830102400200\n" +
                             table + ",location=us-eastcoast raining=F 1465839830102400200\n" +
                             table + ",location=us-westcost raining=False 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\training\ttimestamp\n" +
                     "us-eastcoast\ttrue\t2016-06-13T17:43:50.100400Z\n" +
@@ -493,10 +463,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                                     table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                                     table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                                     table + ",location=us-westcost temperature=82 1465839830102500200\n";
-                    do {
-                        handleContextIO();
-                        Assert.assertFalse(disconnected);
-                    } while (recvBuffer.length() > 0);
+                    handleIO();
                     closeContext();
                     String expected = "location\ttemperature\ttimestamp\n" +
                             "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -536,7 +503,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                                     table + ",location=us-eastcoast temperature=80 50000\n" +
                                     table + ",location=us-westcost temperature=82 40000\n";
                     do {
-                        handleContextIO();
+                        handleContextIO0();
                     } while (!disconnected && recvBuffer.length() > 0);
 
                     Assert.assertTrue(disconnected);
@@ -573,10 +540,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                                     table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                                     table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                                     table + ",location=us-westcost temperature=82 1465839830102500200\n";
-                    do {
-                        handleContextIO();
-                        Assert.assertFalse(disconnected);
-                    } while (recvBuffer.length() > 0);
+                    handleIO();
                     closeContext();
                     String expected = "location\ttemperature\tbroken\ttimestamp\n";
                     assertTable(expected, table);
@@ -604,7 +568,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             microSecondTicks = 1465839830102800L;
             recvBuffer = "t_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
                     "t_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
@@ -626,7 +590,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             recvBuffer = "t_ilp21 l=843530699759026177i\n" +
                     "t_ilp21 l=\"843530699759026178\"\n" +
                     "t_ilp21 l=843530699759026179i\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "l\n" +
@@ -648,10 +612,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -676,10 +637,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -706,10 +664,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -735,10 +690,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89,Timestamp=1465839830102400200t\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -764,10 +716,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=89\n" +
                             table + ",location=us-eastcoast timestamp=1465839830102400200t,temperature=80\n" +
                             table + ",location=us-westcost timestamp=1465839830102500200t,temperature=82\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttimestamp\ttemperature\n" +
                     "us-midwest\t2016-06-13T17:43:50.100400Z\t82.0\n" +
@@ -793,10 +742,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100200Z\n" +
@@ -832,10 +778,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80,time=1465839830102500200t\n" +
                             table + ",location=us-westcost temperature=82,time=1465839830102600200t 1465839830102700200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttime\tcity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100300Z\t\n" +
@@ -871,10 +814,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast Temperature=89,temperature=88 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82,timestamp=1465839830102500200t\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tcity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
@@ -900,10 +840,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -929,10 +866,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -958,10 +892,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -987,10 +918,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
                             table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
                             table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
                     "us-midwest\t82.0\t2.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1016,10 +944,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
                             table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
                             table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
                     "us-midwest\t82.0\t2.5\t2016-06-13T17:43:50.100400Z\n" +
@@ -1045,10 +970,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
                             table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
                             table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "terület\thőmérséklet\tветер\ttimestamp\n" +
                     "us-midwest\t82.0\t2.5\t2016-06-13T17:43:50.100400Z\n" +
@@ -1084,10 +1006,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82,timestamp=1465839830102500200t\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tcity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
@@ -1123,10 +1042,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",terület=us-eastcoast hőmérséklet=89 1465839830102400200\n" +
                             table + ",terület=us-eastcoast hőmérséklet=80 1465839830102400200\n" +
                             table + ",terület=us-westcost hőmérséklet=82,ветер=2.2 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "terület\thőmérséklet\ttimestamp\tветер\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t2.5\n" +
@@ -1152,10 +1068,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thumidity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
@@ -1181,10 +1094,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89,another=30,humidity=31 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thumidity\tanother\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\n" +
@@ -1210,10 +1120,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89,HuMiditY=28,humidity=29 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thumidity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\n" +
@@ -1239,10 +1146,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1268,10 +1172,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1289,7 +1190,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     public void testEmptyLine() throws Exception {
         runInContext(() -> {
             recvBuffer = "\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
         });
     }
@@ -1303,7 +1204,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             while (n < allMsgs.length()) {
                 recvBuffer = allMsgs.substring(n, n + 1);
                 n++;
-                handleContextIO();
+                handleContextIO0();
                 Assert.assertFalse(disconnected);
             }
             closeContext();
@@ -1337,7 +1238,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertTrue(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -1449,7 +1350,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
         });
 
@@ -1458,17 +1359,17 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         runInContext(() -> {
             recvBuffer = ",location=us-midwest temperature=82,timestamp=1465839830100200200t\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
             recvBuffer = ".,location=us-midwest temperature=82,timestamp=1465839830100200200t\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
             recvBuffer = "..\\/dbRoot,location=us-midwest temperature=82,timestamp=1465839830100200200t\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
 
@@ -1499,10 +1400,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
             Assert.assertFalse(recvBuffer.length() < lineTcpConfiguration.getNetMsgBufferSize());
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1528,10 +1426,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89,pollution=5 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thumidity\tpollution\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\n" +
@@ -1557,10 +1452,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1582,14 +1474,14 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     table + ",location=us-midwest temperature=82 1465839830100400200\n" +
                             table + ",location=us-midwest temperature=83 1465839830100500200\n" +
                             table + ",location=us-eastcoast temperature=81 1465839830101400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             recvBuffer =
                     table + ",location=us-midwest temperature=85 1465839830102300200\n" +
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -1616,7 +1508,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + " temperature=89,pressure=101i 1465839830102400200\n" +
                             table + " temperature=80,pressure=100i 1465839830102400200\n" +
                             table + " temperature=82,pressure=100i 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "temperature\tpressure\ttimestamp\n" +
@@ -1643,7 +1535,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + " temperature=89,pressure=101i 1465839830102400200\n" +
                             table + " temperature=80,pressure=100i 1465839830102400200\n" +
                             table + " temperature=82,pressure=100i 1465839830102500200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "temperature\tpressure\ttimestamp\n" +
@@ -1685,7 +1577,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             recvBuffer = table + ",location=us-midwest temperature=82,timestamp=1465839830100200200t\n" +
                     table + ",location=us-eastcoast temperature=80 1465839830102400200\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
             Assert.assertTrue(disconnected);
@@ -1719,7 +1611,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             recvBuffer = table + ",location=us-midwest temperature=82,timestamp=1465839830100200200t\n" +
                     table + ",location=us-eastcoast temperature=80 1465839830102400200\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
             Assert.assertTrue(disconnected);
@@ -1737,7 +1629,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     table + ",location=us-midwest temperature=83 1465839830100500200\n" +
                     table + ",location=us-eastcoast temperature=80 1465839830102400200\n";
             do {
-                handleContextIO();
+                handleContextIO0();
             } while (recvBuffer.length() > 0);
 
             Assert.assertTrue(disconnected);
@@ -1755,10 +1647,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         runInContext(() -> {
             recvBuffer =
                     "vbw water_speed_longitudinal=0.07,water_speed_traversal=,water_speed_status=\"A\",ground_speed_longitudinal=0,ground_speed_traversal=0,ground_speed_status=\"A\",water_speed_stern_traversal=,water_speed_stern_traversal_status=\"V\",ground_speed_stern_traversal=0,ground_speed_stern_traversal_status=\"V\" 1627046637414969856\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
 
 
@@ -1797,10 +1686,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + " val=4 \n" +
                             table + ",platform=APP2 \n" +
                             table + ",platform=APP3\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "platform\tval\ttimestamp\n" +
                     "APP\t1.0\t1970-01-02T00:00:00.000000Z\n" +
@@ -1825,10 +1711,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             try (Path path = new Path().of(configuration.getRoot()).concat(table).$()) {
                 Assert.assertFalse(configuration.getFilesFacade().exists(path));
@@ -1851,10 +1734,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89,hőmérséklet" + nonPrintable2 + "=26 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80,hőmérséklet" + nonPrintable + "=25,hőmérséklet" + nonPrintable2 + "=23 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\thőmérséklet" + nonPrintable1 + "\thőmérséklet" + nonPrintable2 + "\thőmérséklet" + nonPrintable + "\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\tNaN\tNaN\tNaN\n" +
@@ -1877,7 +1757,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                 recvBuffer += recvBuffer;
             }
             int nUnread = recvBuffer.length() - msgBufferSize;
-            handleContextIO();
+            handleContextIO0();
             Assert.assertTrue(disconnected);
             Assert.assertEquals(nUnread, recvBuffer.length());
         });
@@ -1894,10 +1774,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                     "tbl,t1=tv1\",t2=tv2 f2=\"1\" 1465839830100400200\n" +
                     "tbl,t1=\"tv1,t2=tv2 f2=\"1\" 1465839830100400200\n" +
                     "tbl,t1=tv1,t2=tv2 f1=\"Zen Internet Ltd\",f2=\"fv2\" 1465839830100400200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "t1\tt2\tf1\tf2\ttimestamp\n" +
                     "tv1\ttv2\tfv1\tZen Internet Ltd\t2016-06-13T17:43:50.100400Z\n" +
@@ -1916,7 +1793,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         String table = "singleMeasurement";
         runInContext(() -> {
             recvBuffer = table + ",location=us-midwest temperature=82 1465839830100400200\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -1937,10 +1814,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast raining=\"T\" 1465839830102400200\n" +
                             table + ",location=us-eastcoast raining=\"F\" 1465839830102400200\n" +
                             table + ",location=us-westcost raining=\"False\" 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\training\ttimestamp\n" +
                     "us-eastcoast\ttrue\t2016-06-13T17:43:50.100400Z\n" +
@@ -1965,10 +1839,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             recvBuffer = sb.toString();
 
             // ingesting 2038 rows -> size of location.o file will be 16384 bytes (pageSize)
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
 
             // with this line we are testing that mmap size is calculated correctly even in case of fileSize=pageSize
@@ -1992,10 +1863,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast,sensor=type1 temperature=89 1465839830102402200\n" +
                             table + ",sensor=type3,location=us-eastcoast temperature=80 1465839830102403200\n" +
                             table + ",location=us-westcost,sensor=type1 temperature=82 1465839830102504200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tsensor\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\ttype3\n" +
@@ -2038,10 +1906,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tcity\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t\n" +
@@ -2073,7 +1938,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89\n" +
                             table + ",location=us-eastcoast temperature=80\n" +
                             table + ",location=us-westcost temperature=82\n";
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -2116,6 +1981,13 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         }
     }
 
+    private void handleIO() {
+        do {
+            handleContextIO0();
+            Assert.assertFalse(disconnected);
+        } while (recvBuffer.length() > 0);
+    }
+
     @NotNull
     private String makeMessages(String table) {
         return table + ",location=us-midwest temperature=82 1465839830100400200\n" +
@@ -2134,10 +2006,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
             recvBuffer =
                     table + ",location=us-midwest temperature=82 1465839830100400200\n" +
                             table + ",location=us-eastcoast temperature=81,newcol=" + ilpValue + " 1465839830101400200\n";
-            do {
-                handleContextIO();
-                Assert.assertFalse(disconnected);
-            } while (recvBuffer.length() > 0);
+            handleIO();
             closeContext();
             String expected = "location\ttemperature\ttimestamp\tnewcol\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\t" + emptyValue + "\n" +
@@ -2153,10 +2022,10 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
         runInContext(() -> {
             String allMsgs = makeMessages(table);
             recvBuffer = allMsgs.substring(0, breakPos);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             recvBuffer = allMsgs.substring(breakPos);
-            handleContextIO();
+            handleContextIO0();
             Assert.assertFalse(disconnected);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
@@ -2215,7 +2084,7 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                 }
                 recvBuffer = sink.toString();
                 do {
-                    if (handleContextIO()) {
+                    if (handleContextIO0()) {
                         Os.pause();
                     }
                 } while (recvBuffer.length() > 0);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -259,8 +259,11 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 a=146583983102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -337,8 +340,11 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast broken.col=aString,temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
+
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -363,8 +369,10 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast,broken.col=aString temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -390,8 +398,10 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast,broken.col=aString temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +
@@ -1547,8 +1557,10 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
                             table + ",location=us-eastcoast temperature=89 1465839830102400200\n" +
                             table + ",location=us-eastcoast temperature=80 1465839830102400200\n" +
                             table + ",location=us-westcost temperature=82 1465839830102500200\n";
-            handleContextIO();
-            Assert.assertFalse(disconnected);
+            do {
+                handleContextIO();
+                Assert.assertFalse(disconnected);
+            } while (recvBuffer.length() > 0);
             closeContext();
             String expected = "location\ttemperature\ttimestamp\n" +
                     "us-midwest\t82.0\t2016-06-13T17:43:50.100400Z\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
@@ -903,7 +903,7 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
             }
             recvBuffer = sink.toString();
             do {
-                handleContextIO();
+                handleContextIO0();
                 Assert.assertFalse(disconnected);
             } while (recvBuffer.length() > 0);
             closeContext();

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpTypeConversionTest.java
@@ -270,7 +270,7 @@ public class LineTcpTypeConversionTest extends BaseLineTcpContextTest {
 
             recvBuffer = input;
             do {
-                handleContextIO();
+                handleContextIO0();
                 Assert.assertFalse(disconnected);
             } while (recvBuffer.length() > 0);
             closeContext();

--- a/core/src/test/java/io/questdb/test/griffin/AbstractO3Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/AbstractO3Test.java
@@ -25,10 +25,7 @@
 package io.questdb.test.griffin;
 
 import io.questdb.Metrics;
-import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.CairoEngine;
-import io.questdb.cairo.EntityColumnFilter;
-import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.*;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
@@ -61,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 public class AbstractO3Test extends AbstractTest {
     protected static final StringSink sink = new StringSink();
     protected static final StringSink sink2 = new StringSink();
+    protected static int commitMode = CommitMode.NOSYNC;
     protected static int dataAppendPageSize = -1;
     protected static int o3MemMaxPages = -1;
     protected static long partitionO3SplitThreshold = -1;
@@ -336,6 +334,11 @@ public class AbstractO3Test extends AbstractTest {
                     }
 
                     @Override
+                    public int getCommitMode() {
+                        return commitMode;
+                    }
+
+                    @Override
                     public long getDataAppendPageSize() {
                         return dataAppendPageSize > 0 ? dataAppendPageSize : super.getDataAppendPageSize();
                     }
@@ -368,6 +371,11 @@ public class AbstractO3Test extends AbstractTest {
                     @Override
                     public boolean disableColumnPurgeJob() {
                         return false;
+                    }
+
+                    @Override
+                    public int getCommitMode() {
+                        return commitMode;
                     }
 
                     @Override


### PR DESCRIPTION
ILP jobs were in greedy mode never releasing thread unless socket is empty. This could lead to bad user experience on smaller instances where ILP jobs run from shared pool.

The fix is to re-queue socket after every measurement. There is no notable impact on performance.

In Summary:

- fix O3 test failure when `sync` is enabled
- fix O3 `commit()` hanging when `sync` fails
- fix graceful shutdown under heavy ingest load
- fix graceful shutdown after catastrophic disk failure
