### PR TITLE
test(core): improve FuzzRunner

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/TableMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/sql/TableMetadata.java
@@ -30,5 +30,6 @@ public interface TableMetadata extends TableRecordMetadata {
     long getO3MaxLag();
 
     int getPartitionBy();
+
     boolean isSoftLink();
 }

--- a/core/src/test/java/io/questdb/test/griffin/O3MaxLagFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3MaxLagFuzzTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin;
 
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -45,7 +46,6 @@ import org.junit.Test;
 
 public class O3MaxLagFuzzTest extends AbstractO3Test {
     private final static Log LOG = LogFactory.getLog(O3MaxLagFuzzTest.class);
-
 
     @Test
     public void testFuzzParallel() throws Exception {
@@ -111,9 +111,11 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
         int rowCount = Math.max(1, txCount * rnd.nextInt(200) * 1000);
         try (
                 TableWriter w = TestUtils.getWriter(engine, "x");
+                TableMetadata sequencerMetadata = engine.getSequencerMetadata(w.getTableToken());
                 TableWriter w2 = TestUtils.getWriter(engine, "y")
         ) {
             ObjList<FuzzTransaction> transactions = FuzzTransactionGenerator.generateSet(
+                    sequencerMetadata,
                     w.getMetadata(),
                     rnd,
                     minTs,

--- a/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
@@ -70,8 +70,15 @@ public class AbstractFuzzTest extends AbstractCairoTest {
         return fuzzer.generateRandom(log, s0, s1);
     }
 
-    public ObjList<FuzzTransaction> generateSet(Rnd rnd, TableRecordMetadata metadata, long start, long end, String tableName) {
-        return fuzzer.generateSet(rnd, metadata, start, end, tableName);
+    public ObjList<FuzzTransaction> generateSet(
+            Rnd rnd,
+            TableRecordMetadata sequencerMetadata,
+            TableRecordMetadata readerMetadata,
+            long start,
+            long end,
+            String tableName
+    ) {
+        return fuzzer.generateSet(rnd, sequencerMetadata, readerMetadata, start, end, tableName);
     }
 
     @Before

--- a/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/AbstractFuzzTest.java
@@ -71,7 +71,7 @@ public class AbstractFuzzTest extends AbstractCairoTest {
     }
 
     public ObjList<FuzzTransaction> generateSet(Rnd rnd, TableRecordMetadata metadata, long start, long end, String tableName) {
-        return fuzzer.generateSet(rnd, metadata, start, end, tableName, metadata.getMetadataVersion());
+        return fuzzer.generateSet(rnd, metadata, start, end, tableName);
     }
 
     @Before

--- a/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
@@ -296,8 +296,8 @@ public class FuzzRunner {
         s1 = 0;
     }
 
-    public TableToken createInitialTable(String tableName, boolean awaitTxns) throws SqlException {
-        return createInitialTable(tableName, awaitTxns, initialRowCount);
+    public TableToken createInitialTable(String tableName, boolean isWal) throws SqlException {
+        return createInitialTable(tableName, isWal, initialRowCount);
     }
 
     public TableToken createInitialTable(String tableName, boolean isWal, int rowCount) throws SqlException {


### PR DESCRIPTION
Follow-up for #4014

With this change, col tops columns are included in the fuzzed transactions. Previously it wasn't the case as those columns weren't in the end table when the fuzzer was generating transactions.