### PR TITLE
fix(sql): fix parsing of single character window frame bounds

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.pool.ex.EntryLockedException;
 import io.questdb.cairo.sql.*;
 import io.questdb.griffin.engine.functions.catalogue.*;
+import io.questdb.griffin.engine.functions.constants.CharConstant;
 import io.questdb.griffin.engine.functions.table.AllTablesFunctionFactory;
 import io.questdb.griffin.engine.table.ShowColumnsRecordCursorFactory;
 import io.questdb.griffin.engine.table.ShowPartitionsRecordCursorFactory;
@@ -1862,7 +1863,14 @@ public class SqlOptimiser implements Mutable {
             }
 
             try {
-                long value = loFunc.getLong(null);
+                long value;
+                if (!(loFunc instanceof CharConstant)) {
+                    value = loFunc.getLong(null);
+                } else {
+                    long tmp = (byte) (loFunc.getChar(null) - '0');
+                    value = tmp > -1 && tmp < 10 ? tmp : Numbers.LONG_NaN;
+                }
+
                 if (value < 0) {
                     throw SqlException.$(expr.position, "non-negative integer expression expected");
                 }


### PR DESCRIPTION
Fixes bad parsing of single characters used as window frame boundaries, e.g. 

```sql
create table tab ( key int, value double, ts timestamp) timestamp(ts);

explain select avg(value) over (PARTITION BY key ORDER BY ts RANGE BETWEEN '1' MINUTES PRECEDING AND CURRENT ROW) from tab;

--in master 
Window
  functions: [avg(value) over (partition by [key] range between 2940000000 preceding and current row)]
    DataFrame
        Row forward scan
        Frame forward scan on: tab

--this branch
Window
  functions: [avg(value) over (partition by [key] range between 60000000 preceding and current row)]
    DataFrame
        Row forward scan
        Frame forward scan on: tab
```

The issue was that single character was converted to long as ascii code - 49.