### PR TITLE
Upgrade org.postgresql:postgresql from 42.5.1 to 42.6.0 

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.5.1</version>
+            <version>42.6.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We should keep our dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect our project.