### PR TITLE
fix(sql): fix 'Invalid column' column error for columns used in non-equality join conditions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2989,15 +2989,15 @@ public class SqlOptimiser implements Mutable {
             }
         }
 
+        final ExpressionNode postJoinWhere = model.getPostJoinWhereClause();
+        if (postJoinWhere != null) {
+            emitLiteralsTopDown(postJoinWhere, model);
+        }
+
         // propagate join models columns in separate loop to catch columns added to models prior to the current one
         for (int i = 1, n = joinModels.size(); i < n; i++) {
             final QueryModel jm = joinModels.getQuick(i);
             propagateTopDownColumns0(jm, false, model, true);
-        }
-
-        final ExpressionNode postJoinWhere = model.getPostJoinWhereClause();
-        if (postJoinWhere != null) {
-            emitLiteralsTopDown(postJoinWhere, model);
         }
 
         // If this is group by model we need to add all non-selected keys, only if this is sub-query

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -4639,8 +4639,6 @@ public class ExplainPlanTest extends AbstractCairoTest {
 
     @Test
     public void testPostJoinConditionColumnsAreResolved() throws Exception {
-        test2686Prepare();
-
         assertMemoryLeak(() -> {
             String query = "SELECT count(*)\n" +
                     "FROM test as T1\n" +

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -4638,6 +4638,41 @@ public class ExplainPlanTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testPostJoinConditionColumnsAreResolved() throws Exception {
+        test2686Prepare();
+
+        assertMemoryLeak(() -> {
+            String query = "SELECT count(*)\n" +
+                    "FROM test as T1\n" +
+                    "JOIN ( SELECT * FROM test ) as T2 ON T1.event < T2.event\n" +
+                    "JOIN test as T3 ON T2.created = T3.created";
+
+            ddl("create table test (event int, created timestamp)");
+            insert("insert into test values (1, 1), (2, 2)");
+
+            assertPlan(query,
+                    "Count\n" +
+                            "    Filter filter: T1.event<T2.event\n" +
+                            "        Cross Join\n" +
+                            "            Hash Join Light\n" +
+                            "              condition: T3.created=T2.created\n" +
+                            "                DataFrame\n" +
+                            "                    Row forward scan\n" +
+                            "                    Frame forward scan on: test\n" +
+                            "                Hash\n" +
+                            "                    DataFrame\n" +
+                            "                        Row forward scan\n" +
+                            "                        Frame forward scan on: test\n" +
+                            "            DataFrame\n" +
+                            "                Row forward scan\n" +
+                            "                Frame forward scan on: test\n"
+            );
+
+            assertSql("count\n1\n", query);
+        });
+    }
+
+    @Test
     public void testRewriteAggregateWithAddition() throws Exception {
         assertMemoryLeak(() -> {
             compile("  CREATE TABLE tab ( x int );");


### PR DESCRIPTION
Fixes #3733 

PR fixes propagation of non-equality join condition columns .
Example:

```sql
create table test (event int, created timestamp);

SELECT count(*)
FROM test as T1
JOIN ( SELECT * FROM test ) as T2 ON T1.event < T2.event
JOIN test as T3 ON T2.created = T3.created;
```

returns `invalid column T2.event` error because T2.event is pushed to top-most T2 only model.