### PR TITLE
chore(sql): add simple tool to produce content for repo sql-grammar ts files

### DIFF
--- a/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
+++ b/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
@@ -1,0 +1,82 @@
+package io.questdb.misc;
+
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.engine.functions.catalogue.Constants;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+public class SqlGrammarUtil {
+    private static void print(String header, Set<String> names) {
+        System.out.printf("%s:%n", header);
+        for (String name : names) {
+            System.out.printf("\"%s\",%n", name);
+        }
+        System.out.print("\n=====\n");
+    }
+
+    public static void main(String... args) {
+        // static
+        final Set<String> staticSet = new TreeSet<>();
+        Collections.addAll(
+                staticSet,
+                "&", "|", "^", "~", "[]",
+                "!=", "!~", "%", "*", "+",
+                "-", ".", "/", "<", "<=",
+                "<>", "<>all", "=", ">", ">="
+        );
+
+        // function names
+        final Set<String> names = new TreeSet<>();
+        for (FunctionFactory factory : ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader())) {
+            if (factory.getClass().getName().contains("test")) {
+                continue;
+            }
+            String signature = factory.getSignature();
+            String name = signature.substring(0, signature.indexOf('('));
+            if (staticSet.contains(name)) {
+                continue;
+            }
+            names.add(name);
+            // add != counterparts to equality function factories
+            if (factory.isBoolean()) {
+                if (name.equals("=")) {
+                    names.add("!=");
+                    names.add("<>");
+                } else if (name.equals("<")) {
+                    names.add("<=");
+                    names.add(">=");
+                    names.add(">");
+                }
+            }
+        }
+        print("FUNCTIONS", names);
+
+        // keywords
+        names.clear();
+        try {
+            Field field = Constants.class.getDeclaredField("KEYWORDS");
+            field.setAccessible(true);
+            for (CharSequence keyword : (CharSequence[]) field.get(null)) {
+                names.add((String) keyword);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        print("FUNCTIONS", names);
+
+        // types
+        names.clear();
+        final Set<String> skipSet = new HashSet<>();
+        Collections.addAll(skipSet, "unknown", "regclass", "regprocedure", "VARARG", "text[]", "CURSOR", "RECORD", "PARAMETER");
+        for (int type = 1; type < ColumnType.MAX; type++) {
+            String name = ColumnType.nameOf(type);
+            if (!skipSet.contains(name)) {
+                names.add(name.toLowerCase());
+            }
+        }
+        print("TYPES", names);
+    }
+}

--- a/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
+++ b/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
@@ -65,7 +65,7 @@ public class SqlGrammarUtil {
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
-        print("FUNCTIONS", names);
+        print("KEYWORDS", names);
 
         // types
         names.clear();


### PR DESCRIPTION
Simply run the main method from within the IDE and, for each category (functions, keywords, types), find the relevant appropriatedly named ts file, and wack the entries, to be then replaced with the ones produced by the tool