### PR TITLE
perf(sql): micro optimizations SqlKeywords implementation (short-circuit evaluation, inline variable)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -37,224 +37,204 @@ public class SqlKeywords {
     private static final LowerCaseCharSequenceHashSet TIMESTAMP_PART_SET = new LowerCaseCharSequenceHashSet();
 
     public static boolean isAddKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 'd'
+                && (tok.charAt(2) | 32) == 'd';
     }
 
     public static boolean isAlignKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 'i'
+                && (tok.charAt(3) | 32) == 'g'
+                && (tok.charAt(4) | 32) == 'n';
     }
 
     public static boolean isAllKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 'l';
     }
 
     public static boolean isAlterKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r';
     }
 
     public static boolean isAndKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'd';
     }
 
     public static boolean isAsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 's';
     }
 
     public static boolean isAscKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'c';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'c';
     }
 
     public static boolean isAtKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 't';
     }
 
     public static boolean isAttachKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'a'
+                && (tok.charAt(1) | 32) == 't'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 'h';
     }
 
     public static boolean isBatchKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'b'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'h';
     }
 
     public static boolean isBetweenKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'b'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'w'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'e'
+                && (tok.charAt(6) | 32) == 'n';
     }
 
     public static boolean isByKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'b'
+                && (tok.charAt(1) | 32) == 'y';
     }
 
     public static boolean isBypassKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'b'
+                && (tok.charAt(1) | 32) == 'y'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isCacheKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'h'
+                && (tok.charAt(4) | 32) == 'e';
     }
 
     public static boolean isCalendarKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 8
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'n'
+                && (tok.charAt(5) | 32) == 'd'
+                && (tok.charAt(6) | 32) == 'a'
+                && (tok.charAt(7) | 32) == 'r';
     }
 
     public static boolean isCancelKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'l';
     }
 
     public static boolean isCapacityKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 8
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 'i'
+                && (tok.charAt(6) | 32) == 't'
+                && (tok.charAt(7) | 32) == 'y';
     }
 
     public static boolean isCaseKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isCastKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 't';
     }
 
     public static boolean isCenturyKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 't'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 'r'
+                && (tok.charAt(6) | 32) == 'y';
     }
 
     public static boolean isColonColon(CharSequence tok) {
-        return tok.length() == 2 && tok.charAt(0) == ':' && tok.charAt(1) == ':';
+        return tok.length() == 2
+                && tok.charAt(0) == ':'
+                && tok.charAt(1) == ':';
     }
 
     public static boolean isColumnKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'n';
     }
 
     public static boolean isColumnsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'n'
+                && (tok.charAt(6) | 32) == 's';
     }
 
     public static boolean isConcatKeyword(CharSequence tok) {
@@ -265,237 +245,215 @@ public class SqlKeywords {
         // Reference equal in case it's already replaced token name
         if (tok == CONCAT_FUNC_NAME) return true;
 
-        int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 't';
+        return (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isConcatOperator(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && tok.charAt(i++) == '|'
-                && tok.charAt(i) == '|';
+                && tok.charAt(0) == '|'
+                && tok.charAt(1) == '|';
     }
 
     public static boolean isCopyKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 'y';
     }
 
     public static boolean isCountKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'u'
+                && (tok.charAt(3) | 32) == 'n'
+                && (tok.charAt(4) | 32) == 't';
     }
 
     public static boolean isCreateKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isCurrentKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 't'
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'n'
+                && (tok.charAt(6) | 32) == 't'
                 ;
     }
 
     public static boolean isDatabaseKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 8
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'b'
+                && (tok.charAt(5) | 32) == 'a'
+                && (tok.charAt(6) | 32) == 's'
+                && (tok.charAt(7) | 32) == 'e';
     }
 
     public static boolean isDateKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isDateStyleKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 't'
+                && (tok.charAt(6) | 32) == 'y'
+                && (tok.charAt(7) | 32) == 'l'
+                && (tok.charAt(8) | 32) == 'e';
     }
 
     public static boolean isDayKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'y';
     }
 
     public static boolean isDaysKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'y'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isDecadeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'd'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isDedupKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'p';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'd'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'p';
     }
 
     public static boolean isDeduplicateKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'd'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'p'
+                && (tok.charAt(5) | 32) == 'l'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 'a'
+                && (tok.charAt(9) | 32) == 't'
+                && (tok.charAt(10) | 32) == 'e';
     }
 
     public static boolean isDelimiterKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'i'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'i'
+                && (tok.charAt(6) | 32) == 't'
+                && (tok.charAt(7) | 32) == 'e'
+                && (tok.charAt(8) | 32) == 'r';
     }
 
     public static boolean isDescKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'c';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'c';
     }
 
     public static boolean isDetachKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 'h';
     }
 
     public static boolean isDisableKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'b'
+                && (tok.charAt(5) | 32) == 'l'
+                && (tok.charAt(6) | 32) == 'e';
     }
 
     public static boolean isDistinctKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 8
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 't'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 'n'
+                && (tok.charAt(6) | 32) == 'c'
+                && (tok.charAt(7) | 32) == 't';
     }
 
     public static boolean isDowKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'w';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'w';
     }
 
     public static boolean isDoyKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'y';
     }
 
     public static boolean isDropKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'p';
+                && (tok.charAt(0) | 32) == 'd'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'p';
     }
 
     public static boolean isEmptyAlias(CharSequence tok) {
@@ -504,220 +462,200 @@ public class SqlKeywords {
     }
 
     public static boolean isEnableKeyword(@NotNull CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'b'
+                && (tok.charAt(4) | 32) == 'l'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isEndKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'd';
     }
 
     public static boolean isEpochKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'p'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'h';
     }
 
     public static boolean isExceptKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'p'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isExcludeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 'd'
+                && (tok.charAt(6) | 32) == 'e';
     }
 
     public static boolean isExclusiveKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'v'
+                && (tok.charAt(8) | 32) == 'e';
     }
 
     public static boolean isExistsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'i'
+                && (tok.charAt(3) | 32) == 's'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isExplainKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 'i'
+                && (tok.charAt(6) | 32) == 'n';
     }
 
     public static boolean isExtractKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 'c'
+                && (tok.charAt(6) | 32) == 't';
     }
 
     public static boolean isFalseKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 's'
+                && (tok.charAt(4) | 32) == 'e';
     }
 
     public static boolean isFalseKeyword(Utf8Sequence tok) {
-        int i = 0;
         return tok.size() == 5
-                && (tok.byteAt(i++) | 32) == 'f'
-                && (tok.byteAt(i++) | 32) == 'a'
-                && (tok.byteAt(i++) | 32) == 'l'
-                && (tok.byteAt(i++) | 32) == 's'
-                && (tok.byteAt(i) | 32) == 'e';
+                && (tok.byteAt(0) | 32) == 'f'
+                && (tok.byteAt(1) | 32) == 'a'
+                && (tok.byteAt(2) | 32) == 'l'
+                && (tok.byteAt(3) | 32) == 's'
+                && (tok.byteAt(4) | 32) == 'e';
     }
 
     public static boolean isFillKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l';
     }
 
     public static boolean isFirstKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 's'
+                && (tok.charAt(4) | 32) == 't';
     }
 
     public static boolean isFloat4Keyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == '4';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5)) == '4';
     }
 
     public static boolean isFloat8Keyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i)) == '8';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5)) == '8';
     }
 
     // only for Python drivers, which use 'float' keyword to represent double in Java
     // for example, 'NaN'::float   'Infinity'::float
     public static boolean isFloatKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'l'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 't';
     }
 
     public static boolean isFollowingKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'g';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'o'
+                && (tok.charAt(5) | 32) == 'w'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'n'
+                && (tok.charAt(8) | 32) == 'g';
     }
 
     public static boolean isFormatKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 'm'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isFromKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'm';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'm';
     }
 
     public static boolean isFullKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'f'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l';
     }
 
     public static boolean isGeoHashKeyword(CharSequence tok) {
@@ -726,183 +664,165 @@ public class SqlKeywords {
     }
 
     public static boolean isGroupKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'p';
+                && (tok.charAt(0) | 32) == 'g'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'p';
     }
 
     public static boolean isGroupsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'g'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'p'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isHeaderKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'h'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'd'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'r';
     }
 
     public static boolean isHourKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'h'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'u'
+                && (tok.charAt(3) | 32) == 'r';
     }
 
     public static boolean isHoursKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'h'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'u'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 's';
     }
 
     public static boolean isIfKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 'f';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'f';
     }
 
     public static boolean isInKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n';
     }
 
     public static boolean isIndexKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'x';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'd'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'x';
     }
 
     public static boolean isInsertKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isIntersectKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 't';
     }
 
     public static boolean isIntoKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'o';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'o';
     }
 
     public static boolean isIsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 's';
     }
 
     public static boolean isIsoDowKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'w';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'd'
+                && (tok.charAt(4) | 32) == 'o'
+                && (tok.charAt(5) | 32) == 'w';
     }
 
     public static boolean isIsoYearKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'y'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'a'
+                && (tok.charAt(6) | 32) == 'r';
     }
 
     public static boolean isIsolationKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 't'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'o'
+                && (tok.charAt(8) | 32) == 'n';
     }
 
     public static boolean isJsonKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'j'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'j'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'n';
     }
 
     public static boolean isKeepKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'k'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'p';
+                && (tok.charAt(0) | 32) == 'k'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'p';
     }
 
     public static boolean isKeysKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'k'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'k'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'y'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isKeyword(CharSequence text) {
@@ -913,1003 +833,918 @@ public class SqlKeywords {
     }
 
     public static boolean isLastKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 't';
     }
 
     public static boolean isLatestKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isLeftKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'f'
+                && (tok.charAt(3) | 32) == 't';
     }
 
     public static boolean isLevelKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'v'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'l';
     }
 
     public static boolean isLikeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'k'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'k'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isLimitKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'i'
+                && (tok.charAt(4) | 32) == 't';
     }
 
     public static boolean isLinearKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 'r';
     }
 
     public static boolean isListKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 't';
     }
 
     public static boolean isLockKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 'k';
+                && (tok.charAt(0) | 32) == 'l'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'k';
     }
 
     public static boolean isMapsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isMaxIdentifierLength(CharSequence tok) {
-        int i = 0;
         return tok.length() == 21
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'x'
-                && tok.charAt(i++) == '_'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && tok.charAt(i++) == '_'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'x'
+                && tok.charAt(3) == '_'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 'd'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'n'
+                && (tok.charAt(8) | 32) == 't'
+                && (tok.charAt(9) | 32) == 'i'
+                && (tok.charAt(10) | 32) == 'f'
+                && (tok.charAt(11) | 32) == 'i'
+                && (tok.charAt(12) | 32) == 'e'
+                && (tok.charAt(13) | 32) == 'r'
+                && tok.charAt(14) == '_'
+                && (tok.charAt(15) | 32) == 'l'
+                && (tok.charAt(16) | 32) == 'e'
+                && (tok.charAt(17) | 32) == 'n'
+                && (tok.charAt(18) | 32) == 'g'
+                && (tok.charAt(19) | 32) == 't'
+                && (tok.charAt(20) | 32) == 'h';
     }
 
     public static boolean isMaxUncommittedRowsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 18
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'x'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'n'
+                && (tok.charAt(5) | 32) == 'c'
+                && (tok.charAt(6) | 32) == 'o'
+                && (tok.charAt(7) | 32) == 'm'
+                && (tok.charAt(8) | 32) == 'm'
+                && (tok.charAt(9) | 32) == 'i'
+                && (tok.charAt(10) | 32) == 't'
+                && (tok.charAt(11) | 32) == 't'
+                && (tok.charAt(12) | 32) == 'e'
+                && (tok.charAt(13) | 32) == 'd'
+                && (tok.charAt(14) | 32) == 'r'
+                && (tok.charAt(15) | 32) == 'o'
+                && (tok.charAt(16) | 32) == 'w'
+                && (tok.charAt(17) | 32) == 's';
     }
 
     public static boolean isMicrosecondKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'o'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 'o'
+                && (tok.charAt(9) | 32) == 'n'
+                && (tok.charAt(10) | 32) == 'd';
     }
 
     public static boolean isMicrosecondsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 12
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'o'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 'o'
+                && (tok.charAt(9) | 32) == 'n'
+                && (tok.charAt(10) | 32) == 'd'
+                && (tok.charAt(11) | 32) == 's';
     }
 
     public static boolean isMillenniumKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 10
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'm';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'n'
+                && (tok.charAt(6) | 32) == 'n'
+                && (tok.charAt(7) | 32) == 'i'
+                && (tok.charAt(8) | 32) == 'u'
+                && (tok.charAt(9) | 32) == 'm';
     }
 
     public static boolean isMillisecondKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 'o'
+                && (tok.charAt(9) | 32) == 'n'
+                && (tok.charAt(10) | 32) == 'd';
     }
 
 
     public static boolean isMillisecondsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 12
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'e'
+                && (tok.charAt(7) | 32) == 'c'
+                && (tok.charAt(8) | 32) == 'o'
+                && (tok.charAt(9) | 32) == 'n'
+                && (tok.charAt(10) | 32) == 'd'
+                && (tok.charAt(11) | 32) == 's';
     }
 
     public static boolean isMinuteKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isMinutesKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 'e'
+                && (tok.charAt(6) | 32) == 's';
     }
 
     public static boolean isMonthKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'm'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 't'
+                && (tok.charAt(4) | 32) == 'h';
     }
 
     public static boolean isNanKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'n';
     }
 
     public static boolean isNoCacheKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 'h'
+                && (tok.charAt(6) | 32) == 'e';
     }
 
     public static boolean isNoKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'o';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'o';
     }
 
     public static boolean isNoneKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isNotJoinKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() != 4
-                || (tok.charAt(i++) | 32) != 'j'
-                || (tok.charAt(i++) | 32) != 'o'
-                || (tok.charAt(i++) | 32) != 'i'
-                || (tok.charAt(i) | 32) != 'n';
+                || (tok.charAt(0) | 32) != 'j'
+                || (tok.charAt(1) | 32) != 'o'
+                || (tok.charAt(2) | 32) != 'i'
+                || (tok.charAt(3) | 32) != 'n';
     }
 
     public static boolean isNotKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 't';
     }
 
     public static boolean isNullKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'n'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l';
     }
 
     public static boolean isNullKeyword(Utf8Sequence tok) {
-        int i = 0;
         return tok.size() == 4
-                && (tok.byteAt(i++) | 32) == 'n'
-                && (tok.byteAt(i++) | 32) == 'u'
-                && (tok.byteAt(i++) | 32) == 'l'
-                && (tok.byteAt(i) | 32) == 'l';
+                && (tok.byteAt(0) | 32) == 'n'
+                && (tok.byteAt(1) | 32) == 'u'
+                && (tok.byteAt(2) | 32) == 'l'
+                && (tok.byteAt(3) | 32) == 'l';
     }
 
     public static boolean isO3MaxLagKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 8
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == '3'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'g';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == '3'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'x'
+                && (tok.charAt(5) | 32) == 'l'
+                && (tok.charAt(6) | 32) == 'a'
+                && (tok.charAt(7) | 32) == 'g';
     }
 
     public static boolean isObservationKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'b'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r'
+                && (tok.charAt(5) | 32) == 'v'
+                && (tok.charAt(6) | 32) == 'a'
+                && (tok.charAt(7) | 32) == 't'
+                && (tok.charAt(8) | 32) == 'i'
+                && (tok.charAt(9) | 32) == 'o'
+                && (tok.charAt(10) | 32) == 'n';
     }
 
     public static boolean isOffsetKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'f'
+                && (tok.charAt(2) | 32) == 'f'
+                && (tok.charAt(3) | 32) == 's'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isOnKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'n';
     }
 
     public static boolean isOnlyKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'y';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'y';
     }
 
     public static boolean isOrKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'r';
     }
 
     public static boolean isOrderKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'd'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r';
     }
 
     public static boolean isOthersKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 't'
+                && (tok.charAt(2) | 32) == 'h'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isOuterKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r';
     }
 
     public static boolean isOverKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'v'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'r';
     }
 
     public static boolean isParamKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'm';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'm';
     }
 
     public static boolean isPartitionKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 't'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 't'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'o'
+                && (tok.charAt(8) | 32) == 'n';
     }
 
     public static boolean isPartitionsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 10
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 't'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 't'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'o'
+                && (tok.charAt(8) | 32) == 'n'
+                && (tok.charAt(9) | 32) == 's';
     }
 
     public static boolean isPrecedingKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'g';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'd'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'n'
+                && (tok.charAt(8) | 32) == 'g';
     }
 
     public static boolean isPrecisionKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'c'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'o'
+                && (tok.charAt(8) | 32) == 'n';
     }
 
     public static boolean isPrevKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'v';
+                && (tok.charAt(0) | 32) == 'p'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'v';
     }
 
     public static boolean isQuarterKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 'q'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'q'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 'e'
+                && (tok.charAt(6) | 32) == 'r';
     }
 
     public static boolean isQuote(CharSequence tok) {
-        return tok.length() == 1 && tok.charAt(0) == '\'';
+        return tok.length() == 1
+                && tok.charAt(0) == '\'';
     }
 
     public static boolean isRangeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'g'
+                && (tok.charAt(4) | 32) == 'e';
     }
 
     public static boolean isRenameKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isResumeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isRightKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'g'
+                && (tok.charAt(3) | 32) == 'h'
+                && (tok.charAt(4) | 32) == 't';
     }
 
     public static boolean isRowKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'w';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'w';
     }
 
     public static boolean isRowsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'w'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isSampleKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'p'
+                && (tok.charAt(4) | 32) == 'l'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isSearchPath(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++)) == '_'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 'h'
+                && (tok.charAt(6)) == '_'
+                && (tok.charAt(7) | 32) == 'p'
+                && (tok.charAt(8) | 32) == 'a'
+                && (tok.charAt(9) | 32) == 't'
+                && (tok.charAt(10) | 32) == 'h';
     }
 
     public static boolean isSecondKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'o'
+                && (tok.charAt(4) | 32) == 'n'
+                && (tok.charAt(5) | 32) == 'd';
     }
 
     public static boolean isSecondsKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 7
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'o'
+                && (tok.charAt(4) | 32) == 'n'
+                && (tok.charAt(5) | 32) == 'd'
+                && (tok.charAt(6) | 32) == 's';
     }
 
     public static boolean isSelectKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'c'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isSemicolon(CharSequence token) {
-        return Chars.equals(token, ';');
+        return token.length() == 1
+                && token.charAt(0) == ';';
     }
 
     public static boolean isSetKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 't';
     }
 
     public static boolean isSquashKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'q'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'q'
+                && (tok.charAt(2) | 32) == 'u'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 'h';
     }
 
     public static boolean isStandardConformingStrings(CharSequence tok) {
-        int i = 0;
         return tok.length() == 27
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++)) == '_'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'f'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++)) == '_'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 't'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'n'
+                && (tok.charAt(4) | 32) == 'd'
+                && (tok.charAt(5) | 32) == 'a'
+                && (tok.charAt(6) | 32) == 'r'
+                && (tok.charAt(7) | 32) == 'd'
+                && (tok.charAt(8)) == '_'
+                && (tok.charAt(9) | 32) == 'c'
+                && (tok.charAt(10) | 32) == 'o'
+                && (tok.charAt(11) | 32) == 'n'
+                && (tok.charAt(12) | 32) == 'f'
+                && (tok.charAt(13) | 32) == 'o'
+                && (tok.charAt(14) | 32) == 'r'
+                && (tok.charAt(15) | 32) == 'm'
+                && (tok.charAt(16) | 32) == 'i'
+                && (tok.charAt(17) | 32) == 'n'
+                && (tok.charAt(18) | 32) == 'g'
+                && (tok.charAt(19)) == '_'
+                && (tok.charAt(20) | 32) == 's'
+                && (tok.charAt(21) | 32) == 't'
+                && (tok.charAt(22) | 32) == 'r'
+                && (tok.charAt(23) | 32) == 'i'
+                && (tok.charAt(24) | 32) == 'n'
+                && (tok.charAt(25) | 32) == 'g'
+                && (tok.charAt(26) | 32) == 's';
     }
 
     public static boolean isSumKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'm';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'm';
     }
 
     public static boolean isSymbolKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'y'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'b'
+                && (tok.charAt(4) | 32) == 'o'
+                && (tok.charAt(5) | 32) == 'l';
     }
 
     public static boolean isTableKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'b'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'e';
     }
 
     public static boolean isTablesKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'b'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isTextKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'x'
+                && (tok.charAt(3) | 32) == 't';
     }
 
     public static boolean isTiesKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isTimeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isTimestampKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'p';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 'm'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 't'
+                && (tok.charAt(6) | 32) == 'a'
+                && (tok.charAt(7) | 32) == 'm'
+                && (tok.charAt(8) | 32) == 'p';
     }
 
     public static boolean isToKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 2
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'o';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'o';
     }
 
     public static boolean isTransactionIsolation(CharSequence tok) {
-        int i = 0;
         return tok.length() == 21
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++)) == '_'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'n'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 'a'
+                && (tok.charAt(6) | 32) == 'c'
+                && (tok.charAt(7) | 32) == 't'
+                && (tok.charAt(8) | 32) == 'i'
+                && (tok.charAt(9) | 32) == 'o'
+                && (tok.charAt(10) | 32) == 'n'
+                && (tok.charAt(11)) == '_'
+                && (tok.charAt(12) | 32) == 'i'
+                && (tok.charAt(13) | 32) == 's'
+                && (tok.charAt(14) | 32) == 'o'
+                && (tok.charAt(15) | 32) == 'l'
+                && (tok.charAt(16) | 32) == 'a'
+                && (tok.charAt(17) | 32) == 't'
+                && (tok.charAt(18) | 32) == 'i'
+                && (tok.charAt(19) | 32) == 'o'
+                && (tok.charAt(20) | 32) == 'n';
     }
 
     public static boolean isTransactionKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 11
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'c'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'n'
+                && (tok.charAt(4) | 32) == 's'
+                && (tok.charAt(5) | 32) == 'a'
+                && (tok.charAt(6) | 32) == 'c'
+                && (tok.charAt(7) | 32) == 't'
+                && (tok.charAt(8) | 32) == 'i'
+                && (tok.charAt(9) | 32) == 'o'
+                && (tok.charAt(10) | 32) == 'n';
     }
 
     public static boolean isTrueKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'u'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isTrueKeyword(Utf8Sequence tok) {
-        int i = 0;
         return tok.size() == 4
-                && (tok.byteAt(i++) | 32) == 't'
-                && (tok.byteAt(i++) | 32) == 'r'
-                && (tok.byteAt(i++) | 32) == 'u'
-                && (tok.byteAt(i) | 32) == 'e';
+                && (tok.byteAt(0) | 32) == 't'
+                && (tok.byteAt(1) | 32) == 'r'
+                && (tok.byteAt(2) | 32) == 'u'
+                && (tok.byteAt(3) | 32) == 'e';
     }
 
     public static boolean isTxnKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'x'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'x'
+                && (tok.charAt(2) | 32) == 'n';
     }
 
     public static boolean isTypeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 't'
+                && (tok.charAt(1) | 32) == 'y'
+                && (tok.charAt(2) | 32) == 'p'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean isUnboundedKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 9
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'b'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'd';
+                && (tok.charAt(0) | 32) == 'u'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'b'
+                && (tok.charAt(3) | 32) == 'o'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 'n'
+                && (tok.charAt(6) | 32) == 'd'
+                && (tok.charAt(7) | 32) == 'e'
+                && (tok.charAt(8) | 32) == 'd';
     }
 
     public static boolean isUnionKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'u'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'i'
+                && (tok.charAt(3) | 32) == 'o'
+                && (tok.charAt(4) | 32) == 'n';
     }
 
     public static boolean isUpdateKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 'd'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'u'
+                && (tok.charAt(1) | 32) == 'p'
+                && (tok.charAt(2) | 32) == 'd'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 't'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isUpsertKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'p'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 't';
+                && (tok.charAt(0) | 32) == 'u'
+                && (tok.charAt(1) | 32) == 'p'
+                && (tok.charAt(2) | 32) == 's'
+                && (tok.charAt(3) | 32) == 'e'
+                && (tok.charAt(4) | 32) == 'r'
+                && (tok.charAt(5) | 32) == 't';
     }
 
     public static boolean isValuesKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 's';
+                && (tok.charAt(0) | 32) == 'v'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 's';
     }
 
     public static boolean isVolumeKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'l'
-                && (tok.charAt(i++) | 32) == 'u'
-                && (tok.charAt(i++) | 32) == 'm'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'v'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'm'
+                && (tok.charAt(5) | 32) == 'e';
     }
 
     public static boolean isWalKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 3
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'l';
+                && (tok.charAt(0) | 32) == 'w'
+                && (tok.charAt(1) | 32) == 'a'
+                && (tok.charAt(2) | 32) == 'l';
     }
 
     public static boolean isWeekKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i) | 32) == 'k';
+                && (tok.charAt(0) | 32) == 'w'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'k';
     }
 
     public static boolean isWhereKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 5
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'w'
+                && (tok.charAt(1) | 32) == 'h'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'r'
+                && (tok.charAt(4) | 32) == 'e';
     }
 
     public static boolean isWithKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i) | 32) == 'h';
+                && (tok.charAt(0) | 32) == 'w'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'h';
     }
 
     public static boolean isWithinKeyword(CharSequence tok) {
-        int i = 0;
         return tok != null
                 && tok.length() == 6
-                && (tok.charAt(i++) | 32) == 'w'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 't'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i) | 32) == 'n';
+                && (tok.charAt(0) | 32) == 'w'
+                && (tok.charAt(1) | 32) == 'i'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 'h'
+                && (tok.charAt(4) | 32) == 'i'
+                && (tok.charAt(5) | 32) == 'n';
     }
 
     public static boolean isYearKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'y'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i) | 32) == 'r';
+                && (tok.charAt(0) | 32) == 'y'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'a'
+                && (tok.charAt(3) | 32) == 'r';
     }
 
     public static boolean isZoneKeyword(CharSequence tok) {
-        int i = 0;
         return tok.length() == 4
-                && (tok.charAt(i++) | 32) == 'z'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'n'
-                && (tok.charAt(i) | 32) == 'e';
+                && (tok.charAt(0) | 32) == 'z'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'n'
+                && (tok.charAt(3) | 32) == 'e';
     }
 
     public static boolean startsWithGeoHashKeyword(CharSequence tok) {
@@ -1936,33 +1771,31 @@ public class SqlKeywords {
     }
 
     private static boolean isGeoHashKeywordInternal(CharSequence tok) {
-        int i = 0;
-        return (tok.charAt(i++) | 32) == 'g'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i++) | 32) == 'h'
-                && (tok.charAt(i++) | 32) == 'a'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i) | 32) == 'h';
+        return (tok.charAt(0) | 32) == 'g'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'h'
+                && (tok.charAt(4) | 32) == 'a'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'h';
     }
 
     public static boolean isServerVersionKeyword(CharSequence tok) {
-        int i = 0;
-        return (tok.length() == 14)
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++)) == '_'
-                && (tok.charAt(i++) | 32) == 'v'
-                && (tok.charAt(i++) | 32) == 'e'
-                && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 's'
-                && (tok.charAt(i++) | 32) == 'i'
-                && (tok.charAt(i++) | 32) == 'o'
-                && (tok.charAt(i) | 32) == 'n';
+        return tok.length() == 14
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 'r'
+                && (tok.charAt(3) | 32) == 'v'
+                && (tok.charAt(4) | 32) == 'e'
+                && (tok.charAt(5) | 32) == 'r'
+                && (tok.charAt(6)) == '_'
+                && (tok.charAt(7) | 32) == 'v'
+                && (tok.charAt(8) | 32) == 'e'
+                && (tok.charAt(9) | 32) == 'r'
+                && (tok.charAt(10) | 32) == 's'
+                && (tok.charAt(11) | 32) == 'i'
+                && (tok.charAt(12) | 32) == 'o'
+                && (tok.charAt(13) | 32) == 'n';
     }
 
     static void assertTableNameIsQuotedOrNotAKeyword(CharSequence keyword, int position) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -37,23 +37,17 @@ public class SqlKeywords {
     private static final LowerCaseCharSequenceHashSet TIMESTAMP_PART_SET = new LowerCaseCharSequenceHashSet();
 
     public static boolean isAddKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i) | 32) == 'd';
     }
 
     public static boolean isAlignKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'g'
@@ -61,23 +55,17 @@ public class SqlKeywords {
     }
 
     public static boolean isAllKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isAlterKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -85,54 +73,39 @@ public class SqlKeywords {
     }
 
     public static boolean isAndKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i) | 32) == 'd';
     }
 
     public static boolean isAsKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isAscKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 'c';
     }
 
     public static boolean isAtKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isAttachKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'a'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -141,12 +114,9 @@ public class SqlKeywords {
     }
 
     public static boolean isBatchKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'b'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'c'
@@ -154,12 +124,9 @@ public class SqlKeywords {
     }
 
     public static boolean isBetweenKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'b'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'w'
@@ -169,22 +136,16 @@ public class SqlKeywords {
     }
 
     public static boolean isByKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'b'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isBypassKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'b'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -193,12 +154,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCacheKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'h'
@@ -206,12 +164,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCalendarKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 8
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -222,12 +177,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCancelKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'c'
@@ -236,12 +188,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCapacityKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 8
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -252,36 +201,27 @@ public class SqlKeywords {
     }
 
     public static boolean isCaseKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isCastKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isCenturyKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
@@ -295,12 +235,9 @@ public class SqlKeywords {
     }
 
     public static boolean isColumnKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -309,12 +246,9 @@ public class SqlKeywords {
     }
 
     public static boolean isColumnsKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -341,34 +275,25 @@ public class SqlKeywords {
     }
 
     public static boolean isConcatOperator(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return tok.charAt(i++) == '|'
+        return tok.length() == 2
+                && tok.charAt(i++) == '|'
                 && tok.charAt(i) == '|';
     }
 
     public static boolean isCopyKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isCountKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'n'
@@ -376,12 +301,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCreateKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -390,12 +312,9 @@ public class SqlKeywords {
     }
 
     public static boolean isCurrentKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'c'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -406,12 +325,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDatabaseKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 8
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -422,24 +338,18 @@ public class SqlKeywords {
     }
 
     public static boolean isDateKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isDateStyleKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -451,35 +361,26 @@ public class SqlKeywords {
     }
 
     public static boolean isDayKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isDaysKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isDecadeKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -488,12 +389,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDedupKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -501,12 +399,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDeduplicateKeyword(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -520,12 +415,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDelimiterKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
@@ -537,24 +429,18 @@ public class SqlKeywords {
     }
 
     public static boolean isDescKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 'c';
     }
 
     public static boolean isDetachKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -563,12 +449,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDisableKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -578,12 +461,9 @@ public class SqlKeywords {
     }
 
     public static boolean isDistinctKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 8
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 't'
@@ -594,54 +474,39 @@ public class SqlKeywords {
     }
 
     public static boolean isDowKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'w';
     }
 
     public static boolean isDoyKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isDropKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'd'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'p';
     }
 
     public static boolean isEmptyAlias(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
-        return (tok.charAt(0) == '\'' && tok.charAt(1) == '\'') || (tok.charAt(0) == '"' && tok.charAt(1) == '"');
+        return tok.length() == 2
+                && ((tok.charAt(0) == '\'' && tok.charAt(1) == '\'') || (tok.charAt(0) == '"' && tok.charAt(1) == '"'));
     }
 
     public static boolean isEnableKeyword(@NotNull CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'b'
@@ -650,23 +515,17 @@ public class SqlKeywords {
     }
 
     public static boolean isEndKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i) | 32) == 'd';
     }
 
     public static boolean isEpochKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'c'
@@ -674,12 +533,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExceptKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -688,12 +544,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExcludeKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -703,12 +556,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExclusiveKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -720,12 +570,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExistsKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
@@ -734,12 +581,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExplainKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -749,12 +593,9 @@ public class SqlKeywords {
     }
 
     public static boolean isExtractKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'e'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -764,12 +605,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFalseKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 's'
@@ -777,12 +615,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFalseKeyword(Utf8Sequence tok) {
-        if (tok.size() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.byteAt(i++) | 32) == 'f'
+        return tok.size() == 5
+                && (tok.byteAt(i++) | 32) == 'f'
                 && (tok.byteAt(i++) | 32) == 'a'
                 && (tok.byteAt(i++) | 32) == 'l'
                 && (tok.byteAt(i++) | 32) == 's'
@@ -790,24 +625,18 @@ public class SqlKeywords {
     }
 
     public static boolean isFillKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isFirstKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 's'
@@ -815,12 +644,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFloat4Keyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -829,12 +655,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFloat8Keyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -845,12 +668,9 @@ public class SqlKeywords {
     // only for Python drivers, which use 'float' keyword to represent double in Java
     // for example, 'NaN'::float   'Infinity'::float
     public static boolean isFloatKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -858,12 +678,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFollowingKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -875,12 +692,9 @@ public class SqlKeywords {
     }
 
     public static boolean isFormatKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'm'
@@ -889,45 +703,32 @@ public class SqlKeywords {
     }
 
     public static boolean isFromKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'm';
     }
 
     public static boolean isFullKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'f'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isGeoHashKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
-        int i = 0;
-        return isGeoHashKeyword(tok, i);
+        return tok.length() == 7
+                && isGeoHashKeywordInternal(tok);
     }
 
     public static boolean isGroupKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'g'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'g'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -935,12 +736,9 @@ public class SqlKeywords {
     }
 
     public static boolean isGroupsKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'g'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'g'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -949,12 +747,9 @@ public class SqlKeywords {
     }
 
     public static boolean isHeaderKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'h'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'h'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'd'
@@ -963,24 +758,18 @@ public class SqlKeywords {
     }
 
     public static boolean isHourKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'h'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'h'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isHoursKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'h'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'h'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -988,32 +777,23 @@ public class SqlKeywords {
     }
 
     public static boolean isIfKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i) | 32) == 'f';
     }
 
     public static boolean isInKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i) | 32) == 'n';
     }
 
     public static boolean isIndexKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1021,12 +801,9 @@ public class SqlKeywords {
     }
 
     public static boolean isInsertKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1035,12 +812,9 @@ public class SqlKeywords {
     }
 
     public static boolean isIntersectKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1052,34 +826,25 @@ public class SqlKeywords {
     }
 
     public static boolean isIntoKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i) | 32) == 'o';
     }
 
     public static boolean isIsKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isIsoDowKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'd'
@@ -1088,12 +853,9 @@ public class SqlKeywords {
     }
 
     public static boolean isIsoYearKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'y'
@@ -1103,12 +865,9 @@ public class SqlKeywords {
     }
 
     public static boolean isIsolationKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'i'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -1120,36 +879,27 @@ public class SqlKeywords {
     }
 
     public static boolean isJsonKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'j'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'j'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'n';
     }
 
     public static boolean isKeepKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'k'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'k'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 'p';
     }
 
     public static boolean isKeysKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'k'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'k'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i) | 32) == 's';
@@ -1163,24 +913,18 @@ public class SqlKeywords {
     }
 
     public static boolean isLastKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isLatestKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1189,24 +933,18 @@ public class SqlKeywords {
     }
 
     public static boolean isLeftKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isLevelKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'v'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1214,24 +952,18 @@ public class SqlKeywords {
     }
 
     public static boolean isLikeKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'k'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isLimitKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
@@ -1239,12 +971,9 @@ public class SqlKeywords {
     }
 
     public static boolean isLinearKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1253,48 +982,36 @@ public class SqlKeywords {
     }
 
     public static boolean isListKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isLockKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'l'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i) | 32) == 'k';
     }
 
     public static boolean isMapsKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isMaxIdentifierLength(CharSequence tok) {
-        if (tok.length() != 21) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 21
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'x'
                 && tok.charAt(i++) == '_'
@@ -1318,12 +1035,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMaxUncommittedRowsKeyword(CharSequence tok) {
-        if (tok.length() != 18) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 18
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -1344,12 +1058,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMicrosecondKeyword(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -1363,12 +1074,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMicrosecondsKeyword(CharSequence tok) {
-        if (tok.length() != 12) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 12
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -1383,12 +1091,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMillenniumKeyword(CharSequence tok) {
-        if (tok.length() != 10) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 10
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -1401,12 +1106,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMillisecondKeyword(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -1421,12 +1123,9 @@ public class SqlKeywords {
 
 
     public static boolean isMillisecondsKeyword(CharSequence tok) {
-        if (tok.length() != 12) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 12
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -1441,12 +1140,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMinuteKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -1455,12 +1151,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMinutesKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -1470,12 +1163,9 @@ public class SqlKeywords {
     }
 
     public static boolean isMonthKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'm'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 't'
@@ -1483,23 +1173,17 @@ public class SqlKeywords {
     }
 
     public static boolean isNanKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 'n';
     }
 
     public static boolean isNoCacheKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -1509,81 +1193,60 @@ public class SqlKeywords {
     }
 
     public static boolean isNoKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i) | 32) == 'o';
     }
 
     public static boolean isNoneKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isNotJoinKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return true;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) != 'j'
+        return tok.length() != 4
+                || (tok.charAt(i++) | 32) != 'j'
                 || (tok.charAt(i++) | 32) != 'o'
                 || (tok.charAt(i++) | 32) != 'i'
                 || (tok.charAt(i) | 32) != 'n';
     }
 
     public static boolean isNotKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isNullKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'n'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isNullKeyword(Utf8Sequence tok) {
-        if (tok.size() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.byteAt(i++) | 32) == 'n'
+        return tok.size() == 4
+                && (tok.byteAt(i++) | 32) == 'n'
                 && (tok.byteAt(i++) | 32) == 'u'
                 && (tok.byteAt(i++) | 32) == 'l'
                 && (tok.byteAt(i) | 32) == 'l';
     }
 
     public static boolean isO3MaxLagKeyword(CharSequence tok) {
-        if (tok.length() != 8) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 8
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == '3'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -1594,12 +1257,9 @@ public class SqlKeywords {
     }
 
     public static boolean isObservationKeyword(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1613,12 +1273,9 @@ public class SqlKeywords {
     }
 
     public static boolean isOffsetKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 'f'
                 && (tok.charAt(i++) | 32) == 's'
@@ -1627,44 +1284,32 @@ public class SqlKeywords {
     }
 
     public static boolean isOnKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'n';
     }
 
     public static boolean isOnlyKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i) | 32) == 'y';
     }
 
     public static boolean isOrKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isOrderKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1672,12 +1317,9 @@ public class SqlKeywords {
     }
 
     public static boolean isOthersKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'h'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1686,12 +1328,9 @@ public class SqlKeywords {
     }
 
     public static boolean isOuterKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1699,24 +1338,18 @@ public class SqlKeywords {
     }
 
     public static boolean isOverKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'o'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'v'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isParamKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -1724,12 +1357,9 @@ public class SqlKeywords {
     }
 
     public static boolean isPartitionKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 't'
@@ -1741,12 +1371,9 @@ public class SqlKeywords {
     }
 
     public static boolean isPartitionsKeyword(CharSequence tok) {
-        if (tok.length() != 10) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 10
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 't'
@@ -1759,12 +1386,9 @@ public class SqlKeywords {
     }
 
     public static boolean isPrecedingKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'c'
@@ -1776,12 +1400,9 @@ public class SqlKeywords {
     }
 
     public static boolean isPrecisionKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'c'
@@ -1793,24 +1414,18 @@ public class SqlKeywords {
     }
 
     public static boolean isPrevKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'p'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 'v';
     }
 
     public static boolean isQuarterKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'q'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 'q'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -1824,12 +1439,9 @@ public class SqlKeywords {
     }
 
     public static boolean isRangeKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'g'
@@ -1837,12 +1449,9 @@ public class SqlKeywords {
     }
 
     public static boolean isRenameKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -1851,12 +1460,9 @@ public class SqlKeywords {
     }
 
     public static boolean isResumeKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -1865,12 +1471,9 @@ public class SqlKeywords {
     }
 
     public static boolean isRightKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'g'
                 && (tok.charAt(i++) | 32) == 'h'
@@ -1878,35 +1481,26 @@ public class SqlKeywords {
     }
 
     public static boolean isRowKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i) | 32) == 'w';
     }
 
     public static boolean isRowsKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'r'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isSampleKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'p'
@@ -1915,12 +1509,9 @@ public class SqlKeywords {
     }
 
     public static boolean isSearchPath(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -1934,12 +1525,9 @@ public class SqlKeywords {
     }
 
     public static boolean isSecondKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
@@ -1948,12 +1536,9 @@ public class SqlKeywords {
     }
 
     public static boolean isSecondsKeyword(CharSequence tok) {
-        if (tok.length() != 7) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 7
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'c'
                 && (tok.charAt(i++) | 32) == 'o'
@@ -1963,12 +1548,9 @@ public class SqlKeywords {
     }
 
     public static boolean isSelectKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -1981,23 +1563,17 @@ public class SqlKeywords {
     }
 
     public static boolean isSetKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isSquashKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'q'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -2006,12 +1582,9 @@ public class SqlKeywords {
     }
 
     public static boolean isStandardConformingStrings(CharSequence tok) {
-        if (tok.length() != 27) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 27
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
@@ -2041,23 +1614,17 @@ public class SqlKeywords {
     }
 
     public static boolean isSumKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i) | 32) == 'm';
     }
 
     public static boolean isSymbolKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 's'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'b'
@@ -2066,12 +1633,9 @@ public class SqlKeywords {
     }
 
     public static boolean isTableKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -2079,12 +1643,9 @@ public class SqlKeywords {
     }
 
     public static boolean isTablesKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'l'
@@ -2093,48 +1654,36 @@ public class SqlKeywords {
     }
 
     public static boolean isTextKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i) | 32) == 't';
     }
 
     public static boolean isTiesKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isTimeKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isTimestampKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'm'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -2146,22 +1695,16 @@ public class SqlKeywords {
     }
 
     public static boolean isToKeyword(CharSequence tok) {
-        if (tok.length() != 2) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 2
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i) | 32) == 'o';
     }
 
     public static boolean isTransactionIsolation(CharSequence tok) {
-        if (tok.length() != 21) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 21
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
@@ -2185,12 +1728,9 @@ public class SqlKeywords {
     }
 
     public static boolean isTransactionKeyword(CharSequence tok) {
-        if (tok.length() != 11) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 11
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'n'
@@ -2204,59 +1744,44 @@ public class SqlKeywords {
     }
 
     public static boolean isTrueKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'r'
                 && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isTrueKeyword(Utf8Sequence tok) {
-        if (tok.size() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.byteAt(i++) | 32) == 't'
+        return tok.size() == 4
+                && (tok.byteAt(i++) | 32) == 't'
                 && (tok.byteAt(i++) | 32) == 'r'
                 && (tok.byteAt(i++) | 32) == 'u'
                 && (tok.byteAt(i) | 32) == 'e';
     }
 
     public static boolean isTxnKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'x'
                 && (tok.charAt(i) | 32) == 'n';
     }
 
     public static boolean isTypeKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 't'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean isUnboundedKeyword(CharSequence tok) {
-        if (tok.length() != 9) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'u'
+        return tok.length() == 9
+                && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'b'
                 && (tok.charAt(i++) | 32) == 'o'
@@ -2268,12 +1793,9 @@ public class SqlKeywords {
     }
 
     public static boolean isUnionKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'u'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 'o'
@@ -2281,12 +1803,9 @@ public class SqlKeywords {
     }
 
     public static boolean isUpdateKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'u'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 'd'
                 && (tok.charAt(i++) | 32) == 'a'
@@ -2295,12 +1814,9 @@ public class SqlKeywords {
     }
 
     public static boolean isUpsertKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'u'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'u'
                 && (tok.charAt(i++) | 32) == 'p'
                 && (tok.charAt(i++) | 32) == 's'
                 && (tok.charAt(i++) | 32) == 'e'
@@ -2309,12 +1825,9 @@ public class SqlKeywords {
     }
 
     public static boolean isValuesKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'v'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'v'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -2323,12 +1836,9 @@ public class SqlKeywords {
     }
 
     public static boolean isVolumeKeyword(CharSequence tok) {
-        if (tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'v'
+        return tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'v'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'l'
                 && (tok.charAt(i++) | 32) == 'u'
@@ -2337,35 +1847,26 @@ public class SqlKeywords {
     }
 
     public static boolean isWalKeyword(CharSequence tok) {
-        if (tok.length() != 3) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'w'
+        return tok.length() == 3
+                && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 'l';
     }
 
     public static boolean isWeekKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'w'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i) | 32) == 'k';
     }
 
     public static boolean isWhereKeyword(CharSequence tok) {
-        if (tok.length() != 5) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'w'
+        return tok.length() == 5
+                && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i++) | 32) == 'h'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'r'
@@ -2373,24 +1874,19 @@ public class SqlKeywords {
     }
 
     public static boolean isWithKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'w'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i) | 32) == 'h';
     }
 
     public static boolean isWithinKeyword(CharSequence tok) {
-        if (tok == null || tok.length() != 6) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'w'
+        return tok != null
+                && tok.length() == 6
+                && (tok.charAt(i++) | 32) == 'w'
                 && (tok.charAt(i++) | 32) == 'i'
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'h'
@@ -2399,36 +1895,26 @@ public class SqlKeywords {
     }
 
     public static boolean isYearKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'y'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'y'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'a'
                 && (tok.charAt(i) | 32) == 'r';
     }
 
     public static boolean isZoneKeyword(CharSequence tok) {
-        if (tok.length() != 4) {
-            return false;
-        }
-
         int i = 0;
-        return (tok.charAt(i++) | 32) == 'z'
+        return tok.length() == 4
+                && (tok.charAt(i++) | 32) == 'z'
                 && (tok.charAt(i++) | 32) == 'o'
                 && (tok.charAt(i++) | 32) == 'n'
                 && (tok.charAt(i) | 32) == 'e';
     }
 
     public static boolean startsWithGeoHashKeyword(CharSequence tok) {
-        if (tok.length() < 7) {
-            return false;
-        }
-
-        int i = 0;
-        return isGeoHashKeyword(tok, i);
+        return (tok.length() >= 7)
+                && isGeoHashKeywordInternal(tok);
     }
 
     public static boolean validateExtractPart(CharSequence token) {
@@ -2449,7 +1935,8 @@ public class SqlKeywords {
         }
     }
 
-    private static boolean isGeoHashKeyword(CharSequence tok, int i) {
+    private static boolean isGeoHashKeywordInternal(CharSequence tok) {
+        int i = 0;
         return (tok.charAt(i++) | 32) == 'g'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'o'


### PR DESCRIPTION
I did some code optimization in the `SqlKeywords` class.
I know, this kind of optimization could be seen controversial, and I'm keen to get your feedback.

I did two things, which slightly sacrifice the readability - I hope it's still OK.
* refactor using short-circuit evaluation in SqlKeywords only
* refactor using a constant as array-index instead of a variable 

Both approaches together lead to a 12.4% smaller (compiled) .class file size. And also, the local variable is removed.
Looking at the compiled .class file, I believe the JIT will more often inline these functions (because smaller and technically simpler code) and the resulting assembly code will be somewhat smaller. 
That said, I also think the overall performance gain is very small, as local variables easily are buffered by the L1 cache.

PS:
Anyhow, it was a fun exercise ... I did use some regex and Python script to rewrite the code to avoid human errors.
Did execute and pass all griffin.* test classes prior to this PR and beeing sure the CI/CD will for sure pass as well.