### PR TITLE
feat(core): add support for configurable JVM flags using environment variables

### DIFF
--- a/core/src/main/bin/questdb.sh
+++ b/core/src/main/bin/questdb.sh
@@ -183,6 +183,7 @@ function start {
     -XX:+UnlockExperimentalVMOptions
     -XX:+AlwaysPreTouch
     -XX:+UseParallelGC
+    ${JVM_PREPEND}
     "
 
     if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Fixes #3981 

In this PR, I've modified questdb.sh file to set JVM flags using environment variables.  Please let me know if anything has to be changed in code.

Appreciate if you can review.

Thanks!