### PR TITLE
fix(sql): fix edge case internal error in case-switch expression

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
@@ -42,7 +42,6 @@ public class SwitchFunctionFactory implements FunctionFactory {
     private static final IntMethod GET_INT = SwitchFunctionFactory::getInt;
     private static final LongMethod GET_LONG = SwitchFunctionFactory::getLong;
     private static final IntMethod GET_SHORT = SwitchFunctionFactory::getShort;
-    private static final CharSequenceMethod GET_STRING = SwitchFunctionFactory::getString;
     private static final LongMethod GET_TIMESTAMP = SwitchFunctionFactory::getTimestamp;
 
     @Override
@@ -120,7 +119,7 @@ public class SwitchFunctionFactory implements FunctionFactory {
                 return getIfElseFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch);
             case ColumnType.STRING:
             case ColumnType.SYMBOL:
-                return getCharSequenceKeyedFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch, GET_STRING);
+                return getCharSequenceKeyedFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch);
             default:
                 throw SqlException.
                         $(argPositions.getQuick(0), "type ")
@@ -157,10 +156,6 @@ public class SwitchFunctionFactory implements FunctionFactory {
         return function.getStr(record);
     }
 
-    private static CharSequence getSymbol(Function function, Record record) {
-        return function.getSymbol(record);
-    }
-
     private static long getTimestamp(Function function, Record record) {
         return function.getTimestamp(record);
     }
@@ -172,15 +167,14 @@ public class SwitchFunctionFactory implements FunctionFactory {
             int n,
             Function keyFunction,
             int valueType,
-            Function elseBranch,
-            CharSequenceMethod method
+            Function elseBranch
     ) throws SqlException {
         final CharSequenceObjHashMap<Function> map = new CharSequenceObjHashMap<>();
         final ObjList<Function> argsToPoke = new ObjList<>();
         Function nullFunc = null;
         for (int i = 1; i < n; i += 2) {
             final Function fun = args.getQuick(i);
-            final CharSequence key = method.getKey(fun, null);
+            final CharSequence key = SwitchFunctionFactory.getString(fun, null);
             if (key == null) {
                 nullFunc = args.getQuick(i + 1);
             } else {
@@ -197,7 +191,7 @@ public class SwitchFunctionFactory implements FunctionFactory {
         final CaseFunctionPicker picker;
         if (nullFunc == null) {
             picker = record -> {
-                final CharSequence value = method.getKey(keyFunction, record);
+                final CharSequence value = SwitchFunctionFactory.getString(keyFunction, record);
                 if (value != null) {
                     final int index = map.keyIndex(value);
                     if (index < 0) {
@@ -209,7 +203,7 @@ public class SwitchFunctionFactory implements FunctionFactory {
         } else {
             final Function nullFuncRef = nullFunc;
             picker = record -> {
-                final CharSequence value = method.getKey(keyFunction, record);
+                final CharSequence value = SwitchFunctionFactory.getString(keyFunction, record);
                 if (value == null) {
                     return nullFuncRef;
                 }
@@ -359,11 +353,6 @@ public class SwitchFunctionFactory implements FunctionFactory {
         argsToPoke.add(keyFunction);
 
         return CaseCommon.getCaseFunction(position, valueType, picker, argsToPoke);
-    }
-
-    @FunctionalInterface
-    private interface CharSequenceMethod {
-        CharSequence getKey(Function function, Record record);
     }
 
     @FunctionalInterface

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
@@ -43,7 +43,6 @@ public class SwitchFunctionFactory implements FunctionFactory {
     private static final LongMethod GET_LONG = SwitchFunctionFactory::getLong;
     private static final IntMethod GET_SHORT = SwitchFunctionFactory::getShort;
     private static final CharSequenceMethod GET_STRING = SwitchFunctionFactory::getString;
-    private static final CharSequenceMethod GET_SYMBOL = SwitchFunctionFactory::getSymbol;
     private static final LongMethod GET_TIMESTAMP = SwitchFunctionFactory::getTimestamp;
 
     @Override
@@ -120,9 +119,8 @@ public class SwitchFunctionFactory implements FunctionFactory {
             case ColumnType.BOOLEAN:
                 return getIfElseFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch);
             case ColumnType.STRING:
-                return getCharSequenceKeyedFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch, GET_STRING);
             case ColumnType.SYMBOL:
-                return getCharSequenceKeyedFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch, GET_SYMBOL);
+                return getCharSequenceKeyedFunction(args, argPositions, position, n, keyFunction, returnType, elseBranch, GET_STRING);
             default:
                 throw SqlException.
                         $(argPositions.getQuick(0), "type ")

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -956,28 +956,6 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testSingleCharSymbol() throws Exception {
-//        assertQuery(
-//                "category\tres\n" +
-//                        "V\tfalse\n" +
-//                        "T\tfalse\n" +
-//                        "J\tfalse\n" +
-//                        "W\ttrue\n" +
-//                        "C\tfalse\n" +
-//                        "P\tfalse\n" +
-//                        "S\tfalse\n" +
-//                        "W\ttrue\n" +
-//                        "H\tfalse\n" +
-//                        "Y\tfalse\n",
-//                "select * from tab where category = 'W';",
-//                "create table tab as (" +
-//                        "select rnd_char()::symbol as category" +
-//                        " from long_sequence(10)" +
-//                        ")",
-//                null,
-//                true,
-//                true
-//        );
-
         assertQuery(
                 "category\tres\n" +
                         "V\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -330,28 +330,28 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testCaseErrors() throws Exception {
-        assertException("select case from long_sequence(1)",  7, "unbalanced 'case'");
-        assertException("select case end from long_sequence(1)",  12, "'when' expected");
-        assertException("select case x end from long_sequence(1)",  14, "'when' expected");
+        assertException("select case from long_sequence(1)", 7, "unbalanced 'case'");
+        assertException("select case end from long_sequence(1)", 12, "'when' expected");
+        assertException("select case x end from long_sequence(1)", 14, "'when' expected");
         assertException("select case 1 end from long_sequence(1)", 14, "'when' expected");
-        assertException("select case false end from long_sequence(1)",  18, "'when' expected");
-        assertException("select case x/2 end from long_sequence(1)",  16, "'when' expected");
-        assertException("select case x/2 z end from long_sequence(1)",  18, "'when' expected");
-        assertException("select case 1+5 end from long_sequence(1)",  16, "'when' expected");
-        assertException("select case rnd_double() end from long_sequence(1)",  25, "'when' expected");
-        assertException("select case x else 2 end from long_sequence(1)",  14, "'when' expected");
-        assertException("select case x when else 2 end from long_sequence(1)",  19, "missing arguments");
-        assertException("select case x when 1 end from long_sequence(1)",  21, "'then' expected");
-        assertException("select case x when 1 else 2 end from long_sequence(1)",  21, "'then' expected");
-        assertException("select case x when 1 then else 2 end from long_sequence(1)",  26, "missing arguments");
-        assertException("select case x when 1 then 1 else else end from long_sequence(1)",  33, "missing arguments");
-        assertException("select case x when 1 then 1 when else 2 end from long_sequence(1)",  33, "missing arguments");
-        assertException("select case x when 1 then 1 when 2 else 2 end from long_sequence(1)",  35, "'then' expected");
+        assertException("select case false end from long_sequence(1)", 18, "'when' expected");
+        assertException("select case x/2 end from long_sequence(1)", 16, "'when' expected");
+        assertException("select case x/2 z end from long_sequence(1)", 18, "'when' expected");
+        assertException("select case 1+5 end from long_sequence(1)", 16, "'when' expected");
+        assertException("select case rnd_double() end from long_sequence(1)", 25, "'when' expected");
+        assertException("select case x else 2 end from long_sequence(1)", 14, "'when' expected");
+        assertException("select case x when else 2 end from long_sequence(1)", 19, "missing arguments");
+        assertException("select case x when 1 end from long_sequence(1)", 21, "'then' expected");
+        assertException("select case x when 1 else 2 end from long_sequence(1)", 21, "'then' expected");
+        assertException("select case x when 1 then else 2 end from long_sequence(1)", 26, "missing arguments");
+        assertException("select case x when 1 then 1 else else end from long_sequence(1)", 33, "missing arguments");
+        assertException("select case x when 1 then 1 when else 2 end from long_sequence(1)", 33, "missing arguments");
+        assertException("select case x when 1 then 1 when 2 else 2 end from long_sequence(1)", 35, "'then' expected");
         assertException("select case when end from long_sequence(1)", 17, "missing arguments");
         assertException("select case when then else end from long_sequence(1)", 17, "missing arguments");
         assertException("select case when else end from long_sequence(1)", 17, "missing arguments");
-        assertException("select case when x end from long_sequence(1)",  19, "'then' expected");
-        assertException("select case when x else end from long_sequence(1)",  19, "'then' expected");
+        assertException("select case when x end from long_sequence(1)", 19, "'then' expected");
+        assertException("select case when x else end from long_sequence(1)", 19, "'then' expected");
         assertException("select case when x else 2 end from long_sequence(1)", 19, "'then' expected");
         assertException("select case when x then end from long_sequence(1)", 24, "missing arguments");
         assertException("select case when x then else end from long_sequence(1)", 24, "missing arguments");
@@ -381,7 +381,7 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testCaseWithNoElseInWhereClause() throws Exception {
-        assertException("select x from long_sequence(3) where case x when 1 then 0 end",  37, "boolean expression expected");
+        assertException("select x from long_sequence(3) where case x when 1 then 0 end", 37, "boolean expression expected");
 
         assertQuery("x\n1\n",
                 "select x from long_sequence(3) where case when x<2 then true end", null, true, false);
@@ -955,6 +955,58 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSingleCharSymbol() throws Exception {
+//        assertQuery(
+//                "category\tres\n" +
+//                        "V\tfalse\n" +
+//                        "T\tfalse\n" +
+//                        "J\tfalse\n" +
+//                        "W\ttrue\n" +
+//                        "C\tfalse\n" +
+//                        "P\tfalse\n" +
+//                        "S\tfalse\n" +
+//                        "W\ttrue\n" +
+//                        "H\tfalse\n" +
+//                        "Y\tfalse\n",
+//                "select * from tab where category = 'W';",
+//                "create table tab as (" +
+//                        "select rnd_char()::symbol as category" +
+//                        " from long_sequence(10)" +
+//                        ")",
+//                null,
+//                true,
+//                true
+//        );
+
+        assertQuery(
+                "category\tres\n" +
+                        "V\tfalse\n" +
+                        "T\tfalse\n" +
+                        "J\tfalse\n" +
+                        "W\ttrue\n" +
+                        "C\tfalse\n" +
+                        "P\tfalse\n" +
+                        "S\tfalse\n" +
+                        "W\ttrue\n" +
+                        "H\tfalse\n" +
+                        "Y\tfalse\n",
+                "SELECT category, \n" +
+                        "  CASE\n" +
+                        "    WHEN category = 'W' THEN true\n" +
+                        "    ELSE false\n" +
+                        "  END AS res\n" +
+                        "FROM tab",
+                "create table tab as (" +
+                        "select rnd_char()::symbol as category" +
+                        " from long_sequence(10)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testIntToStringCastOnBranch() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1011,7 +1063,7 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
             // however, for int etc, only the value 1 will evaluate to 1
             assertSql("sum\n" +
                     (type.equals("BOOLEAN") ? "10\n" : "1\n"), "select sum(case x when CAST(1 as " + type + ") then 1 else 0 end) " +
-                            "from tt"
+                    "from tt"
             );
 
             drop("drop table tt");


### PR DESCRIPTION
This could happen when a single letter string literal was recognized as a CharConstant and the switch function would call `getSymbol()` on it.

I see no good reason for differentiation between getString() and getSymbol() in the switch factory. As both work with CharSequence anyway.