### PR TITLE
chore(wal): unify WalListener API

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/DefaultWalListener.java
+++ b/core/src/main/java/io/questdb/cairo/wal/DefaultWalListener.java
@@ -38,7 +38,11 @@ public class DefaultWalListener implements WalListener {
     }
 
     @Override
-    public void segmentClosed(final TableToken tabletoken, int walId, int segmentId) {
+    public void segmentClosed(final TableToken tabletoken, long txn, long timestamp, int walId, int segmentId) {
+    }
+
+    @Override
+    public void tableCreated(TableToken tableToken, long txn, long timestamp) {
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/wal/DefaultWalListener.java
+++ b/core/src/main/java/io/questdb/cairo/wal/DefaultWalListener.java
@@ -38,11 +38,11 @@ public class DefaultWalListener implements WalListener {
     }
 
     @Override
-    public void segmentClosed(final TableToken tabletoken, long txn, long timestamp, int walId, int segmentId) {
+    public void segmentClosed(final TableToken tabletoken, long txn, int walId, int segmentId) {
     }
 
     @Override
-    public void tableCreated(TableToken tableToken, long txn, long timestamp) {
+    public void tableCreated(TableToken tableToken, long timestamp) {
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/wal/WalListener.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalListener.java
@@ -32,9 +32,9 @@ public interface WalListener {
 
     void nonDataTxnCommitted(TableToken tableToken, long txn, long timestamp);
 
-    void segmentClosed(final TableToken tabletoken, long txn, long timestamp, int walId, int segmentId);
+    void segmentClosed(final TableToken tabletoken, long txn, int walId, int segmentId);
 
-    void tableCreated(TableToken tableToken, long txn, long timestamp);
+    void tableCreated(TableToken tableToken, long timestamp);
 
     void tableDropped(TableToken tableToken, long txn, long timestamp);
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalListener.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalListener.java
@@ -32,7 +32,9 @@ public interface WalListener {
 
     void nonDataTxnCommitted(TableToken tableToken, long txn, long timestamp);
 
-    void segmentClosed(final TableToken tabletoken, int walId, int segmentId);
+    void segmentClosed(final TableToken tabletoken, long txn, long timestamp, int walId, int segmentId);
+
+    void tableCreated(TableToken tableToken, long txn, long timestamp);
 
     void tableDropped(TableToken tableToken, long txn, long timestamp);
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -310,7 +310,6 @@ public class TableSequencerAPI implements QuietCloseable {
                 TableSequencerImpl tableSequencer = getTableSequencerEntry(tableToken, SequencerLockType.WRITE, (key, tt) -> {
                     final TableSequencerEntry sequencer = new TableSequencerEntry(this, engine, (TableToken) tt, getSeqTxnTracker((TableToken) tt));
                     sequencer.create(tableId, tableDescriptor);
-                    sequencer.open(tableToken);
                     return sequencer;
                 })
         ) {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -310,6 +310,7 @@ public class TableSequencerAPI implements QuietCloseable {
                 TableSequencerImpl tableSequencer = getTableSequencerEntry(tableToken, SequencerLockType.WRITE, (key, tt) -> {
                     final TableSequencerEntry sequencer = new TableSequencerEntry(this, engine, (TableToken) tt, getSeqTxnTracker((TableToken) tt));
                     sequencer.create(tableId, tableDescriptor);
+                    sequencer.open(tableToken);
                     return sequencer;
                 })
         ) {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -286,10 +286,8 @@ public class TableSequencerAPI implements QuietCloseable {
         return getSeqTxnTracker(tableToken).notifyOnCheck(seqTxn);
     }
 
-    public void notifySegmentClosed(TableToken tableToken, int walId, int segmentId) {
-        final long txn = lastTxn(tableToken);
-        final long timestamp = configuration.getMicrosecondClock().getTicks();
-        engine.getWalListener().segmentClosed(tableToken, txn, timestamp, walId, segmentId);
+    public void notifySegmentClosed(TableToken tableToken, long txn, int walId, int segmentId) {
+        engine.getWalListener().segmentClosed(tableToken, txn, walId, segmentId);
     }
 
     @TestOnly

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -287,7 +287,9 @@ public class TableSequencerAPI implements QuietCloseable {
     }
 
     public void notifySegmentClosed(TableToken tableToken, int walId, int segmentId) {
-        engine.getWalListener().segmentClosed(tableToken, walId, segmentId);
+        final long txn = lastTxn(tableToken);
+        final long timestamp = configuration.getMicrosecondClock().getTicks();
+        engine.getWalListener().segmentClosed(tableToken, txn, timestamp, walId, segmentId);
     }
 
     @TestOnly

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -412,7 +412,7 @@ public class TableSequencerImpl implements TableSequencer {
             metadata.create(tableStruct, tableToken, path, rootLen, tableId);
             final long timestamp = microClock.getTicks();
             openInit(tableToken, timestamp);
-            engine.getWalListener().tableCreated(tableToken, 0, timestamp);
+            engine.getWalListener().tableCreated(tableToken, timestamp);
         } finally {
             schemaLock.writeLock().unlock();
         }

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLog.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLog.java
@@ -211,6 +211,7 @@ public class TableTransactionLog implements Closeable {
             txnMem.jumpTo(0L);
             txnMem.putInt(WAL_FORMAT_VERSION);
             txnMem.putLong(0L);
+            assert tableCreateTimestamp != Long.MIN_VALUE;
             txnMem.putLong(tableCreateTimestamp);
             txnMem.jumpTo(HEADER_SIZE);
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLog.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLog.java
@@ -49,9 +49,9 @@ import static io.questdb.cairo.wal.WalUtils.*;
 public class TableTransactionLog implements Closeable {
     public final static int HEADER_RESERVED = 7 * Long.BYTES;
     public static final long MAX_TXN_OFFSET = Integer.BYTES;
+    public static final int STRUCTURAL_CHANGE_WAL_ID = -1;
     public static final long TABLE_CREATE_TIMESTAMP_OFFSET = MAX_TXN_OFFSET + Long.BYTES;
     public static final long HEADER_SIZE = TABLE_CREATE_TIMESTAMP_OFFSET + Long.BYTES + HEADER_RESERVED;
-    public static final int STRUCTURAL_CHANGE_WAL_ID = -1;
     private static final Log LOG = LogFactory.getLog(TableTransactionLog.class);
     private static final long TX_LOG_STRUCTURE_VERSION_OFFSET = 0L;
     private static final long TX_LOG_WAL_ID_OFFSET = TX_LOG_STRUCTURE_VERSION_OFFSET + Long.BYTES;
@@ -157,6 +157,24 @@ public class TableTransactionLog implements Closeable {
         txnMetaMemIndex.putLong(varMemBegin + len);
     }
 
+    void create(Path path, long tableCreateTimestamp) {
+
+        openFiles(path);
+
+        txnMem.jumpTo(0L);
+        txnMem.putInt(WAL_FORMAT_VERSION);
+        txnMem.putLong(0L);
+        txnMem.putLong(tableCreateTimestamp);
+        txnMem.sync(false);
+
+        txnMetaMem.jumpTo(0L);
+        txnMetaMem.sync(false); // empty
+
+        txnMetaMemIndex.jumpTo(0L);
+        txnMetaMemIndex.putLong(0L); // N + 1, first entry is 0.
+        txnMetaMemIndex.sync(false);
+    }
+
     long endMetadataChangeEntry() {
         sync();
 
@@ -192,40 +210,32 @@ public class TableTransactionLog implements Closeable {
     }
 
     void open(Path path) {
-        open(path, Long.MIN_VALUE); // ignore the timestamp
-    }
-
-    void open(Path path, long tableCreateTimestamp) {
         this.rootPath.clear();
         path.toSink(this.rootPath);
 
-        final int pathLength = path.length();
-        openSmallFile(ff, path, pathLength, txnMem, TXNLOG_FILE_NAME, MemoryTag.MMAP_TX_LOG);
-        openSmallFile(ff, path, pathLength, txnMetaMem, TXNLOG_FILE_NAME_META_VAR, MemoryTag.MMAP_TX_LOG);
-        openSmallFile(ff, path, pathLength, txnMetaMemIndex, TXNLOG_FILE_NAME_META_INX, MemoryTag.MMAP_TX_LOG);
+        if (!txnMem.isOpen()) {
+            openFiles(path);
+        }
 
         long lastTxn = txnMem.getLong(MAX_TXN_OFFSET);
         maxTxn.set(lastTxn);
 
-        if (lastTxn == 0) {
-            txnMem.jumpTo(0L);
-            txnMem.putInt(WAL_FORMAT_VERSION);
-            txnMem.putLong(0L);
-            assert tableCreateTimestamp != Long.MIN_VALUE;
-            txnMem.putLong(tableCreateTimestamp);
-            txnMem.jumpTo(HEADER_SIZE);
+        txnMem.jumpTo(HEADER_SIZE);
+        txnMetaMemIndex.jumpTo(8); // first entry is 0.
+        txnMetaMem.jumpTo(0L);
+        long maxStructureVersion = txnMem.getLong(HEADER_SIZE + (lastTxn - 1) * RECORD_SIZE + TX_LOG_STRUCTURE_VERSION_OFFSET);
+        txnMem.jumpTo(HEADER_SIZE + lastTxn * RECORD_SIZE);
+        long structureAppendOffset = maxStructureVersion * Long.BYTES;
+        long txnMetaMemSize = txnMetaMemIndex.getLong(structureAppendOffset);
+        txnMetaMemIndex.jumpTo(structureAppendOffset + Long.BYTES);
+        txnMetaMem.jumpTo(txnMetaMemSize);
+    }
 
-            txnMetaMemIndex.jumpTo(0L);
-            txnMetaMemIndex.putLong(0L); // N + 1, first entry is 0.
-            txnMetaMem.jumpTo(0L);
-        } else {
-            long maxStructureVersion = txnMem.getLong(HEADER_SIZE + (lastTxn - 1) * RECORD_SIZE + TX_LOG_STRUCTURE_VERSION_OFFSET);
-            txnMem.jumpTo(HEADER_SIZE + lastTxn * RECORD_SIZE);
-            long structureAppendOffset = maxStructureVersion * Long.BYTES;
-            long txnMetaMemSize = txnMetaMemIndex.getLong(structureAppendOffset);
-            txnMetaMemIndex.jumpTo(structureAppendOffset + Long.BYTES);
-            txnMetaMem.jumpTo(txnMetaMemSize);
-        }
+    void openFiles(Path path) {
+        final int pathLength = path.length();
+        openSmallFile(ff, path, pathLength, txnMem, TXNLOG_FILE_NAME, MemoryTag.MMAP_TX_LOG);
+        openSmallFile(ff, path, pathLength, txnMetaMem, TXNLOG_FILE_NAME_META_VAR, MemoryTag.MMAP_TX_LOG);
+        openSmallFile(ff, path, pathLength, txnMetaMemIndex, TXNLOG_FILE_NAME_META_INX, MemoryTag.MMAP_TX_LOG);
     }
 
     AlterOperation readTableMetadataChangeLog(long structureVersion, MemorySerializer serializer) {

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
@@ -166,7 +166,7 @@ public class WalListenerTest extends AbstractCairoTest {
                     new WalListenerEvent(
                             WalListenerEventType.SEGMENT_CLOSED,
                             tableToken1.get(),
-                            2,
+                            1,
                             0,
                             1,
                             0,
@@ -279,12 +279,12 @@ public class WalListenerTest extends AbstractCairoTest {
         }
 
         @Override
-        public void segmentClosed(TableToken tabletoken, long txn, long timestamp, int walId, int segmentId) {
+        public void segmentClosed(TableToken tabletoken, long txn, int walId, int segmentId) {
             events.add(new WalListenerEvent(
                     WalListenerEventType.SEGMENT_CLOSED,
                     tabletoken,
                     txn,
-                    timestamp,
+                    0,
                     walId,
                     segmentId,
                     -1,
@@ -293,11 +293,11 @@ public class WalListenerTest extends AbstractCairoTest {
         }
 
         @Override
-        public void tableCreated(TableToken tableToken, long txn, long timestamp) {
+        public void tableCreated(TableToken tableToken, long timestamp) {
             events.add(new WalListenerEvent(
                     WalListenerEventType.TABLE_CREATED,
                     tableToken,
-                    txn,
+                    0,
                     timestamp,
                     -1,
                     -1,

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1271,7 +1271,7 @@ public class WalWriterTest extends AbstractCairoTest {
                     throw new RuntimeException("Test failure");
                 } catch (Exception e) {
                     final StackTraceElement[] stackTrace = e.getStackTrace();
-                    if (stackTrace[4].getClassName().endsWith("TableSequencerImpl") && stackTrace[4].getMethodName().equals("open")) {
+                    if (stackTrace[4].getClassName().endsWith("TableSequencerImpl") && stackTrace[4].getMethodName().equals("openInit")) {
                         throw e;
                     }
                 }

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1271,7 +1271,7 @@ public class WalWriterTest extends AbstractCairoTest {
                     throw new RuntimeException("Test failure");
                 } catch (Exception e) {
                     final StackTraceElement[] stackTrace = e.getStackTrace();
-                    if (stackTrace[4].getClassName().endsWith("TableSequencerImpl") && stackTrace[4].getMethodName().equals("openInit")) {
+                    if (stackTrace[4].getClassName().endsWith("TableSequencerImpl") && stackTrace[4].getMethodName().equals("open")) {
                         throw e;
                     }
                 }


### PR DESCRIPTION
- Introduce `tableCreated` notification.
- Persist table creation timestamp in the transaction log header (backward-compatible modification).
- Align segmentClose signature with others, incorporating txn and ~~timestamp~~ arguments.