### PR TITLE
fix(sql): improve error reporting on non-boolean join conditions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -182,6 +182,20 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         throw SqlException.$(expr.position, "boolean expression expected");
     }
 
+    @NotNull
+    public Function compileJoinFilter(
+            ExpressionNode expr,
+            JoinRecordMetadata metadata,
+            SqlExecutionContext executionContext
+    ) throws SqlException {
+        try {
+            return compileBooleanFilter(expr, metadata, executionContext);
+        } catch (Throwable t) {
+            Misc.free(metadata);
+            throw t;
+        }
+    }
+
     public RecordCursorFactory generate(QueryModel model, SqlExecutionContext executionContext) throws SqlException {
         return generateQuery(model, executionContext, true);
     }
@@ -1509,7 +1523,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             case JOIN_CROSS_LEFT:
                                 assert slaveModel.getOuterJoinExpressionClause() != null;
                                 joinMetadata = createJoinMetadata(masterAlias, masterMetadata, slaveModel.getName(), slaveMetadata);
-                                filter = functionParser.parseFunction(slaveModel.getOuterJoinExpressionClause(), joinMetadata, executionContext);
+                                filter = compileJoinFilter(slaveModel.getOuterJoinExpressionClause(), joinMetadata, executionContext);
 
                                 master = new NestedLoopLeftJoinRecordCursorFactory(
                                         joinMetadata,
@@ -1676,7 +1690,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                                 joinMetadata = createJoinMetadata(masterAlias, masterMetadata, slaveModel.getName(), slaveMetadata);
                                 if (slaveModel.getOuterJoinExpressionClause() != null) {
-                                    filter = functionParser.parseFunction(slaveModel.getOuterJoinExpressionClause(), joinMetadata, executionContext);
+                                    filter = compileJoinFilter(slaveModel.getOuterJoinExpressionClause(), joinMetadata, executionContext);
                                 }
 
                                 if (joinType == JOIN_OUTER &&
@@ -1715,9 +1729,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 ExpressionNode filterExpr = slaveModel.getPostJoinWhereClause();
                 if (filterExpr != null) {
                     if (executionContext.isParallelFilterEnabled() && master.supportPageFrameCursor()) {
-                        final Function filter = compileBooleanFilter(
+                        final Function filter = compileJoinFilter(
                                 filterExpr,
-                                master.getMetadata(),
+                                (JoinRecordMetadata) master.getMetadata(),
                                 executionContext
                         );
 
@@ -1742,7 +1756,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     } else {
                         master = new FilteredRecordCursorFactory(
                                 master,
-                                functionParser.parseFunction(filterExpr, master.getMetadata(), executionContext)
+                                compileJoinFilter(filterExpr, (JoinRecordMetadata) master.getMetadata(), executionContext)
                         );
                     }
                 }


### PR DESCRIPTION
Fixes #3386

PR makes compiler reject non-boolean join filters, e.g. 

```sql
create table a ( ts timestamp, i int) timestamp(ts);
create table b ( ts timestamp, i int) timestamp(ts);

select * from a left join b on a.i - b.i;
select * from a join b on a.ts = b.ts and a.i - b.i;
```

Queries above now return `boolean expression expected` during compilation instead of `UnsupportedOperationException` during query execution.
