### PR TITLE
fix(ilp): fix race condition in ILP authentication

### DIFF
--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -228,7 +228,7 @@ public class ServerMain implements Closeable {
             CharSequenceObjHashMap<PublicKey> authDb = AuthUtils.loadAuthDb(absPath);
             authenticatorFactory = new EllipticCurveAuthenticatorFactory(
                     configuration.getLineTcpReceiverConfiguration().getNetworkFacade(),
-                    new StaticChallengeResponseMatcher(authDb)
+                    () -> new StaticChallengeResponseMatcher(authDb)
             );
         } else {
             authenticatorFactory = DefaultLineAuthenticatorFactory.INSTANCE;

--- a/core/src/main/java/io/questdb/cutlass/auth/EllipticCurveAuthenticatorFactory.java
+++ b/core/src/main/java/io/questdb/cutlass/auth/EllipticCurveAuthenticatorFactory.java
@@ -26,18 +26,19 @@ package io.questdb.cutlass.auth;
 
 import io.questdb.cutlass.line.tcp.auth.EllipticCurveAuthenticator;
 import io.questdb.network.NetworkFacade;
+import io.questdb.std.ObjectFactory;
 
 public class EllipticCurveAuthenticatorFactory implements LineAuthenticatorFactory {
-    private final ChallengeResponseMatcher matcher;
+    private final ObjectFactory<ChallengeResponseMatcher> matcherFactory;
     private final NetworkFacade networkFacade;
 
-    public EllipticCurveAuthenticatorFactory(NetworkFacade networkFacade, ChallengeResponseMatcher matcher) {
+    public EllipticCurveAuthenticatorFactory(NetworkFacade networkFacade, ObjectFactory<ChallengeResponseMatcher> matcherFactory) {
         this.networkFacade = networkFacade;
-        this.matcher = matcher;
+        this.matcherFactory = matcherFactory;
     }
 
     @Override
     public Authenticator getLineTCPAuthenticator() {
-        return new EllipticCurveAuthenticator(networkFacade, matcher);
+        return new EllipticCurveAuthenticator(networkFacade, matcherFactory.newInstance());
     }
 }

--- a/core/src/test/java/io/questdb/test/AbstractBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractBootstrapTest.java
@@ -55,6 +55,7 @@ public abstract class AbstractBootstrapTest extends AbstractTest {
     protected static final Properties PG_CONNECTION_PROPERTIES = new Properties();
     protected static final int PG_PORT = 8822;
     protected static final String PG_CONNECTION_URI = getPgConnectionUri(PG_PORT);
+    protected static int ILP_WORKER_COUNT = 1;
     protected static Path auxPath;
     protected static Path dbPath;
     protected static int dbPathLen;
@@ -125,7 +126,7 @@ public abstract class AbstractBootstrapTest extends AbstractTest {
             writer.println("http.min.worker.count=1");
             writer.println("pg.worker.count=1");
             writer.println("line.tcp.writer.worker.count=1");
-            writer.println("line.tcp.io.worker.count=1");
+            writer.println("line.tcp.io.worker.count=" + ILP_WORKER_COUNT);
 
             // extra
             if (extra != null) {

--- a/core/src/test/java/io/questdb/test/ConcurrentTcpSenderBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/ConcurrentTcpSenderBootstrapTest.java
@@ -1,0 +1,76 @@
+package io.questdb.test;
+
+import io.questdb.ServerMain;
+import io.questdb.client.Sender;
+import io.questdb.std.Files;
+import io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+
+public class ConcurrentTcpSenderBootstrapTest extends AbstractBootstrapTest {
+
+    private static final int CONCURRENCY_LEVEL = 64;
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        final String confPath = root + Files.SEPARATOR + "conf";
+        String file = confPath + Files.SEPARATOR + "auth.txt";
+        TestUtils.unchecked(() -> {
+            ILP_WORKER_COUNT = CONCURRENCY_LEVEL;
+            createDummyConfiguration("line.tcp.auth.db.path=conf/auth.txt");
+            try (PrintWriter writer = new PrintWriter(file, CHARSET)) {
+                writer.println("testUser1	ec-p-256-sha256	AKfkxOBlqBN8uDfTxu2Oo6iNsOPBnXkEH4gt44tBJKCY	AL7WVjoH-IfeX_CXo5G1xXKp_PqHUrdo3xeRyDuWNbBX");
+            } catch (FileNotFoundException | UnsupportedEncodingException e) {
+                throw new AssertionError("Failed to create auth.txt", e);
+            }
+        });
+        dbPath.parent().$();
+    }
+
+
+    @Test
+    public void testConcurrentAuth() throws Exception {
+        int nThreads = CONCURRENCY_LEVEL;
+        int iterationCount = 10;
+        // this test uses more complex bootstrap configuration than most of the other TCP Sender/Receiver tests
+        // the goal is to have it as close to the real production QuestDB server as possible.
+        // including using the same authentication factories and configuration
+        TestUtils.assertMemoryLeak(() -> {
+            // run multiple iteration to increase chances of hitting a race condition
+            for (int i = 0; i < iterationCount; i++) {
+                testConcurrentSenders(nThreads, i + nThreads);
+            }
+        });
+    }
+
+    private static void testConcurrentSenders(int nThreads, int startingOffset) {
+        try (final ServerMain serverMain = new ServerMain(getServerMainArgs())) {
+            serverMain.start();
+            for (int i = startingOffset; i < nThreads + startingOffset; i++) {
+                int threadNo = i;
+                new Thread(() -> {
+                    try (Sender sender = Sender.builder()
+                            .address("localhost")
+                            .port(serverMain.getConfiguration().getLineTcpReceiverConfiguration().getDispatcherConfiguration().getBindPort())
+                            .enableAuth(AbstractLineTcpReceiverTest.AUTH_KEY_ID1)
+                            .authToken(AbstractLineTcpReceiverTest.AUTH_TOKEN_KEY1)
+                            .build()) {
+                        sender.table("test" + threadNo).stringColumn("value", "test").atNow();
+                        sender.flush();
+                    }
+                }).start();
+            }
+            for (int i = startingOffset; i < nThreads + startingOffset; i++) {
+                while (serverMain.getEngine().getTableTokenIfExists("test" + i) == null) {
+                    // intentionally empty
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -109,7 +109,7 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
             URL u = getClass().getResource("authDb.txt");
             assert u != null;
             CharSequenceObjHashMap<PublicKey> authDb = AuthUtils.loadAuthDb(u.getFile());
-            return new EllipticCurveAuthenticatorFactory(nf, new StaticChallengeResponseMatcher(authDb));
+            return new EllipticCurveAuthenticatorFactory(nf, () -> new StaticChallengeResponseMatcher(authDb));
         }
     };
     protected int partitionByDefault = PartitionBy.DAY;

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpContextTest.java
@@ -145,7 +145,7 @@ abstract class BaseLineTcpContextTest extends AbstractCairoTest {
                     URL u = getClass().getResource("authDb.txt");
                     assert u != null;
                     CharSequenceObjHashMap<PublicKey> authDb = AuthUtils.loadAuthDb(u.getFile());
-                    return new EllipticCurveAuthenticatorFactory(nf, new StaticChallengeResponseMatcher(authDb));
+                    return new EllipticCurveAuthenticatorFactory(nf, () -> new StaticChallengeResponseMatcher(authDb));
                 }
                 return super.getLineAuthenticatorFactory();
             }


### PR DESCRIPTION
Previously, there could be multiple threads sharing the same buffer inside StaticChallengeResponseMatcher. This could lead to signature being mangled and thus valid user could be refused to connect. This bug could not be abused to get access without having a valid key.

This fix will create a StaticChallengeResponseMatcher instance for each EllipticCurveAuthenticator instance.