### PR TITLE
fix(sql): fix table name case sensitivity in SQL UPDATE

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -4794,7 +4794,7 @@ public class SqlOptimiser implements Mutable {
             TableToken tableToken = metadata.getTableToken();
             sqlExecutionContext.getSecurityContext().authorizeTableUpdate(tableToken, literalCollectorANames);
 
-            if (!sqlExecutionContext.isWalApplication() && !Chars.equals(tableToken.getTableName(), updateQueryModel.getTableName())) {
+            if (!sqlExecutionContext.isWalApplication() && !Chars.equalsIgnoreCase(tableToken.getTableName(), updateQueryModel.getTableName())) {
                 // Table renamed
                 throw TableReferenceOutOfDateException.of(updateQueryModel.getTableName());
             }


### PR DESCRIPTION
SQL UPDATE treats table names as case sensitive.

This bug originates from validateUpdateColumns throwing TableReferenceOutOfDateException whenver the UPDATE name case does not strictly match the table name. Changing the evaluation function from Chars.equals to Chars.equalsIgnoreCase fixed the problem.

Also added new test to ensure UPDATE is table-name case insensitive.

This closes #3656