### PR TITLE
fix(sql): fix join column propagation

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2873,6 +2873,9 @@ public class SqlOptimiser {
                     emitLiteralsTopDown(jc.aNodes.getQuick(k), model);
                     emitLiteralsTopDown(jc.bNodes.getQuick(k), model);
 
+                    emitLiteralsTopDown(jc.aNodes.getQuick(k), jm);
+                    emitLiteralsTopDown(jc.bNodes.getQuick(k), jm);
+
                     if (papaModel != null) {
                         emitLiteralsTopDown(jc.aNodes.getQuick(k), papaModel);
                         emitLiteralsTopDown(jc.bNodes.getQuick(k), papaModel);


### PR DESCRIPTION
Fixes #3383 

Fixes propagation of join columns into join models when join columns aren't used  in outer query.  
