### PR TITLE
feat(core): add connection count gauge metrics for all network interfaces

### DIFF
--- a/benchmarks/src/main/java/org/questdb/PongMain.java
+++ b/benchmarks/src/main/java/org/questdb/PongMain.java
@@ -26,6 +26,7 @@ package org.questdb;
 
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.metrics.NullLongGauge;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.*;
 import io.questdb.std.Chars;
@@ -69,7 +70,7 @@ public class PongMain {
         private int writtenLen;
 
         protected PongConnectionContext(SocketFactory socketFactory, NetworkFacade nf, Log log) {
-            super(socketFactory, nf, log);
+            super(socketFactory, nf, log, NullLongGauge.INSTANCE);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -27,6 +27,7 @@ package io.questdb;
 import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cairo.wal.WalMetrics;
 import io.questdb.cutlass.http.processors.JsonQueryMetrics;
+import io.questdb.cutlass.line.LineMetrics;
 import io.questdb.cutlass.pgwire.PGWireMetrics;
 import io.questdb.metrics.*;
 import io.questdb.std.MemoryTag;
@@ -39,6 +40,7 @@ public class Metrics implements Scrapable {
     private final GCMetrics gcMetrics;
     private final HealthMetricsImpl healthCheck;
     private final JsonQueryMetrics jsonQuery;
+    private final LineMetrics line;
     private final MetricsRegistry metricsRegistry;
     private final PGWireMetrics pgWire;
     private final Runtime runtime = Runtime.getRuntime();
@@ -53,6 +55,7 @@ public class Metrics implements Scrapable {
         this.gcMetrics = new GCMetrics();
         this.jsonQuery = new JsonQueryMetrics(metricsRegistry);
         this.pgWire = new PGWireMetrics(metricsRegistry);
+        this.line = new LineMetrics(metricsRegistry);
         this.healthCheck = new HealthMetricsImpl(metricsRegistry);
         this.tableWriter = new TableWriterMetrics(metricsRegistry);
         this.walMetrics = new WalMetrics(metricsRegistry);
@@ -68,10 +71,6 @@ public class Metrics implements Scrapable {
         return new Metrics(true, new MetricsRegistryImpl());
     }
 
-    public WalMetrics getWalMetrics() {
-        return walMetrics;
-    }
-
     public HealthMetricsImpl health() {
         return healthCheck;
     }
@@ -82,6 +81,10 @@ public class Metrics implements Scrapable {
 
     public JsonQueryMetrics jsonQuery() {
         return jsonQuery;
+    }
+
+    public LineMetrics line() {
+        return line;
     }
 
     public PGWireMetrics pgWire() {
@@ -98,6 +101,10 @@ public class Metrics implements Scrapable {
 
     public TableWriterMetrics tableWriter() {
         return tableWriter;
+    }
+
+    public WalMetrics walMetrics() {
+        return walMetrics;
     }
 
     private void createMemoryGauges(MetricsRegistry metricsRegistry) {

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -84,7 +84,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
         CairoConfiguration configuration = engine.getConfiguration();
         microClock = configuration.getMicrosecondClock();
         walEventReader = new WalEventReader(configuration.getFilesFacade());
-        metrics = engine.getMetrics().getWalMetrics();
+        metrics = engine.getMetrics().walMetrics();
         lookAheadTransactionCount = configuration.getWalApplyLookAheadTransactionCount();
         tableTimeQuotaMicros = configuration.getWalApplyTableTimeQuota() >= 0 ? configuration.getWalApplyTableTimeQuota() * 1000L : Timestamps.DAY_MICROS;
     }

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -95,6 +95,7 @@ public class WalWriter implements TableWriterAPI {
     private long currentTxnStartRowNum = -1;
     private boolean distressed;
     private int lastSegmentTxn = -1;
+    private long lastSeqTxn = NO_TXN;
     private boolean open;
     private boolean rollSegmentOnNextRow = false;
     private int segmentId = -1;
@@ -106,7 +107,6 @@ public class WalWriter implements TableWriterAPI {
     private long txnMinTimestamp = Long.MAX_VALUE;
     private boolean txnOutOfOrder = false;
     private int walLockFd = -1;
-    private long lastSeqTxn = NO_TXN;
 
     public WalWriter(
             CairoConfiguration configuration,
@@ -270,7 +270,7 @@ public class WalWriter implements TableWriterAPI {
                         .$(", minTimestamp=").$ts(txnMinTimestamp).$(", maxTimestamp=").$ts(txnMaxTimestamp).I$();
                 resetDataTxnProperties();
                 mayRollSegmentOnNextRow();
-                metrics.getWalMetrics().addRowsWritten(rowsToCommit);
+                metrics.walMetrics().addRowsWritten(rowsToCommit);
                 return seqTxn;
             }
         } catch (CairoException ex) {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -76,7 +76,8 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         super(
                 socketFactory,
                 configuration.getHttpContextConfiguration().getNetworkFacade(),
-                LOG
+                LOG,
+                metrics.jsonQuery().connectionCountGauge()
         );
         final HttpContextConfiguration contextConfiguration = configuration.getHttpContextConfiguration();
         this.configuration = contextConfiguration;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
@@ -35,9 +35,11 @@ public class JsonQueryMetrics {
     private final Counter cacheMissCounter;
     private final LongGauge cachedQueriesGauge;
     private final Counter completedQueriesCounter;
+    private final LongGauge connectionCountGauge;
     private final Counter startedQueriesCounter;
 
     public JsonQueryMetrics(MetricsRegistry metricsRegistry) {
+        this.connectionCountGauge = metricsRegistry.newLongGauge("http_connections");
         this.startedQueriesCounter = metricsRegistry.newCounter("json_queries");
         this.completedQueriesCounter = metricsRegistry.newCounter("json_queries_completed");
         this.cachedQueriesGauge = metricsRegistry.newLongGauge("json_queries_cached");
@@ -60,6 +62,10 @@ public class JsonQueryMetrics {
     @TestOnly
     public long completedQueriesCount() {
         return completedQueriesCounter.getValue();
+    }
+
+    public LongGauge connectionCountGauge() {
+        return connectionCountGauge;
     }
 
     public void markComplete() {

--- a/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cutlass.line;
+
+import io.questdb.metrics.LongGauge;
+import io.questdb.metrics.MetricsRegistry;
+
+public class LineMetrics {
+
+    private final LongGauge connectionCountGauge;
+
+    public LineMetrics(MetricsRegistry metricsRegistry) {
+        this.connectionCountGauge = metricsRegistry.newLongGauge("line_tcp_connections");
+    }
+
+    public LongGauge connectionCountGauge() {
+        return connectionCountGauge;
+    }
+}

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -72,7 +72,12 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
     private long nextCommitTime;
 
     public LineTcpConnectionContext(LineTcpReceiverConfiguration configuration, LineTcpMeasurementScheduler scheduler, Metrics metrics) {
-        super(configuration.getFactoryProvider().getLineSocketFactory(), configuration.getNetworkFacade(), LOG);
+        super(
+                configuration.getFactoryProvider().getLineSocketFactory(),
+                configuration.getNetworkFacade(),
+                LOG,
+                metrics.line().connectionCountGauge()
+        );
         this.configuration = configuration;
         nf = configuration.getNetworkFacade();
         disconnectOnError = configuration.getDisconnectOnError();

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -210,7 +210,12 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             SqlExecutionContextImpl sqlExecutionContext,
             NetworkSqlExecutionCircuitBreaker circuitBreaker
     ) {
-        super(configuration.getFactoryProvider().getPGWireSocketFactory(), configuration.getNetworkFacade(), LOG);
+        super(
+                configuration.getFactoryProvider().getPGWireSocketFactory(),
+                configuration.getNetworkFacade(),
+                LOG,
+                engine.getMetrics().pgWire().connectionCountGauge()
+        );
         this.engine = engine;
         this.utf8Sink = new DirectCharSink(engine.getConfiguration().getTextConfiguration().getUtf8SinkSize());
         this.bindVariableService = new BindVariableServiceImpl(engine.getConfiguration());

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
@@ -32,11 +32,13 @@ public class PGWireMetrics {
 
     private final LongGauge cachedSelectsGauge;
     private final LongGauge cachedUpdatesGauge;
+    private final LongGauge connectionCountGauge;
     private final Counter errorCounter;
     private final Counter selectCacheHitCounter;
     private final Counter selectCacheMissCounter;
 
     public PGWireMetrics(MetricsRegistry metricsRegistry) {
+        this.connectionCountGauge = metricsRegistry.newLongGauge("pg_wire_connections");
         this.cachedSelectsGauge = metricsRegistry.newLongGauge("pg_wire_select_queries_cached");
         this.cachedUpdatesGauge = metricsRegistry.newLongGauge("pg_wire_update_queries_cached");
         this.selectCacheHitCounter = metricsRegistry.newCounter("pg_wire_select_cache_hits");
@@ -50,6 +52,10 @@ public class PGWireMetrics {
 
     public LongGauge cachedUpdatesGauge() {
         return cachedUpdatesGauge;
+    }
+
+    public LongGauge connectionCountGauge() {
+        return connectionCountGauge;
     }
 
     public Counter getErrorCounter() {

--- a/core/src/main/java/io/questdb/network/IOContext.java
+++ b/core/src/main/java/io/questdb/network/IOContext.java
@@ -25,6 +25,7 @@
 package io.questdb.network;
 
 import io.questdb.log.Log;
+import io.questdb.metrics.LongGauge;
 import io.questdb.std.Mutable;
 import io.questdb.std.QuietCloseable;
 import org.jetbrains.annotations.NotNull;
@@ -33,9 +34,11 @@ public abstract class IOContext<T extends IOContext<T>> implements Mutable, Quie
     protected final Socket socket;
     protected IODispatcher<T> dispatcher;
     protected long heartbeatId = -1;
+    private LongGauge connectionCountGauge;
 
-    protected IOContext(SocketFactory socketFactory, NetworkFacade nf, Log log) {
+    protected IOContext(SocketFactory socketFactory, NetworkFacade nf, Log log, LongGauge connectionCountGauge) {
         this.socket = socketFactory.newInstance(nf, log);
+        this.connectionCountGauge = connectionCountGauge;
     }
 
     @Override
@@ -82,11 +85,14 @@ public abstract class IOContext<T extends IOContext<T>> implements Mutable, Quie
     }
 
     public boolean invalid() {
-        return socket.getFd() == -1;
+        return socket.isClosed();
     }
 
     @SuppressWarnings("unchecked")
     public T of(int fd, @NotNull IODispatcher<T> dispatcher) {
+        if (fd != -1) {
+            connectionCountGauge.inc();
+        }
         socket.of(fd);
         this.dispatcher = dispatcher;
         return (T) this;
@@ -97,6 +103,9 @@ public abstract class IOContext<T extends IOContext<T>> implements Mutable, Quie
     }
 
     private void _clear() {
+        if (socket.getFd() != -1) {
+            connectionCountGauge.dec();
+        }
         heartbeatId = -1;
         socket.close();
         dispatcher = null;

--- a/core/src/test/java/io/questdb/test/cutlass/IODispatcherHeartbeatTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/IODispatcherHeartbeatTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.cutlass;
 
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.metrics.NullLongGauge;
 import io.questdb.network.*;
 import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
@@ -471,7 +472,7 @@ public class IODispatcherHeartbeatTest {
         SuspendEvent suspendEvent;
 
         public TestContext(int fd, IODispatcher<TestContext> dispatcher, long heartbeatInterval) {
-            super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG);
+            super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG, NullLongGauge.INSTANCE);
             socket.of(fd);
             this.dispatcher = dispatcher;
             this.heartbeatInterval = heartbeatInterval;

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -47,6 +47,7 @@ import io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactor
 import io.questdb.jit.JitUtil;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.metrics.NullLongGauge;
 import io.questdb.mp.*;
 import io.questdb.network.*;
 import io.questdb.std.*;
@@ -8564,7 +8565,7 @@ public class IODispatcherTest extends AbstractTest {
                 private long heartbeatId;
 
                 public TestIOContext(int fd, IntHashSet serverConnectedFds) {
-                    super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG);
+                    super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG, NullLongGauge.INSTANCE);
                     socket.of(fd);
                     this.serverConnectedFds = serverConnectedFds;
                 }
@@ -8822,7 +8823,7 @@ public class IODispatcherTest extends AbstractTest {
         private final SOCountDownLatch closeLatch;
 
         public HelloContext(int fd, SOCountDownLatch closeLatch, IODispatcher<HelloContext> dispatcher) {
-            super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG);
+            super(PlainSocketFactory.INSTANCE, NetworkFacadeImpl.INSTANCE, LOG, NullLongGauge.INSTANCE);
             socket.of(fd);
             this.closeLatch = closeLatch;
             this.dispatcher = dispatcher;


### PR DESCRIPTION
Refs: #2794

Adds the following gauges for Prometheus metrics:
```
questdb_http_connections
questdb_pg_wire_connections
questdb_line_tcp_connections
```