### PR TITLE
fix(sql): fix create table like with dedup

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1745,6 +1745,9 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable {
                     model.cached(rdr.getSymbolMapReader(i).isCached());
                 }
                 model.setIndexFlags(rdrMetadata.isColumnIndexed(i), rdrMetadata.getIndexValueBlockCapacity(i));
+                if (rdrMetadata.isDedupKey(i)) {
+                    model.setDedupKeyFlag(i);
+                }
             }
             model.setPartitionBy(SqlUtil.nextLiteral(sqlNodePool, PartitionBy.toString(rdr.getPartitionedBy()), 0));
             if (rdrMetadata.getTimestampIndex() != -1) {

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -465,6 +465,28 @@ public class CreateTableTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateTableLikeTableWithDedup() throws Exception {
+        ddl(
+                "CREATE TABLE foo (" +
+                    "ts TIMESTAMP," +
+                    "a INT,"+
+                    "b STRING"+
+                ") " +
+                "TIMESTAMP(ts) PARTITION BY DAY WAL " +
+                "DEDUP UPSERT KEYS(ts, a)"
+        );
+        ddl("create table foo_clone ( like foo)");
+        assertSql(
+                "column\ttype\tindexed\tindexBlockCapacity\tsymbolCached\tsymbolCapacity\tdesignated\tupsertKey\n" +
+                        "ts\tTIMESTAMP\tfalse\t0\tfalse\t0\ttrue\ttrue\n" +
+                        "a\tINT\tfalse\t0\tfalse\t0\tfalse\ttrue\n" +
+                        "b\tSTRING\tfalse\t0\tfalse\t0\tfalse\tfalse\n"
+                ,
+                "SHOW COLUMNS FROM foo_clone"
+        );
+    }
+
+    @Test
     public void testCreateTableParallel() throws Throwable {
         assertMemoryLeak(() -> {
             int threadCount = 2;


### PR DESCRIPTION
Fixes #3961 

The dedup flags were not being copied to the CreateTable model.