### PR TITLE
docs(core): Fix syntax in all-contributorsrc file

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -10,7 +10,7 @@
     "i18n/README.zh-cn.md",
     "i18n/README.zh-hk.md",
     "i18n/README.tr-tr.md",
-    "i18n/README.hn-in.md",
+    "i18n/README.hn-in.md"
   ],
   "imageSize": 100,
   "commit": false,

--- a/ci/validate-pr-title/validate.js
+++ b/ci/validate-pr-title/validate.js
@@ -8,7 +8,6 @@ const allowedTypes = [
   "perf",
   "test",
   "ci",
-  "chore",
   "revert",
 ];
 


### PR DESCRIPTION
Remove trailing slash to ensure valid JSON syntax.

This file is used as the payload for our internal API, which is later used to build questdb.io website.

`.all-contributorsrc` is expected to be a JSON file, however, a single trailing comma broke it.

Due to this, the result of the internal API was `server error` and thus some data in questdb.io website was not populated.

Namely, the contributors count on questdb.io/about-us does not show a number.

This PR fixes the issue.