### PR TITLE
chore(ui): web console bump to 0.2.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.2.5</web.console.version>
+        <web.console.version>0.2.6</web.console.version>
     </properties>
 
     <version>7.3.1-SNAPSHOT</version>


### PR DESCRIPTION
Relies on two sequential PRs being deployed:

1. [This PR](https://github.com/questdb/sql-grammar/pull/25) in `sql-grammar`
2. [This PR](https://github.com/questdb/ui/pull/187) in `ui`