### PR TITLE
chore(core): fix reload race WAL Apply when sequencer files are updated externally

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -262,7 +262,8 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                             boolean hasNext;
                             if (structuralChangeCursor == null || !(hasNext = structuralChangeCursor.hasNext())) {
                                 Misc.free(structuralChangeCursor);
-                                structuralChangeCursor = tableSequencerAPI.getMetadataChangeLog(tableToken, newStructureVersion - 1);
+                                // Re-read the sequencer files to get the metadata change cursor.
+                                structuralChangeCursor = tableSequencerAPI.getMetadataChangeLogSlow(tableToken, newStructureVersion - 1);
                                 hasNext = structuralChangeCursor.hasNext();
                             }
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencer.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencer.java
@@ -32,7 +32,12 @@ public interface TableSequencer extends QuietCloseable {
 
     void dropTable();
 
+    // This method can return empty cursor if the structureVersionLo
+    // equals to the sequencer metadata structure version.
     TableMetadataChangeLog getMetadataChangeLog(long structureVersionLo);
+
+    // This method will always read files to get the metadata change cursor.
+    TableMetadataChangeLog getMetadataChangeLogSlow(long structureVersionLo);
 
     int getNextWalId();
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -205,6 +205,18 @@ public class TableSequencerAPI implements QuietCloseable {
         }
     }
 
+    public TableMetadataChangeLog getMetadataChangeLogSlow(final TableToken tableToken, long structureVersionLo) {
+        try (TableSequencerImpl tableSequencer = openSequencerLocked(tableToken, SequencerLockType.READ)) {
+            TableMetadataChangeLog metadataChangeLog;
+            try {
+                metadataChangeLog = tableSequencer.getMetadataChangeLogSlow(structureVersionLo);
+            } finally {
+                tableSequencer.unlockRead();
+            }
+            return metadataChangeLog;
+        }
+    }
+
     public int getNextWalId(final TableToken tableToken) {
         try (TableSequencerImpl tableSequencer = openSequencerLocked(tableToken, SequencerLockType.READ)) {
             int walId;

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -131,6 +131,13 @@ public class TableSequencerImpl implements TableSequencer {
     }
 
     @Override
+    public TableMetadataChangeLog getMetadataChangeLogSlow(long structureVersionLo) {
+        checkDropped();
+        // Do not check cached metadata version.
+        return tableTransactionLog.getTableMetadataChangeLog(structureVersionLo, alterCommandWalFormatter);
+    }
+
+    @Override
     public int getNextWalId() {
         return (int) walIdGenerator.getNextId();
     }


### PR DESCRIPTION
If the sequencer file can be updated externally, Apply WAL job can have errors 

```
could not apply structure change from WAL to table. WAL metadata change does not exist [structureVersion=1], errno=0
```

The fix is for Apply WAL job to always open fresh cursor from files without trying to optimise comparing the searched meta version with the sequencer meta version.