### PR TITLE
fix(core): fix wal apply incorrect partition truncate under write presure

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1577,12 +1577,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     txWriter.setLagMaxTimestamp(Math.max(o3TimestampMax, txWriter.getLagMaxTimestamp()));
 
                     // Try to fast apply records from LAG to last partition which are before commitToTimestamp
-                    return applyFromWalLagToLastPartition(commitToTimestamp);
+                    return applyFromWalLagToLastPartition(commitToTimestamp, true);
                 }
 
                 // Try to fast apply records from LAG to last partition which are before o3TimestampMin and commitToTimestamp.
                 // This application will not include the current transaction data, only what's already in WAL lag.
-                if (applyFromWalLagToLastPartition(Math.min(o3TimestampMin, commitToTimestamp)) != Long.MIN_VALUE) {
+                if (applyFromWalLagToLastPartition(Math.min(o3TimestampMin, commitToTimestamp), false) != Long.MIN_VALUE) {
                     walLagRowCount = txWriter.getLagRowCount();
                     totalUncommitted = walLagRowCount + commitRowCount;
                 }
@@ -2323,7 +2323,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         return index;
     }
 
-    private long applyFromWalLagToLastPartition(long commitToTimestamp) {
+    private long applyFromWalLagToLastPartition(long commitToTimestamp, boolean commitTerminates) {
         long lagMinTimestamp = txWriter.getLagMinTimestamp();
         if (txWriter.getLagRowCount() > 0
                 && txWriter.isLagOrdered()
@@ -2337,7 +2337,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             if (lagMaxTimestamp <= commitToTimestamp) {
                 // Easy case, all lag data can be marked as committed in the last partition
                 LOG.debug().$("fast apply full lag to last partition [table=").$(tableToken).I$();
-                applyLagToLastPartition(lagMaxTimestamp, txWriter.getLagRowCount(), Long.MAX_VALUE);
+                applyLagToLastPartition(lagMaxTimestamp, txWriter.getLagRowCount(), Long.MAX_VALUE, commitTerminates);
                 return lagMaxTimestamp;
             } else if (lagMinTimestamp <= commitToTimestamp) {
                 // Find the max row which can be marked as committed in the last timestamp
@@ -2365,7 +2365,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     long newMaxTimestamp = Unsafe.getUnsafe().getLong(timestampAddr + (applyCount - 1) * Long.BYTES);
                     assert newMinLagTimestamp > commitToTimestamp && commitToTimestamp >= newMaxTimestamp;
 
-                    applyLagToLastPartition(newMaxTimestamp, (int) applyCount, newMinLagTimestamp);
+                    applyLagToLastPartition(newMaxTimestamp, (int) applyCount, newMinLagTimestamp, commitTerminates);
 
                     LOG.debug().$("partial apply lag to last partition [table=").$(tableToken)
                             .$(" ,lagSize=").$(lagRows)
@@ -2383,7 +2383,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         return Long.MIN_VALUE;
     }
 
-    private void applyLagToLastPartition(long maxTimestamp, int lagRowCount, long lagMinTimestamp) {
+    private void applyLagToLastPartition(long maxTimestamp, int lagRowCount, long lagMinTimestamp, boolean commitTerminates) {
         long initialTransientRowCount = txWriter.transientRowCount;
         txWriter.transientRowCount += lagRowCount;
         txWriter.updatePartitionSizeByTimestamp(lastPartitionTimestamp, txWriter.transientRowCount);
@@ -2408,7 +2408,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
         // set append position on columns so that the files are truncated to the correct size
         // if the partition is closed after the commit.
-        setAppendPosition(txWriter.getTransientRowCount() + txWriter.getLagTxnCount(), false);
+        // If wal commit terminates here, column positions should include lag to not truncate the WAL lag data.
+        // Otherwise, lag will be copied out and ok to truncate to the transient row count.
+        long partitionTruncateRowCount = txWriter.getTransientRowCount() + (commitTerminates ? txWriter.getLagRowCount() : 0);
+        setAppendPosition(partitionTruncateRowCount, false);
     }
 
     private boolean assertColumnPositionIncludeWalLag() {

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -245,14 +245,14 @@ public class WalTableSqlTest extends AbstractGriffinTest {
             compile("create table " + tableName + " (" +
                     "x long," +
                     "ts timestamp" +
-                    ") timestamp(ts) partition by DAY WAL WITH maxUncommittedRows=" + rnd.nextInt(20));
+                    ") timestamp(ts) partition by HOUR WAL WITH maxUncommittedRows=" + rnd.nextInt(20));
 
-            int count = rnd.nextInt(57);
+            int count = rnd.nextInt(22);
             long rowCount = 0;
             for (int i = 0; i < 2; i++) {
                 int rows = rnd.nextInt(200);
                 compile("insert into " + tableName +
-                        " select x, timestamp_sequence('2022-02-24T00:0" + i + "', 1000000) from long_sequence(" + rows + ")", sqlExecutionContext);
+                        " select x, timestamp_sequence('2022-02-24T0" + i + "', 1000000*60) from long_sequence(" + rows + ")", sqlExecutionContext);
                 rowCount += rows;
 
             }
@@ -266,7 +266,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
                     engine.releaseInactive();
                     int rows = rnd.nextInt(200);
                     compile("insert into " + tableName +
-                            " select x, timestamp_sequence('2022-02-24T00:" + String.format("%02d", i + 2) + "', 1000000) from long_sequence(" + rows + ")", sqlExecutionContext);
+                            " select x, timestamp_sequence('2022-02-24T" + String.format("%02d", i + 2) + "', 1000000*60) from long_sequence(" + rows + ")", sqlExecutionContext);
                     rowCount += rows;
                 }
             }


### PR DESCRIPTION
Fix the possibility that wal writing can truncate partition incorrectly, leaving WAL lag data.
Happened 

https://dev.azure.com/questdb/questdb/_build/results?buildId=29763&view=logs&j=85bc06a8-a627-555e-552b-b210a8c8389c&t=1911a705-fea7-57b4-1a55-212279d03594

```
seeds 382272609839L, 1686587029154L
023-06-12T16:23:50.229783Z E i.q.t.TestListener ***** Test Failed *****io.questdb.test.griffin.wal.WalWriterFuzzTest.testWalWriteRollbackHeavy duration_ms=1076 : 
java.lang.AssertionError
	at io.questdb.cairo.TableWriter.doClose(TableWriter.java:3289)
	at io.questdb.cairo.TableWriter.close(TableWriter.java:856)
	at io.questdb.cairo.pool.WriterPool.closeWriter(WriterPool.java:355)
	at io.questdb.cairo.pool.WriterPool.releaseAll(WriterPool.java:575)
	at io.questdb.cairo.pool.AbstractPool.releaseAll(AbstractPool.java:72)
	at io.questdb.cairo.CairoEngine.releaseAllWriters(CairoEngine.java:663)

```

It's not trivial to reproduce outside of fuzz tests.