### PR TITLE
fix(core): fix database stuck on startup after some table drops

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -231,8 +231,10 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     count++;
                     long ts = rec.getTimestamp(0);
                     if (ts != lastTs || taskRun == null) {
-                        if (taskRun != null && !taskRun.isEmpty()) {
-                            columnPurgeOperator.purgeExclusive(taskRun);
+                        if (taskRun != null) {
+                            if (!taskRun.isEmpty()) {
+                                columnPurgeOperator.purgeExclusive(taskRun);
+                            }
                         } else {
                             taskRun = taskPool.pop();
                         }

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -269,8 +269,10 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     long partitionNameTxn = rec.getLong(PARTITION_NAME_COLUMN);
                     taskRun.appendColumnInfo(columnVersion, partitionTs, partitionNameTxn, rec.getUpdateRowId());
                 }
-                if (taskRun != null && !taskRun.isEmpty()) {
-                    columnPurgeOperator.purgeExclusive(taskRun);
+                if (taskRun != null) {
+                    if (!taskRun.isEmpty()) {
+                        columnPurgeOperator.purgeExclusive(taskRun);
+                    }
                     taskPool.push(taskRun);
                 }
             }

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -231,7 +231,7 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     count++;
                     long ts = rec.getTimestamp(0);
                     if (ts != lastTs || taskRun == null) {
-                        if (taskRun != null) {
+                        if (taskRun != null && !taskRun.isEmpty()) {
                             columnPurgeOperator.purgeExclusive(taskRun);
                         } else {
                             taskRun = taskPool.pop();
@@ -269,7 +269,7 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     long partitionNameTxn = rec.getLong(PARTITION_NAME_COLUMN);
                     taskRun.appendColumnInfo(columnVersion, partitionTs, partitionNameTxn, rec.getUpdateRowId());
                 }
-                if (taskRun != null) {
+                if (taskRun != null && !taskRun.isEmpty()) {
                     columnPurgeOperator.purgeExclusive(taskRun);
                     taskPool.push(taskRun);
                 }

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
@@ -91,6 +91,7 @@ public class ColumnPurgeOperator implements Closeable {
     }
 
     public boolean purge(ColumnPurgeTask task) {
+        assert task.getTableName() != null;
         try {
             boolean done = purge0(task, ScoreboardUseMode.INTERNAL);
             setCompletionTimestamp(completedRowIds, microClock.getTicks());
@@ -103,6 +104,7 @@ public class ColumnPurgeOperator implements Closeable {
     }
 
     public boolean purge(ColumnPurgeTask task, TableReader tableReader) {
+        assert task.getTableName() != null;
         try {
             txReader = tableReader.getTxFile();
             txnScoreboard = tableReader.getTxnScoreboard();
@@ -115,6 +117,7 @@ public class ColumnPurgeOperator implements Closeable {
     }
 
     public void purgeExclusive(ColumnPurgeTask task) {
+        assert task.getTableName() != null;
         try {
             purge0(task, ScoreboardUseMode.EXCLUSIVE);
         } catch (Throwable ex) {

--- a/core/src/main/java/io/questdb/tasks/ColumnPurgeTask.java
+++ b/core/src/main/java/io/questdb/tasks/ColumnPurgeTask.java
@@ -27,6 +27,7 @@ package io.questdb.tasks;
 import io.questdb.cairo.TableToken;
 import io.questdb.std.LongList;
 import io.questdb.std.Mutable;
+import org.jetbrains.annotations.NotNull;
 
 public class ColumnPurgeTask implements Mutable {
     public static final int BLOCK_SIZE = 4;
@@ -100,7 +101,12 @@ public class ColumnPurgeTask implements Mutable {
         return updatedColumnInfo;
     }
 
+    public boolean isEmpty() {
+        return tableName == null;
+    }
+
     public void of(
+            @NotNull
             TableToken tableName,
             CharSequence columnName,
             int tableId,
@@ -120,6 +126,7 @@ public class ColumnPurgeTask implements Mutable {
     }
 
     public void of(
+            @NotNull
             TableToken tableName,
             CharSequence columnName,
             int tableId,


### PR DESCRIPTION
Some fuzz tests in CI were stuck because logging exceptions did not return the logging sequence.