### PR TITLE
fix(sql): truncate nanos in textual timestamps

### DIFF
--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -456,6 +456,15 @@ public final class IntervalUtils {
                                 }
                                 micr *= tenPow(micrLim - p);
 
+                                // truncate remaining nanos if any
+                                for (int nlim = Math.min(lim, p + 3); p < nlim; p++) {
+                                    char c = seq.charAt(p);
+                                    if (Numbers.notDigit(c)) {
+                                        // Timezone
+                                        break;
+                                    }
+                                }
+
                                 // micros
                                 ts = Timestamps.yearMicros(year, l)
                                         + Timestamps.monthOfYearMicros(month, l)

--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -447,7 +447,7 @@ public final class IntervalUtils {
                                 int micr = 0;
                                 for (; p < mlim; p++) {
                                     char c = seq.charAt(p);
-                                    if (c < '0' || c > '9') {
+                                    if (Numbers.notDigit(c)) {
                                         // Timezone
                                         break;
                                     }

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -4241,12 +4241,16 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     @Test
     public void testInsertTimestampAsStr() throws Exception {
         final String expected = "ts\n" +
+                "2020-01-10T12:00:01.111143Z\n" +
                 "2020-01-10T15:00:01.000143Z\n" +
                 "2020-01-10T18:00:01.800000Z\n" +
                 "\n";
 
         assertMemoryLeak(() -> {
             ddl("create table xy (ts timestamp)");
+            // execute insert with nanos - we expect the nanos to be truncated
+            insert("insert into xy(ts) values ('2020-01-10T12:00:01.111143123Z')");
+
             // execute insert with micros
             insert("insert into xy(ts) values ('2020-01-10T15:00:01.000143Z')");
 
@@ -5176,6 +5180,20 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
         assertQuery("c\n\n",
                 "select * from x where c in null",
                 "create table x as (select 1::timestamp c union all select null::timestamp )",
+                null, true, false
+        );
+    }
+
+    @Test
+    public void testTimestampWithNanosInWhereClause() throws Exception {
+        assertQuery("x\tts\n" +
+                        "2\t2019-10-17T00:00:00.200000Z\n" +
+                        "3\t2019-10-17T00:00:00.700000Z\n" +
+                        "4\t2019-10-17T00:00:00.800000Z\n",
+                "select * from x where ts between '2019-10-17T00:00:00.200000123Z' and '2019-10-17T00:00:00.800000123Z'",
+                "create table x as " +
+                        "(SELECT x, timestamp_sequence(to_timestamp('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss'), rnd_short(1,5) * 100000L) as ts FROM long_sequence(5)" +
+                        ")",
                 null, true, false
         );
     }

--- a/core/src/test/java/io/questdb/test/griffin/model/IntervalUtilsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/model/IntervalUtilsTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin.model;
 
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.std.LongList;
+import io.questdb.std.NumericException;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -92,6 +93,24 @@ public class IntervalUtilsTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testParseFloorPartialTimestamp_truncateNanos() throws NumericException {
+        long expected = IntervalUtils.parseFloorPartialTimestamp("2019-01-01T00:00:00.123456Z");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.123456789Z");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.12345678Z");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.1234567Z");
+
+        // with offset
+        expected = IntervalUtils.parseFloorPartialTimestamp("2019-01-01T00:00:00.123456+01:00");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.123456789+01:00");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.12345678+01:00");
+        assertParseFloorPartialTimestampEquals(expected, "2019-01-01T00:00:00.1234567+01:00");
+    }
+
+    private static void assertParseFloorPartialTimestampEquals(long expectedTimestamp, CharSequence actual) throws NumericException {
+        Assert.assertEquals(expectedTimestamp, IntervalUtils.parseFloorPartialTimestamp(actual));
     }
 
     @Test


### PR DESCRIPTION
Attempt to make QuestDB compatible with Grafana alerting. 
related to https://github.com/grafana/grafana/issues/51611