### PR TITLE
fix(core): fix excessive disk space consumption on Windows under heavy load

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -384,9 +384,8 @@ public class CairoEngine implements Closeable, WriterSource {
             if (lockedReason == null) {
                 try {
                     path.of(configuration.getRoot()).concat(tableToken).$();
-                    int errno;
-                    if ((errno = configuration.getFilesFacade().unlinkOrRemove(path, LOG)) != 0) {
-                        throw CairoException.critical(errno).put("could not remove table [name=").put(tableToken)
+                    if (!configuration.getFilesFacade().unlinkOrRemove(path, LOG)) {
+                        throw CairoException.critical(configuration.getFilesFacade().errno()).put("could not remove table [name=").put(tableToken)
                                 .put(", dirName=").put(tableToken.getDirName()).put(']');
                     }
                 } finally {
@@ -778,6 +777,7 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     @Nullable
+    // todo: is this used?
     public TableToken lockTableName(CharSequence tableName, String dirName, int tableId, boolean isWal) {
         String tableNameStr = Chars.toString(tableName);
         return tableNameRegistry.lockTableName(tableNameStr, dirName, tableId, isWal);

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -781,7 +781,6 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     @Nullable
-    // todo: is this used?
     public TableToken lockTableName(CharSequence tableName, String dirName, int tableId, boolean isWal) {
         String tableNameStr = Chars.toString(tableName);
         return tableNameRegistry.lockTableName(tableNameStr, dirName, tableId, isWal);

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -555,6 +555,10 @@ public class CairoEngine implements Closeable, WriterSource {
         return readerPool.entries();
     }
 
+    public Map<CharSequence, WriterPool.Entry> getWriterPoolEntries() {
+        return writerPool.entries();
+    }
+
     public TableReader getReaderWithRepair(TableToken tableToken) {
         // todo: untested verification
         verifyTableToken(tableToken);

--- a/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgent.java
+++ b/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgent.java
@@ -153,7 +153,7 @@ public class DatabaseSnapshotAgent implements QuietCloseable {
             // Delete all contents of the snapshot/db dir.
             if (ff.exists(path.slash$())) {
                 path.trimTo(snapshotLen).$();
-                if (ff.rmdir(path) != 0) {
+                if (!ff.rmdir(path)) {
                     throw CairoException.critical(ff.errno()).put("Could not remove snapshot dir [dir=").put(path).put(']');
                 }
             }
@@ -440,7 +440,7 @@ public class DatabaseSnapshotAgent implements QuietCloseable {
             // Delete snapshot directory to avoid recovery on next restart.
             srcPath.trimTo(snapshotRootLen).$();
             memFile.close();
-            if (ff.rmdir(srcPath) != 0) {
+            if (!ff.rmdir(srcPath)) {
                 throw CairoException.critical(ff.errno())
                         .put("could not remove snapshot dir [dir=").put(srcPath)
                         .put(", errno=").put(ff.errno())

--- a/core/src/main/java/io/questdb/cairo/TableConverter.java
+++ b/core/src/main/java/io/questdb/cairo/TableConverter.java
@@ -98,7 +98,7 @@ public class TableConverter {
                                         tableSequencerAPI.registerTable(tableId, metadata, token);
                                     }
 
-                                    // Reset structure versoin in _meta and _txn files
+                                    // Reset structure version in _meta and _txn files
                                     metaMem.putLong(TableUtils.META_OFFSET_METADATA_VERSION, 0);
                                     path.trimTo(rootLen).concat(dirName);
                                     txWriter.resetStructureVersionUnsafe();
@@ -154,7 +154,7 @@ public class TableConverter {
 
     private static void removeWalPersistence(Path path, int rootLen, FilesFacade ff, String dirName) {
         path.trimTo(rootLen).concat(dirName).concat(WalUtils.SEQ_DIR).$();
-        if (ff.rmdir(path) != 0) {
+        if (!ff.rmdir(path)) {
             LOG.error()
                     .$("Could not remove sequencer dir [errno=").$(ff.errno())
                     .$(", path=").$(path)
@@ -179,7 +179,7 @@ public class TableConverter {
                                         .I$();
                             }
                         } else {
-                            if (ff.rmdir(path) != 0) {
+                            if (!ff.rmdir(path)) {
                                 LOG.error()
                                         .$("Could not remove wal dir [errno=").$(ff.errno())
                                         .$(", path=").$(path)

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryFileStore.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryFileStore.java
@@ -361,6 +361,9 @@ public class TableNameRegistryFileStore implements Closeable {
                     } else {
                         reverseTableNameTokenMap.put(dirName, ReverseTableMapItem.ofDropped(token));
                     }
+                } else {
+                    reverseTableNameTokenMap.remove(dirName);
+                    tableToCompact++;
                 }
             } else {
                 if (tableIds.contains(tableId)) {

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.*;
 import io.questdb.griffin.AnyRecordMetadata;
@@ -451,7 +450,7 @@ public final class TableUtils {
                 throw CairoException.critical(ff.errno()).put("could not create [dir=").put(path).put(']');
             }
             if (ff.softLink(path.trimTo(rootLen).$(), normalPath) != 0) {
-                if (ff.rmdir(path.slash$()) != 0) {
+                if (!ff.rmdir(path.slash$())) {
                     LOG.error().$("cannot remove table directory in volume [errno=").$(ff.errno()).$(", path=").utf8(path.trimTo(rootLen).$()).I$();
                 }
                 throw CairoException.critical(ff.errno()).put("could not create soft link [src=").put(path.trimTo(rootLen).$()).put(", tableDir=").put(tableDir).put(']');

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * This class maintains cache of open writers to avoid OS overhead of
@@ -105,6 +106,10 @@ public class WriterPool extends AbstractPool {
             }
         }
         return count;
+    }
+
+    public Map<CharSequence, Entry> entries() {
+        return entries;
     }
 
     /**
@@ -619,7 +624,7 @@ public class WriterPool extends AbstractPool {
         return removed;
     }
 
-    private class Entry implements LifecycleManager {
+    public class Entry implements LifecycleManager {
         private CairoException ex = null;
         // time writer was last released
         private volatile long lastReleaseTime;
@@ -645,6 +650,23 @@ public class WriterPool extends AbstractPool {
                 writer = null;
             }
             return w;
+        }
+
+        public long getLastReleaseTime() {
+            return lastReleaseTime;
+        }
+
+
+        public long getOwnerThread() {
+            return owner;
+        }
+
+        public String getOwnershipReason() {
+            return ownershipReason;
+        }
+
+        public TableToken getTableToken() {
+            return writer != null ? writer.getTableToken() : null;
         }
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -110,7 +110,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                     int type = ff.findType(p);
                     if (ff.isDirOrSoftLinkDirNoDots(tempPath, rootLen, pUtf8NameZ, type)) {
                         if (!CairoKeywords.isTxnSeq(pUtf8NameZ) && !CairoKeywords.isWal(pUtf8NameZ)) {
-                            if (ff.unlinkOrRemove(tempPath, LOG) != 0) {
+                            if (!ff.unlinkOrRemove(tempPath, LOG)) {
                                 allClean = false;
                             }
                         }

--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -53,9 +53,8 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
     private final ObjHashSet<TableToken> tablesToCheck = new ObjHashSet<>();
     private final TxReader txReader;
     private long lastProcessedCount = 0;
-    private RenameTrackingMetadataService renameTrackingMetadataService = new RenameTrackingMetadataService();
+    private final RenameTrackingMetadataService renameTrackingMetadataService = new RenameTrackingMetadataService();
     private Path threadLocalPath;
-
 
     public CheckWalTransactionsJob(CairoEngine engine) {
         this.engine = engine;

--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -102,9 +102,9 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
                 threadLocalPath.trimTo(dbRoot.length()).concat(tableToken).concat(TableUtils.META_FILE_NAME).$();
                 if (ff.exists(threadLocalPath)) {
                     threadLocalPath.trimTo(dbRoot.length()).concat(tableToken).concat(TableUtils.TXN_FILE_NAME).$();
-                    try (TxReader txReader2 = txReader.ofRO(threadLocalPath, PartitionBy.NONE)) {
-                        TableUtils.safeReadTxn(txReader, millisecondClock, spinLockTimeout);
-                        if (engine.getTableSequencerAPI().initTxnTracker(tableToken, txReader2.getSeqTxn(), seqTxn)) {
+                    try (TxReader txReader = this.txReader.ofRO(threadLocalPath, PartitionBy.NONE)) {
+                        TableUtils.safeReadTxn(this.txReader, millisecondClock, spinLockTimeout);
+                        if (engine.getTableSequencerAPI().initTxnTracker(tableToken, txReader.getSeqTxn(), seqTxn)) {
                             engine.notifyWalTxnCommitted(tableToken);
                         }
                     }

--- a/core/src/main/java/io/questdb/cairo/wal/WalPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalPurgeJob.java
@@ -188,9 +188,9 @@ public class WalPurgeJob extends SynchronizedJob implements Closeable {
                             symLinkTarget = null;
                         }
                     }
-                    ff.rmdir(pathToDelete);
+                    ff.rmdir(pathToDelete, false);
                     if (symLinkTarget != null) {
-                        ff.rmdir(symLinkTarget);
+                        ff.rmdir(symLinkTarget, false);
                     }
                     TableUtils.lockName(pathToDelete);
                     ff.remove(pathToDelete);
@@ -344,10 +344,11 @@ public class WalPurgeJob extends SynchronizedJob implements Closeable {
     }
 
     private void recursiveDelete(Path path) {
-        final int errno = ff.rmdir(path);
-        if (errno > 0 && !CairoException.errnoRemovePathDoesNotExist(errno)) {
-            LOG.error().$("could not delete directory [path=").utf8(path)
-                    .$(", errno=").$(errno).$(']').$();
+        if (!ff.rmdir(path, false) && !CairoException.errnoRemovePathDoesNotExist(ff.errno())) {
+            LOG.debug()
+                    .$("could not delete directory [path=").utf8(path)
+                    .$(", errno=").$(ff.errno())
+                    .I$();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/SeqTxnTracker.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/SeqTxnTracker.java
@@ -45,7 +45,7 @@ public class SeqTxnTracker {
             seqTxn = this.seqTxn;
         }
         long writerTxn = this.writerTxn;
-        while ((writerTxn == -1 || writerTxn < this.writerTxn) && !Unsafe.cas(this, WRITER_TXN_OFFSET, writerTxn, newWriterTxn)) {
+        while (newWriterTxn > writerTxn && !Unsafe.cas(this, WRITER_TXN_OFFSET, writerTxn, newWriterTxn)) {
             writerTxn = this.writerTxn;
         }
         return this.suspendedState > 0 && this.seqTxn > 0 && this.seqTxn > this.writerTxn;

--- a/core/src/main/java/io/questdb/cairo/wal/seq/SeqTxnTracker.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/SeqTxnTracker.java
@@ -45,10 +45,10 @@ public class SeqTxnTracker {
             seqTxn = this.seqTxn;
         }
         long writerTxn = this.writerTxn;
-        while (writerTxn < this.writerTxn && !Unsafe.cas(this, WRITER_TXN_OFFSET, writerTxn, newWriterTxn)) {
+        while ((writerTxn == -1 || writerTxn < this.writerTxn) && !Unsafe.cas(this, WRITER_TXN_OFFSET, writerTxn, newWriterTxn)) {
             writerTxn = this.writerTxn;
         }
-        return this.suspendedState > 0 && this.seqTxn > this.writerTxn;
+        return this.suspendedState > 0 && this.seqTxn > 0 && this.seqTxn > this.writerTxn;
     }
 
     public boolean isInitialised() {

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -250,10 +250,13 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         try (Path path = new Path()) {
             switch (TableUtils.exists(ff, path, root, tableDir)) {
                 case TableUtils.TABLE_EXISTS:
-                    int errno;
-                    if ((errno = ff.rmdir(path)) != 0) {
-                        LOG.error().$("could not overwrite table [tableName='").utf8(tableName).$("',path='").utf8(path).$(", errno=").$(errno).I$();
-                        throw CairoException.critical(errno).put("could not overwrite [tableName=").put(tableName).put("]");
+                    if (!ff.rmdir(path)) {
+                        LOG.error()
+                                .$("could not overwrite table [tableName='").utf8(tableName)
+                                .$("',path='").utf8(path)
+                                .$(", errno=").$(ff.errno())
+                                .I$();
+                        throw CairoException.critical(ff.errno()).put("could not overwrite [tableName=").put(tableName).put("]");
                     }
                 case TableUtils.TABLE_DOES_NOT_EXIST:
                     securityContext.authorizeTableCreate();
@@ -1309,9 +1312,8 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
 
             LOG.info().$("removing import work directory [path='").$(workDirPath).$("']").$();
 
-            int errno = ff.rmdir(workDirPath);
-            if (errno != 0) {
-                throw TextException.$("could not remove import work directory [path='").put(workDirPath).put("', errno=").put(errno).put(']');
+            if (!ff.rmdir(workDirPath)) {
+                throw TextException.$("could not remove import work directory [path='").put(workDirPath).put("', errno=").put(ff.errno()).put(']');
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -3233,9 +3233,8 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable {
                         .$(", errno=").$(e.getErrno())
                         .$(']').$();
                 auxPath.of(cachedBackupTmpRoot).concat(tableToken).slash$();
-                int errno;
-                if ((errno = ff.rmdir(auxPath)) != 0) {
-                    LOG.error().$("could not delete directory [path=").utf8(auxPath).$(", errno=").$(errno).I$();
+                if (!ff.rmdir(auxPath)) {
+                    LOG.error().$("could not delete directory [path=").utf8(auxPath).$(", errno=").$(ff.errno()).I$();
                 }
                 throw e;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/WriterPoolFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/WriterPoolFunctionFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.table;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.griffin.engine.table.WriterPoolRecordCursorFactory;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class WriterPoolFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "writer_pool()";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CursorFunction(new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine()));
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/WriterPoolRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/WriterPoolRecordCursorFactory.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table;
+
+import io.questdb.cairo.*;
+import io.questdb.cairo.pool.WriterPool;
+import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.Numbers;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public final class WriterPoolRecordCursorFactory extends AbstractRecordCursorFactory {
+    private static final RecordMetadata METADATA;
+    private static final int OWNER_THREAD_COLUMN_INDEX = 1;
+    private static final int TABLE_NAME_COLUMN_INDEX = 0;
+    private static final int LAST_ACCESS_TIMESTAMP_COLUMN_INDEX = 2;
+    private static final int OWNERSHIP_REASON_COLUMN_INDEX = 3;
+    private final CairoEngine cairoEngine;
+
+    public WriterPoolRecordCursorFactory(CairoEngine cairoEngine) {
+        super(METADATA);
+        this.cairoEngine = cairoEngine;
+    }
+
+    @Override
+    public RecordCursor getCursor(SqlExecutionContext executionContext) {
+        WriterPoolCursor writerPoolCursor = new WriterPoolCursor();
+        writerPoolCursor.of(cairoEngine.getWriterPoolEntries());
+        return writerPoolCursor;
+    }
+
+    @Override
+    public boolean recordCursorSupportsRandomAccess() {
+        return false;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.type("writer_pool");
+    }
+
+    private static class WriterPoolCursor implements NoRandomAccessRecordCursor {
+        private final ReaderPoolEntryRecord record = new ReaderPoolEntryRecord();
+        private Iterator<Map.Entry<CharSequence, WriterPool.Entry>> iterator;
+        private long owner_thread;
+        private Map<CharSequence, WriterPool.Entry> writerPoolEntries;
+        private TableToken tableToken;
+        private String ownershipReason;
+        private long lastAccessTimestamp;
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Record getRecord() {
+            return record;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (iterator.hasNext()) {
+                Map.Entry<CharSequence, WriterPool.Entry> mapEntry = iterator.next();
+                final WriterPool.Entry poolEntry = mapEntry.getValue();
+                owner_thread = poolEntry.getOwnerThread();
+                lastAccessTimestamp = poolEntry.getLastReleaseTime();
+                tableToken = poolEntry.getTableToken();
+                ownershipReason = poolEntry.getOwnershipReason();
+                return true;
+            }
+            return false;
+        }
+
+        public void of(Map<CharSequence, WriterPool.Entry> readerPoolEntries) {
+            this.writerPoolEntries = readerPoolEntries;
+            toTop();
+        }
+
+        @Override
+        public long size() {
+            return -1;
+        }
+
+        @Override
+        public void toTop() {
+            iterator = writerPoolEntries.entrySet().iterator();
+        }
+
+        private class ReaderPoolEntryRecord implements Record {
+            @Override
+            public long getLong(int col) {
+                if (col == OWNER_THREAD_COLUMN_INDEX) {
+                    return owner_thread == -1 ? Numbers.LONG_NaN : owner_thread;
+                }
+                throw CairoException.nonCritical().put("unsupported column number. [column=").put(col).put("]");
+            }
+
+            @Override
+            public CharSequence getStr(int col) {
+                switch (col) {
+                    case TABLE_NAME_COLUMN_INDEX:
+                        return tableToken.getTableName();
+                    case OWNERSHIP_REASON_COLUMN_INDEX:
+                        return ownershipReason;
+                    default:
+                        throw CairoException.nonCritical().put("unsupported column number. [column=").put(col).put("]");
+                }
+            }
+
+            @Override
+            public CharSequence getStrB(int col) {
+                return getStr(col);
+            }
+
+            @Override
+            public long getTimestamp(int col) {
+                assert col == LAST_ACCESS_TIMESTAMP_COLUMN_INDEX;
+                return lastAccessTimestamp;
+            }
+        }
+    }
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(TABLE_NAME_COLUMN_INDEX, new TableColumnMetadata("table_name", ColumnType.STRING))
+                .add(OWNER_THREAD_COLUMN_INDEX, new TableColumnMetadata("owner_thread_id", ColumnType.LONG))
+                .add(LAST_ACCESS_TIMESTAMP_COLUMN_INDEX, new TableColumnMetadata("last_access_timestamp", ColumnType.TIMESTAMP))
+                .add(OWNERSHIP_REASON_COLUMN_INDEX, new TableColumnMetadata("ownership_reason", ColumnType.STRING))
+        ;
+        METADATA = metadata;
+    }
+}

--- a/core/src/main/java/io/questdb/std/FilesFacade.java
+++ b/core/src/main/java/io/questdb/std/FilesFacade.java
@@ -144,7 +144,9 @@ public interface FilesFacade {
 
     int rename(LPSZ from, LPSZ to);
 
-    int rmdir(Path name);
+    boolean rmdir(Path name);
+
+    boolean rmdir(Path name, boolean lazy);
 
     int softLink(LPSZ src, LPSZ softLink);
 
@@ -158,9 +160,9 @@ public interface FilesFacade {
 
     int unlink(LPSZ softLink);
 
-    int unlinkOrRemove(Path path, Log LOG);
+    boolean unlinkOrRemove(Path path, Log LOG);
 
-    int unlinkOrRemove(Path path, int checkedType, Log LOG);
+    boolean unlinkOrRemove(Path path, int checkedType, Log LOG);
 
     void walk(Path src, FindVisitor func);
 

--- a/core/src/main/java/io/questdb/std/FilesFacadeImpl.java
+++ b/core/src/main/java/io/questdb/std/FilesFacadeImpl.java
@@ -373,12 +373,12 @@ public class FilesFacadeImpl implements FilesFacade {
 
     @Override
     public boolean rmdir(Path name) {
-        return Files.rmdir(name, true) == 0;
+        return Files.rmdir(name, true);
     }
 
     @Override
     public boolean rmdir(Path name, boolean lazy) {
-        return Files.rmdir(name, lazy) == 0;
+        return Files.rmdir(name, lazy);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/FilesFacadeImpl.java
+++ b/core/src/main/java/io/questdb/std/FilesFacadeImpl.java
@@ -372,8 +372,13 @@ public class FilesFacadeImpl implements FilesFacade {
     }
 
     @Override
-    public int rmdir(Path name) {
-        return Files.rmdir(name);
+    public boolean rmdir(Path name) {
+        return Files.rmdir(name, true) == 0;
+    }
+
+    @Override
+    public boolean rmdir(Path name, boolean lazy) {
+        return Files.rmdir(name, lazy) == 0;
     }
 
     @Override
@@ -407,33 +412,32 @@ public class FilesFacadeImpl implements FilesFacade {
     }
 
     @Override
-    public int unlinkOrRemove(Path path, Log LOG) {
+    public boolean unlinkOrRemove(Path path, Log LOG) {
         int checkedType = isSoftLink(path) ? Files.DT_LNK : Files.DT_UNKNOWN;
         return unlinkOrRemove(path, checkedType, LOG);
     }
 
     @Override
-    public int unlinkOrRemove(Path path, int checkedType, Log LOG) {
+    public boolean unlinkOrRemove(Path path, int checkedType, Log LOG) {
         if (checkedType == Files.DT_LNK) {
             // in Windows ^ ^ will return DT_DIR, but that is ok as the behaviour
             // is to delete the link, not the contents of the target. in *nix
             // systems we can simply unlink, which deletes the link and leaves
             // the contents of the target intact
             if (unlink(path) == 0) {
-                LOG.info().$("removed by unlink [path=").utf8(path).I$();
-                return 0;
+                LOG.debug().$("removed by unlink [path=").utf8(path).I$();
+                return true;
             } else {
-                LOG.error().$("failed to unlink, will remove [path=").utf8(path).I$();
+                LOG.debug().$("failed to unlink, will remove [path=").utf8(path).I$();
             }
         }
 
-        int errno;
-        if ((errno = rmdir(path)) == 0) {
-            LOG.info().$("removed [path=").utf8(path).I$();
-        } else {
-            LOG.error().$("cannot remove [path=").utf8(path).$(", errno=").$(errno).I$();
+        if (rmdir(path)) {
+            LOG.debug().$("removed [path=").utf8(path).I$();
+            return true;
         }
-        return errno;
+        LOG.debug().$("cannot remove [path=").utf8(path).$(", errno=").$(errno()).I$();
+        return false;
     }
 
     public void walk(Path path, FindVisitor func) {

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -710,6 +710,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.table.TablePartitionsFunctionFactory,
             io.questdb.griffin.engine.functions.table.TouchTableFunctionFactory,
             io.questdb.griffin.engine.functions.table.ReaderPoolFunctionFactory,
+            io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory,
             io.questdb.griffin.engine.functions.table.TableWriterMetricsFunctionFactory,
             io.questdb.griffin.engine.functions.table.MemoryMetricsFunctionFactory,
 

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -702,6 +702,7 @@ io.questdb.griffin.engine.functions.table.TableColumnsFunctionFactory
 io.questdb.griffin.engine.functions.table.TablePartitionsFunctionFactory
 io.questdb.griffin.engine.functions.table.TouchTableFunctionFactory
 io.questdb.griffin.engine.functions.table.ReaderPoolFunctionFactory
+io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory
 io.questdb.griffin.engine.functions.table.TableWriterMetricsFunctionFactory
 io.questdb.griffin.engine.functions.table.MemoryMetricsFunctionFactory
 

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -469,7 +469,7 @@ public abstract class AbstractCairoTest extends AbstractTest {
         if (inputWorkRoot != null) {
             try (Path path = new Path().of(inputWorkRoot).$()) {
                 if (Files.exists(path)) {
-                    Files.rmdir(path);
+                    Files.rmdir(path, true);
                 }
             }
         }
@@ -1472,14 +1472,14 @@ public abstract class AbstractCairoTest extends AbstractTest {
         final Path srcWal = Path.PATH.get().of(srcNode.getRoot()).concat(srcTableToken).concat(wal).$();
         final Path dstWal = Path.PATH2.get().of(dstNode.getRoot()).concat(dstTableToken).concat(wal).$();
         if (ff.exists(dstWal)) {
-            Assert.assertEquals(0, ff.rmdir(dstWal));
+            Assert.assertTrue(ff.rmdir(dstWal));
         }
         Assert.assertEquals(0, ff.mkdir(dstWal, mkdirMode));
         Assert.assertEquals(0, ff.copyRecursive(srcWal, dstWal, mkdirMode));
 
         final Path srcTxnLog = Path.PATH.get().of(srcNode.getRoot()).concat(srcTableToken).concat(WalUtils.SEQ_DIR).$();
         final Path dstTxnLog = Path.PATH2.get().of(dstNode.getRoot()).concat(dstTableToken).concat(WalUtils.SEQ_DIR).$();
-        Assert.assertEquals(0, ff.rmdir(dstTxnLog));
+        Assert.assertTrue(ff.rmdir(dstTxnLog));
         Assert.assertEquals(0, ff.copyRecursive(srcTxnLog, dstTxnLog, mkdirMode));
 
         dstNode.getEngine().getTableSequencerAPI().openSequencer(srcTableToken);

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -893,8 +893,8 @@ public abstract class AbstractCairoTest extends AbstractTest {
         }
     }
 
-    protected static void assertExceptionNoLeakCheck(CharSequence sql, int errorPos, CharSequence contains) throws Exception {
-        assertException(sql, errorPos, contains, false);
+    protected static void assertExceptionNoLeakCheck(CharSequence sql, int errorPos) throws Exception {
+        assertException(sql, errorPos, "inconvertible types: TIMESTAMP -> INT", false);
     }
 
     protected static void assertFactoryMemoryUsage() {
@@ -1211,8 +1211,8 @@ public abstract class AbstractCairoTest extends AbstractTest {
         node1.getConfigurationOverrides().setWalApplyTableTimeQuota(walApplyTableTimeQuota);
     }
 
-    protected static void configOverrideWalMaxLagTxnCount(int walMaxLagTxnCount) {
-        node1.getConfigurationOverrides().setWalMaxLagTxnCount(walMaxLagTxnCount);
+    protected static void configOverrideWalMaxLagTxnCount() {
+        node1.getConfigurationOverrides().setWalMaxLagTxnCount(1);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -206,7 +206,7 @@ public class FilesTest {
                         dst.concat("subdir").concat("file2");
                         TestUtils.assertFileContentsEquals(src, dst);
                     } finally {
-                        Files.rmdir(p2);
+                        Files.rmdir(p2, true);
                     }
                 }
             }
@@ -239,11 +239,11 @@ public class FilesTest {
                 Assert.assertEquals(0, Files.softLink(targetPath, linkPath));
                 Assert.assertTrue(Files.isSoftLink(linkPath));
 
-                Assert.assertEquals(0, Files.rmdir(linkPath));
+                Assert.assertEquals(0, Files.rmdir(linkPath, true));
                 Assert.assertFalse(new File(linkPath.toString()).exists());
                 Assert.assertTrue(r.exists());
                 Assert.assertEquals(0L, Files.getDirSize(targetPath));
-                Assert.assertEquals(0, Files.rmdir(targetPath.slash().$()));
+                Assert.assertEquals(0, Files.rmdir(targetPath.slash().$(), true));
                 Assert.assertFalse(r.exists());
             }
         });
@@ -478,7 +478,7 @@ public class FilesTest {
                         dst.concat("subdir").concat("file2");
                         TestUtils.assertFileContentsEquals(src, dst);
                     } finally {
-                        Files.rmdir(p2);
+                        Files.rmdir(p2, true);
                     }
                 }
             }

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -239,11 +239,11 @@ public class FilesTest {
                 Assert.assertEquals(0, Files.softLink(targetPath, linkPath));
                 Assert.assertTrue(Files.isSoftLink(linkPath));
 
-                Assert.assertEquals(0, Files.rmdir(linkPath, true));
+                Assert.assertTrue(Files.rmdir(linkPath, true));
                 Assert.assertFalse(new File(linkPath.toString()).exists());
                 Assert.assertTrue(r.exists());
                 Assert.assertEquals(0L, Files.getDirSize(targetPath));
-                Assert.assertEquals(0, Files.rmdir(targetPath.slash().$(), true));
+                Assert.assertTrue(Files.rmdir(targetPath.slash().$(), true));
                 Assert.assertFalse(r.exists());
             }
         });

--- a/core/src/test/java/io/questdb/test/ServerMainBackupDatabaseTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainBackupDatabaseTest.java
@@ -207,7 +207,7 @@ public class ServerMainBackupDatabaseTest extends AbstractBootstrapTest {
                 }
                 Assert.assertTrue(totalRows > (expectedTotalRows.get() * 0.5));
             } finally {
-                Assert.assertEquals(0, Files.rmdir(dbPath.of(newRoot).$()));
+                Assert.assertEquals(0, Files.rmdir(dbPath.of(newRoot).$(), true));
             }
         });
     }
@@ -253,7 +253,7 @@ public class ServerMainBackupDatabaseTest extends AbstractBootstrapTest {
                 if (!f.getName().equals("tmp")) {
                     roots.add(f);
                 } else {
-                    Assert.assertEquals(0, Files.rmdir(auxPath.of(f.getAbsolutePath()).$()));
+                    Assert.assertEquals(0, Files.rmdir(auxPath.of(f.getAbsolutePath()).$(), true));
                 }
             }
         }
@@ -262,7 +262,7 @@ public class ServerMainBackupDatabaseTest extends AbstractBootstrapTest {
         roots.sort(Comparator.comparing(File::lastModified));
         String newRoot = roots.get(len - 1).getAbsolutePath();
         for (int i = 0; i < len - 1; i++) {
-            Assert.assertEquals(0, Files.rmdir(auxPath.of(roots.get(i).getAbsolutePath()).$()));
+            Assert.assertEquals(0, Files.rmdir(auxPath.of(roots.get(i).getAbsolutePath()).$(), true));
         }
         return newRoot;
     }

--- a/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test;
+
+import io.questdb.ServerMain;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.std.str.StringSink;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
+    @Test
+    public void testServerMainStartIlpAuthEnabled() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+
+            StringSink sink = new StringSink();
+
+            // create two tables:
+            // 1. empty
+            // 2. non-empty with a couple of translations
+
+            try (
+                    final ServerMain serverMain = new ServerMain(getServerMainArgs());
+                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(serverMain.getEngine(), 1).with(AllowAllSecurityContext.INSTANCE, null)
+            ) {
+                serverMain.start();
+                serverMain.getEngine().compile("create table x (a int, t timestamp) timestamp(t) partition by day wal", sqlExecutionContext);
+                serverMain.getEngine().compile("create table y (b int, t timestamp) timestamp(t) partition by day wal", sqlExecutionContext);
+                serverMain.getEngine().compile("insert into y values(100, 1)", sqlExecutionContext);
+                serverMain.getEngine().compile("insert into y values(200, 2)", sqlExecutionContext);
+
+                // ensure transactions
+                TestUtils.assertSql(
+                        serverMain.getEngine(),
+                        sqlExecutionContext,
+                        "select * from wal_tables order by 1",
+                        sink,
+                        "name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\n" +
+                                "x\tfalse\t0\t0\t0\n" +
+                                "y\tfalse\t0\t0\t2\n"
+                );
+
+
+                TestUtils.assertSql(
+                        serverMain.getEngine(),
+                        sqlExecutionContext,
+                        "select table_name, ownership_reason from writer_pool order by 1",
+                        sink,
+                        "table_name\townership_reason\n" +
+                                "sys.column_versions_purge_log\tQuestDB system\n" +
+                                "sys.telemetry_wal\ttelemetry\n" +
+                                "telemetry\ttelemetry\n" +
+                                "telemetry_config\ttelemetryConfig\n" +
+                                "x\t\n" +
+                                "y\t\n"
+                );
+
+            }
+
+            // start a new server; it should not attempt to open new writers
+            try (
+                    final ServerMain serverMain = new ServerMain(getServerMainArgs());
+                    SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(serverMain.getEngine(), 1).with(AllowAllSecurityContext.INSTANCE, null)
+            ) {
+                serverMain.start();
+
+                TestUtils.assertSql(
+                        serverMain.getEngine(),
+                        sqlExecutionContext,
+                        "select table_name, ownership_reason from writer_pool order by 1",
+                        sink,
+                        "table_name\townership_reason\n" +
+                                "sys.column_versions_purge_log\tQuestDB system\n" +
+                                "sys.telemetry_wal\ttelemetry\n" +
+                                "telemetry\ttelemetry\n" +
+                                "telemetry_config\ttelemetryConfig\n"
+                );
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
@@ -34,11 +34,19 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.std.Os;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
+    @Before
+    public void setUp() {
+        super.setUp();
+        TestUtils.unchecked(() -> createDummyConfiguration());
+        dbPath.parent().$();
+    }
+
     @Test
-    public void testServerMainStartIlpAuthEnabled() throws Exception {
+    public void testServerMainCleanStart() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
             StringSink sink = new StringSink();
@@ -88,13 +96,9 @@ public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
                 TestUtils.assertSql(
                         serverMain.getEngine(),
                         sqlExecutionContext,
-                        "select table_name, ownership_reason from writer_pool order by 1",
+                        "select table_name, ownership_reason from writer_pool where table_name in ('x','y') order by 1",
                         sink,
                         "table_name\townership_reason\n" +
-                                "sys.column_versions_purge_log\tQuestDB system\n" +
-                                "sys.telemetry_wal\ttelemetry\n" +
-                                "telemetry\ttelemetry\n" +
-                                "telemetry_config\ttelemetryConfig\n" +
                                 "x\t\n" +
                                 "y\t\n"
                 );
@@ -111,13 +115,9 @@ public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
                 TestUtils.assertSql(
                         serverMain.getEngine(),
                         sqlExecutionContext,
-                        "select table_name, ownership_reason from writer_pool order by 1",
+                        "select table_name, ownership_reason from writer_pool where table_name in ('x','y') order by 1",
                         sink,
-                        "table_name\townership_reason\n" +
-                                "sys.column_versions_purge_log\tQuestDB system\n" +
-                                "sys.telemetry_wal\ttelemetry\n" +
-                                "telemetry\ttelemetry\n" +
-                                "telemetry_config\ttelemetryConfig\n"
+                        "table_name\townership_reason\n"
                 );
             }
         });

--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -84,7 +84,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
 
     @AfterClass
     public static void tearDownStatic() {
-        Assert.assertEquals(0, Files.rmdir(auxPath.of(otherVolume).$()));
+        Assert.assertEquals(0, Files.rmdir(auxPath.of(otherVolume).$(), true));
         AbstractBootstrapTest.tearDownStatic();
     }
 
@@ -211,7 +211,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
 
                 String tablePathStr = dbPath.toString();
                 String foreignPathStr = foreignPath.toString();
-                Assert.assertEquals(0, Files.rmdir(auxPath.of(tablePathStr).$()));
+                Assert.assertEquals(0, Files.rmdir(auxPath.of(tablePathStr).$(), true));
                 Assert.assertFalse(Files.exists(dbPath));
                 createSoftLink(foreignPathStr, tablePathStr);
                 Assert.assertTrue(Files.exists(dbPath));

--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -84,7 +84,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
 
     @AfterClass
     public static void tearDownStatic() {
-        Assert.assertEquals(0, Files.rmdir(auxPath.of(otherVolume).$(), true));
+        Assert.assertTrue(Files.rmdir(auxPath.of(otherVolume).$(), true));
         AbstractBootstrapTest.tearDownStatic();
     }
 
@@ -211,7 +211,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
 
                 String tablePathStr = dbPath.toString();
                 String foreignPathStr = foreignPath.toString();
-                Assert.assertEquals(0, Files.rmdir(auxPath.of(tablePathStr).$(), true));
+                Assert.assertTrue(Files.rmdir(auxPath.of(tablePathStr).$(), true));
                 Assert.assertFalse(Files.exists(dbPath));
                 createSoftLink(foreignPathStr, tablePathStr);
                 Assert.assertTrue(Files.exists(dbPath));

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -278,7 +278,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
 
                             // Remove table directory
                             rmPath.trimTo(len).$();
-                            for (int i = 0; i < 1000 && ff.rmdir(rmPath) != 0; i++) {
+                            for (int i = 0; i < 1000 && !ff.rmdir(rmPath); i++) {
                                 Os.sleep(50L);
                             }
                         }
@@ -411,7 +411,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
 
             engine.releaseInactive();
             FilesFacade ff = configuration.getFilesFacade();
-            Assert.assertEquals(0, ff.rmdir(Path.getThreadLocal2(root).concat(tt1).$()));
+            Assert.assertTrue(ff.rmdir(Path.getThreadLocal2(root).concat(tt1).$()));
 
             engine.reloadTableNames();
 

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -2796,9 +2796,9 @@ public class TableReaderTest extends AbstractCairoTest {
 
             FilesFacade ff = new TestFilesFacadeImpl() {
                 @Override
-                public int rmdir(Path name) {
+                public boolean rmdir(Path name) {
                     if (Chars.endsWith(name, "2017-12-14" + Files.SEPARATOR)) {
-                        return 1;
+                        return false;
                     }
                     return super.rmdir(name);
                 }

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -805,8 +805,8 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
             class X extends FilesFacadeImpl {
                 @Override
-                public int rmdir(Path name) {
-                    return -1;
+                public boolean rmdir(Path name) {
+                    return false;
                 }
             }
 
@@ -929,10 +929,10 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 if (this.fd != -1) {
                     // Access denied, file is open
-                    return 5;
+                    return false;
                 }
                 return super.rmdir(name);
             }
@@ -1182,9 +1182,9 @@ public class TableWriterTest extends AbstractCairoTest {
                 boolean fail = false;
 
                 @Override
-                public int rmdir(Path name) {
+                public boolean rmdir(Path name) {
                     if (fail) {
-                        return -1;
+                        return false;
                     }
                     return super.rmdir(name);
                 }
@@ -2669,10 +2669,10 @@ public class TableWriterTest extends AbstractCairoTest {
             boolean removeAttempted = false;
 
             @Override
-            public int rmdir(Path from) {
+            public boolean rmdir(Path from) {
                 if (Chars.endsWith(from, "2013-03-12.0")) {
                     removeAttempted = true;
-                    return 1;
+                    return false;
                 }
                 return super.rmdir(from);
             }
@@ -2720,10 +2720,10 @@ public class TableWriterTest extends AbstractCairoTest {
             boolean removeAttempted = false;
 
             @Override
-            public int rmdir(Path path) {
+            public boolean rmdir(Path path) {
                 if (Chars.endsWith(path, "2013-03-12.0")) {
                     removeAttempted = true;
-                    return 1;
+                    return false;
                 }
                 return super.rmdir(path);
             }

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
@@ -738,16 +738,14 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
 
                 assertExceptionNoLeakCheck(
                         "UPDATE " + tableName + " SET INT=systimestamp()",
-                        43,
-                        "inconvertible types: TIMESTAMP -> INT"
+                        43
                 );
                 drainWalQueue();
                 assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName(tableName)));
 
                 assertExceptionNoLeakCheck(
                         "UPDATE " + tableCopyName + " SET INT=systimestamp()",
-                        48,
-                        "inconvertible types: TIMESTAMP -> INT"
+                        48
                 );
                 assertSqlCursors(tableCopyName, tableName);
             }

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1402,7 +1402,7 @@ public class WalWriterTest extends AbstractCairoTest {
     @Test
     public void testMaxLagTxnCount() throws Exception {
         configOverrideWalApplyTableTimeQuota(0);
-        configOverrideWalMaxLagTxnCount(1);
+        configOverrideWalMaxLagTxnCount();
         assertMemoryLeak(() -> {
             TableToken tableToken = createTable(testName.getMethodName());
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1563,8 +1563,8 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         runInContext((receiver) -> {
             ff = new TestFilesFacadeImpl() {
                 @Override
-                public int rmdir(Path path) {
-                    return 5;
+                public boolean rmdir(Path path) {
+                    return false;
                 }
             };
 

--- a/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
@@ -807,9 +807,9 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 if (Chars.endsWith(name, tab34_0)) {
-                    return -1;
+                    return false;
                 }
                 return super.rmdir(name);
             }
@@ -822,7 +822,7 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
                 PartitionBy.MONTH,
                 "ts",
                 null,
-                "import failed [phase=partition_import, msg=`[-1] could not overwrite [tableName=" + tab34_0 + "]`]"
+                "import failed [phase=partition_import, msg=`[3] could not overwrite [tableName=" + tab34_0 + "]`]"
         );
     }
 
@@ -909,9 +909,9 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 if (Chars.equals(name, tempDir)) {
-                    return -1;
+                    return false;
                 }
                 return super.rmdir(name);
             }
@@ -942,9 +942,9 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 if (Chars.endsWith(name, mangledPartDir)) {
-                    return -1;
+                    return false;
                 }
                 return super.rmdir(name);
             }
@@ -958,7 +958,7 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
                 PartitionBy.MONTH,
                 "ts",
                 null,
-                "import failed [phase=partition_import, msg=`[-1] could not overwrite [tableName=" + mangledPartDir + "]`]"
+                "import failed [phase=partition_import, msg=`[3] could not overwrite [tableName=" + mangledPartDir + "]`]"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
@@ -822,7 +822,7 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
                 PartitionBy.MONTH,
                 "ts",
                 null,
-                "import failed [phase=partition_import, msg=`[3] could not overwrite [tableName=" + tab34_0 + "]`]"
+                "could not overwrite [tableName=" + tab34_0 + "]`]"
         );
     }
 
@@ -958,7 +958,7 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
                 PartitionBy.MONTH,
                 "ts",
                 null,
-                "import failed [phase=partition_import, msg=`[3] could not overwrite [tableName=" + mangledPartDir + "]`]"
+                "could not overwrite [tableName=" + mangledPartDir + "]`]"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
@@ -3331,7 +3331,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 final String dirName = extractLast(name);
                 if (!dirName.equals("seq")) {
                     rmdirCallCount.getAndIncrement();
@@ -3339,7 +3339,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                         Assert.fail(dirName + " not expected");
                     }
                 }
-                return Files.rmdir(name);
+                return super.rmdir(name);
             }
 
             @Override

--- a/core/src/test/java/io/questdb/test/griffin/AbstractSqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AbstractSqlParserTest.java
@@ -123,7 +123,7 @@ public class AbstractSqlParserTest extends AbstractCairoTest {
                 TableModel tableModel = tableModels[i];
                 TableToken tableToken = engine.verifyTableName(tableModel.getName());
                 Path path = tableModel.getPath().of(tableModel.getConfiguration().getRoot()).concat(tableToken).slash$();
-                Assert.assertEquals(0, filesFacade.rmdir(path));
+                Assert.assertTrue(filesFacade.rmdir(path));
                 tableModel.close();
             }
             engine.reloadTableNames();

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionTest.java
@@ -1188,7 +1188,7 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
                 TestUtils.assertContains(e.getFlyweightMessage(), errorMessage);
             }
             TableToken tableToken = engine.verifyTableName(dstTableName);
-            Files.rmdir(path.of(root).concat(tableToken).concat("2022-08-01").put(configuration.getAttachPartitionSuffix()).$());
+            Files.rmdir(path.of(root).concat(tableToken).concat("2022-08-01").put(configuration.getAttachPartitionSuffix()).$(), true);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -568,10 +568,10 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         AtomicInteger counter = new AtomicInteger();
         ff = new TestFilesFacadeImpl() {
             @Override
-            public int rmdir(Path path) {
+            public boolean rmdir(Path path) {
                 if (Chars.contains(path, "2022-06-03")) {
                     if (counter.getAndIncrement() == 0) {
-                        return 1;
+                        return false;
                     }
                 }
                 return super.rmdir(path);
@@ -613,11 +613,11 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             }
 
             @Override
-            public int rmdir(Path path) {
+            public boolean rmdir(Path path) {
                 if (!copyCalled) {
                     return super.rmdir(path);
                 }
-                return 1;
+                return false;
             }
         };
         assertMemoryLeak(

--- a/core/src/test/java/io/questdb/test/griffin/DistinctKeyRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctKeyRecordCursorFactoryTest.java
@@ -125,7 +125,7 @@ public class DistinctKeyRecordCursorFactoryTest extends AbstractCairoTest {
 
             TableToken tableToken = engine.verifyTableName("tab");
             try (Path path = new Path().of(engine.getConfiguration().getRoot()).concat(tableToken).concat(partition).$()) {
-                Assert.assertEquals(0, Files.rmdir(path, true));
+                Assert.assertTrue(Files.rmdir(path, true));
             }
 
             try {

--- a/core/src/test/java/io/questdb/test/griffin/DistinctKeyRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctKeyRecordCursorFactoryTest.java
@@ -125,7 +125,7 @@ public class DistinctKeyRecordCursorFactoryTest extends AbstractCairoTest {
 
             TableToken tableToken = engine.verifyTableName("tab");
             try (Path path = new Path().of(engine.getConfiguration().getRoot()).concat(tableToken).concat(partition).$()) {
-                Assert.assertEquals(0, Files.rmdir(path));
+                Assert.assertEquals(0, Files.rmdir(path, true));
             }
 
             try {

--- a/core/src/test/java/io/questdb/test/griffin/EngineMigrationTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/EngineMigrationTest.java
@@ -1586,7 +1586,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
 
         // Remove first partition
         to.of(configuration.getRoot()).concat(copyTableWithMissingPartitions);
-        if (ff.rmdir(to.concat("1970-01-01").put(Files.SEPARATOR).$()) != 0) {
+        if (!ff.rmdir(to.concat("1970-01-01").put(Files.SEPARATOR).$())) {
             throw CairoException.critical(ff.errno()).put("cannot remove ").put(to);
         }
 

--- a/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
@@ -482,10 +482,10 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
             AtomicInteger deleteAttempts = new AtomicInteger();
             ff = new TestFilesFacadeImpl() {
                 @Override
-                public int rmdir(Path name) {
+                public boolean rmdir(Path name) {
                     if (Chars.endsWith(name, "1970-01-10")) {
                         deleteAttempts.incrementAndGet();
-                        return 5;
+                        return false;
                     }
                     return super.rmdir(name);
                 }
@@ -518,10 +518,10 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
             AtomicInteger deleteAttempts = new AtomicInteger();
             ff = new TestFilesFacadeImpl() {
                 @Override
-                public int rmdir(Path name) {
+                public boolean rmdir(Path name) {
                     if (Chars.endsWith(name, "1970-01-10")) {
                         if (deleteAttempts.incrementAndGet() < 3) {
-                            return 5;
+                            return false;
                         }
                     }
                     return super.rmdir(name);

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -2518,7 +2518,7 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
             File table = new File(target);
             Assert.assertTrue(table.exists());
             Assert.assertTrue(table.isDirectory());
-            Assert.assertEquals(0, FilesFacadeImpl.INSTANCE.rmdir(path.of(target).slash$()));
+            Assert.assertTrue(FilesFacadeImpl.INSTANCE.rmdir(path.of(target).slash$()));
             Assert.assertTrue(volume.delete());
         }
     }

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -2481,9 +2481,9 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
             }
 
             @Override
-            public int rmdir(Path name) {
+            public boolean rmdir(Path name) {
                 Assert.assertEquals(target + Files.SEPARATOR, name.toString());
-                return -1;
+                return false;
             }
 
             @Override

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -7915,7 +7915,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         TableModel tableModel = tableModels[i];
                         TableToken tableToken = engine.verifyTableName(tableModel.getName());
                         Path path = tableModel.getPath().of(tableModel.getConfiguration().getRoot()).concat(tableToken).slash$();
-                        Assert.assertEquals(0, configuration.getFilesFacade().rmdir(path));
+                        Assert.assertTrue(configuration.getFilesFacade().rmdir(path));
                         tableModel.close();
                     }
                 }

--- a/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
@@ -50,7 +50,7 @@ public class TableRepairTest extends AbstractCairoTest {
                 try (Path path = new Path()) {
                     TableToken tableToken = engine.verifyTableName("tst");
                     path.of(configuration.getRoot()).concat(tableToken).concat("1970-01-12").$();
-                    Assert.assertEquals(0, Files.rmdir(path, true));
+                    Assert.assertTrue(Files.rmdir(path, true));
                 }
 
                 Assert.assertEquals(100000, reader.size());
@@ -89,7 +89,7 @@ public class TableRepairTest extends AbstractCairoTest {
                 try (Path path = new Path()) {
                     TableToken tableToken = engine.verifyTableName("tst");
                     path.of(configuration.getRoot()).concat(tableToken).concat("1970-01-09").$();
-                    Assert.assertEquals(0, Files.rmdir(path, true));
+                    Assert.assertTrue(Files.rmdir(path, true));
                 }
 
                 Assert.assertEquals(100000, reader.size());

--- a/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
@@ -50,7 +50,7 @@ public class TableRepairTest extends AbstractCairoTest {
                 try (Path path = new Path()) {
                     TableToken tableToken = engine.verifyTableName("tst");
                     path.of(configuration.getRoot()).concat(tableToken).concat("1970-01-12").$();
-                    Assert.assertEquals(0, Files.rmdir(path));
+                    Assert.assertEquals(0, Files.rmdir(path, true));
                 }
 
                 Assert.assertEquals(100000, reader.size());
@@ -89,7 +89,7 @@ public class TableRepairTest extends AbstractCairoTest {
                 try (Path path = new Path()) {
                     TableToken tableToken = engine.verifyTableName("tst");
                     path.of(configuration.getRoot()).concat(tableToken).concat("1970-01-09").$();
-                    Assert.assertEquals(0, Files.rmdir(path));
+                    Assert.assertEquals(0, Files.rmdir(path, true));
                 }
 
                 Assert.assertEquals(100000, reader.size());

--- a/core/src/test/java/io/questdb/test/griffin/TableWriterAsyncCmdTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableWriterAsyncCmdTest.java
@@ -198,7 +198,7 @@ public class TableWriterAsyncCmdTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             ff = new TestFilesFacadeImpl() {
                 @Override
-                public int rmdir(Path name) {
+                public boolean rmdir(Path name) {
                     if (Chars.contains(name, "2020-01-01")) {
                         throw CairoException.critical(11).put("could not remove [path=").put(name).put(']');
                     }

--- a/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
+import io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory;
+import io.questdb.griffin.engine.table.ReaderPoolRecordCursorFactory;
+import io.questdb.griffin.engine.table.WriterPoolRecordCursorFactory;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class WriterPoolTableFunctionTest extends AbstractCairoTest {
+    @Test
+    public void testCursorDoesHaveUpfrontSize() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    RecordCursorFactory factory = select("select * from writer_pool()");
+                    RecordCursor cursor = factory.getCursor(sqlExecutionContext)
+            ) {
+                Assert.assertEquals(-1, cursor.size());
+            }
+        });
+    }
+
+    @Test
+    public void testCursorNotRuntimeConstant() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Function cursorFunction = new WriterPoolFunctionFactory().newInstance(0, new ObjList<>(), new IntList(), configuration, sqlExecutionContext)) {
+                Assert.assertFalse(cursorFunction.isRuntimeConstant());
+            }
+        });
+    }
+
+    @Test
+    public void testEmptyPool() throws Exception {
+        assertMemoryLeak(() -> assertSql("table_name\towner_thread_id\tlast_access_timestamp\townership_reason\n", "select * from writer_pool()"));
+    }
+
+    @Test
+    public void testFactoryDoesNotSupportRandomAccess() throws Exception {
+        assertMemoryLeak(() -> {
+            try (RecordCursorFactory factory = select("select * from writer_pool()")) {
+                Assert.assertFalse(factory.recordCursorSupportsRandomAccess());
+            }
+        });
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        assertMemoryLeak(() -> {
+            try (RecordCursorFactory factory = select("select * from writer_pool()")) {
+                RecordMetadata metadata = factory.getMetadata();
+                Assert.assertEquals(4, metadata.getColumnCount());
+                Assert.assertEquals("table_name", metadata.getColumnName(0));
+                Assert.assertEquals("owner_thread_id", metadata.getColumnName(1));
+                Assert.assertEquals("last_access_timestamp", metadata.getColumnName(2));
+                Assert.assertEquals("ownership_reason", metadata.getColumnName(3));
+                Assert.assertEquals(ColumnType.STRING, metadata.getColumnType(0));
+                Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(1));
+                Assert.assertEquals(ColumnType.TIMESTAMP, metadata.getColumnType(2));
+                Assert.assertEquals(ColumnType.STRING, metadata.getColumnType(3));
+            }
+        });
+    }
+
+    @Test
+    public void testWriterList() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table a(u int)");
+            ddl("create table b(u int)");
+            ddl("create table c(u int)");
+            ddl("create table d(u int)");
+
+            assertSql(
+                    "table_name\townership_reason\n" +
+                            "a\t\n" +
+                            "b\t\n" +
+                            "c\t\n" +
+                            "d\t\n",
+                    "select table_name,ownership_reason from writer_pool order by 1"
+            );
+
+            // assert ordering
+            assertSql(
+                    "table_name\townership_reason\n" +
+                            "d\t\n" +
+                            "c\t\n" +
+                            "b\t\n" +
+                            "a\t\n",
+                    "select table_name,ownership_reason from writer_pool order by 1 desc"
+            );
+
+            engine.releaseAllWriters();
+
+            assertSql(
+                    "table_name\townership_reason\n",
+                    "select table_name,ownership_reason from writer_pool order by 1"
+            );
+
+            assertSql(
+                    "table_name\townership_reason\n",
+                    "select table_name,ownership_reason from writer_pool order by 1 desc"
+            );
+
+            try (TableWriter ignored = engine.getWriter(engine.getTableTokenIfExists("a"), "test reason")) {
+                assertSql(
+                        "table_name\townership_reason\n" +
+                                "a\ttest reason\n",
+                        "select table_name,ownership_reason from writer_pool order by 1 desc"
+                );
+            }
+
+            assertSql(
+                    "table_name\townership_reason\n" +
+                            "a\t\n",
+                    "select table_name,ownership_reason from writer_pool order by 1 desc"
+            );
+        });
+    }
+
+    @Test
+    public void testRandomAccessUnsupported() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
+            ) {
+                Record record = readerPoolCursor.getRecord();
+                readerPoolCursor.recordAt(record, 0);
+                Assert.fail("Random access is not expected to be implemented");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        });
+    }
+
+    @Test
+    public void testRecordBNotImplemented() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
+            ) {
+                readerPoolCursor.getRecordB();
+                Assert.fail("RecordB is not expected to be implemented");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        });
+    }
+
+    @Test
+    public void testToTop() throws Exception {
+        assertMemoryLeak(() -> {
+            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
+                tm.timestamp("ts").col("ID", ColumnType.INT);
+                createPopulateTable(tm, 20, "2020-01-01", 1);
+            }
+
+            try (TableReader ignored = getReader("tab1");
+                 RecordCursorFactory readerPoolFactory = new ReaderPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                 RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)) {
+                // scroll cursor ignoring its contents
+                //noinspection StatementWithEmptyBody
+                while (readerPoolCursor.hasNext()) {
+                }
+                readerPoolCursor.toTop();
+                assertTrue(readerPoolCursor.hasNext());
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalPurgeJobTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalPurgeJobTest.java
@@ -610,9 +610,9 @@ public class WalPurgeJobTest extends AbstractCairoTest {
         AtomicBoolean canDelete = new AtomicBoolean(false);
         FilesFacade ff = new TestFilesFacadeImpl() {
             @Override
-            public int rmdir(Path path) {
+            public boolean rmdir(Path path, boolean lazy) {
                 if (Chars.endsWith(path, Files.SEPARATOR + WalUtils.WAL_NAME_BASE + "1") && !canDelete.get()) {
-                    return 5;  // Access denied.
+                    return false;
                 } else {
                     return super.rmdir(path);
                 }

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -921,10 +921,10 @@ public class WalTableSqlTest extends AbstractCairoTest {
             int count = 0;
 
             @Override
-            public int rmdir(Path path) {
+            public boolean rmdir(Path path) {
                 if (Chars.equals(path, pretendNotExist.get()) && count++ == 0) {
                     super.rmdir(Path.getThreadLocal(pretendNotExist.get()).concat(SEQ_DIR).$());
-                    return -1;
+                    return false;
                 }
                 return super.rmdir(path);
             }
@@ -991,7 +991,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testDroppedTableHappendIntheMiddleOfWalApplication() throws Exception {
+    public void testDroppedTableHappendInTheMiddleOfWalApplication() throws Exception {
         String tableName = testName.getMethodName();
         FilesFacade ff = new TestFilesFacadeImpl() {
             @Override

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1471,8 +1471,9 @@ public final class TestUtils {
 
     public static void removeTestPath(CharSequence root) {
         final Path path = Path.getThreadLocal(root);
-        final int rc = TestFilesFacadeImpl.INSTANCE.rmdir(path.slash$());
-        Assert.assertTrue("Test dir cleanup error, rc=" + rc, rc <= 0);
+        FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
+        path.slash$();
+        Assert.assertTrue("Test dir cleanup error", !ff.exists(path) || ff.rmdir(path.slash$()));
     }
 
     public static void setupWorkerPool(WorkerPool workerPool, CairoEngine cairoEngine) throws SqlException {

--- a/utils/src/test/java/io/questdb/cliutil/Table2IlpTest.java
+++ b/utils/src/test/java/io/questdb/cliutil/Table2IlpTest.java
@@ -96,7 +96,7 @@ public class Table2IlpTest {
 
     public static void removeTestPath(CharSequence root) {
         Path path = Path.getThreadLocal(root);
-        Files.rmdir(path.slash$());
+        Files.rmdir(path.slash$(), true);
     }
 
     public static void setCairoStatic() {

--- a/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
+++ b/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
@@ -58,7 +58,7 @@ public class TxSerializerTest {
 
     public static void removeTestPath(CharSequence root) {
         Path path = Path.getThreadLocal(root);
-        Assert.assertEquals(0, Files.rmdir(path.slash$()));
+        Assert.assertEquals(0, Files.rmdir(path.slash$(), true));
     }
 
     public static void setCairoStatic() {

--- a/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
+++ b/utils/src/test/java/io/questdb/cliutil/TxSerializerTest.java
@@ -58,7 +58,7 @@ public class TxSerializerTest {
 
     public static void removeTestPath(CharSequence root) {
         Path path = Path.getThreadLocal(root);
-        Assert.assertEquals(0, Files.rmdir(path.slash$(), true));
+        Assert.assertTrue(Files.rmdir(path.slash$(), true));
     }
 
     public static void setCairoStatic() {


### PR DESCRIPTION
On windows hard link cannot be removed if hardlink target is open. This caused wal purge job to give up too early leaving disk space used up. The fix is to delete whatever is possible to delete leaving only hard links, that do not consume much space (there is no data in them)

- eager `rmdir()`
- rmdir() lib function returns `bool` instead of `int`
- removed duplicate `rmdir()` impl in test

There is one minor outstanding issue:
- on startup we open table writers on empty tables. This is unnecessary but not critical