### PR TITLE
chore(core): replace table name reserved error with table does not exist in some cases

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -413,7 +413,7 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     public TableReader getReader(CharSequence tableName) {
-        return getReader(verifyTableName(tableName));
+        return getReader(verifyTableNameForRead(tableName));
     }
 
     public TableReader getReader(TableToken tableToken) {
@@ -519,7 +519,7 @@ public class CairoEngine implements Closeable, WriterSource {
 
     @Override
     public TableWriterAPI getTableWriterAPI(CharSequence tableName, String lockReason) {
-        return getTableWriterAPI(verifyTableName(tableName), lockReason);
+        return getTableWriterAPI(verifyTableNameForRead(tableName), lockReason);
     }
 
     public Telemetry<TelemetryTask> getTelemetry() {
@@ -690,12 +690,6 @@ public class CairoEngine implements Closeable, WriterSource {
     @TestOnly
     public void reloadTableNames(ObjList<TableToken> convertedTables) {
         tableNameRegistry.reloadTableNameCache(convertedTables);
-    }
-
-    public int removeDirectory(@Transient Path path, CharSequence dir) {
-        path.of(configuration.getRoot()).concat(dir);
-        final FilesFacade ff = configuration.getFilesFacade();
-        return ff.rmdir(path.slash$());
     }
 
     public void removeTableToken(TableToken tableToken) {
@@ -917,6 +911,15 @@ public class CairoEngine implements Closeable, WriterSource {
                     .put("invalid table name [table=").putAsPrintable(tableName)
                     .put(']');
         }
+    }
+
+    @NotNull
+    private TableToken verifyTableNameForRead(CharSequence tableName) {
+        TableToken token = getTableTokenIfExists(tableName);
+        if (token == null || token == TableNameRegistry.LOCKED_TOKEN) {
+            throw CairoException.tableDoesNotExist(tableName);
+        }
+        return token;
     }
 
     private class EngineMaintenanceJob extends SynchronizedJob {


### PR DESCRIPTION
To address test failure and to generally remove table reserved error which only makes sense on concurrent table create but does not make sense on reading or writing to the table.

```
2023-05-25T23:35:09.758329Z E i.q.t.c.l.t.LineTcpReceiverFuzzTest 
io.questdb.cairo.CairoException: [-1] table name is reserved [table=weather0]
	at io.questdb.cairo.CairoException.critical(CairoException.java:62)
	at io.questdb.cairo.CairoException.nonCritical(CairoException.java:114)
	at io.questdb.cairo.CairoEngine.verifyTableName(CairoEngine.java:802)
	at io.questdb.cairo.CairoEngine.getReader(CairoEngine.java:416)
	at io.questdb.test.AbstractCairoTest.getReader(AbstractCairoTest.java:449)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.checkTable(AbstractLineTcpReceiverFuzzTest.java:326)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.waitForTable(AbstractLineTcpReceiverFuzzTest.java:596)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.waitDone(AbstractLineTcpReceiverFuzzTest.java:583)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.lambda$runTest$2(AbstractLineTcpReceiverFuzzTest.java:527)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.lambda$runInContext$2(AbstractLineTcpReceiverTest.java:299)
	at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$4(AbstractCairoTest.java:285)
	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:540)
	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:282)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:291)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:315)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.runTest(AbstractLineTcpReceiverFuzzTest.java:511)
	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.runTest(AbstractLineTcpReceiverFuzzTest.java:484)
	at io.questdb.test.cutlass.line.tcp.LineTcpReceiverFuzzTest.testLoad(LineTcpReceiverFuzzTest.java:99)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.lang.Thread.run(Thread.java:829)

```