### PR TITLE
chore(sql): fix query registry with acl issues

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/RegisteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/RegisteredRecordCursorFactory.java
@@ -76,6 +76,16 @@ public class RegisteredRecordCursorFactory extends AbstractRecordCursorFactory {
     }
 
     @Override
+    public String getBaseColumnName(int idx) {
+        return base.getBaseColumnName(idx);
+    }
+
+    @Override
+    public String getBaseColumnNameNoRemap(int idx) {
+        return base.getBaseColumnNameNoRemap(idx);
+    }
+
+    @Override
     public RecordCursorFactory getBaseFactory() {
         return base;
     }


### PR DESCRIPTION
Required by https://github.com/questdb/questdb-enterprise/pull/320
PR pushes RegisteredRecordCursorFactory creation into overloaded method so that outermost factory is the one checking permissions . 