### PR TITLE
Upgrade io.prometheus:simpleeclient from 0.10.0 to 0.16.0

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.10.0</version>
+            <version>0.16.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -41,7 +41,7 @@ RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     ./gosu --version && \
     ./gosu nobody true
 
-FROM debian:bullseye-slim
+FROM debian:12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Upgrade io.prometheus:simpleeclient from 0.10.0 to 0.16.0 to reduce vulnerability
We should keep our dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect our project.

