### PR TITLE
fix(sql): fix symbol value comparison with <, <=, >, >= operators

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtStrFunctionFactory.java
@@ -111,7 +111,7 @@ public class LtStrFunctionFactory implements FunctionFactory {
 
         @Override
         public void toPlan(PlanSink sink) {
-            sink.val(constant);
+            sink.val('\'').val(constant).val('\'');
             if (negated) {
                 sink.val(">=");
             } else {
@@ -161,7 +161,7 @@ public class LtStrFunctionFactory implements FunctionFactory {
             } else {
                 sink.val("<");
             }
-            sink.val(constant);
+            sink.val('\'').val(constant).val('\'');
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/CompiledFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CompiledFilterTest.java
@@ -476,6 +476,36 @@ public class CompiledFilterTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testSymbolComparison() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table test (s symbol)");
+            insert("insert into test values ('C'), ('B'), ('A')");
+
+            assertSql("s\nB\nA\n", "select s from test where s <  'C'");
+            assertSql("s\nC\nB\nA\n", "select s from test where s <= 'C'");
+            assertSql("s\n", "select s from test where s >  'C'");
+            assertSql("s\nC\n", "select s from test where s >= 'C'");
+
+            assertSql("s\nA\n", "select s from test where s <  'B'");
+            assertSql("s\nB\nA\n", "select s from test where s <= 'B'");
+            assertSql("s\nC\n", "select s from test where s >  'B'");
+            assertSql("s\nC\nB\n", "select s from test where s >= 'B'");
+
+            assertSql("s\n", "select s from test where s <  'A'");
+            assertSql("s\nA\n", "select s from test where s <= 'A'");
+            assertSql("s\nC\nB\n", "select s from test where s >  'A'");
+            assertSql("s\nC\nB\nA\n", "select s from test where s >= 'A'");
+
+            assertSql("s\nC\nB\nA\n", "select s from test where s <  'Z'");
+            assertSql("s\nC\nB\nA\n", "select s from test where s <= 'Z'");
+            assertSql("s\n", "select s from test where s >  'Z'");
+            assertSql("s\n", "select s from test where s >= 'Z'");
+
+            assertSql("s\n", "select s from test where s <  null");
+        });
+    }
+
     private void indexBindVariableReplacedContext(boolean jit) throws SqlException {
 
         bindVariableService.clear();

--- a/core/src/test/java/io/questdb/test/jit/CompiledFilterIRSerializerTest.java
+++ b/core/src/test/java/io/questdb/test/jit/CompiledFilterIRSerializerTest.java
@@ -207,7 +207,7 @@ public class CompiledFilterIRSerializerTest extends BaseFunctionFactoryTest {
         Map<String, String[]> typeToColumn = new HashMap<>();
         typeToColumn.put("i8", new String[]{"aboolean", "abyte", "ageobyte"});
         typeToColumn.put("i16", new String[]{"ashort", "ageoshort", "achar"});
-        typeToColumn.put("i32", new String[]{"anint", "ageoint", "asymbol"});
+        typeToColumn.put("i32", new String[]{"anint", "ageoint"/*, "asymbol"*/});
         typeToColumn.put("i64", new String[]{"along", "ageolong", "adate", "atimestamp"});
         typeToColumn.put("i128", new String[]{"auuid", "along128"});
         typeToColumn.put("f32", new String[]{"afloat"});


### PR DESCRIPTION
Fixes #3828 

PR rejects <, <=, >, >= operator serialization with symbol arguments because they require string value comparison and JIT doesn't handle string types yet. 