### PR TITLE
fix(sql): fix Invalid Column error with multiple JOIN

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -754,11 +754,6 @@ public class SqlOptimiser {
                     if (qualifies) {
                         postFilterRemoved.add(k);
                         QueryModel m = parent.getJoinModels().getQuick(index);
-                        // it is possible that filter references only top query via alias
-                        // we will need to strip these aliases before assigning filter
-                        if (index == 0) {
-                            traversalAlgo.traverse(node, literalRewritingVisitor.of(m.getAliasToColumnNameMap()));
-                        }
                         m.setPostJoinWhereClause(concatFilters(m.getPostJoinWhereClause(), node));
                     }
                 }
@@ -2933,6 +2928,11 @@ public class SqlOptimiser {
             }
 
             propagateTopDownColumns0(jm, false, model, true);
+        }
+
+        final ExpressionNode postJoinWhere = model.getPostJoinWhereClause();
+        if (postJoinWhere != null) {
+            emitLiteralsTopDown(postJoinWhere, model);
         }
 
         // If this is group by model we need to add all non-selected keys, only if this is sub-query

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerTest.java
@@ -4152,6 +4152,34 @@ public class SqlCompilerTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testNonEqualityJoinCondition() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table tab ( created timestamp, value long ) timestamp(created) ");
+            compile("insert into tab values (0, 0), (1, 1)");
+
+            assertQuery("count\n" +
+                            "1\n",
+                    "SELECT " +
+                            "  count(*) " +
+                            "FROM " +
+                            "  tab as T1 " +
+                            "  JOIN tab as T2 ON T1.created < T2.created " +
+                            "  JOIN tab as T3 ON T2.created = T3.created",
+                    null, false, true);
+
+            assertQuery("count\n" +
+                            "1\n",
+                    "SELECT " +
+                            "  count(*) " +
+                            "FROM " +
+                            "  tab as T1 " +
+                            "  JOIN tab as T2 ON T1.created < T2.created " +
+                            "  JOIN tab as T3 ON T2.value = T3.value",
+                    null, false, true);
+        });
+    }
+
+    @Test
     public void testOrderByDouble() throws Exception {
         assertQuery("d\n" +
                         "NaN\n" +


### PR DESCRIPTION
Fixes #3595 

Fixes 'Invalid column' error occurring for columns in non-equality join condition when join order is different from that in query . 