### PR TITLE
chore(build): add aws packer plugin for AMI deployment

### DIFF
--- a/ci/ami-market-pipeline.yml
+++ b/ci/ami-market-pipeline.yml
@@ -16,6 +16,7 @@ steps:
       sudo apt-get update
       sudo apt-get install awscli
       cd "$(Build.SourcesDirectory)"/pkg/ami/marketplace
+      make install_aws_plugin
       make build_release
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)

--- a/pkg/ami/marketplace/Makefile
+++ b/pkg/ami/marketplace/Makefile
@@ -9,6 +9,9 @@ git    ?= git
 aws    ?= aws
 jq     ?= jq
 
+install_aws_plugin:
+	$(packer) plugins install github.com/hashicorp/amazon
+
 build: QUESTDB_VERSION?=$(shell $(git) rev-parse --short HEAD)-snapshot
 build:
 	$(packer) build \


### PR DESCRIPTION
Previous CI error: 
![image](https://github.com/questdb/questdb/assets/84250061/3ff3298b-08df-4985-9c65-8f5d93bf9d0a)
My guess is that underlying container image has a updated packer version that does not bundle the plugins on install