### PR TITLE
chore(core): fix flaky LineTcpReceiverTest.testRenameTable()

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -708,7 +708,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     weather + ",location=north,source=sensor4 temp=70 1465839830101000200\n" +
                     meteorology + ",location=south temperature=80 1465839830101000200\n";
 
-            sendWaitWalReleaseCount(lineData, 3);
+            sendWaitWalReleaseCount(lineData, 4);
 
             mayDrainWalQueue();
 


### PR DESCRIPTION
asserting on the data should happen after the 4th WalWriter release, not after the 3rd.

the 4 WalWriter release on the log:
```
2023-10-04T12:29:00.8040948Z 2023-10-04T12:29:00.803778Z I i.q.t.c.l.t.LineTcpReceiverTest === released WAL writer === weather~1:meteorology
2023-10-04T12:29:00.8116531Z 2023-10-04T12:29:00.811299Z I i.q.t.c.l.t.LineTcpReceiverTest === released WAL writer === weather~1:meteorology
2023-10-04T12:29:00.8294231Z 2023-10-04T12:29:00.828671Z I i.q.t.c.l.t.LineTcpReceiverTest === released WAL writer === weather~1:meteorology
2023-10-04T12:29:00.8417991Z 2023-10-04T12:29:00.841487Z I i.q.t.c.l.t.LineTcpReceiverTest === released WAL writer === weather~2:weather
```