### PR TITLE
fix(sql): fix empty result on second run of query with group by and limit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3364,14 +3364,10 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         tempVaf.getQuick(i).pushValueTypes(arrayColumnTypes);
                     }
 
-                    if (tempVaf.size() == 0) {// select distinct case 
-                        ArrayColumnTypes columnTypes = new ArrayColumnTypes();
-                        columnTypes.clear();
-                        columnTypes.add(metadata.getColumnType(0));
-
+                    if (tempVaf.size() == 0) {// similar to DistinctKeyRecordCursorFactory, handles e.g. select id from tab group by id  
                         int keyKind = specialCaseKeys ? SqlCodeGenerator.GKK_HOUR_INT : SqlCodeGenerator.GKK_VANILLA_INT;
                         CountVectorAggregateFunction countFunction = new CountVectorAggregateFunction(keyKind);
-                        countFunction.pushValueTypes(columnTypes);
+                        countFunction.pushValueTypes(arrayColumnTypes);
                         tempVaf.add(countFunction);
 
                         tempSymbolSkewIndexes.clear();

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3364,6 +3364,20 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         tempVaf.getQuick(i).pushValueTypes(arrayColumnTypes);
                     }
 
+                    if (tempVaf.size() == 0) {// select distinct case 
+                        ArrayColumnTypes columnTypes = new ArrayColumnTypes();
+                        columnTypes.clear();
+                        columnTypes.add(metadata.getColumnType(0));
+
+                        int keyKind = specialCaseKeys ? SqlCodeGenerator.GKK_HOUR_INT : SqlCodeGenerator.GKK_VANILLA_INT;
+                        CountVectorAggregateFunction countFunction = new CountVectorAggregateFunction(keyKind);
+                        countFunction.pushValueTypes(columnTypes);
+                        tempVaf.add(countFunction);
+
+                        tempSymbolSkewIndexes.clear();
+                        tempSymbolSkewIndexes.add(0);
+                    }
+
                     try {
                         GroupByUtils.validateGroupByColumns(model, 1);
                     } catch (Throwable e) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/VirtualFunctionSkewedSymbolRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/VirtualFunctionSkewedSymbolRecordCursor.java
@@ -41,6 +41,7 @@ public class VirtualFunctionSkewedSymbolRecordCursor extends AbstractVirtualFunc
     @Override
     public void close() {
         managedCursor = Misc.free(managedCursor);
+        super.close();
     }
 
     public void of(RecordCursor managedCursor, RecordCursor baseCursor) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/VirtualFunctionSkewedSymbolRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/VirtualFunctionSkewedSymbolRecordCursor.java
@@ -41,7 +41,7 @@ public class VirtualFunctionSkewedSymbolRecordCursor extends AbstractVirtualFunc
     @Override
     public void close() {
         managedCursor = Misc.free(managedCursor);
-        super.close();
+        baseCursor = null;
     }
 
     public void of(RecordCursor managedCursor, RecordCursor baseCursor) {

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3159,10 +3159,12 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     @Test
     public void testGroupByInt2() throws SqlException {
         ddl("create table if not exists test(ts timestamp)");
-        insert("insert into test select x::timestamp from long_sequence(3)");
+        insert("insert into test select (x*3600000)::timestamp from long_sequence(2999)");
 
         assertSql("hour\n" +
-                "0\n", "select hour(ts) " +
+                "0\n" +
+                "1\n" +
+                "2\n", "select hour(ts) " +
                 "from test " +
                 "group by 1 " +
                 "order by 1 ");

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3143,6 +3143,33 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGroupByInt() throws SqlException {
+        ddl("create table if not exists test(id int)");
+        insert("insert into test(id) select rnd_int() from long_sequence(3)");
+
+        assertSql("id\n" +
+                "-1148479920\n" +
+                "315515118\n" +
+                "1548800833\n", "select id " +
+                "from test " +
+                "group by id " +
+                "order by id ");
+    }
+
+    @Test
+    public void testGroupByInt2() throws SqlException {
+        ddl("create table if not exists test(ts timestamp)");
+        insert("insert into test select x::timestamp from long_sequence(3)");
+
+        assertSql("hour\n" +
+                "0\n", "select hour(ts) " +
+                "from test " +
+                "group by 1 " +
+                "order by 1 ");
+    }
+
+
+    @Test
     public void testGroupByLimit() throws SqlException {
         ddl("create table if not exists test(id uuid)");
         insert("insert into test(id) select rnd_uuid4() from long_sequence(3)");
@@ -3152,15 +3179,28 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
                         "group by id " +
                         "limit 10")) {
 
-            assertCursor("id\n" +
+            String expected = "id\n" +
                     "0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
                     "9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
-                    "7bcd48d8-c77a-4655-b2a2-15ba0462ad15\n", factory, true, false, false);
-            assertCursor("id\n" +
-                    "0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
-                    "9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
-                    "7bcd48d8-c77a-4655-b2a2-15ba0462ad15\n", factory, true, false, false);
+                    "7bcd48d8-c77a-4655-b2a2-15ba0462ad15\n";
+
+            assertCursor(expected, factory, true, false, false);
+            assertCursor(expected, factory, true, false, false);
         }
+    }
+
+    @Test
+    public void testGroupBySymbol() throws SqlException {
+        ddl("create table if not exists test(id symbol)");
+        insert("insert into test(id) select rnd_symbol('A', 'B', 'C') from long_sequence(10)");
+
+        assertSql("id\n" +
+                "A\n" +
+                "B\n" +
+                "C\n", "select id " +
+                "from test " +
+                "group by id " +
+                "order by id ");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3143,6 +3143,27 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGroupByLimit() throws SqlException {
+        ddl("create table if not exists test(id uuid)");
+        insert("insert into test(id) select rnd_uuid4() from long_sequence(3)");
+        try (RecordCursorFactory factory = select(
+                "select id " +
+                        "from test " +
+                        "group by id " +
+                        "limit 10")) {
+
+            assertCursor("id\n" +
+                    "0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
+                    "9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
+                    "7bcd48d8-c77a-4655-b2a2-15ba0462ad15\n", factory, true, false, false);
+            assertCursor("id\n" +
+                    "0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
+                    "9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
+                    "7bcd48d8-c77a-4655-b2a2-15ba0462ad15\n", factory, true, false, false);
+        }
+    }
+
+    @Test
     public void testInLongTypeMismatch() throws Exception {
         assertFailure(43, "cannot compare LONG with type DOUBLE", "select 1 from long_sequence(1) where x in (123.456)");
     }


### PR DESCRIPTION
Fixes #3750 

Fixes: 
- bug in group by cursor size re-caculation where cursor.size() method relied on element that wasn't cleared on close() method call 
- bug in handling of group by with empty aggregate list that caused it to skip processing data, e.g. `select id from users group by id`
- 
