### PR TITLE
fix(sql): fix modulo int operator result with nulls

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/RemIntFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/RemIntFunctionFactory.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.IntFunction;
 import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class RemIntFunctionFactory implements FunctionFactory {
@@ -58,7 +59,15 @@ public class RemIntFunctionFactory implements FunctionFactory {
 
         @Override
         public int getInt(Record rec) {
-            return left.getInt(rec) % right.getInt(rec);
+            int l = this.left.getInt(rec);
+            if (l == Numbers.INT_NaN) {
+                return Numbers.INT_NaN;
+            }
+            int r = this.right.getInt(rec);
+            if (r == 0 || r == Numbers.INT_NaN) {
+                return Numbers.INT_NaN;
+            }
+            return l % r;
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/math/RemIntFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/math/RemIntFunctionFactoryTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.math;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.math.RemIntFunctionFactory;
+import io.questdb.std.Numbers;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class RemIntFunctionFactoryTest extends AbstractFunctionFactoryTest {
+    @Test
+    public void testDivByZero() throws SqlException {
+        call(10, 0).andAssert(Numbers.INT_NaN);
+    }
+
+    @Test
+    public void testLeftNan() throws SqlException {
+        call(Numbers.INT_NaN, 5).andAssert(Numbers.INT_NaN);
+    }
+
+    @Test
+    public void testRightNan() throws SqlException {
+        call(123, Numbers.INT_NaN).andAssert(Numbers.INT_NaN);
+    }
+
+    @Test
+    public void testSimple() throws SqlException {
+        call(10, 4).andAssert(2);
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new RemIntFunctionFactory();
+    }
+}


### PR DESCRIPTION
Fixes #3849 

PR fixes modulo ( remainder )  operator to return null when one argument is null or divisor is 0 . 

Examples:

```sql
select null % 1;
select 1 % null;
select null % null;
select 1 % 0 ;
```
All of the above return now `null`. 