### PR TITLE
fix(core): fix column not found error after column rename

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3591,6 +3591,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             } else {
                 long columnNameTxn = columnVersionWriter.getColumnNameTxn(txWriter.getLastPartitionTimestamp(), columnIndex);
                 hardLinkAndPurgeColumnFiles(columnName, columnIndex, columnType, newName, txWriter.getLastPartitionTimestamp(), -1L, newColumnNameTxn, columnNameTxn);
+                long columnTop = columnVersionWriter.getColumnTop(txWriter.getLastPartitionTimestamp(), columnIndex);
+                columnVersionWriter.upsert(txWriter.getLastPartitionTimestamp(), columnIndex, newColumnNameTxn, columnTop);
             }
 
             if (ColumnType.isSymbol(columnType)) {


### PR DESCRIPTION
The PR fixes the column version not set when the column is renamed. Specific to non-partitioned tables only.

Found by fuzz test runs.

```
io.questdb.griffin.SqlException: [0] [2]: could not open read-only [file=/tmp/junit1029390315418332203/dbRoot/y~/default/new_col_17.d.14]
	at io.questdb.griffin.SqlException.position(SqlException.java:107)
	at io.questdb.griffin.SqlOptimiser.openReaderAndEnumerateColumns(SqlOptimiser.java:2496)
	at io.questdb.griffin.SqlOptimiser.enumerateTableColumns(SqlOptimiser.java:1770)
	at io.questdb.griffin.SqlOptimiser.enumerateTableColumns(SqlOptimiser.java:1775)
	at io.questdb.griffin.SqlOptimiser.optimise(SqlOptimiser.java:4646)
	at io.questdb.griffin.SqlCompiler.compileExecutionModel0(SqlCompiler.java:1172)
	at io.questdb.griffin.SqlCompiler.compileExecutionModel(SqlCompiler.java:1161)
	at io.questdb.griffin.SqlCompiler.compileUsingModel(SqlCompiler.java:1244)
	at io.questdb.griffin.SqlCompiler.compileInner(SqlCompiler.java:1213)
	at io.questdb.griffin.SqlCompiler.compile(SqlCompiler.java:207)
	at io.questdb.test.tools.TestUtils.assertEquals(TestUtils.java:425)
	at io.questdb.test.griffin.O3MaxLagFuzzTest.testFuzz00(O3MaxLagFuzzTest.java:149)
	at io.questdb.test.griffin.O3MaxLagFuzzTest.testFuzz0(O3MaxLagFuzzTest.java:158)
```