### PR TITLE
fix(http): make HTTP text import for WAL tables to write via WAL

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -492,7 +492,7 @@ public class CairoEngine implements Closeable, WriterSource {
         return messageBus;
     }
 
-    public TableRecordMetadata getMetadata(TableToken tableToken) {
+    public TableMetadata getMetadata(TableToken tableToken) {
         verifyTableToken(tableToken);
         try {
             return metadataPool.get(tableToken);

--- a/core/src/main/java/io/questdb/cairo/DynamicTableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/DynamicTableReaderMetadata.java
@@ -83,13 +83,14 @@ public class DynamicTableReaderMetadata extends TableReaderMetadata implements C
     public void reload() {
         if (!initialized) {
             initialize(configuration, getTableToken());
+        } else {
+            if (acquireTxn()) {
+                return;
+            }
+            reloadSlow();
+            // partition reload will apply truncate if necessary
+            // applyTruncate for non-partitioned tables only
         }
-        if (acquireTxn()) {
-            return;
-        }
-        reloadSlow();
-        // partition reload will apply truncate if necessary
-        // applyTruncate for non-partitioned tables only
     }
 
     public long size() {

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -24,7 +24,7 @@
 
 package io.questdb.cairo;
 
-import io.questdb.cairo.sql.TableRecordMetadata;
+import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMA;
 import io.questdb.cairo.vm.api.MemoryMR;
@@ -32,7 +32,7 @@ import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.Path;
 
-public class TableReaderMetadata extends AbstractRecordMetadata implements TableRecordMetadata, Mutable {
+public class TableReaderMetadata extends AbstractRecordMetadata implements TableMetadata, Mutable {
     private final CairoConfiguration configuration;
     private final FilesFacade ff;
     private final LowerCaseCharSequenceIntHashMap tmpValidationMap = new LowerCaseCharSequenceIntHashMap();
@@ -207,6 +207,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         return o3MaxLag;
     }
 
+    @Override
     public int getPartitionBy() {
         return partitionBy;
     }
@@ -221,6 +222,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         return tableToken;
     }
 
+    @Override
     public boolean isWalEnabled() {
         return walEnabled;
     }

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -28,6 +28,7 @@ import io.questdb.MessageBus;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.*;
 import io.questdb.griffin.AnyRecordMetadata;
@@ -621,6 +622,15 @@ public final class TableUtils {
         return type;
     }
 
+    public static int getMaxUncommittedRows(TableRecordMetadata metadata, CairoEngine engine) {
+        if (!metadata.isWalEnabled() && metadata instanceof TableWriterMetadata) {
+            return ((TableWriterMetadata) metadata).getMaxUncommittedRows();
+        }
+        try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+            return tableMetadata.getMaxUncommittedRows();
+        }
+    }
+
     public static long getNullLong(int columnType, @SuppressWarnings("unused") int longIndex) {
         // In theory, we can have a column type where `NULL` value will be different `LONG` values,
         // then this should return different values on longIndex. At the moment there are no such types.
@@ -656,6 +666,29 @@ public final class TableUtils {
             default:
                 assert false : "Invalid column type: " + columnType;
                 return 0;
+        }
+    }
+
+    public static long getO3MaxLag(TableRecordMetadata metadata, CairoEngine engine) {
+        if (!metadata.isWalEnabled()) {
+            if (metadata instanceof TableWriterMetadata) {
+                return ((TableWriterMetadata) metadata).getO3MaxLag();
+            }
+
+            try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+                return tableMetadata.getO3MaxLag();
+            }
+        }
+        // Does not have effect for WAL enabled tables
+        return 0;
+    }
+
+    public static int getPartitionBy(TableRecordMetadata metadata, CairoEngine engine) {
+        if (!metadata.isWalEnabled() && metadata instanceof TableWriterMetadata) {
+            return ((TableWriterMetadata) metadata).getPartitionBy();
+        }
+        try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+            return tableMetadata.getPartitionBy();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -25,10 +25,7 @@
 package io.questdb.cairo;
 
 import io.questdb.MessageBus;
-import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.SymbolTable;
-import io.questdb.cairo.sql.TableRecordMetadata;
+import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.*;
 import io.questdb.griffin.AnyRecordMetadata;
@@ -626,7 +623,7 @@ public final class TableUtils {
         if (!metadata.isWalEnabled() && metadata instanceof TableWriterMetadata) {
             return ((TableWriterMetadata) metadata).getMaxUncommittedRows();
         }
-        try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+        try (TableMetadata tableMetadata = engine.getMetadata(metadata.getTableToken())) {
             return tableMetadata.getMaxUncommittedRows();
         }
     }
@@ -675,7 +672,7 @@ public final class TableUtils {
                 return ((TableWriterMetadata) metadata).getO3MaxLag();
             }
 
-            try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+            try (TableMetadata tableMetadata = engine.getMetadata(metadata.getTableToken())) {
                 return tableMetadata.getO3MaxLag();
             }
         }
@@ -687,7 +684,7 @@ public final class TableUtils {
         if (!metadata.isWalEnabled() && metadata instanceof TableWriterMetadata) {
             return ((TableWriterMetadata) metadata).getPartitionBy();
         }
-        try (var tableMetadata = engine.getMetadata(metadata.getTableToken())) {
+        try (TableMetadata tableMetadata = engine.getMetadata(metadata.getTableToken())) {
             return tableMetadata.getPartitionBy();
         }
     }

--- a/core/src/main/java/io/questdb/cairo/sql/TableMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/sql/TableMetadata.java
@@ -24,16 +24,10 @@
 
 package io.questdb.cairo.sql;
 
-import io.questdb.cairo.TableToken;
-import io.questdb.std.QuietCloseable;
+public interface TableMetadata extends TableRecordMetadata {
+    int getMaxUncommittedRows();
 
-public interface TableRecordMetadata extends RecordMetadata, QuietCloseable {
+    long getO3MaxLag();
 
-    long getMetadataVersion();
-
-    int getTableId();
-
-    TableToken getTableToken();
-
-    boolean isWalEnabled();
+    int getPartitionBy();
 }

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -233,14 +233,6 @@ public class CairoTextWriter implements Closeable, Mutable {
         return metadata.getTimestampIndex() > -1 ? metadata.getColumnName(metadata.getTimestampIndex()) : null;
     }
 
-    private long getO3MaxLag(TableWriterAPI writer) {
-        if (!writer.supportsMultipleWriters()) {
-            return ((TableWriter) writer).getMetaO3MaxLag();
-        }
-        // For WAL tables this parameter doesn't matter
-        return 0;
-    }
-
     private int getTablePartitionBy(TableWriterAPI writer) {
         // This is a bit of a hack. We need to know if the table is partitioned or not, mostly for compatibility with the non-WAL test cases.
         if (!writer.supportsMultipleWriters()) {
@@ -410,7 +402,7 @@ public class CairoTextWriter implements Closeable, Mutable {
             // We want to limit memory consumption during the import, so make sure
             // to use table's maxUncommittedRows and o3MaxLag if they're not set.
             if (o3MaxLag == -1) {
-                o3MaxLag = getO3MaxLag(writer);
+                o3MaxLag = writer.getMetadata().getO3MaxLag();
                 LOG.info().$("using table's o3MaxLag ").$(o3MaxLag).$(", table=").utf8(tableName).$();
             }
             if (maxUncommittedRows == -1) {

--- a/core/src/test/java/io/questdb/test/cairo/TableMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableMetadataTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.cairo.PartitionBy;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TableMetadataTest extends AbstractCairoTest {
+    private final boolean walEnabled;
+
+    public TableMetadataTest(WalMode walMode) {
+        this.walEnabled = (walMode == WalMode.WITH_WAL);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {WalMode.WITH_WAL}, {WalMode.NO_WAL}
+        });
+    }
+
+    @Test
+    public void testMetadataPool() throws Exception {
+        assertMemoryLeak(() -> {
+            String tableName = "x";
+            ddl("create table x (a int, b long, c double, d symbol capacity 10, e string, ts timestamp) timestamp (ts) partition by WEEK " + (walEnabled ? "WAL" : ""));
+            var tt = engine.verifyTableName(tableName);
+            int maxUncommitted = 1234;
+
+            try (var m1 = engine.getMetadata(tt)) {
+                Assert.assertEquals(configuration.getMaxUncommittedRows(), m1.getMaxUncommittedRows());
+                Assert.assertEquals(configuration.getO3MaxLag(), m1.getO3MaxLag());
+                Assert.assertEquals(PartitionBy.WEEK, m1.getPartitionBy());
+
+                compile("alter table x set param maxUncommittedRows = " + maxUncommitted);
+                compile("alter table x set param o3MaxLag = 50s");
+
+                if (walEnabled) {
+                    try (var m2 = engine.getMetadata(tt)) {
+                        Assert.assertEquals(configuration.getMaxUncommittedRows(), m2.getMaxUncommittedRows());
+                        drainWalQueue();
+                        Assert.assertEquals(configuration.getMaxUncommittedRows(), m2.getMaxUncommittedRows());
+                    }
+                }
+
+                try (var m2 = engine.getMetadata(tt)) {
+                    Assert.assertEquals(maxUncommitted, m2.getMaxUncommittedRows());
+                    if (!walEnabled) {
+                        // Not effective for WAL mode
+                        Assert.assertEquals(50 * 1_000_000, m2.getO3MaxLag());
+                    }
+                }
+
+                // No change on existing metadata
+                Assert.assertEquals(configuration.getMaxUncommittedRows(), m1.getMaxUncommittedRows());
+                Assert.assertEquals(configuration.getO3MaxLag(), m1.getO3MaxLag());
+                Assert.assertEquals(PartitionBy.WEEK, m1.getPartitionBy());
+            }
+
+            try (var m2 = engine.getMetadata(tt)) {
+                Assert.assertEquals(maxUncommitted, m2.getMaxUncommittedRows());
+
+                if (!walEnabled) {
+                    // Not effective for WAL mode
+                    Assert.assertEquals(50 * 1_000_000, m2.getO3MaxLag());
+                }
+                try (var m1 = engine.getMetadata(tt)) {
+                    Assert.assertEquals(maxUncommitted, m1.getMaxUncommittedRows());
+
+                    if (!walEnabled) {
+                        // Not effective for WAL mode
+                        Assert.assertEquals(50 * 1_000_000, m1.getO3MaxLag());
+                    }
+                }
+            }
+
+            compile("alter table x add column f int");
+            try (var m1 = engine.getMetadata(tt)) {
+                // No delay in meta changes for WAL tables
+                Assert.assertEquals(m1.getColumnCount() - 1, m1.getColumnIndex("f"));
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/TableMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableMetadataTest.java
@@ -25,6 +25,8 @@
 package io.questdb.test.cairo;
 
 import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,10 +56,10 @@ public class TableMetadataTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             String tableName = "x";
             ddl("create table x (a int, b long, c double, d symbol capacity 10, e string, ts timestamp) timestamp (ts) partition by WEEK " + (walEnabled ? "WAL" : ""));
-            var tt = engine.verifyTableName(tableName);
+            TableToken tt = engine.verifyTableName(tableName);
             int maxUncommitted = 1234;
 
-            try (var m1 = engine.getMetadata(tt)) {
+            try (TableMetadata m1 = engine.getMetadata(tt)) {
                 Assert.assertEquals(configuration.getMaxUncommittedRows(), m1.getMaxUncommittedRows());
                 Assert.assertEquals(configuration.getO3MaxLag(), m1.getO3MaxLag());
                 Assert.assertEquals(PartitionBy.WEEK, m1.getPartitionBy());
@@ -66,14 +68,14 @@ public class TableMetadataTest extends AbstractCairoTest {
                 compile("alter table x set param o3MaxLag = 50s");
 
                 if (walEnabled) {
-                    try (var m2 = engine.getMetadata(tt)) {
+                    try (TableMetadata m2 = engine.getMetadata(tt)) {
                         Assert.assertEquals(configuration.getMaxUncommittedRows(), m2.getMaxUncommittedRows());
                         drainWalQueue();
                         Assert.assertEquals(configuration.getMaxUncommittedRows(), m2.getMaxUncommittedRows());
                     }
                 }
 
-                try (var m2 = engine.getMetadata(tt)) {
+                try (TableMetadata m2 = engine.getMetadata(tt)) {
                     Assert.assertEquals(maxUncommitted, m2.getMaxUncommittedRows());
                     if (!walEnabled) {
                         // Not effective for WAL mode
@@ -87,14 +89,14 @@ public class TableMetadataTest extends AbstractCairoTest {
                 Assert.assertEquals(PartitionBy.WEEK, m1.getPartitionBy());
             }
 
-            try (var m2 = engine.getMetadata(tt)) {
+            try (TableMetadata m2 = engine.getMetadata(tt)) {
                 Assert.assertEquals(maxUncommitted, m2.getMaxUncommittedRows());
 
                 if (!walEnabled) {
                     // Not effective for WAL mode
                     Assert.assertEquals(50 * 1_000_000, m2.getO3MaxLag());
                 }
-                try (var m1 = engine.getMetadata(tt)) {
+                try (TableMetadata m1 = engine.getMetadata(tt)) {
                     Assert.assertEquals(maxUncommitted, m1.getMaxUncommittedRows());
 
                     if (!walEnabled) {
@@ -105,7 +107,7 @@ public class TableMetadataTest extends AbstractCairoTest {
             }
 
             compile("alter table x add column f int");
-            try (var m1 = engine.getMetadata(tt)) {
+            try (TableMetadata m1 = engine.getMetadata(tt)) {
                 // No delay in meta changes for WAL tables
                 Assert.assertEquals(m1.getColumnCount() - 1, m1.getColumnIndex("f"));
             }

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpAlterTableTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpAlterTableTest.java
@@ -38,6 +38,8 @@ import org.junit.rules.Timeout;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.questdb.test.tools.TestUtils.drainWalQueue;
+
 public class HttpAlterTableTest extends AbstractTest {
 
     private static final String JSON_DDL_RESPONSE = "0c\r\n" +
@@ -127,15 +129,6 @@ public class HttpAlterTableTest extends AbstractTest {
 
             sendAndReceiveDdl("ALTER TABLE test SQUASH PARTITIONS");
         });
-    }
-
-    private static void drainWalQueue(CairoEngine engine) {
-        try (final ApplyWal2TableJob walApplyJob = new ApplyWal2TableJob(engine, 1, 1)) {
-            walApplyJob.drain(0);
-            new CheckWalTransactionsJob(engine).run(0);
-            // run once again as there might be notifications to handle now
-            walApplyJob.drain(0);
-        }
     }
 
     private static void sendAndReceive(String request, CharSequence response) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -790,7 +790,7 @@ public class ImportIODispatcherTest extends AbstractTest {
                                 "count\n24\n"
                         );
 
-                        engine.compile("alter table trips dedup enable upsert keys(Pickup_DateTime)", sqlExecutionContext);
+                        engine.compile("alter table trips dedup upsert keys(Pickup_DateTime)", sqlExecutionContext);
 
                         // resend the same request
                         new SendAndReceiveRequestBuilder().execute(request, response);

--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -34,6 +34,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
+import io.questdb.std.Misc;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -51,7 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static io.questdb.test.tools.TestUtils.getSendDelayNetworkFacade;
+import static io.questdb.test.tools.TestUtils.*;
 
 public class ImportIODispatcherTest extends AbstractTest {
     private static final Log LOG = LogFactory.getLog(ImportIODispatcherTest.class);
@@ -747,6 +748,64 @@ public class ImportIODispatcherTest extends AbstractTest {
             TestUtils.removeTestPath(root);
             TestUtils.createTestPath(root);
         }
+    }
+
+    @Test
+    public void testImportWithDedupEnabled() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(2)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((engine) -> {
+
+                    try (SqlExecutionContext sqlExecutionContext = TestUtils.createSqlExecutionCtx(engine)) {
+                        engine.compile(
+                                "create table trips (" +
+                                        "Col1 STRING," +
+                                        "Pickup_DateTime TIMESTAMP," +
+                                        "DropOff_datetime STRING" +
+                                        ") timestamp(Pickup_DateTime) partition by DAY WAL",
+                                sqlExecutionContext
+                        );
+
+                        String request = ValidImportRequest1
+                                .replace("POST /upload?name=trips HTTP", "POST /upload?name=trips&timestamp=Pickup_DateTime HTTP");
+
+                        String response = WarningValidImportResponse1
+                                .replace("\r\n" +
+                                                "|   Partition by  |                                              NONE  |                 |         |  From Table  |\r\n" +
+                                                "|      Timestamp  |                                              NONE  |                 |         |  From Table  |",
+                                        "\r\n" +
+                                                "|   Partition by  |                                               DAY  |                 |         |              |\r\n" +
+                                                "|      Timestamp  |                                   Pickup_DateTime  |                 |         |              |");
+                        new SendAndReceiveRequestBuilder().execute(request, response);
+
+                        drainWalQueue(engine);
+                        assertSql(
+                                engine,
+                                sqlExecutionContext,
+                                "select count() from trips",
+                                Misc.getThreadLocalBuilder(),
+                                "count\n24\n"
+                        );
+
+                        engine.compile("alter table trips dedup enable upsert keys(Pickup_DateTime)", sqlExecutionContext);
+
+                        // resend the same request
+                        new SendAndReceiveRequestBuilder().execute(request, response);
+                        drainWalQueue(engine);
+
+                        // check deduplication worked
+                        assertSql(
+                                engine,
+                                sqlExecutionContext,
+                                "select count() from trips",
+                                Misc.getThreadLocalBuilder(),
+                                "count\n24\n"
+                        );
+                    }
+                });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
@@ -1319,7 +1319,7 @@ public class TextLoaderTest extends AbstractCairoTest {
         importWithO3MaxLagAndMaxUncommittedRowsTableNotExists(
                 240_000_000, // 4 minutes, precision is micro
                 3,
-                setOf("2021-01-01.2", "2021-01-01.1", "2021-01-01.4", "2021-01-02.1")
+                setOf("2021-01-01", "2021-01-01.1", "2021-01-01.3", "2021-01-02", "2021-01-02.2", "2021-01-02.3")
         );
     }
 
@@ -1328,7 +1328,7 @@ public class TextLoaderTest extends AbstractCairoTest {
         importWithO3MaxLagAndMaxUncommittedRowsTableNotExists(
                 60_000_000, // 1 minute, precision is micro
                 2,
-                setOf("2021-01-01.2", "2021-01-01.1", "2021-01-01.4", "2021-01-02.1", "2021-01-02.2", "2021-01-02.4")
+                setOf("2021-01-01", "2021-01-01.1", "2021-01-01.2", "2021-01-01.4", "2021-01-01.6", "2021-01-02.0", "2021-01-02.1", "2021-01-02.5")
         );
     }
 
@@ -3313,7 +3313,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                 if (!dirName.equals("seq")) {
                     rmdirCallCount.getAndIncrement();
                     if (!expectedPartitionNames.contains(dirName)) {
-                        Assert.fail();
+                        Assert.fail(dirName + " not expected");
                     }
                 }
                 return Files.rmdir(name);

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.griffin.*;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
@@ -2945,16 +2946,16 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
                                     "partition by DAY WITH maxUncommittedRows=10000, o3MaxLag=250ms;"
                     );
 
-                    try (TableWriter writer = getWriter("x")) {
+                    try (TableWriter writer = getWriter("x");
+                         TableMetadata tableMetadata = engine.getMetadata(writer.getTableToken())) {
                         sink.clear();
-                        TableRecordMetadata metadata = writer.getMetadata();
-                        metadata.toJson(sink);
+                        tableMetadata.toJson(sink);
                         TestUtils.assertEquals(
                                 "{\"columnCount\":3,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"INT\"},{\"index\":1,\"name\":\"t\",\"type\":\"TIMESTAMP\"},{\"index\":2,\"name\":\"y\",\"type\":\"BOOLEAN\"}],\"timestampIndex\":1}",
                                 sink
                         );
-                        Assert.assertEquals(10000, metadata.getMaxUncommittedRows());
-                        Assert.assertEquals(250000, metadata.getO3MaxLag());
+                        Assert.assertEquals(10000, tableMetadata.getMaxUncommittedRows());
+                        Assert.assertEquals(250000, tableMetadata.getO3MaxLag());
                     }
                 }
         );

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -31,6 +31,8 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
+import io.questdb.cairo.wal.ApplyWal2TableJob;
+import io.questdb.cairo.wal.CheckWalTransactionsJob;
 import io.questdb.cutlass.text.CopyRequestJob;
 import io.questdb.griffin.*;
 import io.questdb.griffin.model.IntervalUtils;
@@ -976,6 +978,15 @@ public final class TestUtils {
     public static void drainTextImportJobQueue(CairoEngine engine) throws Exception {
         try (CopyRequestJob copyRequestJob = new CopyRequestJob(engine, 1)) {
             copyRequestJob.drain(0);
+        }
+    }
+
+    public static void drainWalQueue(CairoEngine engine) {
+        try (final ApplyWal2TableJob walApplyJob = new ApplyWal2TableJob(engine, 1, 1)) {
+            walApplyJob.drain(0);
+            new CheckWalTransactionsJob(engine).run(0);
+            // run once again as there might be notifications to handle now
+            walApplyJob.drain(0);
         }
     }
 


### PR DESCRIPTION
REST `imp` endpoint was not updated to write to WAL tables using WAL infrastructure. This PR makes the writing to behave as expected. Also fixes #3632 