### PR TITLE
fix(core): avoid unbounded growth of transactions in O3 lag of WAL tables

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -293,6 +293,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long walApplyWorkerSleepThreshold;
     private final long walApplyWorkerYieldThreshold;
     private final boolean walEnabledDefault;
+    private final int walMaxLagTxnCount;
     private final long walPurgeInterval;
     private final int walRecreateDistressedSequencerAttempts;
     private final long walSegmentRolloverRowCount;
@@ -507,6 +508,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.walSegmentRolloverRowCount = getLong(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 200_000);
         this.walWriterDataAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, PropertyKey.CAIRO_WAL_WRITER_DATA_APPEND_PAGE_SIZE, Numbers.SIZE_1MB));
         this.walSquashUncommittedRowsMultiplier = getDouble(properties, env, PropertyKey.CAIRO_WAL_SQUASH_UNCOMMITTED_ROWS_MULTIPLIER, 20.0);
+        this.walMaxLagTxnCount = getInt(properties, env, PropertyKey.CAIRO_WAL_MAX_LAG_TXN_COUNT, Math.max((int) Math.round(walSquashUncommittedRowsMultiplier), 1));
         this.walApplyTableTimeQuota = getLong(properties, env, PropertyKey.CAIRO_WAL_APPLY_TABLE_TIME_QUOTA, 1000);
         this.walApplyLookAheadTransactionCount = getInt(properties, env, PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 20);
         this.tableTypeConversionEnabled = getBoolean(properties, env, PropertyKey.TABLE_TYPE_CONVERSION_ENABLED, true);
@@ -2431,6 +2433,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean getWalEnabledDefault() {
             return walEnabledDefault;
+        }
+
+        @Override
+        public int getWalMaxLagTxnCount() {
+            return walMaxLagTxnCount;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -398,6 +398,7 @@ public enum PropertyKey implements ConfigProperty {
     CAIRO_WAL_RECREATE_DISTRESSED_SEQUENCER_ATTEMPTS("cairo.wal.recreate.distressed.sequencer.attempts"),
     CAIRO_WAL_INACTIVE_WRITER_TTL("cairo.wal.inactive.writer.ttl"),
     CAIRO_WAL_SQUASH_UNCOMMITTED_ROWS_MULTIPLIER("cairo.wal.squash.uncommitted.rows.multiplier"),
+    CAIRO_WAL_MAX_LAG_TXN_COUNT("cairo.wal.max.lag.txn.count"),
     CAIRO_WAL_APPLY_TABLE_TIME_QUOTA("cairo.wal.apply.table.time.quota"),
     CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT("cairo.wal.apply.look.ahead.txn.count"),
     READ_ONLY_INSTANCE("readonly"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -434,6 +434,8 @@ public interface CairoConfiguration {
 
     boolean getWalEnabledDefault();
 
+    int getWalMaxLagTxnCount();
+
     long getWalPurgeInterval();
 
     int getWalRecreateDistressedSequencerAttempts();

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -625,7 +625,7 @@ public class CairoEngine implements Closeable, WriterSource {
                 pubSeq.done(cursor);
                 return;
             } else if (cursor == -1L) {
-                LOG.debug().$("cannot publish WAL notifications, queue is full [current=")
+                LOG.info().$("cannot publish WAL notifications, queue is full [current=")
                         .$(pubSeq.current()).$(", table=").utf8(tableToken.getDirName())
                         .I$();
                 // queue overflow, throw away notification and notify a job to rescan all tables

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -846,6 +846,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getWalMaxLagTxnCount() {
+        return 20;
+    }
+
+    @Override
     public long getWalPurgeInterval() {
         return 30_000;
     }

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -231,9 +231,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
 
         try (TransactionLogCursor transactionLogCursor = tableSequencerAPI.getCursor(tableToken, writer.getAppliedSeqTxn())) {
             TableMetadataChangeLog structuralChangeCursor = null;
-
             try {
-
                 int iTransaction = 0;
                 int totalTransactionCount = 0;
                 long rowsAdded = 0;
@@ -330,7 +328,6 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                                 }
                             }
 
-
                             isTerminating = runStatus.isTerminating();
                             final long added = processWalCommit(
                                     writer,
@@ -402,7 +399,6 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 case DATA:
                     final WalEventCursor.DataInfo dataInfo = walEventCursor.getDataInfo();
                     if (writer.getWalTnxDetails().hasRecord(seqTxn)) {
-
                         long rowCount = dataInfo.getEndRowID() - dataInfo.getStartRowID();
                         final long start = microClock.getTicks();
                         walTelemetryFacade.store(WAL_TXN_APPLY_START, writer.getTableToken(), walId, seqTxn, -1L, -1L, start - commitTimestamp);
@@ -498,7 +494,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
     /**
      * Returns transaction number, which is always > -1. Negative values are used as status code.
      */
-    long applyWAL(
+    long applyWal(
             TableToken tableToken,
             CairoEngine engine,
             OperationCompiler operationCompiler,
@@ -569,7 +565,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
             subSeq.done(cursor);
         }
 
-        final long txn = applyWAL(tableToken, engine, operationCompiler, runStatus);
+        final long txn = applyWal(tableToken, engine, operationCompiler, runStatus);
         if (txn == WAL_APPLY_FAILED) {
             try {
                 engine.getTableSequencerAPI().suspendTable(tableToken);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/WalTableListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/WalTableListFunctionFactory.java
@@ -51,6 +51,7 @@ public class WalTableListFunctionFactory implements FunctionFactory {
     private static final int nameColumn;
     private static final int sequencerTxnColumn;
     private static final int suspendedColumn;
+    private static final int writerLagTxnCountColumn;
     private static final int writerTxnColumn;
 
     @Override
@@ -176,6 +177,7 @@ public class WalTableListFunctionFactory implements FunctionFactory {
                 private long sequencerTxn;
                 private boolean suspendedFlag;
                 private String tableName;
+                private long writerLagTxnCount;
                 private long writerTxn;
 
                 @Override
@@ -190,6 +192,9 @@ public class WalTableListFunctionFactory implements FunctionFactory {
                 public long getLong(int col) {
                     if (col == writerTxnColumn) {
                         return writerTxn;
+                    }
+                    if (col == writerLagTxnCountColumn) {
+                        return writerLagTxnCount;
                     }
                     if (col == sequencerTxnColumn) {
                         return sequencerTxn;
@@ -245,6 +250,7 @@ public class WalTableListFunctionFactory implements FunctionFactory {
                         long spinLockTimeout = engine.getConfiguration().getSpinLockTimeout();
                         TableUtils.safeReadTxn(txReader, millisecondClock, spinLockTimeout);
                         writerTxn = txReader.getSeqTxn();
+                        writerLagTxnCount = txReader.getLagTxnCount();
                         return true;
                     } catch (CairoException ex) {
                         if (ex.errnoReadPathDoesNotExist()) {
@@ -265,6 +271,8 @@ public class WalTableListFunctionFactory implements FunctionFactory {
         suspendedColumn = metadata.getColumnCount() - 1;
         metadata.add(new TableColumnMetadata("writerTxn", ColumnType.LONG));
         writerTxnColumn = metadata.getColumnCount() - 1;
+        metadata.add(new TableColumnMetadata("writerLagTxnCount", ColumnType.LONG));
+        writerLagTxnCountColumn = metadata.getColumnCount() - 1;
         metadata.add(new TableColumnMetadata("sequencerTxn", ColumnType.LONG));
         sequencerTxnColumn = metadata.getColumnCount() - 1;
         METADATA = metadata;

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -664,6 +664,10 @@ cairo.wal.enabled.default=true
 # Setting it too high may cause excessive memory usage and increase the latency.
 #cairo.wal.squash.uncommitted.rows.multiplier=20.0
 
+# Maximum number of transactions to keep in O3 lag for WAL tables. Once the number is reached, full commit occurs.
+# If not set, defaults to the rounded value of cairo.wal.squash.uncommitted.rows.multiplier.
+#cairo.wal.max.lag.txn.count=20
+
 # When WAL apply job processes transactions this is the minimum number of transaction
 # to look ahead and read metadata of before applying any of them.
 #cairo.wal.apply.look.ahead.txn.count=20

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -379,6 +379,14 @@ public abstract class AbstractCairoTest extends AbstractTest {
         node1.getConfigurationOverrides().setSqlJoinMetadataPageSize(sqlJoinMetadataPageSize);
     }
 
+    protected static void configOverrideWalApplyTableTimeQuota(long walApplyTableTimeQuota) {
+        node1.getConfigurationOverrides().setWalApplyTableTimeQuota(walApplyTableTimeQuota);
+    }
+
+    protected static void configOverrideWalMaxLagTxnCount(int walMaxLagTxnCount) {
+        node1.getConfigurationOverrides().setWalMaxLagTxnCount(walMaxLagTxnCount);
+    }
+
     @SuppressWarnings("SameParameterValue")
     protected static void configOverrideWalSegmentRolloverRowCount(long walSegmentRolloverRowCount) {
         node1.getConfigurationOverrides().setWalSegmentRolloverRowCount(walSegmentRolloverRowCount);
@@ -551,6 +559,14 @@ public abstract class AbstractCairoTest extends AbstractTest {
 
     protected static void runWalPurgeJob() {
         runWalPurgeJob(engine.getConfiguration().getFilesFacade());
+    }
+
+    protected static void tickWalQueue(int ticks) {
+        try (ApplyWal2TableJob walApplyJob = createWalApplyJob()) {
+            for (int i = 0; i < ticks; i++) {
+                walApplyJob.run(0);
+            }
+        }
     }
 
     protected void assertCursor(CharSequence expected, RecordCursor cursor, RecordMetadata metadata, boolean header) {

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -397,6 +397,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(4, configuration.getCairoConfiguration().getO3LagCalculationWindowsSize());
         Assert.assertEquals(200_000, configuration.getCairoConfiguration().getWalSegmentRolloverRowCount());
         Assert.assertEquals(20.0d, configuration.getCairoConfiguration().getWalSquashUncommittedRowsMultiplier(), 0.00001);
+        Assert.assertEquals(20, configuration.getCairoConfiguration().getWalMaxLagTxnCount());
         Assert.assertEquals(1048576, configuration.getCairoConfiguration().getWalDataAppendPageSize());
         Assert.assertTrue(configuration.getCairoConfiguration().isTableTypeConversionEnabled());
 
@@ -1202,6 +1203,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(120, configuration.getCairoConfiguration().getO3LagCalculationWindowsSize());
             Assert.assertEquals(100, configuration.getCairoConfiguration().getWalSegmentRolloverRowCount());
             Assert.assertEquals(42.2d, configuration.getCairoConfiguration().getWalSquashUncommittedRowsMultiplier(), 0.00001);
+            Assert.assertEquals(4242, configuration.getCairoConfiguration().getWalMaxLagTxnCount());
             Assert.assertEquals(262144, configuration.getCairoConfiguration().getWalDataAppendPageSize());
 
             Assert.assertEquals(1, configuration.getCairoConfiguration().getO3LastPartitionMaxSplits());

--- a/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
@@ -295,12 +295,17 @@ public class CairoTestConfiguration extends DefaultTestCairoConfiguration {
 
     @Override
     public long getWalApplyTableTimeQuota() {
-        return overrides.getWalApplyTableTimeQuote() >= 0 ? overrides.getWalApplyTableTimeQuote() : super.getWalApplyTableTimeQuota();
+        return overrides.getWalApplyTableTimeQuota() >= 0 ? overrides.getWalApplyTableTimeQuota() : super.getWalApplyTableTimeQuota();
     }
 
     @Override
     public boolean getWalEnabledDefault() {
         return overrides.getDefaultTableWriteMode() < 0 ? super.getWalEnabledDefault() : overrides.getDefaultTableWriteMode() == 1;
+    }
+
+    @Override
+    public int getWalMaxLagTxnCount() {
+        return overrides.getWalMaxLagTxnCount() >= 0 ? overrides.getWalMaxLagTxnCount() : super.getWalMaxLagTxnCount();
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/ConfigurationOverrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/ConfigurationOverrides.java
@@ -125,7 +125,9 @@ public interface ConfigurationOverrides {
 
     MicrosecondClock getTestMicrosClock();
 
-    long getWalApplyTableTimeQuote();
+    long getWalApplyTableTimeQuota();
+
+    int getWalMaxLagTxnCount();
 
     long getWalPurgeInterval();
 
@@ -261,7 +263,9 @@ public interface ConfigurationOverrides {
 
     void setTestMicrosClock(MicrosecondClock testMicrosClock);
 
-    void setWalApplyTableTimeQuote(long walApplyTableTimeQuote);
+    void setWalApplyTableTimeQuota(long walApplyTableTimeQuota);
+
+    void setWalMaxLagTxnCount(int walMaxLagTxnCount);
 
     void setWalPurgeInterval(long walPurgeInterval);
 

--- a/core/src/test/java/io/questdb/test/cairo/Overrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/Overrides.java
@@ -48,8 +48,6 @@ public class Overrides implements ConfigurationOverrides {
     private Boolean copyPartitionOnAttach = null;
     private long currentMicros = -1;
     private final MicrosecondClock defaultMicrosecondClock = () -> currentMicros >= 0 ? currentMicros : MicrosecondClockImpl.INSTANCE.getTicks();
-    private int o3PartitionSplitMaxCount = -1;
-    private long partitionO3SplitThreshold;
     private MicrosecondClock testMicrosClock = defaultMicrosecondClock;
     private long dataAppendPageSize = -1;
     private CharSequence defaultMapType;
@@ -68,12 +66,14 @@ public class Overrides implements ConfigurationOverrides {
     private int o3ColumnMemorySize = -1;
     private long o3MaxLag = -1;
     private long o3MinLag = -1;
+    private int o3PartitionSplitMaxCount = -1;
     private boolean o3QuickSortEnabled = false;
     private int pageFrameMaxRows = -1;
     private int pageFrameReduceQueueCapacity = -1;
     private int pageFrameReduceShardCount = -1;
     private Boolean parallelFilterEnabled = null;
     private int parallelImportStatusLogKeepNDays = -1;
+    private long partitionO3SplitThreshold;
     private int queryCacheEventQueueCapacity = -1;
     private int recreateDistressedSequencerAttempts = 3;
     private int repeatMigrationsFromVersion = -1;
@@ -88,7 +88,8 @@ public class Overrides implements ConfigurationOverrides {
     private int sqlJoinMetadataMaxResizes = -1;
     private int sqlJoinMetadataPageSize = -1;
     private int tableRegistryCompactionThreshold;
-    private long walApplyTableTimeQuote = -1;
+    private long walApplyTableTimeQuota = -1;
+    private int walMaxLagTxnCount = -1;
     private long walPurgeInterval = -1;
     private long walSegmentRolloverRowCount = -1;
     private int walTxnNotificationQueueCapacity = -1;
@@ -329,8 +330,13 @@ public class Overrides implements ConfigurationOverrides {
     }
 
     @Override
-    public long getWalApplyTableTimeQuote() {
-        return walApplyTableTimeQuote;
+    public long getWalApplyTableTimeQuota() {
+        return walApplyTableTimeQuota;
+    }
+
+    @Override
+    public int getWalMaxLagTxnCount() {
+        return walMaxLagTxnCount;
     }
 
     @Override
@@ -448,7 +454,8 @@ public class Overrides implements ConfigurationOverrides {
         walPurgeInterval = -1;
         tableRegistryCompactionThreshold = -1;
         maxOpenPartitions = -1;
-        walApplyTableTimeQuote = -1;
+        walApplyTableTimeQuota = -1;
+        walMaxLagTxnCount = -1;
         repeatMigrationsFromVersion = -1;
         factoryProvider = null;
     }
@@ -713,8 +720,13 @@ public class Overrides implements ConfigurationOverrides {
         this.testMicrosClock = testMicrosClock;
     }
 
-    public void setWalApplyTableTimeQuote(long walApplyTableTimeQuote) {
-        this.walApplyTableTimeQuote = walApplyTableTimeQuote;
+    @Override
+    public void setWalApplyTableTimeQuota(long walApplyTableTimeQuota) {
+        this.walApplyTableTimeQuota = walApplyTableTimeQuota;
+    }
+
+    public void setWalMaxLagTxnCount(int walMaxLagTxnCount) {
+        this.walMaxLagTxnCount = walMaxLagTxnCount;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1401,6 +1401,44 @@ public class WalWriterTest extends AbstractGriffinTest {
     }
 
     @Test
+    public void testMaxLagTxnCount() throws Exception {
+        configOverrideWalApplyTableTimeQuota(0);
+        configOverrideWalMaxLagTxnCount(1);
+        assertMemoryLeak(() -> {
+            TableToken tableToken = createTable(testName.getMethodName());
+
+            executeInsert("insert into " + tableToken.getTableName() + "(ts) values ('2023-08-04T23:00:00.000000Z')");
+            tickWalQueue(1);
+
+            assertSql(tableToken.getTableName(), "a\tb\tts\n" +
+                    "0\t\t2023-08-04T23:00:00.000000Z\n");
+
+            executeInsert("insert into " + tableToken.getTableName() + "(ts) values ('2023-08-04T22:00:00.000000Z')");
+            executeInsert("insert into " + tableToken.getTableName() + "(ts) values ('2023-08-04T21:00:00.000000Z')");
+            executeInsert("insert into " + tableToken.getTableName() + "(ts) values ('2023-08-04T20:00:00.000000Z')");
+
+            // Run WAL apply job two times:
+            // Tick 1. Put row 2023-08-04T22 into the lag.
+            // Tick 2. Instead of putting row 2023-08-04T21 into the lag, we force full commit.
+            tickWalQueue(2);
+
+            // We expect all, but the last row to be visible.
+            assertSql(tableToken.getTableName(), "a\tb\tts\n" +
+                    "0\t\t2023-08-04T21:00:00.000000Z\n" +
+                    "0\t\t2023-08-04T22:00:00.000000Z\n" +
+                    "0\t\t2023-08-04T23:00:00.000000Z\n");
+
+            drainWalQueue();
+
+            assertSql(tableToken.getTableName(), "a\tb\tts\n" +
+                    "0\t\t2023-08-04T20:00:00.000000Z\n" +
+                    "0\t\t2023-08-04T21:00:00.000000Z\n" +
+                    "0\t\t2023-08-04T22:00:00.000000Z\n" +
+                    "0\t\t2023-08-04T23:00:00.000000Z\n");
+        });
+    }
+
+    @Test
     public void testOverlappingStructureChangeCannotCreateFile() throws Exception {
         final FilesFacade ff = new TestFilesFacadeImpl() {
             @Override

--- a/core/src/test/java/io/questdb/test/cutlass/text/CairoConfigurationWrapper.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/CairoConfigurationWrapper.java
@@ -837,6 +837,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getWalMaxLagTxnCount() {
+        return conf.getWalMaxLagTxnCount();
+    }
+
+    @Override
     public long getWalPurgeInterval() {
         return conf.getWalPurgeInterval();
     }

--- a/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
@@ -37,7 +37,6 @@ import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.log.Log;
 import io.questdb.mp.WorkerPool;
 import io.questdb.std.*;
-import io.questdb.std.Misc;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractGriffinTest;
@@ -754,7 +753,7 @@ public class AbstractFuzzTest extends AbstractGriffinTest {
     }
 
     protected void setFuzzProperties(long maxApplyTimePerTable, long splitPartitionThreshold, int o3PartitionSplitMaxCount) {
-        node1.getConfigurationOverrides().setWalApplyTableTimeQuote(maxApplyTimePerTable);
+        node1.getConfigurationOverrides().setWalApplyTableTimeQuota(maxApplyTimePerTable);
         node1.getConfigurationOverrides().setPartitionO3SplitThreshold(splitPartitionThreshold);
         node1.getConfigurationOverrides().setO3PartitionSplitMaxCount(o3PartitionSplitMaxCount);
     }

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
@@ -1075,7 +1075,7 @@ public class WalTableFailureTest extends AbstractGriffinTest {
 
             assertSql(tableToken.getTableName(), "x\tsym\tts\tsym2\n1\tAB\t2022-02-24T00:00:00.000000Z\tEF\n");
 
-            assertSql("wal_tables()", "name\tsuspended\twriterTxn\tsequencerTxn\n" + tableToken.getTableName() + "\ttrue\t1\t4\n");
+            assertSql("wal_tables()", "name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\n" + tableToken.getTableName() + "\ttrue\t1\t0\t4\n");
 
             compile("alter table " + tableToken.getTableName() + " resume wal");
             compile("alter table " + tableToken.getTableName() + " resume wal from transaction 0"); // ignored
@@ -1084,7 +1084,7 @@ public class WalTableFailureTest extends AbstractGriffinTest {
             engine.releaseInactive(); // release writer from the pool
             drainWalQueue();
             assertSql(tableToken.getTableName(), "x\tsym\tts\tsym2\n1111\tXXX\t2022-02-24T00:00:00.000000Z\tYYY\n");
-            assertSql("wal_tables()", "name\tsuspended\twriterTxn\tsequencerTxn\n" + tableToken.getTableName() + "\tfalse\t4\t4\n");
+            assertSql("wal_tables()", "name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\n" + tableToken.getTableName() + "\tfalse\t4\t0\t4\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -258,7 +258,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
             }
 
             // Eject after every transaction
-            node1.getConfigurationOverrides().setWalApplyTableTimeQuote(1);
+            node1.getConfigurationOverrides().setWalApplyTableTimeQuota(1);
 
             try (ApplyWal2TableJob walApplyJob = createWalApplyJob()) {
                 for (int i = 0; i < count; i++) {
@@ -270,7 +270,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
                     rowCount += rows;
                 }
             }
-            node1.getConfigurationOverrides().setWalApplyTableTimeQuote(Timestamps.MINUTE_MICROS);
+            node1.getConfigurationOverrides().setWalApplyTableTimeQuota(Timestamps.MINUTE_MICROS);
             drainWalQueue();
 
             assertSql("select count(*) from " + tableName, "count\n" + rowCount + "\n");
@@ -1066,8 +1066,8 @@ public class WalTableSqlTest extends AbstractGriffinTest {
 
             drainWalQueue();
 
-            assertSql("wal_tables()", "name\tsuspended\twriterTxn\tsequencerTxn\n" +
-                    "testEmptyTruncate\tfalse\t1\t1\n");
+            assertSql("wal_tables()", "name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\n" +
+                    "testEmptyTruncate\tfalse\t1\t0\t1\n");
         });
     }
 
@@ -1117,7 +1117,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
             compile("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T02', 'a2a2')");
 
 
-            node1.getConfigurationOverrides().setWalApplyTableTimeQuote(0);
+            node1.getConfigurationOverrides().setWalApplyTableTimeQuota(0);
             runApplyOnce();
 
             TableToken token = engine.verifyTableName(tableName);
@@ -1490,7 +1490,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
             compile("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T02', 'a2a2')");
 
 
-            node1.getConfigurationOverrides().setWalApplyTableTimeQuote(0);
+            node1.getConfigurationOverrides().setWalApplyTableTimeQuota(0);
             runApplyOnce();
 
             TableToken token = engine.verifyTableName(tableName);
@@ -1549,7 +1549,7 @@ public class WalTableSqlTest extends AbstractGriffinTest {
 
         });
     }
-    
+
     @Test
     public void testWhenApplyJobTerminatesEarlierLagCommitted() throws Exception {
         AtomicBoolean isTerminating = new AtomicBoolean();

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -281,6 +281,7 @@ cairo.wal.recreate.distressed.sequencer.attempts=13
 cairo.wal.inactive.writer.ttl=333303
 cairo.wal.apply.look.ahead.txn.count=23
 cairo.wal.squash.uncommitted.rows.multiplier=42.2
+cairo.wal.max.lag.txn.count=4242
 
 table.type.conversion.enabled=false
 cairo.o3.lag.calculation.windows.size=120

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -634,6 +634,10 @@ cairo.wal.enabled.default=true
 # Setting it too high may cause excessive memory usage and increase the latency.
 #cairo.wal.squash.uncommitted.rows.multiplier=20.0
 
+# Maximum number of transactions to keep in O3 lag for WAL tables. Once the number is reached, full commit occurs.
+# If not set, defaults to the rounded value of cairo.wal.squash.uncommitted.rows.multiplier.
+#cairo.wal.max.lag.txn.count=20
+
 # When WAL apply job processes transactions this is the minimum number of transaction
 # to look ahead and read metadata of before applying any of them.
 #cairo.wal.apply.look.ahead.txn.count=20


### PR DESCRIPTION
Previously, it could happen that the O3 lag, i.e. the invisible part of a WAL table, was growing almost unbounded. This patch ensures that we force a full commit each `cairo.wal.max.lag.txn.count` transactions (by default, set to 20). This makes sure that the data periodically becomes visible to table readers.

Also, adds `writerLagTxnCount` column to `wal_tables()` pseudo-table to allow monitoring transaction count in the table's lag.

An example of the described scenario may be seen in the below screenshot.

![Screenshot from 2023-08-04 15-29-50](https://github.com/questdb/questdb/assets/37772591/e4af9867-7ea4-4afb-8295-db8af97da061)