### PR TITLE
fix(core): fix incorrect truncation of WAL table partition leading to read errors

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/MapWriter.java
@@ -27,7 +27,6 @@ package io.questdb.cairo;
 import io.questdb.cairo.vm.api.MemoryMA;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.MemoryTag;
-import io.questdb.std.Misc;
 import io.questdb.std.str.Path;
 
 import static io.questdb.cairo.TableUtils.charFileName;
@@ -45,13 +44,13 @@ public interface MapWriter extends SymbolCountProvider {
     ) {
         int plen = path.length();
         try {
-            mem.wholeFile(ff, offsetFileName(path.trimTo(plen), columnName, columnNameTxn), MemoryTag.MMAP_INDEX_WRITER);
+            mem.smallFile(ff, offsetFileName(path.trimTo(plen), columnName, columnNameTxn), MemoryTag.MMAP_INDEX_WRITER);
             mem.jumpTo(0);
             mem.putInt(symbolCapacity);
             mem.putBool(symbolCacheFlag);
             mem.jumpTo(SymbolMapWriter.HEADER_SIZE);
             mem.sync(false);
-            mem.close();
+            mem.close(false);
 
             if (!ff.touch(charFileName(path.trimTo(plen), columnName, columnNameTxn))) {
                 throw CairoException.critical(ff.errno()).put("Cannot create ").put(path);
@@ -62,7 +61,7 @@ public interface MapWriter extends SymbolCountProvider {
             mem.sync(false);
             ff.touch(BitmapIndexUtils.valueFileName(path.trimTo(plen), columnName, columnNameTxn));
         } finally {
-            Misc.free(mem);
+            mem.close(false);
             path.trimTo(plen);
         }
     }

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -1476,6 +1476,10 @@ public final class TableUtils {
                     symbolMapCount++;
                 }
             }
+            // truncate _meta file exactly, the file size never changes.
+            // Metadata updates are written to a new file and then swapped by renaming.
+            mem.close(true, Vm.TRUNCATE_TO_POINTER);
+
             mem.smallFile(ff, path.trimTo(rootLen).concat(TXN_FILE_NAME).$(), MemoryTag.MMAP_DEFAULT);
             createTxn(mem, symbolMapCount, 0L, 0L, INITIAL_TXN, 0L, 0L, 0L, 0L);
             mem.sync(false);

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -35,6 +35,8 @@ import io.questdb.std.FilesFacade;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.str.LPSZ;
 
+import static io.questdb.cairo.vm.Vm.PARANOIA_MODE;
+
 //contiguous mapped readable 
 public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
     private static final Log LOG = LogFactory.getLog(MemoryCMRImpl.class);
@@ -91,6 +93,7 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
                 throw CairoException.critical(ff.errno()).put("could not get length: ").put(name);
             }
         }
+        assert !PARANOIA_MODE || size <= ff.length(fd);
         map(ff, name, size);
     }
 

--- a/core/src/main/java/io/questdb/cairo/vm/Vm.java
+++ b/core/src/main/java/io/questdb/cairo/vm/Vm.java
@@ -35,6 +35,8 @@ public class Vm {
 
     public static final byte TRUNCATE_TO_PAGE = 0;
     public static final byte TRUNCATE_TO_POINTER = 1;
+    // Set to true to enable the assertion of pointers and buffer sizes which are too expensive for production.
+    public static final boolean PARANOIA_MODE = false;
 
     public static void bestEffortClose(FilesFacade ff, Log log, int fd, long size, byte truncateMode) {
         try {

--- a/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3FailureTest.java
@@ -682,7 +682,7 @@ public class O3FailureTest extends AbstractO3Test {
     @Test
     public void testFailOnResizingIndexContended() throws Exception {
         // this places break point on resize of key file
-        counter.set(152 + 12 + 20 + 19 + 8);
+        counter.set(152 + 12 + 20 + 19);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -1008,13 +1008,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTail() throws Exception {
-        counter.set(174 + 12 + 19 + 8);
+        counter.set(174 + 12 + 19);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailContended() throws Exception {
-        counter.set(174 + 12 + 19 + 8);
+        counter.set(174 + 12 + 19);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
@@ -1032,25 +1032,25 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOODataNotNullStrTailParallel() throws Exception {
-        counter.set(174 + 45 + 12 + 27 + 12);
+        counter.set(174 + 45 + 12 + 27);
         executeWithPool(2, O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODatThenRegularAppend() throws Exception {
-        counter.set(165 + 45 + 12 + 21 + 9);
+        counter.set(165 + 45 + 12 + 21);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODatThenRegularAppend0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOOData() throws Exception {
-        counter.set(165 + 45 + 12 + 18 + 8);
+        counter.set(165 + 45 + 12 + 18);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataContended() throws Exception {
-        counter.set(165 + 45 + 12 + 21 + 9);
+        counter.set(165 + 45 + 12 + 21);
         executeWithPool(0, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
@@ -1116,13 +1116,13 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallel() throws Exception {
-        counter.set(193 + 45 + 18 + 27 + 12);
+        counter.set(193 + 45 + 18 + 27);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetry0, ffAllocateFailure);
     }
 
     @Test
     public void testPartitionedDataAppendOOPrependOODataParallelNoReopen() throws Exception {
-        counter.set(176 + 45 + 18 + 26 + 12);
+        counter.set(176 + 45 + 18 + 26);
         executeWithPool(4, O3FailureTest::testPartitionedDataAppendOOPrependOODataFailRetryNoReopen, ffAllocateFailure);
     }
 
@@ -1197,7 +1197,7 @@ public class O3FailureTest extends AbstractO3Test {
 
     @Test
     public void testSetAppendPositionFails() throws Exception {
-        counter.set(169 + 12 + 20 + 19 + 8);
+        counter.set(169 + 12 + 20);
         executeWithoutPool(O3FailureTest::testPartitionedDataAppendOODataNotNullStrTailFailRetry0, ffAllocateFailure);
     }
 


### PR DESCRIPTION
Fix WAL table writing bug which can lead to incorrect partition data truncation. This then manifests in the reading error similar to

```
java.lang.InternalError: a fault occurred in a recent unsafe memory access operation in compiled Java code
```

The issue was that Table Writer did not advance column files truncate positions under certain circumstances before switching to the next partition while applying WAL. This results in the incorrect trimming of the partition and if the trimming difference is bigger than File page size it leads to read errors like the one listed above.