### PR TITLE
feat(sql): sql functions to support traffic light widget in the Web Console

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -37,6 +37,7 @@ import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.ThreadLocal;
+import java.util.Map;
 import java.util.function.LongSupplier;
 
 public interface CairoConfiguration {
@@ -139,6 +140,10 @@ public interface CairoConfiguration {
     int getDetachedMkDirMode();
 
     int getDoubleToStrCastScale();
+
+    default Map<String, String> getEnv() {
+        return System.getenv();
+    }
 
     int getExplainPoolCapacity();
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/metadata/AbstrtactEnvVariableValueFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/metadata/AbstrtactEnvVariableValueFunctionFactory.java
@@ -24,7 +24,6 @@
 
 package io.questdb.griffin.engine.functions.metadata;
 
-import io.questdb.BuildInformation;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.griffin.FunctionFactory;
@@ -35,13 +34,8 @@ import io.questdb.std.ObjList;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-public class BuildFunctionFactory implements FunctionFactory {
+public abstract class AbstrtactEnvVariableValueFunctionFactory implements FunctionFactory {
     private final AtomicReference<StrConstant> functionRef = new AtomicReference<>();
-
-    @Override
-    public String getSignature() {
-        return "build()";
-    }
 
     @Override
     public boolean isRuntimeConstant() {
@@ -58,18 +52,10 @@ public class BuildFunctionFactory implements FunctionFactory {
     ) {
         StrConstant that = functionRef.get();
         if (that == null) {
-            // we are assuming build information is constant for the instance runtime
-            final BuildInformation buildInformation = configuration.getBuildInformation();
-            final CharSequence information = "Build Information: " +
-                    buildInformation.getSwName() + " " +
-                    buildInformation.getSwVersion() +
-                    ", JDK " +
-                    buildInformation.getJdkVersion() +
-                    ", Commit Hash " +
-                    buildInformation.getCommitHash();
-
-            functionRef.set(that = new StrConstant(information));
+            functionRef.set(that = new StrConstant(configuration.getEnv().get(getEnvVariableName())));
         }
         return that;
     }
+
+    abstract protected String getEnvVariableName();
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/metadata/InstanceNameFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/metadata/InstanceNameFunctionFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.metadata;
+
+public class InstanceNameFunctionFactory extends AbstrtactEnvVariableValueFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "instance_name()";
+    }
+
+    @Override
+    protected String getEnvVariableName() {
+        return "QDB_INSTANCE_NAME";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/metadata/InstanceRGBFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/metadata/InstanceRGBFunctionFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.metadata;
+
+public class InstanceRGBFunctionFactory extends AbstrtactEnvVariableValueFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "instance_rgb()";
+    }
+
+    @Override
+    protected String getEnvVariableName() {
+        return "QDB_INSTANCE_RGB";
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -798,6 +798,8 @@ open module io.questdb {
 
             // metadata functions
             io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory,
+            io.questdb.griffin.engine.functions.metadata.InstanceNameFunctionFactory,
+            io.questdb.griffin.engine.functions.metadata.InstanceRGBFunctionFactory,
             // geohash functions
             io.questdb.griffin.engine.functions.geohash.GeoHashFromCoordinatesFunctionFactory,
             // bin functions

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -788,6 +788,8 @@ io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory
 
 # metadata functions
 io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory
+io.questdb.griffin.engine.functions.metadata.InstanceNameFunctionFactory
+io.questdb.griffin.engine.functions.metadata.InstanceRGBFunctionFactory
 
 # Bitwise operators
 io.questdb.griffin.engine.functions.math.BitwiseAndLongFunctionFactory

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -66,6 +66,7 @@ import org.junit.runner.Description;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1157,6 +1158,10 @@ public abstract class AbstractCairoTest extends AbstractTest {
 
     protected static void configOverrideMaxUncommittedRows(int maxUncommittedRows) {
         node1.getConfigurationOverrides().setMaxUncommittedRows(maxUncommittedRows);
+    }
+
+    protected static void configOverrideEnv(Map<String, String> env) {
+        node1.getConfigurationOverrides().setEnv(env);
     }
 
     protected static void configOverrideO3ColumnMemorySize(int size) {

--- a/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
@@ -36,6 +36,8 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+
 public class CairoTestConfiguration extends DefaultTestCairoConfiguration {
     private final ConfigurationOverrides overrides;
     private final TelemetryConfiguration telemetryConfiguration;
@@ -202,6 +204,11 @@ public class CairoTestConfiguration extends DefaultTestCairoConfiguration {
     @Override
     public boolean getSimulateCrashEnabled() {
         return overrides.getSimulateCrashEnabled();
+    }
+
+    @Override
+    public Map<String, String> getEnv() {
+        return overrides.getEnv();
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/ConfigurationOverrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/ConfigurationOverrides.java
@@ -31,6 +31,8 @@ import io.questdb.std.RostiAllocFacade;
 import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 
+import java.util.Map;
+
 @SuppressWarnings("unused")
 public interface ConfigurationOverrides {
     String getAttachableDirSuffix();
@@ -60,6 +62,8 @@ public interface ConfigurationOverrides {
     CharSequence getDefaultMapType();
 
     int getDefaultTableWriteMode();
+
+    Map<String, String> getEnv();
 
     FactoryProvider getFactoryProvider();
 
@@ -195,9 +199,9 @@ public interface ConfigurationOverrides {
 
     void setDefaultTableWriteMode(int defaultTableWriteMode);
 
-    void setFactoryProvider(FactoryProvider factoryProvider);
+    void setEnv(Map<String, String> env);
 
-    void setSimulateCrashEnabled(boolean enabled);
+    void setFactoryProvider(FactoryProvider factoryProvider);
 
     void setFilesFacade(FilesFacade ff);
 
@@ -254,6 +258,8 @@ public interface ConfigurationOverrides {
     void setRostiAllocFacade(RostiAllocFacade rostiAllocFacade);
 
     void setSampleByIndexSearchPageSize(int sampleByIndexSearchPageSize);
+
+    void setSimulateCrashEnabled(boolean enabled);
 
     void setSnapshotInstanceId(String snapshotInstanceId);
 

--- a/core/src/test/java/io/questdb/test/cairo/Overrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/Overrides.java
@@ -34,6 +34,8 @@ import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 
+import java.util.Map;
+
 public class Overrides implements ConfigurationOverrides {
     private String attachableDirSuffix = null;
     private CharSequence backupDir;
@@ -52,6 +54,7 @@ public class Overrides implements ConfigurationOverrides {
     private long dataAppendPageSize = -1;
     private CharSequence defaultMapType;
     private int defaultTableWriteMode = SqlWalMode.WAL_NOT_SET;
+    private Map<String, String> env = null;
     private FactoryProvider factoryProvider = null;
     private FilesFacade ff;
     private boolean hideTelemetryTable = false;
@@ -170,6 +173,11 @@ public class Overrides implements ConfigurationOverrides {
     @Override
     public int getDefaultTableWriteMode() {
         return defaultTableWriteMode;
+    }
+
+    @Override
+    public Map<String, String> getEnv() {
+        return env != null ? env : System.getenv();
     }
 
     @Override
@@ -474,6 +482,7 @@ public class Overrides implements ConfigurationOverrides {
         repeatMigrationsFromVersion = -1;
         factoryProvider = null;
         simulateCrashEnabled = false;
+        env = null;
     }
 
     @Override
@@ -551,14 +560,13 @@ public class Overrides implements ConfigurationOverrides {
         this.defaultTableWriteMode = defaultTableWriteMode;
     }
 
-    @Override
-    public void setFactoryProvider(FactoryProvider factoryProvider) {
-        this.factoryProvider = factoryProvider;
+    public void setEnv(Map<String, String> env) {
+        this.env = env;
     }
 
     @Override
-    public void setSimulateCrashEnabled(boolean enabled) {
-        this.simulateCrashEnabled = enabled;
+    public void setFactoryProvider(FactoryProvider factoryProvider) {
+        this.factoryProvider = factoryProvider;
     }
 
     @Override
@@ -699,6 +707,11 @@ public class Overrides implements ConfigurationOverrides {
     @Override
     public void setSampleByIndexSearchPageSize(int sampleByIndexSearchPageSize) {
         this.sampleByIndexSearchPageSize = sampleByIndexSearchPageSize;
+    }
+
+    @Override
+    public void setSimulateCrashEnabled(boolean enabled) {
+        this.simulateCrashEnabled = enabled;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/griffin/MetadataFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/MetadataFunctionTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetadataFunctionTest extends AbstractCairoTest {
+
+    @Test
+    public void testInstanceName() throws SqlException {
+        Map<String, String> env = new HashMap<>();
+        env.put("QDB_INSTANCE_NAME", "my instance");
+        configOverrideEnv(env);
+        assertSql(
+                "instance_name\n" +
+                        "my instance\n",
+                "select instance_name"
+        );
+    }
+
+    @Test
+    public void testInstanceRGB() throws SqlException {
+        Map<String, String> env = new HashMap<>();
+        env.put("QDB_INSTANCE_RGB", "R");
+        configOverrideEnv(env);
+        assertSql(
+                "instance_rgb\n" +
+                        "R\n",
+                "select instance_rgb"
+        );
+    }
+}


### PR DESCRIPTION
added two functions:

```sql
select instance_name
```

This function returns value of the env variable `QDB_INSTANCE_NAME`

```sql
select instance_rgb
```

This function returns instance "color", it should be one of the 3 letters, `R`, `G` or `B`. Value is read from env variable `QDB_INSTANCE_RGB`

Web console should have 3 different color schemes for each of the "colors". All colors should be shows "inverted", e.g. white text on red background
