### PR TITLE
fix(http): avoid running out of memory when importing partitioned table over REST API

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -40,7 +40,10 @@ import io.questdb.cairo.vm.api.*;
 import io.questdb.cairo.wal.*;
 import io.questdb.cairo.wal.seq.TableSequencer;
 import io.questdb.cairo.wal.seq.TransactionLogCursor;
-import io.questdb.griffin.*;
+import io.questdb.griffin.DropIndexOperator;
+import io.questdb.griffin.PurgingOperator;
+import io.questdb.griffin.SqlUtil;
+import io.questdb.griffin.UpdateOperatorImpl;
 import io.questdb.griffin.engine.ops.AbstractOperation;
 import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.UpdateOperation;
@@ -1332,8 +1335,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     @Override
-    public long getMetaMaxUncommittedRows() {
+    public int getMetaMaxUncommittedRows() {
         return metadata.getMaxUncommittedRows();
+    }
+
+    @Override
+    public long getMetaO3MaxLag() {
+        return metadata.getO3MaxLag();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/wal/MetadataService.java
+++ b/core/src/main/java/io/questdb/cairo/wal/MetadataService.java
@@ -97,7 +97,9 @@ public interface MetadataService {
 
     void enableDeduplicationWithUpsertKeys(LongList columnsIndexes);
 
-    long getMetaMaxUncommittedRows();
+    int getMetaMaxUncommittedRows();
+
+    long getMetaO3MaxLag();
 
     TableRecordMetadata getMetadata();
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1528,6 +1528,11 @@ public class WalWriter implements TableWriterAPI {
         }
 
         @Override
+        public long getMetaO3MaxLag() {
+            return 0;
+        }
+
+        @Override
         public TableRecordMetadata getMetadata() {
             return metadata;
         }

--- a/core/src/main/java/io/questdb/cairo/wal/seq/MetadataServiceStub.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/MetadataServiceStub.java
@@ -67,7 +67,12 @@ public interface MetadataServiceStub extends MetadataService {
     }
 
     @Override
-    default long getMetaMaxUncommittedRows() {
+    default int getMetaMaxUncommittedRows() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default long getMetaO3MaxLag() {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -87,7 +87,8 @@ public interface Sender extends Closeable {
      * This behavior can be adjusted by QuestDB server configuration. See <code>line.tcp.timestamp</code> in
      * <a href="https://questdb.io/docs/reference/configuration/">QuestDB server documentation</a>
      *
-     * @param timestamp time since 1st Jan 1970 UTC (epoch)
+     * @param timestamp timestamp value since epoch (in nanoseconds by default; see "line.tcp.timestamp" configuration
+     *                  option to learn how to change the unit on the server side)
      */
     void at(long timestamp);
 
@@ -184,7 +185,7 @@ public interface Sender extends Closeable {
      * Add a column with a non-designated timestamp value.
      *
      * @param name  name of the column
-     * @param value value to add (in microseconds since epoch)
+     * @param value timestamp value since epoch (in microseconds)
      * @return this instance for method chaining
      */
     Sender timestampColumn(CharSequence name, long value);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextImportProcessor.java
@@ -373,7 +373,6 @@ public class TextImportProcessor implements HttpRequestProcessor, HttpMultipartC
                 pad(socket, TO_STRING_COL4_PAD, "Locale");
                 pad(socket, TO_STRING_COL5_PAD, "Errors").put(Misc.EOL);
 
-
                 socket.put('|');
                 pad(socket, TO_STRING_COL1_PAD, "Partition by");
                 pad(socket, TO_STRING_COL2_PAD, PartitionBy.toString(textLoaderCompletedState.getPartitionBy()));

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -51,7 +51,7 @@ public class TableUpdateDetails implements Closeable {
     private static final DirectByteSymbolLookup NOT_FOUND_LOOKUP = value -> SymbolTable.VALUE_NOT_FOUND;
     private final long commitInterval;
     private final DefaultColumnTypes defaultColumnTypes;
-    private final long defaultMaxUncommittedRows;
+    private final int defaultMaxUncommittedRows;
     private final CairoEngine engine;
     private final ThreadLocalDetails[] localDetailsArray;
     private final MillisecondClock millisecondClock;
@@ -269,7 +269,7 @@ public class TableUpdateDetails implements Closeable {
         }
     }
 
-    private long getMetaMaxUncommittedRows() {
+    private int getMetaMaxUncommittedRows() {
         if (metadataService != null) {
             return metadataService.getMetaMaxUncommittedRows();
         }

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -86,6 +86,8 @@ public class CairoTextWriter implements Closeable, Mutable {
         designatedTimestampIndex = NO_INDEX;
         timestampIndex = NO_INDEX;
         importedTimestampColumnName = null;
+        maxUncommittedRows = -1;
+        o3MaxLag = -1;
         remapIndex.clear();
     }
 
@@ -110,8 +112,16 @@ public class CairoTextWriter implements Closeable, Mutable {
         return columnErrorCounts;
     }
 
+    public int getMaxUncommittedRows() {
+        return maxUncommittedRows;
+    }
+
     public RecordMetadata getMetadata() {
         return metadata;
+    }
+
+    public long getO3MaxLag() {
+        return o3MaxLag;
     }
 
     public int getPartitionBy() {
@@ -195,7 +205,7 @@ public class CairoTextWriter implements Closeable, Mutable {
 
     private void checkUncommittedRowCount() {
         if (writer != null && maxUncommittedRows > 0 && writer.getO3RowCount() >= maxUncommittedRows) {
-            writer.ic(this.o3MaxLag);
+            writer.ic(o3MaxLag);
         }
     }
 
@@ -290,7 +300,7 @@ public class CairoTextWriter implements Closeable, Mutable {
         LOG.info()
                 .$("mis-detected [table=").$(tableName)
                 .$(", column=").$(i)
-                .$(", type=").$(ColumnType.nameOf(this.types.getQuick(i).getType()))
+                .$(", type=").$(ColumnType.nameOf(types.getQuick(i).getType()))
                 .$(']').$();
     }
 
@@ -381,6 +391,18 @@ public class CairoTextWriter implements Closeable, Mutable {
             }
         } else {
             LOG.info().$("cannot update metadata attributes o3MaxLag and maxUncommittedRows when the table exists and parameter overwrite is false").$();
+        }
+        if (PartitionBy.isPartitioned(partitionBy)) {
+            // We want to limit memory consumption during the import, so make sure
+            // to use table's maxUncommittedRows and o3MaxLag if they're not set.
+            if (o3MaxLag == -1) {
+                o3MaxLag = writer.getMetaO3MaxLag();
+                LOG.info().$("using table's o3MaxLag ").$(o3MaxLag).$(", table=").utf8(tableName).$();
+            }
+            if (maxUncommittedRows == -1) {
+                maxUncommittedRows = writer.getMetaMaxUncommittedRows();
+                LOG.info().$("using table's maxUncommittedRows ").$(maxUncommittedRows).$(", table=").utf8(tableName).$();
+            }
         }
         size = writer.size();
         columnErrorCounts.seed(writer.getMetadata().getColumnCount(), 0);

--- a/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
@@ -176,8 +176,16 @@ public class TextLoader implements Closeable, Mutable {
         return lexer != null ? lexer.getErrorCount() : 0;
     }
 
+    public int getMaxUncommittedRows() {
+        return textWriter.getMaxUncommittedRows();
+    }
+
     public RecordMetadata getMetadata() {
         return textWriter.getMetadata();
+    }
+
+    public long getO3MaxLag() {
+        return textWriter.getO3MaxLag();
     }
 
     public long getParsedLineCount() {

--- a/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
@@ -491,18 +491,21 @@ public class TextLoaderTest extends AbstractCairoTest {
                 180_000_000,
                 721,
                 180_000_000,
-                721);
+                721
+        );
     }
 
     @Test
     public void testCanUpdateO3MaxLagAndMaxUncommittedRowsToZeroIfTableExistsAndOverwriteIsTrue() throws Exception {
-        importWithO3MaxLagAndMaxUncommittedRowsTableExists("partition by DAY with maxUncommittedRows = 2, o3MaxLag = 2s",
+        importWithO3MaxLagAndMaxUncommittedRowsTableExists(
+                "partition by DAY with maxUncommittedRows = 2, o3MaxLag = 2s",
                 true,
                 PartitionBy.DAY,
                 0,
                 0,
                 0,
-                0);
+                0
+        );
     }
 
     @Test
@@ -3244,13 +3247,15 @@ public class TextLoaderTest extends AbstractCairoTest {
         textLoader.configureColumnDelimiter((byte) 44);
     }
 
-    private void importWithO3MaxLagAndMaxUncommittedRowsTableExists(String createStmtExtra,
-                                                                    boolean overwrite,
-                                                                    int partitionBy,
-                                                                    long o3MaxLagUs,
-                                                                    int maxUncommittedRows,
-                                                                    long expectedO3MaxLag,
-                                                                    int expectedMaxUncommittedRows) throws Exception {
+    private void importWithO3MaxLagAndMaxUncommittedRowsTableExists(
+            String createStmtExtra,
+            boolean overwrite,
+            int partitionBy,
+            long o3MaxLagUs,
+            int maxUncommittedRows,
+            long expectedO3MaxLag,
+            int expectedMaxUncommittedRows
+    ) throws Exception {
         assertNoLeak(
                 textLoader -> {
                     String createStmt = "create table test(ts timestamp, int int) timestamp(ts) " + createStmtExtra;
@@ -3430,6 +3435,8 @@ public class TextLoaderTest extends AbstractCairoTest {
         textLoader.setSkipLinesWithExtraValues(skipLinesWithExtraValues);
         boolean forceHeader = textLoader.isForceHeaders();
         byte delimiter = textLoader.getColumnDelimiter();
+        int maxUncommittedRows = textLoader.getMaxUncommittedRows();
+        long o3MaxLag = textLoader.getO3MaxLag();
         playText0(textLoader, text, firstBufSize, manipulator);
         sink.clear();
         textLoader.getMetadata().toJson(sink);
@@ -3445,6 +3452,8 @@ public class TextLoaderTest extends AbstractCairoTest {
 
         textLoader.setSkipLinesWithExtraValues(skipLinesWithExtraValues);
         textLoader.setForceHeaders(forceHeader);
+        textLoader.setMaxUncommittedRows(maxUncommittedRows);
+        textLoader.setO3MaxLag(o3MaxLag);
         if (delimiter > 0) {
             textLoader.configureColumnDelimiter(delimiter);
         }

--- a/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static io.questdb.test.tools.TestUtils.assertEquals;
 
 public class DedupInsertFuzzTest extends AbstractFuzzTest {
+
     @Test
     public void testDedupWithRandomShiftAndStep() throws Exception {
         assertMemoryLeak(() -> {
@@ -108,8 +109,6 @@ public class DedupInsertFuzzTest extends AbstractFuzzTest {
                             " (ts timestamp, commit int, s symbol) " +
                             " , index(s) timestamp(ts) partition by DAY WAL "
                             + " DEDUP UPSERT KEYS(ts, s)"
-                    ,
-                    sqlExecutionContext
             );
 
             ObjList<FuzzTransaction> transactions = new ObjList<>();
@@ -654,7 +653,7 @@ public class DedupInsertFuzzTest extends AbstractFuzzTest {
                     tableNameWal,
                     comaSeparatedUpsertCols
             );
-            compile(alterStatement, sqlExecutionContext);
+            compile(alterStatement);
 
             O3Utils.setupWorkerPool(sharedWorkerPool, engine, null);
             sharedWorkerPool.start(LOG);


### PR DESCRIPTION
Fixes #3480

By default, the POST `/imp` REST API endpoint doesn't issue intermediate commits. This PR makes sure that we initialize `maxUncommittedRows` and `o3MaxLag` parameters of the `CairoTextWriter` with the table's defaults, so that `writer.ic()` calls are made during the import. As a result, the O3 memory won't be unboundedly growing when importing O3 data and chances to run OOM become much smaller.

Also improves timestamp unit description in `Sender`'s Javadoc