### PR TITLE
fix(sql): fix implicit type casting in coalesce() function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -528,7 +528,7 @@ public class ExpressionParser {
                                     if (prevBranch != BRANCH_GEOHASH) {
                                         // validate type
                                         final short columnTypeTag = ColumnType.tagOf(node.token);
-                                        if (((columnTypeTag < ColumnType.BOOLEAN || (columnTypeTag > ColumnType.LONG256 && columnTypeTag != ColumnType.UUID)) && !asPoppedNull) ||
+                                        if (((columnTypeTag < ColumnType.BOOLEAN || (columnTypeTag > ColumnType.LONG256 && columnTypeTag != ColumnType.UUID && columnTypeTag != ColumnType.IPv4)) && !asPoppedNull) ||
                                                 (columnTypeTag == ColumnType.GEOHASH && node.type == ExpressionNode.LITERAL)) {
                                             throw SqlException.$(node.position, "unsupported cast");
                                         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastIPv4ToStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastIPv4ToStrFunctionFactory.java
@@ -49,7 +49,7 @@ public class CastIPv4ToStrFunctionFactory implements FunctionFactory {
         Function IPv4Func = args.getQuick(0);
         if (IPv4Func.isConstant()) {
             StringSink sink = Misc.getThreadLocalBuilder();
-            sink.put(IPv4Func.getIPv4(null));
+            Numbers.intToIPv4Sink(sink, IPv4Func.getIPv4(null));
             return new StrConstant(Chars.toString(sink));
         }
         return new CastIPv4ToStrFunctionFactory.CastIPv4ToStrFunction(args.getQuick(0));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TypeOfFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TypeOfFunctionFactory.java
@@ -92,5 +92,7 @@ public class TypeOfFunctionFactory implements FunctionFactory {
             final int type = ColumnType.getGeoHashTypeWithBits(b);
             TYPE_NAMES.put(type, new StrConstant(ColumnType.nameOf(type)));
         }
+
+        TYPE_NAMES.put(ColumnType.IPv4, new StrConstant(ColumnType.nameOf(ColumnType.IPv4)));
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
@@ -211,6 +211,7 @@ public class CaseCommon {
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.INT, ColumnType.UUID), ColumnType.STRING);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.IPv4, ColumnType.IPv4), ColumnType.IPv4);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.IPv4, ColumnType.STRING), ColumnType.STRING);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.LONG, ColumnType.BYTE), ColumnType.LONG);
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.LONG, ColumnType.BOOLEAN), ColumnType.LONG);
@@ -301,6 +302,7 @@ public class CaseCommon {
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.STRING, ColumnType.STRING), ColumnType.STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.STRING, ColumnType.SYMBOL), ColumnType.STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.STRING, ColumnType.UUID), ColumnType.STRING);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.STRING, ColumnType.IPv4), ColumnType.STRING);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.SYMBOL, ColumnType.BYTE), ColumnType.STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(ColumnType.SYMBOL, ColumnType.BOOLEAN), ColumnType.STRING);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
@@ -64,6 +64,11 @@ public class CoalesceFunctionFactory implements FunctionFactory {
         for (int i = 0; i < argsSize; i++) {
             returnType = CaseCommon.getCommonType(returnType, args.getQuick(i).getType(), argPositions.getQuick(i));
         }
+
+        for (int i = 0; i < args.size(); i++) {
+            args.setQuick(i, CaseCommon.getCastFunction(args.getQuick(i), argPositions.getQuick(i), returnType, configuration, sqlExecutionContext));
+        }
+
         switch (ColumnType.tagOf(returnType)) {
             case ColumnType.DOUBLE:
                 return argsSize == 2 ? new TwoDoubleCoalesceFunction(args) : new DoubleCoalesceFunction(args, argsSize);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TypeOfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TypeOfFunctionFactoryTest.java
@@ -25,6 +25,7 @@
 package io.questdb.test.griffin.engine.functions.catalogue;
 
 import io.questdb.cairo.ColumnType;
+import io.questdb.std.Chars;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.griffin.SqlException;
 import io.questdb.test.tools.TestUtils;
@@ -56,6 +57,28 @@ public class TypeOfFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testTooManyArgs() throws Exception {
         assertSyntaxError("select typeOf(1,2)");
+    }
+
+    @Test
+    public void testTypeOfAllRegularDataTypes() throws SqlException {
+        for (int i = ColumnType.BOOLEAN; i < ColumnType.MAX; i++) {
+            String name = ColumnType.nameOf(i);
+            if (Chars.equals("unknown", name)
+                    || i == ColumnType.CURSOR
+                    || i == ColumnType.VAR_ARG
+                    || i == ColumnType.RECORD
+                    || i == ColumnType.GEOHASH
+                    || i == ColumnType.LONG128
+                    || i == ColumnType.REGCLASS
+                    || i == ColumnType.REGPROCEDURE
+                    || i == ColumnType.ARRAY_STRING
+                    || i == ColumnType.PARAMETER
+            ) {
+                continue;
+            }
+
+            assertSql("typeOf\n" + ColumnType.nameOf(i) + "\n", "select typeOf(cast(null as " + name + "  ))");
+        }
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
@@ -173,7 +173,7 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
             try {
                 ddl(
                         "select coalesce(b)\n" +
-                        "from alex"
+                                "from alex"
                 );
                 Assert.fail("SqlException expected");
             } catch (SqlException ex) {
@@ -345,16 +345,16 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testStrCoalesceSymbolNocacheSorted() throws Exception {
         assertQuery("coalesce\tx\ta\n", "select coalesce(x, a) as coalesce, x, a\n" +
-                        "from t\n" +
-                        "order by 1", "create table t (x string, a symbol nocache)", null, "insert into t select " +
-                        " rnd_str(NULL, 'X', 'Y') as x,\n" +
-                        " rnd_symbol('A', 'B', NULL) as a\n" +
-                        "from long_sequence(5)", "coalesce\tx\ta\n" +
-                        "A\t\tA\n" +
-                        "B\t\tB\n" +
-                        "X\tX\t\n" +
-                        "Y\tY\tB\n" +
-                        "Y\tY\t\n", true, true, false);
+                "from t\n" +
+                "order by 1", "create table t (x string, a symbol nocache)", null, "insert into t select " +
+                " rnd_str(NULL, 'X', 'Y') as x,\n" +
+                " rnd_symbol('A', 'B', NULL) as a\n" +
+                "from long_sequence(5)", "coalesce\tx\ta\n" +
+                "A\t\tA\n" +
+                "B\t\tB\n" +
+                "X\tX\t\n" +
+                "Y\tY\tB\n" +
+                "Y\tY\t\n", true, true, false);
     }
 
     @Test
@@ -474,52 +474,64 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testSymbolNocache3ArgsSorted() throws Exception {
         assertQuery("coalesce\tx\ta\tb\n", "select coalesce(x, a, b) coalesce, x, a, b " +
-                        "from t\n" +
-                        "order by 1", "create table t (x symbol nocache, a symbol nocache, b symbol nocache)", null, "insert into t select " +
-                        " rnd_symbol('X', 'Y', NULL) as x,\n" +
-                        " rnd_symbol('A', 'AA', NULL) as a,\n" +
-                        " rnd_symbol('B', 'BB', NULL) as b\n" +
-                        "from long_sequence(5)", "coalesce\tx\ta\tb\n" +
-                        "\t\t\t\n" +
-                        "AA\t\tAA\tB\n" +
-                        "X\tX\tA\tBB\n" +
-                        "Y\tY\tAA\tBB\n" +
-                        "Y\tY\tAA\t\n", true, true, false);
+                "from t\n" +
+                "order by 1", "create table t (x symbol nocache, a symbol nocache, b symbol nocache)", null, "insert into t select " +
+                " rnd_symbol('X', 'Y', NULL) as x,\n" +
+                " rnd_symbol('A', 'AA', NULL) as a,\n" +
+                " rnd_symbol('B', 'BB', NULL) as b\n" +
+                "from long_sequence(5)", "coalesce\tx\ta\tb\n" +
+                "\t\t\t\n" +
+                "AA\t\tAA\tB\n" +
+                "X\tX\tA\tBB\n" +
+                "Y\tY\tAA\tBB\n" +
+                "Y\tY\tAA\t\n", true, true, false);
     }
 
     @Test
     public void testSymbolNocacheCoalesceSorted() throws Exception {
         assertQuery("coalesce\tx\ta\n", "select coalesce(a, x) as coalesce, x, a\n" +
-                        "from t\n" +
-                        "order by 1", "create table t (x symbol nocache, a symbol nocache)", null, "insert into t select " +
-                        " rnd_symbol('X', 'Y', 'Z', NULL) as x,\n" +
-                        " rnd_symbol('A', 'B', 'C', NULL) as a\n" +
-                        "from long_sequence(10)", "coalesce\tx\ta\n" +
-                        "A\tY\tA\n" +
-                        "A\tX\tA\n" +
-                        "A\tZ\tA\n" +
-                        "B\tX\tB\n" +
-                        "C\tY\tC\n" +
-                        "C\tX\tC\n" +
-                        "Y\tY\t\n" +
-                        "Y\tY\t\n" +
-                        "Z\tZ\t\n" +
-                        "Z\tZ\t\n", true, true, false);
+                "from t\n" +
+                "order by 1", "create table t (x symbol nocache, a symbol nocache)", null, "insert into t select " +
+                " rnd_symbol('X', 'Y', 'Z', NULL) as x,\n" +
+                " rnd_symbol('A', 'B', 'C', NULL) as a\n" +
+                "from long_sequence(10)", "coalesce\tx\ta\n" +
+                "A\tY\tA\n" +
+                "A\tX\tA\n" +
+                "A\tZ\tA\n" +
+                "B\tX\tB\n" +
+                "C\tY\tC\n" +
+                "C\tX\tC\n" +
+                "Y\tY\t\n" +
+                "Y\tY\t\n" +
+                "Z\tZ\t\n" +
+                "Z\tZ\t\n", true, true, false);
     }
 
     @Test
     public void testSymbolNocacheCoalesceStrSorted() throws Exception {
         assertQuery("coalesce\tx\ta\n", "select coalesce(a, x) as coalesce, x, a\n" +
-                        "from t\n" +
-                        "order by 1", "create table t (x string, a symbol nocache)", null, "insert into t select " +
-                        " rnd_str('X', NULL) as x,\n" +
-                        " rnd_symbol('A', 'AA') as a\n" +
-                        "from long_sequence(5)", "coalesce\tx\ta\n" +
-                        "A\tX\tA\n" +
-                        "A\tX\tA\n" +
-                        "AA\tX\tAA\n" +
-                        "AA\t\tAA\n" +
-                        "AA\t\tAA\n", true, true, false);
+                "from t\n" +
+                "order by 1", "create table t (x string, a symbol nocache)", null, "insert into t select " +
+                " rnd_str('X', NULL) as x,\n" +
+                " rnd_symbol('A', 'AA') as a\n" +
+                "from long_sequence(5)", "coalesce\tx\ta\n" +
+                "A\tX\tA\n" +
+                "A\tX\tA\n" +
+                "AA\tX\tAA\n" +
+                "AA\t\tAA\n" +
+                "AA\t\tAA\n", true, true, false);
+    }
+
+    @Test
+    public void testTestCoalesceImplicitCasts() throws Exception {
+        assertCoalesce("1::byte", "1");
+        assertCoalesce("1::short", "1");
+        assertCoalesce("1", "1");
+        assertCoalesce("1L", "1");
+        assertCoalesce("1.0f", "1.0000");
+        assertCoalesce("1.0d", "1.0");
+        assertCoalesce("'10000000-0000-0000-2000-000000000000'::uuid", "10000000-0000-0000-2000-000000000000");
+        assertCoalesce("cast('0.0.1.1' as ipv4)", "0.0.1.1");
     }
 
     @Test
@@ -544,5 +556,10 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
                 true,
                 true
         );
+    }
+
+    private void assertCoalesce(String value, String expected) throws Exception {
+        assertQuery("coalesce\n" + expected + "\n", "select coalesce(" + value + ", '')", true);
+        assertQuery("coalesce\n" + expected + "\n", "select coalesce(" + value + ", " + value + ", '')", true);
     }
 }


### PR DESCRIPTION
Fixes #3622 
Also fixes : 
- `select typeOf(ipv4_expression)`
- implicit cast between string and ipv4 types 