### PR TITLE
fix(sql): ensure EXPLAIN (FORMAT JSON) returns valid JSON 

### DIFF
--- a/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
@@ -171,6 +171,7 @@ public class JsonPlanSink extends BasePlanSink {
 
     @Override
     public PlanSink val(int i) {
+        quoteValue = false;
         checkType(NODE_VALUE);
         sink.put(i);
         return this;
@@ -178,6 +179,7 @@ public class JsonPlanSink extends BasePlanSink {
 
     @Override
     public PlanSink val(long l) {
+        quoteValue = false;
         checkType(NODE_VALUE);
         sink.put(l);
         return this;
@@ -185,6 +187,7 @@ public class JsonPlanSink extends BasePlanSink {
 
     @Override
     public PlanSink val(float f) {
+        quoteValue = false;
         checkType(NODE_VALUE);
         sink.put(f);
         return this;
@@ -192,6 +195,7 @@ public class JsonPlanSink extends BasePlanSink {
 
     @Override
     public PlanSink val(double d) {
+        quoteValue = false;
         checkType(NODE_VALUE);
         sink.put(d);
         return this;
@@ -199,6 +203,7 @@ public class JsonPlanSink extends BasePlanSink {
 
     @Override
     public PlanSink val(boolean b) {
+        quoteValue = false;
         checkType(NODE_VALUE);
         sink.put(b);
         return this;

--- a/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
@@ -95,7 +95,12 @@ public class JsonPlanSink extends BasePlanSink {
         switch (lastNodeType) {
             case NODE_TYPE:
             case NODE_VALUE:
-                sink.putNoEsc("\",\n");
+                if (quoteValue) {
+                    sink.setCharAt(valueStartPos, '"');
+                    sink.putNoEsc("\"\n");
+                } else {
+                    sink.putNoEsc("\n");
+                }
                 break;
             case NODE_META:
             case NODE_ATTR:

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -1450,8 +1450,8 @@ public class ExplainPlanTest extends AbstractCairoTest {
                     "                    \"Plans\": [\n" +
                     "                    {\n" +
                     "                        \"Node Type\": \"Async JIT Filter\",\n" +
-                    "                        \"workers\": \"1\",\n" +
-                    "                        \"limit\": \"4\",\n" +
+                    "                        \"workers\":  1,\n" +
+                    "                        \"limit\":  4,\n" +
                     "                        \"filter\": \"10<l\",\n" +
                     "                        \"Plans\": [\n" +
                     "                        {\n" +

--- a/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
@@ -47,7 +47,7 @@ public class JsonPlanSinkTest {
                 "        \"double\": \"0.0\",\n" +
                 "        \"float\": \"1.0\",\n" +
                 "        \"uuid\": \"00000000-0000-0002-0000-000000000001\",\n" +
-                "        \"uuid_null\": \"null\",\n" +
+                "        \"uuid_null\": \"null\"\n" +
                 "    }\n" +
                 "  }\n" +
                 "]";

--- a/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
@@ -127,7 +127,7 @@ public class JsonPlanSinkTest {
             sink.attr("int");
             sink.val(2);
             sink.attr("long");
-            sink.val(100);
+            sink.val(100L);
         }
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
@@ -44,8 +44,6 @@ public class JsonPlanSinkTest {
                 "        \"geohash\": \"\"00000000000000011000101010010010\"\",\n" +
                 "        \"long256\": \"0x04000000000000000300000000000000020000000000000001\",\n" +
                 "        \"plan\": \"null\",\n" +
-                "        \"double\": \"0.0\",\n" +
-                "        \"float\": \"1.0\",\n" +
                 "        \"uuid\": \"00000000-0000-0002-0000-000000000001\",\n" +
                 "        \"uuid_null\": \"null\"\n" +
                 "    }\n" +
@@ -54,6 +52,26 @@ public class JsonPlanSinkTest {
 
         JsonPlanSink sink = new JsonPlanSink();
         sink.of(new TestFactory(), null);
+        Assert.assertEquals(expected, sink.getSink().toString());
+    }
+
+    @Test
+    public void testSinkWithNumericalValues() {
+        String expected = "[\n" +
+                "  {\n" +
+                "    \"Plan\": {\n" +
+                "        \"Node Type\": \"test\",\n" +
+                "        \"testString\": \"data\",\n" +
+                "        \"double\":  0.0,\n" +
+                "        \"float\":  1.0,\n" +
+                "        \"int\":  2,\n" +
+                "        \"long\":  100\n" +
+                "    }\n" +
+                "  }\n" +
+                "]";
+
+        JsonPlanSink sink = new JsonPlanSink();
+        sink.of(new NumericalTestFactory(), null);
         Assert.assertEquals(expected, sink.getSink().toString());
     }
 
@@ -78,14 +96,38 @@ public class JsonPlanSinkTest {
             sink.val(1L, 2L, 3L, 4L);
             sink.attr("plan");
             sink.val((Plannable) null);
-            sink.attr("double");
-            sink.val(0.0f);
-            sink.attr("float");
-            sink.val(1.0d);
             sink.attr("uuid");
             sink.valUuid(1L, 2L);
             sink.attr("uuid_null");
             sink.valUuid(Numbers.LONG_NaN, Numbers.LONG_NaN);
+        }
+    }
+
+    static class NumericalTestFactory implements RecordCursorFactory {
+
+        @Override
+        public RecordMetadata getMetadata() {
+            return null;
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.type("test");
+            sink.attr("testString");
+            sink.val("data");
+            sink.attr("double");
+            sink.val(0.0d);
+            sink.attr("float");
+            sink.val(1.0f);
+            sink.attr("int");
+            sink.val(2);
+            sink.attr("long");
+            sink.val(100);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/questdb/questdb/issues/3721
Fixes https://github.com/questdb/questdb/issues/3720: Apparently, #3804 was processed faster than this PR, so this has been fixed

When ending a JSON explain tag, previously, both a `"` and `,` were inserted.

`,` should never be necessary in this context, because the whole JSON is being finished up.
`"` is only necessary if the type is a string (counterexample: int)

Also fixes a more general and widespread bug where a numerical value would be encased in `"`, if a string-type value has been inserted before that in the JSON document (excluding the node type)