### PR TITLE
fix(sql): improve compatibility with grafana

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/Constants.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/Constants.java
@@ -123,6 +123,7 @@ public class Constants {
     };
     public static final String PG_COMPATIBLE_VERSION = "12.3";
     public static final StrConstant PG_CATALOG_VERSION_CONSTANT = new StrConstant("PostgreSQL " + PG_COMPATIBLE_VERSION + ", compiled by Visual C++ build 1914, 64-bit, QuestDB");
+    public static final StrConstant PG_COMPATIBLE_VERSION_NUM_CONSTANT = new StrConstant("123000");
     public static final String PUBLIC = "public";
     public static final String USER_NAME = "admin";
     static final String[] NAMESPACES = {"pg_catalog", PUBLIC};

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentSettingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentSettingFunctionFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.constants.StrConstant;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+// stub implementation used in grafana meta queries
+public class CurrentSettingFunctionFactory implements FunctionFactory {
+
+    public static final String SERVER_VERSION_NUM = "server_version_num";
+
+    @Override
+    public String getSignature() {
+        return "current_setting(s)";
+    }
+
+    @Override
+    public boolean isRuntimeConstant() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        Function arg = args.get(0);
+        CharSequence argValue = arg.getStr(null);
+
+        if (Chars.equalsNc(SERVER_VERSION_NUM, argValue)) {
+            return Constants.PG_COMPATIBLE_VERSION_NUM_CONSTANT;
+        } else {
+            return new StrConstant("");
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaTablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaTablesFunctionFactory.java
@@ -1,0 +1,215 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.TelemetryConfigLogger;
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.*;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjHashSet;
+import io.questdb.std.ObjList;
+import io.questdb.tasks.TelemetryTask;
+
+// information_schema.tables basic implementation
+// used in grafana meta queries
+public class InformationSchemaTablesFunctionFactory implements FunctionFactory {
+
+    private static final int COLUMN_CATALOG = 0;
+    private static final int COLUMN_IS_INSERTABLE_INTO = 9;
+    private static final int COLUMN_IS_TYPED = 10;
+    private static final int COLUMN_NAME = 2;
+    private static final int COLUMN_SCHEMA = 1;
+    private static final int COLUMN_TYPE = 3;
+    private static final RecordMetadata METADATA;
+
+    @Override
+    public String getSignature() {
+        return "information_schema.tables()";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions,
+                                CairoConfiguration configuration,
+                                SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new CursorFunction(new InformationSchemaTablesCursorFactory(configuration, METADATA)) {
+            @Override
+            public boolean isRuntimeConstant() {
+                return true;
+            }
+        };
+    }
+
+    public static class InformationSchemaTablesCursorFactory extends AbstractRecordCursorFactory {
+        private final TableListRecordCursor cursor = new TableListRecordCursor();
+        private final boolean hideTelemetryTables;
+        private final CharSequence sysTablePrefix;
+        private final CharSequence tempPendingRenameTablePrefix;
+        private CairoEngine engine;
+        private TableToken tableToken;
+
+        public InformationSchemaTablesCursorFactory(CairoConfiguration configuration, RecordMetadata metadata) {
+            super(metadata);
+            tempPendingRenameTablePrefix = configuration.getTempRenamePendingTablePrefix();
+            sysTablePrefix = configuration.getSystemTableNamePrefix();
+            hideTelemetryTables = configuration.getTelemetryConfiguration().hideTables();
+        }
+
+        @Override
+        public RecordCursor getCursor(SqlExecutionContext executionContext) {
+            engine = executionContext.getCairoEngine();
+            cursor.toTop();
+            return cursor;
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.type("information_schema.tables");
+        }
+
+        @Override
+        protected void _close() {
+            cursor.close();
+            engine = null;
+        }
+
+        private class TableListRecordCursor implements NoRandomAccessRecordCursor {
+            private final TableListRecord record = new TableListRecord();
+            private final ObjHashSet<TableToken> tableBucket = new ObjHashSet<>();
+            private int tableIndex = -1;
+
+            @Override
+            public void close() {
+                tableIndex = -1;
+            }
+
+            @Override
+            public io.questdb.cairo.sql.Record getRecord() {
+                return record;
+            }
+
+            @Override
+            public boolean hasNext() {
+                if (tableIndex < 0) {
+                    engine.getTableTokens(tableBucket, false);
+                    tableIndex = -1;
+                }
+                tableIndex++;
+                int n = tableBucket.size();
+                for (; tableIndex < n; tableIndex++) {
+                    tableToken = tableBucket.get(tableIndex);
+                    if (!TableUtils.isPendingRenameTempTableName(tableToken.getTableName(), tempPendingRenameTablePrefix) &&
+                            !isSystemTable(tableToken)) {
+                        break;
+                    }
+                }
+                return tableIndex < n;
+            }
+
+            @Override
+            public long size() {
+                return -1;
+            }
+
+            @Override
+            public void toTop() {
+                tableIndex = -1;
+            }
+
+            private boolean isSystemTable(TableToken tableToken) {
+                return (hideTelemetryTables &&
+                        (Chars.equals(tableToken.getTableName(), TelemetryTask.TABLE_NAME) || Chars.equals(tableToken.getTableName(), TelemetryConfigLogger.TELEMETRY_CONFIG_TABLE_NAME)))
+                        || Chars.startsWith(tableToken.getTableName(), sysTablePrefix);
+            }
+
+            private class TableListRecord implements Record {
+                @Override
+                public boolean getBool(int col) {
+                    if (col == COLUMN_IS_TYPED) {
+                        return false;
+                    }
+                    return col == COLUMN_IS_INSERTABLE_INTO;
+                }
+
+                @Override
+                public CharSequence getStr(int col) {
+                    if (col == COLUMN_NAME) {
+                        return tableToken.getTableName();
+                    }
+                    if (col == COLUMN_CATALOG) {
+                        return "qdb";
+                    }
+                    if (col == COLUMN_SCHEMA) {
+                        return "public";
+                    }
+                    if (col == COLUMN_TYPE) {
+                        return "BASE TABLE";
+                    }
+                    return null;
+                }
+
+                @Override
+                public CharSequence getStrB(int col) {
+                    return getStr(col);
+                }
+
+                @Override
+                public int getStrLen(int col) {
+                    CharSequence str = getStr(col);
+                    return str != null ? str.length() : TableUtils.NULL_LEN;
+                }
+            }
+        }
+    }
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(new TableColumnMetadata("table_catalog", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("table_schema", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("table_name", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("table_type", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("self_referencing_column_name", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("reference_generation", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("user_defined_type_catalog", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("user_defined_type_schema", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("user_defined_type_name", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("is_insertable_into", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("is_typed", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("commit_action", ColumnType.STRING));
+
+        METADATA = metadata;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgExtensionFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgExtensionFunctionFactory.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+// pg_extension stub implementation returning a single row with questdb 'extension' metadata
+// used in grafana meta queries
+public class PgExtensionFunctionFactory implements FunctionFactory {
+    private static final int COLUMN_EXTVERSION = 5;
+
+    private static final RecordMetadata METADATA;
+
+    @Override
+    public String getSignature() {
+        return "pg_extension()";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new CursorFunction(new PgExtensionCursorFactory(configuration));
+    }
+
+    private static class PgExtensionCursorFactory extends AbstractRecordCursorFactory {
+        private final PgExtensionRecordCursor cursor;
+
+        public PgExtensionCursorFactory(CairoConfiguration configuration) {
+            super(METADATA);
+            cursor = new PgExtensionRecordCursor(configuration.getBuildInformation().getSwVersion());
+        }
+
+        @Override
+        public RecordCursor getCursor(SqlExecutionContext executionContext) {
+            cursor.toTop();
+            return cursor;
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.type("pg_extension()");
+        }
+
+        private static class PgExtensionRecordCursor implements RecordCursor {
+
+            private static final String[][] EXTENSIONS = {{"1", "questdb", "1", "1", "false", null, null, null}};
+            private final PgExtensionRecord record = new PgExtensionRecord();
+            private final CharSequence version;
+            private int index = -1;
+
+            public PgExtensionRecordCursor(CharSequence version) {
+                this.version = version;
+            }
+
+            @Override
+            public void close() {
+                // no-op
+            }
+
+            @Override
+            public Record getRecord() {
+                return record;
+            }
+
+            @Override
+            public Record getRecordB() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean hasNext() {
+                return ++index < EXTENSIONS.length;
+            }
+
+            @Override
+            public void recordAt(Record record, long atRowId) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long size() {
+                return EXTENSIONS.length;
+            }
+
+            @Override
+            public void toTop() {
+                index = -1;
+            }
+
+            public class PgExtensionRecord implements Record {
+                @Override
+                public boolean getBool(int col) {
+                    return false;
+                }
+
+                @Override
+                public CharSequence getStr(int col) {
+                    if (col == COLUMN_EXTVERSION) {
+                        return version;
+                    } else {
+                        return EXTENSIONS[0][col];
+                    }
+                }
+
+                @Override
+                public CharSequence getStrB(int col) {
+                    return getStr(col);
+                }
+
+                @Override
+                public int getStrLen(int col) {
+                    CharSequence str = getStr(col);
+                    if (str != null) {
+                        return str.length();
+                    }
+
+                    return TableUtils.NULL_LEN;
+                }
+            }
+        }
+    }
+
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(new TableColumnMetadata("oid", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extname", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extowner", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extnamespace", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extrelocatable", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("extversion", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extconfig", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("extcondition", ColumnType.STRING));
+        METADATA = metadata;
+    }
+
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PrefixedPgExtensionFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PrefixedPgExtensionFunctionFactory.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+public class PrefixedPgExtensionFunctionFactory extends PgExtensionFunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "pg_catalog.pg_extension()";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/QuoteIdentFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/QuoteIdentFunctionFactory.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.StrFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.StrConstant;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.StringSink;
+
+
+// Returns the given string suitably quoted to be used as an identifier in an SQL statement string.
+// Quotes are added only if necessary (i.e., if the string contains non-identifier characters or would be case-folded)
+public class QuoteIdentFunctionFactory implements FunctionFactory {
+
+    private static final String NAME = "quote_ident";
+
+    @Override
+    public String getSignature() {
+        return NAME + "(S)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        Function arg = args.getQuick(0);
+        if (arg.isConstant()) {
+            CharSequence val = arg.getStr(null);
+            if (val == null) {
+                return StrConstant.NULL;
+            } else {
+                StringSink quotedVal = QuoteIdentFunction.quote(Misc.getThreadLocalSink(), val);
+                return new StrConstant(quotedVal.toString());
+            }
+        }
+
+        return new QuoteIdentFunction(arg);
+    }
+
+    static class QuoteIdentFunction extends StrFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        private final StringSink sinkA = new StringSink();
+        private final StringSink sinkB = new StringSink();
+
+        public QuoteIdentFunction(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public CharSequence getStr(Record rec) {
+            return quote(sinkA, arg.getStr(rec));
+        }
+
+        @Override
+        public CharSequence getStrB(Record rec) {
+            return quote(sinkB, arg.getStr(rec));
+        }
+
+        private static StringSink quote(StringSink sink, CharSequence str) {
+            if (str == null) {
+                return null;
+            }
+
+            sink.clear();
+
+            boolean needsQuoting = false;
+            int len = str.length();
+            for (int i = 0; i < len; i++) {
+                char c = str.charAt(i);
+
+                if (!(Character.isLetter(c) ||
+                        Character.isDigit(c) ||
+                        c == '_' ||
+                        c == '$')) {
+                    needsQuoting = true;
+                    break;
+                }
+            }
+
+            if (!needsQuoting) {
+                sink.put(str);
+            } else {
+                sink.put('"');
+                for (int i = 0; i < len; i++) {
+                    char c = str.charAt(i);
+                    if (c != '"') {
+                        sink.put(c);
+                    } else {
+                        sink.put('"').put('"');
+                    }
+                }
+                sink.put('"');
+            }
+
+            return sink;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstValueDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstValueDoubleWindowFunctionFactory.java
@@ -368,6 +368,11 @@ public class FirstValueDoubleWindowFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public double getDouble(Record rec) {
+            return firstValue;
+        }
+
+        @Override
         public String getName() {
             return NAME;
         }
@@ -382,7 +387,6 @@ public class FirstValueDoubleWindowFunctionFactory implements FunctionFactory {
             computeNext(record);
             Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), firstValue);
         }
-
     }
 
     // Handles first_value() over (partition by x order by ts range between y preceding and [z preceding | current row])

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -683,6 +683,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgRolesFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.InformationSchemaFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.InformationSchemaColumnsFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.InformationSchemaTablesFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgTypeFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgDescriptionFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgNamespaceFunctionFactory,
@@ -697,11 +698,14 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentDatabaseFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.CurrentSchemasFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemasFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.CurrentSettingFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.CurrentSchemaFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemaFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.CurrentUserFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.CursorDereferenceFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PgDescriptionFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.PgExtensionFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.PrefixedPgExtensionFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PgInheritsFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.PrefixedPgInheritsFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.SessionUserFunctionFactory,
@@ -798,6 +802,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory,
             // substring
             io.questdb.griffin.engine.functions.str.SubStringFunctionFactory,
+            io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory,
 
             // trim
             io.questdb.griffin.engine.functions.str.TrimFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -640,6 +640,7 @@ io.questdb.griffin.engine.functions.catalogue.PgRolesFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgRolesFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.InformationSchemaFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.InformationSchemaColumnsFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.InformationSchemaTablesFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgTypeFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgDescriptionFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgNamespaceFunctionFactory
@@ -652,8 +653,11 @@ io.questdb.griffin.engine.functions.catalogue.PgLocksFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgLocksFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.CurrentSchemasFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemasFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.CurrentSettingFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.CursorDereferenceFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PgDescriptionFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.PgExtensionFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.PrefixedPgExtensionFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PgInheritsFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgInheritsFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.SessionUserFunctionFactory
@@ -713,6 +717,7 @@ io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory
 
 # substring()
 io.questdb.griffin.engine.functions.str.SubStringFunctionFactory
+io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory
 
 #starts_with()
 io.questdb.griffin.engine.functions.str.StartsWithStrFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/CurrentSettingFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/CurrentSettingFunctionFactoryTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.catalogue;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.catalogue.Constants;
+import io.questdb.griffin.engine.functions.catalogue.CurrentSettingFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class CurrentSettingFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void test() throws SqlException {
+        call("").andAssert("");
+        call((String) null).andAssert("");
+        call("eee").andAssert("");
+        call(CurrentSettingFunctionFactory.SERVER_VERSION_NUM).andAssert(Constants.PG_COMPATIBLE_VERSION_NUM_CONSTANT.getStr(null));
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new CurrentSettingFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/InformationSchemaTablesFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/InformationSchemaTablesFunctionFactoryTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.catalogue;
+
+import io.questdb.TelemetryConfigLogger;
+import io.questdb.tasks.TelemetryTask;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class InformationSchemaTablesFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testSelectWhenTelemetryTablesAreHidden() throws Exception {
+        assertMemoryLeak(() -> {
+            configOverrideHideTelemetryTable(true);
+            ddl("create table " + TelemetryConfigLogger.TELEMETRY_CONFIG_TABLE_NAME + " (i int)");
+            ddl("create table " + TelemetryTask.TABLE_NAME + " (i int)");
+
+
+            assertQuery("table_catalog\ttable_schema\ttable_name\ttable_type\tself_referencing_column_name\treference_generation\tuser_defined_type_catalog\tuser_defined_type_schema\tuser_defined_type_name\tis_insertable_into\tis_typed\tcommit_action\n",
+                    "select * from information_schema.tables() order by table_name",
+                    null, true, false);
+        });
+    }
+
+    @Test
+    public void testSelectWhenThereAreNoTables() throws Exception {
+        assertMemoryLeak(() -> assertQuery("table_catalog\ttable_schema\ttable_name\ttable_type\tself_referencing_column_name\treference_generation\tuser_defined_type_catalog\tuser_defined_type_schema\tuser_defined_type_name\tis_insertable_into\tis_typed\tcommit_action\n",
+                "select * from information_schema.tables()",
+                null, false, false));
+    }
+
+    @Test
+    public void testSelectWhenThereAreTables() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table first_table(i int)");
+            ddl("create table second_table(i int)");
+
+            assertQuery("table_catalog\ttable_schema\ttable_name\ttable_type\tself_referencing_column_name\treference_generation\tuser_defined_type_catalog\tuser_defined_type_schema\tuser_defined_type_name\tis_insertable_into\tis_typed\tcommit_action\n" +
+                            "qdb\tpublic\tfirst_table\tBASE TABLE\t\t\t\t\t\ttrue\tfalse\t\n" +
+                            "qdb\tpublic\tsecond_table\tBASE TABLE\t\t\t\t\t\ttrue\tfalse\t\n",
+                    "select * from information_schema.tables() order by table_name",
+                    null, true, false);
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/PgExtensionFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/PgExtensionFunctionFactoryTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.catalogue;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class PgExtensionFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testPgExtensionFunction() throws Exception {
+        assertMemoryLeak(() -> assertQuery("oid\textname\textowner\textnamespace\textrelocatable\textversion\textconfig\textcondition\n" +
+                        "1\tquestdb\t1\t1\tfalse\t[DEVELOPMENT]\t\t\n",
+                "select * from pg_extension",
+                null, false, true));
+    }
+
+    @Test
+    public void testPrefixedPgExtensionFunction() throws Exception {
+        assertMemoryLeak(() -> assertQuery("oid\textname\textowner\textnamespace\textrelocatable\textversion\textconfig\textcondition\n" +
+                        "1\tquestdb\t1\t1\tfalse\t[DEVELOPMENT]\t\t\n",
+                "select * from pg_catalog.pg_extension",
+                null, false, true));
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/QuoteIdentFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/QuoteIdentFunctionFactoryTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class QuoteIdentFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void test() throws SqlException {
+        call("").andAssert("");
+        call((String) null).andAssert(null);
+        call("test").andAssert("test");
+        call("TEST").andAssert("TEST");
+
+        call("a b").andAssert("\"a b\"");
+        call("a\tb").andAssert("\"a\tb\"");
+        call("a^b").andAssert("\"a^b\"");
+        call("a\"b").andAssert("\"a\"\"b\"");
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new QuoteIdentFunctionFactory();
+    }
+}


### PR DESCRIPTION
PR improves compatibility with metadata sql issued by grafana's query builder and code editor by adding : 
- quote_ident() function 
- information_schema.tables 
- pg_extension stub 
- current_setting() function stub 

PR also fixes a bug in first_value() function not working with non-caching Window Factory and `over (partition by x)` clause variant. 

Related grafana PR -> https://github.com/grafana/grafana/pull/79066