### PR TITLE
fix(ui): Fix broken image link in translated READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Java and C++, with no dependencies and zero garbage collection.
 
 <div align="center">
   <a href="https://demo.questdb.io">
-    <img alt="QuestDB Web Console showing s SQL statement and query result" src="https://raw.githubusercontent.com/questdb/questdb/master/.github/console.png" width="800" />
+    <img alt="QuestDB Web Console showing a SQL statement and query result" src="https://raw.githubusercontent.com/questdb/questdb/master/.github/console.png" width="600" />
   </a>
 </div>
 

--- a/i18n/README.ar-dz.md
+++ b/i18n/README.ar-dz.md
@@ -103,7 +103,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="مخطط بياني يقارن الحد الأقصى من الإنتاجية لكل من QuestDB و ClickHouse و TimescaleDB و InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.ar-dz.md
+++ b/i18n/README.ar-dz.md
@@ -1,9 +1,5 @@
 <div align="center">
-  <img
-    alt="QuestDB Logo"
-    src="https://raw.githubusercontent.com/questdb/questdb/master/.github/logo-readme.png"
-    width="305px"
-  />
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.ar-dz.md
+++ b/i18n/README.ar-dz.md
@@ -99,7 +99,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="مخطط بياني يقارن الحد الأقصى من الإنتاجية لكل من QuestDB و ClickHouse و TimescaleDB و InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="مخطط بياني يقارن الحد الأقصى من الإنتاجية لكل من QuestDB و ClickHouse و TimescaleDB و InfluxDB." width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.ar-dz.md
+++ b/i18n/README.ar-dz.md
@@ -105,7 +105,7 @@ questdb stop  // To stop questdb
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
     <img
       alt="مخطط بياني يقارن الحد الأقصى من الإنتاجية لكل من QuestDB و ClickHouse و TimescaleDB و InfluxDB."
-      src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"
+      src="../.github/readme-benchmark.png"
     />
   </a>
 </div>

--- a/i18n/README.ar-dz.md
+++ b/i18n/README.ar-dz.md
@@ -103,10 +103,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img
-      alt="مخطط بياني يقارن الحد الأقصى من الإنتاجية لكل من QuestDB و ClickHouse و TimescaleDB و InfluxDB."
-      src="../.github/readme-benchmark.png"
-    />
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.es-es.md
+++ b/i18n/README.es-es.md
@@ -88,7 +88,7 @@ En este link se puede ver los resultados para un caso de uso de alta cardinalida
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"/>
+    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" src="../.github/readme-benchmark.png"/>
   </a>
 </div>
 

--- a/i18n/README.es-es.md
+++ b/i18n/README.es-es.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/>
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.es-es.md
+++ b/i18n/README.es-es.md
@@ -88,7 +88,7 @@ En este link se puede ver los resultados para un caso de uso de alta cardinalida
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" src="../.github/readme-benchmark.png"/>
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.es-es.md
+++ b/i18n/README.es-es.md
@@ -88,7 +88,7 @@ En este link se puede ver los resultados para un caso de uso de alta cardinalida
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.es-es.md
+++ b/i18n/README.es-es.md
@@ -88,7 +88,7 @@ En este link se puede ver los resultados para un caso de uso de alta cardinalida
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Una gráfica que compara el rendimiento máximo de QuestDB, ClickHouse, TimescaleDB e InfluxDB" width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.it-it.md
+++ b/i18n/README.it-it.md
@@ -90,7 +90,7 @@ risultati ottenuti usando `cpu-only` con 6 workers su un AMD Ryzen 3970X:
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.it-it.md
+++ b/i18n/README.it-it.md
@@ -90,7 +90,7 @@ risultati ottenuti usando `cpu-only` con 6 workers su un AMD Ryzen 3970X:
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"/>
+    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="../.github/readme-benchmark.png"/>
   </a>
 </div>
 

--- a/i18n/README.it-it.md
+++ b/i18n/README.it-it.md
@@ -90,7 +90,7 @@ risultati ottenuti usando `cpu-only` con 6 workers su un AMD Ryzen 3970X:
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.it-it.md
+++ b/i18n/README.it-it.md
@@ -90,7 +90,7 @@ risultati ottenuti usando `cpu-only` con 6 workers su un AMD Ryzen 3970X:
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Grafico che compara la massima portata di QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="../.github/readme-benchmark.png"/>
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.it-it.md
+++ b/i18n/README.it-it.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/>
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.ja-ja.md
+++ b/i18n/README.ja-ja.md
@@ -92,7 +92,7 @@ AMD Ryzen 3970X で 6 ワーカーの「cpu-only」ユース ケースを使用�
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
 <!--     <img  src=".github/tsbs-results.png"/> -->
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.ja-ja.md
+++ b/i18n/README.ja-ja.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/>
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.pt.md
+++ b/i18n/README.pt.md
@@ -108,7 +108,7 @@ resultados usando o `cpu-only` caso de uso com 6 trabalhadores em um AMD Ryzen 3
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="../.github/readme-benchmark.png"/>
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.pt.md
+++ b/i18n/README.pt.md
@@ -108,7 +108,7 @@ resultados usando o `cpu-only` caso de uso com 6 trabalhadores em um AMD Ryzen 3
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.pt.md
+++ b/i18n/README.pt.md
@@ -108,7 +108,7 @@ resultados usando o `cpu-only` caso de uso com 6 trabalhadores em um AMD Ryzen 3
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"/>
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." src="../.github/readme-benchmark.png"/>
   </a>
 </div>
 

--- a/i18n/README.pt.md
+++ b/i18n/README.pt.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/>
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.ua-ua.md
+++ b/i18n/README.ua-ua.md
@@ -83,7 +83,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.ua-ua.md
+++ b/i18n/README.ua-ua.md
@@ -83,7 +83,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." src="../.github/readme-benchmark.png"/>
+    <img alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.ua-ua.md
+++ b/i18n/README.ua-ua.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/>
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 

--- a/i18n/README.ua-ua.md
+++ b/i18n/README.ua-ua.md
@@ -83,7 +83,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"/>
+    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." src="../.github/readme-benchmark.png"/>
   </a>
 </div>
 

--- a/i18n/README.ua-ua.md
+++ b/i18n/README.ua-ua.md
@@ -83,7 +83,7 @@ questdb stop  // To stop questdb
 
 <div align="center">
   <a href="https://questdb.io/blog/2021/06/16/high-cardinality-time-series-data-performance/">
-    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." width="1042" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
+    <img alt="Діаграма порівняння максимальної пропускної здатності QuestDB, ClickHouse, TimescaleDB і InfluxDB." width="600" alt="tsbs-results" src="https://user-images.githubusercontent.com/91843271/197382161-e5f3f5b0-18bf-439a-94e4-83ab4bf91d7c.png">
   </a>
 </div>
 

--- a/i18n/README.zh-cn.md
+++ b/i18n/README.zh-cn.md
@@ -127,7 +127,7 @@ questdb stop  // To stop questdb
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
       src="../.github/readme-benchmark.png"
-      width="1024"
+      width="600"
     />
   </a>
 </div>

--- a/i18n/README.zh-cn.md
+++ b/i18n/README.zh-cn.md
@@ -1,9 +1,5 @@
 <div align="center">
-  <img
-    alt="QuestDB Logo"
-    src="https://raw.githubusercontent.com/questdb/questdb/master/.github/logo-readme.png"
-    width="305px"
-  />
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 
@@ -131,6 +127,7 @@ questdb stop  // To stop questdb
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
       src="../.github/readme-benchmark.png"
+      width="1024"
     />
   </a>
 </div>

--- a/i18n/README.zh-cn.md
+++ b/i18n/README.zh-cn.md
@@ -130,7 +130,7 @@ questdb stop  // To stop questdb
   <a href="https://questdb.io/time-series-benchmark-suite/">
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
-      src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"
+      src="../.github/readme-benchmark.png"
     />
   </a>
 </div>

--- a/i18n/README.zh-hk.md
+++ b/i18n/README.zh-hk.md
@@ -127,7 +127,7 @@ questdb stop  // To stop questdb
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
       src="../.github/readme-benchmark.png"
-      width="1024"
+      width="600"
     />
   </a>
 </div>

--- a/i18n/README.zh-hk.md
+++ b/i18n/README.zh-hk.md
@@ -1,9 +1,5 @@
 <div align="center">
-  <img
-    alt="QuestDB Logo"
-    src="https://raw.githubusercontent.com/questdb/questdb/master/.github/logo-readme.png"
-    width="305px"
-  />
+   <a href="https://questdb.io/" target="blank"><img alt="QuestDB Logo" src="https://questdb.io/img/questdb-logo-themed.svg" width="305px"/></a>
 </div>
 <p>&nbsp;</p>
 
@@ -131,6 +127,7 @@ questdb stop  // To stop questdb
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
       src="../.github/readme-benchmark.png"
+      width="1024"
     />
   </a>
 </div>

--- a/i18n/README.zh-hk.md
+++ b/i18n/README.zh-hk.md
@@ -130,7 +130,7 @@ questdb stop  // To stop questdb
   <a href="https://questdb.io/time-series-benchmark-suite/">
     <img
       alt="A chart comparing the maximum throughput of QuestDB, ClickHouse, TimescaleDB and InfluxDB."
-      src="https://raw.githubusercontent.com/questdb/questdb/master/.github/tsbs-results.png"
+      src="../.github/readme-benchmark.png"
     />
   </a>
 </div>


### PR DESCRIPTION
All but one of the current translated READMEs used a fully-qualified URL to a PNG image that no longer exists. This fixes the image srcs to point to the equivalent image.

Curiously, some translations describe their TSDB image in the way that corresponds to the English README, but many others refer to a different benchmark using a `Ryzen 3970X`. I have for the time being amended any translation that uses that exact phrase to use the latter benchmark image, although I'm unsure where it came from.