### PR TITLE
perf(sql): optimize order by designated timestamp and other columns with limit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -409,7 +409,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
     // Checks if lo, hi is set and lo >= 0 while hi < 0 (meaning - return whole result set except some rows at start and some at the end)
     // because such case can't really be optimized by topN/bottomN
-    private boolean canBeOptimized(QueryModel model, SqlExecutionContext context, Function loFunc, Function hiFunc) {
+    private boolean canSortAndLimitBeOptimized(QueryModel model, SqlExecutionContext context, Function loFunc, Function hiFunc) {
         if (model.getLimitLo() == null && model.getLimitHi() == null) {
             return false;
         }
@@ -2263,6 +2263,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     }
                 }
 
+                boolean preSortedByTs = false;
                 // if first column index is the same as timestamp of underlying record cursor factory
                 // we could have two possibilities:
                 // 1. if we only have one column to order by - the cursor would already be ordered
@@ -2280,6 +2281,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_BACKWARD) {
                                 return recordCursorFactory;
                             }
+                        } else { //orderByColumnCount > 1
+                            preSortedByTs = (orderBy.get(column) == QueryModel.ORDER_DIRECTION_ASCENDING && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_FORWARD) ||
+                                    (orderBy.get(column) == ORDER_DIRECTION_DESCENDING && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_BACKWARD);
                         }
                     }
                 }
@@ -2294,8 +2298,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 final Function hiFunc = getHiFunction(model, executionContext);
 
                 if (recordCursorFactory.recordCursorSupportsRandomAccess()) {
-                    if (canBeOptimized(model, executionContext, loFunc, hiFunc)) {
+                    if (canSortAndLimitBeOptimized(model, executionContext, loFunc, hiFunc)) {
                         model.setLimitImplemented(true);
+                        int baseCursorTimestampIndex = preSortedByTs ? timestampIndex : -1;
                         return new LimitedSizeSortedLightRecordCursorFactory(
                                 configuration,
                                 orderedMetadata,
@@ -2303,7 +2308,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 recordComparatorCompiler.compile(metadata, listColumnFilterA),
                                 loFunc,
                                 hiFunc,
-                                listColumnFilterA.copy()
+                                listColumnFilterA.copy(),
+                                baseCursorTimestampIndex
                         );
                     } else {
                         return new SortedLightRecordCursorFactory(

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizePartiallySortedLightRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizePartiallySortedLightRecordCursor.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.orderby;
+
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.RecordComparator;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+
+/**
+ * SortedLightRecordCursor which implements LIMIT clause and assumes that base cursor is already sorted on designated timestamp, which is the first sort key.
+ * Base record cursor processing is stopped when enough records with different timestamp values are found.
+ */
+public class LimitedSizePartiallySortedLightRecordCursor implements DelegatingRecordCursor {
+
+    private final LimitedSizeLongTreeChain chain;
+    private final LimitedSizeLongTreeChain.TreeCursor chainCursor;
+    private final RecordComparator comparator;
+    private final long limit; // <0 - limit disabled; =0 means don't fetch any rows; >0 - apply limit
+    private final long skipFirst; // skip first N rows
+    private final long skipLast;  // skip last N rows
+    private final int timestampIndex;
+    private RecordCursor base;
+    private Record baseRecord;
+    private SqlExecutionCircuitBreaker circuitBreaker;
+    private boolean isChainBuilt;
+    private boolean isOpen;
+    private long rowsInGroup;
+    private long rowsLeft;
+    private long rowsSoFar;
+    private boolean timestampInitialized;
+    private long timestampValue;
+
+    public LimitedSizePartiallySortedLightRecordCursor(
+            LimitedSizeLongTreeChain chain,
+            RecordComparator comparator,
+            long limit,
+            long skipFirst,
+            long skipLast,
+            int timestampIndex
+    ) {
+        this.chain = chain;
+        this.comparator = comparator;
+        this.chainCursor = chain.getCursor();
+        this.limit = limit;
+        this.skipFirst = skipFirst;
+        this.skipLast = skipLast;
+        this.isOpen = true;
+        this.timestampIndex = timestampIndex;
+    }
+
+    @Override
+    public void close() {
+        if (isOpen) {
+            Misc.free(chain);
+            Misc.free(base);
+            isOpen = false;
+        }
+    }
+
+    @Override
+    public Record getRecord() {
+        return baseRecord;
+    }
+
+    @Override
+    public Record getRecordB() {
+        return base.getRecordB();
+    }
+
+    @Override
+    public SymbolTable getSymbolTable(int columnIndex) {
+        return base.getSymbolTable(columnIndex);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!isChainBuilt) {
+            buildChain();
+            isChainBuilt = true;
+        }
+        if (rowsLeft-- > 0 && chainCursor.hasNext()) {
+            base.recordAt(baseRecord, chainCursor.next());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public SymbolTable newSymbolTable(int columnIndex) {
+        return base.newSymbolTable(columnIndex);
+    }
+
+    @Override
+    public void of(RecordCursor base, SqlExecutionContext executionContext) {
+        if (!isOpen) {
+            chain.reopen();
+            isOpen = true;
+        }
+
+        this.base = base;
+        baseRecord = base.getRecord();
+        circuitBreaker = executionContext.getCircuitBreaker();
+        isChainBuilt = false;
+        rowsInGroup = 0;
+        rowsSoFar = 0;
+        timestampValue = Numbers.LONG_NaN;
+        timestampInitialized = false;
+        chain.clear();
+    }
+
+    @Override
+    public void recordAt(Record record, long atRowId) {
+        base.recordAt(record, atRowId);
+    }
+
+    @Override
+    public long size() {
+        return isChainBuilt ? Math.max(chain.size() - skipFirst - skipLast, 0) : -1;
+    }
+
+    @Override
+    public void toTop() {
+        chainCursor.toTop();
+
+        long skipLeft = skipFirst;
+        while (skipLeft-- > 0 && chainCursor.hasNext()) {
+            chainCursor.next();
+        }
+
+        rowsLeft = Math.max(chain.size() - skipFirst - skipLast, 0);
+    }
+
+    private void buildChain() {
+        final Record placeHolderRecord = base.getRecordB();
+        if (limit != 0) {
+            // first record ever, we've to find the timestamp value
+            if (!timestampInitialized) {
+                if (base.hasNext()) {
+                    chain.put(
+                            baseRecord,
+                            base,
+                            placeHolderRecord,
+                            comparator
+                    );
+                    timestampValue = baseRecord.getTimestamp(timestampIndex);
+                    rowsInGroup = 1;
+                    timestampInitialized = true;
+                }
+            }
+
+            while (base.hasNext()) {
+                circuitBreaker.statefulThrowExceptionIfTripped();
+
+                long currentTimestamp = baseRecord.getTimestamp(timestampIndex);
+                if (timestampValue == currentTimestamp) {
+                    rowsInGroup++;
+                } else {
+                    rowsSoFar += rowsInGroup;
+                    if (rowsSoFar > limit) {
+                        break;
+                    }
+
+                    timestampValue = currentTimestamp;
+                    rowsInGroup = 1;
+                }
+
+                // Tree chain is liable to re-position record to
+                // other rows to do record comparison. We must use our
+                // own record instance in case base cursor keeps
+                // state in the record it returns.
+                chain.put(
+                        baseRecord,
+                        base,
+                        placeHolderRecord,
+                        comparator
+                );
+            }
+        }
+        toTop();
+    }
+}
+

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
@@ -181,7 +181,7 @@ public class LimitedSizeSortedLightRecordCursorFactory extends AbstractRecordCur
                 limit
         );
 
-        if (timestampIndex == -1) {
+        if (timestampIndex == -1 || !isFirstN) {
             this.cursor = new LimitedSizeSortedLightRecordCursor(chain, comparator, limit, skipFirst, skipLast);
         } else {
             this.cursor = new LimitedSizePartiallySortedLightRecordCursor(chain, comparator, limit, skipFirst, skipLast, timestampIndex);

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeSortedLightRecordCursorFactory.java
@@ -46,7 +46,7 @@ public class LimitedSizeSortedLightRecordCursorFactory extends AbstractRecordCur
     private final Function hiFunction;
     private final Function loFunction;
     private final ListColumnFilter sortColumnFilter;
-    int timestampIndex;
+    private final int timestampIndex;
     // initialization delayed to getCursor() because lo/hi need to be evaluated
     private DelegatingRecordCursor cursor; // LimitedSizeSortedLightRecordCursor or SortedLightRecordCursor
 

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -4647,7 +4647,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab (i int, ts timestamp) timestamp(ts)",
                 "select * from (select * from tab order by ts, i desc limit 10) order by ts",
-                "Sort light lo: 10\n" +
+                "Sort light lo: 10 partiallySorted: true\n" +
                         "  keys: [ts, i desc]\n" +
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
@@ -5927,15 +5927,6 @@ public class ExplainPlanTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testSelectWalTransactions() throws Exception {
-        assertPlan(
-                "create table tab ( s string, sy symbol, i int, ts timestamp) timestamp(ts) partition by day WAL",
-                "select * from wal_transactions('tab')",
-                "wal_transactions of: tab\n"
-        );
-    }
-
-    @Test
     public void testSelectFromTableWriterMetrics() throws Exception {
         assertPlan(
                 "select * from table_writer_metrics()",
@@ -6880,6 +6871,15 @@ public class ExplainPlanTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSelectWalTransactions() throws Exception {
+        assertPlan(
+                "create table tab ( s string, sy symbol, i int, ts timestamp) timestamp(ts) partition by day WAL",
+                "select * from wal_transactions('tab')",
+                "wal_transactions of: tab\n"
+        );
+    }
+
+    @Test
     public void testSelectWhereOrderByLimit() throws Exception {
         assertPlan(
                 "create table xx ( x long, str string) ",
@@ -7754,7 +7754,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         "where i1*i2 != 0",
                 "SelectedRecord\n" +
                         "    Filter filter: i1*i2!=0\n" +
-                        "        Sort light lo: 100\n" +
+                        "        Sort light lo: 100 partiallySorted: true\n" +
                         "          keys: [ts1, l1]\n" +
                         "            SelectedRecord\n" +
                         "                SelectedRecord\n" +
@@ -7842,7 +7842,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                     "select * from (select * from a order by ts asc, l limit 10) lt join (select * from a) order by ts asc",
                     "SelectedRecord\n" +
                             "    Lt Join\n" +
-                            "        Sort light lo: 10\n" +
+                            "        Sort light lo: 10 partiallySorted: true\n" +
                             "          keys: [ts, l]\n" +
                             "            DataFrame\n" +
                             "                Row forward scan\n" +


### PR DESCRIPTION
Fixes #4022 
If base cursor (subquery) is already sorted on designated timestamp then 
```sql 
ORDER BY  designated_timestamp, col1, ..., colN 
LIMIT N
```
can stop traversing base cursor when enough different timestamps have been found, e.g. 
N records with timestamp T0 and 1 record with T1 . 
Hot runs of:
```sql
SELECT SearchPhrase FROM hits WHERE SearchPhrase IS NOT NULL ORDER BY EventTime, SearchPhrase LIMIT 10;
```
take (on my desktop):  
master) 450 ms  
this pr) 22 ms 
