### PR TITLE
fix(ilp): fix data loss causes by concurrent column drop transactions

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -315,7 +315,7 @@ class LineTcpMeasurementEvent implements Closeable {
             LineTcpParser.ProtoEntity entity = parser.getEntity(nEntity);
             byte entityType = entity.getType();
             int colType;
-            int columnWriterIndex = localDetails.getColumnIndex(entity.getName(), parser.hasNonAsciiChars());
+            int columnWriterIndex = localDetails.getColumnWriterIndex(entity.getName(), parser.hasNonAsciiChars());
             if (columnWriterIndex > -1) {
                 // column index found, processing column by index
                 if (columnWriterIndex == tud.getTimestampIndex()) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -367,55 +367,66 @@ public class LineTcpMeasurementScheduler implements Closeable {
         final int entCount = parser.getEntityCount();
         for (int i = 0; i < entCount; i++) {
             final LineTcpParser.ProtoEntity ent = parser.getEntity(i);
-            int columnIndex = ld.getColumnIndex(ent.getName(), parser.hasNonAsciiChars(), metadata);
-            int columnType = ColumnType.UNDEFINED;
-            if (columnIndex == COLUMN_NOT_FOUND) {
-                final String columnNameUtf16 = ld.getColNameUtf16();
-                if (autoCreateNewColumns && TableUtils.isValidColumnName(columnNameUtf16, cairoConfiguration.getMaxFileNameLength())) {
-                    columnIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
-                    if (columnIndex < 0) {
-                        securityContext.authorizeLineAlterTableAddColumn(writer.getTableToken());
-                        tud.commit(false);
-                        try {
-                            writer.addColumn(columnNameUtf16, ld.getColumnType(ld.getColNameUtf8(), ent.getType()));
-                            securityContext.onColumnAdded(tud.getTableToken(), columnNameUtf16);
-                            columnIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
-                        } catch (CairoException e) {
-                            columnIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
-                            if (columnIndex < 0) {
-                                // the column is still not there, something must be wrong
-                                throw e;
-                            }
-                            // all good, someone added the column concurrently
+            int columnWriterIndex = ld.getColumnWriterIndex(ent.getName(), parser.hasNonAsciiChars(), metadata);
+
+            switch (columnWriterIndex) {
+                default:
+                    final int columnType = metadata.getColumnType(columnWriterIndex);
+                    if (columnType > -1) {
+                        if (columnWriterIndex == tud.getTimestampIndex()) {
+                            timestamp = timestampAdapter.getMicros(ent.getLongValue());
+                            ld.addColumnType(DUPLICATED_COLUMN, ColumnType.UNDEFINED);
+                        } else {
+                            ld.addColumnType(columnWriterIndex, metadata.getColumnType(columnWriterIndex));
                         }
+                        break;
+                    } else {
+                        // column has been deleted from the metadata, but it is in our utf8 cache
+                        ld.removeFromCaches(ent.getName(), parser.hasNonAsciiChars());
+                        // act as if we did not find this column and fall through
                     }
-                    if (ld.getMetadataVersion() != initialMetadataVersion) {
-                        // Restart the whole line,
-                        // some columns can be deleted or renamed in tud.commit and ww.addColumn calls
-                        throw MetadataChangedException.INSTANCE;
+                case COLUMN_NOT_FOUND:
+                    final String columnNameUtf16 = ld.getColNameUtf16();
+                    if (autoCreateNewColumns && TableUtils.isValidColumnName(columnNameUtf16, cairoConfiguration.getMaxFileNameLength())) {
+                        columnWriterIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
+                        if (columnWriterIndex < 0) {
+                            securityContext.authorizeLineAlterTableAddColumn(writer.getTableToken());
+                            tud.commit(false);
+                            try {
+                                writer.addColumn(columnNameUtf16, ld.getColumnType(ld.getColNameUtf8(), ent.getType()));
+                                securityContext.onColumnAdded(tud.getTableToken(), columnNameUtf16);
+                                columnWriterIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
+                            } catch (CairoException e) {
+                                columnWriterIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
+                                if (columnWriterIndex < 0) {
+                                    // the column is still not there, something must be wrong
+                                    throw e;
+                                }
+                                // all good, someone added the column concurrently
+                            }
+                        }
+                        if (ld.getMetadataVersion() != initialMetadataVersion) {
+                            // Restart the whole line,
+                            // some columns can be deleted or renamed in tud.commit and ww.addColumn calls
+                            throw MetadataChangedException.INSTANCE;
+                        }
+                        ld.addColumnType(columnWriterIndex, metadata.getColumnType(columnWriterIndex));
+                    } else if (!autoCreateNewColumns) {
+                        throw newColumnsNotAllowed(tud, columnNameUtf16);
+                    } else {
+                        throw invalidColNameError(tud, columnNameUtf16);
                     }
-                    columnType = metadata.getColumnType(columnIndex);
-                } else if (!autoCreateNewColumns) {
-                    throw newColumnsNotAllowed(tud, columnNameUtf16);
-                } else {
-                    throw invalidColNameError(tud, columnNameUtf16);
-                }
-            } else if (columnIndex > -1) {
-                if (columnIndex == tud.getTimestampIndex()) {
-                    timestamp = timestampAdapter.getMicros(ent.getLongValue());
-                    columnIndex = DUPLICATED_COLUMN;
-                }
-                columnType = columnIndex < 0 ? ColumnType.UNDEFINED : metadata.getColumnType(columnIndex);
+                    break;
+                case DUPLICATED_COLUMN:
+                    // indicate to the second loop that writer index does not exist
+                    ld.addColumnType(DUPLICATED_COLUMN, ColumnType.UNDEFINED);
+                    break;
             }
-            ld.addColumnType(columnIndex, columnType);
         }
 
         TableWriter.Row r = writer.newRow(timestamp);
         try {
             for (int i = 0; i < entCount; i++) {
-                final LineTcpParser.ProtoEntity ent = parser.getEntity(i);
-
-                short entType = ent.getType();
                 int colTypeAndIndex = ld.getColumnType(i);
                 int colType = Numbers.decodeLowShort(colTypeAndIndex);
                 int columnIndex = Numbers.decodeHighShort(colTypeAndIndex);
@@ -424,7 +435,8 @@ public class LineTcpMeasurementScheduler implements Closeable {
                     continue;
                 }
 
-                switch (entType) {
+                final LineTcpParser.ProtoEntity ent = parser.getEntity(i);
+                switch (ent.getType()) {
                     case LineTcpParser.ENTITY_TYPE_TAG: {
                         if (ColumnType.tagOf(colType) == ColumnType.SYMBOL) {
                             r.putSymUtf8(columnIndex, ent.getValue(), parser.hasNonAsciiChars());
@@ -754,12 +766,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                         // Use actual table name from the "details" to avoid case mismatches in the
                         // WriterPool. There was an error in the LineTcpReceiverFuzzTest, which helped
                         // to identify the cause
-                        tud = unsafeAssignTableToWriterThread(
-                                securityContext,
-                                tudKeyIndex,
-                                tud.getTableNameUtf16(),
-                                tud.getTableNameUtf8()
-                        );
+                        tud = unsafeAssignTableToWriterThread(tudKeyIndex, tud.getTableNameUtf16(), tud.getTableNameUtf8());
                     } else {
                         idleTableUpdateDetailsUtf16.removeAt(idleTudKeyIndex);
                         tableUpdateDetailsUtf16.putAt(tudKeyIndex, tud.getTableNameUtf16(), tud);
@@ -783,12 +790,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                         ctx.addTableUpdateDetails(ByteCharSequence.newInstance(tableNameUtf8), tud);
                         return tud;
                     } else {
-                        tud = unsafeAssignTableToWriterThread(
-                                securityContext,
-                                tudKeyIndex,
-                                tableNameUtf16,
-                                ByteCharSequence.newInstance(tableNameUtf8)
-                        );
+                        tud = unsafeAssignTableToWriterThread(tudKeyIndex, tableNameUtf16, ByteCharSequence.newInstance(tableNameUtf8));
                     }
                 }
             }
@@ -808,7 +810,6 @@ public class LineTcpMeasurementScheduler implements Closeable {
 
     @NotNull
     private TableUpdateDetails unsafeAssignTableToWriterThread(
-            SecurityContext securityContext,
             int tudKeyIndex,
             CharSequence tableNameUtf16,
             ByteCharSequence tableNameUtf8

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -463,7 +463,7 @@ public class TableUpdateDetails implements Closeable {
 
         private int getColumnIndex0(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars, @NotNull TableRecordMetadata metadata) {
             // lookup was unsuccessful we have to check whether the column can be passed by name to the writer
-            final CharSequence colNameUtf16 = utf8ToUtf16(colNameUtf8, tempSink, hasNonAsciiChars);
+            final CharSequence colNameUtf16 = utf8toUtf16(colNameUtf8, hasNonAsciiChars);
             final int index = addedColsUtf16.keyIndex(colNameUtf16);
             if (index > -1) {
                 // column has not been sent to the writer by name on this line before
@@ -487,7 +487,7 @@ public class TableUpdateDetails implements Closeable {
                 }
                 // cannot not resolve column index even from the reader
                 // column will be passed to the writer by name
-                this.colNameUtf16 = colNameUtf16.toString();
+                this.colNameUtf16 = Chars.toString(colNameUtf16);
                 this.colNameUtf8 = onHeapColNameUtf8;
                 addedColsUtf16.addAt(index, this.colNameUtf16);
                 return COLUMN_NOT_FOUND;
@@ -535,8 +535,8 @@ public class TableUpdateDetails implements Closeable {
                     geoHashBits == 0 ? 0 : Numbers.encodeLowHighShorts((short) geoHashBits, ColumnType.tagOf(colType)));
         }
 
-        void addColumnType(int colIndex, int colType) {
-            columnTypes.add(Numbers.encodeLowHighShorts((short) colType, (short) colIndex));
+        void addColumnType(int columnWriterIndex, int colType) {
+            columnTypes.add(Numbers.encodeLowHighShorts((short) colType, (short) columnWriterIndex));
         }
 
         void clear() {
@@ -579,14 +579,31 @@ public class TableUpdateDetails implements Closeable {
             return colNameUtf8;
         }
 
+        int getColumnType(int colIndex) {
+            return columnTypes.getQuick(colIndex);
+        }
+
+        int getColumnType(ByteCharSequence colName, byte entityType) {
+            int colType = columnTypeByNameUtf8.get(colName);
+            if (colType < 0) {
+                colType = defaultColumnTypes.DEFAULT_COLUMN_TYPES[entityType];
+                columnTypeByNameUtf8.put(colName, colType);
+            }
+            return colType;
+        }
+
+        int getColumnTypeMeta(int colIndex) {
+            return columnTypeMeta.getQuick(colIndex + 1); // first val accounts for new cols, index -1
+        }
+
         // returns the column index for column name passed in colNameUtf8,
         // or COLUMN_NOT_FOUND if column index cannot be resolved (i.e. new column),
         // or DUPLICATED_COLUMN if the column has already been processed on the current event
-        int getColumnIndex(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars) {
+        int getColumnWriterIndex(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars) {
             int colWriterIndex = columnIndexByNameUtf8.get(colNameUtf8);
             if (colWriterIndex < 0) {
                 // lookup was unsuccessful we have to check whether the column can be passed by name to the writer
-                final CharSequence colNameUtf16 = utf8ToUtf16(colNameUtf8, tempSink, hasNonAsciiChars);
+                final CharSequence colNameUtf16 = utf8toUtf16(colNameUtf8, hasNonAsciiChars);
                 final int index = addedColsUtf16.keyIndex(colNameUtf16);
                 if (index > -1) {
                     // column has not been sent to the writer by name on this line before
@@ -603,7 +620,7 @@ public class TableUpdateDetails implements Closeable {
                     } else {
                         // cannot not resolve column index even from the reader
                         // column will be passed to the writer by name
-                        this.colNameUtf16 = colNameUtf16.toString();
+                        this.colNameUtf16 = Chars.toString(colNameUtf16);
                         this.colNameUtf8 = onHeapColNameUtf8;
                         addedColsUtf16.addAt(index, this.colNameUtf16);
                         return COLUMN_NOT_FOUND;
@@ -621,7 +638,7 @@ public class TableUpdateDetails implements Closeable {
             return colWriterIndex;
         }
 
-        int getColumnIndex(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars, @NotNull TableRecordMetadata metadata) {
+        int getColumnWriterIndex(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars, @NotNull TableRecordMetadata metadata) {
             final int colWriterIndex = columnIndexByNameUtf8.get(colNameUtf8);
             if (colWriterIndex < 0) {
                 // Hot path optimisation to allow the body of the current method to be small
@@ -634,23 +651,6 @@ public class TableUpdateDetails implements Closeable {
                 return DUPLICATED_COLUMN;
             }
             return colWriterIndex;
-        }
-
-        int getColumnType(int colIndex) {
-            return columnTypes.getQuick(colIndex);
-        }
-
-        int getColumnType(ByteCharSequence colName, byte entityType) {
-            int colType = columnTypeByNameUtf8.get(colName);
-            if (colType < 0) {
-                colType = defaultColumnTypes.DEFAULT_COLUMN_TYPES[entityType];
-                columnTypeByNameUtf8.put(colName, colType);
-            }
-            return colType;
-        }
-
-        int getColumnTypeMeta(int colIndex) {
-            return columnTypeMeta.getQuick(colIndex + 1); // first val accounts for new cols, index -1
         }
 
         long getMetadataVersion() {
@@ -669,6 +669,11 @@ public class TableUpdateDetails implements Closeable {
                 return addSymbolCache(columnIndex);
             }
             return NOT_FOUND_LOOKUP;
+        }
+
+        void removeFromCaches(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars) {
+            columnIndexByNameUtf8.remove(colNameUtf8);
+            addedColsUtf16.remove(utf8toUtf16(colNameUtf8, hasNonAsciiChars));
         }
 
         void resetStateIfNecessary() {
@@ -695,6 +700,10 @@ public class TableUpdateDetails implements Closeable {
                     }
                 }
             }
+        }
+
+        CharSequence utf8toUtf16(DirectByteCharSequence colNameUtf8, boolean hasNonAsciiChars) {
+            return utf8ToUtf16(colNameUtf8, tempSink, hasNonAsciiChars);
         }
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
@@ -539,9 +539,11 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                         .append('\n');
             }
             lineData = sb.toString();
-            SqlException exception = sendWithAlterStatement(lineData,
+            SqlException exception = sendWithAlterStatement(
+                    lineData,
                     "ALTER TABLE plug DROP COLUMN room",
-                    true, 1);
+                    true, 1
+            );
             Assert.assertNull(exception);
             drainWalQueue();
 
@@ -553,7 +555,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
 
     @Test
     public void testDropColumnConcurrentlyManyAttempts() throws Exception {
-        final int rows = 10_000;
+        final int rows = 15_000;
         runInContext((server) -> {
             String lineData = "plug,room=0i watts=\"1\",power=220 2631819999000\n";
             // pre-create the table


### PR DESCRIPTION
Fuzz test that drops column concurrently with ILP ingestion found a problem. It is a race condition in ILP, which can lead to data loss. More specifically, column name is double-cached in ILP, once for UTF8 and second time UTF16. These maps can diverge and column index begins to return negative column types that ILP doesn't know what to do with.

To help the review, i replaced "if" clause inside loop that is trying to determine if column has be added, with "switch" statement. It was not clear that there are three branches. I feel "switch" makes it easier to understand what's going on. I also renamed `columnIndex` to `columnWriterIndex` which is what this variable is.

Log is below:

```
2023-07-13T08:34:28.5574001Z 2023-07-13T08:34:26.075837Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5576026Z 2023-07-13T08:34:26.075847Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5578403Z 2023-07-13T08:34:26.075858Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5580466Z 2023-07-13T08:34:26.075868Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5582543Z 2023-07-13T08:34:26.075879Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5584602Z 2023-07-13T08:34:26.075889Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5586655Z 2023-07-13T08:34:26.075900Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5588701Z 2023-07-13T08:34:26.075910Z E i.q.c.l.t.LineTcpMeasurementScheduler could not write line protocol measurement [tableName=plug, message=cast error for line protocol tag [columnWriterIndex=0, columnType=unknown:-12, name=room]]
2023-07-13T08:34:28.5590205Z 2023-07-13T08:34:26.075947Z I IODispatcher scheduling disconnect [fd=57, reason=0]
2023-07-13T08:34:28.5591355Z 2023-07-13T08:34:26.075985Z I IODispatcher disconnected [ip=127.0.0.1, fd=57, src=queue]
2023-07-13T08:34:28.5592542Z 2023-07-13T08:34:26.076067Z I i.q.c.l.t.TableUpdateDetails closing table writer [tableName=plug]
2023-07-13T08:34:28.5593762Z 2023-07-13T08:34:26.076072Z I i.q.c.l.t.TableUpdateDetails closing table parsers [tableName=plug]
2023-07-13T08:34:28.5594937Z 2023-07-13T08:34:26.076111Z I i.q.t.c.l.t.AlterWalTableLineTcpReceiverTest EV_RETURN plug
2023-07-13T08:34:28.5596043Z 2023-07-13T08:34:26.077902Z I i.q.c.p.WriterPool >> [table=`plug~1`, thread=2470]
2023-07-13T08:34:28.5597833Z 2023-07-13T08:34:26.078152Z I i.q.c.TableWriter processing WAL [path=/tmp/junit6785161057291922642/dbRoot/plug~1/wal1/0, roLo=0, roHi=1, seqTxn=1, tsMin=1970-01-01T00:43:51.819999Z, tsMax=1970-01-01T00:43:51.819999Z, commitToTimestamp=294247-01-10T04:00:54.775807Z]
2023-07-13T08:34:28.5599591Z 2023-07-13T08:34:26.078316Z I i.q.c.TableWriter switched partition [path='/tmp/junit6785161057291922642/dbRoot/plug~1/1970-01-01']
2023-07-13T08:34:28.5600932Z 2023-07-13T08:34:26.078616Z I i.q.c.TableWriter removed [path=/tmp/junit6785161057291922642/dbRoot/plug~1/1970-01-01]
2023-07-13T08:34:28.5603585Z 2023-07-13T08:34:26.078626Z I i.q.c.TableWriter o3 partition task [table=plug, partitionIsReadOnly=false, srcOooBatchRowSize=1, srcOooLo=0, srcOooHi=0, srcOooMax=1, o3RowCount=1, o3LagRowCount=0, srcDataMax=0, o3TimestampMin=1970-01-01T00:43:51.819999Z, o3Timestamp=1970-01-01T00:43:51.819999Z, o3TimestampMax=1970-01-01T00:43:51.819999Z, partitionTimestamp=1970-01-01T00:00:00.000000Z, partitionIndex=-1, partitionSize=1, maxTimestamp=, last=false, append=false, pCount=1, flattenTimestamp=false, memUsed=20430424]
2023-07-13T08:34:28.5605925Z 2023-07-13T08:34:26.079074Z I i.q.c.TableWriter switched partition [path='/tmp/junit6785161057291922642/dbRoot/plug~1/1970-01-01']
2023-07-13T08:34:28.5607266Z 2023-07-13T08:34:26.079320Z I i.q.c.TableWriter removing [column=room, path=/tmp/junit6785161057291922642/dbRoot/plug~1]
2023-07-13T08:34:28.5608549Z 2023-07-13T08:34:26.081981Z I i.q.c.TableWriter column complete [table=plug, column=room, newColumnVersion=1]
2023-07-13T08:34:28.5609863Z 2023-07-13T08:34:26.081988Z I i.q.c.TableWriter REMOVED column 'room[SYMBOL]' from /tmp/junit6785161057291922642/dbRoot/plug~1
2023-07-13T08:34:28.5611880Z 2023-07-13T08:34:26.082051Z I i.q.c.TableWriter processing WAL [path=/tmp/junit6785161057291922642/dbRoot/plug~1/wal2/0, roLo=0, roHi=1000, seqTxn=3, tsMin=1970-01-01T00:43:51.819999Z, tsMax=1970-01-01T00:43:51.820998Z, commitToTimestamp=294247-01-10T04:00:54.775807Z]
2023-07-13T08:34:28.5615101Z 2023-07-13T08:34:26.082206Z I i.q.c.TableWriter o3 partition task [table=plug, partitionIsReadOnly=false, srcOooBatchRowSize=1000, srcOooLo=0, srcOooHi=999, srcOooMax=1000, o3RowCount=1000, o3LagRowCount=0, srcDataMax=1, o3TimestampMin=1970-01-01T00:43:51.819999Z, o3Timestamp=1970-01-01T00:43:51.819999Z, o3TimestampMax=1970-01-01T00:43:51.820998Z, partitionTimestamp=1970-01-01T00:00:00.000000Z, partitionIndex=0, partitionSize=1001, maxTimestamp=1970-01-01T00:43:51.819999Z, last=true, append=true, pCount=1, flattenTimestamp=false, memUsed=36219148]
2023-07-13T08:34:28.5617803Z 2023-07-13T08:34:26.082412Z I i.q.c.w.ApplyWal2TableJob job finished [table=plug~1, seqTxn=3, transactions=2, rows=1001, time=1ms, rate=672715rows/s, physicalWrittenRowsMultiplier=1.0]
2023-07-13T08:34:28.5619112Z 2023-07-13T08:34:26.082439Z I i.q.c.p.WriterPool << [table=`plug~1`, thread=2470]
2023-07-13T08:34:46.4144766Z 2023-07-13T08:34:46.411994Z E i.q.t.c.l.t.AbstractLineTcpReceiverTest Stopping ILP worker pool because of an error
2023-07-13T08:34:46.4146205Z java.lang.AssertionError: expected:<10001> but was:<1001>
2023-07-13T08:34:46.4147000Z 	at org.junit.Assert.fail(Assert.java:89)
2023-07-13T08:34:46.4147796Z 	at org.junit.Assert.failNotEquals(Assert.java:835)
2023-07-13T08:34:46.4150581Z 	at org.junit.Assert.assertEquals(Assert.java:647)
2023-07-13T08:34:46.4151426Z 	at org.junit.Assert.assertEquals(Assert.java:633)
2023-07-13T08:34:46.4154662Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$assertTableSize$24(AlterWalTableLineTcpReceiverTest.java:909)
2023-07-13T08:34:46.4155862Z 	at io.questdb.test.tools.TestUtils.assertEventually(TestUtils.java:452)
2023-07-13T08:34:46.4156980Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.assertTableSize(AlterWalTableLineTcpReceiverTest.java:906)
2023-07-13T08:34:46.4158286Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$testDropColumnConcurrently$15(AlterWalTableLineTcpReceiverTest.java:550)
2023-07-13T08:34:46.4183662Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.lambda$runInContext$2(AbstractLineTcpReceiverTest.java:298)
2023-07-13T08:34:46.4184921Z 	at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$4(AbstractCairoTest.java:285)
2023-07-13T08:34:46.4185904Z 	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:519)
2023-07-13T08:34:46.4186884Z 	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:282)
2023-07-13T08:34:46.4187952Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:290)
2023-07-13T08:34:46.4189120Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:314)
2023-07-13T08:34:46.4190310Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:285)
2023-07-13T08:34:46.4191556Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.testDropColumnConcurrently(AlterWalTableLineTcpReceiverTest.java:528)
2023-07-13T08:34:46.4192622Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-07-13T08:34:46.4193583Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2023-07-13T08:34:46.4194624Z 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-07-13T08:34:46.4195576Z 	at java.lang.reflect.Method.invoke(Method.java:566)
2023-07-13T08:34:46.4196936Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2023-07-13T08:34:46.4197969Z 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2023-07-13T08:34:46.4199212Z 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
2023-07-13T08:34:46.4200214Z 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2023-07-13T08:34:46.4201216Z 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
2023-07-13T08:34:46.4202201Z 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2023-07-13T08:34:46.4203140Z 	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
2023-07-13T08:34:46.4204809Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
2023-07-13T08:34:46.4205936Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
2023-07-13T08:34:46.4206918Z 	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
2023-07-13T08:34:46.4207744Z 	at java.lang.Thread.run(Thread.java:829)
2023-07-13T08:34:46.4209163Z 2023-07-13T08:34:46.415226Z I i.q.t.c.l.t.AbstractLineTcpReceiverTest cleaned worker [name=testing, worker=0, total=1]
2023-07-13T08:34:46.4210572Z 2023-07-13T08:34:46.415236Z I i.q.t.c.l.t.AbstractLineTcpReceiverTest os scheduled worker stopped [name=questdb-testing-1392]
2023-07-13T08:34:46.4212463Z 2023-07-13T08:34:46.417589Z I i.q.c.l.t.LineTcpWriterJob line protocol writer closing [threadId=0]
2023-07-13T08:34:46.4213623Z 2023-07-13T08:34:46.417651Z I IODispatcher closed
2023-07-13T08:34:46.4214800Z 2023-07-13T08:34:46.417655Z E i.q.t.c.l.t.AbstractLineTcpReceiverTest Stopping ILP receiver because of an error
2023-07-13T08:34:46.4215820Z java.lang.AssertionError: expected:<10001> but was:<1001>
2023-07-13T08:34:46.4216765Z 	at org.junit.Assert.fail(Assert.java:89)
2023-07-13T08:34:46.4218062Z 	at org.junit.Assert.failNotEquals(Assert.java:835)
2023-07-13T08:34:46.4218882Z 	at org.junit.Assert.assertEquals(Assert.java:647)
2023-07-13T08:34:46.4219687Z 	at org.junit.Assert.assertEquals(Assert.java:633)
2023-07-13T08:34:46.4220720Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$assertTableSize$24(AlterWalTableLineTcpReceiverTest.java:909)
2023-07-13T08:34:46.4221736Z 	at io.questdb.test.tools.TestUtils.assertEventually(TestUtils.java:452)
2023-07-13T08:34:46.4222728Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.assertTableSize(AlterWalTableLineTcpReceiverTest.java:906)
2023-07-13T08:34:46.4223919Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$testDropColumnConcurrently$15(AlterWalTableLineTcpReceiverTest.java:550)
2023-07-13T08:34:46.4225117Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.lambda$runInContext$2(AbstractLineTcpReceiverTest.java:298)
2023-07-13T08:34:46.4226156Z 	at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$4(AbstractCairoTest.java:285)
2023-07-13T08:34:46.4227059Z 	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:519)
2023-07-13T08:34:46.4227937Z 	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:282)
2023-07-13T08:34:46.4228929Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:290)
2023-07-13T08:34:46.4230097Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:314)
2023-07-13T08:34:46.4231187Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:285)
2023-07-13T08:34:46.4232316Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.testDropColumnConcurrently(AlterWalTableLineTcpReceiverTest.java:528)
2023-07-13T08:34:46.4233274Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-07-13T08:34:46.4234126Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2023-07-13T08:34:46.4235103Z 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-07-13T08:34:46.4236136Z 	at java.lang.reflect.Method.invoke(Method.java:566)
2023-07-13T08:34:46.4236977Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2023-07-13T08:34:46.4238129Z 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2023-07-13T08:34:46.4239057Z 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
2023-07-13T08:34:46.4239981Z 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2023-07-13T08:34:46.4240899Z 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
2023-07-13T08:34:46.4241807Z 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2023-07-13T08:34:46.4242663Z 	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
2023-07-13T08:34:46.4243576Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
2023-07-13T08:34:46.4244608Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
2023-07-13T08:34:46.4245511Z 	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
2023-07-13T08:34:46.4246302Z 	at java.lang.Thread.run(Thread.java:829)
2023-07-13T08:34:46.4247368Z 2023-07-13T08:34:46.418035Z I i.q.c.TableWriter closed 'plug'
2023-07-13T08:34:46.4248510Z 2023-07-13T08:34:46.418037Z I i.q.c.p.WriterPool closed [table=`plug~1`, reason=POOL_CLOSED, by=2470]
2023-07-13T08:34:46.4249740Z 2023-07-13T08:34:46.418147Z I i.q.c.w.s.TableSequencerAPI releasing idle table sequencer [tableDir=plug~1]
2023-07-13T08:34:46.4250848Z 2023-07-13T08:34:46.422883Z I i.q.c.w.WalWriter closed 'plug'
2023-07-13T08:34:46.4280664Z 2023-07-13T08:34:46.426824Z I i.q.c.w.WalWriter closed 'plug'
2023-07-13T08:34:46.4281982Z 2023-07-13T08:34:46.426930Z I i.q.t.AbstractCairoTest Tearing down test AlterWalTableLineTcpReceiverTest#testDropColumnConcurrently
2023-07-13T08:34:46.4341973Z 2023-07-13T08:34:46.430827Z E i.q.t.TestListener ***** Test Failed *****io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.testDropColumnConcurrently duration_ms=20657 : 
2023-07-13T08:34:46.4343445Z java.lang.AssertionError: expected:<10001> but was:<1001>
2023-07-13T08:34:46.4344317Z 	at org.junit.Assert.fail(Assert.java:89)
2023-07-13T08:34:46.4345110Z 	at org.junit.Assert.failNotEquals(Assert.java:835)
2023-07-13T08:34:46.4345932Z 	at org.junit.Assert.assertEquals(Assert.java:647)
2023-07-13T08:34:46.4346755Z 	at org.junit.Assert.assertEquals(Assert.java:633)
2023-07-13T08:34:46.4347801Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$assertTableSize$24(AlterWalTableLineTcpReceiverTest.java:909)
2023-07-13T08:34:46.4348936Z 	at io.questdb.test.tools.TestUtils.assertEventually(TestUtils.java:452)
2023-07-13T08:34:46.4350045Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.assertTableSize(AlterWalTableLineTcpReceiverTest.java:906)
2023-07-13T08:34:46.4351358Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.lambda$testDropColumnConcurrently$15(AlterWalTableLineTcpReceiverTest.java:550)
2023-07-13T08:34:46.4352646Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.lambda$runInContext$2(AbstractLineTcpReceiverTest.java:298)
2023-07-13T08:34:46.4353775Z 	at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$4(AbstractCairoTest.java:285)
2023-07-13T08:34:46.4354764Z 	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:519)
2023-07-13T08:34:46.4355726Z 	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:282)
2023-07-13T08:34:46.4356800Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:290)
2023-07-13T08:34:46.4357975Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:314)
2023-07-13T08:34:46.4359134Z 	at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:285)
2023-07-13T08:34:46.4360615Z 	at io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.testDropColumnConcurrently(AlterWalTableLineTcpReceiverTest.java:528)
2023-07-13T08:34:46.4361666Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-07-13T08:34:46.4362603Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2023-07-13T08:34:46.4363679Z 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-07-13T08:34:46.4364653Z 	at java.lang.reflect.Method.invoke(Method.java:566)
2023-07-13T08:34:46.4365566Z 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2023-07-13T08:34:46.4366562Z 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2023-07-13T08:34:46.4367490Z 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
2023-07-13T08:34:46.4368430Z 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2023-07-13T08:34:46.4369357Z 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
2023-07-13T08:34:46.4370256Z 	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2023-07-13T08:34:46.4371098Z 	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
2023-07-13T08:34:46.4372029Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
2023-07-13T08:34:46.4373140Z 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
2023-07-13T08:34:46.4374052Z 	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
2023-07-13T08:34:46.4374789Z 	at java.lang.Thread.run(Thread.java:829)
2023-07-13T08:34:46.4380241Z 2023-07-13T08:34:46.430942Z I i.q.t.TestListener <<<< io.questdb.test.cutlass.line.tcp.AlterWalTableLineTcpReceiverTest.testDropColumnConcurrently duration_ms=20657
```