### PR TITLE
chore(core): SimpleWaitingLock liveness improvements and simplification

### DIFF
--- a/core/src/main/java/io/questdb/mp/SimpleWaitingLock.java
+++ b/core/src/main/java/io/questdb/mp/SimpleWaitingLock.java
@@ -84,11 +84,17 @@ public final class SimpleWaitingLock {
 
     /**
      * Releases the lock, allowing other threads to acquire it.
-     * If the lock is not currently owned, an IllegalStateException is thrown.
+     * <p>
+     * If the lock is not currently owned by any thread, an IllegalStateException is thrown.
      * If there is another thread waiting to acquire the lock, it is unparked.
-     * If there are no waiting threads, the method returns without any additional action.
+     * If there is no waiting thread, the method returns without any additional action.
+     * <p>
+     * Implementation note: This method does not validate the calling thread is the owner of the lock. The method
+     * releases the lock regardless of the calling thread. This makes it somewhat similar to a single permit semaphore.
+     * In such case it may set the unpark flag for the formerly owning thread. The unpark flag should have no negative
+     * side effect on the formerly owning thread as programs must be designed to handle spurious wakeups anyway.
      *
-     * @throws IllegalStateException if the lock is not owned by the calling thread
+     * @throws IllegalStateException if the lock is not owned by any thread
      */
     public void unlock() {
         Thread currentThread = Thread.currentThread();

--- a/core/src/main/java/io/questdb/mp/SimpleWaitingLock.java
+++ b/core/src/main/java/io/questdb/mp/SimpleWaitingLock.java
@@ -24,75 +24,83 @@
 
 package io.questdb.mp;
 
-import io.questdb.std.Os;
-
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
-public class SimpleWaitingLock {
-    private final AtomicBoolean lock = new AtomicBoolean(false);
-    private volatile Thread waiter = null;
+/**
+ * Simple blocking lock which allows 2 arbitrary threads to compete for ownership. Behaviour is undefined for more than 2 threads.
+ * The lock is not reentrant.
+ */
+public final class SimpleWaitingLock {
+    private final AtomicReference<Thread> ownerOrWaiter = new AtomicReference<>(null);
 
     public boolean isLocked() {
-        return lock.get();
+        return ownerOrWaiter.get() != null;
     }
 
+    /**
+     * Acquires the lock. The method will block until the lock is acquired.
+     */
     public void lock() {
-        this.waiter = Thread.currentThread();
-        while (true) {
-            while (lock.get()) {
-                // Don't use LockSupport.park() here.
-                // Once in a while there can be a delay between check of lock.get()
-                // and parking and unlock() will be called before LockSupport.park().
-                // Limit the parking time by using Os.park() instead of LockSupport.park()
-                Os.park();
-            }
-            if (!lock.getAndSet(true)) {
-                return;
-            }
-        }
+        tryLock(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
     }
 
+    /**
+     * Tries to acquire the lock, allowing for a specified timeout period.
+     * If the lock is not acquired within the given timeout, the method returns false.
+     *
+     * @param timeout the maximum time to wait for acquiring the lock, in the given TimeUnit
+     * @param unit    the time unit of the timeout parameter
+     * @return true if the lock was acquired within the timeout period, false otherwise
+     */
     public boolean tryLock(long timeout, TimeUnit unit) {
-        if (tryLock()) {
-            return true;
-        }
-
-        if (timeout <= 0L) {
-            return false;
-        }
-
-        long nanos = unit.toNanos(timeout);
-        this.waiter = Thread.currentThread();
-        while (true) {
-            long start = System.nanoTime();
-            LockSupport.parkNanos(nanos);
-            long elapsed = System.nanoTime() - start;
-
-            if (elapsed < nanos) {
-                if (tryLock()) {
+        Thread currentThread = Thread.currentThread();
+        Thread expectedOwner = null;
+        long deadline = System.nanoTime() + unit.toNanos(timeout); // this might overflow, but that's OK. we subtract current nanoTime and that makes it positive again
+        for (long remainingNanos = deadline - System.nanoTime(); remainingNanos > 0; remainingNanos = deadline - System.nanoTime()) {
+            Thread actualOwner = ownerOrWaiter.compareAndExchange(expectedOwner, currentThread);
+            if (actualOwner == expectedOwner) {
+                if (expectedOwner == null) {
+                    // there was no owner before -> we acquired the lock and we are the new owner. yay!
                     return true;
                 }
-            } else {
-                return false;
+                // we succeeded with exchange, but there was an owner before -> we are a waiter
+                LockSupport.parkNanos(remainingNanos);
             }
+            expectedOwner = actualOwner;
         }
+        return false;
     }
 
+    /**
+     * Tries to acquire the lock. If the lock is available, it is acquired and the method returns true.
+     * If the lock is already acquired by another thread, the method returns false.
+     *
+     * @return true if the lock was acquired, false otherwise
+     */
     public boolean tryLock() {
-        return lock.compareAndSet(false, true);
+        return ownerOrWaiter.compareAndSet(null, Thread.currentThread());
     }
 
+    /**
+     * Releases the lock, allowing other threads to acquire it.
+     * If the lock is not currently owned, an IllegalStateException is thrown.
+     * If there is another thread waiting to acquire the lock, it is unparked.
+     * If there are no waiting threads, the method returns without any additional action.
+     *
+     * @throws IllegalStateException if the lock is not owned by the calling thread
+     */
     public void unlock() {
-        if (lock.compareAndSet(true, false)) {
-            Thread waiter = this.waiter;
-            this.waiter = null;
-            if (waiter != null) {
-                LockSupport.unpark(waiter);
-            }
-        } else {
-            throw new IllegalStateException();
+        Thread currentThread = Thread.currentThread();
+        Thread waitingOrOwningThread = ownerOrWaiter.getAndSet(null);
+        if (waitingOrOwningThread == null) {
+            throw new IllegalStateException("Lock is not owned");
         }
+        if (waitingOrOwningThread == currentThread) {
+            // no waiters
+            return;
+        }
+        LockSupport.unpark(waitingOrOwningThread);
     }
 }


### PR DESCRIPTION
The problem with the old code. Imagine this scenario:
1. The lock is available
2. Thread1 and Thread2 are competing to acquire it
3. Thread1 set itself as a waiter
4. Thread2 overwrites it and set itself as a waiter!
5. Both threads see the `lock.get()` as `false`
6. Thread2 wins the `getAndSet()` race and returns
7. Thread1 will park
8. Threads2 releases the lock and unpark ... itself
9. Thread1 will be stuck until the `Os.park();` timeouts!

This change also simplifies reasoning:
1. It reduces concurrent state updates to just a single reference.
2. `lock()` is just `tryLock()` with a very long timeout