### PR TITLE
test(core): fix fuzz tests to handle table dropping

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
@@ -25,6 +25,7 @@
 package io.questdb.test.griffin.wal;
 
 import io.questdb.cairo.*;
+import io.questdb.cairo.pool.ex.EntryLockedException;
 import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.api.MemoryR;
@@ -602,7 +603,8 @@ public class FuzzRunner {
                 return getReader(tableNameWal);
             } catch (CairoException e) {
                 if (Chars.contains(e.getFlyweightMessage(), "table does not exist")
-                        || Chars.contains(e.getFlyweightMessage(), "table name is reserved")) {
+                        || Chars.contains(e.getFlyweightMessage(), "table name is reserved")
+                        || e instanceof EntryLockedException) {
                     LOG.error().$((Throwable) e).$();
                     Os.sleep(10);
                 } else {

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -168,7 +168,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
 
     @Test
     public void testWalWriteFullRandom() throws Exception {
-        Rnd rnd = generateRandom(LOG);
+        Rnd rnd = generateRandom(LOG, 1157852240565L, 1701288457416L);
         setRandomAppendPageSize(rnd);
         setFuzzProperties(rnd.nextLong(MAX_WAL_APPLY_TIME_PER_TABLE_CEIL), getRndO3PartitionSplit(rnd), getRndO3PartitionSplitMaxCount(rnd), getMaxWalSize(rnd), getMaxWalFdCache(rnd));
         fullRandomFuzz(rnd);

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -168,7 +168,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
 
     @Test
     public void testWalWriteFullRandom() throws Exception {
-        Rnd rnd = generateRandom(LOG, 1157852240565L, 1701288457416L);
+        Rnd rnd = generateRandom(LOG);
         setRandomAppendPageSize(rnd);
         setFuzzProperties(rnd.nextLong(MAX_WAL_APPLY_TIME_PER_TABLE_CEIL), getRndO3PartitionSplit(rnd), getRndO3PartitionSplitMaxCount(rnd), getMaxWalSize(rnd), getMaxWalFdCache(rnd));
         fullRandomFuzz(rnd);


### PR DESCRIPTION
Fixes fuzz test failure happened in CI when table drop step is performed. This locks the table to drop but Fuzz test infrastructure does not handle the locked exception well.

```
2023-11-29T20:07:39.793525Z E i.q.t.TestListener ***** Test Failed *****io.questdb.test.griffin.wal.WalWriterFuzzTest.testWalWriteFullRandom[NO_MIXED_IO] duration_ms=2378 : 
java.lang.RuntimeException: io.questdb.cairo.pool.ex.EntryLockedException: [-1] table busy [reason=unknown]
	at io.questdb.test.griffin.wal.FuzzRunner.applyManyWalParallel(FuzzRunner.java:180)
	at io.questdb.test.griffin.wal.FuzzRunner.applyWalParallel(FuzzRunner.java:434)
	at io.questdb.test.griffin.wal.FuzzRunner.runFuzz(FuzzRunner.java:787)
	...
Caused by: io.questdb.cairo.pool.ex.EntryLockedException: [-1] table busy [reason=unknown]
	at io.questdb.std.ThreadLocal.get(ThreadLocal.java:46)
	at io.questdb.cairo.pool.ex.EntryLockedException.instance(EntryLockedException.java:34)
	at io.questdb.cairo.pool.AbstractMultiTenantPool.get(AbstractMultiTenantPool.java:75)
	at io.questdb.cairo.CairoEngine.getReader(CairoEngine.java:451)
	at io.questdb.test.griffin.wal.FuzzRunner.getReader(FuzzRunner.java:596)
	at io.questdb.test.griffin.wal.FuzzRunner.getReaderHandleTableDropped(FuzzRunner.java:602)
	at io.questdb.test.griffin.wal.FuzzRunner.runPurgePartitionJob(FuzzRunner.java:656)
	at io.questdb.test.griffin.wal.FuzzRunner.lambda$applyManyWalParallel$2(FuzzRunner.java:164)
```

This fix treats EntryLockedException the same way as the table does not exist e.g. waits for the table to be re-created