### PR TITLE
chore(core): avoid type pollution in WalWriter

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.vm.Vm;
-import io.questdb.cairo.vm.api.MemoryA;
 import io.questdb.cairo.vm.api.MemoryMA;
 import io.questdb.cairo.vm.api.MemoryMAR;
 import io.questdb.cairo.vm.api.NullMemory;
@@ -552,7 +551,7 @@ public class WalWriter implements TableWriterAPI {
         this.tableToken = tableToken;
     }
 
-    private static void configureNullSetters(ObjList<Runnable> nullers, int type, MemoryA mem1, MemoryA mem2) {
+    private static void configureNullSetters(ObjList<Runnable> nullers, int type, MemoryMA mem1, MemoryMA mem2) {
         switch (ColumnType.tagOf(type)) {
             case ColumnType.BOOLEAN:
             case ColumnType.BYTE:
@@ -1755,7 +1754,7 @@ public class WalWriter implements TableWriterAPI {
 
         @Override
         public void putLong128(int columnIndex, long lo, long hi) {
-            MemoryA primaryColumn = getPrimaryColumn(columnIndex);
+            MemoryMA primaryColumn = getPrimaryColumn(columnIndex);
             primaryColumn.putLong(lo);
             primaryColumn.putLong(hi);
             setRowValueNotNull(columnIndex);
@@ -1860,11 +1859,11 @@ public class WalWriter implements TableWriterAPI {
             putLong128(columnIndex, uuid.getLo(), uuid.getHi());
         }
 
-        private MemoryA getPrimaryColumn(int columnIndex) {
+        private MemoryMA getPrimaryColumn(int columnIndex) {
             return columns.getQuick(getPrimaryColumnIndex(columnIndex));
         }
 
-        private MemoryA getSecondaryColumn(int columnIndex) {
+        private MemoryMA getSecondaryColumn(int columnIndex) {
             return columns.getQuick(getSecondaryColumnIndex(columnIndex));
         }
 


### PR DESCRIPTION
Based on the report collected with https://github.com/RedHatPerf/type-pollution-agent:
```
--------------------------
Type Pollution:
--------------------------
1:	io.questdb.cairo.vm.MemoryPMARImpl
Count:	60851191
Types:
	io.questdb.cairo.vm.api.MemoryA
	io.questdb.cairo.vm.api.MemoryMA
Traces:
	io.questdb.cairo.wal.WalWriter$RowImpl.getPrimaryColumn(WalWriter.java:1864)
		class: io.questdb.cairo.vm.api.MemoryA
		count: 30427173
	io.questdb.cairo.wal.WalWriter.getPrimaryColumn(WalWriter.java:1023)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 30413843
	io.questdb.cairo.TableWriter.getPrimaryColumn(TableWriter.java:3540)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 3990
	io.questdb.cairo.TableWriter.closeAppendMemoryTruncate(TableWriter.java:2841)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 1838
	io.questdb.cairo.O3PartitionJob.publishOpenColumnTasks(O3PartitionJob.java:1028)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 1727
	io.questdb.cairo.TableWriter.o3MoveWalFromFilesToLastPartition(TableWriter.java:4703)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 1156
	io.questdb.cairo.TableWriter.o3MergeFixColumnLag(TableWriter.java:4219)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 952
	io.questdb.cairo.TableWriter.isLastPartitionClosed(TableWriter.java:3701)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 208
	io.questdb.cairo.TableWriter.processO3Block(TableWriter.java:5623)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 152
	io.questdb.cairo.O3PartitionJob.processPartition(O3PartitionJob.java:180)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 84
	io.questdb.cairo.TableWriter.processWalBlock(TableWriter.java:1600)
		class: io.questdb.cairo.vm.api.MemoryMA
		count: 68
--------------------------
```

The report was collected while running TSBS ingestion benchmark over 2 workers. I haven't noticed any performance difference at least with such a low number of threads, however, it might be a good idea to keep this agent on our radar.

Here is the command I used to run the agent:
```bash
java -javaagent:agent/target/type-pollution-agent-0.1-SNAPSHOT.jar=io.questdb -p /home/puzpuzpuz/projects/questdb/core/target/questdb-7.1.4-SNAPSHOT.jar -m io.questdb/io.questdb.ServerMain -d /tmp/questdb
```