### PR TITLE
chore(core): add mechanism to flag RecordCursorFactories as non cacheable for PGWire

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -582,6 +582,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         if (securityContext != null) {
             ddlListener.onColumnAdded(securityContext, tableToken, columnName);
         }
+        LOG.info().$("ADDED column '").utf8(columnName).$('[').$(ColumnType.nameOf(columnType)).$("]' to ").$(path).$();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
@@ -31,6 +31,7 @@ import io.questdb.griffin.Plannable;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.mp.SCSequence;
+import io.questdb.std.Cacheable;
 import io.questdb.std.Sinkable;
 import io.questdb.std.str.CharSink;
 
@@ -57,7 +58,7 @@ import java.io.Closeable;
  * }
  * }
  */
-public interface RecordCursorFactory extends Closeable, Sinkable, Plannable {
+public interface RecordCursorFactory extends Cacheable, Closeable, Sinkable, Plannable {
 
     int SCAN_DIRECTION_BACKWARD = 2;
     int SCAN_DIRECTION_FORWARD = 1;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -2064,10 +2064,13 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
                 typesAndSelect.of(cq.getRecordCursorFactory(), bindVariableService);
                 queryTag = TAG_EXPLAIN;
             case CompiledQuery.SELECT:
+                typesAndSelectIsCached = cq.getRecordCursorFactory().isPgWireSelectCacheable();
                 typesAndSelect = typesAndSelectPool.pop();
                 typesAndSelect.of(cq.getRecordCursorFactory(), bindVariableService);
                 queryTag = TAG_SELECT;
-                LOG.debug().$("cache select [sql=").$(queryText).$(", thread=").$(Thread.currentThread().getId()).$(']').$();
+                if (typesAndSelectIsCached) {
+                    LOG.debug().$("cache select [sql=").$(queryText).$(", thread=").$(Thread.currentThread().getId()).$(']').$();
+                }
                 break;
             case CompiledQuery.INSERT:
                 queryTag = TAG_INSERT;

--- a/core/src/main/java/io/questdb/std/Cacheable.java
+++ b/core/src/main/java/io/questdb/std/Cacheable.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+public interface Cacheable {
+    default boolean isPgWireSelectCacheable() {
+        return true;
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
@@ -527,7 +527,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
             lineData = sb.toString();
             SqlException exception = sendWithAlterStatement(
                     lineData,
-                    "ALTER TABLE plug DROP COLUMN room",
+                    "ALTER TABLE plug DROP COLUMN 'room'",
                     1, 1
             );
             Assert.assertNull(exception);


### PR DESCRIPTION
 Some record cursor factories (show permissions) look the same in text, but their results vary depending on the user that logged in (default parameter is "self" and "self" is the logged user).