### PR TITLE
fix(core): fix failed SQL update not suspending table potentially leading to data loss

### DIFF
--- a/core/src/main/java/io/questdb/cairo/AttachDetachStatus.java
+++ b/core/src/main/java/io/questdb/cairo/AttachDetachStatus.java
@@ -25,7 +25,7 @@
 package io.questdb.cairo;
 
 public enum AttachDetachStatus {
-    OK,
+    OK(false),
     DETACH_ERR_ACTIVE(false),
     DETACH_ERR_MISSING_PARTITION(false),
     DETACH_ERR_MISSING_PARTITION_DIR,
@@ -37,9 +37,9 @@ public enum AttachDetachStatus {
     ATTACH_ERR_PARTITION_EXISTS(false),
     ATTACH_ERR_RENAME,
     ATTACH_ERR_COPY,
-    ATTACH_ERR_MISSING_PARTITION,
-    ATTACH_ERR_DIR_EXISTS,
-    ATTACH_ERR_EMPTY_PARTITION;
+    ATTACH_ERR_MISSING_PARTITION(false),
+    ATTACH_ERR_DIR_EXISTS(false),
+    ATTACH_ERR_EMPTY_PARTITION(false);
 
     private final boolean isCritical;
 
@@ -61,7 +61,7 @@ public enum AttachDetachStatus {
         assert status != OK;
         CairoException exception = isCritical ?
                 CairoException.critical(CairoException.METADATA_VALIDATION) :
-                CairoException.nonCritical();
+                CairoException.partitionManipulationRecoverable();
         String statusName = status.name();
         String operation = statusName.split("_")[0].toLowerCase();
         exception.put("could not ").put(operation)

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -548,7 +548,9 @@ public class CairoEngine implements Closeable, WriterSource {
         try {
             return tableReaderMetadataPool.get(tableToken);
         } catch (CairoException e) {
-            if (!tableToken.isWal()) {
+            if (tableToken.isWal()) {
+                throw e;
+            } else {
                 tryRepairTable(tableToken, e);
             }
         }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
@@ -424,7 +424,7 @@ public class AlterOperation extends AbstractOperation implements Mutable {
         for (int i = 0, n = extraInfo.size() / 2; i < n; i++) {
             long partitionTimestamp = extraInfo.getQuick(i * 2);
             if (!svc.removePartition(partitionTimestamp)) {
-                throw CairoException.nonCritical()
+                throw CairoException.partitionManipulationRecoverable()
                         .put("could not remove partition [table=").put(tableToken != null ? tableToken.getTableName() : "<null>")
                         .put(", partitionTimestamp=").ts(partitionTimestamp)
                         .put(", partitionBy=").put(PartitionBy.toString(svc.getPartitionBy()))

--- a/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
@@ -257,7 +257,7 @@ public class DropIndexTest extends AbstractCairoTest {
             assertException(
                     "ALTER TABLE підрахунок ALTER COLUMN колонка DROP INDEX",
                     36,
-                    "column is not indexed [name=колонка]"
+                    "column is not indexed [column=колонка]"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/JoinRecordMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/JoinRecordMetadataTest.java
@@ -24,10 +24,10 @@
 
 package io.questdb.test.griffin.engine.join;
 
-import io.questdb.griffin.engine.join.JoinRecordMetadata;
-import io.questdb.test.AbstractCairoTest;
 import io.questdb.cairo.ColumnType;
+import io.questdb.griffin.engine.join.JoinRecordMetadata;
 import io.questdb.std.str.StringSink;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,14 +41,14 @@ public class JoinRecordMetadataTest extends AbstractCairoTest {
             metadata.add("a", "X", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X], [alias=a]");
+            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X, alias=a]");
         }
 
         try {
             metadata.add("A", "X", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X], [alias=A]");
+            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X, alias=A]");
         }
 
         Assert.assertEquals(0, metadata.getColumnIndexQuiet("x"));
@@ -71,7 +71,7 @@ public class JoinRecordMetadataTest extends AbstractCairoTest {
             metadata.add("b", "y", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=y], [alias=b]");
+            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=y, alias=b]");
         }
 
         metadata.add(null, "c.x", ColumnType.STRING, false, 0, false, null);


### PR DESCRIPTION
Fixes part of the problem described in #4011 that failed UPDATE SQL does not suspend WAL table.

The reason the UPDATE described in the issue fails is fixed in #3975 and this PR adds a test for the scenario.