### PR TITLE
chore(core): user enabled and endpoint permission checks on every query

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -115,13 +115,6 @@ public interface SecurityContext {
     }
 
     /**
-     * Returns authentication type that led to the context creation.
-     */
-    default byte getAuthType() {
-        return AUTH_TYPE_NONE;
-    }
-
-    /**
      * User account used for permission checks, i.e. the session user account
      * or the service account defined by an executed ASSUME statement.
      */

--- a/core/src/main/java/io/questdb/cairo/SecurityContext.java
+++ b/core/src/main/java/io/questdb/cairo/SecurityContext.java
@@ -101,9 +101,10 @@ public interface SecurityContext {
 
     /**
      * Should throw an exception if:
-     * - logged in as a user and the user has been disabled,
-     * - logged in as a service account and the service account has been disabled,
+     * - logged in as a user and the user has been disabled, or it has no permissions to connect via the endpoint used,
+     * - logged in as a service account and the service account has been disabled, or it has no permissions to connect via the endpoint used,
      * - logged in as a user, then assumed a service account and either the user or the service account has been disabled,
+     * or either the user or the service account has no permissions to connect via the endpoint used,
      * or access to the service account has been revoked from the user
      */
     void checkEntityEnabled();

--- a/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContextFactory.java
+++ b/core/src/main/java/io/questdb/cairo/security/AllowAllSecurityContextFactory.java
@@ -33,7 +33,7 @@ public class AllowAllSecurityContextFactory implements SecurityContextFactory {
     }
 
     @Override
-    public SecurityContext getInstance(CharSequence principal, byte authType, int interfaceId) {
+    public SecurityContext getInstance(CharSequence principal, byte authType, byte interfaceId) {
         return AllowAllSecurityContext.INSTANCE;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContextFactory.java
+++ b/core/src/main/java/io/questdb/cairo/security/ReadOnlySecurityContextFactory.java
@@ -6,7 +6,7 @@ public final class ReadOnlySecurityContextFactory implements SecurityContextFact
     public static final ReadOnlySecurityContextFactory INSTANCE = new ReadOnlySecurityContextFactory();
 
     @Override
-    public SecurityContext getInstance(CharSequence principal, byte authType, int interfaceId) {
+    public SecurityContext getInstance(CharSequence principal, byte authType, byte interfaceId) {
         return ReadOnlySecurityContext.INSTANCE;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/security/SecurityContextFactory.java
+++ b/core/src/main/java/io/questdb/cairo/security/SecurityContextFactory.java
@@ -28,11 +28,11 @@ import io.questdb.cairo.SecurityContext;
 import io.questdb.std.Transient;
 
 public interface SecurityContextFactory {
-    int HTTP = 0;
-    int ILP = 2;
-    int PGWIRE = 1;
+    byte HTTP = 0;
+    byte ILP = 2;
+    byte PGWIRE = 1;
 
-    SecurityContext getInstance(@Transient CharSequence principal, byte authType, int interfaceId);
+    SecurityContext getInstance(@Transient CharSequence principal, byte authType, byte interfaceId);
 
     default SecurityContext getRootContext() {
         return AllowAllSecurityContext.INSTANCE;

--- a/core/src/main/java/io/questdb/cutlass/auth/Authenticator.java
+++ b/core/src/main/java/io/questdb/cutlass/auth/Authenticator.java
@@ -44,7 +44,7 @@ public interface Authenticator extends QuietCloseable {
     default void close() {
     }
 
-    default int denyAccess() throws AuthenticatorException {
+    default int denyAccess(CharSequence message) throws AuthenticatorException {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -673,16 +673,16 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
                     return rejectUnauthenticatedRequest();
                 }
 
-                try {
-                    securityContext.checkEntityEnabled();
-                } catch (CairoException e) {
-                    return rejectForbiddenRequest(e.getFlyweightMessage());
-                }
-
                 if (configuration.areCookiesEnabled()) {
                     if (!processor.processCookies(this, securityContext)) {
                         return false;
                     }
+                }
+
+                try {
+                    securityContext.checkEntityEnabled();
+                } catch (CairoException e) {
+                    return rejectForbiddenRequest(e.getFlyweightMessage());
                 }
 
                 if (multipartRequest && !multipartProcessor) {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.cutlass.http.HttpConstants.HEADER_CONTENT_ACCEPT_ENCODING;
 import static io.questdb.network.IODispatcher.*;
+import static java.net.HttpURLConnection.*;
 
 public class HttpConnectionContext extends IOContext<HttpConnectionContext> implements Locality, Retry {
     private static final Log LOG = LogFactory.getLog(HttpConnectionContext.class);
@@ -425,7 +426,6 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
                     authenticator.getAuthType(),
                     SecurityContextFactory.HTTP
             );
-            securityContext.authorizeHttp();
         }
         return true;
     }
@@ -673,6 +673,12 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
                     return rejectUnauthenticatedRequest();
                 }
 
+                try {
+                    securityContext.checkEntityEnabled();
+                } catch (CairoException e) {
+                    return rejectForbiddenRequest(e.getFlyweightMessage());
+                }
+
                 if (configuration.areCookiesEnabled()) {
                     if (!processor.processCookies(this, securityContext)) {
                         return false;
@@ -802,14 +808,18 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         return false;
     }
 
+    private boolean rejectForbiddenRequest(CharSequence userMessage) throws PeerDisconnectedException, PeerIsSlowToReadException {
+        return rejectRequest(HTTP_FORBIDDEN, userMessage, null, null);
+    }
+
     private boolean rejectRequest(CharSequence userMessage) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        return rejectRequest(404, userMessage, null, null);
+        return rejectRequest(HTTP_NOT_FOUND, userMessage, null, null);
     }
 
     private boolean rejectUnauthenticatedRequest() throws PeerDisconnectedException, PeerIsSlowToReadException {
         reset();
         LOG.error().$("rejecting unauthenticated request [fd=").$(getFd()).I$();
-        simpleResponse().sendStatusWithHeader(401, "WWW-Authenticate: Basic realm=\"questdb\", charset=\"UTF-8\"");
+        simpleResponse().sendStatusWithHeader(HTTP_UNAUTHORIZED, "WWW-Authenticate: Basic realm=\"questdb\", charset=\"UTF-8\"");
         dispatcher.registerChannel(this, IOOperation.READ);
         return false;
     }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -268,7 +268,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
                             SecurityContextFactory.ILP
                     );
                     try {
-                        securityContext.authorizeLineTcp();
+                        securityContext.checkEntityEnabled();
                     } catch (CairoException e) {
                         LOG.error().$('[').$(getFd()).$("] ").$(e.getFlyweightMessage()).$();
                         return IOContextResult.NEEDS_DISCONNECT;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -534,9 +534,6 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             handleException(-1, e.getFlyweightMessage(), false, -1, true);
         } catch (CairoException e) {
             handleException(e.getPosition(), e.getFlyweightMessage(), e.isCritical(), e.getErrno(), e.isInterruption());
-            if (e.isEntityDisabled()) {
-                throw PeerDisconnectedException.INSTANCE;
-            }
         } catch (PeerDisconnectedException | PeerIsSlowToReadException | PeerIsSlowToWriteException |
                  QueryPausedException | BadProtocolException e) {
             throw e;
@@ -1709,17 +1706,18 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         try {
             r = authenticator.handleIO();
             if (r == Authenticator.OK) {
-                SecurityContext securityContext = securityContextFactory.getInstance(
-                        authenticator.getPrincipal(),
-                        authenticator.getAuthType(),
-                        SecurityContextFactory.PGWIRE
-                );
                 try {
-                    securityContext.authorizePGWire();
+                    final SecurityContext securityContext = securityContextFactory.getInstance(
+                            authenticator.getPrincipal(),
+                            authenticator.getAuthType(),
+                            SecurityContextFactory.PGWIRE
+                    );
                     sqlExecutionContext.with(securityContext, bindVariableService, rnd, getFd(), circuitBreaker);
+                    securityContext.checkEntityEnabled();
                     r = authenticator.loginOK();
                 } catch (CairoException e) {
-                    r = authenticator.denyAccess();
+                    LOG.error().$("failed to authenticate [error=").$(e.getFlyweightMessage()).I$();
+                    r = authenticator.denyAccess(e.getFlyweightMessage());
                 }
             }
         } catch (AuthenticatorException e) {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/ReadOnlyUsersAwareSecurityContextFactory.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/ReadOnlyUsersAwareSecurityContextFactory.java
@@ -18,7 +18,7 @@ public final class ReadOnlyUsersAwareSecurityContextFactory implements SecurityC
     }
 
     @Override
-    public SecurityContext getInstance(CharSequence principal, byte authType, int interfaceId) {
+    public SecurityContext getInstance(CharSequence principal, byte authType, byte interfaceId) {
         switch (interfaceId) {
             case SecurityContextFactory.HTTP:
                 return httpReadOnly ? ReadOnlySecurityContext.INSTANCE : AllowAllSecurityContext.INSTANCE;


### PR DESCRIPTION
Separate the handling of endpoint permission and user enabled checks from authentication, and run the checks for every request.

required by https://github.com/questdb/questdb-enterprise/pull/307