### PR TITLE
chore(core): authorizations for enable/disable user, add/remove pwd, create/drop jwk 

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -33,7 +33,19 @@ public interface SecurityContext {
     default void assumeRole(CharSequence roleName) {
     }
 
+    default void authorizeAddPassword() {
+    }
+
+    default void authorizeAddUser() {
+    }
+
     default void authorizeAlterTableAddColumn(TableToken tableToken) {
+    }
+
+    default void authorizeAlterTableAddIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
+    }
+
+    default void authorizeAlterTableAlterColumnCache(TableToken tableToken, ObjList<CharSequence> columnNames) {
     }
 
     default void authorizeAlterTableAttachPartition(TableToken tableToken) {
@@ -42,19 +54,13 @@ public interface SecurityContext {
     default void authorizeAlterTableDetachPartition(TableToken tableToken) {
     }
 
-    default void authorizeAlterTableDropPartition(TableToken tableToken) {
-    }
-
-    default void authorizeAlterTableAddIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
+    default void authorizeAlterTableDropColumn(TableToken tableToken, ObjList<CharSequence> columnNames) {
     }
 
     default void authorizeAlterTableDropIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
     }
 
-    default void authorizeAlterTableAlterColumnCache(TableToken tableToken, ObjList<CharSequence> columnNames) {
-    }
-
-    default void authorizeAlterTableDropColumn(TableToken tableToken, ObjList<CharSequence> columnNames) {
+    default void authorizeAlterTableDropPartition(TableToken tableToken) {
     }
 
     // the names are pairs from-to
@@ -64,13 +70,46 @@ public interface SecurityContext {
     default void authorizeAlterTableSetType(TableToken tableToken) {
     }
 
+    default void authorizeAssignRole() {
+    }
+
     default void authorizeCopy() {
     }
 
     default void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
     }
 
+    default void authorizeCreateGroup() {
+    }
+
+    default void authorizeCreateJwk() {
+    }
+
+    default void authorizeCreateRole() {
+    }
+
+    default void authorizeCreateUser() {
+    }
+
     default void authorizeDatabaseSnapshot() {
+    }
+
+    default void authorizeDisableUser() {
+    }
+
+    default void authorizeDropGroup() {
+    }
+
+    default void authorizeDropJwk() {
+    }
+
+    default void authorizeDropRole() {
+    }
+
+    default void authorizeDropUser() {
+    }
+
+    default void authorizeEnableUser() {
     }
 
     @SuppressWarnings("unused")
@@ -81,34 +120,10 @@ public interface SecurityContext {
     default void authorizeInsert(TableToken tableToken, ObjList<CharSequence> columnNames) {
     }
 
-    default void authorizeAddUser() {
+    default void authorizeRemovePassword() {
     }
 
     default void authorizeRemoveUser() {
-    }
-
-    default void authorizeAssignRole() {
-    }
-
-    default void authorizeUnassignRole() {
-    }
-
-    default void authorizeCreateGroup() {
-    }
-
-    default void authorizeDropGroup() {
-    }
-
-    default void authorizeCreateUser() {
-    }
-
-    default void authorizeDropUser() {
-    }
-
-    default void authorizeCreateRole() {
-    }
-
-    default void authorizeDropRole() {
     }
 
     default void authorizeSelect(TableToken tableToken, ObjList<CharSequence> columnNames) {
@@ -137,6 +152,9 @@ public interface SecurityContext {
     }
 
     default void authorizeTableVacuum(TableToken tableToken) {
+    }
+
+    default void authorizeUnassignRole() {
     }
 
     default void exitRole(CharSequence roleName) {

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -34,6 +34,31 @@ public class ReadOnlySecurityContext implements SecurityContext {
     public static final ReadOnlySecurityContext INSTANCE = new ReadOnlySecurityContext();
 
     @Override
+    public void authorizeAddPassword() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAddUser() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAlterTableAddColumn(TableToken tableToken) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAlterTableAddIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAlterTableAlterColumnCache(TableToken tableToken, ObjList<CharSequence> columnNames) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
     public void authorizeAlterTableAttachPartition(TableToken tableToken) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
@@ -44,32 +69,17 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeAlterTableDropPartition(TableToken tableToken) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeAlterTableAddColumn(TableToken tableToken) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public  void authorizeAlterTableAddIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public  void authorizeAlterTableDropIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public  void authorizeAlterTableAlterColumnCache(TableToken tableToken, ObjList<CharSequence> columnNames) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
     public void authorizeAlterTableDropColumn(TableToken tableToken, ObjList<CharSequence> columnNames) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAlterTableDropIndex(TableToken tableToken, ObjList<CharSequence> columnNames) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeAlterTableDropPartition(TableToken tableToken) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 
@@ -84,7 +94,7 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
+    public void authorizeAssignRole() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 
@@ -94,7 +104,62 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
+    public void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeCreateGroup() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeCreateJwk() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeCreateRole() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeCreateUser() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
     public void authorizeDatabaseSnapshot() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeDisableUser() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeDropGroup() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeDropJwk() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeDropRole() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeDropUser() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeEnableUser() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 
@@ -109,52 +174,12 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeAddUser() {
+    public void authorizeRemovePassword() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 
     @Override
     public void authorizeRemoveUser() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeAssignRole() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeUnassignRole() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeCreateGroup() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeDropGroup() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeCreateUser() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeDropUser() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeCreateRole() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeDropRole() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 
@@ -195,6 +220,11 @@ public class ReadOnlySecurityContext implements SecurityContext {
 
     @Override
     public void authorizeTableVacuum(TableToken tableToken) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeUnassignRole() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 }


### PR DESCRIPTION
It is hard to see because the files are reformatted, but the PR only adds 6 new authorize...() methods to the security context for enable/disable user, add/remove pwd, create/drop jwk.