### PR TITLE
fix(build): create dbroot directory inside user home on MacOS

### DIFF
--- a/core/src/main/bin/questdb.sh
+++ b/core/src/main/bin/questdb.sh
@@ -57,7 +57,11 @@ export QDB_OS=`uname`
 case `uname` in
    Darwin|FreeBSD)
        export PS_CMD="ps aux"
-       export QDB_DEFAULT_ROOT="/usr/local/var/questdb"
+       if [ -d "/usr/local/var/questdb" ] || [ "$(id -u)" = "0" ]; then
+           export QDB_DEFAULT_ROOT="/usr/local/var/questdb"
+       else
+           export QDB_DEFAULT_ROOT="$HOME/.questdb"
+       fi
        ;;
    *)
        export PS_CMD="ps -ef"


### PR DESCRIPTION
fixes #3996

Reasoning: QuestDB no-jre fails to start on MacOS. Because it's trying to create /usr/local/var/questdb which it cannot do without sudo. When installed via brew the DBRoot is created during the installation process and set explicitly.

I assume there is the same problem with the no-jre version on FreeBSD.