### PR TITLE
perf(sql): get rid of offset packing in FastMap

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -275,7 +275,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlJitIRMemoryPageSize;
     private final int sqlJitMode;
     private final int sqlJitPageAddressCacheThreshold;
-    private final int sqlJitRowsThreshold;
     private final int sqlJoinContextPoolCapacity;
     private final int sqlJoinMetadataMaxResizes;
     private final int sqlJoinMetadataPageSize;
@@ -342,9 +341,9 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long walApplyWorkerSleepThreshold;
     private final long walApplyWorkerYieldThreshold;
     private final boolean walEnabledDefault;
-    private final int walMaxSegmentFileDescriptorsCache;
     private final long walMaxLagSize;
     private final int walMaxLagTxnCount;
+    private final int walMaxSegmentFileDescriptorsCache;
     private final long walPurgeInterval;
     private final int walPurgeWaitBeforeDelete;
     private final int walRecreateDistressedSequencerAttempts;
@@ -942,7 +941,6 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.sqlJitIRMemoryMaxPages = getInt(properties, env, PropertyKey.CAIRO_SQL_JIT_IR_MEMORY_MAX_PAGES, 8);
             this.sqlJitBindVarsMemoryPageSize = getIntSize(properties, env, PropertyKey.CAIRO_SQL_JIT_BIND_VARS_MEMORY_PAGE_SIZE, 4 * 1024);
             this.sqlJitBindVarsMemoryMaxPages = getInt(properties, env, PropertyKey.CAIRO_SQL_JIT_BIND_VARS_MEMORY_MAX_PAGES, 8);
-            this.sqlJitRowsThreshold = getIntSize(properties, env, PropertyKey.CAIRO_SQL_JIT_ROWS_THRESHOLD, 1024 * 1024);
             this.sqlJitPageAddressCacheThreshold = getIntSize(properties, env, PropertyKey.CAIRO_SQL_JIT_PAGE_ADDRESS_CACHE_THRESHOLD, 1024 * 1024);
             this.sqlJitDebugEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_JIT_DEBUG_ENABLED, false);
 
@@ -1637,7 +1635,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             registerDeprecated(PropertyKey.LINE_UDP_TIMESTAMP);
             registerDeprecated(PropertyKey.LINE_TCP_TIMESTAMP);
             registerDeprecated(PropertyKey.CAIRO_QUERY_CACHE_EVENT_QUEUE_CAPACITY);
-
+            registerDeprecated(PropertyKey.CAIRO_SQL_JIT_ROWS_THRESHOLD);
             registerDeprecated(
                     PropertyKey.CAIRO_SQL_ANALYTIC_COLUMN_POOL_CAPACITY,
                     PropertyKey.CAIRO_SQL_WINDOW_COLUMN_POOL_CAPACITY
@@ -2389,11 +2387,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getSqlJitRowsThreshold() {
-            return sqlJitRowsThreshold;
-        }
-
-        @Override
         public int getSqlJoinContextPoolCapacity() {
             return sqlJoinContextPoolCapacity;
         }
@@ -2613,11 +2606,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getWalMaxSegmentFileDescriptorsCache() {
-            return walMaxSegmentFileDescriptorsCache;
-        }
-
-        @Override
         public long getWalMaxLagSize() {
             return walMaxLagSize;
         }
@@ -2625,6 +2613,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getWalMaxLagTxnCount() {
             return walMaxLagTxnCount;
+        }
+
+        @Override
+        public int getWalMaxSegmentFileDescriptorsCache() {
+            return walMaxSegmentFileDescriptorsCache;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -206,8 +206,6 @@ public interface CairoConfiguration {
 
     int getMaxUncommittedRows();
 
-    int getWalMaxSegmentFileDescriptorsCache();
-
     int getMetadataPoolCapacity();
 
     @NotNull
@@ -390,8 +388,6 @@ public interface CairoConfiguration {
 
     int getSqlJitPageAddressCacheThreshold();
 
-    int getSqlJitRowsThreshold();
-
     int getSqlJoinContextPoolCapacity();
 
     int getSqlJoinMetadataMaxResizes();
@@ -492,6 +488,8 @@ public interface CairoConfiguration {
     long getWalMaxLagSize();
 
     int getWalMaxLagTxnCount();
+
+    int getWalMaxSegmentFileDescriptorsCache();
 
     long getWalPurgeInterval();
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -346,11 +346,6 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public int getWalMaxSegmentFileDescriptorsCache() {
-        return delegate.getWalMaxSegmentFileDescriptorsCache();
-    }
-
-    @Override
     public int getMetadataPoolCapacity() {
         return delegate.getMetadataPoolCapacity();
     }
@@ -646,11 +641,6 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public int getSqlJitRowsThreshold() {
-        return delegate.getSqlJitRowsThreshold();
-    }
-
-    @Override
     public int getSqlJoinContextPoolCapacity() {
         return delegate.getSqlJoinContextPoolCapacity();
     }
@@ -878,6 +868,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     @Override
     public int getWalMaxLagTxnCount() {
         return delegate.getWalMaxLagTxnCount();
+    }
+
+    @Override
+    public int getWalMaxSegmentFileDescriptorsCache() {
+        return delegate.getWalMaxSegmentFileDescriptorsCache();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -647,11 +647,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public int getSqlJitRowsThreshold() {
-        return Numbers.SIZE_1MB;
-    }
-
-    @Override
     public int getSqlJoinContextPoolCapacity() {
         return 64;
     }
@@ -872,11 +867,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public int getWalMaxSegmentFileDescriptorsCache() {
-        return 1000;
-    }
-
-    @Override
     public long getWalMaxLagSize() {
         return 75 * Numbers.SIZE_1MB;
     }
@@ -884,6 +874,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getWalMaxLagTxnCount() {
         return 20;
+    }
+
+    @Override
+    public int getWalMaxSegmentFileDescriptorsCache() {
+        return 1000;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/map/FastMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/FastMap.java
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.TestOnly;
  * <p>
  * The hash table is organized into two main parts:
  * <ul>
- * <li>1. Off-heap list for heap offsets</li>
+ * <li>1. Off-heap list for heap offsets and cached hash codes</li>
  * <li>2. Off-heap memory for key-value pairs a.k.a. "key memory"</li>
  * </ul>
  * The offset list contains [compressed_offset, hash_code] pairs. An offset value contains an offset to
@@ -76,6 +76,7 @@ public class FastMap implements Map, Reopenable {
     private static final long MAX_HEAP_SIZE = (Integer.toUnsignedLong(-1) - 1) << 3;
     private static final int MIN_INITIAL_CAPACITY = 128;
     private final FastMapCursor cursor;
+    private final int heapMemoryTag;
     private final int initialKeyCapacity;
     private final int initialPageSize;
     private final BaseKey key;
@@ -84,7 +85,6 @@ public class FastMap implements Map, Reopenable {
     private final int keySize;
     private final int listMemoryTag;
     private final double loadFactor;
-    private final int mapMemoryTag;
     private final int maxResizes;
     private final FastMapRecord record;
     private final FastMapValue value;
@@ -100,8 +100,9 @@ public class FastMap implements Map, Reopenable {
     private int keyCapacity;
     private int mask;
     private int nResizes;
+    // Holds [compressed_offset, hash_code] pairs.
     // Offsets are shifted by +1 (0 -> 1, 1 -> 2, etc.), so that we fill the memory with 0.
-    private DirectLongList offsets;
+    private DirectIntList offsets;
     private int size = 0;
 
     public FastMap(
@@ -134,7 +135,7 @@ public class FastMap implements Map, Reopenable {
             double loadFactor,
             int maxResizes
     ) {
-        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, MemoryTag.NATIVE_FAST_MAP, MemoryTag.NATIVE_FAST_MAP_LONG_LIST);
+        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, MemoryTag.NATIVE_FAST_MAP, MemoryTag.NATIVE_FAST_MAP_INT_LIST);
     }
 
     FastMap(
@@ -144,25 +145,25 @@ public class FastMap implements Map, Reopenable {
             int keyCapacity,
             double loadFactor,
             int maxResizes,
-            int mapMemoryTag,
+            int heapMemoryTag,
             int listMemoryTag
     ) {
         assert pageSize > 3;
         assert loadFactor > 0 && loadFactor < 1d;
 
-        this.mapMemoryTag = mapMemoryTag;
+        this.heapMemoryTag = heapMemoryTag;
         this.listMemoryTag = listMemoryTag;
         initialKeyCapacity = keyCapacity;
         initialPageSize = pageSize;
         this.loadFactor = loadFactor;
-        heapStart = kPos = Unsafe.malloc(capacity = pageSize, mapMemoryTag);
+        heapStart = kPos = Unsafe.malloc(capacity = pageSize, heapMemoryTag);
         heapLimit = heapStart + pageSize;
         this.keyCapacity = (int) (keyCapacity / loadFactor);
         this.keyCapacity = this.keyCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(this.keyCapacity);
         mask = this.keyCapacity - 1;
         free = (int) (this.keyCapacity * loadFactor);
-        offsets = new DirectLongList(this.keyCapacity, listMemoryTag);
-        offsets.setPos(this.keyCapacity);
+        offsets = new DirectIntList((long) this.keyCapacity << 1, listMemoryTag);
+        offsets.setPos((long) this.keyCapacity << 1);
         offsets.zero(0);
         nResizes = 0;
         this.maxResizes = maxResizes;
@@ -230,7 +231,7 @@ public class FastMap implements Map, Reopenable {
     public final void close() {
         Misc.free(offsets);
         if (heapStart != 0) {
-            Unsafe.free(heapStart, capacity, mapMemoryTag);
+            Unsafe.free(heapStart, capacity, heapMemoryTag);
             heapLimit = heapStart = kPos = 0;
             free = 0;
             size = 0;
@@ -278,15 +279,15 @@ public class FastMap implements Map, Reopenable {
 
     @Override
     public void restoreInitialCapacity() {
-        heapStart = kPos = Unsafe.realloc(heapStart, heapLimit - heapStart, capacity = initialPageSize, mapMemoryTag);
+        heapStart = kPos = Unsafe.realloc(heapStart, heapLimit - heapStart, capacity = initialPageSize, heapMemoryTag);
         heapLimit = heapStart + initialPageSize;
         keyCapacity = (int) (initialKeyCapacity / loadFactor);
         keyCapacity = keyCapacity < MIN_INITIAL_CAPACITY ? MIN_INITIAL_CAPACITY : Numbers.ceilPow2(keyCapacity);
         mask = keyCapacity - 1;
         free = (int) (keyCapacity * loadFactor);
         offsets.resetCapacity();
-        offsets.setCapacity(keyCapacity);
-        offsets.setPos(keyCapacity);
+        offsets.setCapacity((long) keyCapacity << 1);
+        offsets.setPos((long) keyCapacity << 1);
         offsets.zero(0);
         nResizes = 0;
     }
@@ -310,34 +311,28 @@ public class FastMap implements Map, Reopenable {
         return key.init();
     }
 
-    private static long getPackedOffset(DirectLongList offsets, int index) {
-        return offsets.get(index);
+    private static int getHashCode(DirectIntList offsets, int index) {
+        return offsets.get(((long) index << 1) | 1);
     }
 
-    private static void setPackedOffset(DirectLongList offsets, int index, long offset, int hashCode) {
-        offsets.set(index, Numbers.encodeLowHighInts((int) ((offset >> 3) + 1), hashCode));
+    private static long getOffset(DirectIntList offsets, int index) {
+        return ((long) offsets.get((long) index << 1) - 1) << 3;
     }
 
-    private static void setPackedOffset(DirectLongList offsets, int index, long packedOffset) {
-        offsets.set(index, packedOffset);
+    private static void setHashCode(DirectIntList offsets, int index, int hashCode) {
+        offsets.set(((long) index << 1) | 1, hashCode);
     }
 
-    private static int unpackHashCode(long packedOffset) {
-        return Numbers.decodeHighInt(packedOffset);
-    }
-
-    private static long unpackOffset(long packedOffset) {
-        return (Integer.toUnsignedLong(Numbers.decodeLowInt(packedOffset)) - 1) << 3;
+    private static void setOffset(DirectIntList offsets, int index, long offset) {
+        offsets.set((long) index << 1, (int) ((offset >> 3) + 1));
     }
 
     private FastMapValue asNew(BaseKey keyWriter, int index, int hashCode, FastMapValue value) {
         kPos = keyWriter.appendAddress + valueSize;
         // Align current pointer to 8 bytes, so that we can store compressed offsets.
-        if ((kPos & 0x7) != 0) {
-            kPos |= 0x7;
-            kPos++;
-        }
-        setPackedOffset(offsets, index, keyWriter.startAddress - heapStart, hashCode);
+        kPos = (kPos + 7) & ~0x7;
+        setOffset(offsets, index, keyWriter.startAddress - heapStart);
+        setHashCode(offsets, index, hashCode);
         if (--free == 0) {
             rehash();
         }
@@ -346,10 +341,9 @@ public class FastMap implements Map, Reopenable {
     }
 
     private FastMapValue probe0(BaseKey keyWriter, int index, int hashCode, int keySize, FastMapValue value) {
-        long packedOffset;
         long offset;
-        while ((offset = unpackOffset(packedOffset = getPackedOffset(offsets, index = (++index & mask)))) > -1) {
-            if (hashCode == unpackHashCode(packedOffset) && keyWriter.eq(offset)) {
+        while ((offset = getOffset(offsets, index = (++index & mask))) > -1) {
+            if (hashCode == getHashCode(offsets, index) && keyWriter.eq(offset)) {
                 long startAddress = heapStart + offset;
                 return valueOf(startAddress, startAddress + keyOffset + keySize, false, value);
             }
@@ -357,11 +351,10 @@ public class FastMap implements Map, Reopenable {
         return asNew(keyWriter, index, hashCode, value);
     }
 
-    private FastMapValue probeReadOnly(BaseKey keyWriter, int index, long hashCode, int keySize, FastMapValue value) {
-        long packedOffset;
+    private FastMapValue probeReadOnly(BaseKey keyWriter, int index, int hashCode, int keySize, FastMapValue value) {
         long offset;
-        while ((offset = unpackOffset(packedOffset = getPackedOffset(offsets, index = (++index & mask)))) > -1) {
-            if (hashCode == unpackHashCode(packedOffset) && keyWriter.eq(offset)) {
+        while ((offset = getOffset(offsets, index = (++index & mask))) > -1) {
+            if (hashCode == getHashCode(offsets, index) && keyWriter.eq(offset)) {
                 long startAddress = heapStart + offset;
                 return valueOf(startAddress, startAddress + keyOffset + keySize, false, value);
             }
@@ -372,22 +365,22 @@ public class FastMap implements Map, Reopenable {
     private void rehash() {
         int capacity = keyCapacity << 1;
         mask = capacity - 1;
-        DirectLongList newOffsets = new DirectLongList(capacity, listMemoryTag);
-        newOffsets.setPos(capacity);
+        DirectIntList newOffsets = new DirectIntList((long) capacity << 1, listMemoryTag);
+        newOffsets.setPos((long) capacity << 1);
         newOffsets.zero(0);
 
-        for (int i = 0, k = (int) offsets.size(); i < k; i++) {
-            long packedOffset = getPackedOffset(offsets, i);
-            long offset = unpackOffset(packedOffset);
+        for (int i = 0, k = (int) (offsets.size() / 2); i < k; i++) {
+            long offset = getOffset(offsets, i);
             if (offset < 0) {
                 continue;
             }
-            int hashCode = unpackHashCode(packedOffset);
+            int hashCode = getHashCode(offsets, i);
             int index = hashCode & mask;
-            while (unpackOffset(getPackedOffset(newOffsets, index)) > -1) {
+            while (getOffset(newOffsets, index) > -1) {
                 index = (index + 1) & mask;
             }
-            setPackedOffset(newOffsets, index, packedOffset);
+            setOffset(newOffsets, index, offset);
+            setHashCode(newOffsets, index, hashCode);
         }
         offsets.close();
         offsets = newOffsets;
@@ -406,7 +399,7 @@ public class FastMap implements Map, Reopenable {
             if (kCapacity > MAX_HEAP_SIZE) {
                 throw LimitOverflowException.instance().put("limit of ").put(MAX_HEAP_SIZE).put(" memory exceeded in FastMap");
             }
-            long kAddress = Unsafe.realloc(heapStart, capacity, kCapacity, mapMemoryTag);
+            long kAddress = Unsafe.realloc(heapStart, capacity, kCapacity, heapMemoryTag);
 
             this.capacity = kCapacity;
             long delta = kAddress - heapStart;
@@ -493,12 +486,11 @@ public class FastMap implements Map, Reopenable {
             // [ key size | key block | value block ]
             int hashCode = hash();
             int index = hashCode & mask;
-            long packedOffset = getPackedOffset(offsets, index);
-            long offset = unpackOffset(packedOffset);
+            long offset = getOffset(offsets, index);
 
             if (offset < 0) {
                 return asNew(this, index, hashCode, value);
-            } else if (hashCode == unpackHashCode(packedOffset) && eq(offset)) {
+            } else if (hashCode == getHashCode(offsets, index) && eq(offset)) {
                 long startAddress = heapStart + offset;
                 return valueOf(startAddress, startAddress + keyOffset + keySize, false, value);
             } else {
@@ -510,12 +502,11 @@ public class FastMap implements Map, Reopenable {
             int keySize = commit();
             int hashCode = hash();
             int index = hashCode & mask;
-            long packedOffset = getPackedOffset(offsets, index);
-            long offset = unpackOffset(packedOffset);
+            long offset = getOffset(offsets, index);
 
             if (offset < 0) {
                 return null;
-            } else if (hashCode == unpackHashCode(packedOffset) && eq(offset)) {
+            } else if (hashCode == getHashCode(offsets, index) && eq(offset)) {
                 long startAddress = heapStart + offset;
                 return valueOf(startAddress, startAddress + keyOffset + keySize, false, value);
             } else {

--- a/core/src/main/java/io/questdb/std/MemoryTag.java
+++ b/core/src/main/java/io/questdb/std/MemoryTag.java
@@ -46,14 +46,14 @@ public final class MemoryTag {
     public static final int NATIVE_CB3 = 30;
     public static final int NATIVE_CB4 = 31;
     public static final int NATIVE_CB5 = 32;
+    public static final int NATIVE_CIRCULAR_BUFFER = 56;
     public static final int NATIVE_COMPACT_MAP = 8;
     public static final int NATIVE_DEFAULT = 1;
     public static final int NATIVE_DIRECT_BYTE_SINK = 54;
-    public static final int NATIVE_CIRCULAR_BUFFER = 56;
     public static final int NATIVE_DIRECT_CHAR_SINK = 51;
     public static final int NATIVE_DIRECT_UTF8_SINK = 55;
     public static final int NATIVE_FAST_MAP = 9;
-    public static final int NATIVE_FAST_MAP_LONG_LIST = 10;
+    public static final int NATIVE_FAST_MAP_INT_LIST = 10;
     public static final int NATIVE_FUNC_RSS = 50;
     public static final int NATIVE_HTTP_CONN = 11;
     public static final int NATIVE_ILP_RSS = 46;
@@ -100,7 +100,7 @@ public final class MemoryTag {
         tagNameMap.extendAndSet(MMAP_TABLE_READER, "MMAP_TABLE_READER");
         tagNameMap.extendAndSet(NATIVE_COMPACT_MAP, "NATIVE_COMPACT_MAP");
         tagNameMap.extendAndSet(NATIVE_FAST_MAP, "NATIVE_FAST_MAP");
-        tagNameMap.extendAndSet(NATIVE_FAST_MAP_LONG_LIST, "NATIVE_FAST_MAP_LONG_LIST");
+        tagNameMap.extendAndSet(NATIVE_FAST_MAP_INT_LIST, "NATIVE_FAST_MAP_INT_LIST");
         tagNameMap.extendAndSet(NATIVE_HTTP_CONN, "NATIVE_HTTP_CONN");
         tagNameMap.extendAndSet(NATIVE_PGW_CONN, "NATIVE_PGW_CONN");
         tagNameMap.extendAndSet(MMAP_INDEX_READER, "MMAP_INDEX_READER");

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -412,9 +412,6 @@ query.timeout.sec=60
 #cairo.sql.jit.bind.vars.memory.page.size=4K
 #cairo.sql.jit.bind.vars.memory.max.pages=8
 
-# sets minimum number of rows to shrink filtered rows memory after query execution
-#cairo.sql.jit.rows.threshold=1M
-
 # sets minimum cache size to shrink page address cache after query execution
 #cairo.sql.jit.page.address.cache.threshold=1M
 

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -256,7 +256,6 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(8, configuration.getCairoConfiguration().getSqlJitIRMemoryMaxPages());
         Assert.assertEquals(4096, configuration.getCairoConfiguration().getSqlJitBindVarsMemoryPageSize());
         Assert.assertEquals(8, configuration.getCairoConfiguration().getSqlJitBindVarsMemoryMaxPages());
-        Assert.assertEquals(1024 * 1024, configuration.getCairoConfiguration().getSqlJitRowsThreshold());
         Assert.assertEquals(1024 * 1024, configuration.getCairoConfiguration().getSqlJitPageAddressCacheThreshold());
         Assert.assertFalse(configuration.getCairoConfiguration().isSqlJitDebugEnabled());
 
@@ -1103,7 +1102,6 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(2, configuration.getCairoConfiguration().getSqlJitIRMemoryMaxPages());
             Assert.assertEquals(1024, configuration.getCairoConfiguration().getSqlJitBindVarsMemoryPageSize());
             Assert.assertEquals(1, configuration.getCairoConfiguration().getSqlJitBindVarsMemoryMaxPages());
-            Assert.assertEquals(1024, configuration.getCairoConfiguration().getSqlJitRowsThreshold());
             Assert.assertEquals(1024, configuration.getCairoConfiguration().getSqlJitPageAddressCacheThreshold());
             Assert.assertTrue(configuration.getCairoConfiguration().isSqlJitDebugEnabled());
 

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -347,7 +347,6 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.sql.jit.ir.memory.page.size\tQDB_CAIRO_SQL_JIT_IR_MEMORY_PAGE_SIZE\t8192\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.jit.mode\tQDB_CAIRO_SQL_JIT_MODE\ton\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.jit.page.address.cache.threshold\tQDB_CAIRO_SQL_JIT_PAGE_ADDRESS_CACHE_THRESHOLD\t1048576\tdefault\tfalse\tfalse\n" +
-                                    "cairo.sql.jit.rows.threshold\tQDB_CAIRO_SQL_JIT_ROWS_THRESHOLD\t1048576\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.join.context.pool.capacity\tQDB_CAIRO_SQL_JOIN_CONTEXT_POOL_CAPACITY\t64\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.join.metadata.max.resizes\tQDB_CAIRO_SQL_JOIN_METADATA_MAX_RESIZES\t2147483647\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.join.metadata.page.size\tQDB_CAIRO_SQL_JOIN_METADATA_PAGE_SIZE\t16384\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -141,7 +141,6 @@ cairo.sql.jit.ir.memory.page.size=2K
 cairo.sql.jit.ir.memory.max.pages=2
 cairo.sql.jit.bind.vars.memory.page.size=1K
 cairo.sql.jit.bind.vars.memory.max.pages=1
-cairo.sql.jit.rows.threshold=1K
 cairo.sql.jit.page.address.cache.threshold=1K
 cairo.sql.jit.debug.enabled=true
 cairo.writer.alter.busy.wait.timeout=333000

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -383,9 +383,6 @@ query.timeout.sec=60
 #cairo.sql.jit.bind.vars.memory.page.size=4K
 #cairo.sql.jit.bind.vars.memory.max.pages=8
 
-# sets minimum number of rows to shrink filtered rows memory after query execution
-#cairo.sql.jit.rows.threshold=1M
-
 # sets minimum cache size to shrink page address cache after query execution
 #cairo.sql.jit.page.address.cache.threshold=1M
 


### PR DESCRIPTION
Before:
```
Benchmark                          Mode  Cnt  Score   Error  Units
FastMapWriteBenchmark.testFastMap  avgt    3  0.367 ± 0.017  us/op
```

After:
```
Benchmark                          Mode  Cnt  Score   Error  Units
FastMapWriteBenchmark.testFastMap  avgt    3  0.347 ± 0.004  us/op
```