### PR TITLE
fix(sql): fix error on UPDATE statement with WAL tables after ALTER

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3121,7 +3121,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
     private RecordCursorFactory generateSelectCursor(
             @Transient QueryModel model,
-            @Transient SqlExecutionContext executionContext) throws SqlException {
+            @Transient SqlExecutionContext executionContext
+    ) throws SqlException {
         // sql parser ensures this type of model always has only one column
         return new RecordAsAFieldRecordCursorFactory(
                 generate(model.getNestedModel(), executionContext),
@@ -3799,12 +3800,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
 
         final TableToken tableToken = executionContext.getTableToken(tab);
-        if (model.isUpdate() && !executionContext.isWalApplication()) {
-            try (
-                    TableReader reader = executionContext.getReader(tableToken);
-                    TableRecordMetadata metadata = engine.getMetadata(tableToken, model.getMetadataVersion())
-            ) {
-                return generateTableQuery0(model, executionContext, latestBy, supportsRandomAccess, reader, metadata);
+        if (model.isUpdate() && !executionContext.isWalApplication() && executionContext.getCairoEngine().isWalTable(tableToken)) {
+            try (TableRecordMetadata metadata = engine.getMetadata(tableToken, model.getMetadataVersion())) {
+                return generateTableQuery0(model, executionContext, latestBy, supportsRandomAccess, null, metadata);
             }
         } else {
             try (TableReader reader = executionContext.getReader(tableToken, model.getMetadataVersion())) {
@@ -3818,7 +3816,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             @Transient SqlExecutionContext executionContext,
             ObjList<ExpressionNode> latestBy,
             boolean supportsRandomAccess,
-            @Transient TableReader reader,
+            @Transient @Nullable TableReader reader,
             @Transient TableRecordMetadata metadata
     ) throws SqlException {
         // create metadata based on top-down columns that are required
@@ -3894,11 +3892,25 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             }
         }
 
-        GenericRecordMetadata dfcFactoryMeta = GenericRecordMetadata.deepCopyOf(reader.getMetadata());
+        if (reader == null) {
+            // This is WAL serialisation compilation. We don't need to read data from table
+            // and don't need optimisation for query validation.
+            return new AbstractRecordCursorFactory(myMeta) {
+                @Override
+                public boolean recordCursorSupportsRandomAccess() {
+                    return false;
+                }
+
+                @Override
+                public boolean supportsUpdateRowId(TableToken tableToken) {
+                    return metadata.getTableToken() == tableToken;
+                }
+            };
+        }
+
+        GenericRecordMetadata dfcFactoryMeta = GenericRecordMetadata.deepCopyOf(metadata);
         final int latestByColumnCount = prepareLatestByColumnIndexes(latestBy, myMeta);
-        // Reader TableToken can have out of date table name in getLoggingName().
-        // We need to resolve it from the engine to get correct value.
-        final TableToken tableToken = reader.getTableToken();
+        final TableToken tableToken = metadata.getTableToken();
 
         final ExpressionNode withinExtracted = whereClauseParser.extractWithin(
                 model,


### PR DESCRIPTION
Fix transient `NullPointerException` when WAL table is updated with the filter by symbol column shortly after ALTER table renames this symbol column.

```
2023-10-26T11:44:35.5430250Z java.lang.NullPointerException
2023-10-26T11:44:35.5430791Z 	at io.questdb.griffin.SqlCodeGenerator.generateTableQuery0(SqlCodeGenerator.java:4117)
2023-10-26T11:44:35.5431603Z 	at io.questdb.griffin.SqlCodeGenerator.generateTableQuery(SqlCodeGenerator.java:3807)
2023-10-26T11:44:35.5432379Z 	at io.questdb.griffin.SqlCodeGenerator.generateNoSelect(SqlCodeGenerator.java:2208)
2023-10-26T11:44:35.5433133Z 	at io.questdb.griffin.SqlCodeGenerator.generateSelect(SqlCodeGenerator.java:2764)
2023-10-26T11:44:35.5433878Z 	at io.questdb.griffin.SqlCodeGenerator.generateQuery0(SqlCodeGenerator.java:2357)
2023-10-26T11:44:35.5434615Z 	at io.questdb.griffin.SqlCodeGenerator.generateQuery(SqlCodeGenerator.java:2345)
2023-10-26T11:44:35.5435364Z 	at io.questdb.griffin.SqlCodeGenerator.generateSubQuery(SqlCodeGenerator.java:3783)
2023-10-26T11:44:35.5436154Z 	at io.questdb.griffin.SqlCodeGenerator.generateSelectVirtual(SqlCodeGenerator.java:3483)
2023-10-26T11:44:35.5436930Z 	at io.questdb.griffin.SqlCodeGenerator.generateSelect(SqlCodeGenerator.java:2753)
2023-10-26T11:44:35.5437681Z 	at io.questdb.griffin.SqlCodeGenerator.generateQuery0(SqlCodeGenerator.java:2357)
2023-10-26T11:44:35.5438418Z 	at io.questdb.griffin.SqlCodeGenerator.generateQuery(SqlCodeGenerator.java:2345)
2023-10-26T11:44:35.5439124Z 	at io.questdb.griffin.SqlCodeGenerator.generate(SqlCodeGenerator.java:201)
2023-10-26T11:44:35.5439857Z 	at com.questdb.griffin.EntSqlCompilerImpl.generateFactory(EntSqlCompilerImpl.java:396)
2023-10-26T11:44:35.5440761Z 	at io.questdb.griffin.SqlCompilerImpl.prepareForUpdate(SqlCompilerImpl.java:2389)
2023-10-26T11:44:35.5441678Z 	at io.questdb.griffin.SqlCompilerImpl.generateUpdate(SqlCompilerImpl.java:2007)
2023-10-26T11:44:35.5442706Z 	at io.questdb.griffin.SqlCompilerImpl.compileUsingModel(SqlCompilerImpl.java:1458)
2023-10-26T11:44:35.5444499Z 	at io.questdb.griffin.SqlCompilerImpl.compileInner(SqlCompilerImpl.java:1408)
2023-10-26T11:44:35.5445550Z 	at io.questdb.griffin.SqlCompilerImpl.compile(SqlCompilerImpl.java:231)
2023-10-26T11:44:35.5446249Z 	at io.questdb.cairo.pool.SqlCompilerPool$C.compile(SqlCompilerPool.java:98)
2023-10-26T11:44:35.5447040Z 	at io.questdb.cutlass.pgwire.PGConnectionContext.compileQuery(PGConnectionContext.java:1323)
2023-10-26T11:44:35.5447905Z 	at io.questdb.cutlass.pgwire.PGConnectionContext.parseQueryText(PGConnectionContext.java:1926)
2023-10-26T11:44:35.5448766Z 	at io.questdb.cutlass.pgwire.PGConnectionContext.processParse(PGConnectionContext.java:2439)
2023-10-26T11:44:35.5449586Z 	at io.questdb.cutlass.pgwire.PGConnectionContext.parse(PGConnectionContext.java:1861)
2023-10-26T11:44:35.5450442Z 	at io.questdb.cutlass.pgwire.PGConnectionContext.handleClientOperation(PGConnectionContext.java:515)
2023-10-26T11:44:35.5451252Z 	at io.questdb.cutlass.pgwire.PGWireServer$1.lambda$$0(PGWireServer.java:86)
2023-10-26T11:44:35.5451998Z 	at io.questdb.network.AbstractIODispatcher.processIOQueue(AbstractIODispatcher.java:199)
2023-10-26T11:44:35.5452720Z 	at io.questdb.cutlass.pgwire.PGWireServer$1.run(PGWireServer.java:124)
2023-10-26T11:44:35.5453415Z 	at io.questdb.mp.Worker.run(Worker.java:148)

```