### PR TITLE
chore(core): table level insert permission

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -67,8 +67,6 @@ public interface SecurityContext {
 
     void authorizeAssignServiceAccount(CharSequence serviceAccountName);
 
-    void authorizeCopy();
-
     void authorizeCopyCancel(SecurityContext cancellingSecurityContext);
 
     void authorizeCreateGroup();

--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -95,15 +95,6 @@ public interface SecurityContext {
 
     void authorizeInsert(TableToken tableToken);
 
-    // Add column over ILP/TCP.
-    void authorizeLineAlterTableAddColumn(TableToken tableToken);
-
-    // Insert over ILP/TCP.
-    void authorizeLineInsert(TableToken tableToken);
-
-    // Create table over ILP/TCP.
-    void authorizeLineTableCreate();
-
     void authorizeRemovePassword(CharSequence userOrServiceAccountName);
 
     void authorizeRemoveUser();

--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -95,8 +95,7 @@ public interface SecurityContext {
 
     void authorizeGrant(LongList permissions, CharSequence tableName, @NotNull ObjList<CharSequence> columns);
 
-    // columnNames - empty means all columns
-    void authorizeInsert(TableToken tableToken, @NotNull ObjList<CharSequence> columnNames);
+    void authorizeInsert(TableToken tableToken);
 
     // Add column over ILP/TCP.
     void authorizeLineAlterTableAddColumn(TableToken tableToken);

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -107,10 +107,6 @@ public class AllowAllSecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeCopy() {
-    }
-
-    @Override
     public void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
     }
 

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -163,18 +163,6 @@ public class AllowAllSecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeLineAlterTableAddColumn(TableToken tableToken) {
-    }
-
-    @Override
-    public void authorizeLineInsert(TableToken tableToken) {
-    }
-
-    @Override
-    public void authorizeLineTableCreate() {
-    }
-
-    @Override
     public void authorizeRemovePassword(CharSequence userOrServiceAccountName) {
     }
 

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -163,7 +163,7 @@ public class AllowAllSecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeInsert(TableToken tableToken, @NotNull ObjList<CharSequence> columnNames) {
+    public void authorizeInsert(TableToken tableToken) {
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -194,21 +194,6 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeLineAlterTableAddColumn(TableToken tableToken) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeLineInsert(TableToken tableToken) {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
-    public void authorizeLineTableCreate() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
     public void authorizeRemovePassword(CharSequence userOrServiceAccountName) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -194,7 +194,7 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeInsert(TableToken tableToken, @NotNull ObjList<CharSequence> columnNames) {
+    public void authorizeInsert(TableToken tableToken) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }
 

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -124,11 +124,6 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
-    public void authorizeCopy() {
-        throw CairoException.authorization().put("Write permission denied").setCacheable(true);
-    }
-
-    @Override
     public void authorizeCopyCancel(SecurityContext cancellingSecurityContext) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -331,13 +331,8 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
     }
 
     protected final IOContextResult parseMeasurements(NetworkIOJob netIoJob) {
-        long i = 0;
         while (true) {
             try {
-                if ((i++ & 8191) == 0 && !securityContext.isEnabled()) {
-                    return IOContextResult.NEEDS_DISCONNECT;
-                }
-
                 ParseResult rc = goodMeasurement ? parser.parseMeasurement(recvBufPos) : parser.skipMeasurement(recvBufPos);
                 switch (rc) {
                     case MEASUREMENT_COMPLETE: {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementEvent.java
@@ -308,7 +308,7 @@ class LineTcpMeasurementEvent implements Closeable {
         final TableUpdateDetails.ThreadLocalDetails localDetails = tud.getThreadLocalDetails(workerId);
         localDetails.resetStateIfNecessary();
         tableUpdateDetails = tud;
-        securityContext.authorizeLineInsert(tud.getTableToken());
+        securityContext.authorizeInsert(tud.getTableToken());
         long timestamp = parser.getTimestamp();
         if (timestamp != LineTcpParser.NULL_TIMESTAMP) {
             timestamp = timestampAdapter.getMicros(timestamp);
@@ -336,7 +336,7 @@ class LineTcpMeasurementEvent implements Closeable {
                 // send column by name
                 final String colNameUtf16 = localDetails.getColNameUtf16();
                 if (autoCreateNewColumns && TableUtils.isValidColumnName(colNameUtf16, maxColumnNameLength)) {
-                    securityContext.authorizeLineAlterTableAddColumn(tud.getTableToken());
+                    securityContext.authorizeAlterTableAddColumn(tud.getTableToken());
                     offset = buffer.addColumnName(offset, colNameUtf16, securityContext.getPrincipal());
                     colType = localDetails.getColumnType(localDetails.getColNameUtf8(), entityType);
                 } else if (!autoCreateNewColumns) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -390,7 +390,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                     if (autoCreateNewColumns && TableUtils.isValidColumnName(columnNameUtf16, cairoConfiguration.getMaxFileNameLength())) {
                         columnWriterIndex = metadata.getColumnIndexQuiet(columnNameUtf16);
                         if (columnWriterIndex < 0) {
-                            securityContext.authorizeLineAlterTableAddColumn(writer.getTableToken());
+                            securityContext.authorizeAlterTableAddColumn(writer.getTableToken());
                             tud.commit(false);
                             try {
                                 writer.addColumn(columnNameUtf16, ld.getColumnType(ld.getColNameUtf8(), ent.getType()), securityContext);
@@ -759,7 +759,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                             throw CairoException.nonCritical().put("unknown column type [columnName=").put(tsa.getColumnName(i)).put(']');
                         }
                     }
-                    securityContext.authorizeLineTableCreate();
+                    securityContext.authorizeTableCreate();
                     tableToken = engine.createTableInsecure(securityContext, ddlMem, path, true, tsa, false, false);
                     LOG.info().$("created table [tableName=").$(tableNameUtf16).I$();
                 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -265,7 +265,7 @@ public class TableUpdateDetails implements Closeable {
 
     private void authorizeWalCommit() {
         if (ownSecurityContext != null) {
-            ownSecurityContext.authorizeLineInsert(tableToken);
+            ownSecurityContext.authorizeInsert(tableToken);
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -26,7 +26,6 @@ package io.questdb.cutlass.text;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.text.types.*;
@@ -380,7 +379,7 @@ public class CairoTextWriter implements Closeable, Mutable {
                     }
                     partitionBy = tablePartitionBy;
                     tableStructureAdapter.of(names, detectedTypes);
-                    securityContext.authorizeInsert(tableToken, names);
+                    securityContext.authorizeInsert(tableToken);
                 }
                 break;
             default:

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -857,7 +857,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         this.writer = writer;//next call can throw exception
 
         // authorize only columns present in the file 
-        securityContext.authorizeInsert(tableToken, names);
+        securityContext.authorizeInsert(tableToken);
 
         // add table columns missing in input file
         if (names.size() < metadata.getColumnCount()) {

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1253,13 +1253,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable {
         }
     }
 
-    private void compileBegin(SqlExecutionContext executionContext) {
-        compiledQuery.ofBegin();
-    }
-
-    private void compileCommit(SqlExecutionContext executionContext) {
-        compiledQuery.ofCommit();
-    }
 
     private CharSequence authorizeInsertForCopy(SecurityContext securityContext, CopyModel model) {
         final CharSequence tableName = GenericLexer.unquote(model.getTarget().token);
@@ -1270,6 +1263,14 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable {
             securityContext.authorizeInsert(tt);
         }
         return tableName;
+    }
+
+    private void compileBegin(SqlExecutionContext executionContext) {
+        compiledQuery.ofBegin();
+    }
+
+    private void compileCommit(SqlExecutionContext executionContext) {
+        compiledQuery.ofCommit();
     }
 
     private RecordCursorFactory compileCopy(SecurityContext securityContext, CopyModel model) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1346,7 +1346,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable {
                     lightlyValidateInsertModel(insertModel);
                 }
                 final TableToken tableToken = engine.getTableTokenIfExists(insertModel.getTableName());
-                executionContext.getSecurityContext().authorizeInsert(tableToken, insertModel.getColumnNameList());
+                executionContext.getSecurityContext().authorizeInsert(tableToken);
                 return insertModel;
             }
             case ExecutionModel.UPDATE:

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
@@ -36,7 +36,10 @@ import io.questdb.cairo.sql.WriterOutOfDateException;
 import io.questdb.griffin.InsertRowImpl;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.ReadOnlyObjList;
 
 public class InsertOperationImpl implements InsertOperation {
 
@@ -69,7 +72,7 @@ public class InsertOperationImpl implements InsertOperation {
     @Override
     public InsertMethod createMethod(SqlExecutionContext executionContext, WriterSource writerSource) throws SqlException {
         SecurityContext securityContext = executionContext.getSecurityContext();
-        securityContext.authorizeInsert(tableToken, columnNames);
+        securityContext.authorizeInsert(tableToken);
 
         initContext(executionContext);
         if (insertMethod.writer == null) {

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGSecurityTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGSecurityTest.java
@@ -109,6 +109,7 @@ public class PGSecurityTest extends BasePGTest {
 
     @Test
     public void testDisallowCopy() throws Exception {
+        ddl("create table testDisallowCopySerial (l long)");
         assertMemoryLeak(() -> assertQueryDisallowed("copy testDisallowCopySerial from '/test-alltypes.csv' with header true"));
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
@@ -358,6 +358,7 @@ public class SecurityTest extends AbstractCairoTest {
     public void testCopyDeniedOnNoWriteAccess() throws Exception {
         assertMemoryLeak(() -> {
             try {
+                ddl("create table testDisallowCopySerial (l long)");
                 assertException("copy testDisallowCopySerial from '/test-alltypes.csv' with header true", readOnlyExecutionContext);
             } catch (CairoException ex) {
                 TestUtils.assertContains(ex.toString(), "permission denied");


### PR DESCRIPTION
- move INSERT permission to table level
- use INSERT permission instead of COPY
- remove ILP specific permissions and use their counterparts (INSERT, CREATE TABLE, ADD COLUMN) instead

required by https://github.com/questdb/questdb-enterprise/pull/172