### PR TITLE
fix(sql): better error reporting of some implicit casting failures

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ImplicitCastException.java
+++ b/core/src/main/java/io/questdb/cairo/ImplicitCastException.java
@@ -33,6 +33,17 @@ public class ImplicitCastException extends RuntimeException implements Flyweight
     private static final StackTraceElement[] EMPTY_STACK_TRACE = {};
     private static final ThreadLocal<ImplicitCastException> tlException = new ThreadLocal<>(ImplicitCastException::new);
     protected final StringSink message = new StringSink();
+    private int position;
+
+    @Override
+    public int getPosition() {
+        return position;
+    }
+
+    public ImplicitCastException setPosition(int position) {
+        this.position = position;
+        return this;
+    }
 
     public static ImplicitCastException inconvertibleValue(double value, int fromType, int toType) {
         return instance().put("inconvertible value: ")
@@ -107,6 +118,7 @@ public class ImplicitCastException extends RuntimeException implements Flyweight
         // This is to have correct stack trace in local debugging with -ea option
         assert (ex = new ImplicitCastException()) != null;
         ex.message.clear();
+        ex.position = 0;
         return ex;
     }
 

--- a/core/src/main/java/io/questdb/griffin/FunctionParser.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionParser.java
@@ -796,6 +796,13 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor, Mutab
                 }
             } else if (argTypeTag == ColumnType.UUID && sigArgTypeTag == ColumnType.STRING) {
                 args.setQuick(k, new CastUuidToStrFunctionFactory.Func(arg));
+            } else if (argTypeTag == ColumnType.STRING && sigArgTypeTag == ColumnType.LONG && arg.isConstant()) {
+                CharSequence str = arg.getStr(null);
+                try {
+                    args.setQuick(k, LongConstant.newInstance(SqlUtil.implicitCastStrAsLong(str)));
+                } catch (ImplicitCastException e) {
+                    throw e.setPosition(argPositions.getQuick(k));
+                }
             }
         }
         return checkAndCreateFunction(candidate, args, argPositions, node, configuration);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToLongFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToLongFunctionFactory.java
@@ -50,7 +50,7 @@ public class CastStrToLongFunctionFactory implements FunctionFactory {
         return new Func(args.getQuick(0));
     }
 
-    private static class Func extends AbstractCastToLongFunction {
+    public static class Func extends AbstractCastToLongFunction {
         public Func(Function arg) {
             super(arg);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToLongFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToLongFunctionFactory.java
@@ -50,7 +50,7 @@ public class CastStrToLongFunctionFactory implements FunctionFactory {
         return new Func(args.getQuick(0));
     }
 
-    public static class Func extends AbstractCastToLongFunction {
+    private static class Func extends AbstractCastToLongFunction {
         public Func(Function arg) {
             super(arg);
         }


### PR DESCRIPTION
Implicit casting of string constants is very common, we should report a nice error. This is an imperfect fix as it does not solve all cases, but it should cover the common case.

Also: even when casting is successful this will avoid casting the constant for every row.  