### PR TITLE
test(pgwire): fix a flaky pgwire cancellation test

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -2355,7 +2355,7 @@ if __name__ == "__main__":
 
         assertWithPgServer(CONN_AWARE_EXTENDED_BINARY, (connection, binary) -> {
             ddl("create table if not exists tab as " +
-                    "(select x::timestamp ts, x, rnd_double() d from long_sequence(1000000)) timestamp(ts) partition by day");
+                    "(select x::timestamp ts, x, rnd_double() d from long_sequence(5000000)) timestamp(ts) partition by day");
             ddl("create table if not exists dest as (select x l from long_sequence(10000))");
             mayDrainWalQueue();
 


### PR DESCRIPTION
fixes #3180

reasoning: if the query is completed before the cancelling thread is scheduled for execution then the test fails. this can happen on under-powered boxes (e.g. Windows CI) where a scheduler has to shuffle a lot of tasks. this changeset makes the queries slower thus the cancelling thread has a higher chance to cancel the query.