### PR TITLE
feat(sql): add string comparison operator

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrFunctionFactory.java
@@ -37,6 +37,7 @@ import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
 public class EqStrFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
         return "=(SS)";
@@ -48,14 +49,20 @@ public class EqStrFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         // there are optimisation opportunities
         // 1. when one of args is constant null comparison can boil down to checking
         //    length of non-constant (must be -1)
         // 2. when one of arguments is constant, save method call and use a field
 
-        Function a = args.getQuick(0);
-        Function b = args.getQuick(1);
+        final Function a = args.getQuick(0);
+        final Function b = args.getQuick(1);
 
         if (a.isConstant() && !b.isConstant()) {
             return createHalfConstantFunc(a, b);
@@ -134,7 +141,6 @@ public class EqStrFunctionFactory implements FunctionFactory {
             } else {
                 return "=";
             }
-
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtCharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtCharFunctionFactory.java
@@ -73,9 +73,8 @@ public class LtCharFunctionFactory implements FunctionFactory {
 
         @Override
         public boolean getBool(Record rec) {
-            char left = this.left.getChar(rec);
-            char right = this.right.getChar(rec);
-
+            final char left = this.left.getChar(rec);
+            final char right = this.right.getChar(rec);
             if (left == CHAR_NULL || right == CHAR_NULL) {
                 return false;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrFunctionFactory.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class LtStrFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "<(SS)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        final Function a = args.getQuick(0);
+        final Function b = args.getQuick(1);
+        if (a.isConstant() && !b.isConstant()) {
+            CharSequence constValue = a.getStr(null);
+            if (constValue == null) {
+                return BooleanConstant.FALSE;
+            }
+            return new ConstOnLeftFunc(constValue, b);
+        }
+        if (!a.isConstant() && b.isConstant()) {
+            CharSequence constValue = b.getStr(null);
+            if (constValue == null) {
+                return BooleanConstant.FALSE;
+            }
+            return new ConstOnRightFunc(a, constValue);
+        }
+        return new Func(a, b);
+    }
+
+    private static class ConstOnLeftFunc extends NegatableBooleanFunction implements UnaryFunction {
+        private final CharSequence constant;
+        private final Function right;
+
+        public ConstOnLeftFunc(CharSequence constant, Function right) {
+            this.constant = constant;
+            this.right = right;
+        }
+
+        @Override
+        public Function getArg() {
+            return right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            final CharSequence r = right.getStrB(rec);
+            if (r == null) {
+                return false;
+            }
+            return negated == (Chars.compare(constant, r) >= 0);
+        }
+
+        @Override
+        public String getName() {
+            if (negated) {
+                return ">=";
+            } else {
+                return "<";
+            }
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(constant);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val("<");
+            }
+            sink.val(right);
+        }
+    }
+
+    private static class ConstOnRightFunc extends NegatableBooleanFunction implements UnaryFunction {
+        private final CharSequence constant;
+        private final Function left;
+
+        public ConstOnRightFunc(Function left, CharSequence constant) {
+            this.left = left;
+            this.constant = constant;
+        }
+
+        @Override
+        public Function getArg() {
+            return left;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            final CharSequence l = left.getStrB(rec);
+            if (l == null) {
+                return false;
+            }
+            return negated == (Chars.compare(l, constant) >= 0);
+        }
+
+        @Override
+        public String getName() {
+            if (negated) {
+                return ">=";
+            } else {
+                return "<";
+            }
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(left);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val("<");
+            }
+            sink.val(constant);
+        }
+    }
+
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function left;
+        private final Function right;
+
+        public Func(Function left, Function right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            // important to compare A and B strings in case
+            // these are columns of the same record
+            // records have re-usable character sequences
+            final CharSequence l = left.getStr(rec);
+            final CharSequence r = right.getStrB(rec);
+            if (l == null || r == null) {
+                return false;
+            }
+            return negated == (Chars.compare(l, r) >= 0);
+        }
+
+        @Override
+        public Function getLeft() {
+            return left;
+        }
+
+        @Override
+        public String getName() {
+            if (negated) {
+                return ">=";
+            } else {
+                return "<";
+            }
+        }
+
+        @Override
+        public Function getRight() {
+            return right;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(left);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val('<');
+            }
+            sink.val(right);
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -163,6 +163,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory,
+            io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtLong256FunctionFactory,
 

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -77,6 +77,7 @@ io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory
+io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtLong256FunctionFactory
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -7138,6 +7138,84 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testStrAndNullComparisonInFilter() throws Exception {
+        assertQuery(
+                "res\n",
+                "SELECT 1 as res FROM x WHERE x.b > NULL LIMIT 1;",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from long_sequence(5)" +
+                        ") timestamp(k) partition by DAY",
+                null,
+                true,
+                false
+        );
+    }
+
+    @Test
+    public void testStrAndNullComparisonInSelect() throws Exception {
+        assertQuery(
+                "column\n" +
+                        "false\n",
+                "SELECT x.b > NULL FROM x LIMIT 1;",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from long_sequence(5)" +
+                        ") timestamp(k) partition by DAY",
+                null,
+                true,
+                false
+        );
+    }
+
+    @Test
+    public void testStrComparisonInSelect() throws Exception {
+        assertQuery(
+                "a\tb\tcolumn\tcolumn1\tcolumn2\tcolumn3\tcolumn4\tcolumn5\n" +
+                        "TJ\tCP\tfalse\ttrue\tfalse\ttrue\ttrue\tfalse\n" +
+                        "WH\tRX\tfalse\ttrue\tfalse\ttrue\tfalse\ttrue\n" +
+                        "EH\tRX\ttrue\tfalse\ttrue\tfalse\tfalse\ttrue\n" +
+                        "ZS\tUX\tfalse\ttrue\tfalse\ttrue\tfalse\ttrue\n" +
+                        "BB\tGP\ttrue\tfalse\ttrue\tfalse\ttrue\tfalse\n" +
+                        "WF\tYU\ttrue\tfalse\tfalse\ttrue\tfalse\ttrue\n" +
+                        "EY\tQE\ttrue\tfalse\ttrue\tfalse\ttrue\tfalse\n" +
+                        "BH\tOW\ttrue\tfalse\ttrue\tfalse\ttrue\tfalse\n" +
+                        "PD\tYS\ttrue\tfalse\ttrue\tfalse\tfalse\ttrue\n" +
+                        "EO\tOJ\ttrue\tfalse\ttrue\tfalse\ttrue\tfalse\n" +
+                        "HR\tED\tfalse\ttrue\ttrue\tfalse\ttrue\tfalse\n" +
+                        "QQ\tLO\tfalse\ttrue\tfalse\ttrue\ttrue\tfalse\n" +
+                        "JG\tTJ\ttrue\tfalse\ttrue\tfalse\tfalse\ttrue\n" +
+                        "\t\tfalse\tfalse\tfalse\tfalse\tfalse\tfalse\n" +
+                        "SR\tRF\tfalse\ttrue\tfalse\ttrue\tfalse\ttrue\n" +
+                        "VT\tHG\tfalse\ttrue\tfalse\ttrue\ttrue\tfalse\n" +
+                        "\tZZ\tfalse\tfalse\tfalse\tfalse\tfalse\ttrue\n" +
+                        "DZ\tMY\ttrue\tfalse\ttrue\tfalse\ttrue\tfalse\n" +
+                        "CC\tZO\ttrue\tfalse\ttrue\tfalse\tfalse\ttrue\n" +
+                        "IC\tEK\tfalse\ttrue\ttrue\tfalse\ttrue\tfalse\n",
+                "SELECT a, b, a < b, a > b, a < 'QQ', a >= 'QQ', b < 'QQ', b >= 'QQ' FROM x;",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_str(2,2,5) a," +
+                        " rnd_str(2,2,5) b," +
+                        " timestamp_sequence(0, 100000000000) k" +
+                        " from long_sequence(20)" +
+                        ") timestamp(k) partition by DAY",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testStrippingRowId() throws Exception {
         assertMemoryLeak(() -> {
             compiler.compile("create table x (a int)", sqlExecutionContext);

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -7151,7 +7151,7 @@ public class SqlCodeGeneratorTest extends AbstractGriffinTest {
                         " from long_sequence(5)" +
                         ") timestamp(k) partition by DAY",
                 null,
-                true,
+                false,
                 false
         );
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/LtStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/LtStrFunctionFactoryTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.lt;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.constants.StrConstant;
+import io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class LtStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
+    @Test
+    public void testAll() throws SqlException {
+        call("a", "z").andAssert(true);
+        call("B", "B").andAssert(false);
+        call("aaaa zzzz", "aaaa aaaa").andAssert(false);
+        call("foobar", "foobarbaz").andAssert(true);
+        final CharSequence nullStr = StrConstant.NULL.getStr(null);
+        call(nullStr, "7").andAssert(false);
+        call("0", nullStr).andAssert(false);
+        call(nullStr, nullStr).andAssert(false);
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new LtStrFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
@@ -29,7 +29,10 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
 import io.questdb.cairo.sql.async.PageFrameSequence;
-import io.questdb.griffin.*;
+import io.questdb.griffin.QueryFutureUpdateListener;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.analytic.AnalyticContext;
 import io.questdb.griffin.engine.table.AsyncFilteredRecordCursorFactory;
 import io.questdb.griffin.engine.table.AsyncJitFilteredRecordCursorFactory;
@@ -831,11 +834,6 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
         }
 
         @Override
-        public @NotNull SecurityContext getSecurityContext() {
-            return sqlExecutionContext.getSecurityContext();
-        }
-
-        @Override
         public @NotNull SqlExecutionCircuitBreaker getCircuitBreaker() {
             return sqlExecutionContext.getCircuitBreaker();
         }
@@ -873,6 +871,11 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractGriffinTest {
         @Override
         public long getRequestFd() {
             return sqlExecutionContext.getRequestFd();
+        }
+
+        @Override
+        public @NotNull SecurityContext getSecurityContext() {
+            return sqlExecutionContext.getSecurityContext();
         }
 
         @Override


### PR DESCRIPTION
Fixes #3454

Adds support for string comparison operator, so the following queries are now possible:
```sql
SELECT 'abc' < 'def'
FROM my_table
WHERE str_col_1 >= str_col_2;
```