### PR TITLE
feat(sql): add support for INTERSECT ALL/EXCEPT ALL statements

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -908,12 +908,28 @@ public class SqlParser {
             }
 
             if (isExceptKeyword(tok)) {
-                prevModel.setSetOperationType(QueryModel.SET_OPERATION_EXCEPT);
+                tok = tok(lexer, "all or select");
+                if (isAllKeyword(tok)) {
+                    prevModel.setSetOperationType(QueryModel.SET_OPERATION_EXCEPT_ALL);
+                    modelPosition = lexer.getPosition();
+                } else {
+                    prevModel.setSetOperationType(QueryModel.SET_OPERATION_EXCEPT);
+                    lexer.unparseLast();
+                    modelPosition = lexer.lastTokenPosition();
+                }
                 continue;
             }
 
             if (isIntersectKeyword(tok)) {
-                prevModel.setSetOperationType(QueryModel.SET_OPERATION_INTERSECT);
+                tok = tok(lexer, "all or select");
+                if (isAllKeyword(tok)) {
+                    prevModel.setSetOperationType(QueryModel.SET_OPERATION_INTERSECT_ALL);
+                    modelPosition = lexer.getPosition();
+                } else {
+                    prevModel.setSetOperationType(QueryModel.SET_OPERATION_INTERSECT);
+                    lexer.unparseLast();
+                    modelPosition = lexer.lastTokenPosition();
+                }
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllCastRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllCastRecordCursor.java
@@ -27,70 +27,68 @@ package io.questdb.griffin.engine.union;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
-import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.SqlException;
 import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
 
-class ExceptRecordCursor extends AbstractSetRecordCursor {
-    private final Map mapA;
-    private final Map mapB;
+class ExceptAllCastRecordCursor extends AbstractSetRecordCursor {
+    private final UnionCastRecord castRecord;
+    private final Map map;
     private final RecordSink recordSink;
     private boolean isCursorBHashed;
     private boolean isOpen;
-    private Record recordA;
-    private Record recordB;
+    // this is the B record of except cursor, required by sort algo
+    private UnionCastRecord recordB;
 
-    public ExceptRecordCursor(Map mapA, Map mapB, RecordSink recordSink) {
-        this.mapA = mapA;
-        this.mapB = mapB;
-        this.recordSink = recordSink;
+    public ExceptAllCastRecordCursor(Map map, RecordSink recordSink, ObjList<Function> castFunctionsA, ObjList<Function> castFunctionsB) {
+        this.map = map;
         isOpen = true;
+        this.recordSink = recordSink;
+        castRecord = new UnionCastRecord(castFunctionsA, castFunctionsB);
     }
 
     @Override
     public void close() {
         if (isOpen) {
             isOpen = false;
-            mapA.close();
-            mapB.close();
+            map.close();
             super.close();
         }
     }
 
     @Override
     public Record getRecord() {
-        return recordA;
+        return castRecord;
     }
 
     @Override
     public Record getRecordB() {
-        return cursorA.getRecordB();
-    }
-
-    @Override
-    public SymbolTable getSymbolTable(int columnIndex) {
-        return cursorA.getSymbolTable(columnIndex);
+        if (recordB == null) {
+            recordB = new UnionCastRecord(castRecord.getCastFunctionsA(), castRecord.getCastFunctionsB());
+            recordB.setAb(true);
+            // we do not need cursorB here, it is likely to be closed anyway
+            recordB.of(cursorA.getRecordB(), null);
+        }
+        return recordB;
     }
 
     @Override
     public boolean hasNext() {
         if (!isCursorBHashed) {
             hashCursorB();
+            castRecord.setAb(true);
             toTop();
             isCursorBHashed = true;
         }
         while (cursorA.hasNext()) {
-            MapKey keyB = mapB.withKey();
-            keyB.put(recordA, recordSink);
-            if (keyB.notFound()) {
-                MapKey keyA = mapA.withKey();
-                keyA.put(recordA, recordSink);
-                if (keyA.create()) {
-                    return true;
-                }
+            MapKey key = map.withKey();
+            key.put(castRecord, recordSink);
+            if (key.notFound()) {
+                return true;
             }
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
@@ -98,13 +96,8 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
     }
 
     @Override
-    public SymbolTable newSymbolTable(int columnIndex) {
-        return cursorA.newSymbolTable(columnIndex);
-    }
-
-    @Override
     public void recordAt(Record record, long atRowId) {
-        cursorA.recordAt(record, atRowId);
+        cursorA.recordAt(((UnionCastRecord) record).getRecordA(), atRowId);
     }
 
     @Override
@@ -115,32 +108,30 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
     @Override
     public void toTop() {
         cursorA.toTop();
-        mapA.clear();
     }
 
     private void hashCursorB() {
         while (cursorB.hasNext()) {
-            MapKey keyB = mapB.withKey();
-            keyB.put(recordB, recordSink);
-            keyB.createValue();
+            MapKey key = map.withKey();
+            key.put(castRecord, recordSink);
+            key.createValue();
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
         // this is an optimisation to release TableReader in case "this"
         // cursor lingers around. If there is exception or circuit breaker fault
         // we will rely on close() method to release reader.
-        this.cursorB = Misc.free(this.cursorB);
+        cursorB = Misc.free(cursorB);
     }
 
     void of(RecordCursor cursorA, RecordCursor cursorB, SqlExecutionCircuitBreaker circuitBreaker) throws SqlException {
         if (!isOpen) {
-            mapA.reopen();
-            mapB.reopen();
             isOpen = true;
+            map.reopen();
         }
 
         super.of(cursorA, cursorB, circuitBreaker);
-        recordA = cursorA.getRecord();
-        recordB = cursorB.getRecord();
+        castRecord.of(cursorA.getRecord(), cursorB.getRecord());
+        castRecord.setAb(false);
         isCursorBHashed = false;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllRecordCursor.java
@@ -34,18 +34,16 @@ import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.SqlException;
 import io.questdb.std.Misc;
 
-class ExceptRecordCursor extends AbstractSetRecordCursor {
-    private final Map mapA;
-    private final Map mapB;
+class ExceptAllRecordCursor extends AbstractSetRecordCursor {
+    private final Map map;
     private final RecordSink recordSink;
     private boolean isCursorBHashed;
     private boolean isOpen;
     private Record recordA;
     private Record recordB;
 
-    public ExceptRecordCursor(Map mapA, Map mapB, RecordSink recordSink) {
-        this.mapA = mapA;
-        this.mapB = mapB;
+    public ExceptAllRecordCursor(Map map, RecordSink recordSink) {
+        this.map = map;
         this.recordSink = recordSink;
         isOpen = true;
     }
@@ -54,8 +52,7 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
     public void close() {
         if (isOpen) {
             isOpen = false;
-            mapA.close();
-            mapB.close();
+            map.close();
             super.close();
         }
     }
@@ -83,14 +80,10 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
             isCursorBHashed = true;
         }
         while (cursorA.hasNext()) {
-            MapKey keyB = mapB.withKey();
-            keyB.put(recordA, recordSink);
-            if (keyB.notFound()) {
-                MapKey keyA = mapA.withKey();
-                keyA.put(recordA, recordSink);
-                if (keyA.create()) {
-                    return true;
-                }
+            MapKey key = map.withKey();
+            key.put(recordA, recordSink);
+            if (key.notFound()) {
+                return true;
             }
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
@@ -115,14 +108,13 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
     @Override
     public void toTop() {
         cursorA.toTop();
-        mapA.clear();
     }
 
     private void hashCursorB() {
         while (cursorB.hasNext()) {
-            MapKey keyB = mapB.withKey();
-            keyB.put(recordB, recordSink);
-            keyB.createValue();
+            MapKey key = map.withKey();
+            key.put(recordB, recordSink);
+            key.createValue();
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
         // this is an optimisation to release TableReader in case "this"
@@ -133,8 +125,7 @@ class ExceptRecordCursor extends AbstractSetRecordCursor {
 
     void of(RecordCursor cursorA, RecordCursor cursorB, SqlExecutionCircuitBreaker circuitBreaker) throws SqlException {
         if (!isOpen) {
-            mapA.reopen();
-            mapB.reopen();
+            map.reopen();
             isOpen = true;
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/ExceptAllRecordCursorFactory.java
@@ -37,9 +37,9 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
 import org.jetbrains.annotations.NotNull;
 
-public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory {
+public class ExceptAllRecordCursorFactory extends AbstractSetRecordCursorFactory {
 
-    public IntersectRecordCursorFactory(
+    public ExceptAllRecordCursorFactory(
             CairoConfiguration configuration,
             RecordMetadata metadata,
             RecordCursorFactory factoryA,
@@ -51,13 +51,12 @@ public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory
             @Transient @NotNull ColumnTypes mapValueTypes
     ) {
         super(metadata, factoryA, factoryB, castFunctionsA, castFunctionsB);
-        Map mapA = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
-        Map mapB = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
+        Map map = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
         if (castFunctionsA == null && castFunctionsB == null) {
-            cursor = new IntersectRecordCursor(mapA, mapB, recordSink);
+            cursor = new ExceptAllRecordCursor(map, recordSink);
         } else {
             assert castFunctionsA != null && castFunctionsB != null;
-            cursor = new IntersectCastRecordCursor(mapA, mapB, recordSink, castFunctionsA, castFunctionsB);
+            cursor = new ExceptAllCastRecordCursor(map, recordSink, castFunctionsA, castFunctionsB);
         }
     }
 
@@ -74,7 +73,7 @@ public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory
 
     @Override
     protected CharSequence getOperation() {
-        return "Intersect";
+        return "Except All";
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/union/ExceptRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/ExceptRecordCursorFactory.java
@@ -51,12 +51,13 @@ public class ExceptRecordCursorFactory extends AbstractSetRecordCursorFactory {
             @Transient @NotNull ColumnTypes mapValueTypes
     ) {
         super(metadata, factoryA, factoryB, castFunctionsA, castFunctionsB);
-        Map map = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
+        Map mapA = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
+        Map mapB = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
         if (castFunctionsA == null && castFunctionsB == null) {
-            cursor = new ExceptRecordCursor(map, recordSink);
+            cursor = new ExceptRecordCursor(mapA, mapB, recordSink);
         } else {
             assert castFunctionsA != null && castFunctionsB != null;
-            cursor = new ExceptCastRecordCursor(map, recordSink, castFunctionsA, castFunctionsB);
+            cursor = new ExceptCastRecordCursor(mapA, mapB, recordSink, castFunctionsA, castFunctionsB);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/union/IntersectAllRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/IntersectAllRecordCursorFactory.java
@@ -37,9 +37,9 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
 import org.jetbrains.annotations.NotNull;
 
-public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory {
+public class IntersectAllRecordCursorFactory extends AbstractSetRecordCursorFactory {
 
-    public IntersectRecordCursorFactory(
+    public IntersectAllRecordCursorFactory(
             CairoConfiguration configuration,
             RecordMetadata metadata,
             RecordCursorFactory factoryA,
@@ -51,13 +51,12 @@ public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory
             @Transient @NotNull ColumnTypes mapValueTypes
     ) {
         super(metadata, factoryA, factoryB, castFunctionsA, castFunctionsB);
-        Map mapA = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
-        Map mapB = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
+        Map map = MapFactory.createMap(configuration, mapKeyTypes, mapValueTypes);
         if (castFunctionsA == null && castFunctionsB == null) {
-            cursor = new IntersectRecordCursor(mapA, mapB, recordSink);
+            cursor = new IntersectAllRecordCursor(map, recordSink);
         } else {
             assert castFunctionsA != null && castFunctionsB != null;
-            cursor = new IntersectCastRecordCursor(mapA, mapB, recordSink, castFunctionsA, castFunctionsB);
+            cursor = new IntersectAllCastRecordCursor(map, recordSink, castFunctionsA, castFunctionsB);
         }
     }
 
@@ -74,7 +73,7 @@ public class IntersectRecordCursorFactory extends AbstractSetRecordCursorFactory
 
     @Override
     protected CharSequence getOperation() {
-        return "Intersect";
+        return "Intersect All";
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/union/IntersectRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/union/IntersectRecordCursor.java
@@ -35,15 +35,17 @@ import io.questdb.griffin.SqlException;
 import io.questdb.std.Misc;
 
 class IntersectRecordCursor extends AbstractSetRecordCursor {
-    private final Map map;
+    private final Map mapA;
+    private final Map mapB;
     private final RecordSink recordSink;
     private boolean isCursorBHashed;
     private boolean isOpen;
     private Record recordA;
     private Record recordB;
 
-    public IntersectRecordCursor(Map map, RecordSink recordSink) {
-        this.map = map;
+    public IntersectRecordCursor(Map mapA, Map mapB, RecordSink recordSink) {
+        this.mapA = mapA;
+        this.mapB = mapB;
         this.recordSink = recordSink;
         this.isOpen = true;
     }
@@ -52,7 +54,8 @@ class IntersectRecordCursor extends AbstractSetRecordCursor {
     public void close() {
         if (isOpen) {
             isOpen = false;
-            this.map.close();
+            mapA.close();
+            mapB.close();
             super.close();
         }
     }
@@ -80,10 +83,14 @@ class IntersectRecordCursor extends AbstractSetRecordCursor {
             isCursorBHashed = true;
         }
         while (cursorA.hasNext()) {
-            MapKey key = map.withKey();
-            key.put(recordA, recordSink);
-            if (key.findValue() != null) {
-                return true;
+            MapKey keyB = mapB.withKey();
+            keyB.put(recordA, recordSink);
+            if (!keyB.notFound()) {
+                MapKey keyA = mapA.withKey();
+                keyA.put(recordA, recordSink);
+                if (keyA.create()) {
+                    return true;
+                }
             }
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
@@ -108,13 +115,14 @@ class IntersectRecordCursor extends AbstractSetRecordCursor {
     @Override
     public void toTop() {
         cursorA.toTop();
+        mapA.clear();
     }
 
     private void hashCursorB() {
         while (cursorB.hasNext()) {
-            MapKey key = map.withKey();
-            key.put(recordB, recordSink);
-            key.createValue();
+            MapKey keyB = mapB.withKey();
+            keyB.put(recordB, recordSink);
+            keyB.createValue();
             circuitBreaker.statefulThrowExceptionIfTripped();
         }
         // this is an optimisation to release TableReader in case "this"
@@ -125,7 +133,8 @@ class IntersectRecordCursor extends AbstractSetRecordCursor {
 
     void of(RecordCursor cursorA, RecordCursor cursorB, SqlExecutionCircuitBreaker circuitBreaker) throws SqlException {
         if (!isOpen) {
-            map.reopen();
+            mapA.reopen();
+            mapB.reopen();
             isOpen = true;
         }
 

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -69,9 +69,11 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     public static final int SELECT_MODEL_NONE = 0;
     public static final int SELECT_MODEL_VIRTUAL = 2;
     public static final int SET_OPERATION_EXCEPT = 2;
-    public static final int SET_OPERATION_INTERSECT = 3;
+    public static final int SET_OPERATION_EXCEPT_ALL = 3;
+    public static final int SET_OPERATION_INTERSECT = 4;
+    public static final int SET_OPERATION_INTERSECT_ALL = 5;
     public static final int SET_OPERATION_UNION = 1;
-    //types of set operations between this and union model
+    // types of set operations between this and union model
     public static final int SET_OPERATION_UNION_ALL = 0;
     public static final String SUB_QUERY_ALIAS_PREFIX = "_xQdbA";
     private static final ObjList<String> modelTypeName = new ObjList<>();
@@ -1482,8 +1484,12 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         if (unionModel != null) {
             if (setOperationType == QueryModel.SET_OPERATION_INTERSECT) {
                 sink.put(" intersect ");
+            } else if (setOperationType == QueryModel.SET_OPERATION_INTERSECT_ALL) {
+                sink.put(" intersect all ");
             } else if (setOperationType == QueryModel.SET_OPERATION_EXCEPT) {
                 sink.put(" except ");
+            } else if (setOperationType == QueryModel.SET_OPERATION_EXCEPT_ALL) {
+                sink.put(" except all ");
             } else {
                 sink.put(" union ");
                 if (setOperationType == QueryModel.SET_OPERATION_UNION_ALL) {

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGQuerySuspendabilityTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGQuerySuspendabilityTest.java
@@ -309,11 +309,23 @@ public class PGQuerySuspendabilityTest extends BasePGTest {
         // ExceptCastRecordCursor
         addTestCase("(select s sym from x) except (select sym from y)", true);
 
+        // ExceptAllRecordCursor
+        addTestCase("x except all y", true);
+
+        // ExceptAllCastRecordCursor
+        addTestCase("(select s sym from x) except all (select sym from y)", true);
+
         // IntersectRecordCursor
         addTestCase("x intersect y");
 
         // IntersectCastRecordCursor
         addTestCase("(select s sym from x) intersect (select sym from y)");
+
+        // IntersectAllRecordCursor
+        addTestCase("x intersect all y");
+
+        // IntersectAllCastRecordCursor
+        addTestCase("(select s sym from x) intersect all (select sym from y)");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/ExceptTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExceptTest.java
@@ -32,7 +32,49 @@ import org.junit.Test;
 public class ExceptTest extends AbstractCairoTest {
 
     @Test
-    public void testIntersectOfAllSupportedTypes() throws Exception {
+    public void testExceptAllCastDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,3,0) i, rnd_str('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
+                    "3\tC\n" +
+                    "2\tA\n" +
+                    "2\tB\n" +
+                    "2\tB\n" + // <--- duplicate here
+                    "1\tC\n" +
+                    "2\tA\n";  // <--- duplicate here
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) except all (select i,s from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testExceptAllDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
+                    "3\tC\n" +
+                    "2\tA\n" +
+                    "2\tB\n" +
+                    "2\tB\n" + // <--- duplicate here
+                    "1\tC\n" +
+                    "2\tA\n";  // <--- duplicate here
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) except all (select i,first(s) from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testExceptAllOfAllSupportedTypes() throws Exception {
         assertMemoryLeak(() -> {
             final String expected = "a\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tl256\tchr\n" +
                     "1569490116\tfalse\tZ\tNaN\t0.7611\t428\t2015-05-16T20:27:48.158Z\tVTJW\t-8671107786057422727\t1970-01-01T00:00:00.000000Z\t26\t00000000 68 61 26 af 19 c4 95 94 36 53 49\tFOWLPD\t0x5f20a35e80e154f458dfd08eeb9cc39ecec82869edec121bc2593f82b430328d\tE\n" +
@@ -73,7 +115,8 @@ public class ExceptTest extends AbstractCairoTest {
                     "-1433178628\tfalse\tW\t0.9246085617322545\t0.9217\t578\t2015-06-28T14:27:36.686Z\t\t7861908914614478025\t1970-01-01T05:00:00.000000Z\t32\t00000000 0e 98 0a 8a 0b 1e c4 fd a2 9e b3 77 f8 f6 78\tRPXZSFXUNYQXT\t0x98065c0bf90d68899f5ac37d91bde62260af712d2a1cbb23579b0bab5109229c\tI\n" +
                     "94087085\ttrue\tY\t0.5675831821917149\t0.4634\t872\t2015-11-16T04:04:55.664Z\tPEHN\t8951464047863942551\t1970-01-01T05:16:40.000000Z\t26\t00000000 33 3f b2 67 da 98 47 47 bf 4f ea 5f 48 ed\tDDCIHCNP\t0x680d2fd4ebf181c6960658463c4b85af603e1494ba44804a7fa40f7e4efac82e\tP\n";
 
-            ddl("create table x as " +
+            ddl(
+                    "create table x as " +
                             "(" +
                             "select" +
                             " rnd_int() a," +
@@ -92,8 +135,7 @@ public class ExceptTest extends AbstractCairoTest {
                             " rnd_long256() l256," +
                             " rnd_char() chr" +
                             " from" +
-                            " long_sequence(20))",
-                    sqlExecutionContext
+                            " long_sequence(20))"
             );
 
             snapshotMemoryUsage();
@@ -103,7 +145,8 @@ public class ExceptTest extends AbstractCairoTest {
 
             SharedRandom.RANDOM.get().reset();
 
-            ddl("create table y as " +
+            ddl(
+                    "create table y as " +
                             "(" +
                             "select" +
                             " rnd_int() a," +
@@ -126,14 +169,14 @@ public class ExceptTest extends AbstractCairoTest {
             );
 
             snapshotMemoryUsage();
-            try (RecordCursorFactory factory = select("select * from x except y")) {
+            try (RecordCursorFactory factory = select("select * from x except all y")) {
                 assertCursor(expected2, factory, true, false);
             }
         });
     }
 
     @Test
-    public void testIntersectOfSymbolFor3Tables() throws Exception {
+    public void testExceptAllOfSymbolFor3Tables() throws Exception {
         assertMemoryLeak(() -> {
             final String expected = "t\n" +
                     "CAR\n" +
@@ -176,7 +219,147 @@ public class ExceptTest extends AbstractCairoTest {
             ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
 
             snapshotMemoryUsage();
-            try (RecordCursorFactory factory = select("select distinct t from x except y except z")) {
+            try (RecordCursorFactory factory = select("select distinct t from x except all y except all z")) {
+                assertCursor(expected2, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testExceptCastNoDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,3,0) i, rnd_str('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
+                    "3\tC\n" +
+                    "2\tA\n" +
+                    "2\tB\n" +
+                    "1\tC\n";
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) except (select i,s from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testExceptNoDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,3,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
+                    "3\tC\n" +
+                    "2\tA\n" +
+                    "2\tB\n" +
+                    "1\tC\n";
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) except (select i,first(s) from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testExceptOfAllSupportedTypes() throws Exception {
+        assertMemoryLeak(() -> {
+            final String expected = "a\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tl256\tchr\n" +
+                    "1569490116\tfalse\tZ\tNaN\t0.7611\t428\t2015-05-16T20:27:48.158Z\tVTJW\t-8671107786057422727\t1970-01-01T00:00:00.000000Z\t26\t00000000 68 61 26 af 19 c4 95 94 36 53 49\tFOWLPD\t0x5f20a35e80e154f458dfd08eeb9cc39ecec82869edec121bc2593f82b430328d\tE\n" +
+                    "-461611463\tfalse\tJ\t0.9687423276940171\t0.6762\t279\t2015-11-21T14:32:13.134Z\tHYRX\t-6794405451419334859\t1970-01-01T00:16:40.000000Z\t6\t\tETJRSZSRYR\t0x69440048957ae05360802a2ca499f211b771e27f939096b9c356f99ae70523b5\tM\n" +
+                    "-1515787781\tfalse\t\t0.8001121139739173\t0.1877\t759\t2015-06-17T02:40:55.328Z\tCPSW\t-4091897709796604687\t1970-01-01T00:33:20.000000Z\t6\t00000000 9c 1d 06 ac 37 c8 cd 82 89 2b 4d 5f f6 46 90 c3\tDYYCTGQOLYXWCKYL\t0x78c594c496995885aa1896d0ad3419d2910aa7b6d58506dc7c97a2cb4ac4b047\tS\n" +
+                    "1235206821\ttrue\t\t0.9540069089049732\t0.2553\t310\t\tVTJW\t6623443272143014835\t1970-01-01T00:50:00.000000Z\t17\t00000000 cc 76 48 a3 bb 64 d2 ad 49 1c f2 3c ed 39 ac\tVSJOJIPHZEPIHVLT\t0xb942438168662cb7aa21f9d816335363d27e6df7d9d5b758ea7a0db859a19e14\tU\n" +
+                    "454820511\tfalse\tL\t0.9918093114862231\t0.3242\t727\t2015-02-10T08:56:03.707Z\t\t5703149806881083206\t1970-01-01T01:06:40.000000Z\t36\t00000000 68 79 8b 43 1d 57 34 04 23 8d d8 57\tWVDKFLOPJOXPK\t0x550988dbaca497348692bc8c04e4bb71d24b84c08ea7606a70061ac6a4115ca7\tH\n" +
+                    "1728220848\tfalse\tO\t0.24642266252221556\t0.2672\t174\t2015-02-20T01:11:53.748Z\t\t2151565237758036093\t1970-01-01T01:23:20.000000Z\t31\t\tHZSQLDGLOGIFO\t0x8531876c963316d961f392242addf45287dd0b29ca2c4c8455b68bf3e1f27620\tZ\n" +
+                    "-120660220\tfalse\tB\t0.07594017197103131\t0.0638\t542\t2015-01-16T16:01:53.328Z\tVTJW\t5048272224871876586\t1970-01-01T01:40:00.000000Z\t23\t00000000 f5 0f 2d b3 14 33 80 c9 eb a3 67 7a 1a 79 e4 35\n" +
+                    "00000010 e4 3a dc 5c\tULIGYVFZ\t0x99193c2e0a9e76da695f8ae33a2cc2aa529d71aba0f6fec5172a489c48c26926\tL\n" +
+                    "-1548274994\ttrue\tX\t0.9292491654871197\tNaN\t523\t2015-01-05T19:01:46.416Z\tHYRX\t9044897286885345735\t1970-01-01T01:56:40.000000Z\t16\t00000000 cd 47 0b 0c 39 12 f7 05 10 f4 6d f1 e3 ee 58 35\n" +
+                    "00000010 61\tMXSLUQDYOPHNIMYF\t0x483c83d88ac674e3894499a1a1680580cfedff23a67d918fb49b3c24e456ad6e\tP\n" +
+                    "1430716856\tfalse\tP\t0.7707249647497968\tNaN\t162\t2015-02-05T10:14:02.889Z\t\t7046578844650327247\t1970-01-01T02:13:20.000000Z\t47\t\tLEGPUHHIUGGLNYR\t0x36be4fe79117ebd53756b77218c738a7737b1dacd6be597192384aabd888ecb3\tD\n" +
+                    "-772867311\tfalse\tQ\t0.7653255982993546\tNaN\t681\t2015-05-07T02:45:07.603Z\t\t4794469881975683047\t1970-01-01T02:30:00.000000Z\t31\t00000000 4e d6 b2 57 5b e3 71 3d 20 e2 37 f2 64 43 84 55\n" +
+                    "00000010 a0 dd\tVTNPIW\t0x2d1c6f57bbfd47ec39bd4dd9ad497a2721dc4adc870c62fe19b2faa4e8255a0d\tP\n" +
+                    "494704403\ttrue\tC\t0.4834201611292943\t0.7943\t28\t2015-06-16T21:00:55.459Z\tHYRX\t6785355388782691241\t1970-01-01T02:46:40.000000Z\t39\t\tRVNGSTEQOD\t0xbabcd0482f05618f926cdd99e63abb35650d1fb462d014df59070392ef6aa389\tW\n" +
+                    "-173290754\ttrue\tK\t0.7198854503668188\tNaN\t114\t2015-06-15T20:39:39.538Z\tVTJW\t9064962137287142402\t1970-01-01T03:03:20.000000Z\t20\t00000000 3b 94 5f ec d3 dc f8 43 b2 e3\tTIZKYFLUHZQSNPX\t0x74c509677990f1c962588b84eddb7b4a64a4822086748dc4b096d89b65baebef\tM\n" +
+                    "-2041781509\ttrue\tE\t0.44638626240707313\t0.0347\t605\t\tVTJW\t415951511685691973\t1970-01-01T03:20:00.000000Z\t28\t00000000 00 7c fb 01 19 ca f2 bf 84 5a 6f 38 35\t\t0x543554ee7efea2c341b1a691af3ce51f91a63337ac2e96836e87bac2e9746529\tW\n" +
+                    "813111021\ttrue\t\t0.1389067130304884\t0.3730\t259\t\tCPSW\t4422067104162111415\t1970-01-01T03:36:40.000000Z\t19\t00000000 2d 16 f3 89 a3 83 64 de d6 fd c4 5b c4 e9\tPNXHQUTZODWKOC\t0x50902704a317faeea7fc3b8563ada5ab985499c7f07368a33b8ad671f6730aab\tP\n" +
+                    "980916820\tfalse\tC\t0.8353079103853974\t0.0111\t670\t2015-10-06T01:12:57.175Z\t\t7536661420632276058\t1970-01-01T03:53:20.000000Z\t37\t\tFDBZWNIJEE\t0xb265942d3a1f96a1cff85f9258847e03a6f2e2a772cd2f3751d822a67dff3d23\tP\n" +
+                    "-2016176825\ttrue\tT\tNaN\t0.2357\t813\t2015-12-27T00:19:42.415Z\tCPSW\t3464609208866088600\t1970-01-01T04:10:00.000000Z\t49\t\tFNUHNR\t0x8ca81bb363d7ac4585afb517c8aee023d107b1affff76a2c79189b578191a8f6\tW\n" +
+                    "1173790070\tfalse\t\t0.5380626833618448\tNaN\t440\t2015-07-18T08:33:51.750Z\tCPSW\t-5206126114193456581\t1970-01-01T04:26:40.000000Z\t31\t00000000 a1 46 87 28 92 a3 9b e3 cb c2 64 8a b0 35 d8 ab\n" +
+                    "00000010 3f a1 f5\t\t0x8e230f5d5b94e76393ce26b5c735a6c94d2c5190fa645a018c7dd745bfadc2ea\tQ\n" +
+                    "2146422524\ttrue\tI\t0.11025007918539531\t0.8641\t539\t\t\t5637967617527425113\t1970-01-01T04:43:20.000000Z\t12\t00000000 81 c6 3d bc b5 05 2b 73 51 cf c3 7e c0 1d 6c\t\t0x70c4f4015e9b707986026ba259cee6ad9c3c470dfd351e81960599005766a265\tC\n" +
+                    "-1433178628\tfalse\tW\t0.9246085617322545\t0.9217\t578\t2015-06-28T14:27:36.686Z\t\t7861908914614478025\t1970-01-01T05:00:00.000000Z\t32\t00000000 0e 98 0a 8a 0b 1e c4 fd a2 9e b3 77 f8 f6 78\tRPXZSFXUNYQXT\t0x98065c0bf90d68899f5ac37d91bde62260af712d2a1cbb23579b0bab5109229c\tI\n" +
+                    "94087085\ttrue\tY\t0.5675831821917149\t0.4634\t872\t2015-11-16T04:04:55.664Z\tPEHN\t8951464047863942551\t1970-01-01T05:16:40.000000Z\t26\t00000000 33 3f b2 67 da 98 47 47 bf 4f ea 5f 48 ed\tDDCIHCNP\t0x680d2fd4ebf181c6960658463c4b85af603e1494ba44804a7fa40f7e4efac82e\tP\n";
+
+            final String expected2 = "a\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tl256\tchr\n" +
+                    "494704403\ttrue\tC\t0.4834201611292943\t0.7943\t28\t2015-06-16T21:00:55.459Z\tHYRX\t6785355388782691241\t1970-01-01T02:46:40.000000Z\t39\t\tRVNGSTEQOD\t0xbabcd0482f05618f926cdd99e63abb35650d1fb462d014df59070392ef6aa389\tW\n" +
+                    "-173290754\ttrue\tK\t0.7198854503668188\tNaN\t114\t2015-06-15T20:39:39.538Z\tVTJW\t9064962137287142402\t1970-01-01T03:03:20.000000Z\t20\t00000000 3b 94 5f ec d3 dc f8 43 b2 e3\tTIZKYFLUHZQSNPX\t0x74c509677990f1c962588b84eddb7b4a64a4822086748dc4b096d89b65baebef\tM\n" +
+                    "-2041781509\ttrue\tE\t0.44638626240707313\t0.0347\t605\t\tVTJW\t415951511685691973\t1970-01-01T03:20:00.000000Z\t28\t00000000 00 7c fb 01 19 ca f2 bf 84 5a 6f 38 35\t\t0x543554ee7efea2c341b1a691af3ce51f91a63337ac2e96836e87bac2e9746529\tW\n" +
+                    "813111021\ttrue\t\t0.1389067130304884\t0.3730\t259\t\tCPSW\t4422067104162111415\t1970-01-01T03:36:40.000000Z\t19\t00000000 2d 16 f3 89 a3 83 64 de d6 fd c4 5b c4 e9\tPNXHQUTZODWKOC\t0x50902704a317faeea7fc3b8563ada5ab985499c7f07368a33b8ad671f6730aab\tP\n" +
+                    "980916820\tfalse\tC\t0.8353079103853974\t0.0111\t670\t2015-10-06T01:12:57.175Z\t\t7536661420632276058\t1970-01-01T03:53:20.000000Z\t37\t\tFDBZWNIJEE\t0xb265942d3a1f96a1cff85f9258847e03a6f2e2a772cd2f3751d822a67dff3d23\tP\n" +
+                    "-2016176825\ttrue\tT\tNaN\t0.2357\t813\t2015-12-27T00:19:42.415Z\tCPSW\t3464609208866088600\t1970-01-01T04:10:00.000000Z\t49\t\tFNUHNR\t0x8ca81bb363d7ac4585afb517c8aee023d107b1affff76a2c79189b578191a8f6\tW\n" +
+                    "1173790070\tfalse\t\t0.5380626833618448\tNaN\t440\t2015-07-18T08:33:51.750Z\tCPSW\t-5206126114193456581\t1970-01-01T04:26:40.000000Z\t31\t00000000 a1 46 87 28 92 a3 9b e3 cb c2 64 8a b0 35 d8 ab\n" +
+                    "00000010 3f a1 f5\t\t0x8e230f5d5b94e76393ce26b5c735a6c94d2c5190fa645a018c7dd745bfadc2ea\tQ\n" +
+                    "2146422524\ttrue\tI\t0.11025007918539531\t0.8641\t539\t\t\t5637967617527425113\t1970-01-01T04:43:20.000000Z\t12\t00000000 81 c6 3d bc b5 05 2b 73 51 cf c3 7e c0 1d 6c\t\t0x70c4f4015e9b707986026ba259cee6ad9c3c470dfd351e81960599005766a265\tC\n" +
+                    "-1433178628\tfalse\tW\t0.9246085617322545\t0.9217\t578\t2015-06-28T14:27:36.686Z\t\t7861908914614478025\t1970-01-01T05:00:00.000000Z\t32\t00000000 0e 98 0a 8a 0b 1e c4 fd a2 9e b3 77 f8 f6 78\tRPXZSFXUNYQXT\t0x98065c0bf90d68899f5ac37d91bde62260af712d2a1cbb23579b0bab5109229c\tI\n" +
+                    "94087085\ttrue\tY\t0.5675831821917149\t0.4634\t872\t2015-11-16T04:04:55.664Z\tPEHN\t8951464047863942551\t1970-01-01T05:16:40.000000Z\t26\t00000000 33 3f b2 67 da 98 47 47 bf 4f ea 5f 48 ed\tDDCIHCNP\t0x680d2fd4ebf181c6960658463c4b85af603e1494ba44804a7fa40f7e4efac82e\tP\n";
+
+            ddl(
+                    "create table x as " +
+                            "(" +
+                            "select" +
+                            " rnd_int() a," +
+                            " rnd_boolean() b," +
+                            " rnd_str(1,1,2) c," +
+                            " rnd_double(2) d," +
+                            " rnd_float(2) e," +
+                            " rnd_short(10,1024) f," +
+                            " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                            " rnd_symbol(4,4,4,2) i," +
+                            " rnd_long() j," +
+                            " timestamp_sequence(0, 1000000000) k," +
+                            " rnd_byte(2,50) l," +
+                            " rnd_bin(10, 20, 2) m," +
+                            " rnd_str(5,16,2) n," +
+                            " rnd_long256() l256," +
+                            " rnd_char() chr" +
+                            " from" +
+                            " long_sequence(20))"
+            );
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory rcf = select("x")) {
+                assertCursor(expected, rcf, true, true);
+            }
+
+            SharedRandom.RANDOM.get().reset();
+
+            ddl(
+                    "create table y as " +
+                            "(" +
+                            "select" +
+                            " rnd_int() a," +
+                            " rnd_boolean() b," +
+                            " rnd_str(1,1,2) c," +
+                            " rnd_double(2) d," +
+                            " rnd_float(2) e," +
+                            " rnd_short(10,1024) f," +
+                            " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                            " rnd_symbol(4,4,4,2) i," +
+                            " rnd_long() j," +
+                            " timestamp_sequence(0, 1000000000) k," +
+                            " rnd_byte(2,50) l," +
+                            " rnd_bin(10, 20, 2) m," +
+                            " rnd_str(5,16,2) n," +
+                            " rnd_long256() l256," +
+                            " rnd_char() chr" +
+                            " from" +
+                            " long_sequence(10))"
+            );
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("select * from x except y")) {
                 assertCursor(expected2, factory, true, false);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -48,12 +48,7 @@ import io.questdb.griffin.engine.functions.conditional.CoalesceFunctionFactory;
 import io.questdb.griffin.engine.functions.conditional.SwitchFunctionFactory;
 import io.questdb.griffin.engine.functions.constants.*;
 import io.questdb.griffin.engine.functions.date.*;
-import io.questdb.griffin.engine.functions.eq.ContainsIPv4FunctionFactory;
-import io.questdb.griffin.engine.functions.eq.ContainsEqIPv4FunctionFactory;
-import io.questdb.griffin.engine.functions.eq.NegContainsEqIPv4FunctionFactory;
-import io.questdb.griffin.engine.functions.eq.NegContainsIPv4FunctionFactory;
-import io.questdb.griffin.engine.functions.eq.EqIPv4FunctionFactory;
-import io.questdb.griffin.engine.functions.eq.EqIntStrCFunctionFactory;
+import io.questdb.griffin.engine.functions.eq.*;
 import io.questdb.griffin.engine.functions.rnd.LongSequenceFunctionFactory;
 import io.questdb.griffin.engine.functions.rnd.RndIPv4CCFunctionFactory;
 import io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory;
@@ -473,7 +468,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                                 "        DataFrame\n" +
                                 "            Row forward scan\n" +
                                 "            Frame forward scan on: b\n",
-                                sqlExecutionContext
+                        sqlExecutionContext
                 );
             }
         });
@@ -981,6 +976,20 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan("create table a ( i int, s string);",
                 "select * from a except select * from a",
                 "Except\n" +
+                        "    DataFrame\n" +
+                        "        Row forward scan\n" +
+                        "        Frame forward scan on: a\n" +
+                        "    Hash\n" +
+                        "        DataFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: a\n");
+    }
+
+    @Test
+    public void testExceptAll() throws Exception {
+        assertPlan("create table a ( i int, s string);",
+                "select * from a except all select * from a",
+                "Except All\n" +
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: a\n" +
@@ -1773,11 +1782,11 @@ public class ExplainPlanTest extends AbstractCairoTest {
                                 args.add(new StrConstant("12.6.5.10/24"));
                             } else if (factory instanceof ContainsEqIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("12.6.5.10/24"));
-                            } else if(factory instanceof NegContainsEqIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
+                            } else if (factory instanceof NegContainsEqIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("34.56.22.11/12"));
-                            } else if(factory instanceof NegContainsIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
+                            } else if (factory instanceof NegContainsIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("32.12.22.11/12"));
-                            } else if(factory instanceof RndIPv4CCFunctionFactory) {
+                            } else if (factory instanceof RndIPv4CCFunctionFactory) {
                                 args.add(new StrConstant("4.12.22.11/12"));
                                 args.add(new IntConstant(2));
                             } else if (!useConst) {
@@ -2487,6 +2496,20 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         "            DataFrame\n" +
                         "                Row forward scan\n" +
                         "                Frame forward scan on: a\n");
+    }
+
+    @Test
+    public void testIntersectAll() throws Exception {
+        assertPlan("create table a ( i int, s string);",
+                "select * from a intersect all select * from a",
+                "Intersect All\n" +
+                        "    DataFrame\n" +
+                        "        Row forward scan\n" +
+                        "        Frame forward scan on: a\n" +
+                        "    Hash\n" +
+                        "        DataFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: a\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -2109,7 +2109,7 @@ public class IPv4Test extends AbstractCairoTest {
                 "col1\n" +
                         "0.0.0.1\n" +
                         "0.0.0.2\n",
-                "select col1 from x intersect select col2 from y"
+                "select col1 from x intersect all select col2 from y"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/IntersectTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/IntersectTest.java
@@ -32,7 +32,26 @@ import org.junit.Test;
 public class IntersectTest extends AbstractCairoTest {
 
     @Test
-    public void testIntersectDuplicateColumnException() throws Exception {
+    public void testIntersectAllCastDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,5,0) i, rnd_str('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
+                    "4\tB\n" +
+                    "2\tC\n" +
+                    "2\tC\n" + // <--- duplicate here
+                    "4\tB\n";  // <--- duplicate here
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) intersect all (select i,s from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testIntersectAllDuplicateRows() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
             ddl("create table y as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(20))");
@@ -40,8 +59,196 @@ public class IntersectTest extends AbstractCairoTest {
             final String expected = "i\ts\n" +
                     "4\tB\n" +
                     "2\tC\n" +
-                    "2\tC\n" +
+                    "2\tC\n" + // <--- duplicate here
+                    "4\tB\n" + // <--- duplicate here
+                    "5\tB\n" +
+                    "1\tA\n";
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) intersect all (select i,first(s) from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testIntersectAllOfAllSupportedTypes() throws Exception {
+        assertMemoryLeak(() -> {
+            final String expected = "a\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tl256\tchr\n" +
+                    "1569490116\tfalse\tZ\tNaN\t0.7611\t428\t2015-05-16T20:27:48.158Z\tVTJW\t-8671107786057422727\t1970-01-01T00:00:00.000000Z\t26\t00000000 68 61 26 af 19 c4 95 94 36 53 49\tFOWLPD\t0x5f20a35e80e154f458dfd08eeb9cc39ecec82869edec121bc2593f82b430328d\tE\n" +
+                    "-461611463\tfalse\tJ\t0.9687423276940171\t0.6762\t279\t2015-11-21T14:32:13.134Z\tHYRX\t-6794405451419334859\t1970-01-01T00:16:40.000000Z\t6\t\tETJRSZSRYR\t0x69440048957ae05360802a2ca499f211b771e27f939096b9c356f99ae70523b5\tM\n" +
+                    "-1515787781\tfalse\t\t0.8001121139739173\t0.1877\t759\t2015-06-17T02:40:55.328Z\tCPSW\t-4091897709796604687\t1970-01-01T00:33:20.000000Z\t6\t00000000 9c 1d 06 ac 37 c8 cd 82 89 2b 4d 5f f6 46 90 c3\tDYYCTGQOLYXWCKYL\t0x78c594c496995885aa1896d0ad3419d2910aa7b6d58506dc7c97a2cb4ac4b047\tS\n" +
+                    "1235206821\ttrue\t\t0.9540069089049732\t0.2553\t310\t\tVTJW\t6623443272143014835\t1970-01-01T00:50:00.000000Z\t17\t00000000 cc 76 48 a3 bb 64 d2 ad 49 1c f2 3c ed 39 ac\tVSJOJIPHZEPIHVLT\t0xb942438168662cb7aa21f9d816335363d27e6df7d9d5b758ea7a0db859a19e14\tU\n" +
+                    "454820511\tfalse\tL\t0.9918093114862231\t0.3242\t727\t2015-02-10T08:56:03.707Z\t\t5703149806881083206\t1970-01-01T01:06:40.000000Z\t36\t00000000 68 79 8b 43 1d 57 34 04 23 8d d8 57\tWVDKFLOPJOXPK\t0x550988dbaca497348692bc8c04e4bb71d24b84c08ea7606a70061ac6a4115ca7\tH\n" +
+                    "1728220848\tfalse\tO\t0.24642266252221556\t0.2672\t174\t2015-02-20T01:11:53.748Z\t\t2151565237758036093\t1970-01-01T01:23:20.000000Z\t31\t\tHZSQLDGLOGIFO\t0x8531876c963316d961f392242addf45287dd0b29ca2c4c8455b68bf3e1f27620\tZ\n" +
+                    "-120660220\tfalse\tB\t0.07594017197103131\t0.0638\t542\t2015-01-16T16:01:53.328Z\tVTJW\t5048272224871876586\t1970-01-01T01:40:00.000000Z\t23\t00000000 f5 0f 2d b3 14 33 80 c9 eb a3 67 7a 1a 79 e4 35\n" +
+                    "00000010 e4 3a dc 5c\tULIGYVFZ\t0x99193c2e0a9e76da695f8ae33a2cc2aa529d71aba0f6fec5172a489c48c26926\tL\n" +
+                    "-1548274994\ttrue\tX\t0.9292491654871197\tNaN\t523\t2015-01-05T19:01:46.416Z\tHYRX\t9044897286885345735\t1970-01-01T01:56:40.000000Z\t16\t00000000 cd 47 0b 0c 39 12 f7 05 10 f4 6d f1 e3 ee 58 35\n" +
+                    "00000010 61\tMXSLUQDYOPHNIMYF\t0x483c83d88ac674e3894499a1a1680580cfedff23a67d918fb49b3c24e456ad6e\tP\n" +
+                    "1430716856\tfalse\tP\t0.7707249647497968\tNaN\t162\t2015-02-05T10:14:02.889Z\t\t7046578844650327247\t1970-01-01T02:13:20.000000Z\t47\t\tLEGPUHHIUGGLNYR\t0x36be4fe79117ebd53756b77218c738a7737b1dacd6be597192384aabd888ecb3\tD\n" +
+                    "-772867311\tfalse\tQ\t0.7653255982993546\tNaN\t681\t2015-05-07T02:45:07.603Z\t\t4794469881975683047\t1970-01-01T02:30:00.000000Z\t31\t00000000 4e d6 b2 57 5b e3 71 3d 20 e2 37 f2 64 43 84 55\n" +
+                    "00000010 a0 dd\tVTNPIW\t0x2d1c6f57bbfd47ec39bd4dd9ad497a2721dc4adc870c62fe19b2faa4e8255a0d\tP\n" +
+                    "494704403\ttrue\tC\t0.4834201611292943\t0.7943\t28\t2015-06-16T21:00:55.459Z\tHYRX\t6785355388782691241\t1970-01-01T02:46:40.000000Z\t39\t\tRVNGSTEQOD\t0xbabcd0482f05618f926cdd99e63abb35650d1fb462d014df59070392ef6aa389\tW\n" +
+                    "-173290754\ttrue\tK\t0.7198854503668188\tNaN\t114\t2015-06-15T20:39:39.538Z\tVTJW\t9064962137287142402\t1970-01-01T03:03:20.000000Z\t20\t00000000 3b 94 5f ec d3 dc f8 43 b2 e3\tTIZKYFLUHZQSNPX\t0x74c509677990f1c962588b84eddb7b4a64a4822086748dc4b096d89b65baebef\tM\n" +
+                    "-2041781509\ttrue\tE\t0.44638626240707313\t0.0347\t605\t\tVTJW\t415951511685691973\t1970-01-01T03:20:00.000000Z\t28\t00000000 00 7c fb 01 19 ca f2 bf 84 5a 6f 38 35\t\t0x543554ee7efea2c341b1a691af3ce51f91a63337ac2e96836e87bac2e9746529\tW\n" +
+                    "813111021\ttrue\t\t0.1389067130304884\t0.3730\t259\t\tCPSW\t4422067104162111415\t1970-01-01T03:36:40.000000Z\t19\t00000000 2d 16 f3 89 a3 83 64 de d6 fd c4 5b c4 e9\tPNXHQUTZODWKOC\t0x50902704a317faeea7fc3b8563ada5ab985499c7f07368a33b8ad671f6730aab\tP\n" +
+                    "980916820\tfalse\tC\t0.8353079103853974\t0.0111\t670\t2015-10-06T01:12:57.175Z\t\t7536661420632276058\t1970-01-01T03:53:20.000000Z\t37\t\tFDBZWNIJEE\t0xb265942d3a1f96a1cff85f9258847e03a6f2e2a772cd2f3751d822a67dff3d23\tP\n" +
+                    "-2016176825\ttrue\tT\tNaN\t0.2357\t813\t2015-12-27T00:19:42.415Z\tCPSW\t3464609208866088600\t1970-01-01T04:10:00.000000Z\t49\t\tFNUHNR\t0x8ca81bb363d7ac4585afb517c8aee023d107b1affff76a2c79189b578191a8f6\tW\n" +
+                    "1173790070\tfalse\t\t0.5380626833618448\tNaN\t440\t2015-07-18T08:33:51.750Z\tCPSW\t-5206126114193456581\t1970-01-01T04:26:40.000000Z\t31\t00000000 a1 46 87 28 92 a3 9b e3 cb c2 64 8a b0 35 d8 ab\n" +
+                    "00000010 3f a1 f5\t\t0x8e230f5d5b94e76393ce26b5c735a6c94d2c5190fa645a018c7dd745bfadc2ea\tQ\n" +
+                    "2146422524\ttrue\tI\t0.11025007918539531\t0.8641\t539\t\t\t5637967617527425113\t1970-01-01T04:43:20.000000Z\t12\t00000000 81 c6 3d bc b5 05 2b 73 51 cf c3 7e c0 1d 6c\t\t0x70c4f4015e9b707986026ba259cee6ad9c3c470dfd351e81960599005766a265\tC\n" +
+                    "-1433178628\tfalse\tW\t0.9246085617322545\t0.9217\t578\t2015-06-28T14:27:36.686Z\t\t7861908914614478025\t1970-01-01T05:00:00.000000Z\t32\t00000000 0e 98 0a 8a 0b 1e c4 fd a2 9e b3 77 f8 f6 78\tRPXZSFXUNYQXT\t0x98065c0bf90d68899f5ac37d91bde62260af712d2a1cbb23579b0bab5109229c\tI\n" +
+                    "94087085\ttrue\tY\t0.5675831821917149\t0.4634\t872\t2015-11-16T04:04:55.664Z\tPEHN\t8951464047863942551\t1970-01-01T05:16:40.000000Z\t26\t00000000 33 3f b2 67 da 98 47 47 bf 4f ea 5f 48 ed\tDDCIHCNP\t0x680d2fd4ebf181c6960658463c4b85af603e1494ba44804a7fa40f7e4efac82e\tP\n";
+
+            final String expected2 = "a\tb\tc\td\te\tf\tg\ti\tj\tk\tl\tm\tn\tl256\tchr\n" +
+                    "1569490116\tfalse\tZ\tNaN\t0.7611\t428\t2015-05-16T20:27:48.158Z\tVTJW\t-8671107786057422727\t1970-01-01T00:00:00.000000Z\t26\t00000000 68 61 26 af 19 c4 95 94 36 53 49\tFOWLPD\t0x5f20a35e80e154f458dfd08eeb9cc39ecec82869edec121bc2593f82b430328d\tE\n" +
+                    "-461611463\tfalse\tJ\t0.9687423276940171\t0.6762\t279\t2015-11-21T14:32:13.134Z\tHYRX\t-6794405451419334859\t1970-01-01T00:16:40.000000Z\t6\t\tETJRSZSRYR\t0x69440048957ae05360802a2ca499f211b771e27f939096b9c356f99ae70523b5\tM\n" +
+                    "-1515787781\tfalse\t\t0.8001121139739173\t0.1877\t759\t2015-06-17T02:40:55.328Z\tCPSW\t-4091897709796604687\t1970-01-01T00:33:20.000000Z\t6\t00000000 9c 1d 06 ac 37 c8 cd 82 89 2b 4d 5f f6 46 90 c3\tDYYCTGQOLYXWCKYL\t0x78c594c496995885aa1896d0ad3419d2910aa7b6d58506dc7c97a2cb4ac4b047\tS\n" +
+                    "1235206821\ttrue\t\t0.9540069089049732\t0.2553\t310\t\tVTJW\t6623443272143014835\t1970-01-01T00:50:00.000000Z\t17\t00000000 cc 76 48 a3 bb 64 d2 ad 49 1c f2 3c ed 39 ac\tVSJOJIPHZEPIHVLT\t0xb942438168662cb7aa21f9d816335363d27e6df7d9d5b758ea7a0db859a19e14\tU\n" +
+                    "454820511\tfalse\tL\t0.9918093114862231\t0.3242\t727\t2015-02-10T08:56:03.707Z\t\t5703149806881083206\t1970-01-01T01:06:40.000000Z\t36\t00000000 68 79 8b 43 1d 57 34 04 23 8d d8 57\tWVDKFLOPJOXPK\t0x550988dbaca497348692bc8c04e4bb71d24b84c08ea7606a70061ac6a4115ca7\tH\n" +
+                    "1728220848\tfalse\tO\t0.24642266252221556\t0.2672\t174\t2015-02-20T01:11:53.748Z\t\t2151565237758036093\t1970-01-01T01:23:20.000000Z\t31\t\tHZSQLDGLOGIFO\t0x8531876c963316d961f392242addf45287dd0b29ca2c4c8455b68bf3e1f27620\tZ\n" +
+                    "-120660220\tfalse\tB\t0.07594017197103131\t0.0638\t542\t2015-01-16T16:01:53.328Z\tVTJW\t5048272224871876586\t1970-01-01T01:40:00.000000Z\t23\t00000000 f5 0f 2d b3 14 33 80 c9 eb a3 67 7a 1a 79 e4 35\n" +
+                    "00000010 e4 3a dc 5c\tULIGYVFZ\t0x99193c2e0a9e76da695f8ae33a2cc2aa529d71aba0f6fec5172a489c48c26926\tL\n" +
+                    "-1548274994\ttrue\tX\t0.9292491654871197\tNaN\t523\t2015-01-05T19:01:46.416Z\tHYRX\t9044897286885345735\t1970-01-01T01:56:40.000000Z\t16\t00000000 cd 47 0b 0c 39 12 f7 05 10 f4 6d f1 e3 ee 58 35\n" +
+                    "00000010 61\tMXSLUQDYOPHNIMYF\t0x483c83d88ac674e3894499a1a1680580cfedff23a67d918fb49b3c24e456ad6e\tP\n" +
+                    "1430716856\tfalse\tP\t0.7707249647497968\tNaN\t162\t2015-02-05T10:14:02.889Z\t\t7046578844650327247\t1970-01-01T02:13:20.000000Z\t47\t\tLEGPUHHIUGGLNYR\t0x36be4fe79117ebd53756b77218c738a7737b1dacd6be597192384aabd888ecb3\tD\n" +
+                    "-772867311\tfalse\tQ\t0.7653255982993546\tNaN\t681\t2015-05-07T02:45:07.603Z\t\t4794469881975683047\t1970-01-01T02:30:00.000000Z\t31\t00000000 4e d6 b2 57 5b e3 71 3d 20 e2 37 f2 64 43 84 55\n" +
+                    "00000010 a0 dd\tVTNPIW\t0x2d1c6f57bbfd47ec39bd4dd9ad497a2721dc4adc870c62fe19b2faa4e8255a0d\tP\n";
+
+            ddl(
+                    "create table x as " +
+                            "(" +
+                            "select" +
+                            " rnd_int() a," +
+                            " rnd_boolean() b," +
+                            " rnd_str(1,1,2) c," +
+                            " rnd_double(2) d," +
+                            " rnd_float(2) e," +
+                            " rnd_short(10,1024) f," +
+                            " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                            " rnd_symbol(4,4,4,2) i," +
+                            " rnd_long() j," +
+                            " timestamp_sequence(0, 1000000000) k," +
+                            " rnd_byte(2,50) l," +
+                            " rnd_bin(10, 20, 2) m," +
+                            " rnd_str(5,16,2) n," +
+                            " rnd_long256() l256," +
+                            " rnd_char() chr" +
+                            " from" +
+                            " long_sequence(20))"
+            );
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory rcf = select("x")) {
+                assertCursor(expected, rcf, true, true);
+            }
+
+            SharedRandom.RANDOM.get().reset();
+
+            ddl(
+                    "create table y as " +
+                            "(" +
+                            "select" +
+                            " rnd_int() a," +
+                            " rnd_boolean() b," +
+                            " rnd_str(1,1,2) c," +
+                            " rnd_double(2) d," +
+                            " rnd_float(2) e," +
+                            " rnd_short(10,1024) f," +
+                            " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                            " rnd_symbol(4,4,4,2) i," +
+                            " rnd_long() j," +
+                            " timestamp_sequence(0, 1000000000) k," +
+                            " rnd_byte(2,50) l," +
+                            " rnd_bin(10, 20, 2) m," +
+                            " rnd_str(5,16,2) n," +
+                            " rnd_long256() l256," +
+                            " rnd_char() chr" +
+                            " from" +
+                            " long_sequence(10))"
+            );
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("select * from x intersect all y")) {
+                assertCursor(expected2, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testIntersectAllOfSymbolFor3Tables() throws Exception {
+        assertMemoryLeak(() -> {
+            final String expected = "t\n" +
+                    "CAR\n" +
+                    "CAR\n" +
+                    "VAN\n" +
+                    "MOTORBIKE\n" +
+                    "MOTORBIKE\n" +
+                    "MOTORBIKE\n" +
+                    "MOTORBIKE\n";
+
+            final String expected2 = "t\n" +
+                    "MOTORBIKE\n";
+
+            ddl(
+                    "CREATE TABLE x as " +
+                            "(SELECT " +
+                            " rnd_symbol('CAR', 'VAN', 'MOTORBIKE') t " +
+                            " FROM long_sequence(7) x)"
+            );
+            snapshotMemoryUsage();
+            try (RecordCursorFactory rcf = select("x")) {
+                assertCursor(expected, rcf, true, true);
+            }
+
+            SharedRandom.RANDOM.get().reset();
+
+            ddl(
+                    "CREATE TABLE y as " +
+                            "(SELECT " +
+                            " rnd_symbol('PLANE', 'MOTORBIKE', 'SCOOTER') t " +
+                            " FROM long_sequence(7) x)"
+            );
+
+            ddl(
+                    "CREATE TABLE z as " +
+                            "(SELECT " +
+                            " rnd_symbol('MOTORBIKE', 'HELICOPTER', 'VAN') t " +
+                            " FROM long_sequence(13) x)"
+            ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("select distinct t from x intersect all y intersect all z")) {
+                assertCursor(expected2, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testIntersectCastNoDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,5,0) i, rnd_str('A', 'B', 'C') s FROM long_sequence(3))");
+
+            final String expected = "i\ts\n" +
                     "4\tB\n" +
+                    "2\tC\n";
+
+            snapshotMemoryUsage();
+            try (RecordCursorFactory factory = select("(select i,s from x) intersect (select i,s from y)")) {
+                assertCursor(expected, factory, true, false);
+            }
+        });
+    }
+
+    @Test
+    public void testIntersectNoDuplicateRows() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(10))");
+            ddl("create table y as (SELECT rnd_int(1,5,0) i, rnd_symbol('A', 'B', 'C') s FROM long_sequence(20))");
+
+            final String expected = "i\ts\n" +
+                    "4\tB\n" +
+                    "2\tC\n" +
                     "5\tB\n" +
                     "1\tA\n";
 
@@ -96,7 +303,8 @@ public class IntersectTest extends AbstractCairoTest {
                     "-772867311\tfalse\tQ\t0.7653255982993546\tNaN\t681\t2015-05-07T02:45:07.603Z\t\t4794469881975683047\t1970-01-01T02:30:00.000000Z\t31\t00000000 4e d6 b2 57 5b e3 71 3d 20 e2 37 f2 64 43 84 55\n" +
                     "00000010 a0 dd\tVTNPIW\t0x2d1c6f57bbfd47ec39bd4dd9ad497a2721dc4adc870c62fe19b2faa4e8255a0d\tP\n";
 
-            ddl("create table x as " +
+            ddl(
+                    "create table x as " +
                             "(" +
                             "select" +
                             " rnd_int() a," +
@@ -125,7 +333,8 @@ public class IntersectTest extends AbstractCairoTest {
 
             SharedRandom.RANDOM.get().reset();
 
-            ddl("create table y as " +
+            ddl(
+                    "create table y as " +
                             "(" +
                             "select" +
                             " rnd_int() a," +
@@ -148,55 +357,6 @@ public class IntersectTest extends AbstractCairoTest {
             );
             snapshotMemoryUsage();
             try (RecordCursorFactory factory = select("select * from x intersect y")) {
-                assertCursor(expected2, factory, true, false);
-            }
-        });
-    }
-
-    @Test
-    public void testIntersectOfSymbolFor3Tables() throws Exception {
-        assertMemoryLeak(() -> {
-            final String expected = "t\n" +
-                    "CAR\n" +
-                    "CAR\n" +
-                    "VAN\n" +
-                    "MOTORBIKE\n" +
-                    "MOTORBIKE\n" +
-                    "MOTORBIKE\n" +
-                    "MOTORBIKE\n";
-
-            final String expected2 = "t\n" +
-                    "MOTORBIKE\n";
-
-            ddl(
-                    "CREATE TABLE x as " +
-                            "(SELECT " +
-                            " rnd_symbol('CAR', 'VAN', 'MOTORBIKE') t " +
-                            " FROM long_sequence(7) x)"
-            );
-            snapshotMemoryUsage();
-            try (RecordCursorFactory rcf = select("x")) {
-                assertCursor(expected, rcf, true, true);
-            }
-
-            SharedRandom.RANDOM.get().reset();
-
-            ddl(
-                    "CREATE TABLE y as " +
-                            "(SELECT " +
-                            " rnd_symbol('PLANE', 'MOTORBIKE', 'SCOOTER') t " +
-                            " FROM long_sequence(7) x)"
-            );
-
-            ddl(
-                    "CREATE TABLE z as " +
-                            "(SELECT " +
-                            " rnd_symbol('MOTORBIKE', 'HELICOPTER', 'VAN') t " +
-                            " FROM long_sequence(13) x)"
-            ); //produces HELICOPTER MOTORBIKE HELICOPTER HELICOPTER VAN HELICOPTER HELICOPTER HELICOPTER MOTORBIKE MOTORBIKE HELICOPTER MOTORBIKE HELICOPTER
-
-            snapshotMemoryUsage();
-            try (RecordCursorFactory factory = select("select distinct t from x intersect y intersect z")) {
                 assertCursor(expected2, factory, true, false);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -27,8 +27,10 @@ package io.questdb.test.griffin;
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.TableMetadata;
-import io.questdb.cairo.sql.TableRecordMetadata;
-import io.questdb.griffin.*;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlCompilerImpl;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -5092,8 +5094,10 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
 
         assertFailure(96, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "UNION"));
         assertFailure(99, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "UNION ALL"));
-        assertFailure(0, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "EXCEPT"));
-        assertFailure(0, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "INTERSECT"));
+        assertFailure(97, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "EXCEPT"));
+        assertFailure(100, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "EXCEPT ALL"));
+        assertFailure(100, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "INTERSECT"));
+        assertFailure(103, "unsupported cast [column=1, from=CHAR, to=DOUBLE]", query.replace("#SETOP#", "INTERSECT ALL"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3580

This is a breaking change: the behavior of the old INTERSECT/EXCEPT was the same as the newly added INTERSECT ALL/EXCEPT ALL, i.e. they were not removing duplicate rows. Now they do.

So, if previously

```sql
(SELECT 1 UNION ALL SELECT 1) EXCEPT (SELECT 0);
```

would return `[(1,),(1,)]`, now it returns `[(1,)]`.