### PR TITLE
fix(sql): fix splice join validation

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -1662,7 +1662,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     releaseSlave = false;
                                     validateBothTimestampOrders(master, slave, slaveModel.getJoinKeywordPosition());
                                 } else {
-                                    assert false;
+                                    if (!master.recordCursorSupportsRandomAccess()) {
+                                        throw SqlException.position(slaveModel.getJoinKeywordPosition()).put("left side of splice join doesn't support random access");
+                                    } else if (!slave.recordCursorSupportsRandomAccess()) {
+                                        throw SqlException.position(slaveModel.getJoinKeywordPosition()).put("right side of splice join doesn't support random access");
+                                    } else {
+                                        throw SqlException.position(slaveModel.getJoinKeywordPosition()).put("splice join doesn't support full fat mode");
+                                    }
                                 }
                                 break;
                             default:


### PR DESCRIPTION
Change makes sql compiler reject splice join over subqueries that don't support random access.

Example:

```sql
CREATE TABLE trade 
(
  ts TIMESTAMP,
  instrument SYMBOL,
  price DOUBLE,
  qty DOUBLE
) timestamp (ts) PARTITION BY MONTH;

SELECT *
FROM
(
  SELECT ts, SUM(price * qty) / SUM(qty) sm
  FROM trade 
  WHERE instrument = 'A'
  SAMPLE by 5m ALIGN TO CALENDAR
)
SPLICE JOIN trade;
```

now produces `left side of splice join doesn't support random access` error message instead of internal error with following stack trace : 

2023-05-22T11:17:33.975794Z C i.q.c.h.p.JsonQueryProcessorState [25] Uh-oh. Error!
2023-05-22 13:17:33 java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 16
2023-05-22 13:17:33 at io.questdb.std.ObjList.getQuick(ObjList.java:174)
2023-05-22 13:17:33 at io.questdb.cairo.AbstractRecordMetadata.getColumnMetadata(AbstractRecordMetadata.java:63)
2023-05-22 13:17:33 at io.questdb.cairo.AbstractRecordMetadata.getColumnType(AbstractRecordMetadata.java:73)
2023-05-22 13:17:33 at io.questdb.griffin.SqlCodeGenerator.generateSelectChoose(SqlCodeGenerator.java:2984)
2023-05-22 13:17:33 at io.questdb.griffin.SqlCodeGenerator.generateSelect(SqlCodeGenerator.java:2663)
2023-05-22 13:17:33 at io.questdb.griffin.SqlCodeGenerator.generateQuery0(SqlCodeGenerator.java:2272)
2023-05-22 13:17:33 at io.questdb.griffin.SqlCodeGenerator.generateQuery(SqlCodeGenerator.java:2259)
...

Actual stack trace depends on whether assertion checking is enabled   