### PR TITLE
refactor(core): rename Utf8Native to DirectUtf8Sequence

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableToken.java
+++ b/core/src/main/java/io/questdb/cairo/TableToken.java
@@ -27,7 +27,7 @@ package io.questdb.cairo;
 import io.questdb.std.Sinkable;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.GcUtf8String;
-import io.questdb.std.str.Utf8Native;
+import io.questdb.std.str.DirectUtf8Sequence;
 import org.jetbrains.annotations.NotNull;
 
 public class TableToken implements Sinkable {
@@ -86,7 +86,7 @@ public class TableToken implements Sinkable {
     /**
      * @return UTF-8 buffer naming the directory where the table is located.
      */
-    public @NotNull Utf8Native getDirNameUtf8() {
+    public @NotNull DirectUtf8Sequence getDirNameUtf8() {
         return dirName;
     }
 

--- a/core/src/main/java/io/questdb/std/str/DirectUtf8Sequence.java
+++ b/core/src/main/java/io/questdb/std/str/DirectUtf8Sequence.java
@@ -29,7 +29,7 @@ import io.questdb.std.Unsafe;
 /**
  * Read-only interface for a UTF-8 string with native ptr access.
  */
-public interface Utf8Native extends Utf8Sequence {
+public interface DirectUtf8Sequence extends Utf8Sequence {
     /**
      * Returns byte at index.
      * Note: Unchecked bounds.

--- a/core/src/main/java/io/questdb/std/str/GcUtf8String.java
+++ b/core/src/main/java/io/questdb/std/str/GcUtf8String.java
@@ -31,12 +31,11 @@ import java.lang.reflect.Field;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.stream.IntStream;
 
 /**
  * A garbage-collected immutable UTF-8 string over owned native memory, originating from a Java String.
  */
-public class GcUtf8String implements Utf8Native {
+public class GcUtf8String implements DirectUtf8Sequence {
     private static final long BUFFER_ADDRESS_OFFSET;
     @SuppressWarnings("FieldCanBeLocal")  // We need to hold a reference to `buffer` or it will be GC'd.
     private final ByteBuffer buffer;  // We use a ByteBuffer here, instead of a ptr, to avoid Closeable requirement.

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -1,0 +1,41 @@
+package io.questdb.std.str;
+
+public interface Utf8s {
+    static boolean equals(Utf8Sequence a, Utf8Sequence b) {
+        if (a == b) {
+            return true;
+        }
+
+        if (a == null || b == null) {
+            return false;
+        }
+
+        if (a.size() != b.size()) {
+            return false;
+        }
+
+        for (int index = 0, n = a.size(); index < n; index++) {
+            if (a.byteAt(index) != b.byteAt(index)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static boolean equals(DirectUtf8Sequence a, DirectUtf8Sequence b) {
+        if (a == b) {
+            return true;
+        }
+
+        if (a == null || b == null) {
+            return false;
+        }
+
+        if (a.ptr() == b.ptr() && a.size() == b.size()) {
+            return true;
+        }
+
+        return equals(a, (Utf8Sequence) b);
+    }
+}

--- a/core/src/test/java/io/questdb/test/std/str/GcUtf8StringTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/GcUtf8StringTest.java
@@ -24,7 +24,7 @@
 
 package io.questdb.test.std.str;
 
-import io.questdb.std.str.Utf8Native;
+import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.GcUtf8String;
 import org.junit.Assert;
@@ -112,13 +112,13 @@ public class GcUtf8StringTest {
 
     @Test
     public void testUtf8Native() {
-        final Utf8Native s1 = new GcUtf8String("");
+        final DirectUtf8Sequence s1 = new GcUtf8String("");
         Assert.assertNotEquals(0, s1.ptr());
         Assert.assertNotEquals(0, s1.lo());
         Assert.assertNotEquals(0, s1.hi());
         Assert.assertEquals(s1.lo(), s1.hi());
 
-        final Utf8Native s2 = new GcUtf8String("hi");
+        final DirectUtf8Sequence s2 = new GcUtf8String("hi");
         Assert.assertEquals(2, s2.size());
         Assert.assertNotEquals(0, s2.ptr());
         Assert.assertNotEquals(0, s2.lo());

--- a/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
@@ -1,0 +1,42 @@
+package io.questdb.test.std.str;
+
+import io.questdb.std.str.GcUtf8String;
+import io.questdb.std.str.DirectUtf8Sequence;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8s;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Utf8sTest {
+    @Test
+    public void testEquals() {
+        final DirectUtf8Sequence nullDirect = null;
+        final DirectUtf8Sequence str1a = new GcUtf8String("test1");
+        final DirectUtf8Sequence str1b = new GcUtf8String("test1");
+        final DirectUtf8Sequence str2 = new GcUtf8String("test2");
+        final DirectUtf8Sequence str3 = new GcUtf8String("a_longer_string");
+        Assert.assertNotEquals(str1a.ptr(), str1b.ptr());
+
+        Assert.assertTrue(Utf8s.equals(nullDirect, nullDirect));
+        Assert.assertFalse(Utf8s.equals(nullDirect, str1a));
+        Assert.assertFalse(Utf8s.equals(str1a, null));
+        Assert.assertTrue(Utf8s.equals(str1a, str1a));
+        Assert.assertTrue(Utf8s.equals(str1a, str1b));
+        Assert.assertFalse(Utf8s.equals(str1a, str2));
+        Assert.assertFalse(Utf8s.equals(str2, str3));
+
+        final Utf8Sequence nullSequence = null;
+        final Utf8Sequence seq1a = str1a;
+        final Utf8Sequence seq1b = str1b;
+        final Utf8Sequence seq2 = str2;
+        final Utf8Sequence seq3 = str3;
+
+        Assert.assertTrue(Utf8s.equals(nullSequence, nullSequence));
+        Assert.assertFalse(Utf8s.equals(nullSequence, seq1a));
+        Assert.assertFalse(Utf8s.equals(seq1a, nullSequence));
+        Assert.assertTrue(Utf8s.equals(seq1a, seq1a));
+        Assert.assertTrue(Utf8s.equals(seq1a, seq1b));
+        Assert.assertFalse(Utf8s.equals(seq1a, seq2));
+        Assert.assertFalse(Utf8s.equals(seq2, seq3));
+    }
+}


### PR DESCRIPTION
Aligned naming of Utf8 types with the naming scheme we use in the rest of the code base.