### PR TITLE
fix(core): increase max open files limit on MacOS

### DIFF
--- a/core/src/main/bin/questdb.sh
+++ b/core/src/main/bin/questdb.sh
@@ -180,8 +180,11 @@ function start {
     "
 
     if [ "$(uname)" == "Darwin" ]; then
-        N_MAX_OPEN_FILES=$(sysctl -n kern.maxfilesperproc)
-        ulimit -n $N_MAX_OPEN_FILES
+        # JVM on MacOS has its own max open files limit, set to 10240
+        # This limit can be removed by passing the -XX:-MaxFDLimit option
+        # However, if this built-in limit is removed, the JVM starts to use the soft limit as if it was the hard limit,
+        # so we should set the soft limit to the same value as the hard limit
+        ulimit -n $(ulimit -H -n)
         JAVA_OPTS="$JAVA_OPTS 
         -XX:-MaxFDLimit
         "

--- a/core/src/main/bin/questdb.sh
+++ b/core/src/main/bin/questdb.sh
@@ -57,11 +57,7 @@ function read_link {
 }
 
 function usage {
-    if [ "$(uname)" == "Darwin" ]; then
-        echo "Usage: $0 start|status|stop [-f] [-d path] [-t tag] [-mof max-open-files]"
-    else
-        echo "Usage: $0 start|status|stop [-f] [-d path] [-t tag]"
-    fi
+    echo "Usage: $0 start|status|stop [-f] [-d path] [-t tag]"
     echo
     exit 55
 }
@@ -136,15 +132,6 @@ function export_args {
                 export QDB_PROCESS_LABEL="QuestDB-Runtime-$2"
                 shift
                 ;;
-            -mof)
-                if [ "$(uname)" == "Darwin" ]; then
-                    export N_MAX_OPEN_FILES="$2"
-                else
-                    echo "Warning: the option $1 is valid only on MacOS."
-                    usage
-                fi
-                shift
-            ;;
             *)
                 echo "Unexpected option: $key"
                 usage
@@ -193,21 +180,8 @@ function start {
     "
 
     if [ "$(uname)" == "Darwin" ]; then
-        # echo "OS: $(uname)"
-        n_mof=$(sysctl -n kern.maxfilesperproc)
-        # echo "$n_mof"
-        if [ -z "$N_MAX_OPEN_FILES" ]; then
-            # echo "n_mof: $n_mof"
-            N_MAX_OPEN_FILES="$n_mof"
-        else
-            echo "N_MAX_OPEN_FILES: $N_MAX_OPEN_FILES"
-            if [ $n_mof -lt $N_MAX_OPEN_FILES ]; then
-                echo "Warning: the max number of open files should not exceed $N_MAX_OPEN_FILES. To modify this limit, please modify the system level configuration."
-                N_MAX_OPEN_FILES=$n_mof
-            fi
-        fi
+        N_MAX_OPEN_FILES=$(sysctl -n kern.maxfilesperproc)
         ulimit -n $N_MAX_OPEN_FILES
-        # echo "#Max-Open-Files: $(ulimit -n)"
         JAVA_OPTS="$JAVA_OPTS 
         -XX:-MaxFDLimit
         "


### PR DESCRIPTION
To fix the bug mentiend in the issue [#3405](https://github.com/questdb/questdb/issues/3405#issue-1727198171). QuestDB would reach the max number of open files when requesting a bunch of tables simultaneously. However, modify the system level configuration does not work. I add some code in questdb.sh so that #max-open-files can be configured on MacOS.