### PR TITLE
feat(sql): add covariance and corr built-in functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
@@ -38,8 +38,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * The abstract class, in addition, provides a method to aggregate bivariate/regression statistics.
  * We use an algorithm similar to B. P. Welford's which works by first aggregating sum of squares of 
- * independent and dependent variables Sxx = sum[(X - meanX) ^ 2], Syy = sum[(Y - meanY) ^ 2], Sxy = sum[(X - meanX) * (Y - meanY)].
- * Computation of covariance and correlation is then simple (e.g. covariance = Sxy / (n - 1), correlation = Sxy / sqrt(Sxx * Syy))
+ * independent and dependent variables Sxy = sum[(X - meanX) * (Y - meanY)].
+ * Computation of covariance is then simple, e.g. covariance = Sxy / (n - 1)
  *
  * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
  */

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
@@ -44,38 +44,32 @@ import org.jetbrains.annotations.NotNull;
  * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
  */
 
-public abstract class AbstractRegressionGroupByFunction extends DoubleFunction implements GroupByFunction, BinaryFunction {
+public abstract class AbstractCovarGroupByFunction extends DoubleFunction implements GroupByFunction, BinaryFunction {
     protected final Function xFunction;
     protected final Function yFunction;
     protected int valueIndex;
 
-    protected AbstractRegressionGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
+    protected AbstractCovarGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
         this.xFunction = arg0;
         this.yFunction = arg1;
     }
 
     protected void aggregate(MapValue mapValue, double x, double y) {
         double meanX = mapValue.getDouble(valueIndex);
-        double sumX = mapValue.getDouble(valueIndex + 1);
-        double meanY = mapValue.getDouble(valueIndex + 2);
-        double sumY = mapValue.getDouble(valueIndex + 3);
-        double sumXY = mapValue.getDouble(valueIndex + 4);
-        long count = mapValue.getLong(valueIndex + 5) + 1;
+        double meanY = mapValue.getDouble(valueIndex + 1);
+        double sumXY = mapValue.getDouble(valueIndex + 2);
+        long count = mapValue.getLong(valueIndex + 3) + 1;
 
         double oldMeanX = meanX;
         meanX += (x - meanX) / count;
-        sumX += (x - meanX) * (x - oldMeanX);
         double oldMeanY = meanY;
         meanY += (y - meanY) / count;
-        sumY += (y - meanY) * (y - oldMeanY);
         sumXY += (x - oldMeanX) * (y - meanY);
 
         mapValue.putDouble(valueIndex, meanX);
-        mapValue.putDouble(valueIndex + 1, sumX);
-        mapValue.putDouble(valueIndex + 2, meanY);
-        mapValue.putDouble(valueIndex + 3, sumY);
-        mapValue.putDouble(valueIndex + 4, sumXY);
-        mapValue.addLong(valueIndex + 5, 1L);
+        mapValue.putDouble(valueIndex + 1, meanY);
+        mapValue.putDouble(valueIndex + 2, sumXY);
+        mapValue.addLong(valueIndex + 3, 1L);
     }
 
     @Override
@@ -85,9 +79,7 @@ public abstract class AbstractRegressionGroupByFunction extends DoubleFunction i
         mapValue.putDouble(valueIndex, 0);
         mapValue.putDouble(valueIndex + 1, 0);
         mapValue.putDouble(valueIndex + 2, 0);
-        mapValue.putDouble(valueIndex + 3, 0);
-        mapValue.putDouble(valueIndex + 4, 0);
-        mapValue.putLong(valueIndex + 5, 0);
+        mapValue.putLong(valueIndex + 3, 0);
 
         if (Numbers.isFinite(x) && Numbers.isFinite(y)) {
             aggregate(mapValue, x, y);
@@ -124,15 +116,13 @@ public abstract class AbstractRegressionGroupByFunction extends DoubleFunction i
         columnTypes.add(ColumnType.DOUBLE);
         columnTypes.add(ColumnType.DOUBLE);
         columnTypes.add(ColumnType.DOUBLE);
-        columnTypes.add(ColumnType.DOUBLE);
-        columnTypes.add(ColumnType.DOUBLE);
         columnTypes.add(ColumnType.LONG);
     }
 
     @Override
     public void setDouble(MapValue mapValue, double value) {
-        mapValue.putDouble(valueIndex + 4, value);
-        mapValue.putLong(valueIndex + 5, 1L);
+        mapValue.putDouble(valueIndex + 2, value);
+        mapValue.putLong(valueIndex + 3, 1L);
     }
 
     @Override
@@ -140,9 +130,7 @@ public abstract class AbstractRegressionGroupByFunction extends DoubleFunction i
         mapValue.putDouble(valueIndex, Double.NaN);
         mapValue.putDouble(valueIndex + 1, Double.NaN);
         mapValue.putDouble(valueIndex + 2, Double.NaN);
-        mapValue.putDouble(valueIndex + 3, Double.NaN);
-        mapValue.putDouble(valueIndex + 4, Double.NaN);
-        mapValue.putLong(valueIndex + 5, 0);
+        mapValue.putLong(valueIndex + 3, 0);
     }
 }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractRegressionGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractRegressionGroupByFunction.java
@@ -36,7 +36,10 @@ import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * ...
+ * The abstract class, in addition, provides a method to aggregate bivariate/regression statistics.
+ * We use an algorithm similar to B. P. Welford's which works by first aggregating sum of squares of 
+ * independent and dependent variables Sxx = sum[(X - meanX) ^ 2], Syy = sum[(Y - meanY) ^ 2], Sxy = sum[(X - meanX) * (Y - meanY)].
+ * Computation of covariance and correlation is then simple (e.g. covariance = Sxy / (n - 1), correlation = Sxy / sqrt(Sxx * Syy))
  *
  * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
  */

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractRegressionGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractRegressionGroupByFunction.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * ...
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
+ */
+
+public abstract class AbstractRegressionGroupByFunction extends DoubleFunction implements GroupByFunction, BinaryFunction {
+    protected final Function xFunction;
+    protected final Function yFunction;
+    protected int valueIndex;
+
+    protected AbstractRegressionGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
+        this.xFunction = arg0;
+        this.yFunction = arg1;
+    }
+
+    protected void aggregate(MapValue mapValue, double x, double y) {
+        double meanX = mapValue.getDouble(valueIndex);
+        double sumX = mapValue.getDouble(valueIndex + 1);
+        double meanY = mapValue.getDouble(valueIndex + 2);
+        double sumY = mapValue.getDouble(valueIndex + 3);
+        double sumXY = mapValue.getDouble(valueIndex + 4);
+        long count = mapValue.getLong(valueIndex + 5) + 1;
+
+        double oldMeanX = meanX;
+        meanX += (x - meanX) / count;
+        sumX += (x - meanX) * (x - oldMeanX);
+        double oldMeanY = meanY;
+        meanY += (y - meanY) / count;
+        sumY += (y - meanY) * (y - oldMeanY);
+        sumXY += (x - oldMeanX) * (y - meanY);
+
+        mapValue.putDouble(valueIndex, meanX);
+        mapValue.putDouble(valueIndex + 1, sumX);
+        mapValue.putDouble(valueIndex + 2, meanY);
+        mapValue.putDouble(valueIndex + 3, sumY);
+        mapValue.putDouble(valueIndex + 4, sumXY);
+        mapValue.addLong(valueIndex + 5, 1L);
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record) {
+        final double x = xFunction.getDouble(record);
+        final double y = yFunction.getDouble(record);
+        mapValue.putDouble(valueIndex, 0);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putDouble(valueIndex + 3, 0);
+        mapValue.putDouble(valueIndex + 4, 0);
+        mapValue.putLong(valueIndex + 5, 0);
+
+        if (Numbers.isFinite(x) && Numbers.isFinite(y)) {
+            aggregate(mapValue, x, y);
+        }
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record) {
+        final double x = xFunction.getDouble(record);
+        final double y = yFunction.getDouble(record);
+        if (Numbers.isFinite(x) && Numbers.isFinite(y)) {
+            aggregate(mapValue, x, y);
+        }
+    }
+
+    @Override
+    public Function getLeft() {
+        return xFunction;
+    }
+
+    @Override
+    public Function getRight() {
+        return yFunction;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public void pushValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.LONG);
+    }
+
+    @Override
+    public void setDouble(MapValue mapValue, double value) {
+        mapValue.putDouble(valueIndex + 4, value);
+        mapValue.putLong(valueIndex + 5, 1L);
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
+        mapValue.putDouble(valueIndex + 1, Double.NaN);
+        mapValue.putDouble(valueIndex + 2, Double.NaN);
+        mapValue.putDouble(valueIndex + 3, Double.NaN);
+        mapValue.putDouble(valueIndex + 4, Double.NaN);
+        mapValue.putLong(valueIndex + 5, 0);
+    }
+}
+

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
@@ -36,9 +36,9 @@ import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The abstract class, in addition, provides a method to aggregate statistics.
+ * The abstract class, in addition, provides a method to aggregate univariate statistics.
  * We use the B. P. Welford algorithm which works by first aggregating sum of squares Sxx = sum[(X - mean) ^ 2].
- * Computation of standard deviation and variance is then simple (e.g. variance = Sxx / (n - 1))
+ * Computation of standard deviation and variance is then simple (e.g. variance = Sxx / (n - 1), standard deviation = sqrt(variance))
  *
  * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm">Welford's algorithm</a>
  */

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * We use an algorithm similar to B. P. Welford's which works by first aggregating sum of squares of 
  * independent and dependent variables Sxx = sum[(X - meanX) ^ 2], Syy = sum[(Y - meanY) ^ 2], Sxy = sum[(X - meanX) * (Y - meanY)].
- * Computation of correlation is then simple, e.g. covariance = Sxy / (n - 1)
+ * Computation of correlation is then simple, e.g. correlation = Sxy / sqrt(Sxx * Syy)
  *
  * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
  */

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
@@ -35,10 +35,71 @@ import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
-public class CorrGroupByFunction extends AbstractRegressionGroupByFunction {
+/**
+ * We use an algorithm similar to B. P. Welford's which works by first aggregating sum of squares of 
+ * independent and dependent variables Sxx = sum[(X - meanX) ^ 2], Syy = sum[(Y - meanY) ^ 2], Sxy = sum[(X - meanX) * (Y - meanY)].
+ * Computation of correlation is then simple, e.g. covariance = Sxy / (n - 1)
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Welford's algorithm</a>
+ */
+
+public class CorrGroupByFunction extends DoubleFunction implements GroupByFunction, BinaryFunction {
+    protected final Function xFunction;
+    protected final Function yFunction;
+    protected int valueIndex;
 
     protected CorrGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
-        super(arg0, arg1);
+        this.xFunction = arg0;
+        this.yFunction = arg1;
+    }
+
+    protected void aggregate(MapValue mapValue, double x, double y) {
+        double meanX = mapValue.getDouble(valueIndex);
+        double sumX = mapValue.getDouble(valueIndex + 1);
+        double meanY = mapValue.getDouble(valueIndex + 2);
+        double sumY = mapValue.getDouble(valueIndex + 3);
+        double sumXY = mapValue.getDouble(valueIndex + 4);
+        long count = mapValue.getLong(valueIndex + 5) + 1;
+
+        double oldMeanX = meanX;
+        meanX += (x - meanX) / count;
+        sumX += (x - meanX) * (x - oldMeanX);
+        double oldMeanY = meanY;
+        meanY += (y - meanY) / count;
+        sumY += (y - meanY) * (y - oldMeanY);
+        sumXY += (x - oldMeanX) * (y - meanY);
+
+        mapValue.putDouble(valueIndex, meanX);
+        mapValue.putDouble(valueIndex + 1, sumX);
+        mapValue.putDouble(valueIndex + 2, meanY);
+        mapValue.putDouble(valueIndex + 3, sumY);
+        mapValue.putDouble(valueIndex + 4, sumXY);
+        mapValue.addLong(valueIndex + 5, 1L);
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record) {
+        final double x = xFunction.getDouble(record);
+        final double y = yFunction.getDouble(record);
+        mapValue.putDouble(valueIndex, 0);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putDouble(valueIndex + 3, 0);
+        mapValue.putDouble(valueIndex + 4, 0);
+        mapValue.putLong(valueIndex + 5, 0);
+
+        if (Numbers.isFinite(x) && Numbers.isFinite(y)) {
+            aggregate(mapValue, x, y);
+        }
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record) {
+        final double x = xFunction.getDouble(record);
+        final double y = yFunction.getDouble(record);
+        if (Numbers.isFinite(x) && Numbers.isFinite(y)) {
+            aggregate(mapValue, x, y);
+        }
     }
 
     @Override
@@ -59,5 +120,46 @@ public class CorrGroupByFunction extends AbstractRegressionGroupByFunction {
     @Override
     public String getName() {
         return "corr";
+    }
+    @Override
+    public Function getLeft() {
+        return xFunction;
+    }
+
+    @Override
+    public Function getRight() {
+        return yFunction;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public void pushValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.LONG);
+    }
+
+    @Override
+    public void setDouble(MapValue mapValue, double value) {
+        mapValue.putDouble(valueIndex + 4, value);
+        mapValue.putLong(valueIndex + 5, 1L);
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
+        mapValue.putDouble(valueIndex + 1, Double.NaN);
+        mapValue.putDouble(valueIndex + 2, Double.NaN);
+        mapValue.putDouble(valueIndex + 3, Double.NaN);
+        mapValue.putDouble(valueIndex + 4, Double.NaN);
+        mapValue.putLong(valueIndex + 5, 0);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
@@ -43,7 +43,6 @@ public class CorrGroupByFunction extends AbstractRegressionGroupByFunction {
 
     @Override
     public double getDouble(Record rec) {
-        // corr = Sxy / sqrt(Sx * Sy)
         double sumX = rec.getDouble(valueIndex + 1);
         double sumY = rec.getDouble(valueIndex + 3);
         double sumXY = rec.getDouble(valueIndex + 4);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+public class CorrGroupByFunction extends AbstractRegressionGroupByFunction {
+
+    protected CorrGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
+        super(arg0, arg1);
+    }
+
+    @Override
+    public double getDouble(Record rec) {
+        // corr = Sxy / sqrt(Sx * Sy)
+        double sumX = rec.getDouble(valueIndex + 1);
+        double sumY = rec.getDouble(valueIndex + 3);
+        double sumXY = rec.getDouble(valueIndex + 4);
+        double count = rec.getLong(valueIndex + 5);
+        if (count <= 0) {
+            return Double.NaN;
+        }
+        if (sumX == 0 || sumY == 0) {
+            return Double.NaN;
+        }
+        return sumXY / Math.sqrt(sumX * sumY);
+    }
+
+    @Override
+    public String getName() {
+        return "corr";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunctionFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class CorrGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "corr(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CorrGroupByFunction(args.getQuick(0), args.getQuick(1));
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunction.java
@@ -24,18 +24,11 @@
 
 package io.questdb.griffin.engine.functions.groupby;
 
-import io.questdb.cairo.ArrayColumnTypes;
-import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.engine.functions.DoubleFunction;
-import io.questdb.griffin.engine.functions.GroupByFunction;
-import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
-public class CovarPopGroupByFunction extends AbstractRegressionGroupByFunction {
+public class CovarPopGroupByFunction extends AbstractCovarGroupByFunction {
 
     protected CovarPopGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
         super(arg0, arg1);
@@ -43,9 +36,9 @@ public class CovarPopGroupByFunction extends AbstractRegressionGroupByFunction {
 
     @Override
     public double getDouble(Record rec) {
-        long count = rec.getLong(valueIndex + 5);
+        long count = rec.getLong(valueIndex + 3);
         if (count > 0) {
-            double sumXY = rec.getDouble(valueIndex + 4);
+            double sumXY = rec.getDouble(valueIndex + 2);
             return sumXY / count;
         }
         return Double.NaN;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+public class CovarPopGroupByFunction extends AbstractRegressionGroupByFunction {
+
+    protected CovarPopGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
+        super(arg0, arg1);
+    }
+
+    @Override
+    public double getDouble(Record rec) {
+        long count = rec.getLong(valueIndex + 5);
+        if (count > 0) {
+            double sumXY = rec.getDouble(valueIndex + 4);
+            return sumXY / count;
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public String getName() {
+        return "covar_pop";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class CovarPopGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "covar_pop(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CovarPopGroupByFunction(args.getQuick(0), args.getQuick(1));
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+public class CovarSampleGroupByFunction extends AbstractRegressionGroupByFunction {
+
+    protected CovarSampleGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
+        super(arg0, arg1);
+    }
+
+    @Override
+    public double getDouble(Record rec) {
+        long count = rec.getLong(valueIndex + 5);
+        if (count - 1 > 0) {
+            double sumXY = rec.getDouble(valueIndex + 4);
+            return sumXY / (count - 1);
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public String getName() {
+        return "covar_samp";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunction.java
@@ -24,18 +24,11 @@
 
 package io.questdb.griffin.engine.functions.groupby;
 
-import io.questdb.cairo.ArrayColumnTypes;
-import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.engine.functions.DoubleFunction;
-import io.questdb.griffin.engine.functions.GroupByFunction;
-import io.questdb.griffin.engine.functions.BinaryFunction;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
-public class CovarSampleGroupByFunction extends AbstractRegressionGroupByFunction {
+public class CovarSampleGroupByFunction extends AbstractCovarGroupByFunction {
 
     protected CovarSampleGroupByFunction(@NotNull Function arg0, @NotNull Function arg1) {
         super(arg0, arg1);
@@ -43,9 +36,9 @@ public class CovarSampleGroupByFunction extends AbstractRegressionGroupByFunctio
 
     @Override
     public double getDouble(Record rec) {
-        long count = rec.getLong(valueIndex + 5);
+        long count = rec.getLong(valueIndex + 3);
         if (count - 1 > 0) {
-            double sumXY = rec.getDouble(valueIndex + 4);
+            double sumXY = rec.getDouble(valueIndex + 2);
             return sumXY / (count - 1);
         }
         return Double.NaN;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class CovarSampleGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "covar_samp(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CovarSampleGroupByFunction(args.getQuick(0), args.getQuick(1));
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -757,6 +757,12 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.groupby.VarSampleGroupByFunctionFactory,
 //                 var_pop()
             io.questdb.griffin.engine.functions.groupby.VarPopGroupByFunctionFactory,
+//                 covar_samp()
+            io.questdb.griffin.engine.functions.groupby.CovarSampleGroupByFunctionFactory,
+//                 covar_pop()
+            io.questdb.griffin.engine.functions.groupby.CovarPopGroupByFunctionFactory,
+//                 corr()
+            io.questdb.griffin.engine.functions.groupby.CorrGroupByFunctionFactory,
 //                  ^
             io.questdb.griffin.engine.functions.math.PowDoubleFunctionFactory,
             io.questdb.griffin.engine.functions.table.AllTablesFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -744,6 +744,15 @@ io.questdb.griffin.engine.functions.groupby.VarSampleGroupByFunctionFactory
 # var_pop()
 io.questdb.griffin.engine.functions.groupby.VarPopGroupByFunctionFactory
 
+# covar_samp()
+io.questdb.griffin.engine.functions.groupby.CovarSampleGroupByFunctionFactory
+
+# covar_pop()
+io.questdb.griffin.engine.functions.groupby.CovarPopGroupByFunctionFactory
+
+# corr()
+io.questdb.griffin.engine.functions.groupby.CorrGroupByFunctionFactory
+
 # strpos()
 io.questdb.griffin.engine.functions.str.StrPosFunctionFactory
 io.questdb.griffin.engine.functions.str.StrPosCharFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testCorrOneColumnAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "corr\nNaN\n", "select corr(x, y) from (select cast(null as double) x, x as y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCorrAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "corr\nNaN\n", "select corr(x, y) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCorrAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 17.2151921 x, x as y from long_sequence(100))");
+            assertSql(
+                    "corr\nNaN\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select x cast(x as double), x as y from long_sequence(100))");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x double, y double)");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            insert("insert into 'tbl1' select x, x as y from long_sequence(100)");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select x cast(x as float), x as y from long_sequence(100))");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select x cast(x as int), x as y from long_sequence(100))");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrLong256Values() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select x cast(x as long256), x as y from long_sequence(100))");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            assertSql(
+                    "corr\nNaN\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            insert("insert into 'tbl1' VALUES " +
+                    "(1, 1)");
+            assertSql(
+                    "corr\nNaN\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrTwoValue() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            insert("insert into 'tbl1' VALUES " +
+                    "(1, 1), (2, 2)");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrOverflow() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 100000000 x, 100000000 y from long_sequence(1000000))");
+            assertSql(
+                    "corr\nNaN\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCorrSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select x cast(x as double), x as y from long_sequence(100))");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            assertSql(
+                    "corr\n1.0\n", "select corr(x, y) from tbl1"
+            );
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
@@ -46,7 +46,7 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCorrAllSameValues() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select 17.2151921 x, x as y from long_sequence(100))");
+            ddl("create table tbl1 as (select 17.2151921 x, 17.2151921 y from long_sequence(100))");
             assertSql(
                     "corr\nNaN\n", "select corr(x, y) from tbl1"
             );
@@ -56,7 +56,7 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCorrDoubleValues() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select x cast(x as double), x as y from long_sequence(100))");
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
             assertSql(
                     "corr\n1.0\n", "select corr(x, y) from tbl1"
             );
@@ -78,7 +78,7 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCorrFloatValues() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select x cast(x as float), x as y from long_sequence(100))");
+            ddl("create table tbl1 as (select cast(x as float) x, cast(x as float) y from long_sequence(100))");
             assertSql(
                     "corr\n1.0\n", "select corr(x, y) from tbl1"
             );
@@ -88,7 +88,7 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCorrIntValues() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select x cast(x as int), x as y from long_sequence(100))");
+            ddl("create table tbl1 as (select cast(x as int) x, cast(x as int) y from long_sequence(100))");
             assertSql(
                     "corr\n1.0\n", "select corr(x, y) from tbl1"
             );
@@ -142,7 +142,7 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCorrSomeNull() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select x cast(x as double), x as y from long_sequence(100))");
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
             insert("insert into 'tbl1' VALUES (null, null)");
             assertSql(
                     "corr\n1.0\n", "select corr(x, y) from tbl1"

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrGroupByFunctionFactoryTest.java
@@ -96,16 +96,6 @@ public class CorrGroupByFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCorrLong256Values() throws Exception {
-        assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select x cast(x as long256), x as y from long_sequence(100))");
-            assertSql(
-                    "corr\n1.0\n", "select corr(x, y) from tbl1"
-            );
-        });
-    }
-
-    @Test
     public void testCorrNoValues() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table tbl1(x int, y int)");

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactoryTest.java
@@ -39,7 +39,7 @@ public class CovarPopGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCovarPopAllNull() throws Exception {
         assertMemoryLeak(() -> assertSql(
-                "covar_pop\nNaN\n", "select covar_pop(x, y) from (select x cast(null as double), cast(null as double) y from long_sequence(100))"
+                "covar_pop\nNaN\n", "select covar_pop(x, y) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))"
         ));
     }
 
@@ -56,7 +56,7 @@ public class CovarPopGroupByFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCovarPopDoubleValues() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table tbl1 as (select cast(x as double) as x, cast(x as double) y from long_sequence(100))");
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
             assertSql(
                     "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
             );

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarPopGroupByFunctionFactoryTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class CovarPopGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testCovarPopOneColumnAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "covar_pop\nNaN\n", "select covar_pop(x, y) from (select cast(null as double) x, x as y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCovarPopAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "covar_pop\nNaN\n", "select covar_pop(x, y) from (select x cast(null as double), cast(null as double) y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCovarPopAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 17.2151921 x, 17.2151921 y from long_sequence(100))");
+            assertSql(
+                    "covar_pop\n0.0\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as double) as x, cast(x as double) y from long_sequence(100))");
+            assertSql(
+                    "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x double, y double)");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            insert("insert into 'tbl1' select x, x as y from long_sequence(100)");
+            assertSql(
+                    "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as float) x, cast(x as float) y from long_sequence(100))");
+            assertSql(
+                    "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as int) x, cast(x as int) y from long_sequence(100))");
+            assertSql(
+                    "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            assertSql(
+                    "covar_pop\nNaN\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            insert("insert into 'tbl1' VALUES " +
+                    "(17.2151920, 17.2151920)");
+            assertSql(
+                    "covar_pop\n0.0\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopOverflow() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 100000000 x, 100000000 y from long_sequence(1000000))");
+            assertSql(
+                    "covar_pop\n0.0\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarPopSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            assertSql(
+                    "covar_pop\n833.25\n", "select covar_pop(x, y) from tbl1"
+            );
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactoryTest.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class CovarSampleGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testCovarSampleOneColumnAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "covar_samp\nNaN\n", "select covar_samp(x, y) from (select cast(null as double) x, x as y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCovarSampleAllNull() throws Exception {
+        assertMemoryLeak(() -> assertSql(
+                "covar_samp\nNaN\n", "select covar_samp(x, y) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))"
+        ));
+    }
+
+    @Test
+    public void testCovarSampleAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 17.2151921 x, 17.2151921 y from long_sequence(100))");
+            assertSql(
+                    "covar_samp\n0.0\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
+            assertSql(
+                    "covar_samp\n841.6666666666666\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x double, y double)");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            insert("insert into 'tbl1' select x, x as y from long_sequence(100)");
+            assertSql(
+                    "covar_samp\n841.6666666666666\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as float) x, cast(x as float) y from long_sequence(100))");
+            assertSql(
+                    "covar_samp\n841.6666666666666\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as int) x, cast(x as int) y from long_sequence(100))");
+            assertSql(
+                    "covar_samp\n841.6666666666666\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            assertSql(
+                    "covar_samp\nNaN\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1(x int, y int)");
+            insert("insert into 'tbl1' VALUES " +
+                    "(17.2151920, 17.2151920)");
+            assertSql(
+                    "covar_samp\nNaN\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleOverflow() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select 100000000 x, 100000000 y from long_sequence(1000000))");
+            assertSql(
+                    "covar_samp\n0.0\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+
+    @Test
+    public void testCovarSampleSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tbl1 as (select cast(x as double) x, cast(x as double) y from long_sequence(100))");
+            insert("insert into 'tbl1' VALUES (null, null)");
+            assertSql(
+                    "covar_samp\n841.6666666666666\n", "select covar_samp(x, y) from tbl1"
+            );
+        });
+    }
+}


### PR DESCRIPTION
Closes #3826

Resolves https://github.com/questdb/roadmap/issues/55

Model after Postgres: ```covar_samp()```, ```covar_pop()```, ```corr()```