### PR TITLE
fix(sql): unregister query on cursor initialization failure

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/RegisteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/RegisteredRecordCursorFactory.java
@@ -94,7 +94,12 @@ public class RegisteredRecordCursorFactory extends AbstractRecordCursorFactory {
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
         if (!cursor.isOpen) {
             queryId = registry.register(sql, executionContext);
-            cursor.of(base.getCursor(executionContext));
+            try {
+                cursor.of(base.getCursor(executionContext));
+            } catch (Throwable t) {
+                registry.unregister(queryId, executionContext);
+                throw t;
+            }
             this.executionContext = executionContext;
             return cursor;
         }


### PR DESCRIPTION
Fixes issue with queries that fail on cursor initialization leaving entry in query registry.

Fixes #4112 
