### PR TITLE
fix(wal): fix wal table error applying transactions after some table alters

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -375,12 +375,12 @@ public class CairoEngine implements Closeable, WriterSource {
         return metadataPool.get(tableToken);
     }
 
-    public TableRecordMetadata getMetadata(TableToken tableToken, long structureVersion) {
+    public TableRecordMetadata getMetadata(TableToken tableToken, long metadataVersion) {
         verifyTableToken(tableToken);
         try {
             final TableRecordMetadata metadata = metadataPool.get(tableToken);
-            if (structureVersion != TableUtils.ANY_TABLE_VERSION && metadata.getStructureVersion() != structureVersion) {
-                final TableReferenceOutOfDateException ex = TableReferenceOutOfDateException.of(tableToken, metadata.getTableId(), metadata.getTableId(), structureVersion, metadata.getStructureVersion());
+            if (metadataVersion != TableUtils.ANY_TABLE_VERSION && metadata.getMetadataVersion() != metadataVersion) {
+                final TableReferenceOutOfDateException ex = TableReferenceOutOfDateException.of(tableToken, metadata.getTableId(), metadata.getTableId(), metadataVersion, metadata.getMetadataVersion());
                 metadata.close();
                 throw ex;
             }

--- a/core/src/main/java/io/questdb/cairo/DynamicTableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/DynamicTableReaderMetadata.java
@@ -81,7 +81,7 @@ public class DynamicTableReaderMetadata extends TableReaderMetadata implements C
     }
 
     public long getVersion() {
-        return this.txFile.getStructureVersion();
+        return this.txFile.getMetadataVersion();
     }
 
     public void reload() {
@@ -143,16 +143,16 @@ public class DynamicTableReaderMetadata extends TableReaderMetadata implements C
         }
     }
 
-    private boolean reloadMetadata(long txnStructureVersion, long deadline) {
+    private boolean reloadMetadata(long txnMetadataVersion, long deadline) {
         // create transition index, which will help us reuse already open resources
-        if (txnStructureVersion == getStructureVersion()) {
+        if (txnMetadataVersion == getMetadataVersion()) {
             return true;
         }
 
         while (true) {
             long pTransitionIndex;
             try {
-                pTransitionIndex = createTransitionIndex(txnStructureVersion);
+                pTransitionIndex = createTransitionIndex(txnMetadataVersion);
                 if (pTransitionIndex < 0) {
                     if (clock.getTicks() < deadline) {
                         return false;
@@ -182,6 +182,6 @@ public class DynamicTableReaderMetadata extends TableReaderMetadata implements C
             readTxnSlow(deadline);
             // Reload _meta if structure version updated, reload _cv if column version updated
             // Start again if _meta with matching structure version cannot be loaded
-        } while (!reloadMetadata(txFile.getStructureVersion(), deadline));
+        } while (!reloadMetadata(txFile.getMetadataVersion(), deadline));
     }
 }

--- a/core/src/main/java/io/questdb/cairo/GenericTableRecordMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/GenericTableRecordMetadata.java
@@ -28,7 +28,7 @@ import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.wal.seq.TableRecordMetadataSink;
 
 public class GenericTableRecordMetadata extends GenericRecordMetadata implements TableRecordMetadata, TableRecordMetadataSink {
-    private long structureVersion;
+    private long metadataVersion;
     private int tableId;
     private TableToken tableToken;
 
@@ -61,8 +61,8 @@ public class GenericTableRecordMetadata extends GenericRecordMetadata implements
     }
 
     @Override
-    public long getStructureVersion() {
-        return structureVersion;
+    public long getMetadataVersion() {
+        return metadataVersion;
     }
 
     @Override
@@ -87,7 +87,7 @@ public class GenericTableRecordMetadata extends GenericRecordMetadata implements
         this.tableId = tableId;
         this.timestampIndex = compressedTimestampIndex;
         // todo: suspended
-        this.structureVersion = structureVersion;
+        this.metadataVersion = structureVersion;
         // todo: maxUncommittedRows where from ?
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -69,11 +69,11 @@ public final class TableUtils {
     public static final long META_OFFSET_COLUMN_TYPES = 128;
     public static final long META_OFFSET_COUNT = 0;
     public static final long META_OFFSET_MAX_UNCOMMITTED_ROWS = 20; // LONG
+    public static final long META_OFFSET_METADATA_VERSION = 32; // LONG
     public static final long META_OFFSET_O3_MAX_LAG = 24; // LONG
     // INT - symbol map count, this is a variable part of transaction file
     // below this offset we will have INT values for symbol map size
     public static final long META_OFFSET_PARTITION_BY = 4;
-    public static final long META_OFFSET_STRUCTURE_VERSION = 32; // LONG
     public static final long META_OFFSET_TABLE_ID = 16;
     public static final long META_OFFSET_TIMESTAMP_INDEX = 8;
     public static final long META_OFFSET_VERSION = 12;

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -525,7 +525,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             throwDistressException(e);
         }
 
-        bumpStructureVersion();
+        bumpColumnStructureVersion();
 
         metadata.addColumn(columnName, columnType, isIndexed, indexValueBlockCapacity, columnIndex);
 
@@ -1211,6 +1211,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         return columnVersionWriter.getColumnNameTxn(partitionTimestamp, columnIndex);
     }
 
+    public long getColumnStructureVersion() {
+        return txWriter.getColumnStructureVersion();
+    }
+
     public long getColumnTop(long partitionTimestamp, int columnIndex, long defaultValue) {
         long colTop = columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex);
         return colTop > -1L ? colTop : defaultValue;
@@ -1241,6 +1245,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     @Override
     public TableRecordMetadata getMetadata() {
         return metadata;
+    }
+
+    @Override
+    public long getMetadataVersion() {
+        return txWriter.getMetadataVersion();
     }
 
     public long getO3RowCount() {
@@ -1290,11 +1299,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     public MemoryMA getStorageColumn(int index) {
         return columns.getQuick(index);
-    }
-
-    @Override
-    public long getStructureVersion() {
-        return txWriter.getStructureVersion();
     }
 
     @Override
@@ -1842,7 +1846,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             throwDistressException(e);
         }
 
-        bumpStructureVersion();
+        bumpColumnStructureVersion();
 
         metadata.removeColumn(index);
         if (timestamp) {
@@ -1920,7 +1924,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             throwDistressException(e);
         }
 
-        bumpStructureVersion();
+        bumpColumnStructureVersion();
 
         // Call finish purge to remove old column files before renaming them in metadata
         finishColumnPurge();
@@ -2729,6 +2733,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    private void bumpColumnStructureVersion() {
+        columnVersionWriter.commit();
+        txWriter.setColumnVersion(columnVersionWriter.getVersion());
+        txWriter.bumpColumnStructureVersion(this.denseSymbolMapWriters);
+        assert txWriter.getMetadataVersion() == metadata.getMetadataVersion();
+    }
+
     private void bumpMasterRef() {
         if ((masterRef & 1) == 0) {
             masterRef++;
@@ -2737,11 +2748,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
-    private void bumpStructureVersion() {
+    private void bumpMetadataVersion() {
         columnVersionWriter.commit();
         txWriter.setColumnVersion(columnVersionWriter.getVersion());
-        txWriter.bumpStructureVersion(this.denseSymbolMapWriters);
-        assert txWriter.getStructureVersion() == metadata.getStructureVersion();
+        txWriter.bumpMetadataVersion(this.denseSymbolMapWriters);
+        assert txWriter.getMetadataVersion() == metadata.getMetadataVersion();
     }
 
     private boolean canSquashOverwritePartitionTail(int partitionIndex) {
@@ -3124,9 +3135,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         ddlMem.putInt(metaMem.getInt(META_OFFSET_TABLE_ID));
         ddlMem.putInt(metaMem.getInt(META_OFFSET_MAX_UNCOMMITTED_ROWS));
         ddlMem.putLong(metaMem.getLong(META_OFFSET_O3_MAX_LAG));
-        ddlMem.putLong(txWriter.getStructureVersion() + 1);
+        ddlMem.putLong(txWriter.getMetadataVersion() + 1);
         ddlMem.putBool(metaMem.getBool(META_OFFSET_WAL_ENABLED));
-        metadata.setStructureVersion(txWriter.getStructureVersion() + 1);
+        metadata.setMetadataVersion(txWriter.getMetadataVersion() + 1);
     }
 
     /**
@@ -3407,7 +3418,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             throwDistressException(e);
         }
 
-        bumpStructureVersion();
+        bumpMetadataVersion();
         metadata.setTableVersion();
     }
 
@@ -6908,7 +6919,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         } catch (CairoException e) {
             throwDistressException(e);
         }
-        bumpStructureVersion();
+        bumpMetadataVersion();
     }
 
     private void swapO3ColumnsExcept(int timestampIndex) {

--- a/core/src/main/java/io/questdb/cairo/TableWriterAPI.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterAPI.java
@@ -87,7 +87,7 @@ public interface TableWriterAPI extends Closeable {
      *
      * @return table structure version
      */
-    long getStructureVersion();
+    long getMetadataVersion();
 
     /**
      * Returns safe watermark for the symbol count stored in the given column.

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -32,7 +32,7 @@ import io.questdb.std.Chars;
 class TableWriterMetadata extends AbstractRecordMetadata implements TableRecordMetadata {
     private int maxUncommittedRows;
     private long o3MaxLag;
-    private long structureVersion;
+    private long metadataVersion;
     private int symbolMapCount;
     private int tableId;
     private TableToken tableToken;
@@ -60,8 +60,8 @@ class TableWriterMetadata extends AbstractRecordMetadata implements TableRecordM
     }
 
     @Override
-    public long getStructureVersion() {
-        return structureVersion;
+    public long getMetadataVersion() {
+        return metadataVersion;
     }
 
     public int getSymbolMapCount() {
@@ -97,7 +97,7 @@ class TableWriterMetadata extends AbstractRecordMetadata implements TableRecordM
         TableUtils.validateMeta(metaMem, columnNameIndexMap, ColumnType.VERSION);
         this.timestampIndex = metaMem.getInt(TableUtils.META_OFFSET_TIMESTAMP_INDEX);
         this.columnMetadata.clear();
-        this.structureVersion = metaMem.getLong(TableUtils.META_OFFSET_STRUCTURE_VERSION);
+        this.metadataVersion = metaMem.getLong(TableUtils.META_OFFSET_METADATA_VERSION);
         this.walEnabled = metaMem.getBool(TableUtils.META_OFFSET_WAL_ENABLED);
 
         long offset = TableUtils.getColumnNameOffset(columnCount);
@@ -136,8 +136,8 @@ class TableWriterMetadata extends AbstractRecordMetadata implements TableRecordM
         this.o3MaxLag = o3MaxLagUs;
     }
 
-    public void setStructureVersion(long value) {
-        this.structureVersion = value;
+    public void setMetadataVersion(long value) {
+        this.metadataVersion = value;
     }
 
     public void setTableVersion() {

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -34,6 +34,7 @@ import java.io.Closeable;
 import static io.questdb.cairo.TableUtils.*;
 
 public final class TxWriter extends TxReader implements Closeable, Mutable, SymbolValueCountCollector {
+    private final CairoConfiguration configuration;
     private long baseVersion;
     private TableWriter.ExtensionListener extensionListener;
     private int lastRecordBaseOffset = -1;
@@ -50,7 +51,6 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     private int txPartitionCount;
     private int writeAreaSize;
     private int writeBaseOffset;
-    private final CairoConfiguration configuration;
 
     public TxWriter(FilesFacade ff, CairoConfiguration configuration) {
         super(ff);
@@ -72,15 +72,25 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         }
     }
 
+    public void bumpColumnStructureVersion(ObjList<? extends SymbolCountProvider> denseSymbolMapWriters) {
+        recordStructureVersion++;
+        structureVersion = Numbers.decodeHighInt(structureVersion) != 0 ? Numbers.encodeLowHighInts(getMetadataVersion() + 1, getColumnStructureVersion() + 1) : structureVersion + 1;
+        commit(denseSymbolMapWriters);
+    }
+
+    public void bumpMetadataVersion(ObjList<? extends SymbolCountProvider> denseSymbolMapWriters) {
+        recordStructureVersion++;
+        int colStoreVersion = getColumnStructureVersion();
+        if (colStoreVersion == 0) {
+            colStoreVersion = NONE_COL_STRUCTURE_VERSION;
+        }
+        structureVersion = Numbers.encodeLowHighInts(getMetadataVersion() + 1, colStoreVersion);
+        commit(denseSymbolMapWriters);
+    }
+
     public void bumpPartitionTableVersion() {
         recordStructureVersion++;
         partitionTableVersion++;
-    }
-
-    public void bumpStructureVersion(ObjList<? extends SymbolCountProvider> denseSymbolMapWriters) {
-        recordStructureVersion++;
-        structureVersion.incrementAndGet();
-        commit(denseSymbolMapWriters);
     }
 
     public void bumpTruncateVersion() {
@@ -387,7 +397,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
                 seqTxn,
                 dataVersion,
                 partitionTableVersion,
-                structureVersion.get(),
+                structureVersion,
                 columnVersion,
                 truncateVersion
         );
@@ -409,18 +419,22 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         return false;
     }
 
-    public void updateMaxTimestamp(long timestamp) {
-        prevMaxTimestamp = maxTimestamp;
-        assert timestamp >= maxTimestamp;
-        maxTimestamp = timestamp;
-    }
-
     public void updateAttachedPartitionSizeByRawIndex(int partitionIndex, long partitionTimestampLo, long partitionSize, long partitionNameTxn) {
         if (partitionIndex > -1) {
             updatePartitionSizeByRawIndex(partitionIndex, partitionSize);
         } else {
             insertPartitionSizeByTimestamp(-(partitionIndex + 1), partitionTimestampLo, partitionSize, partitionNameTxn);
         }
+    }
+
+    public void updateMaxTimestamp(long timestamp) {
+        prevMaxTimestamp = maxTimestamp;
+        assert timestamp >= maxTimestamp;
+        maxTimestamp = timestamp;
+    }
+
+    public void updatePartitionSizeByRawIndex(int partitionIndex, long partitionTimestampLo, long rowCount) {
+        updateAttachedPartitionSizeByRawIndex(partitionIndex, partitionTimestampLo, rowCount, txn - 1);
     }
 
     public void updatePartitionSizeByTimestamp(long timestamp, long rowCount) {
@@ -472,7 +486,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         putLong(TX_OFFSET_FIXED_ROW_COUNT_64, fixedRowCount);
         putLong(TX_OFFSET_MIN_TIMESTAMP_64, minTimestamp);
         putLong(TX_OFFSET_MAX_TIMESTAMP_64, maxTimestamp);
-        putLong(TX_OFFSET_STRUCT_VERSION_64, structureVersion.get());
+        putLong(TX_OFFSET_STRUCT_VERSION_64, structureVersion);
         putLong(TX_OFFSET_DATA_VERSION_64, dataVersion);
         putLong(TX_OFFSET_PARTITION_TABLE_VERSION_64, partitionTableVersion);
         putLong(TX_OFFSET_COLUMN_VERSION_64, columnVersion);
@@ -593,10 +607,6 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
             offset += Integer.BYTES;
             putInt(offset, symCount);
         }
-    }
-
-    public void updatePartitionSizeByRawIndex(int partitionIndex, long partitionTimestampLo, long rowCount) {
-        updateAttachedPartitionSizeByRawIndex(partitionIndex, partitionTimestampLo, rowCount, txn - 1);
     }
 
     private void updateAttachedPartitionSizeByTimestamp(long timestamp, long partitionSize, long partitionNameTxn) {

--- a/core/src/main/java/io/questdb/cairo/pool/MetadataPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/MetadataPool.java
@@ -102,7 +102,7 @@ public class MetadataPool extends AbstractMultiTenantPool<MetadataPool.MetadataT
 
         @Override
         public void refresh() {
-            tableSequencerAPI.reloadMetadataConditionally(tableToken, getStructureVersion(), this);
+            tableSequencerAPI.reloadMetadataConditionally(tableToken, getMetadataVersion(), this);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/TableRecordMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/sql/TableRecordMetadata.java
@@ -33,11 +33,11 @@ public interface TableRecordMetadata extends RecordMetadata, QuietCloseable {
         return Integer.MAX_VALUE;
     }
 
+    long getMetadataVersion();
+
     default long getO3MaxLag() {
         return 0;
     }
-
-    long getStructureVersion();
 
     int getTableId();
 

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -271,10 +271,10 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                             // This is metadata change
                             // to be taken from Sequencer directly
                             final long newStructureVersion = transactionLogCursor.getStructureVersion();
-                            if (writer.getStructureVersion() != newStructureVersion - 1) {
+                            if (writer.getColumnStructureVersion() != newStructureVersion - 1) {
                                 throw CairoException.critical(0)
                                         .put("unexpected new WAL structure version [walStructure=").put(newStructureVersion)
-                                        .put(", tableStructureVersion=").put(writer.getStructureVersion())
+                                        .put(", tableStructureVersion=").put(writer.getColumnStructureVersion())
                                         .put(']');
                             }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -305,17 +305,17 @@ public class WalWriter implements TableWriterAPI {
         return metadata;
     }
 
+    @Override
+    public long getMetadataVersion() {
+        return metadata.getMetadataVersion();
+    }
+
     public int getSegmentId() {
         return segmentId;
     }
 
     public long getSegmentRowCount() {
         return segmentRowCount;
-    }
-
-    @Override
-    public long getStructureVersion() {
-        return metadata.getStructureVersion();
     }
 
     @Override
@@ -454,15 +454,15 @@ public class WalWriter implements TableWriterAPI {
                             .$(", rowCount=").$(uncommittedRows).I$();
 
                     final int commitMode = configuration.getCommitMode();
-                for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-                    final int columnType = metadata.getColumnType(columnIndex);
-                    if (columnType > 0) {
-                        final MemoryMA primaryColumn = getPrimaryColumn(columnIndex);
-                        final MemoryMA secondaryColumn = getSecondaryColumn(columnIndex);
-                        final String columnName = metadata.getColumnName(columnIndex);
+                    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                        final int columnType = metadata.getColumnType(columnIndex);
+                        if (columnType > 0) {
+                            final MemoryMA primaryColumn = getPrimaryColumn(columnIndex);
+                            final MemoryMA secondaryColumn = getSecondaryColumn(columnIndex);
+                            final String columnName = metadata.getColumnName(columnIndex);
 
                             CopyWalSegmentUtils.rollColumnToSegment(
-                                ff,
+                                    ff,
                                     configuration.getWriterFileOpenOpts(),
                                     primaryColumn,
                                     secondaryColumn,
@@ -474,7 +474,7 @@ public class WalWriter implements TableWriterAPI {
                                     uncommittedRows,
                                     newColumnFiles,
                                     columnIndex,
-                                commitMode
+                                    commitMode
                             );
                         } else {
                             rowValueIsNotNull.setQuick(columnIndex, COLUMN_DELETED_NULL_FLAG);
@@ -635,8 +635,8 @@ public class WalWriter implements TableWriterAPI {
     }
 
     private void applyMetadataChangeLog(long structureVersionHi) {
-        try (TableMetadataChangeLog log = sequencer.getMetadataChangeLog(tableToken, metadata.getStructureVersion())) {
-            long structVer = getStructureVersion();
+        try (TableMetadataChangeLog log = sequencer.getMetadataChangeLog(tableToken, getColumnStructureVersion())) {
+            long structVer = getColumnStructureVersion();
             while (log.hasNext() && structVer < structureVersionHi) {
                 TableMetadataChange chg = log.next();
                 try {
@@ -646,7 +646,7 @@ public class WalWriter implements TableWriterAPI {
                     throw e;
                 }
 
-                if (++structVer != getStructureVersion()) {
+                if (++structVer != getColumnStructureVersion()) {
                     distressed = true;
                     throw CairoException.critical(0)
                             .put("could not apply table definition changes to the current transaction, version unchanged");
@@ -660,9 +660,9 @@ public class WalWriter implements TableWriterAPI {
             throw CairoException.critical(0).put("failed to commit ALTER SQL to WAL, sql context is empty [table=").put(tableToken.getTableName()).put(']');
         }
         if (
-                (verifyStructureVersion && op.getTableVersion() != getStructureVersion())
+                (verifyStructureVersion && op.getTableVersion() != getColumnStructureVersion())
                         || op.getTableId() != metadata.getTableId()) {
-            throw TableReferenceOutOfDateException.of(tableToken, metadata.getTableId(), op.getTableId(), getStructureVersion(), op.getTableVersion());
+            throw TableReferenceOutOfDateException.of(tableToken, metadata.getTableId(), op.getTableId(), getColumnStructureVersion(), op.getTableVersion());
         }
 
         try {
@@ -682,12 +682,12 @@ public class WalWriter implements TableWriterAPI {
             try {
                 metaValidatorSvc.startAlterValidation();
                 alterOp.apply(metaValidatorSvc, true);
-                if (metaValidatorSvc.structureVersion != metadata.getStructureVersion() + 1) {
+                if (metaValidatorSvc.structureVersion != getColumnStructureVersion() + 1) {
                     retry = false;
                     throw CairoException.nonCritical()
                             .put("statements containing multiple transactions, such as 'alter table add column col1, col2'" +
                                     " are currently not supported for WAL tables [table=").put(tableToken.getTableName())
-                            .put(", oldStructureVersion=").put(metadata.getStructureVersion())
+                            .put(", oldStructureVersion=").put(getColumnStructureVersion())
                             .put(", newStructureVersion=").put(metaValidatorSvc.structureVersion).put(']');
                 }
             } catch (CairoException e) {
@@ -702,7 +702,7 @@ public class WalWriter implements TableWriterAPI {
             }
 
             try {
-                txn = sequencer.nextStructureTxn(tableToken, metadata.getStructureVersion(), alterOp);
+                txn = sequencer.nextStructureTxn(tableToken, getColumnStructureVersion(), alterOp);
                 if (txn == NO_TXN) {
                     applyMetadataChangeLog(Long.MAX_VALUE);
                 }
@@ -721,6 +721,77 @@ public class WalWriter implements TableWriterAPI {
             distressed = true;
         }
         return txn;
+    }
+
+    private void configureSymbolTable() {
+        boolean initialized = false;
+        try {
+            int denseSymbolIndex = 0;
+
+            for (int i = 0; i < columnCount; i++) {
+                int columnType = metadata.getColumnType(i);
+                if (!ColumnType.isSymbol(columnType)) {
+                    // Maintain sparse list of symbol writers
+                    // Note: we don't need to set initialSymbolCounts and symbolMapNullFlags values
+                    // here since we already filled it with -1 and false initially
+                    symbolMapReaders.extendAndSet(i, null);
+                    symbolMaps.extendAndSet(i, null);
+                    utf8SymbolMaps.extendAndSet(i, null);
+                } else {
+                    if (txReader == null) {
+                        txReader = new TxReader(ff);
+                        columnVersionReader = new ColumnVersionReader();
+                    }
+
+                    if (!initialized) {
+                        MillisecondClock milliClock = configuration.getMillisecondClock();
+                        long spinLockTimeout = configuration.getSpinLockTimeout();
+
+                        // todo: use own path
+                        Path path = Path.PATH2.get();
+                        path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$();
+
+                        // Does not matter which PartitionBy, as long as it is partitioned
+                        // WAL tables must be partitioned
+                        txReader.ofRO(path, PartitionBy.DAY);
+                        path.of(configuration.getRoot()).concat(tableToken).concat(COLUMN_VERSION_FILE_NAME).$();
+                        columnVersionReader.ofRO(ff, path);
+
+                        initialized = true;
+                        long structureVersion = getMetadataVersion();
+
+                        do {
+                            TableUtils.safeReadTxn(txReader, milliClock, spinLockTimeout);
+                            if (txReader.getColumnStructureVersion() != structureVersion) {
+                                initialized = false;
+                                break;
+                            }
+                            columnVersionReader.readSafe(milliClock, spinLockTimeout);
+                        } while (txReader.getColumnVersion() != columnVersionReader.getVersion());
+                    }
+
+                    if (initialized) {
+                        int symbolValueCount = txReader.getSymbolValueCount(denseSymbolIndex);
+                        long columnNameTxn = columnVersionReader.getDefaultColumnNameTxn(i);
+                        configureSymbolMapWriter(i, metadata.getColumnName(i), symbolValueCount, columnNameTxn);
+                    } else {
+                        // table on disk structure version does not match the structure version of the WalWriter
+                        // it is not possible to re-use table symbol table because the column name may not match.
+                        // The symbol counts stored as dense in _txn file and removal of symbols
+                        // shifts the counts that's why it's not possible to find out the symbol count if metadata versions
+                        // don't match.
+                        configureSymbolMapWriter(i, metadata.getColumnName(i), 0, COLUMN_NAME_TXN_NONE);
+                    }
+                }
+
+                if (columnType == ColumnType.SYMBOL || columnType == -ColumnType.SYMBOL) {
+                    denseSymbolIndex++;
+                }
+            }
+        } finally {
+            Misc.free(columnVersionReader);
+            Misc.free(txReader);
+        }
     }
 
     private void checkDistressed() {
@@ -889,75 +960,9 @@ public class WalWriter implements TableWriterAPI {
         symbolMapNullFlags.extendAndSet(columnWriterIndex, symbolMapReader.containsNullValue());
     }
 
-    private void configureSymbolTable() {
-        boolean initialized = false;
-        try {
-            int denseSymbolIndex = 0;
-
-            for (int i = 0; i < columnCount; i++) {
-                int columnType = metadata.getColumnType(i);
-                if (!ColumnType.isSymbol(columnType)) {
-                    // Maintain sparse list of symbol writers
-                    // Note: we don't need to set initialSymbolCounts and symbolMapNullFlags values
-                    // here since we already filled it with -1 and false initially
-                    symbolMapReaders.extendAndSet(i, null);
-                    symbolMaps.extendAndSet(i, null);
-                    utf8SymbolMaps.extendAndSet(i, null);
-                } else {
-                    if (txReader == null) {
-                        txReader = new TxReader(ff);
-                        columnVersionReader = new ColumnVersionReader();
-                    }
-
-                    if (!initialized) {
-                        MillisecondClock milliClock = configuration.getMillisecondClock();
-                        long spinLockTimeout = configuration.getSpinLockTimeout();
-
-                        // todo: use own path
-                        Path path = Path.PATH2.get();
-                        path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$();
-
-                        // Does not matter which PartitionBy, as long as it is partitioned
-                        // WAL tables must be partitioned
-                        txReader.ofRO(path, PartitionBy.DAY);
-                        path.of(configuration.getRoot()).concat(tableToken).concat(COLUMN_VERSION_FILE_NAME).$();
-                        columnVersionReader.ofRO(ff, path);
-
-                        initialized = true;
-                        long structureVersion = getStructureVersion();
-
-                        do {
-                            TableUtils.safeReadTxn(txReader, milliClock, spinLockTimeout);
-                            if (txReader.getStructureVersion() != structureVersion) {
-                                initialized = false;
-                                break;
-                            }
-                            columnVersionReader.readSafe(milliClock, spinLockTimeout);
-                        } while (txReader.getColumnVersion() != columnVersionReader.getVersion());
-                    }
-
-                    if (initialized) {
-                        int symbolValueCount = txReader.getSymbolValueCount(denseSymbolIndex);
-                        long columnNameTxn = columnVersionReader.getDefaultColumnNameTxn(i);
-                        configureSymbolMapWriter(i, metadata.getColumnName(i), symbolValueCount, columnNameTxn);
-                    } else {
-                        // table on disk structure version does not match the structure version of the WalWriter
-                        // it is not possible to re-use table symbol table because the column name may not match.
-                        // The symbol counts stored as dense in _txn file and removal of symbols
-                        // shifts the counts that's why it's not possible to find out the symbol count if metadata versions
-                        // don't match.
-                        configureSymbolMapWriter(i, metadata.getColumnName(i), 0, COLUMN_NAME_TXN_NONE);
-                    }
-                }
-
-                if (columnType == ColumnType.SYMBOL || columnType == -ColumnType.SYMBOL) {
-                    denseSymbolIndex++;
-                }
-            }
-        } finally {
-            Misc.free(columnVersionReader);
-            Misc.free(txReader);
-        }
+    private long getColumnStructureVersion() {
+        // Sequencer metadata version is the same as column structure version of the table.
+        return metadata.getMetadataVersion();
     }
 
     private MemoryMA createSecondaryMem(int columnType) {
@@ -1020,7 +1025,7 @@ public class WalWriter implements TableWriterAPI {
     private long getSequencerTxn() {
         long seqTxn;
         do {
-            seqTxn = sequencer.nextTxn(tableToken, walId, metadata.getStructureVersion(), segmentId, lastSegmentTxn);
+            seqTxn = sequencer.nextTxn(tableToken, walId, getColumnStructureVersion(), segmentId, lastSegmentTxn);
             if (seqTxn == NO_TXN) {
                 applyMetadataChangeLog(Long.MAX_VALUE);
             }
@@ -1481,7 +1486,7 @@ public class WalWriter implements TableWriterAPI {
         }
 
         public void startAlterValidation() {
-            structureVersion = metadata.getStructureVersion();
+            structureVersion = getColumnStructureVersion();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriterMetadata.java
@@ -121,7 +121,7 @@ public class WalWriterMetadata extends AbstractRecordMetadata implements TableRe
     }
 
     @Override
-    public long getStructureVersion() {
+    public long getMetadataVersion() {
         return structureVersion;
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
@@ -106,13 +106,13 @@ public class SequencerMetadata extends AbstractRecordMetadata implements TableRe
         syncToMetaFile();
     }
 
-    public int getRealColumnCount() {
-        return columnNameIndexMap.size();
+    @Override
+    public long getMetadataVersion() {
+        return structureVersion.get();
     }
 
-    @Override
-    public long getStructureVersion() {
-        return structureVersion.get();
+    public int getRealColumnCount() {
+        return columnNameIndexMap.size();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -635,9 +635,9 @@ public class TableUpdateDetails implements Closeable {
             return columnTypeMeta.getQuick(colIndex + 1); // first val accounts for new cols, index -1
         }
 
-        long getStructureVersion() {
+        long getMetadataVersion() {
             if (latestKnownMetadata != null) {
-                return latestKnownMetadata.getStructureVersion();
+                return latestKnownMetadata.getMetadataVersion();
             }
             return ANY_TABLE_VERSION;
         }
@@ -659,8 +659,8 @@ public class TableUpdateDetails implements Closeable {
             // Second, check if writer's structure version has changed
             // compared with the known metadata.
             if (latestKnownMetadata != null) {
-                long structureVersion = writerAPI.getStructureVersion();
-                if (latestKnownMetadata.getStructureVersion() != structureVersion) {
+                long metadataVersion = writerAPI.getMetadataVersion();
+                if (latestKnownMetadata.getMetadataVersion() != metadataVersion) {
                     // clear() frees latestKnownMetadata and sets it to null
                     clear();
                 }

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -1852,7 +1852,7 @@ public class SqlCompiler implements Closeable {
             return new UpdateOperation(
                     updateTableToken,
                     metadata.getTableId(),
-                    metadata.getStructureVersion(),
+                    metadata.getMetadataVersion(),
                     lexer.getPosition()
             );
         }
@@ -1892,8 +1892,8 @@ public class SqlCompiler implements Closeable {
         TableToken token = tableExistsOrFail(tableNameExpr.position, tableNameExpr.token, executionContext);
 
         try (TableRecordMetadata metadata = engine.getMetadata(token)) {
-            final long structureVersion = metadata.getStructureVersion();
-            final InsertOperationImpl insertOperation = new InsertOperationImpl(engine, metadata.getTableToken(), structureVersion);
+            final long metadataVersion = metadata.getMetadataVersion();
+            final InsertOperationImpl insertOperation = new InsertOperationImpl(engine, metadata.getTableToken(), metadataVersion);
             final int metadataTimestampIndex = metadata.getTimestampIndex();
             final ObjList<CharSequence> columnNameList = model.getColumnNameList();
             final int columnSetSize = columnNameList.size();
@@ -2973,7 +2973,7 @@ public class SqlCompiler implements Closeable {
 
                         // _txn
                         mem.smallFile(ff, auxPath.trimTo(tableRootLen).concat(TableUtils.TXN_FILE_NAME).$(), MemoryTag.MMAP_DEFAULT);
-                        TableUtils.createTxn(mem, symbolMapCount, 0L, 0L, TableUtils.INITIAL_TXN, 0L, metadata.getStructureVersion(), 0L, 0L);
+                        TableUtils.createTxn(mem, symbolMapCount, 0L, 0L, TableUtils.INITIAL_TXN, 0L, metadata.getMetadataVersion(), 0L, 0L);
 
                         // _cv
                         mem.smallFile(ff, auxPath.trimTo(tableRootLen).concat(TableUtils.COLUMN_VERSION_FILE_NAME).$(), MemoryTag.MMAP_DEFAULT);
@@ -3011,7 +3011,7 @@ public class SqlCompiler implements Closeable {
                             mem.smallFile(ff, auxPath.trimTo(len).concat(TableUtils.META_FILE_NAME).$(), MemoryTag.MMAP_DEFAULT);
                             WalWriterMetadata.syncToMetaFile(
                                     mem,
-                                    metadata.getStructureVersion(),
+                                    metadata.getMetadataVersion(),
                                     metadata.getColumnCount(),
                                     metadata.getTimestampIndex(),
                                     metadata.getTableId(),

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -1749,7 +1749,7 @@ public class SqlOptimiser {
     }
 
     private void enumerateColumns(QueryModel model, TableRecordMetadata metadata) throws SqlException {
-        model.setTableVersion(metadata.getStructureVersion());
+        model.setTableVersion(metadata.getMetadataVersion());
         model.setTableId(metadata.getTableId());
         copyColumnsFromMetadata(model, metadata, false);
         if (model.isUpdate()) {

--- a/core/src/main/java/io/questdb/griffin/UpdateOperatorImpl.java
+++ b/core/src/main/java/io/questdb/griffin/UpdateOperatorImpl.java
@@ -99,9 +99,9 @@ public class UpdateOperatorImpl implements QuietCloseable, UpdateOperator {
             final TableRecordMetadata tableMetadata = tableWriter.getMetadata();
 
             // Check that table structure hasn't changed between planning and executing the UPDATE
-            if (tableMetadata.getTableId() != tableId || tableWriter.getStructureVersion() != tableVersion) {
+            if (tableMetadata.getTableId() != tableId || tableWriter.getMetadataVersion() != tableVersion) {
                 throw TableReferenceOutOfDateException.of(tableToken, tableId, tableMetadata.getTableId(),
-                        tableVersion, tableWriter.getStructureVersion());
+                        tableVersion, tableWriter.getMetadataVersion());
             }
 
             // Select the rows to be updated

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
@@ -44,13 +44,13 @@ public class InsertOperationImpl implements InsertOperation {
     private final CairoEngine engine;
     private final InsertMethodImpl insertMethod = new InsertMethodImpl();
     private final ObjList<InsertRowImpl> insertRows = new ObjList<>();
-    private final long structureVersion;
+    private final long metadataVersion;
     private final TableToken tableToken;
 
-    public InsertOperationImpl(CairoEngine engine, TableToken tableToken, long structureVersion) {
+    public InsertOperationImpl(CairoEngine engine, TableToken tableToken, long metadataVersion) {
         this.engine = engine;
         this.tableToken = tableToken;
-        this.structureVersion = structureVersion;
+        this.metadataVersion = metadataVersion;
     }
 
     @Override
@@ -63,7 +63,7 @@ public class InsertOperationImpl implements InsertOperation {
         initContext(executionContext);
         if (insertMethod.writer == null) {
             final TableWriterAPI writer = writerSource.getTableWriterAPI(tableToken, "insert");
-            if (writer.getStructureVersion() != structureVersion
+            if (writer.getMetadataVersion() != metadataVersion
                     || !Chars.equals(tableToken.getTableName(), writer.getTableToken().getTableName())) {
                 writer.close();
                 throw WriterOutOfDateException.INSTANCE;

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
@@ -422,7 +422,7 @@ public class TableReaderMetadataTest extends AbstractCairoTest {
                     long structVersion;
                     try (TableWriter writer = newTableWriter(configuration, tableName, metrics)) {
                         manipulator.restructure(writer);
-                        structVersion = writer.getStructureVersion();
+                        structVersion = writer.getMetadataVersion();
                     }
                     long pTransitionIndex = metadata.createTransitionIndex(structVersion);
                     try {

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
@@ -174,7 +174,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 long structureVersion;
                 try (TableWriter writer = newTableWriter(configuration, tableName, metrics)) {
                     writer.removeColumn("timestamp");
-                    structureVersion = writer.getStructureVersion();
+                    structureVersion = writer.getMetadataVersion();
                 }
 
                 long pTransitionIndex = metadata.createTransitionIndex(structureVersion);
@@ -221,7 +221,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 long structVersion;
                 try (TableWriter writer = newTableWriter(configuration, tableName, metrics)) {
                     manipulator.restructure(writer);
-                    structVersion = writer.getStructureVersion();
+                    structVersion = writer.getMetadataVersion();
                 }
 
                 long address = metadata.createTransitionIndex(structVersion);

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -29,8 +29,8 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
-import io.questdb.mp.SOCountDownLatch;
 import io.questdb.griffin.SqlException;
+import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.*;
 import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
@@ -1278,7 +1278,7 @@ public class TableReaderTest extends AbstractCairoTest {
                     while (colAdded < totalColAddCount) {
                         if (colAdded < (newColsAdded = columnsAdded.get())) {
                             reader.reload();
-                            Assert.assertEquals(reader.getTxnStructureVersion(), reader.getMetadata().getStructureVersion());
+                            Assert.assertEquals(reader.getTxnMetadataVersion(), reader.getMetadata().getMetadataVersion());
                             colAdded = newColsAdded;
                             reloadCount.incrementAndGet();
                         }
@@ -1355,7 +1355,7 @@ public class TableReaderTest extends AbstractCairoTest {
                     while (colAdded < totalColAddCount) {
                         if (colAdded < columnsAdded.get()) {
                             if (reader.reload()) {
-                                Assert.assertEquals(reader.getTxnStructureVersion(), reader.getMetadata().getStructureVersion());
+                                Assert.assertEquals(reader.getTxnMetadataVersion(), reader.getMetadata().getMetadataVersion());
                                 colAdded = reader.getMetadata().getColumnCount();
                                 reloadCount.incrementAndGet();
                             }
@@ -1431,7 +1431,7 @@ public class TableReaderTest extends AbstractCairoTest {
                     while (colAdded < totalColAddCount) {
                         if (colAdded < (newColsAdded = columnsAdded.get())) {
                             try (TableReader reader = getReader(tableToken)) {
-                                Assert.assertEquals(reader.getTxnStructureVersion(), reader.getMetadata().getStructureVersion());
+                                Assert.assertEquals(reader.getTxnMetadataVersion(), reader.getMetadata().getMetadataVersion());
                                 colAdded = newColsAdded;
                                 reloadCount.incrementAndGet();
                             }
@@ -1973,7 +1973,7 @@ public class TableReaderTest extends AbstractCairoTest {
                                 configuration.getWriterFileOpenOpts()
                         )
                 ) {
-                    mem.putLong(TableUtils.META_OFFSET_STRUCTURE_VERSION, 0);
+                    mem.putLong(TableUtils.META_OFFSET_METADATA_VERSION, 0);
                 }
 
                 try {

--- a/core/src/test/java/io/questdb/test/cairo/TxnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TxnTest.java
@@ -272,7 +272,7 @@ public class TxnTest extends AbstractCairoTest {
                                     String trace = String.format(
                                             "[txn=%d, structureVersion=%d, partitionCount=%d, symbolCount=%d] ",
                                             txReader.getTxn(),
-                                            txReader.getStructureVersion(),
+                                            txReader.getMetadataVersion(),
                                             txReader.getPartitionCount(),
                                             txReader.getSymbolColumnCount()
                                     );
@@ -280,13 +280,13 @@ public class TxnTest extends AbstractCairoTest {
                                 }
                             }
 
-                            long offset = txReader.getTxn() - txReader.getStructureVersion();
+                            long offset = txReader.getTxn() - txReader.getMetadataVersion();
                             for (int i = txReader.getPartitionCount() - 2; i > -1; i--) {
                                 if (offset + i != txReader.getPartitionSize(i)) {
                                     String trace = String.format(
                                             "[txn=%d, structureVersion=%d, partitionCount=%d, symbolCount=%d] ",
                                             txReader.getTxn(),
-                                            txReader.getStructureVersion(),
+                                            txReader.getMetadataVersion(),
                                             txReader.getPartitionCount(),
                                             txReader.getSymbolColumnCount()
                                     );
@@ -384,13 +384,13 @@ public class TxnTest extends AbstractCairoTest {
                             symbolCounts.setPos(symbolCount);
                             zeroSymbolCounts.setPos(symbolCount);
                         }
-                        txWriter.bumpStructureVersion(symbolCounts);
+                        txWriter.bumpColumnStructureVersion(symbolCounts);
 
                         // Set random number of partitions
                         int partitionCount = rnd.nextInt(maxPartitionCount);
                         int partitions = txWriter.getPartitionCount() - 1; // Last partition always stays
 
-                        long offset = txWriter.getTxn() + 1 - txWriter.getStructureVersion();
+                        long offset = txWriter.getTxn() + 1 - txWriter.getMetadataVersion();
                         // Add / Update
                         for (int i = 0; i < partitionCount; i++) {
                             txWriter.updatePartitionSizeByTimestamp(i * Timestamps.HOUR_MICROS, offset + i);

--- a/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
@@ -24,7 +24,10 @@
 
 package io.questdb.test.cairo.wal;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericTableRecordMetadata;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableToken;
 import io.questdb.cairo.wal.WalWriter;
 import io.questdb.cairo.wal.seq.TransactionLogCursor;
 import io.questdb.std.ObjList;
@@ -64,7 +67,7 @@ public class TableSequencerImplTest extends AbstractCairoTest {
                         TableToken tableToken = engine.verifyTableName(tableName);
                         do {
                             engine.getTableSequencerAPI().getTableMetadata(tableToken, metadata);
-                            Assert.assertEquals(metadata.getColumnCount() - initialColumnCount, metadata.getStructureVersion());
+                            Assert.assertEquals(metadata.getColumnCount() - initialColumnCount, metadata.getMetadataVersion());
                         } while (metadata.getColumnCount() < initialColumnCount + iterations && exception.get() == null);
                     } catch (Throwable e) {
                         exception.set(e);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -222,6 +222,44 @@ public class WalWriterTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testAlterAddChangeLag() throws Exception {
+        assertMemoryLeak(() -> {
+            TableToken tableToken = createTable(testName.getMethodName());
+            compile("alter table " + tableToken.getTableName() + " SET PARAM o3MaxLag = 20s");
+            compile("alter table " + tableToken.getTableName() + " add i2 int");
+
+            drainWalQueue();
+            Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
+        });
+    }
+
+    @Test
+    public void testAlterAddChangeMaxUncommitted() throws Exception {
+        assertMemoryLeak(() -> {
+            TableToken tableToken = createTable(testName.getMethodName());
+            compile("alter table " + tableToken.getTableName() + " set PARAM maxUncommittedRows = 20000");
+            compile("alter table " + tableToken.getTableName() + " add i2 int");
+
+            drainWalQueue();
+            Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
+        });
+    }
+
+    @Test
+    public void testAlterAddDropIndex() throws Exception {
+        assertMemoryLeak(() -> {
+            TableToken tableToken = createTable(testName.getMethodName());
+            compile("alter table " + tableToken.getTableName() + " add sym2 symbol");
+            compile("alter table " + tableToken.getTableName() + " alter column sym2 add index");
+            compile("alter table " + tableToken.getTableName() + " alter column sym2 drop index");
+            compile("alter table " + tableToken.getTableName() + " add i2 int");
+
+            drainWalQueue();
+            Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
+        });
+    }
+
+    @Test
     public void testAddingColumnClosesSegment() throws Exception {
         assertMemoryLeak(() -> {
             TableToken tableToken = createTable(testName.getMethodName());

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
@@ -807,7 +807,7 @@ public class SymbolCacheTest extends AbstractGriffinTest {
         }
 
         @Override
-        public long getStructureVersion() {
+        public long getMetadataVersion() {
             return 0;
         }
 

--- a/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
@@ -540,14 +540,14 @@ public class DropIndexTest extends AbstractGriffinTest {
             txReader.ofRO(path.concat(TXN_FILE_NAME).$(), partitionedBy);
             path.trimTo(pathLen);
             txReader.unsafeLoadAll();
-            Assert.assertEquals(expectedStructureVersion, txReader.getStructureVersion());
+            Assert.assertEquals(expectedStructureVersion, txReader.getMetadataVersion());
             Assert.assertEquals(expectedReaderVersion, txReader.getTxn());
             Assert.assertEquals(expectedReaderVersion, txReader.getVersion());
             Assert.assertEquals(expectedColumnVersion, txReader.getColumnVersion());
             try (TableReader reader = getReader(tableName)) {
                 TableReaderMetadata metadata = reader.getMetadata();
                 Assert.assertEquals(partitionedBy, metadata.getPartitionBy());
-                Assert.assertEquals(expectedStructureVersion, metadata.getStructureVersion());
+                Assert.assertEquals(expectedStructureVersion, metadata.getMetadataVersion());
                 int columnIndex = metadata.getColumnIndex(columnName);
                 Assert.assertEquals(isColumnIndexed, metadata.isColumnIndexed(columnIndex));
                 Assert.assertEquals(indexValueBlockSize, metadata.getIndexValueBlockCapacity(columnIndex));
@@ -558,7 +558,7 @@ public class DropIndexTest extends AbstractGriffinTest {
     private static long countFiles(String columnName, long txn, FileChecker fileChecker) throws IOException {
         TableToken tableToken = engine.verifyTableName(tableName);
         final java.nio.file.Path tablePath = FileSystems.getDefault().getPath(
-                (String) configuration.getRoot(),
+                configuration.getRoot(),
                 tableToken.getDirName()
         );
         try (Stream<?> stream = Files.find(

--- a/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
@@ -882,7 +882,7 @@ public class SnapshotTest extends AbstractGriffinTest {
                             Assert.assertEquals(metadata0.getTableId(), metadata.getTableId());
                             Assert.assertEquals(metadata0.getMaxUncommittedRows(), metadata.getMaxUncommittedRows());
                             Assert.assertEquals(metadata0.getO3MaxLag(), metadata.getO3MaxLag());
-                            Assert.assertEquals(metadata0.getStructureVersion(), metadata.getStructureVersion());
+                            Assert.assertEquals(metadata0.getMetadataVersion(), metadata.getMetadataVersion());
 
                             for (int i = 0, n = metadata0.getColumnCount(); i < n; i++) {
                                 TableColumnMetadata columnMetadata0 = metadata0.getColumnMetadata(i);
@@ -905,7 +905,7 @@ public class SnapshotTest extends AbstractGriffinTest {
                                     Assert.assertEquals(txReader0.getFixedRowCount(), txReader1.getFixedRowCount());
                                     Assert.assertEquals(txReader0.getMinTimestamp(), txReader1.getMinTimestamp());
                                     Assert.assertEquals(txReader0.getMaxTimestamp(), txReader1.getMaxTimestamp());
-                                    Assert.assertEquals(txReader0.getStructureVersion(), txReader1.getStructureVersion());
+                                    Assert.assertEquals(txReader0.getMetadataVersion(), txReader1.getMetadataVersion());
                                     Assert.assertEquals(txReader0.getDataVersion(), txReader1.getDataVersion());
                                     Assert.assertEquals(txReader0.getPartitionTableVersion(), txReader1.getPartitionTableVersion());
                                     Assert.assertEquals(1, txReader0.getTruncateVersion());

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -269,7 +269,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
                     if (!walWriter.goActive(transaction.structureVersion)) {
                         throw CairoException.critical(0).put("cannot apply structure change");
                     }
-                    if (walWriter.getStructureVersion() != transaction.structureVersion) {
+                    if (walWriter.getMetadataVersion() != transaction.structureVersion) {
                         throw CairoException.critical(0)
                                 .put("cannot update wal writer to correct structure version");
                     }


### PR DESCRIPTION
Wal tables are suspended after `alter table set param` or `alter table add / drop index`

```
ALTER TABLE t SET PARAM o3MaxLag=100s
```

These `alter table` commands do not change column structure but create a new version of the table `metadata` file. The fix is to keep 2 values in `_txn` file instead of current 64bit `structureVersion`

- metadata version (low 32bit)
- column structure version (high 32bit)

The metadata version changes with every change to `_meta` file. Column structure version changes on add/drop/rename columns only.  Both values are packed into the same 64 bits  of `_txn` where previously `structureVersion` was stored. For backward compatibility, when then new `column structure version` is 0, it treated as it is the same as `metadata version`.
