### PR TITLE
fix(sql): fix disconnect on sql case statement with one condition and no else 

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -1977,6 +1977,12 @@ public class SqlParser {
             } else {
                 node.args.remove(paramCount - 1);
                 node.paramCount = paramCount - 1;
+
+                if (node.paramCount < 3) {
+                    node.rhs = node.args.get(0);
+                    node.lhs = node.args.get(1);
+                    node.args.clear();
+                }
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/model/ExpressionNode.java
+++ b/core/src/main/java/io/questdb/griffin/model/ExpressionNode.java
@@ -206,22 +206,22 @@ public class ExpressionNode implements Mutable, Sinkable {
             case 1:
                 sink.put(token);
                 sink.put('(');
-                rhs.toSink(sink);
+                toSink(sink, rhs);
                 sink.put(')');
                 break;
             case 2:
                 if (OperatorExpression.isOperator(token)) {
-                    lhs.toSink(sink);
+                    toSink(sink, lhs);
                     sink.put(' ');
                     sink.put(token);
                     sink.put(' ');
-                    rhs.toSink(sink);
+                    toSink(sink, rhs);
                 } else {
                     sink.put(token);
                     sink.put('(');
-                    lhs.toSink(sink);
+                    toSink(sink, lhs);
                     sink.put(',');
-                    rhs.toSink(sink);
+                    toSink(sink, rhs);
                     sink.put(')');
                 }
                 break;
@@ -229,7 +229,7 @@ public class ExpressionNode implements Mutable, Sinkable {
                 int n = args.size();
                 if (OperatorExpression.isOperator(token) && n > 0) {
                     // special case for "in"
-                    args.getQuick(n - 1).toSink(sink);
+                    toSink(sink, args.getQuick(n - 1));
                     sink.put(' ');
                     sink.put(token);
                     sink.put(' ');
@@ -238,7 +238,7 @@ public class ExpressionNode implements Mutable, Sinkable {
                         if (i < n - 2) {
                             sink.put(',');
                         }
-                        args.getQuick(i).toSink(sink);
+                        toSink(sink, args.getQuick(i));
                     }
                     sink.put(')');
                 } else {
@@ -248,7 +248,7 @@ public class ExpressionNode implements Mutable, Sinkable {
                         if (i < n - 1) {
                             sink.put(',');
                         }
-                        args.getQuick(i).toSink(sink);
+                        toSink(sink, args.getQuick(i));
                     }
                     sink.put(')');
                 }
@@ -299,6 +299,14 @@ public class ExpressionNode implements Mutable, Sinkable {
             }
         }
         return true;
+    }
+
+    private static void toSink(CharSink sink, ExpressionNode e) {
+        if (e == null) {
+            sink.put("null");
+        } else {
+            e.toSink(sink);
+        }
     }
 
     public static final class ExpressionNodeFactory implements ObjectFactory<ExpressionNode> {

--- a/core/src/main/java/io/questdb/log/Logger.java
+++ b/core/src/main/java/io/questdb/log/Logger.java
@@ -167,7 +167,18 @@ public final class Logger implements LogRecord, Log {
 
     @Override
     public LogRecord $(Object x) {
-        sink().put(x == null ? "null" : x.toString());
+        if (x == null) {
+            sink().put("null");
+        } else {
+            try {
+                sink().put(x.toString());
+            } catch (Throwable t) {
+                // Complex toString() method could throw e.g. NullPointerException.
+                // If that happens, we've to release cursor to prevent blocking log queue.
+                $();
+                throw t;
+            }
+        }
         return this;
     }
 
@@ -176,7 +187,14 @@ public final class Logger implements LogRecord, Log {
         if (x == null) {
             sink().put("null");
         } else {
-            x.toSink(sink());
+            try {
+                x.toSink(sink());
+            } catch (Throwable t) {
+                // Complex toSink() method could throw e.g. NullPointerException.
+                // If that happens, we've to release cursor to prevent blocking log queue.
+                $();
+                throw t;
+            }
         }
         return this;
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.conditional;
 
+import io.questdb.griffin.SqlException;
 import io.questdb.test.AbstractGriffinTest;
 import org.junit.Test;
 
@@ -325,6 +326,44 @@ public class CaseFunctionFactoryTest extends AbstractGriffinTest {
                 true,
                 true
         );
+    }
+
+    @Test
+    public void testCaseWithNoElseInSelectClause() throws SqlException {
+        assertQuery("c\n0\nNaN\nNaN\n",
+                "select case x when 1 then 0 end c from long_sequence(3)", null, true, true);
+
+        assertQuery("c\nNaN\nNaN\nNaN\n",
+                "select case x when -1 then 0 end c from long_sequence(3)", null, true, true);
+
+        assertQuery("c\n0\n0\n0\n",
+                "select case when x<5 then 0 end c from long_sequence(3)", null, true, true);
+
+        assertQuery("c\n0\nNaN\nNaN\n",
+                "select case when x<2 then 0 end c from long_sequence(3)", null, true, true);
+
+        assertQuery("c\n1\n",
+                "select case when true then 1 end c", null, true, true);
+
+        assertQuery("c\nNaN\n",
+                "select case when false then 2 end c", null, true, true);
+    }
+
+    @Test
+    public void testCaseWithNoElseInWhereClause() throws Exception {
+        assertFailure("select x from long_sequence(3) where case x when 1 then 0 end", null, 37, "boolean expression expected");
+
+        assertQuery("x\n1\n",
+                "select x from long_sequence(3) where case when x<2 then true end", null, true, false);
+
+        assertQuery("x\n1\n2\n",
+                "select x from long_sequence(3) where case when x<3 then true else false end", null, true, false);
+
+        assertQuery("x\n1\n",
+                "select x from long_sequence(3) where case when x<2 then true when x<3 then false end", null, true, false);
+
+        assertQuery("x\n",
+                "select x from long_sequence(3) where case when false then true end", null, false, false);
     }
 
     @Test


### PR DESCRIPTION
Fixes #3376
Fixes #3297

PR fixes internal exception and disconnect happening when executing sql with case that has on condition and no else clause. 
It also catches and releases sequence/cursor on any exception in $(Object) and $(Sinkable) methods to avoid blocking the log message queue.