### PR TITLE
fix(sql): fix thread and reader leak on invalid filter in WHERE clause

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -433,7 +433,6 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
         long cursor;
         int i = dispatchStartFrameIndex;
-        dispatchStartFrameIndex = frameCount;
         OUT:
         for (; i < frameCount; i++) {
             // We cannot process work on this thread. If we do the consumer will
@@ -452,12 +451,11 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                             .$(", cursor=").$(cursor)
                             .I$();
                     reducePubSeq.done(cursor);
+                    dispatchStartFrameIndex = i + 1;
                     dispatched = true;
                     break;
                 } else if (cursor == -1) {
                     idle = false;
-                    // make sure to set the index before the stealWork() call as it may throw
-                    dispatchStartFrameIndex = i;
                     // start stealing work to unload the queue
                     if (stealWork(reduceQueue, reduceSubSeq, record, circuitBreaker)) {
                         continue;

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -457,10 +457,13 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                 } else if (cursor == -1) {
                     idle = false;
                     // start stealing work to unload the queue
-                    if (stealWork(reduceQueue, reduceSubSeq, record, circuitBreaker)) {
-                        continue;
+                    try {
+                        if (stealWork(reduceQueue, reduceSubSeq, record, circuitBreaker)) {
+                            continue;
+                        }
+                    } finally {
+                        dispatchStartFrameIndex = i;
                     }
-                    dispatchStartFrameIndex = i;
                     break OUT;
                 } else {
                     Os.pause();

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -456,13 +456,11 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                     break;
                 } else if (cursor == -1) {
                     idle = false;
+                    // make sure to set the index before the stealWork() call as it may throw
+                    dispatchStartFrameIndex = i;
                     // start stealing work to unload the queue
-                    try {
-                        if (stealWork(reduceQueue, reduceSubSeq, record, circuitBreaker)) {
-                            continue;
-                        }
-                    } finally {
-                        dispatchStartFrameIndex = i;
+                    if (stealWork(reduceQueue, reduceSubSeq, record, circuitBreaker)) {
+                        continue;
                     }
                     break OUT;
                 } else {


### PR DESCRIPTION
Fixes #3489

Missing exception handling could lead to thread (and reader) leak due to an infinite loop in `PageFrameSequence#await()` (`dispatchStartFrameIndex` was assigned to `frameCount` in `dispatch()` and never got updated to the proper value).