### PR TITLE
fix(core): fix transient select error after symbol column rename sequence

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -123,6 +123,10 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
         return SymbolTable.VALUE_IS_NULL;
     }
 
+    public boolean needsReopen(long columnNameTxn) {
+        return this.columnNameTxn != columnNameTxn;
+    }
+
     public StaticSymbolTable newSymbolTableView() {
         return new SymbolTableView();
     }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -647,21 +647,6 @@ public class TableReader implements Closeable, SymbolTableSource {
         toIndexReaders.setQuick(toIndex + 1, bitmapIndexes.getAndSetQuick(fromIndex + 1, null));
     }
 
-    private void copyOrRenewSymbolMapReader(SymbolMapReader reader, int columnIndex) {
-        if (reader != null) {
-            if (reader.isDeleted()) {
-                reader = reloadSymbolMapReader(columnIndex, reader);
-            } else if (reader instanceof SymbolMapReaderImpl) {
-                final int writerColumnIndex = metadata.getWriterIndex(columnIndex);
-                final long columnNameTxn = columnVersionReader.getDefaultColumnNameTxn(writerColumnIndex);
-                if (((SymbolMapReaderImpl) reader).needsReopen(columnNameTxn)) {
-                    reader = reloadSymbolMapReader(columnIndex, reader);
-                }
-            }
-        }
-        symbolMapReaders.setQuick(columnIndex, reader);
-    }
-
     private BitmapIndexReader createBitmapIndexReaderAt(int globalIndex, int columnBase, int columnIndex, long columnNameTxn, int direction, long txn) {
         BitmapIndexReader reader;
         if (!metadata.isColumnIndexed(columnIndex)) {
@@ -1282,6 +1267,29 @@ public class TableReader implements Closeable, SymbolTableSource {
         }
     }
 
+    private void renewSymbolMapReader(SymbolMapReader reader, int columnIndex) {
+        if (ColumnType.isSymbol(metadata.getColumnType(columnIndex))) {
+            final int writerColumnIndex = metadata.getWriterIndex(columnIndex);
+            final long columnNameTxn = columnVersionReader.getDefaultColumnNameTxn(writerColumnIndex);
+            String columnName = metadata.getColumnName(columnIndex);
+            if (!(reader instanceof SymbolMapReaderImpl)) {
+                reader = new SymbolMapReaderImpl(configuration, path, columnName, columnNameTxn, 0);
+            } else {
+                SymbolMapReaderImpl symbolMapReader = (SymbolMapReaderImpl) reader;
+                // Fully reopen the symbol map reader only when necessary
+                if (symbolMapReader.needsReopen(columnNameTxn)) {
+                    ((SymbolMapReaderImpl) reader).of(configuration, path, columnName, columnNameTxn, 0);
+                }
+            }
+        } else {
+            if (reader instanceof SymbolMapReaderImpl) {
+                ((SymbolMapReaderImpl) reader).close();
+                reader = null;
+            }
+        }
+        symbolMapReaders.setQuick(columnIndex, reader);
+    }
+
     private void reopenPartition(int offset, int partitionIndex, long txPartitionNameTxn) {
         openPartition0(partitionIndex);
         openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_NAME_TXN, txPartitionNameTxn);
@@ -1379,10 +1387,10 @@ public class TableReader implements Closeable, SymbolTableSource {
 
             if (copyFrom > -1) {
                 SymbolMapReader rdr = symbolMapReaders.getQuick(copyFrom);
-                copyOrRenewSymbolMapReader(rdr, i);
+                renewSymbolMapReader(rdr, i);
             } else if (copyFrom != Integer.MIN_VALUE) {
                 // New instance
-                symbolMapReaders.getAndSetQuick(i, reloadSymbolMapReader(i, null));
+                renewSymbolMapReader(null, i);
             }
         }
     }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -648,8 +648,16 @@ public class TableReader implements Closeable, SymbolTableSource {
     }
 
     private void copyOrRenewSymbolMapReader(SymbolMapReader reader, int columnIndex) {
-        if (reader != null && reader.isDeleted()) {
-            reader = reloadSymbolMapReader(columnIndex, reader);
+        if (reader != null) {
+            if (reader.isDeleted()) {
+                reader = reloadSymbolMapReader(columnIndex, reader);
+            } else if (reader instanceof SymbolMapReaderImpl) {
+                final int writerColumnIndex = metadata.getWriterIndex(columnIndex);
+                final long columnNameTxn = columnVersionReader.getDefaultColumnNameTxn(writerColumnIndex);
+                if (((SymbolMapReaderImpl) reader).needsReopen(columnNameTxn)) {
+                    reader = reloadSymbolMapReader(columnIndex, reader);
+                }
+            }
         }
         symbolMapReaders.setQuick(columnIndex, reader);
     }
@@ -1351,6 +1359,14 @@ public class TableReader implements Closeable, SymbolTableSource {
             symbolMapReaders.setPos(columnCount);
         }
 
+        // index structure is
+        // [action: int, copy from:int]
+
+        // action: if -1 then current column in slave is deleted or renamed, else it's reused
+        // "copy from" >= 0 indicates that column is to be copied from slave position
+        // "copy from" < 0  indicates that column is new and should be taken from updated metadata position
+        // "copy from" == Integer.MIN_VALUE  indicates that column is deleted for good and should not be re-added from any source
+
         for (int i = 0, n = Math.max(columnCount, this.columnCount); i < n; i++) {
             long offset = pIndexBase + (long) i * Long.BYTES;
             final int action = Unsafe.getUnsafe().getInt(offset);
@@ -1361,15 +1377,9 @@ public class TableReader implements Closeable, SymbolTableSource {
                 Misc.freeIfCloseable(symbolMapReaders.getAndSetQuick(i, null));
             }
 
-            // don't copy entries to themselves, unless symbol map was deleted
-            if (copyFrom == i) {
-                SymbolMapReader reader = symbolMapReaders.getQuick(copyFrom);
-                if (reader != null && reader.isDeleted()) {
-                    symbolMapReaders.setQuick(copyFrom, reloadSymbolMapReader(copyFrom, reader));
-                }
-            } else if (copyFrom > -1) {
-                SymbolMapReader tmp = symbolMapReaders.getQuick(copyFrom);
-                copyOrRenewSymbolMapReader(tmp, i);
+            if (copyFrom > -1) {
+                SymbolMapReader rdr = symbolMapReaders.getQuick(copyFrom);
+                copyOrRenewSymbolMapReader(rdr, i);
             } else if (copyFrom != Integer.MIN_VALUE) {
                 // New instance
                 symbolMapReaders.getAndSetQuick(i, reloadSymbolMapReader(i, null));

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -528,8 +528,9 @@ public final class TableUtils {
                 } else {
                     // new
                     if (slaveIndex < slaveColumnCount) {
-                        // free
+                        // column deleted at slaveIndex
                         Unsafe.getUnsafe().putInt(index + slaveIndex * 8L, -1);
+                        Unsafe.getUnsafe().putInt(index + slaveIndex * 8L + 4, Integer.MIN_VALUE);
                     }
                     Unsafe.getUnsafe().putInt(index + outIndex * 8L + 4, -masterIndex - 1);
                 }
@@ -1153,32 +1154,6 @@ public final class TableUtils {
         memory.close(true, Vm.TRUNCATE_TO_POINTER);
     }
 
-    public static void populateRowIDHashMap(
-            SqlExecutionCircuitBreaker circuitBreaker,
-            RecordCursor cursor,
-            Map keyMap,
-            RecordSink recordSink,
-            LongChain rowIDChain
-    ) {
-        final Record record = cursor.getRecord();
-        while (cursor.hasNext()) {
-            circuitBreaker.statefulThrowExceptionIfTripped();
-
-            MapKey key = keyMap.withKey();
-            key.put(record, recordSink);
-            MapValue value = key.createValue();
-            if (value.isNew()) {
-                final long offset = rowIDChain.put(record.getRowId(), -1);
-                value.putLong(0, offset);
-                value.putLong(1, offset);
-                value.putLong(2, 1);
-            } else {
-                value.putLong(1, rowIDChain.put(record.getRowId(), value.getLong(1)));
-                value.addLong(2, 1);
-            }
-        }
-    }
-
     public static void populateRecordHashMap(
             SqlExecutionCircuitBreaker circuitBreaker,
             RecordCursor cursor,
@@ -1200,6 +1175,32 @@ public final class TableUtils {
                 value.putLong(2, 1);
             } else {
                 value.putLong(1, chain.put(record, value.getLong(1)));
+                value.addLong(2, 1);
+            }
+        }
+    }
+
+    public static void populateRowIDHashMap(
+            SqlExecutionCircuitBreaker circuitBreaker,
+            RecordCursor cursor,
+            Map keyMap,
+            RecordSink recordSink,
+            LongChain rowIDChain
+    ) {
+        final Record record = cursor.getRecord();
+        while (cursor.hasNext()) {
+            circuitBreaker.statefulThrowExceptionIfTripped();
+
+            MapKey key = keyMap.withKey();
+            key.put(record, recordSink);
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                final long offset = rowIDChain.put(record.getRowId(), -1);
+                value.putLong(0, offset);
+                value.putLong(1, offset);
+                value.putLong(2, 1);
+            } else {
+                value.putLong(1, rowIDChain.put(record.getRowId(), value.getLong(1)));
                 value.addLong(2, 1);
             }
         }

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableRenameColumnTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableRenameColumnTest.java
@@ -27,6 +27,8 @@ package io.questdb.test.griffin;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableWriter;
 import io.questdb.griffin.SqlException;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -253,6 +255,145 @@ public class AlterTableRenameColumnTest extends AbstractCairoTest {
     @Test
     public void testRenameExpectColumnName() throws Exception {
         assertFailure("alter table x rename column", 27, "column name expected");
+    }
+
+    @Test
+    public void testRenameSymbolColumnReloadReader() throws Exception {
+
+        FilesFacade ff = new FilesFacadeImpl();
+        assertMemoryLeak(
+                ff,
+                () -> {
+                    try {
+                        ddl(
+                                "create table x as (" +
+                                        "select" +
+                                        " cast(x as int) i," +
+                                        " rnd_symbol('msft','ibm', 'googl') sym," +
+                                        " rnd_symbol('msft','ibm', 'googl') new_col_0," +
+                                        " round(rnd_double(0)*100, 3) amt," +
+                                        " to_timestamp('2018-01', 'yyyy-MM') + x * 720000000 timestamp," +
+                                        " rnd_boolean() b," +
+                                        " rnd_str('ABC', 'CDE', null, 'XYZ') c," +
+                                        " rnd_double(2) d," +
+                                        " rnd_float(2) e," +
+                                        " rnd_short(10,1024) f," +
+                                        " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) g," +
+                                        " rnd_symbol(4,4,4,2) ik," +
+                                        " rnd_long() j," +
+                                        " timestamp_sequence(0, 1000000000) k," +
+                                        " rnd_byte(2,50) l," +
+                                        " rnd_bin(10, 20, 2) m," +
+                                        " rnd_str(5,16,2) n" +
+                                        " from long_sequence(100)" +
+                                        ") timestamp (timestamp) PARTITION BY DAY WAL"
+                        );
+
+                        try (TableReader rdr1 = getReader("x")) {
+
+                            rdr1.goPassive();
+
+                            ddl("alter table x rename column new_col_0 to new_col_1");
+                            ddl("alter table x rename column n to new_col_0");
+                            ddl("alter table x drop column sym");
+                            ddl("alter table x drop column i");
+                            ddl("alter table x rename column new_col_1 to new_col_2");
+                            ddl("alter table x rename column new_col_0 to new_col_1");
+                            ddl("alter table x rename column new_col_2 to new_col_0");
+                            ddl("alter table x rename column ik to new_col_3");
+
+                            drainWalQueue();
+
+
+                            rdr1.reload();
+
+                            String expected = "{\"columnCount\":15,\"columns\":[{\"index\":0,\"name\":\"new_col_0\",\"type\":\"SYMBOL\"},{\"index\":1,\"name\":\"amt\",\"type\":\"DOUBLE\"},{\"index\":2,\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"},{\"index\":3,\"name\":\"b\",\"type\":\"BOOLEAN\"},{\"index\":4,\"name\":\"c\",\"type\":\"STRING\"},{\"index\":5,\"name\":\"d\",\"type\":\"DOUBLE\"},{\"index\":6,\"name\":\"e\",\"type\":\"FLOAT\"},{\"index\":7,\"name\":\"f\",\"type\":\"SHORT\"},{\"index\":8,\"name\":\"g\",\"type\":\"DATE\"},{\"index\":9,\"name\":\"new_col_3\",\"type\":\"SYMBOL\"},{\"index\":10,\"name\":\"j\",\"type\":\"LONG\"},{\"index\":11,\"name\":\"k\",\"type\":\"TIMESTAMP\"},{\"index\":12,\"name\":\"l\",\"type\":\"BYTE\"},{\"index\":13,\"name\":\"m\",\"type\":\"BINARY\"},{\"index\":14,\"name\":\"new_col_1\",\"type\":\"STRING\"}],\"timestampIndex\":2}";
+                            sink.clear();
+                            rdr1.getMetadata().toJson(sink);
+                            TestUtils.assertEquals(expected, sink);
+                        }
+
+                        Assert.assertEquals(0, engine.getBusyWriterCount());
+                        Assert.assertEquals(0, engine.getBusyReaderCount());
+                    } finally {
+                        engine.clear();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testRenameSymbolColumnReloadReader2() throws Exception {
+
+        // Don't use TestFilesFacadeImpl because we want to remove renamed columns file
+        // while they are opened by passive table reader.
+        FilesFacade ff = new FilesFacadeImpl();
+        assertMemoryLeak(
+                ff,
+                () -> {
+                    try {
+                        ddl(
+                                "create table x as (" +
+                                        "select" +
+                                        " rnd_symbol('msft','ibm', 'googl') sym," +
+                                        " to_timestamp('2018-01', 'yyyy-MM') + x * 720000000 timestamp," +
+                                        " timestamp_sequence(0, 1000000000) k," +
+                                        " from long_sequence(1)" +
+                                        ") timestamp (timestamp) PARTITION BY DAY WAL"
+                        );
+
+                        try (TableReader rdr1 = getReader("x")) {
+
+                            rdr1.goPassive();
+
+                            // Circle rename symbol column
+                            ddl("alter table x rename column sym to new_col_1");
+                            ddl("alter table x rename column new_col_1 to sym");
+
+                            drainWalQueue();
+                            rdr1.reload();
+
+                            String expected = "{\"columnCount\":3,\"columns\":[{\"index\":0,\"name\":\"sym\",\"type\":\"SYMBOL\"},{\"index\":1,\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"},{\"index\":2,\"name\":\"k\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":1}";
+                            sink.clear();
+                            rdr1.getMetadata().toJson(sink);
+                            TestUtils.assertEquals(expected, sink);
+
+                            rdr1.goPassive();
+
+                            // Circle rename non-symbol column
+                            ddl("alter table x rename column k to new_col_1");
+                            ddl("alter table x rename column new_col_1 to k");
+
+                            drainWalQueue();
+
+                            rdr1.reload();
+                            sink.clear();
+                            rdr1.getMetadata().toJson(sink);
+                            TestUtils.assertEquals(expected, sink);
+
+                            assertSql("sym\ttimestamp\tk\n" +
+                                    "msft\t2018-01-01T00:12:00.000000Z\t1970-01-01T00:00:00.000000Z\n", "select * from x");
+
+                            rdr1.goPassive();
+
+                            // Symple rename symbol column
+                            ddl("alter table x rename column sym to new_col_1");
+                            drainWalQueue();
+                            rdr1.reload();
+
+                            String expected2 = "{\"columnCount\":3,\"columns\":[{\"index\":0,\"name\":\"new_col_1\",\"type\":\"SYMBOL\"},{\"index\":1,\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"},{\"index\":2,\"name\":\"k\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":1}";
+                            sink.clear();
+                            rdr1.getMetadata().toJson(sink);
+                            TestUtils.assertEquals(expected2, sink);
+                        }
+
+                        Assert.assertEquals(0, engine.getBusyWriterCount());
+                        Assert.assertEquals(0, engine.getBusyReaderCount());
+                    } finally {
+                        engine.clear();
+                    }
+                }
+        );
     }
 
     @Test


### PR DESCRIPTION
Fix TableReader reload error after a series column renames found by fuzz tests.

The symptom is the error:


```
Caused by: io.questdb.griffin.SqlException: [0] [2]: could not open read-only [file=/var/folders/kj/wpw2cl295rbdksb3ysqsj1yw0000gn/T/junit12416700228706723530/dbRoot/db/testFuzzWithSnapshot_2~7/new_col_0.k]
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlException.position(SqlException.java:103)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlOptimiser.openReaderAndEnumerateColumns(SqlOptimiser.java:2523)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlOptimiser.enumerateTableColumns(SqlOptimiser.java:1772)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlOptimiser.enumerateTableColumns(SqlOptimiser.java:1777)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlOptimiser.optimise(SqlOptimiser.java:4705)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileExecutionModel0(SqlCompilerImpl.java:1336)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileExecutionModel(SqlCompilerImpl.java:1325)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileUsingModel(SqlCompilerImpl.java:1418)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileInner(SqlCompilerImpl.java:1389)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compile(SqlCompilerImpl.java:231)
	at io.questdb@7.3.3-SNAPSHOT/io.questdb.cairo.pool.SqlCompilerPool$C.compile(SqlCompilerPool.java:98)
	at com.questdb/com.questdb.cairo.wal.transfer.ReplicationFuzzTest.assertReplicatedTable(ReplicationFuzzTest.java:271)
	at com.questdb/com.questdb.cairo.wal.transfer.ReplicationFuzzTest.lambda$testFuzzWithSnapshot$7(ReplicationFuzzTest.java:553)
```

The fix is to check that the symbol column name has the same `nameTxn` suffix as the one already opened by ``SymbolMapReaderImpl`