### PR TITLE
test(http): increase Socket timeout in MockAlertTarget

### DIFF
--- a/core/src/test/java/io/questdb/test/log/MockAlertTarget.java
+++ b/core/src/test/java/io/questdb/test/log/MockAlertTarget.java
@@ -33,7 +33,7 @@ import java.net.Socket;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class MockAlertTarget extends Thread {
-
+    private static final int SO_TIMEOUT = 20_000;
     static final String ACK = "Ack";
     static final String DEATH_PILL = "]"; // /alert-manager-tpt.json ends with "]\n"
 
@@ -66,7 +66,7 @@ class MockAlertTarget extends Thread {
                 // setup server socket and accept client
                 serverSkt = new ServerSocket(portNumber);
                 serverSkt.setReuseAddress(true);
-                serverSkt.setSoTimeout(5000);
+                serverSkt.setSoTimeout(SO_TIMEOUT);
                 if (portNumber == 0) {
                     portNumber = serverSkt.getLocalPort();
                 }
@@ -77,7 +77,7 @@ class MockAlertTarget extends Thread {
                 in = new BufferedReader(new InputStreamReader(clientSkt.getInputStream()));
                 out = new PrintWriter(clientSkt.getOutputStream(), true);
 
-                clientSkt.setSoTimeout(5000);
+                clientSkt.setSoTimeout(SO_TIMEOUT);
 
                 clientSkt.setTcpNoDelay(true);
                 clientSkt.setKeepAlive(false);


### PR DESCRIPTION
This tests is failing often, I noticed all failed runs run almost exactly 5 seconds, which happens to be the old timeout.

This is from one of the failure log:
```
2023-10-26T08:22:59.7428640Z 2023-10-26T08:22:59.727683Z I i.q.t.TestListener >>>> io.questdb.test.log.LogAlertSocketTest.testFailOverSingleHost
2023-10-26T08:23:04.8725310Z 2023-10-26T08:23:04.735514Z E i.q.t.l.MockAlertTarget
2023-10-26T08:23:04.8786480Z java.net.SocketTimeoutException: Accept timed out
2023-10-26T08:23:04.9378960Z 	at java.net.PlainSocketImpl.socketAccept(Native Method)
2023-10-26T08:23:04.9395110Z 	at java.net.AbstractPlainSocketImpl.accept(AbstractPlainSocketImpl.java:474)
2023-10-26T08:23:04.9398350Z 	at java.net.ServerSocket.implAccept(ServerSocket.java:565)
2023-10-26T08:23:04.9400790Z 	at java.net.ServerSocket.accept(ServerSocket.java:533)
2023-10-26T08:23:04.9403210Z 	at io.questdb.test.log.MockAlertTarget.run(MockAlertTarget.java:75)
2023-10-26T08:23:04.9405910Z 2023-10-26T08:23:04.741607Z I i.q.t.l.LogAlertSocketTest Added alert manager [0]: 127.0.0.1 (127.0.0.1):49442
2023-10-26T08:23:04.9412190Z 2023-10-26T08:23:04.742303Z I i.q.t.l.LogAlertSocketTest Could not connect with [0] 127.0.0.1:49442 [errno=61]
2023-10-26T08:23:04.9419220Z 2023-10-26T08:23:04.742372Z I i.q.t.l.LogAlertSocketTest Failing over from [0] 127.0.0.1:49442 to [0] 127.0.0.1:49442 with a delay of 250 millis (as it is the same alert manager)
2023-10-26T08:23:05.1053330Z 2023-10-26T08:23:05.085308Z I i.q.t.l.LogAlertSocketTest Could not connect with [0] 127.0.0.1:49442 [errno=61]
2023-10-26T08:23:05.1706560Z 2023-10-26T08:23:05.085363Z I i.q.t.l.LogAlertSocketTest Failing over from [0] 127.0.0.1:49442 to [0] 127.0.0.1:49442 with a delay of 250 millis (as it is the same alert manager)
2023-10-26T08:23:05.4945010Z 2023-10-26T08:23:05.455004Z I i.q.t.l.LogAlertSocketTest Could not connect with [0] 127.0.0.1:49442 [errno=61]
2023-10-26T08:23:05.5007850Z 2023-10-26T08:23:05.455112Z I i.q.t.l.LogAlertSocketTest None of the configured alert managers are accepting alerts.
2023-10-26T08:23:05.5022120Z Giving up sending after 2 attempts: [POST /api/v1/alerts HTTP/1.1
```

You can see the `serverSocket.accept()` timeouts before there is even an attempt to connect to it. I'm assuming a JVM/OS hiccup(?) delayed the main thread so the MockServer `accept()` timed out and the subsequent `send()` could not send anything, because at that point there was nobody ready to accept new connections.