### PR TITLE
fix(ilp): faster ILP authentication

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/auth/EllipticCurveAuthenticator.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/auth/EllipticCurveAuthenticator.java
@@ -87,7 +87,10 @@ public class EllipticCurveAuthenticator implements Authenticator {
         switch (authState) {
             case WAITING_FOR_KEY_ID:
                 readKeyId();
-                break;
+                if (authState != AuthState.SENDING_CHALLENGE) {
+                    // fall-through if we are sending challenge
+                    break;
+                }
             case SENDING_CHALLENGE:
                 sendChallenge();
                 break;


### PR DESCRIPTION
do not give up a thread after fully reading keyId

reasoning: we just finished reading `keyId` and we are scheduled on a thread. there is no need to give up on the thread and wait to be scheduled again. we can opportunistically try to send the challenge immediately. given the challenge is only 513 bytes there is a good chance it will fit into a socket in one go. this should improve authentication responsiveness in very busy systems - where it can take a while for an IOContext to be scheduled again. 