### PR TITLE
fix(core): fix potential and unlikely numeric overlflow that could lead to incorrect query results

### DIFF
--- a/core/src/main/c/share/util.h
+++ b/core/src/main/c/share/util.h
@@ -150,8 +150,9 @@ inline int64_t scan_down(T* data, V value, int64_t low, int64_t high) {
 // the "high" boundary is inclusive
 template<class T, class V>
 inline int64_t binary_search(T *data, V value, int64_t low, int64_t high, int32_t scan_dir) {
-    while (high - low > 65) {
-        const int64_t mid = (low + high) / 2;
+    int64_t diff;
+    while ((diff = high - low) > 65) {
+        const int64_t mid = low + diff / 2;
         const T midVal = data[mid];
 
         if (midVal < value) {

--- a/core/src/main/java/io/questdb/cairo/BinarySearch.java
+++ b/core/src/main/java/io/questdb/cairo/BinarySearch.java
@@ -49,7 +49,7 @@ public class BinarySearch {
      */
     public static long find(MemoryR column, long value, long low, long high, int scanDirection) {
         while (low < high) {
-            long mid = (low + high) / 2;
+            long mid = (low + high) >>> 1;
             long midVal = column.getLong(mid * Long.BYTES);
 
             if (midVal < value) {

--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -293,7 +293,7 @@ public final class IntervalUtils {
         int left = 0;
         int right = intervals.size() / 2 - 1;
         while (left <= right) {
-            int mid = (left + right) / 2;
+            int mid = (left + right) >>> 1;
             long lo = getEncodedPeriodLo(intervals, mid * 2);
             long hi = getEncodedPeriodHi(intervals, mid * 2);
             if (lo > timestamp) {

--- a/core/src/main/java/io/questdb/std/DoubleList.java
+++ b/core/src/main/java/io/questdb/std/DoubleList.java
@@ -87,7 +87,7 @@ public class DoubleList implements Mutable, Sinkable {
         int low = 0;
         int high = pos - 1;
         while (high - low > 65) {
-            final int mid = (low + high) / 2;
+            final int mid = (low + high) >>> 1;
             final double midVal = data[mid];
             int cmp = Numbers.compare(midVal, value);
 

--- a/core/src/main/java/io/questdb/std/IntList.java
+++ b/core/src/main/java/io/questdb/std/IntList.java
@@ -65,7 +65,7 @@ public class IntList implements Mutable, Sinkable {
         int low = 0;
         int high = pos - 1;
         while (high - low > 65) {
-            int mid = (low + high) / 2;
+            int mid = (low + high) >>> 1;
             int midVal = buffer[mid];
 
             if (midVal < v)

--- a/core/src/main/java/io/questdb/std/LongList.java
+++ b/core/src/main/java/io/questdb/std/LongList.java
@@ -136,7 +136,7 @@ public class LongList implements Mutable, LongVec, Sinkable {
         int low = 0;
         int high = pos - 1;
         while (high - low > 65) {
-            final int mid = (low + high) / 2;
+            final int mid = (low + high) >>> 1;
             final long midVal = data[mid];
 
             if (midVal < value) {
@@ -177,7 +177,7 @@ public class LongList implements Mutable, LongVec, Sinkable {
         int low = offset >> shl;
         int high = (pos - 1) >> shl;
         while (high - low > 65) {
-            final int mid = (low + high) / 2;
+            final int mid = (low + high) >>> 1;
             final long midVal = data[mid << shl];
 
             if (midVal < value) {


### PR DESCRIPTION
```
	mid = (low + high) / 2;
	      ^^^^^^^^^^^^
		   |
		potential integer overflow
```
Fix :
```
	diff = high - low;
	mid = low + diff / 2;
```

fixes #4087 