### PR TITLE
fix(http): prometheus exporter occasionally fails to send all metrics

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
@@ -54,6 +54,11 @@ public class PrometheusMetricsProcessor implements HttpRequestProcessor {
     }
 
     @Override
+    public void resumeSend(HttpConnectionContext context) throws PeerDisconnectedException, PeerIsSlowToReadException {
+        context.resumeResponseSend();
+    }
+
+    @Override
     public boolean requiresAuthentication() {
         return requiresAuthentication;
     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
@@ -47,6 +47,7 @@ public class HttpMinTestBuilder {
 
     private static final Log LOG = LogFactory.getLog(HttpMinTestBuilder.class);
     private Scrapable scrapable;
+    private int tcpSndBufSize;
     private TemporaryFolder temp;
 
     public void run(HttpQueryTestBuilder.HttpClientCode code) throws Exception {
@@ -54,6 +55,7 @@ public class HttpMinTestBuilder {
             final String baseDir = temp.getRoot().getAbsolutePath();
             final DefaultHttpServerConfiguration httpConfiguration = new HttpServerConfigurationBuilder()
                     .withBaseDir(temp.getRoot().getAbsolutePath())
+                    .withTcpSndBufSize(tcpSndBufSize)
                     .build();
 
             final WorkerPool workerPool = new TestWorkerPool(1);
@@ -89,6 +91,11 @@ public class HttpMinTestBuilder {
 
     public HttpMinTestBuilder withScrapable(Scrapable scrapable) {
         this.scrapable = scrapable;
+        return this;
+    }
+
+    public HttpMinTestBuilder withTcpSndBufSize(int tcpSndBufSize) {
+        this.tcpSndBufSize = tcpSndBufSize;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
@@ -55,12 +55,18 @@ public class HttpServerConfigurationBuilder {
     private int sendBufferSize = 1024 * 1024;
     private boolean serverKeepAlive = true;
     private Boolean staticContentAuthRequired;
+    private int tcpSndBufSize;
 
     public DefaultHttpServerConfiguration build() {
         final IODispatcherConfiguration ioDispatcherConfiguration = new DefaultIODispatcherConfiguration() {
             @Override
             public NetworkFacade getNetworkFacade() {
                 return nf;
+            }
+
+            @Override
+            public int getSndBufSize() {
+                return tcpSndBufSize == 0 ? super.getSndBufSize() : tcpSndBufSize;
             }
         };
 
@@ -323,6 +329,11 @@ public class HttpServerConfigurationBuilder {
 
     public HttpServerConfigurationBuilder withStaticContentAuthRequired(boolean staticContentAuthRequired) {
         this.staticContentAuthRequired = staticContentAuthRequired;
+        return this;
+    }
+
+    public HttpServerConfigurationBuilder withTcpSndBufSize(int tcpSndBufSize) {
+        this.tcpSndBufSize = tcpSndBufSize;
         return this;
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -32,6 +32,7 @@ import io.questdb.metrics.*;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.Chars;
+import io.questdb.std.Os;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
@@ -82,6 +83,8 @@ public class MetricsIODispatcherTest {
                 .run(engine -> {
                     try (HttpClient client = HttpClientFactory.newInstance();
                          HttpClient.ResponseHeaders response = client.newRequest().GET().url("/metrics").send("localhost", DefaultIODispatcherConfiguration.INSTANCE.getBindPort())) {
+
+                        Os.sleep(1000); // wait before consuming response to increase chances of server filling up its tcp send buffer
 
                         response.await(5_000);
                         TestUtils.assertEquals("200", response.getStatusCode());

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -24,9 +24,18 @@
 
 package io.questdb.test.cutlass.http;
 
+import io.questdb.cutlass.http.client.Chunk;
+import io.questdb.cutlass.http.client.ChunkedResponse;
+import io.questdb.cutlass.http.client.HttpClient;
+import io.questdb.cutlass.http.client.HttpClientFactory;
 import io.questdb.metrics.*;
+import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.Chars;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.StringSink;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,6 +61,43 @@ public class MetricsIODispatcherTest {
             .withTimeout(10 * 60 * 1000, TimeUnit.MILLISECONDS)
             .withLookingForStuckThread(true)
             .build();
+
+    @Test
+    public void testPrometheusLongOutput() throws Exception {
+        int metricCount = 10_000;
+
+        MetricsRegistry metrics = new MetricsRegistryImpl();
+        for (int i = 0; i < metricCount; i++) {
+            metrics.newCounter("testMetrics" + i).add(i);
+        }
+        StringBuilder expectedResponse = new StringBuilder();
+        for (int i = 0; i < metricCount; i++) {
+            expectedResponse.append("# TYPE questdb_testMetrics").append(i).append("_total counter").append("\n");
+            expectedResponse.append("questdb_testMetrics").append(i).append("_total ").append(i).append("\n").append("\n");
+        }
+
+        new HttpMinTestBuilder()
+                .withTempFolder(temp)
+                .withScrapable(metrics)
+                .run(engine -> {
+                    try (HttpClient client = HttpClientFactory.newInstance();
+                         HttpClient.ResponseHeaders response = client.newRequest().GET().url("/metrics").send("localhost", DefaultIODispatcherConfiguration.INSTANCE.getBindPort())) {
+
+                        response.await(5_000);
+                        TestUtils.assertEquals("200", response.getStatusCode());
+
+                        Assert.assertTrue(response.isChunked());
+                        ChunkedResponse chunkedResponse = response.getChunkedResponse();
+                        StringSink responseSink = new StringSink();
+
+                        Chunk chunk;
+                        while ((chunk = chunkedResponse.recv(5_000)) != null) {
+                            Chars.utf8toUtf16(chunk.lo(), chunk.hi(), responseSink);
+                        }
+                        TestUtils.assertEquals(expectedResponse, responseSink);
+                    }
+                });
+    }
 
     @Test
     public void testPrometheusTextFormat() throws Exception {

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -80,6 +80,7 @@ public class MetricsIODispatcherTest {
         new HttpMinTestBuilder()
                 .withTempFolder(temp)
                 .withScrapable(metrics)
+                .withTcpSndBufSize(1024)
                 .run(engine -> {
                     try (HttpClient client = HttpClientFactory.newInstance();
                          HttpClient.ResponseHeaders response = client.newRequest().GET().url("/metrics").send("localhost", DefaultIODispatcherConfiguration.INSTANCE.getBindPort())) {


### PR DESCRIPTION
The PrometheusMetricsProcessor wasn't handling resumes after `PeerIsSlowToReadException`.

There is still a theoretical problem when metrics do not fit into the application http buffer, but given the buffer size is 2MB by default the metrics fit in practice.