### PR TITLE
perf(sql): use StringBuilder instead of StringBuffer when possible in regexp_replace

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
     public void computeFirst(MapValue mapValue, Record record) {
         final CompactIntHashSet set;
         if (sets.size() <= setIndex) {
-            sets.extendAndSet(setIndex, set = new CompactIntHashSet());
+            sets.extendAndSet(setIndex, set = new CompactIntHashSet(64, 0.7, Numbers.IPv4_NULL));
         } else {
             set = sets.getQuick(setIndex);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
     public void computeFirst(MapValue mapValue, Record record) {
         final CompactIntHashSet set;
         if (sets.size() <= setIndex) {
-            sets.extendAndSet(setIndex, set = new CompactIntHashSet());
+            sets.extendAndSet(setIndex, set = new CompactIntHashSet(64, 0.7, Numbers.INT_NaN));
         } else {
             set = sets.getQuick(setIndex);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
     public void computeFirst(MapValue mapValue, Record record) {
         final CompactLongHashSet set;
         if (sets.size() <= setIndex) {
-            sets.extendAndSet(setIndex, set = new CompactLongHashSet());
+            sets.extendAndSet(setIndex, set = new CompactLongHashSet(64, 0.7, Numbers.LONG_NaN));
         } else {
             set = sets.getQuick(setIndex);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctStringGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctStringGroupByFunction.java
@@ -82,7 +82,7 @@ public class CountDistinctStringGroupByFunction extends LongFunction implements 
             if (index < 0) {
                 return;
             }
-            set.addAt(index, Chars.toString(val));
+            set.addAt(index, val);
             mapValue.addLong(valueIndex, 1);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -58,7 +58,7 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
     public void computeFirst(MapValue mapValue, Record record) {
         final CompactIntHashSet set;
         if (sets.size() <= setIndex) {
-            sets.extendAndSet(setIndex, set = new CompactIntHashSet());
+            sets.extendAndSet(setIndex, set = new CompactIntHashSet(64, 0.7, VALUE_IS_NULL));
         } else {
             set = sets.getQuick(setIndex);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -57,7 +57,7 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
     public void computeFirst(MapValue mapValue, Record record) {
         LongLongHashSet set;
         if (sets.size() <= setIndex) {
-            sets.extendAndSet(setIndex, set = new LongLongHashSet(16, 0.6, Numbers.LONG_NaN, LongLongHashSet.UUID_STRATEGY));
+            sets.extendAndSet(setIndex, set = new LongLongHashSet(64, 0.6, Numbers.LONG_NaN, LongLongHashSet.UUID_STRATEGY));
         } else {
             set = sets.getQuick(setIndex);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceStrFunctionFactory.java
@@ -85,8 +85,8 @@ public class RegexpReplaceStrFunctionFactory implements FunctionFactory {
         private final int patternPos;
         private final Function replacement;
         private final int replacementPos;
-        private final StringBufferSink sink = new StringBufferSink();
-        private final StringBufferSink sinkB = new StringBufferSink();
+        private final StringBuilderSink sink = new StringBuilderSink();
+        private final StringBuilderSink sinkB = new StringBuilderSink();
         private final Function value;
         private Matcher matcher;
         private String replacementStr;
@@ -111,7 +111,7 @@ public class RegexpReplaceStrFunctionFactory implements FunctionFactory {
             return getStr(rec, sink);
         }
 
-        public CharSequence getStr(Record rec, StringBufferSink sink) {
+        public CharSequence getStr(Record rec, StringBuilderSink sink) {
             CharSequence cs = value.getStr(rec);
             if (cs == null) {
                 return null;
@@ -180,11 +180,12 @@ public class RegexpReplaceStrFunctionFactory implements FunctionFactory {
         }
     }
 
-    // TODO(puzpuzpuz):
-    //  Use StringBuilder instead of StringBuffer here once we drop support for Java 8 where j.u.r.Matcher
-    //  has no method overloads for StringBuilder.
-    private static class StringBufferSink implements CharSequence {
-        private final StringBuffer buffer = new StringBuffer();
+    private static class StringBuilderSink implements CharSequence {
+//#if jdk.version==8
+//$        private final StringBuffer buffer = new StringBuffer();
+//#else
+        private final StringBuilder buffer = new StringBuilder();
+//#endif
 
         @Override
         public char charAt(int index) {

--- a/core/src/main/java/io/questdb/std/AbstractIntHashSet.java
+++ b/core/src/main/java/io/questdb/std/AbstractIntHashSet.java
@@ -64,15 +64,12 @@ public abstract class AbstractIntHashSet implements Mutable {
 
     public int keyIndex(int key) {
         int index = key & mask;
-
         if (keys[index] == noEntryKeyValue) {
             return index;
         }
-
         if (key == keys[index]) {
             return -index - 1;
         }
-
         return probe(key, index);
     }
 

--- a/core/src/main/java/io/questdb/std/AbstractLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/AbstractLongHashSet.java
@@ -62,16 +62,14 @@ public abstract class AbstractLongHashSet implements Mutable {
     }
 
     public int keyIndex(long key) {
-        int index = (int) (key & mask);
-
+        int hashCode = Long.hashCode(key);
+        int index = hashCode & mask;
         if (keys[index] == noEntryKeyValue) {
             return index;
         }
-
         if (key == keys[index]) {
             return -index - 1;
         }
-
         return probe(key, index);
     }
 
@@ -103,7 +101,8 @@ public abstract class AbstractLongHashSet implements Mutable {
                     key != noEntryKeyValue;
                     from = (from + 1) & mask, key = keys[from]
             ) {
-                int idealHit = (int) (key & mask);
+                int hashCode = Long.hashCode(key);
+                int idealHit = hashCode & mask;
                 if (idealHit != from) {
                     int to;
                     if (keys[idealHit] != noEntryKeyValue) {

--- a/core/src/main/java/io/questdb/std/CompactCharSequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/CompactCharSequenceHashSet.java
@@ -30,9 +30,13 @@ import java.util.Arrays;
  * Unlike {@link CharSequenceHashSet} doesn't keep an additional list for faster iteration and index-based access
  * and also has a slightly higher load factor. One more difference is that this set doesn't support {@code null} keys.
  */
-public class CompactCharSequenceHashSet extends AbstractCharSequenceHashSet {
-
+public class CompactCharSequenceHashSet implements Mutable {
     private static final int MIN_INITIAL_CAPACITY = 16;
+    private final double loadFactor;
+    private int capacity;
+    private int free;
+    private String[] keys;
+    private int mask;
 
     public CompactCharSequenceHashSet() {
         this(MIN_INITIAL_CAPACITY);
@@ -43,8 +47,15 @@ public class CompactCharSequenceHashSet extends AbstractCharSequenceHashSet {
     }
 
     private CompactCharSequenceHashSet(int initialCapacity, double loadFactor) {
-        super(initialCapacity, loadFactor);
-        clear();
+        if (loadFactor <= 0d || loadFactor >= 1d) {
+            throw new IllegalArgumentException("0 < loadFactor < 1");
+        }
+
+        free = capacity = initialCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(initialCapacity);
+        this.loadFactor = loadFactor;
+        int len = Numbers.ceilPow2((int) (capacity / loadFactor));
+        keys = new String[len];
+        mask = len - 1;
     }
 
     /**
@@ -71,9 +82,34 @@ public class CompactCharSequenceHashSet extends AbstractCharSequenceHashSet {
         }
     }
 
-    public CharSequence keyAt(int index) {
-        int index1 = -index - 1;
-        return keys[index1];
+    @Override
+    public void clear() {
+        Arrays.fill(keys, null);
+        free = capacity;
+    }
+
+    public boolean contains(CharSequence key) {
+        return keyIndex(key) < 0;
+    }
+
+    public boolean excludes(CharSequence key) {
+        return keyIndex(key) > -1;
+    }
+
+    public int keyIndex(CharSequence key) {
+        int hashCode = Chars.hashCode(key);
+        int index = hashCode & mask;
+        if (keys[index] == null) {
+            return index;
+        }
+        if (hashCode == keys[index].hashCode() && Chars.equals(key, keys[index])) {
+            return -index - 1;
+        }
+        return probe(key, index, hashCode);
+    }
+
+    public int size() {
+        return capacity - free;
     }
 
     @Override
@@ -81,30 +117,31 @@ public class CompactCharSequenceHashSet extends AbstractCharSequenceHashSet {
         return Arrays.toString(keys);
     }
 
+    private int probe(CharSequence key, int index, int hashCode) {
+        do {
+            index = (index + 1) & mask;
+            if (keys[index] == null) {
+                return index;
+            }
+            if (hashCode == keys[index].hashCode() && Chars.equals(key, keys[index])) {
+                return -index - 1;
+            }
+        } while (true);
+    }
+
     private void rehash() {
         int newCapacity = capacity * 2;
         free = capacity = newCapacity;
         int len = Numbers.ceilPow2((int) (newCapacity / loadFactor));
-        CharSequence[] oldKeys = keys;
-        keys = new CharSequence[len];
+        String[] oldKeys = keys;
+        keys = new String[len];
         mask = len - 1;
         for (int i = 0, n = oldKeys.length; i < n; i++) {
-            CharSequence key = oldKeys[i];
-            if (key != noEntryKey) {
+            String key = oldKeys[i];
+            if (key != null) {
                 keys[keyIndex(key)] = key;
                 free--;
             }
         }
-    }
-
-    @Override
-    protected void erase(int index) {
-        keys[index] = noEntryKey;
-    }
-
-    @Override
-    protected void move(int from, int to) {
-        keys[to] = keys[from];
-        erase(from);
     }
 }

--- a/core/src/main/java/io/questdb/std/CompactIntHashSet.java
+++ b/core/src/main/java/io/questdb/std/CompactIntHashSet.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
  * and also has a slightly higher load factor.
  */
 public class CompactIntHashSet extends AbstractIntHashSet {
-
     private static final int MIN_INITIAL_CAPACITY = 16;
 
     public CompactIntHashSet() {
@@ -39,7 +38,7 @@ public class CompactIntHashSet extends AbstractIntHashSet {
     }
 
     public CompactIntHashSet(int initialCapacity) {
-        this(initialCapacity, 0.6, noEntryKey);
+        this(initialCapacity, 0.7, noEntryKey);
     }
 
     public CompactIntHashSet(int initialCapacity, double loadFactor, int noKeyValue) {

--- a/core/src/main/java/io/questdb/std/CompactLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/CompactLongHashSet.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
  * and also has a slightly higher load factor.
  */
 public class CompactLongHashSet extends AbstractLongHashSet {
-
     private static final int MIN_INITIAL_CAPACITY = 16;
 
     public CompactLongHashSet() {
@@ -39,7 +38,7 @@ public class CompactLongHashSet extends AbstractLongHashSet {
     }
 
     public CompactLongHashSet(int initialCapacity) {
-        this(initialCapacity, 0.6, noEntryKey);
+        this(initialCapacity, 0.7, noEntryKey);
     }
 
     public CompactLongHashSet(int initialCapacity, double loadFactor, long noKeyValue) {
@@ -58,7 +57,6 @@ public class CompactLongHashSet extends AbstractLongHashSet {
         if (index < 0) {
             return false;
         }
-
         addAt(index, key);
         return true;
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
@@ -45,6 +45,19 @@ public class CountDistinctIntGroupByFunctionFactoryTest extends AbstractCairoTes
     }
 
     @Test
+    public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        assertQuery(
+                "count_distinct\n" +
+                        "1\n",
+                "select count_distinct(l) from x",
+                "create table x as (select -1::int as l from long_sequence(10))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
     public void testExpression() throws Exception {
         final String expected = "a\tcount_distinct\n" +
                 "a\t5\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLongGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLongGroupByFunctionFactoryTest.java
@@ -45,6 +45,19 @@ public class CountDistinctLongGroupByFunctionFactoryTest extends AbstractCairoTe
     }
 
     @Test
+    public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        assertQuery(
+                "count_distinct\n" +
+                        "1\n",
+                "select count_distinct(l) from x",
+                "create table x as (select -1::long as l from long_sequence(10))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
     public void testExpression() throws Exception {
         final String expected = "a\tcount_distinct\n" +
                 "a\t4\n" +

--- a/core/src/test/java/io/questdb/test/std/CompactCharSequenceHashSetTest.java
+++ b/core/src/test/java/io/questdb/test/std/CompactCharSequenceHashSetTest.java
@@ -69,17 +69,6 @@ public class CompactCharSequenceHashSetTest {
         }
 
         Assert.assertEquals(n, set.size());
-
-        for (int i = 0; i < n; i++) {
-            Assert.assertEquals("at " + i, set.remove(next(rnd)), -1);
-        }
-
-        Rnd rnd4 = new Rnd();
-        for (int i = 0; i < n; i++) {
-            Assert.assertTrue("at " + i, set.remove(next(rnd4)) > -1);
-        }
-
-        Assert.assertEquals(0, set.size());
     }
 
     private static CharSequence next(Rnd rnd) {


### PR DESCRIPTION
Considering that biased locking was removed from OpenJDK, `StringBuffer` became noticeably more expensive than before. On my machine, this change cut down the `regexp_replace` query in ClickBench by ~20 seconds.

Also includes the following changes:
* Fixes no entry values in integer `Compact*HashSet` used in `count_distinct()` functions. The default value was -1 which led to incorrect results
* `CompactCharSequenceHashSet` no longer inherits from `AbstractCharSequenceHashSet`. That's to be able to use `String[]` array to store the keys and use `String#hashCode()` (which is cached) when comparing keys