### PR TITLE
chore(core): PG-specific user enabled check

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -154,6 +154,4 @@ public interface SecurityContext {
     default CharSequence getSessionPrincipal() {
         return getPrincipal();
     }
-
-    boolean isEnabled();
 }

--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -140,6 +140,15 @@ public interface SecurityContext {
 
     void authorizeUnassignServiceAccount(CharSequence serviceAccountName);
 
+    /**
+     * Should throw an exception if:
+     * - logged in as a user and the user has been disabled,
+     * - logged in as a service account and the service account has been disabled,
+     * - logged in as a user, then assumed a service account and either the user or the service account has been disabled,
+     *      or access to the service account has been revoked from the user
+     */
+    void checkEntityEnabled();
+
     void exitServiceAccount(CharSequence serviceAccountName);
 
     /**

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -251,6 +251,10 @@ public class AllowAllSecurityContext implements SecurityContext {
     }
 
     @Override
+    public void checkEntityEnabled() {
+    }
+
+    @Override
     public void exitServiceAccount(CharSequence serviceAccountName) {
     }
 

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContext.java
@@ -258,9 +258,4 @@ public class AllowAllSecurityContext implements SecurityContext {
     public String getPrincipal() {
         return Constants.USER_NAME;
     }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
 }

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -302,9 +302,4 @@ public class ReadOnlySecurityContext implements SecurityContext {
     public CharSequence getPrincipal() {
         return Constants.USER_NAME;
     }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
 }

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContext.java
@@ -294,6 +294,10 @@ public class ReadOnlySecurityContext implements SecurityContext {
     }
 
     @Override
+    public void checkEntityEnabled() {
+    }
+
+    @Override
     public void exitServiceAccount(CharSequence serviceAccountName) {
         throw CairoException.authorization().put("Write permission denied").setCacheable(true);
     }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1814,6 +1814,11 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             throw BadProtocolException.INSTANCE;
         }
 
+        // this check is exactly the same as the one run inside security context on every permission checks.
+        // however, this will run even if the command to be executed does not require permission checks.
+        // this is useful in case a disabled user intends to hammer the database with queries which do not require authorization.
+        sqlExecutionContext.getSecurityContext().checkEntityEnabled();
+
         // msgLen does not take into account type byte
         if (msgLen > len - 1) {
             // When this happens we need to shift our receive buffer left

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1814,10 +1814,6 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             throw BadProtocolException.INSTANCE;
         }
 
-        if (!sqlExecutionContext.getSecurityContext().isEnabled()) {
-            throw CairoException.entityIsDisabled(sqlExecutionContext.getSecurityContext().getPrincipal());
-        }
-
         // msgLen does not take into account type byte
         if (msgLen > len - 1) {
             // When this happens we need to shift our receive buffer left


### PR DESCRIPTION
rework PG-specific user enabled check.
instead of returning a boolean and throw exception, just throw the exception inside the check.
this makes it possible to reuse some code, and also to add the right entity name to the error message when user assumes a service account and the user gets disabled.

required by https://github.com/questdb/questdb-enterprise/pull/183