### PR TITLE
feat(ui): bump web-console version to 0.2.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
         <javac.target>11</javac.target>
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
-        <web.console.version>0.2.0</web.console.version>
+        <web.console.version>0.2.1</web.console.version>
     </properties>
 
     <version>7.1.3-SNAPSHOT</version>


### PR DESCRIPTION
Setting `@questdb/web-console` dependency to 0.2.1

Changes include:
- New feature in CSV Import: Allow editing schema on existing tables (column type, designated timestamp and its pattern, geohash precision) https://github.com/questdb/ui/pull/140
- Small visual updates for the schema editor UI in CSV Import, along with code refactoring for simplicity.