### PR TITLE
fix(core): use the same GC algorithm in Docker image as with other QuestDB distros

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -47,7 +47,7 @@ fi
 # Check if arguments are provided in the configuration file
 if [ $# -eq 0 ]; then
     echo "No arguments found in the configuration, start with default arguments"
-    set -- $JAVA_COMMAND -XX:ErrorFile=${QUESTDB_DATA_DIR}/db/hs_err_pid+%p.log -Dout=${QUESTDB_DATA_DIR}/conf/log.conf -m io.questdb/io.questdb.ServerMain -d ${QUESTDB_DATA_DIR} -f
+    set -- $JAVA_COMMAND -XX:+UseParallelGC -XX:ErrorFile=${QUESTDB_DATA_DIR}/db/hs_err_pid+%p.log -Dout=${QUESTDB_DATA_DIR}/conf/log.conf -m io.questdb/io.questdb.ServerMain -d ${QUESTDB_DATA_DIR} -f
 else
     if [ "${1:0:1}" = '-' ]; then
         echo "Found config arguments $@"


### PR DESCRIPTION
This closes [#3814 ]

With this fix, the ParallelGC would be added as a part of the JVM args if no args passed via configuration file.