### PR TITLE
fix(sql): fix column propagation for queries with set operations and distinct

### DIFF
--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -81,9 +81,9 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     public static final int SHOW_COLUMNS = 2;
     public static final int SHOW_DATE_STYLE = 9;
     public static final int SHOW_MAX_IDENTIFIER_LENGTH = 6;
+    public static final int SHOW_PARAMETERS = 11;
     public static final int SHOW_PARTITIONS = 3;
     public static final int SHOW_SEARCH_PATH = 8;
-    public static final int SHOW_PARAMETERS = 11;
     public static final int SHOW_SERVER_VERSION = 12;
     public static final int SHOW_STANDARD_CONFORMING_STRINGS = 7;
     public static final int SHOW_TABLES = 1;
@@ -334,14 +334,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
      * If this is a SELECT DISTINCT then we don't push since the parent model contains the necessary columns.
      */
     public boolean allowsNestedColumnsChange() {
-        QueryModel union = this;
-        while (union != null) {
-            if (union.getSelectModelType() == QueryModel.SELECT_MODEL_DISTINCT) {
-                return false;
-            }
-            union = union.getUnionModel();
-        }
-        return true;
+        return this.getSelectModelType() != QueryModel.SELECT_MODEL_DISTINCT;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -5604,6 +5604,46 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testUnionAllWithFirstSubQueryUsingDistinct() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table ict ( event int );");
+            insert("insert into ict select x::int from long_sequence(1000)");
+
+            assertWithReorder(
+                    "avg\n" +
+                            "500.5\n",
+                    "union",
+                    "select avg(event) from ict ",
+                    "select distinct avg(event) from ict"
+            );
+
+            assertWithReorder(
+                    "avg\n" +
+                            "500.5\n" +
+                            "500.5\n",
+                    "union all",
+                    "select avg(event) from ict ",
+                    "select distinct avg(event) from ict"
+            );
+
+            assertWithReorder(
+                    "avg\n" +
+                            "500.5\n",
+                    "intersect",
+                    "select avg(event) from ict ",
+                    "select distinct avg(event) from ict"
+            );
+
+            assertWithReorder(
+                    "avg\n",
+                    "except",
+                    "select avg(event) from ict ",
+                    "select distinct avg(event) from ict"
+            );
+        });
+    }
+
+    @Test
     public void testUseExtensionPoints() {
         try (SqlCompilerWrapper compiler = new SqlCompilerWrapper(engine)) {
 
@@ -5928,6 +5968,11 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
                     }
                 }
         );
+    }
+
+    private void assertWithReorder(String expected, String setOperation, String... subqueries) throws SqlException {
+        assertSql(expected, subqueries[0] + " " + setOperation + " " + subqueries[1]);
+        assertSql(expected, subqueries[1] + " " + setOperation + " " + subqueries[0]);
     }
 
     private void selectDoubleInListWithBindVariable() throws Exception {


### PR DESCRIPTION
Fixes #3933 