### PR TITLE
feat(sql): add sign() functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignByteFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignByteFunctionFactory.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.ByteFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class SignByteFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(B)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends ByteFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public byte getByte(Record rec) {
+            byte b = arg.getByte(rec);
+            return (byte) Integer.signum(b);
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignDoubleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignDoubleFunctionFactory.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class SignDoubleFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(D)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends DoubleFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            double d = arg.getDouble(rec);
+            if (d == -0.0d) {
+                return 0.0d;
+            }
+            return Math.signum(d);
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignFloatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignFloatFunctionFactory.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.FloatFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class SignFloatFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(F)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends FloatFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public float getFloat(Record rec) {
+            return Math.signum(arg.getFloat(rec));
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignIntFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignIntFunctionFactory.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.IntFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+
+public class SignIntFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(I)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends IntFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public int getInt(Record rec) {
+            int val = arg.getInt(rec);
+            if (Numbers.INT_NaN == val) {
+                return Numbers.INT_NaN;
+            }
+
+            return Integer.signum(val);
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignLongFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignLongFunctionFactory.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.LongFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+
+public class SignLongFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(L)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends LongFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public long getLong(Record rec) {
+            long val = arg.getLong(rec);
+            if (Numbers.LONG_NaN == val) {
+                return Numbers.LONG_NaN;
+            }
+            return Long.signum(val);
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SignShortFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SignShortFunctionFactory.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.math;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.ShortFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class SignShortFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "sign(E)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new Func(args.get(0));
+    }
+
+    static class Func extends ShortFunction implements UnaryFunction {
+
+        private final Function arg;
+
+        Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public String getName() {
+            return "sign";
+        }
+
+        @Override
+        public short getShort(Record rec) {
+            short s = arg.getShort(rec);
+            return (short) Integer.signum(s);
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -666,6 +666,13 @@ open module io.questdb {
 //                  floor()
             io.questdb.griffin.engine.functions.math.FloorDoubleFunctionFactory,
             io.questdb.griffin.engine.functions.math.FloorFloatFunctionFactory,
+//                  sign()
+            io.questdb.griffin.engine.functions.math.SignByteFunctionFactory,
+            io.questdb.griffin.engine.functions.math.SignDoubleFunctionFactory,
+            io.questdb.griffin.engine.functions.math.SignFloatFunctionFactory,
+            io.questdb.griffin.engine.functions.math.SignIntFunctionFactory,
+            io.questdb.griffin.engine.functions.math.SignLongFunctionFactory,
+            io.questdb.griffin.engine.functions.math.SignShortFunctionFactory,
 //                  case conditional statement
             io.questdb.griffin.engine.functions.conditional.CaseFunctionFactory,
             io.questdb.griffin.engine.functions.conditional.SwitchFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -607,6 +607,14 @@ io.questdb.griffin.engine.functions.math.RoundDownDoubleFunctionFactory
 io.questdb.griffin.engine.functions.math.RoundUpDoubleFunctionFactory
 io.questdb.griffin.engine.functions.math.RoundHalfEvenDoubleFunctionFactory
 
+# sign()
+io.questdb.griffin.engine.functions.math.SignByteFunctionFactory
+io.questdb.griffin.engine.functions.math.SignDoubleFunctionFactory
+io.questdb.griffin.engine.functions.math.SignFloatFunctionFactory
+io.questdb.griffin.engine.functions.math.SignIntFunctionFactory
+io.questdb.griffin.engine.functions.math.SignLongFunctionFactory
+io.questdb.griffin.engine.functions.math.SignShortFunctionFactory
+
 # CeilFunctionFactory
 io.questdb.griffin.engine.functions.math.CeilDoubleFunctionFactory
 io.questdb.griffin.engine.functions.math.CeilFloatFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/math/SignFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/math/SignFunctionFactoryTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.math;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class SignFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testByteShort() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( b byte )");
+            insert("insert into tab values (0), " +
+                    "(1), (127), " +
+                    "(-1), (-128)");
+            assertSql("b\tsign\n" +
+                            "0\t0\n" +
+                            "1\t1\n" +
+                            "127\t1\n" +
+                            "-1\t-1\n" +
+                            "-128\t-1\n",
+                    "select b, sign(b) from tab");
+        });
+    }
+
+    @Test
+    public void testSignDouble() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( d double )");
+            insert("insert into tab values (0.0), (-0.0), " +
+                    "(2.2250738585072014E-308), (1.0), (1.7976931348623157E308), ('Infinity'::double), " +
+                    "(-2.2250738585072014E-308), (-1.0), (-1.7976931348623157E308), ('-Infinity'::double)," +
+                    "(null) ");
+            assertSql("d\tsign\n" +
+                            "0.0\t0.0\n" +
+                            "-0.0\t0.0\n" +
+                            "2.2250738585072014E-308\t1.0\n" +
+                            "1.0\t1.0\n" +
+                            "1.7976931348623157E308\t1.0\n" +
+                            "Infinity\t1.0\n" +
+                            "-2.2250738585072014E-308\t-1.0\n" +
+                            "-1.0\t-1.0\n" +
+                            "-1.7976931348623157E308\t-1.0\n" +
+                            "-Infinity\t-1.0\n" +
+                            "NaN\tNaN\n",
+                    "select d, sign(d) from tab");
+        });
+    }
+
+    @Test
+    public void testSignFloat() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( f float )");
+            insert("insert into tab values (0.0), (-0.0), " +
+                    "(1.4E-45F), (1.0), (3.4028235E38F), (cast('Infinity' as float)), " +
+                    "(-1.4E-45F), (-1.0), (-3.4028235E38F), (cast('-Infinity' as float))," +
+                    "(null) ");
+            assertSql("f\tsign\n" +
+                            "0.0000\t0.0000\n" +
+                            "-0.0000\t-0.0000\n" +
+                            "0.0000\t1.0000\n" +
+                            "1.0000\t1.0000\n" +
+                            "3.4028235E38\t1.0000\n" +
+                            "Infinity\t1.0000\n" +
+                            "-0.0000\t-1.0000\n" +
+                            "-1.0000\t-1.0000\n" +
+                            "-3.4028235E38\t-1.0000\n" +
+                            "-Infinity\t-1.0000\n" +
+                            "NaN\tNaN\n",
+                    "select f, sign(f) from tab");
+        });
+    }
+
+    @Test
+    public void testSignInt() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( i int )");
+            insert("insert into tab values (0), " +
+                    "(1), (2147483647), " +
+                    "(-1), (-2147483647)," +
+                    "(null) ");
+            assertSql("i\tsign\n" +
+                            "0\t0\n" +
+                            "1\t1\n" +
+                            "2147483647\t1\n" +
+                            "-1\t-1\n" +
+                            "-2147483647\t-1\n" +
+                            "NaN\tNaN\n",
+                    "select i, sign(i) from tab");
+        });
+    }
+
+    @Test
+    public void testSignLong() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( l long )");
+            insert("insert into tab values (0L), " +
+                    "(1L), (9223372036854775807L), " +
+                    "(-1L), (-9223372036854775807L)," +
+                    "(null) ");
+            assertSql("l\tsign\n" +
+                            "0\t0\n" +
+                            "1\t1\n" +
+                            "9223372036854775807\t1\n" +
+                            "-1\t-1\n" +
+                            "-9223372036854775807\t-1\n" +
+                            "NaN\tNaN\n",
+                    "select l, sign(l) from tab");
+        });
+    }
+
+    @Test
+    public void testSignShort() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table tab ( s short )");
+            insert("insert into tab values (0), " +
+                    "(1), (32767), " +
+                    "(-1), (-32768)");
+            assertSql("s\tsign\n" +
+                            "0\t0\n" +
+                            "1\t1\n" +
+                            "32767\t1\n" +
+                            "-1\t-1\n" +
+                            "-32768\t-1\n",
+                    "select s, sign(s) from tab");
+        });
+    }
+}


### PR DESCRIPTION
PR adds sign() function for argument of byte, short, int, long, float and double data type.
Example:

```sql
create table tab ( d double );
insert into tab values (0.0), (-0.0), 
                    (2.2250738585072014E-308), (1.0), (1.7976931348623157E308), ('Infinity'::double), 
                    (-2.2250738585072014E-308), (-1.0), (-1.7976931348623157E308), ('-Infinity'::double),
                    (null);
select d, sign(d) from tab;
--returns 
sign | d
-- | --
0 | 0
0 | 0
1 | 0.22250738585072E-307
1 | 1
1 | 1.7976931348623157E+308
1 | Infinity
-1 | -0.22250738585072E-307
-1 | -1
-1 | -1.7976931348623157E+308
-1 | -Infinity
null | null
```

