### PR TITLE
chore(core): restore renaming method accidentally removed

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -160,6 +160,11 @@ public class CairoEngine implements Closeable, WriterSource {
         }
     }
 
+    @SuppressWarnings("unused")
+    public void applyTableRename(TableToken token, TableToken updatedTableToken) {
+        tableNameRegistry.rename(token.getTableName(), updatedTableToken.getTableName(), token);
+    }
+
     @TestOnly
     public boolean clear() {
         boolean b1 = readerPool.releaseAll();

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -160,7 +160,6 @@ public class CairoEngine implements Closeable, WriterSource {
         }
     }
 
-    @SuppressWarnings("unused")
     public void applyTableRename(TableToken token, TableToken updatedTableToken) {
         tableNameRegistry.rename(token.getTableName(), updatedTableToken.getTableName(), token);
     }

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
@@ -57,7 +57,7 @@ public interface TableNameRegistry extends Closeable {
      * @return resolves table name to TableToken. If no token exists, returns null
      */
     TableToken getTableToken(CharSequence tableName);
-
+    
     /**
      * Returns table token by directory name. If table does not exist, returns null.
      *
@@ -138,6 +138,16 @@ public interface TableNameRegistry extends Closeable {
     void reloadTableNameCache(ObjList<TableToken> convertedTables);
 
     void removeAlias(TableToken tableToken);
+
+    /**
+     * Updates table name in registry.
+     *
+     * @param oldName    old table  name
+     * @param newName    new table name
+     * @param tableToken table token to make sure intended table name is updated
+     * @return updated table token
+     */
+    TableToken rename(CharSequence oldName, CharSequence newName, TableToken tableToken);
 
     void replaceAlias(TableToken alias, TableToken replaceWith);
 

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryRO.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryRO.java
@@ -106,6 +106,11 @@ public class TableNameRegistryRO extends AbstractTableNameRegistry {
     }
 
     @Override
+    public TableToken rename(CharSequence oldName, CharSequence newName, TableToken tableToken) {
+        throw CairoException.critical(0).put("instance is read only");
+    }
+
+    @Override
     public void replaceAlias(TableToken alias, TableToken replaceWith) {
         throw CairoException.critical(0).put("instance is read only");
     }

--- a/core/src/test/java/io/questdb/test/griffin/RenameTableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/RenameTableTest.java
@@ -36,6 +36,24 @@ import static io.questdb.griffin.CompiledQuery.RENAME_TABLE;
 public class RenameTableTest extends AbstractGriffinTest {
 
     @Test
+    public void testApplyRename() throws SqlException {
+        compile(
+                "create table x as (" +
+                        "select" +
+                        " cast(x as int) i, " +
+                        " timestamp_sequence(1,1) timestamp " +
+                        " from long_sequence(10)" +
+                        ") timestamp (timestamp);"
+        );
+        TableToken from = engine.verifyTableName("x");
+        TableToken to = from.renamed("y");
+        engine.applyTableRename(from, to);
+
+        Assert.assertEquals(from.getDirName(), engine.verifyTableName("y").getDirName());
+        Assert.assertNull(engine.getTableTokenIfExists("x"));
+    }
+
+    @Test
     public void testFunctionDestTableName() throws Exception {
         assertFailure("rename table x to y()", 18);
     }


### PR DESCRIPTION
Restore removed `CairoEngine.applyTableRename()` method