### PR TITLE
fix(sql): fix latest by factories not reacting to bind variable value change

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/AbstractLatestByValueRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AbstractLatestByValueRecordCursor.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+package io.questdb.griffin.engine.table;
+
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.std.IntList;
+import org.jetbrains.annotations.NotNull;
+
+abstract class AbstractLatestByValueRecordCursor extends AbstractDataFrameRecordCursor {
+
+    protected final int columnIndex;
+    protected SqlExecutionCircuitBreaker circuitBreaker;
+    protected boolean hasNext;
+    protected boolean isFindPending;
+    protected boolean isRecordFound;
+    protected int symbolKey;
+
+    AbstractLatestByValueRecordCursor(@NotNull IntList columnIndexes, int columnIndex, int symbolKey) {
+        super(columnIndexes);
+        this.columnIndex = columnIndex;
+        this.symbolKey = symbolKey;
+    }
+
+    public void setSymbolKey(int symbolKey) {
+        this.symbolKey = symbolKey;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredFilteredRecordCursorFactory.java
@@ -57,7 +57,7 @@ public class LatestByValueDeferredFilteredRecordCursorFactory extends AbstractDe
     }
 
     @Override
-    protected DataFrameRecordCursor createDataFrameCursorFor(int symbolKey) {
+    protected AbstractLatestByValueRecordCursor createDataFrameCursorFor(int symbolKey) {
         if (filter == null) {
             return new LatestByValueRecordCursor(columnIndex, symbolKey, columnIndexes);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredIndexedFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueDeferredIndexedFilteredRecordCursorFactory.java
@@ -57,7 +57,7 @@ public class LatestByValueDeferredIndexedFilteredRecordCursorFactory extends Abs
     }
 
     @Override
-    protected DataFrameRecordCursor createDataFrameCursorFor(int symbolKey) {
+    protected AbstractLatestByValueRecordCursor createDataFrameCursorFor(int symbolKey) {
         assert filter != null;
         return new LatestByValueIndexedFilteredRecordCursor(columnIndex, TableUtils.toIndexKey(symbolKey), filter, columnIndexes);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueFilteredRecordCursor.java
@@ -27,22 +27,15 @@ package io.questdb.griffin.engine.table;
 import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.DataFrameCursor;
 import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import org.jetbrains.annotations.NotNull;
 
-class LatestByValueFilteredRecordCursor extends AbstractDataFrameRecordCursor {
+class LatestByValueFilteredRecordCursor extends AbstractLatestByValueRecordCursor {
 
-    private final int columnIndex;
     private final Function filter;
-    private final int symbolKey;
-    private SqlExecutionCircuitBreaker circuitBreaker;
-    private boolean hasNext;
-    private boolean isFindPending;
-    private boolean isRecordFound;
 
     public LatestByValueFilteredRecordCursor(
             int columnIndex,
@@ -50,9 +43,7 @@ class LatestByValueFilteredRecordCursor extends AbstractDataFrameRecordCursor {
             @NotNull Function filter,
             @NotNull IntList columnIndexes
     ) {
-        super(columnIndexes);
-        this.columnIndex = columnIndex;
-        this.symbolKey = symbolKey;
+        super(columnIndexes, columnIndex, symbolKey);
         this.filter = filter;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueIndexedFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueIndexedFilteredRecordCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.BitmapIndexReader;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
@@ -32,15 +33,9 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import org.jetbrains.annotations.NotNull;
 
-class LatestByValueIndexedFilteredRecordCursor extends AbstractDataFrameRecordCursor {
-
-    protected final int columnIndex;
-    protected final int symbolKey;
+class LatestByValueIndexedFilteredRecordCursor extends AbstractLatestByValueRecordCursor {
     private final Function filter;
     private SqlExecutionCircuitBreaker circuitBreaker;
-    private boolean hasNext;
-    private boolean isFindPending;
-    private boolean isRecordFound;
 
     public LatestByValueIndexedFilteredRecordCursor(
             int columnIndex,
@@ -48,9 +43,7 @@ class LatestByValueIndexedFilteredRecordCursor extends AbstractDataFrameRecordCu
             @NotNull Function filter,
             @NotNull IntList columnIndexes
     ) {
-        super(columnIndexes);
-        this.columnIndex = columnIndex;
-        this.symbolKey = symbolKey;
+        super(columnIndexes, columnIndex, symbolKey);
         this.filter = filter;
     }
 
@@ -77,6 +70,11 @@ class LatestByValueIndexedFilteredRecordCursor extends AbstractDataFrameRecordCu
         filter.init(this, executionContext);
         isRecordFound = false;
         isFindPending = false;
+    }
+
+    @Override
+    public void setSymbolKey(int symbolKey) {
+        super.setSymbolKey(TableUtils.toIndexKey(symbolKey));
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/LatestByValueRecordCursor.java
@@ -26,25 +26,15 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.DataFrameCursor;
-import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import org.jetbrains.annotations.NotNull;
 
-class LatestByValueRecordCursor extends AbstractDataFrameRecordCursor {
-
-    private final int columnIndex;
-    private final int symbolKey;
-    private SqlExecutionCircuitBreaker circuitBreaker;
-    private boolean hasNext;
-    private boolean isFindPending;
-    private boolean isRecordFound;
+class LatestByValueRecordCursor extends AbstractLatestByValueRecordCursor {
 
     public LatestByValueRecordCursor(int columnIndex, int symbolKey, @NotNull IntList columnIndexes) {
-        super(columnIndexes);
-        this.columnIndex = columnIndex;
-        this.symbolKey = symbolKey;
+        super(columnIndexes, columnIndex, symbolKey);
     }
 
     @Override


### PR DESCRIPTION
Fixes a number of latest by factories that cached and used the first bind variable value set.

Example:

```sql
CREATE TABLE IF NOT EXISTS tab (
    ts timestamp, 
    sym symbol, 
    isym symbol,
    h string,
    type char,
    stat char
), index(isym) timestamp(ts) partition by MONTH;

insert into tab values 
(0, 'S1', 'S1', 'h1', 'X', 'Y' ), 
(1, 'S2', 'S2', 'h2', 'X', 'Y' ), 
(3, null, null, 'h3', 'X', 'Y' );

select h, isym from 
(select h, stat, isym from tab 
  where sym = ? and type = 'X' latest on ts partition by sym 
) where stat='Y';
```

Running the last query with "S1" and then "S2" bind variable value or null returns the following in master branch :
```sql
h   isym
h1    S1
```
