### PR TITLE
fix(sql): fix string and char comparison

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3089,6 +3089,43 @@ if __name__ == "__main__":
     }
 
     @Test
+    public void testImplicitStringAndCharConversions() throws Exception {
+        skipOnWalRun();
+        assertWithPgServer(CONN_AWARE_EXTENDED_ALL, (connection, binary) -> {
+            connection.setAutoCommit(false);
+
+            try (PreparedStatement stmt = connection.prepareStatement("select ? > 'a'")) {
+                stmt.setString(1, "ab");
+                ResultSet resultSet = stmt.executeQuery();
+
+                sink.clear();
+                assertResultSet("column[BIT]\n" +
+                        "true\n", sink, resultSet);
+
+                stmt.setString(1, "a");
+                resultSet = stmt.executeQuery();
+
+                sink.clear();
+                assertResultSet("column[BIT]\n" +
+                        "false\n", sink, resultSet);
+
+                stmt.setString(1, "");
+                resultSet = stmt.executeQuery();
+                sink.clear();
+                assertResultSet("column[BIT]\n" +
+                        "false\n", sink, resultSet);
+
+
+                stmt.setString(1, null);
+                resultSet = stmt.executeQuery();
+                sink.clear();
+                assertResultSet("column[BIT]\n" +
+                        "false\n", sink, resultSet);
+            }
+        });
+    }
+
+    @Test
     public void testIndexedSymbolBindVariableNotEqualsSingleValueMultipleExecutions() throws Exception {
         assertMemoryLeak(() -> {
             try (


### PR DESCRIPTION
Fixes #3576 
e.g. 
```sql
select 'ab'>'a'
```

Also fixes function matching for expressions that use bind variables or non-constant arguments, e.g. 
```sql
select ? > 'a'
select rnd_str('be', 'cd') < 'd'
```
that used to expect both char arguments and fail for strings longer than 1 character . 
