### PR TITLE
fix(sql): fix NOT IN expression parsing with function arguments

### DIFF
--- a/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
+++ b/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
@@ -1092,7 +1092,7 @@ public final class WhereClauseParser implements Mutable {
         ExpressionNode col = node.paramCount < 3 ? node.lhs : node.args.getLast();
 
         if (col.type != ExpressionNode.LITERAL) {
-            throw SqlException.$(col.position, "Column name expected");
+            return false;
         }
 
         CharSequence column = translator.translateAlias(col.token);

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3082,6 +3082,23 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testFunctionNotIn() throws SqlException {
+        ddl("create table tab ( timestamp timestamp, col string, id symbol index) timestamp(timestamp);");
+        insert("insert into tab values (1, 'foo', 'A'), (2, 'bah', 'B'), (3, 'dee', 'C')");
+
+        assertSql("timestamp\tcol\tid\n" +
+                        "1970-01-01T00:00:00.000003Z\tdee\tC\n",
+                "SELECT * FROM tab\n" +
+                        "WHERE substring(col, 1, 3) NOT IN ('foo', 'bah')\n");
+
+        assertSql("timestamp\tcol\tid\n" +
+                        "1970-01-01T00:00:00.000003Z\tdee\tC\n",
+                "SELECT * FROM tab\n" +
+                        "WHERE substring(col, 1, 3) NOT IN ('foo', 'bah')\n" +
+                        "LATEST ON timestamp PARTITION BY id");
+    }
+
+    @Test
     public void testGeoLiteralAsColName() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (select rnd_str('#1234', '#88484') as \"#0101a\" from long_sequence(5) )");
@@ -3168,7 +3185,6 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
                 "group by 1 " +
                 "order by 1 ");
     }
-
 
     @Test
     public void testGroupByLimit() throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -2322,13 +2322,12 @@ public class WhereClauseParserTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testNotInIntervalNonLiteral() {
-        try {
-            modelOf("not (timestamp() in  ('2015-05-11T15:00:00.000Z')) and timestamp = '2015-05-11'");
-            Assert.fail();
-        } catch (SqlException e) {
-            TestUtils.assertContains(e.getFlyweightMessage(), "Column name");
-        }
+    public void testNotInIntervalNonLiteral() throws SqlException {
+        IntrinsicModel m = modelOf("not (timestamp() in  ('2015-05-11T15:00:00.000Z')) and timestamp = '2015-05-11'");
+
+        TestUtils.assertEquals("[{lo=2015-05-11T00:00:00.000000Z, hi=2015-05-11T00:00:00.000000Z}]", intervalToString(m));
+        Assert.assertEquals(IntrinsicModel.UNDEFINED, m.intrinsicValue);
+        assertFilter(m, "'2015-05-11T15:00:00.000Z' timestamp in not");
     }
 
     @Test


### PR DESCRIPTION
Fixes parsing of NOT IN expression where first argument is not a column but an expression. 

Example : 

```sql
CREATE TABLE tab ( timestamp TIMESTAMP, col STRING, id SYMBOL INDEX) TIMESTAMP(timestamp);

INSERT INTO tab VALUES (1, 'foo', 'A'), (2, 'bah', 'B'), (3, 'dee', 'C')");

SELECT * FROM tab
WHERE substring(col, 1, 3) NOT IN ('foo', 'bah')
```

Query fails with 'column expected' in current master.
