### PR TITLE
feat(sql): implement function to convert two longs to UUID

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/uuid/LongsToUuidFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/uuid/LongsToUuidFunctionFactory.java
@@ -34,7 +34,6 @@ import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.UuidFunction;
 import io.questdb.griffin.engine.functions.constants.UuidConstant;
 import io.questdb.std.IntList;
-import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
 
 public final class LongsToUuidFunctionFactory implements FunctionFactory {
@@ -62,12 +61,6 @@ public final class LongsToUuidFunctionFactory implements FunctionFactory {
         public LongsToUuidFunction(Function loLong, Function hiLong) {
             this.lo = loLong;
             this.hi = hiLong;
-        }
-
-        @Override
-        public void close() {
-            Misc.free(hi);
-            Misc.free(lo);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/uuid/LongsToUuidFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/uuid/LongsToUuidFunctionFactory.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.uuid;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.UuidFunction;
+import io.questdb.griffin.engine.functions.constants.UuidConstant;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+
+public final class LongsToUuidFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "to_uuid(LL)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        final Function loLong = args.getQuick(0);
+        final Function hiLong = args.getQuick(1);
+        if (loLong.isConstant() && hiLong.isConstant()) {
+            return new UuidConstant(loLong.getLong(null), hiLong.getLong(null));
+        }
+        return new LongsToUuidFunction(loLong, hiLong);
+    }
+
+    private static class LongsToUuidFunction extends UuidFunction implements BinaryFunction {
+
+        private final Function hi;
+        private final Function lo;
+
+        public LongsToUuidFunction(Function loLong, Function hiLong) {
+            this.lo = loLong;
+            this.hi = hiLong;
+        }
+
+        @Override
+        public void close() {
+            Misc.free(hi);
+            Misc.free(lo);
+        }
+
+        @Override
+        public Function getLeft() {
+            return lo;
+        }
+
+        @Override
+        public long getLong128Hi(Record rec) {
+            return hi.getLong(rec);
+        }
+
+        @Override
+        public long getLong128Lo(Record rec) {
+            return lo.getLong(rec);
+        }
+
+        @Override
+        public String getName() {
+            return "to_uuid";
+        }
+
+        @Override
+        public Function getRight() {
+            return hi;
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -257,6 +257,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.rnd.RndUuidFunctionFactory,
             io.questdb.griffin.engine.functions.date.TimestampSequenceFunctionFactory,
             io.questdb.griffin.engine.functions.long128.LongsToLong128FunctionFactory,
+            io.questdb.griffin.engine.functions.uuid.LongsToUuidFunctionFactory,
             io.questdb.griffin.engine.functions.date.TimestampShuffleFunctionFactory,
             io.questdb.griffin.engine.functions.date.TimestampFloorFunctionFactory,
             io.questdb.griffin.engine.functions.date.TimestampCeilFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -188,6 +188,7 @@ io.questdb.griffin.engine.functions.rnd.RndLongFunctionFactory
 io.questdb.griffin.engine.functions.rnd.RndUuidFunctionFactory
 io.questdb.griffin.engine.functions.date.TimestampSequenceFunctionFactory
 io.questdb.griffin.engine.functions.long128.LongsToLong128FunctionFactory
+io.questdb.griffin.engine.functions.uuid.LongsToUuidFunctionFactory
 io.questdb.griffin.engine.functions.rnd.RndByteCCFunctionFactory
 io.questdb.griffin.engine.functions.rnd.RndBinCCCFunctionFactory
 io.questdb.griffin.engine.functions.rnd.RndSymbolListFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/UuidTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UuidTest.java
@@ -441,6 +441,62 @@ public class UuidTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testLongsToUuid_constant() throws Exception {
+        assertQuery(
+                "uuid\n" +
+                        "00000000-0000-0001-0000-000000000001\n",
+                "select to_uuid(1, 1) as uuid from long_sequence(1)",
+                null,
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testLongsToUuid_fromTable() throws Exception {
+        assertCompile("create table x (lo long, hi long)");
+        assertCompile("insert into x values (1, 1)");
+        assertQuery(
+                "uuid\n" +
+                        "00000000-0000-0001-0000-000000000001\n",
+                "select to_uuid(lo, hi) as uuid from x",
+                null,
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testLongsToUuid_nullConstant() throws Exception {
+        assertQuery(
+                "uuid\n" +
+                        "\n",
+                "select to_uuid(null, null) as uuid from long_sequence(1)",
+                null,
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testLongsToUuid_nullFromTable() throws Exception {
+        assertCompile("create table x (lo long, hi long)");
+        assertCompile("insert into x values (null, null)");
+        assertQuery(
+                "uuid\n" +
+                        "\n",
+                "select to_uuid(lo, hi) as uuid from x",
+                null,
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testNegatedEqualityComparisonExplicitCast() throws Exception {
         Uuid uuid = new Uuid();
         uuid.of("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");

--- a/core/src/test/java/io/questdb/test/griffin/UuidTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UuidTest.java
@@ -444,8 +444,8 @@ public class UuidTest extends AbstractGriffinTest {
     public void testLongsToUuid_constant() throws Exception {
         assertQuery(
                 "uuid\n" +
-                        "00000000-0000-0001-0000-000000000001\n",
-                "select to_uuid(1, 1) as uuid from long_sequence(1)",
+                        "00000000-0000-0001-0000-000000000002\n",
+                "select to_uuid(2, 1) as uuid from long_sequence(1)",
                 null,
                 null,
                 true,
@@ -456,10 +456,10 @@ public class UuidTest extends AbstractGriffinTest {
     @Test
     public void testLongsToUuid_fromTable() throws Exception {
         assertCompile("create table x (lo long, hi long)");
-        assertCompile("insert into x values (1, 1)");
+        assertCompile("insert into x values (2, 1)");
         assertQuery(
                 "uuid\n" +
-                        "00000000-0000-0001-0000-000000000001\n",
+                        "00000000-0000-0001-0000-000000000002\n",
                 "select to_uuid(lo, hi) as uuid from x",
                 null,
                 null,


### PR DESCRIPTION
This PR introduces a new SQL function: `to_uuid(long, long)`. The function creates a UUID value out of 2 long values. 

Each long value has 64 bits. UUID values have 128 bits. The function combines bits from both longs to construct a UUID. The first long is interpreted as the lower 64 bits and the 2nd long is used as higher 64 bits of the resulting UUID value. 

Trivial example:
```sql
select to_uuid(2, 1) as uuid from long_sequence(1);
```
Expected result:
```
                uuid
00000000-0000-0001-0000-000000000002
```

Less trivial example:
```sql
create table x (lo long, hi long);
insert into x values (2, 1);
select to_uuid(lo, hi) as uuid from x;
```
Expected result:
```
                uuid
00000000-0000-0001-0000-000000000002
```

Expected use-case: Construct a unique ID out of 2 IDs received from different sources. 