### PR TITLE
fix(http): improve detection of flat file delimiter

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/text/TextDelimiterScanner.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextDelimiterScanner.java
@@ -35,7 +35,7 @@ import java.io.Closeable;
 import java.util.Arrays;
 
 public class TextDelimiterScanner implements Closeable {
-    private static final double DOUBLE_TOLERANCE = 0.05d;
+    private static final double DOUBLE_TOLERANCE = 0.0000005d;
     private static final Log LOG = LogFactory.getLog(TextDelimiterScanner.class);
     private static final byte[] potentialDelimiterBytes = new byte[256];
     private static final byte[] priorities = new byte[Byte.MAX_VALUE + 1];


### PR DESCRIPTION
Depending on data shape of inboud TEXT files the heuristic for detecting column delimiter could malfunction and pick wrong delimiter. This was caused by abnormally high double tolerance value when comparing stddev of each delimiter candites.