### PR TITLE
fix(sql): fix sql error [col in (1,2)] when col is type short

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InLongFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InLongFunctionFactory.java
@@ -128,7 +128,7 @@ public class InLongFunctionFactory implements FunctionFactory {
 
         @Override
         public boolean getBool(Record rec) {
-            long ts = tsFunc.getTimestamp(rec);
+            long ts = tsFunc.getLong(rec);
             return negated != inList.binarySearch(ts, BinarySearch.SCAN_UP) >= 0;
         }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3226,6 +3226,20 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testInShortByteIntLong() throws Exception {
+        ddl("CREATE table abc (aa long, a int, b short, c byte)");
+        insert("insert into abc values(1, 1, 1, 1)");
+        assertSql("aa\ta\tb\tc\n" +
+                "1\t1\t1\t1\n", "select * from abc where aa in (1, 2)");
+        assertSql("aa\ta\tb\tc\n" +
+                "1\t1\t1\t1\n", "select * from abc where a in (1, 2)");
+        assertSql("aa\ta\tb\tc\n" +
+                "1\t1\t1\t1\n", "select * from abc where b in (1, 2)");
+        assertSql("aa\ta\tb\tc\n" +
+                "1\t1\t1\t1\n", "select * from abc where c in (1, 2)");
+    }
+
+    @Test
     public void testInnerJoinConditionPushdown() throws Exception {
         assertMemoryLeak(() -> {
             compile("create table tab ( created timestamp, value long ) timestamp(created) ");

--- a/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
@@ -172,7 +172,7 @@ public class LogAlertSocketTest {
             final SOCountDownLatch haltLatch = new SOCountDownLatch(1);
             final CyclicBarrier startBarrier = new CyclicBarrier(2);
             final MockAlertTarget server = new MockAlertTarget(
-                    0,
+                    9863,
                     haltLatch::countDown,
                     () -> TestUtils.await(startBarrier)
             );


### PR DESCRIPTION
Fixes `UnsupportedOperationException` when running 

```SQL
CREATE table abc (a int, b short) 

insert into abc values(1, 2)

select * from abc where a in (1, 2)

```