### PR TITLE
chore(core): introduce separate set of permissions for ILP

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -202,7 +202,8 @@ public class CairoEngine implements Closeable, WriterSource {
             TableStructure struct,
             boolean keepLock
     ) {
-        return createTable(securityContext, mem, path, ifNotExists, struct, keepLock, false);
+        securityContext.authorizeTableCreate();
+        return createTableInsecure(securityContext, mem, path, ifNotExists, struct, keepLock, false);
     }
 
     public @NotNull TableToken createTableInVolume(
@@ -213,7 +214,72 @@ public class CairoEngine implements Closeable, WriterSource {
             TableStructure struct,
             boolean keepLock
     ) {
-        return createTable(securityContext, mem, path, ifNotExists, struct, keepLock, true);
+        securityContext.authorizeTableCreate();
+        return createTableInsecure(securityContext, mem, path, ifNotExists, struct, keepLock, true);
+    }
+
+    public @NotNull TableToken createTableInsecure(
+            SecurityContext securityContext,
+            MemoryMARW mem,
+            Path path,
+            boolean ifNotExists,
+            TableStructure struct,
+            boolean keepLock,
+            boolean inVolume
+    ) {
+        assert !struct.isWalEnabled() || PartitionBy.isPartitioned(struct.getPartitionBy()) : "WAL is only supported for partitioned tables";
+        securityContext.authorizeTableCreate();
+        final CharSequence tableName = struct.getTableName();
+        validNameOrThrow(tableName);
+
+        int tableId = (int) tableIdGenerator.getNextId();
+        TableToken tableToken = lockTableName(tableName, tableId, struct.isWalEnabled());
+        if (tableToken == null) {
+            if (ifNotExists) {
+                return getTableTokenIfExists(tableName);
+            }
+            throw EntryUnavailableException.instance("table exists");
+        }
+
+        try {
+            String lockedReason = lock(tableToken, "createTable");
+            if (lockedReason == null) {
+                boolean tableCreated = false;
+                try {
+                    if (inVolume) {
+                        createTableInVolumeUnsafe(mem, path, struct, tableToken);
+                    } else {
+                        createTableUnsafe(mem, path, struct, tableToken);
+                    }
+
+                    if (struct.isWalEnabled()) {
+                        tableSequencerAPI.registerTable(tableToken.getTableId(), struct, tableToken);
+                    }
+                    tableCreated = true;
+                } finally {
+                    if (!keepLock) {
+                        unlockTableUnsafe(tableToken, null, tableCreated);
+                        LOG.info().$("unlocked [table=`").$(tableToken).$("`]").$();
+                    }
+                }
+                tableNameRegistry.registerName(tableToken);
+            } else {
+                if (!ifNotExists) {
+                    throw EntryUnavailableException.instance(lockedReason);
+                }
+            }
+        } catch (Throwable th) {
+            if (struct.isWalEnabled()) {
+                // tableToken.getLoggingName() === tableName, table cannot be renamed while creation hasn't finished
+                tableSequencerAPI.dropTable(tableToken, true);
+            }
+            throw th;
+        } finally {
+            tableNameRegistry.unlockTableName(tableToken);
+        }
+
+        securityContext.onTableCreated(tableToken);
+        return tableToken;
     }
 
     public void drop(Path path, TableToken tableToken) {
@@ -691,7 +757,7 @@ public class CairoEngine implements Closeable, WriterSource {
                 }
             } else {
                 String lockedReason = lock(fromTableToken, "renameTable");
-                if (null == lockedReason) {
+                if (lockedReason == null) {
                     try {
                         toTableToken = rename0(fromPath, fromTableToken, toPath, toTableName);
                         TableUtils.overwriteTableNameFile(
@@ -787,70 +853,6 @@ public class CairoEngine implements Closeable, WriterSource {
         if (!tt.equals(tableToken)) {
             throw TableReferenceOutOfDateException.of(tableToken, tableToken.getTableId(), tt.getTableId(), tt.getTableId(), -1);
         }
-    }
-
-    private @NotNull TableToken createTable(
-            SecurityContext securityContext,
-            MemoryMARW mem,
-            Path path,
-            boolean ifNotExists,
-            TableStructure struct,
-            boolean keepLock,
-            boolean inVolume
-    ) {
-        assert !struct.isWalEnabled() || PartitionBy.isPartitioned(struct.getPartitionBy()) : "WAL is only supported for partitioned tables";
-        securityContext.authorizeTableCreate();
-        final CharSequence tableName = struct.getTableName();
-        validNameOrThrow(tableName);
-
-        int tableId = (int) tableIdGenerator.getNextId();
-        TableToken tableToken = lockTableName(tableName, tableId, struct.isWalEnabled());
-        if (tableToken == null) {
-            if (ifNotExists) {
-                return getTableTokenIfExists(tableName);
-            }
-            throw EntryUnavailableException.instance("table exists");
-        }
-
-        try {
-            String lockedReason = lock(tableToken, "createTable");
-            if (lockedReason == null) {
-                boolean tableCreated = false;
-                try {
-                    if (inVolume) {
-                        createTableInVolumeUnsafe(mem, path, struct, tableToken);
-                    } else {
-                        createTableUnsafe(mem, path, struct, tableToken);
-                    }
-
-                    if (struct.isWalEnabled()) {
-                        tableSequencerAPI.registerTable(tableToken.getTableId(), struct, tableToken);
-                    }
-                    tableCreated = true;
-                } finally {
-                    if (!keepLock) {
-                        unlockTableUnsafe(tableToken, null, tableCreated);
-                        LOG.info().$("unlocked [table=`").$(tableToken).$("`]").$();
-                    }
-                }
-                tableNameRegistry.registerName(tableToken);
-            } else {
-                if (!ifNotExists) {
-                    throw EntryUnavailableException.instance(lockedReason);
-                }
-            }
-        } catch (Throwable th) {
-            if (struct.isWalEnabled()) {
-                // tableToken.getLoggingName() === tableName, table cannot be renamed while creation hasn't finished
-                tableSequencerAPI.dropTable(tableToken, true);
-            }
-            throw th;
-        } finally {
-            tableNameRegistry.unlockTableName(tableToken);
-        }
-
-        securityContext.onTableCreated(tableToken);
-        return tableToken;
     }
 
     // caller has to acquire the lock before this method is called and release the lock after the call

--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -30,6 +30,7 @@ import io.questdb.std.ObjList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("unused")
 public interface SecurityContext {
 
     void assumeServiceAccount(CharSequence serviceAccountName);
@@ -91,6 +92,15 @@ public interface SecurityContext {
 
     // columnNames.size() = 0 means all columns
     void authorizeInsert(TableToken tableToken, @NotNull ObjList<CharSequence> columnNames);
+
+    // Add column over ILP/TCP.
+    void authorizeLineAlterTableAddColumn(TableToken tableToken);
+
+    // Insert over ILP/TCP.
+    void authorizeLineInsert(TableToken tableToken);
+
+    // Create table over ILP/TCP.
+    void authorizeLineTableCreate();
 
     void authorizeRemovePassword();
 

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -152,6 +152,18 @@ public class AllowAllSecurityContext implements SecurityContext {
     }
 
     @Override
+    public void authorizeLineAlterTableAddColumn(TableToken tableToken) {
+    }
+
+    @Override
+    public void authorizeLineInsert(TableToken tableToken) {
+    }
+
+    @Override
+    public void authorizeLineTableCreate() {
+    }
+
+    @Override
     public void authorizeRemovePassword() {
     }
 

--- a/core/src/main/java/io/questdb/cairo/security/DenyAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/DenyAllSecurityContext.java
@@ -25,18 +25,12 @@
 package io.questdb.cairo.security;
 
 import io.questdb.cairo.CairoException;
-import io.questdb.cairo.SecurityContext;
 import io.questdb.cairo.TableToken;
 import io.questdb.std.ObjList;
 import org.jetbrains.annotations.NotNull;
 
 public class DenyAllSecurityContext extends ReadOnlySecurityContext {
     public static final DenyAllSecurityContext INSTANCE = new DenyAllSecurityContext();
-
-    @Override
-    public void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
-        throw CairoException.nonCritical().put("permission denied");
-    }
 
     @Override
     public void authorizeSelect(TableToken tableToken, @NotNull ObjList<CharSequence> columnNames) {

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -181,6 +181,21 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
+    public void authorizeLineAlterTableAddColumn(TableToken tableToken) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeLineInsert(TableToken tableToken) {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
+    public void authorizeLineTableCreate() {
+        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
+    }
+
+    @Override
     public void authorizeRemovePassword() {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -148,7 +148,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     }
 
     public void cancel() {
-        this.valid.compareAndSet(true, false);
+        valid.compareAndSet(true, false);
     }
 
     public void clear() {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -301,7 +301,7 @@ class LineTcpMeasurementEvent implements Closeable {
         final TableUpdateDetails.ThreadLocalDetails localDetails = tud.getThreadLocalDetails(workerId);
         localDetails.resetStateIfNecessary();
         tableUpdateDetails = tud;
-        securityContext.authorizeInsert(tud.getTableToken(), TableUpdateDetails.ALL_COLUMNS_AUTHORIZE_LIST);
+        securityContext.authorizeLineInsert(tud.getTableToken());
         long timestamp = parser.getTimestamp();
         if (timestamp != LineTcpParser.NULL_TIMESTAMP) {
             timestamp = timestampAdapter.getMicros(timestamp);
@@ -329,7 +329,7 @@ class LineTcpMeasurementEvent implements Closeable {
                 // send column by name
                 final String colNameUtf16 = localDetails.getColNameUtf16();
                 if (autoCreateNewColumns && TableUtils.isValidColumnName(colNameUtf16, maxColumnNameLength)) {
-                    securityContext.authorizeAlterTableAddColumn(tud.getTableToken());
+                    securityContext.authorizeLineAlterTableAddColumn(tud.getTableToken());
                     offset = buffer.addColumnName(offset, colNameUtf16);
                     colType = localDetails.getColumnType(localDetails.getColNameUtf8(), entityType);
                 } else if (!autoCreateNewColumns) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -374,7 +374,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                 if (autoCreateNewColumns && TableUtils.isValidColumnName(columnNameUtf16, cairoConfiguration.getMaxFileNameLength())) {
                     columnIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
                     if (columnIndex < 0) {
-                        securityContext.authorizeAlterTableAddColumn(writer.getTableToken());
+                        securityContext.authorizeLineAlterTableAddColumn(writer.getTableToken());
                         tud.commit(false);
                         try {
                             writer.addColumn(columnNameUtf16, ld.getColumnType(ld.getColNameUtf8(), ent.getType()));
@@ -736,7 +736,8 @@ public class LineTcpMeasurementScheduler implements Closeable {
                             throw CairoException.nonCritical().put("unknown column type [columnName=").put(tsa.getColumnName(i)).put(']');
                         }
                     }
-                    tableToken = engine.createTable(securityContext, ddlMem, path, true, tsa, false);
+                    securityContext.authorizeLineTableCreate();
+                    tableToken = engine.createTableInsecure(securityContext, ddlMem, path, true, tsa, false, false);
                     LOG.info().$("created table [tableName=").$(tableNameUtf16).I$();
                 }
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -47,7 +47,6 @@ import static io.questdb.cairo.TableUtils.TXN_FILE_NAME;
 import static io.questdb.std.Chars.utf8ToUtf16;
 
 public class TableUpdateDetails implements Closeable {
-    static final ObjList<CharSequence> ALL_COLUMNS_AUTHORIZE_LIST = new ObjList<>();
     private static final Log LOG = LogFactory.getLog(TableUpdateDetails.class);
     private static final DirectByteSymbolLookup NOT_FOUND_LOOKUP = value -> SymbolTable.VALUE_NOT_FOUND;
     private final long commitInterval;
@@ -266,7 +265,7 @@ public class TableUpdateDetails implements Closeable {
 
     private void authorizeWalCommit() {
         if (ownSecurityContext != null) {
-            ownSecurityContext.authorizeInsert(tableToken, ALL_COLUMNS_AUTHORIZE_LIST);
+            ownSecurityContext.authorizeLineInsert(tableToken);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
@@ -38,8 +38,8 @@ import io.questdb.std.Rows;
 
 class AsyncFilteredRecordCursor implements RecordCursor {
 
+    static final String exceptionMessage = "timeout, query aborted";
     private static final Log LOG = LogFactory.getLog(AsyncFilteredRecordCursor.class);
-    private static final String exceptionMessage = "timeout, query aborted";
     private final Function filter;
     private final boolean hasDescendingOrder;
     private final PageAddressCacheRecord record;
@@ -146,7 +146,7 @@ class AsyncFilteredRecordCursor implements RecordCursor {
         }
 
         if (!allFramesActive) {
-            throw CairoException.nonCritical().put(exceptionMessage).setInterruption(true);
+            throwTimeoutException();
         }
         return false;
     }
@@ -238,13 +238,17 @@ class AsyncFilteredRecordCursor implements RecordCursor {
                 }
             } while (frameIndex < frameLimit);
         } catch (Throwable e) {
-            LOG.critical().$("unexpected error [ex=").$(e).I$();
-            throw CairoException.nonCritical().put(exceptionMessage).setInterruption(true);
+            LOG.error().$("unexpected error [ex=").$(e).I$();
+            throwTimeoutException();
         }
     }
 
     private long rowIndex() {
         return hasDescendingOrder ? (frameRowCount - frameRowIndex - 1) : frameRowIndex;
+    }
+
+    private void throwTimeoutException() {
+        throw CairoException.nonCritical().put(exceptionMessage).setInterruption(true);
     }
 
     void of(PageFrameSequence<?> frameSequence, long rowsRemaining) {


### PR DESCRIPTION
Introduces separate permission checks for ILP in `SecurityContext`: create table, add column, insert.

Also includes the following:
* Fix incomplete exception and timeout handling in `AsyncFilteredNegativeLimitRecordCursor`.
* Use error level for errors logged by `AsyncFilteredRecordCursor` and `AsyncFilteredNegativeLimitRecordCursor`. That's to prevent false positive critical level logging in the case of `ImplicitCastException` and similar non-critical ones.