### PR TITLE
chore(core): pool generics fix

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -246,6 +246,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlColumnCastModelPoolCapacity;
     private final int sqlColumnPoolCapacity;
     private final double sqlCompactMapLoadFactor;
+    private final int sqlCompilerPoolMaxSegments;
     private final int sqlCopyBufferSize;
     private final int sqlCopyModelPoolCapacity;
     private final int sqlCreateTableModelPoolCapacity;
@@ -356,6 +357,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long writerDataIndexKeyAppendPageSize;
     private final long writerDataIndexValueAppendPageSize;
     private final long writerFileOpenOpts;
+    private final long writerMemoryLimit;
     private final long writerMiscAppendPageSize;
     private final boolean writerMixedIOEnabled;
     private final int writerTickRowsCountMod;
@@ -468,7 +470,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private boolean stringToCharCastAllowed;
     private boolean symbolAsFieldSupported;
     private long symbolCacheWaitUsBeforeReload;
-    private final long writerMemoryLimit;
 
     public PropServerConfiguration(
             String root,
@@ -844,6 +845,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.parallelIndexThreshold = getInt(properties, env, PropertyKey.CAIRO_PARALLEL_INDEX_THRESHOLD, 100000);
             this.readerPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_READER_POOL_MAX_SEGMENTS, 10);
             this.walWriterPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_WAL_WRITER_POOL_MAX_SEGMENTS, 10);
+            this.sqlCompilerPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_SQL_COMPILER_POOL_MAX_SEGMENTS, 10);
             this.spinLockTimeout = getLong(properties, env, PropertyKey.CAIRO_SPIN_LOCK_TIMEOUT, 1_000);
             this.httpSqlCacheEnabled = getBoolean(properties, env, PropertyKey.HTTP_QUERY_CACHE_ENABLED, true);
             this.httpSqlCacheBlockCount = getInt(properties, env, PropertyKey.HTTP_QUERY_CACHE_BLOCK_COUNT, 4);
@@ -1632,26 +1634,32 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_COLUMN_POOL_CAPACITY,
-                    PropertyKey.CAIRO_SQL_WINDOW_COLUMN_POOL_CAPACITY);
+                    PropertyKey.CAIRO_SQL_WINDOW_COLUMN_POOL_CAPACITY
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_STORE_PAGE_SIZE,
-                    PropertyKey.CAIRO_SQL_WINDOW_STORE_PAGE_SIZE);
+                    PropertyKey.CAIRO_SQL_WINDOW_STORE_PAGE_SIZE
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_STORE_MAX_PAGES,
-                    PropertyKey.CAIRO_SQL_WINDOW_STORE_MAX_PAGES);
+                    PropertyKey.CAIRO_SQL_WINDOW_STORE_MAX_PAGES
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_ROWID_PAGE_SIZE,
-                    PropertyKey.CAIRO_SQL_WINDOW_ROWID_PAGE_SIZE);
+                    PropertyKey.CAIRO_SQL_WINDOW_ROWID_PAGE_SIZE
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_ROWID_MAX_PAGES,
-                    PropertyKey.CAIRO_SQL_WINDOW_ROWID_MAX_PAGES);
+                    PropertyKey.CAIRO_SQL_WINDOW_ROWID_MAX_PAGES
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_TREE_PAGE_SIZE,
-                    PropertyKey.CAIRO_SQL_WINDOW_TREE_PAGE_SIZE);
+                    PropertyKey.CAIRO_SQL_WINDOW_TREE_PAGE_SIZE
+            );
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_TREE_MAX_PAGES,
-                    PropertyKey.CAIRO_SQL_WINDOW_TREE_MAX_PAGES);
-
+                    PropertyKey.CAIRO_SQL_WINDOW_TREE_MAX_PAGES
+            );
         }
 
         public ValidationResult validate(Properties properties) {
@@ -2253,6 +2261,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public double getSqlCompactMapLoadFactor() {
             return sqlCompactMapLoadFactor;
+        }
+
+        @Override
+        public int getSqlCompilerPoolMaxSegments() {
+            return sqlCompilerPoolMaxSegments;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -65,6 +65,7 @@ public enum PropertyKey implements ConfigProperty {
     CAIRO_FAST_MAP_LOAD_FACTOR("cairo.fast.map.load.factor"),
     CAIRO_SQL_JOIN_CONTEXT_POOL_CAPACITY("cairo.sql.join.context.pool.capacity"),
     CAIRO_LEXER_POOL_CAPACITY("cairo.lexer.pool.capacity"),
+    CAIRO_SQL_COMPILER_POOL_MAX_SEGMENTS("cairo.sql.compiler.pool.max.segments"),
     CAIRO_SQL_MAP_KEY_CAPACITY("cairo.sql.map.key.capacity"),
     CAIRO_SQL_SMALL_MAP_KEY_CAPACITY("cairo.sql.small.map.key.capacity"),
     CAIRO_SQL_SMALL_MAP_PAGE_SIZE("cairo.sql.small.map.page.size"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -331,6 +331,8 @@ public interface CairoConfiguration {
 
     double getSqlCompactMapLoadFactor();
 
+    int getSqlCompilerPoolMaxSegments();
+
     int getSqlCopyBufferSize();
 
     // null input root disables "copy" sql

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -522,6 +522,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getSqlCompilerPoolMaxSegments() {
+        return delegate.getSqlCompilerPoolMaxSegments();
+    }
+
+    @Override
     public int getSqlCopyBufferSize() {
         return delegate.getSqlCopyBufferSize();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -532,6 +532,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getSqlCompilerPoolMaxSegments() {
+        return 5;
+    }
+
+    @Override
     public int getSqlCopyBufferSize() {
         return 1024 * 1024;
     }

--- a/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
@@ -39,7 +39,7 @@ import io.questdb.std.Unsafe;
 import java.util.Arrays;
 import java.util.Map;
 
-public abstract class AbstractMultiTenantPool<T extends PoolTenant> extends AbstractPool implements ResourcePool<T> {
+public abstract class AbstractMultiTenantPool<T extends PoolTenant<T>> extends AbstractPool implements ResourcePool<T> {
     public static final int ENTRY_SIZE = 32;
     public final static String NO_LOCK_REASON = "unknown";
     private static final long LOCK_OWNER = Unsafe.getFieldOffset(Entry.class, "lockOwner");

--- a/core/src/main/java/io/questdb/cairo/pool/MetadataPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/MetadataPool.java
@@ -49,7 +49,7 @@ public class MetadataPool extends AbstractMultiTenantPool<MetadataPool.MetadataT
         return new TableReaderMetadataTenant(this, entry, index, tableToken, false);
     }
 
-    public interface MetadataTenant extends TableMetadata, PoolTenant {
+    public interface MetadataTenant extends TableMetadata, PoolTenant<MetadataTenant> {
     }
 
     private static class SequencerMetadataTenant extends GenericTableRecordMetadata implements MetadataTenant {
@@ -90,7 +90,6 @@ public class MetadataPool extends AbstractMultiTenantPool<MetadataPool.MetadataT
             readerMetadataTenant.close();
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public AbstractMultiTenantPool.Entry<MetadataTenant> getEntry() {
             return entry;
@@ -167,7 +166,6 @@ public class MetadataPool extends AbstractMultiTenantPool<MetadataPool.MetadataT
             super.close();
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public AbstractMultiTenantPool.Entry<MetadataTenant> getEntry() {
             return entry;

--- a/core/src/main/java/io/questdb/cairo/pool/PoolListener.java
+++ b/core/src/main/java/io/questdb/cairo/pool/PoolListener.java
@@ -46,8 +46,10 @@ public interface PoolListener {
     short EV_RETURN = 1;
     short EV_UNEXPECTED_CLOSE = 3;
     short EV_UNLOCKED = 8;
+
     byte SRC_METADATA = 3;
     byte SRC_READER = 2;
+    byte SRC_SQL_COMPILER = 6;
     byte SRC_TABLE_REGISTRY = 5;
     byte SRC_WAL_WRITER = 4;
     byte SRC_WRITER = 1;

--- a/core/src/main/java/io/questdb/cairo/pool/PoolTenant.java
+++ b/core/src/main/java/io/questdb/cairo/pool/PoolTenant.java
@@ -27,16 +27,15 @@ package io.questdb.cairo.pool;
 import io.questdb.cairo.TableToken;
 import io.questdb.std.QuietCloseable;
 
-public interface PoolTenant extends QuietCloseable {
+public interface PoolTenant<T extends PoolTenant<T>> extends QuietCloseable {
 
     /**
      * Pool tenant must keep track of the Entry it belongs to and provide this entry when requested. Entry is
      * usually assigned to the tenant in the constructor.
      *
-     * @param <T> typically type of the subclass
      * @return entry instance.
      */
-    <T> AbstractMultiTenantPool.Entry<T> getEntry();
+    AbstractMultiTenantPool.Entry<T> getEntry();
 
     /**
      * Opaque index, which is usually assigned to tenant in the constructor. Tenant instances must keep it safe and

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -61,7 +61,7 @@ public class ReaderPool extends AbstractMultiTenantPool<ReaderPool.R> {
         void onOpenPartition(TableToken tableToken, int partitionIndex);
     }
 
-    public static class R extends TableReader implements PoolTenant {
+    public static class R extends TableReader implements PoolTenant<R> {
         private final int index;
         private final ReaderListener readerListener;
         private Entry<R> entry;
@@ -96,7 +96,6 @@ public class ReaderPool extends AbstractMultiTenantPool<ReaderPool.R> {
             }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public Entry<R> getEntry() {
             return entry;

--- a/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
@@ -61,7 +61,7 @@ public class WalWriterPool extends AbstractMultiTenantPool<WalWriterPool.WalWrit
         );
     }
 
-    public static class WalWriterTenant extends WalWriter implements PoolTenant {
+    public static class WalWriterTenant extends WalWriter implements PoolTenant<WalWriterTenant> {
         private final int index;
         private Entry<WalWriterTenant> entry;
         private AbstractMultiTenantPool<WalWriterTenant> pool;
@@ -104,7 +104,6 @@ public class WalWriterPool extends AbstractMultiTenantPool<WalWriterPool.WalWrit
             }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public Entry<WalWriterTenant> getEntry() {
             return entry;

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -178,6 +178,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(100000, configuration.getCairoConfiguration().getParallelIndexThreshold());
         Assert.assertEquals(10, configuration.getCairoConfiguration().getReaderPoolMaxSegments());
         Assert.assertEquals(1_000, configuration.getCairoConfiguration().getSpinLockTimeout());
+        Assert.assertEquals(10, configuration.getCairoConfiguration().getSqlCompilerPoolMaxSegments());
         Assert.assertEquals(1024, configuration.getCairoConfiguration().getSqlCharacterStoreCapacity());
         Assert.assertEquals(64, configuration.getCairoConfiguration().getSqlCharacterStoreSequencePoolCapacity());
         Assert.assertEquals(4096, configuration.getCairoConfiguration().getSqlColumnPoolCapacity());
@@ -1006,6 +1007,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(1000000, configuration.getCairoConfiguration().getParallelIndexThreshold());
             Assert.assertEquals(42, configuration.getCairoConfiguration().getReaderPoolMaxSegments());
             Assert.assertEquals(5_000_000, configuration.getCairoConfiguration().getSpinLockTimeout());
+            Assert.assertEquals(18, configuration.getCairoConfiguration().getSqlCompilerPoolMaxSegments());
             Assert.assertEquals(2048, configuration.getCairoConfiguration().getSqlCharacterStoreCapacity());
             Assert.assertEquals(128, configuration.getCairoConfiguration().getSqlCharacterStoreSequencePoolCapacity());
             Assert.assertEquals(2048, configuration.getCairoConfiguration().getSqlColumnPoolCapacity());

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -74,6 +74,7 @@ cairo.mkdir.mode=509
 cairo.parallel.index.threshold=1000000
 cairo.reader.pool.max.segments=42
 cairo.spin.lock.timeout=5000000
+cairo.sql.compiler.pool.max.segments=18
 cairo.character.store.capacity=2048
 cairo.character.store.sequence.pool.capacity=128
 cairo.column.pool.capacity=2048


### PR DESCRIPTION
- making PoolTenant generic which allows us to get rid of warnings
- adding max segment config for SQL compiler pool
- adding pool listener id for SQL compiler pool