### PR TITLE
chore(core): FastMap to use Robin Hood hashing

### DIFF
--- a/core/src/main/java/io/questdb/cairo/map/FastMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/FastMap.java
@@ -429,9 +429,9 @@ public class FastMap implements Map, Reopenable {
                 }
 
                 int candidateHashCode = getHashCode(newOffsets, index);
-                int candidateProbeSeqLen = getProbeSequenceLength(candidateHashCode, index);
-                if (candidateProbeSeqLen < probeSeqLen) {
-                    startEvacuationFrom(newOffsets, candidateOffset, candidateHashCode, index, candidateProbeSeqLen);
+                int candidateSeqLen = getProbeSequenceLength(candidateHashCode, index);
+                if (candidateSeqLen < probeSeqLen) {
+                    startEvacuationFrom(newOffsets, candidateOffset, candidateHashCode, index, candidateSeqLen);
                     break;
                 }
                 probeSeqLen++;

--- a/core/src/test/java/io/questdb/test/cairo/map/FastMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/FastMapTest.java
@@ -38,7 +38,64 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+
 public class FastMapTest extends AbstractCairoTest {
+
+    @Test
+    public void testValuesAreNotSpuriouslyOverriden() {
+        Rnd rnd = new Rnd();
+
+        ArrayColumnTypes keyTypes = new ArrayColumnTypes();
+        keyTypes.add(ColumnType.INT);
+
+        ArrayColumnTypes valueTypes = new ArrayColumnTypes();
+        valueTypes.add(ColumnType.INT);
+
+        java.util.Map<Integer, Integer> expected = new HashMap<>();
+
+        try (FastMap map = new FastMap(1024, keyTypes, valueTypes, 500, 0.8, 24)) {
+            final int N = 50;
+            for (int i = 0; i < N; i++) {
+                MapKey key = map.withKey();
+                int rndKey = rnd.nextInt();
+                key.putInt(rndKey);
+
+                MapValue value = key.createValue();
+                if (value.isNew()) {
+                    value.putInt(0, 1);
+                    Assert.assertNull(expected.put(rndKey, 1));
+                } else {
+                    int expectedVal = expected.get(rndKey);
+                    int actualVal = value.getInt(0);
+                    Assert.assertEquals(expectedVal, actualVal);
+                    value.putInt(0, actualVal + 1);
+                    expected.put(rndKey, actualVal + 1);
+                }
+            }
+
+            rnd.reset();
+
+
+            // assert that all values are good
+            for (int i = 0; i < N; i++) {
+                MapKey key = map.withKey();
+                final int rndKey = rnd.nextInt();
+                key.putInt(rndKey);
+                MapValue mapVal = key.findValue();
+
+                Integer expectedVal = expected.get(rndKey);
+                if (expectedVal == null) {
+                    Assert.assertNull(mapVal);
+                } else {
+                    Assert.assertNotNull("Key " + rndKey + " does not exists", mapVal);
+                    Assert.assertFalse("Key " + rndKey + " does not exists", mapVal.isNew());
+                    int actualVal = mapVal.getInt(0);
+                    Assert.assertEquals("Key " + rndKey + " return bad data", expectedVal.intValue(), actualVal);
+                }
+            }
+        }
+    }
 
     @Test
     public void testAllTypesFixedSizeKey() {


### PR DESCRIPTION
FastMap to use Robin Hood hashing. 

Testing setup: Clickbench running on c6a.16xlarge
Query: `SELECT UserID, COUNT(*) AS c FROM hits GROUP BY UserID ORDER BY c DESC LIMIT 10;`

**7.3.8-snapshot [vanilla](a89b83486c2)**
timings:10992530610
timings:10956769125
timings:10934153712
timings:10952430208
timings:10920044785
timings:10868601623
timings:10865651603
timings:10885177297


**7.3.8-snapshot + [Robin Hood FastMap](1157692e598)**
timings:10353366441
timings:10266570821
timings:10262674985
timings:10261647727
timings:10245524141
timings:10273126124
timings:10252424759
timings:10245550197