### PR TITLE
fix(ilp): ilp@http small fixes

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -38,10 +38,13 @@ import io.questdb.std.str.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.HttpURLConnection;
+
 import static io.questdb.cutlass.http.HttpConstants.*;
 
 public abstract class HttpClient implements QuietCloseable {
     private static final String HEADER_CONTENT_LENGTH = "Content-Length: ";
+    private static final String HTTP_NO_CONTENT = String.valueOf(HttpURLConnection.HTTP_NO_CONTENT);
     private static final Log LOG = LogFactory.getLog(HttpClient.class);
     protected final NetworkFacade nf;
     protected final Socket socket;
@@ -172,8 +175,8 @@ public abstract class HttpClient implements QuietCloseable {
     }
 
     public class Request implements Utf8Sink {
+        private static final int STATE_CONTENT = 5;
         private static final int STATE_HEADER = 4;
-        private static final int STATE_CONTENT = STATE_HEADER + 1;
         private static final int STATE_QUERY = 3;
         private static final int STATE_REQUEST = 0;
         private static final int STATE_URL = 1;
@@ -210,6 +213,17 @@ public abstract class HttpClient implements QuietCloseable {
             binarySequenceAdapter.clear();
             binarySequenceAdapter.put(username).colon().put(password);
             Chars.base64Encode(binarySequenceAdapter, (int) binarySequenceAdapter.length(), this);
+            eol();
+            if (cookieHandler != null) {
+                cookieHandler.setCookies(this, username);
+            }
+            return this;
+        }
+
+        public Request authToken(CharSequence username, CharSequence token) {
+            beforeHeader();
+            putAsciiInternal("Authorization: Token ");
+            putAsciiInternal(token);
             eol();
             if (cookieHandler != null) {
                 cookieHandler.setCookies(this, username);
@@ -607,6 +621,10 @@ public abstract class HttpClient implements QuietCloseable {
                 if (len > 0) {
                     // dataLo & dataHi are boundaries of unprocessed data left in the buffer
                     chunkedResponse.begin(parse(bufLo, bufLo + len, false, true), bufLo + len);
+                    final Utf8Sequence statusCode = getStatusCode();
+                    if (statusCode != null && Utf8s.equalsNcAscii(HTTP_NO_CONTENT, getStatusCode())) {
+                        incomplete = false;
+                    }
                 }
             }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
@@ -165,7 +165,7 @@ public class LineHttpProcessor implements HttpRequestProcessor, HttpMultipartCon
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException, QueryPausedException {
         state = LV.get(context);
         assert state != null;
-        
+
         switch (state.getSendStatus()) {
             case HEADER:
                 context.resumeResponseSend();

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -3626,7 +3626,7 @@ public class IODispatcherTest extends AbstractTest {
                         "/query",
                         "\\{\"query\":\"select \\* from test_data_unavailable\\(1, 10\\)\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
                         "select * from test_data_unavailable(1, 10)",
-                        null, null,
+                        null, null, null,
                         "400"
                 ));
     }
@@ -4781,7 +4781,7 @@ public class IODispatcherTest extends AbstractTest {
                                 "/query",
                                 "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
                                 "select i, avg(l), max(l) from t group by i order by i asc limit 3",
-                                null, null,
+                                null, null, null,
                                 "400"
                         );
                     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/TestHttpClient.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/TestHttpClient.java
@@ -31,7 +31,6 @@ import io.questdb.cutlass.http.client.HttpClientFactory;
 import io.questdb.std.CharSequenceObjHashMap;
 import io.questdb.std.Misc;
 import io.questdb.std.QuietCloseable;
-import io.questdb.std.str.CharSink;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.tools.TestUtils;
@@ -70,8 +69,19 @@ public class TestHttpClient implements QuietCloseable {
             CharSequence url,
             CharSequence expectedResponse,
             @Nullable CharSequenceObjHashMap<String> queryParams,
-            CharSequence username,
-            CharSequence password
+            @Nullable CharSequence username,
+            @Nullable CharSequence password
+    ) {
+        assertGet(url, expectedResponse, queryParams, username, password, null);
+    }
+
+    public void assertGet(
+            CharSequence url,
+            CharSequence expectedResponse,
+            @Nullable CharSequenceObjHashMap<String> queryParams,
+            @Nullable CharSequence username,
+            @Nullable CharSequence password,
+            @Nullable CharSequence token
     ) {
         try {
             HttpClient.Request req = httpClient.newRequest();
@@ -86,21 +96,7 @@ public class TestHttpClient implements QuietCloseable {
                 }
             }
 
-            if (username != null && password != null) {
-                req.authBasic(username, password);
-            }
-
-            HttpClient.ResponseHeaders rsp = req.send("localhost", 9001);
-
-            rsp.await();
-            ChunkedResponse chunkedResponse = rsp.getChunkedResponse();
-            Chunk chunk;
-
-            sink.clear();
-            while ((chunk = chunkedResponse.recv()) != null) {
-                Utf8s.utf8ToUtf16(chunk.lo(), chunk.hi(), sink);
-            }
-
+            reqToSink(req, sink, username, password, token, null);
             TestUtils.assertEquals(expectedResponse, sink);
         } finally {
             if (!keepConnection) {
@@ -116,9 +112,19 @@ public class TestHttpClient implements QuietCloseable {
             @Nullable CharSequence username,
             @Nullable CharSequence password
     ) {
+        assertGet(url, expectedResponse, sql, username, password, null);
+    }
+
+    public void assertGet(
+            CharSequence url,
+            CharSequence expectedResponse,
+            CharSequence sql,
+            @Nullable CharSequence username,
+            @Nullable CharSequence password,
+            @Nullable CharSequence token
+    ) {
         try {
-            sink.clear();
-            toSink0(url, sql, sink, username, password, null);
+            toSink0(url, sql, sink, username, password, token, null);
             TestUtils.assertEquals(expectedResponse, sink);
         } finally {
             if (!keepConnection) {
@@ -133,11 +139,11 @@ public class TestHttpClient implements QuietCloseable {
             CharSequence sql,
             @Nullable CharSequence username,
             @Nullable CharSequence password,
+            @Nullable CharSequence token,
             CharSequence expectedStatus
     ) {
         try {
-            sink.clear();
-            toSink0(url, sql, sink, username, password, expectedStatus);
+            toSink0(url, sql, sink, username, password, token, expectedStatus);
             Pattern pattern = Pattern.compile(expectedResponseRegexp);
             String message = "Expected response to match regexp " + expectedResponseRegexp + " but got " + sink + " which does not match";
             Assert.assertTrue(message, pattern.matcher(sink).matches());
@@ -157,9 +163,9 @@ public class TestHttpClient implements QuietCloseable {
         this.keepConnection = keepConnection;
     }
 
-    public void toSink(CharSequence url, CharSequence sql, CharSink sink) {
+    public void toSink(CharSequence url, CharSequence sql, StringSink sink) {
         try {
-            toSink0(url, sql, sink, null, null, null);
+            toSink0(url, sql, sink, null, null, null, null);
         } finally {
             if (!keepConnection) {
                 httpClient.disconnect();
@@ -167,22 +173,22 @@ public class TestHttpClient implements QuietCloseable {
         }
     }
 
-    private void toSink0(
-            CharSequence url,
-            CharSequence sql,
-            CharSink sink,
+    private void reqToSink(
+            HttpClient.Request req,
+            StringSink sink,
             @Nullable CharSequence username,
             @Nullable CharSequence password,
+            @Nullable CharSequence token,
             CharSequence expectedStatus
     ) {
-        HttpClient.Request req = httpClient.newRequest();
-        req
-                .GET()
-                .url(url)
-                .query("query", sql);
-
-        if (username != null && password != null) {
-            req.authBasic(username, password);
+        if (username != null) {
+            if (password != null) {
+                req.authBasic(username, password);
+            } else if (token != null) {
+                req.authToken(username, token);
+            } else {
+                throw new RuntimeException("username specified without pwd or tooken");
+            }
         }
 
         HttpClient.ResponseHeaders rsp = req.send("localhost", 9001);
@@ -195,8 +201,27 @@ public class TestHttpClient implements QuietCloseable {
         ChunkedResponse chunkedResponse = rsp.getChunkedResponse();
         Chunk chunk;
 
+        sink.clear();
         while ((chunk = chunkedResponse.recv()) != null) {
             Utf8s.utf8ToUtf16(chunk.lo(), chunk.hi(), sink);
         }
+    }
+
+    private void toSink0(
+            CharSequence url,
+            CharSequence sql,
+            StringSink sink,
+            @Nullable CharSequence username,
+            @Nullable CharSequence password,
+            @Nullable CharSequence token,
+            CharSequence expectedStatus
+    ) {
+        HttpClient.Request req = httpClient.newRequest();
+        req
+                .GET()
+                .url(url)
+                .query("query", sql);
+
+        reqToSink(req, sink, username, password, token, expectedStatus);
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpFailureTests.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpFailureTests.java
@@ -160,7 +160,6 @@ public class LineHttpFailureTests extends AbstractBootstrapTest {
             )) {
                 serverMain.start();
 
-                final List<String> points = new ArrayList<>();
                 try (HttpClient httpClient = HttpClientFactory.newInstance(new DefaultHttpClientConfiguration())) {
                     String line = "line,sym1=123 field1=123i 1234567890000000000\n";
 


### PR DESCRIPTION
- small fixes for ILP over HTTP, such as using the right security context, returning the right HTTP response code
- HttpClient to support token auth, and proper handling of 204 response code