### PR TITLE
feat(core): add more operators ipv4 operators + alter eq ipv4

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4FunctionFactory.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.lt;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+
+public class LtIPv4FunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "<(XX)";
+    }
+
+    @Override
+    public boolean isBoolean() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new LtIPv4FunctionFactory.LtIPv4Function(args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class LtIPv4Function extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function left;
+        private final Function right;
+
+        public LtIPv4Function(Function left, Function right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            long left = Numbers.ipv4ToLong(this.left.getIPv4(rec));
+            if (left != Numbers.IPv4_NULL) {
+                long right = Numbers.ipv4ToLong(this.right.getIPv4(rec));
+                if (right != Numbers.IPv4_NULL) {
+                    return negated == (left >= right);
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Function getLeft() {
+            return left;
+        }
+
+        @Override
+        public Function getRight() {
+            return right;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(left);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val('<');
+            }
+            sink.val(right);
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -170,6 +170,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory,
+            io.questdb.griffin.engine.functions.lt.LtIPv4FunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory,
             io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -84,6 +84,7 @@ io.questdb.griffin.engine.functions.conditional.NullIfLongFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory
+io.questdb.griffin.engine.functions.lt.LtIPv4FunctionFactory
 io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory
 io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -5179,6 +5179,49 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testLessThanIPv4() throws Exception {
+        assertSql("column\n" +
+                "false\n", "select ipv4 '34.11.45.3' < ipv4 '22.1.200.89'");
+    }
+
+    @Test
+    public void testLessThanEqIPv4() throws Exception {
+        assertSql("column\n" +
+                "true\n", "select ipv4 '34.11.45.3' <= ipv4 '34.11.45.3'");
+    }
+
+    @Test
+    public void testGreaterThanIPv4() throws Exception {
+        assertSql("column\n" +
+                "true\n", "select ipv4 '34.11.45.3' > ipv4 '22.1.200.89'");
+    }
+
+    @Test
+    public void testGreaterThanEqIPv4() throws Exception {
+        assertSql("column\n" +
+                "true\n", "select ipv4 '34.11.45.3' >= ipv4 '22.1.200.89'");
+    }
+
+    @Test
+    public void testGreaterThanEqIPv4Null() throws Exception {
+        assertSql("column\n" +
+                "false\n", "select ipv4 '34.11.45.3' >= ipv4 '0.0.0.0'");
+    }
+
+    @Test
+    public void testGreaterThanEqIPv4Null2() throws Exception {
+        assertSql("column\n" +
+                "false\n", "select ipv4 '34.11.45.3' >= null");
+    }
+
+    @Test
+    public void testGreaterThanEqIPv4BadStr() throws Exception {
+        assertSql("column\n" +
+                "false\n", "select ipv4 '34.11.45.3' >= ipv4 'apple'");
+    }
+
+
+    @Test
     public void testWhereInvalidIPv4() throws Exception {
         assertQuery("ip\tbytes\tk\n",
                 "select * from test where ip = ipv4 'hello'",

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -1939,7 +1939,7 @@ public class IPv4Test extends AbstractCairoTest {
         assertSql(
                 "ip\n" +
                         "0.0.0.1\n",
-                "select * from test where '0.0.0.1' = ip"
+                "select * from test where ipv4 '0.0.0.1' = ip"
         );
     }
 
@@ -1968,7 +1968,7 @@ public class IPv4Test extends AbstractCairoTest {
                         "0.0.0.2\n" +
                         "\n" +
                         "\n",
-                "select * from test where ip != '0.0.0.1'"
+                "select * from test where ip != ipv4 '0.0.0.1'"
         );
     }
 
@@ -1997,7 +1997,7 @@ public class IPv4Test extends AbstractCairoTest {
                         "0.0.0.2\n" +
                         "\n" +
                         "\n",
-                "select * from test where '0.0.0.1' != ip"
+                "select * from test where ipv4 '0.0.0.1' != ip"
         );
     }
 
@@ -5028,7 +5028,7 @@ public class IPv4Test extends AbstractCairoTest {
                         "0.0.0.1\t814\t1970-01-01T02:36:40.000000Z\n" +
                         "0.0.0.1\t511\t1970-01-01T02:41:40.000000Z\n" +
                         "0.0.0.1\t25\t1970-01-01T02:43:20.000000Z\n",
-                "select * from test where ip = '0.0.0.1'",
+                "select * from test where ip = ipv4 '0.0.0.1'",
                 "create table test as " +
                         "(" +
                         "  select" +
@@ -5169,7 +5169,7 @@ public class IPv4Test extends AbstractCairoTest {
                         "(" +
                         "  select" +
                         "    rnd_int(0,9,0)::ipv4 ip1," +
-                        "    rnd_int(0,9,0)::ipv4::string ip2" +
+                        "    rnd_int(0,9,0)::ipv4 ip2" +
                         "  from long_sequence(1000)" +
                         ")",
                 null,
@@ -5180,8 +5180,8 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testWhereInvalidIPv4() throws Exception {
-        assertException(
-                "select * from test where ip = 'hello'",
+        assertQuery("ip\tbytes\tk\n",
+                "select * from test where ip = ipv4 'hello'",
                 "create table test as " +
                         "(" +
                         "  select" +
@@ -5190,8 +5190,9 @@ public class IPv4Test extends AbstractCairoTest {
                         "    timestamp_sequence(0,100000000) k" +
                         "  from long_sequence(100)" +
                         ") timestamp(k)",
-                30,
-                "not a valid IP address: hello"
+                "k",
+                true,
+                false
         );
     }
 }


### PR DESCRIPTION
Adds these operators missing from https://github.com/questdb/questdb/pull/3523:

- `<` **Less than**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is less than another
    - Example
        ``` sql
        select ipv4 '33.1.8.43' < ipv4 '200.6.38.9' -> T
        ``` 
- `>` **Greater than**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is greater than another
    - Example
        ``` sql
        select ipv4 '33.1.8.43' > ipv4 '200.6.38.9' -> F
        ``` 
- `<=` **Less than or equal**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is less than or equal to another
    - Example
        ``` sql
        select ipv4 '33.1.8.43' <= ipv4 '33.1.8.43' -> T
        ``` 
- `>=` **Greater than or equal**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is greater than or equal to another
    - Example
        ``` sql
        select ipv4 '33.1.8.43' >= ipv4 '200.6.38.9' -> F
        ``` 

Fixes the equality operator from https://github.com/questdb/questdb/pull/3523. The `=` operator previously took one IPv4 argument and one string argument, it now takes two IPv4 arguments. Its reverse, `!=` is also supported.

- `=` **Equals**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is equal to another
    - Example
        ``` sql
        select ipv4 '44.8.9.10' = ipv4 '6.2.90.1' -> F
        ``` 
- `!=` **Does not equal**
    - Return value: `boolean`
    - Takes two IPv4 arguments
    - Use case: testing to see if one IP address is not equal to another
    - Example
        ``` sql
        select ipv4 '44.8.9.10' != ipv4 '6.2.90.1' -> T
        ``` 