### PR TITLE
perf(sql): rewrite keyed count_distinct(expr)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToSymbolFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToSymbolFunctionFactory.java
@@ -58,7 +58,7 @@ public class CastStrToSymbolFunctionFactory implements FunctionFactory {
         return new Func(arg);
     }
 
-    private static class Func extends SymbolFunction implements UnaryFunction {
+    public static class Func extends SymbolFunction implements UnaryFunction {
         private final Function arg;
         private final CharSequenceIntHashMap lookupMap = new CharSequenceIntHashMap();
         private final ObjList<CharSequence> symbols = new ObjList<>();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -32,6 +32,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.griffin.engine.functions.cast.CastStrToSymbolFunctionFactory;
 import io.questdb.griffin.engine.functions.columns.*;
 import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.QueryColumn;
@@ -218,6 +219,9 @@ public class GroupByUtils {
                     functionKeyColumnIndex++;
                     func = createColumnFunction(null, functionKeyColumnIndex, type, -1);
                     keyTypes.add(functionKeyColumnIndex - valueCount - 1, func.getType());
+                    if (type == ColumnType.SYMBOL) {
+                        func = new CastStrToSymbolFunctionFactory.Func(func);
+                    }
 
                     recordFunctions.add(func);
                     recordFunctionPositions.add(node.position);


### PR DESCRIPTION
PR rewrites expressions such as :
```sql
   -- implicit group by
   SELECT k1, k2, count_distinct(s) FROM tab WHERE s like '%a ; 
   -- explicit group by
   SELECT k1, k2, count_distinct(s) FROM tab WHERE s like '%a GROUP BY k1, k2;
```

into more parallel-friendly :

```sql
   SELECT k1, k2, count(s)
   FROM 
    (
       SELECT k1, k2, s 
       FROM tab 
       WHERE s like '%a' 
       GROUP BY k1, k2, s
    );
```

On my desktop, it speeds up Q8:
```SELECT RegionID, count_distinct(UserID) AS u FROM hits GROUP BY RegionID ORDER BY u DESC LIMIT 10```
about 6 times.