### PR TITLE
chore(core): fix write error with dedup enabled

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1805,23 +1805,25 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                 o3RowCount = o3Hi - o3Lo + walLagRowCount;
 
-                // Now that everything from WAL lag is in memory or in WAL columns,
-                // we can remove artificial 0 length partition created to store lag when table did not have any partitions
-                if (txWriter.getRowCount() == 0 && txWriter.getPartitionCount() == 1 && txWriter.getPartitionSize(0) == 0) {
-                    txWriter.setMaxTimestamp(Long.MIN_VALUE);
-                    lastPartitionTimestamp = Long.MIN_VALUE;
-                    closeActivePartition(false);
-                    partitionTimestampHi = Long.MIN_VALUE;
-                    long partitionTimestamp = txWriter.getPartitionTimestampByIndex(0);
-                    long partitionNameTxn = txWriter.getPartitionNameTxnByRawIndex(0);
-                    txWriter.removeAttachedPartitions(partitionTimestamp);
-                    safeDeletePartitionDir(partitionTimestamp, partitionNameTxn);
-                }
 
                 // Real data writing into table happens here.
                 // Everything above it is to figure out how much data to write now,
                 // map symbols and sort data if necessary.
                 if (o3Hi > o3Lo) {
+
+                    // Now that everything from WAL lag is in memory or in WAL columns,
+                    // we can remove artificial 0 length partition created to store lag when table did not have any partitions
+                    if (txWriter.getRowCount() == 0 && txWriter.getPartitionCount() == 1 && txWriter.getPartitionSize(0) == 0) {
+                        txWriter.setMaxTimestamp(Long.MIN_VALUE);
+                        lastPartitionTimestamp = Long.MIN_VALUE;
+                        closeActivePartition(false);
+                        partitionTimestampHi = Long.MIN_VALUE;
+                        long partitionTimestamp = txWriter.getPartitionTimestampByIndex(0);
+                        long partitionNameTxn = txWriter.getPartitionNameTxnByRawIndex(0);
+                        txWriter.removeAttachedPartitions(partitionTimestamp);
+                        safeDeletePartitionDir(partitionTimestamp, partitionNameTxn);
+                    }
+                    
                     processO3Block(
                             walLagRowCount,
                             timestampIndex,


### PR DESCRIPTION
Fix write error when dedup is enabled and commit results in moving all rows to lag.
Improve dedup fuzz tests to have more Timestamp collisions.