### PR TITLE
fix(sql): maintain timestamp metadata in window factories

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3567,7 +3567,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     WindowFunction af = (WindowFunction) f;
                     functions.extendAndSet(i, f);
 
-                    //sorting  multiple passes are required, so fall back to old implementation
+                    // sorting and/or  multiple passes are required, so fall back to old implementation
                     if ((osz > 0 && !dismissOrder) || af.getPassCount() != WindowFunction.ZERO_PASS) {
                         isFastPath = false;
                         break;
@@ -3599,6 +3599,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 );
                 functions.extendAndSet(i, function);
 
+                if (baseMetadata.getTimestampIndex() != -1 &&
+                        baseMetadata.getTimestampIndex() == columnIndex) {
+                    factoryMetadata.setTimestampIndex(i);
+                }
+
                 if (Chars.equals(qc.getAst().token, qc.getAlias())) {
                     factoryMetadata.add(i, m);
                 } else {// keep alias
@@ -3612,6 +3617,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             )
                     );
                 }
+
             }
         }
 
@@ -3660,6 +3666,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 listColumnFilterB.extendAndSet(i, columnIndex);
                 intHashSet.add(columnIndex);
                 columnIndexes.extendAndSet(i, columnIndex);
+
+                if (baseMetadata.getTimestampIndex() != -1 &&
+                        baseMetadata.getTimestampIndex() == columnIndex) {
+                    factoryMetadata.setTimestampIndex(i);
+                }
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowRecordCursorFactory.java
@@ -167,6 +167,11 @@ public class CachedWindowRecordCursorFactory extends AbstractRecordCursorFactory
     }
 
     @Override
+    public int getScanDirection() {
+        return base.getScanDirection();
+    }
+
+    @Override
     public boolean recordCursorSupportsRandomAccess() {
         return base.recordCursorSupportsRandomAccess();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowRecordCursorFactory.java
@@ -92,6 +92,11 @@ public class WindowRecordCursorFactory extends AbstractRecordCursorFactory {
     }
 
     @Override
+    public int getScanDirection() {
+        return base.getScanDirection();
+    }
+
+    @Override
     public boolean recordCursorSupportsRandomAccess() {
         return false;
     }

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -8584,14 +8584,13 @@ public class ExplainPlanTest extends AbstractCairoTest {
                             ") order by ts asc",
                     expectedForwardPlan);
 
-            String expectedForwardLimitPlan = "Sort\n" +
-                    "  keys: [ts]\n" +
-                    "    Limit lo: 9223372036854775807L\n" +
-                    "        Window\n" +
-                    "          functions: [avg(usage_system) over (partition by [hostname] rows between 100 preceding and current row)]\n" +
-                    "            DataFrame\n" +
-                    "                Row forward scan\n" +
-                    "                Frame forward scan on: cpu_ts\n";
+            String expectedForwardLimitPlan =
+                    "Limit lo: 9223372036854775807L\n" +
+                            "    Window\n" +
+                            "      functions: [avg(usage_system) over (partition by [hostname] rows between 100 preceding and current row)]\n" +
+                            "        DataFrame\n" +
+                            "            Row forward scan\n" +
+                            "            Frame forward scan on: cpu_ts\n";
 
             assertPlan("select * from " +
                             "( " +
@@ -8648,14 +8647,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                             ") order by ts desc",
                     expectedBackwardPlan);
 
-            String expectedBackwardLimitPlan = "Sort\n" +
-                    "  keys: [ts desc]\n" +
-                    "    Limit lo: 9223372036854775807L\n" +
-                    "        Window\n" +
-                    "          functions: [avg(usage_system) over (partition by [hostname] rows between 100 preceding and current row)]\n" +
-                    "            DataFrame\n" +
-                    "                Row backward scan\n" +
-                    "                Frame backward scan on: cpu_ts\n";
+            String expectedBackwardLimitPlan = "Limit lo: 9223372036854775807L\n" +
+                    "    Window\n" +
+                    "      functions: [avg(usage_system) over (partition by [hostname] rows between 100 preceding and current row)]\n" +
+                    "        DataFrame\n" +
+                    "            Row backward scan\n" +
+                    "            Frame backward scan on: cpu_ts\n";
 
             assertPlan("select * from " +
                             "( " +


### PR DESCRIPTION
PR adds missing metadata to window sub-query/factory to fix e.g.  
```sql
select * from 
(
  select *, avg(t1.price) over(partition by t1.symbol rows between 50 preceding and current row) mavg 
  from trades t1
)
lt join trades  t2
```
returning 'left side of time series join has no timestamp' error .

