### PR TITLE
fix(sql): fix server hang on evaluating large integer addition expression

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/AddIntFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/AddIntFunctionFactory.java
@@ -81,9 +81,11 @@ public class AddIntFunctionFactory implements FunctionFactory {
 
         @Override
         public boolean isConstant() {
-            return left.isConstant() && right.isConstant()
-                    || (left.isConstant() && left.getInt(null) == Numbers.INT_NaN)
-                    || (right.isConstant() && right.getInt(null) == Numbers.INT_NaN);
+            boolean leftIsConstant = left.isConstant();
+            boolean rightIsConstant = right.isConstant();
+            return leftIsConstant && rightIsConstant
+                    || (leftIsConstant && left.getInt(null) == Numbers.INT_NaN)
+                    || (rightIsConstant && right.getInt(null) == Numbers.INT_NaN);
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3028,8 +3028,18 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
         sink.put(" null ");
         String query = sink.toString();
 
-        assertSql("column\n" +
-                "\n", query);
+        assertSql("column\n\n", query);
+
+        sink.clear();
+        sink.put("select ");
+        for (int i = 0; i < 100; i++) {
+            sink.put("x + ");
+        }
+        sink.put(" 1 from tab");
+        query = sink.toString();
+
+        ddl("create table tab as (select 1::int x) ");
+        assertSql("column\n101\n", query);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3019,6 +3019,20 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEvaluateLargeAddIntExpression() throws Exception {
+        StringSink sink = Misc.getThreadLocalSink();
+        sink.put("select ");
+        for (int i = 0; i < 100; i++) {
+            sink.put("(rnd_uuid4()::int) + ");
+        }
+        sink.put(" null ");
+        String query = sink.toString();
+
+        assertSql("column\n" +
+                "\n", query);
+    }
+
+    @Test
     public void testExecuteQuery() throws Exception {
         assertFailure(
                 68,


### PR DESCRIPTION
Fixes #3840 

PR improves performance integer addition expression involving many non-constant elements, e.g.

```sql
select x + x + ... + x 
from tab;
```
or 
```sql
select rnd_int() + rnd_int() + ...
```

Issue was caused by AddIntFunctionFactory's recursively checking whether arguments are constant and not caching partial result .