### PR TITLE
fix(core): fix connection error to HTTP TCP port on MacOS

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -28,7 +28,10 @@ import io.questdb.HttpClientConfiguration;
 import io.questdb.cutlass.http.HttpHeaderParser;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.network.*;
+import io.questdb.network.IOOperation;
+import io.questdb.network.NetworkFacade;
+import io.questdb.network.Socket;
+import io.questdb.network.SocketFactory;
 import io.questdb.std.*;
 import io.questdb.std.str.AbstractCharSink;
 import io.questdb.std.str.CharSink;
@@ -276,7 +279,7 @@ public abstract class HttpClient implements QuietCloseable {
             if (fd < 0) {
                 throw new HttpClientException("could not allocate a file descriptor").errno(nf.errno());
             }
-            Net.configureKeepAlive(fd);
+            nf.configureKeepAlive(fd);
             long addrInfo = nf.getAddrInfo(host, port);
             if (addrInfo == -1) {
                 disconnect();

--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -28,10 +28,7 @@ import io.questdb.HttpClientConfiguration;
 import io.questdb.cutlass.http.HttpHeaderParser;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.network.IOOperation;
-import io.questdb.network.NetworkFacade;
-import io.questdb.network.Socket;
-import io.questdb.network.SocketFactory;
+import io.questdb.network.*;
 import io.questdb.std.*;
 import io.questdb.std.str.AbstractCharSink;
 import io.questdb.std.str.CharSink;
@@ -279,6 +276,7 @@ public abstract class HttpClient implements QuietCloseable {
             if (fd < 0) {
                 throw new HttpClientException("could not allocate a file descriptor").errno(nf.errno());
             }
+            Net.configureKeepAlive(fd);
             long addrInfo = nf.getAddrInfo(host, port);
             if (addrInfo == -1) {
                 disconnect();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/PlainTcpLineChannel.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/PlainTcpLineChannel.java
@@ -28,7 +28,6 @@ import io.questdb.cutlass.line.LineChannel;
 import io.questdb.cutlass.line.LineSenderException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.network.Net;
 import io.questdb.network.NetworkFacade;
 
 public final class PlainTcpLineChannel implements LineChannel {
@@ -43,7 +42,7 @@ public final class PlainTcpLineChannel implements LineChannel {
         if (fd < 0) {
             throw new LineSenderException("could not allocate a file descriptor").errno(nf.errno());
         }
-        Net.configureKeepAlive(fd);
+        nf.configureKeepAlive(fd);
         this.sockaddr = nf.sockaddr(address, port);
         if (nf.connect(fd, sockaddr) != 0) {
             int errno = nf.errno();
@@ -63,7 +62,7 @@ public final class PlainTcpLineChannel implements LineChannel {
         if (fd < 0) {
             throw new LineSenderException("could not allocate a file descriptor").errno(nf.errno());
         }
-        Net.configureKeepAlive(fd);
+        nf.configureKeepAlive(fd);
         long addrInfo = nf.getAddrInfo(host, port);
         if (addrInfo == -1) {
             nf.close(fd, LOG);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/PlainTcpLineChannel.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/PlainTcpLineChannel.java
@@ -28,6 +28,7 @@ import io.questdb.cutlass.line.LineChannel;
 import io.questdb.cutlass.line.LineSenderException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.network.Net;
 import io.questdb.network.NetworkFacade;
 
 public final class PlainTcpLineChannel implements LineChannel {
@@ -42,6 +43,7 @@ public final class PlainTcpLineChannel implements LineChannel {
         if (fd < 0) {
             throw new LineSenderException("could not allocate a file descriptor").errno(nf.errno());
         }
+        Net.configureKeepAlive(fd);
         this.sockaddr = nf.sockaddr(address, port);
         if (nf.connect(fd, sockaddr) != 0) {
             int errno = nf.errno();
@@ -61,6 +63,7 @@ public final class PlainTcpLineChannel implements LineChannel {
         if (fd < 0) {
             throw new LineSenderException("could not allocate a file descriptor").errno(nf.errno());
         }
+        Net.configureKeepAlive(fd);
         long addrInfo = nf.getAddrInfo(host, port);
         if (addrInfo == -1) {
             nf.close(fd, LOG);

--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -24,7 +24,6 @@
 
 package io.questdb.log;
 
-import io.questdb.network.Net;
 import io.questdb.network.NetworkFacade;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
@@ -121,7 +120,7 @@ public class LogAlertSocket implements Closeable {
             logNetworkConnectError("Could not create addr info with");
         } else {
             socketFd = nf.socketTcp(true);
-            Net.configureKeepAlive(socketFd);
+            nf.configureKeepAlive(socketFd);
             if (socketFd > -1) {
                 if (nf.connectAddrInfo(socketFd, addressInfoAddr) != 0) {
                     logNetworkConnectError("Could not connect with");

--- a/core/src/main/java/io/questdb/log/LogAlertSocket.java
+++ b/core/src/main/java/io/questdb/log/LogAlertSocket.java
@@ -24,6 +24,7 @@
 
 package io.questdb.log;
 
+import io.questdb.network.Net;
 import io.questdb.network.NetworkFacade;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
@@ -120,6 +121,7 @@ public class LogAlertSocket implements Closeable {
             logNetworkConnectError("Could not create addr info with");
         } else {
             socketFd = nf.socketTcp(true);
+            Net.configureKeepAlive(socketFd);
             if (socketFd > -1) {
                 if (nf.connectAddrInfo(socketFd, addressInfoAddr) != 0) {
                     logNetworkConnectError("Could not connect with");

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -333,7 +333,7 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
             if (rcvBufSize > 0) {
                 nf.setRcvBuf(fd, rcvBufSize);
             }
-            Net.configureKeepAlive(fd);
+            nf.configureKeepAlive(fd);
 
             LOG.info().$("connected [ip=").$ip(nf.getPeerIP(fd)).$(", fd=").$(fd).I$();
             tlConCount = connectionCount.incrementAndGet();

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -333,6 +333,7 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
             if (rcvBufSize > 0) {
                 nf.setRcvBuf(fd, rcvBufSize);
             }
+            Net.configureKeepAlive(fd);
 
             LOG.info().$("connected [ip=").$ip(nf.getPeerIP(fd)).$(", fd=").$(fd).I$();
             tlConCount = connectionCount.incrementAndGet();

--- a/core/src/main/java/io/questdb/network/Net.java
+++ b/core/src/main/java/io/questdb/network/Net.java
@@ -287,12 +287,10 @@ public final class Net {
     }
 
     public static int socketTcp(boolean blocking) {
-        int fd = Files.bumpFileCount(socketTcp0(blocking));
-        configureKeepAlive(fd);
-        return fd;
+        return Files.bumpFileCount(socketTcp0(blocking));
     }
 
-    private static void configureKeepAlive(int fd) {
+    public static void configureKeepAlive(int fd) {
         if (TCP_KEEPALIVE_SECONDS < 0 || fd < 0) {
             return;
         }

--- a/core/src/main/java/io/questdb/network/NetworkFacade.java
+++ b/core/src/main/java/io/questdb/network/NetworkFacade.java
@@ -122,6 +122,8 @@ public interface NetworkFacade {
 
     int socketTcp(boolean blocking);
 
+    void configureKeepAlive(int fd);
+
     int socketUdp();
 
     /**

--- a/core/src/main/java/io/questdb/network/NetworkFacadeImpl.java
+++ b/core/src/main/java/io/questdb/network/NetworkFacadeImpl.java
@@ -265,6 +265,11 @@ public class NetworkFacadeImpl implements NetworkFacade {
     }
 
     @Override
+    public void configureKeepAlive(int fd) {
+        Net.configureKeepAlive(fd);
+    }
+
+    @Override
     public int socketUdp() {
         return Net.socketUdp();
     }


### PR DESCRIPTION
MacOS TCP/IP stack sometimes stops listening on a server socket when we set KeepAlive. To avoid that we configure KeepAlive on server sockets only after `accept()`, never on `serverFd`.