### PR TITLE
fix(core): fix wal resume exception after table suspended because of an error

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
@@ -98,10 +98,16 @@ public class WalTxnDetails {
     ) {
         if (committedSeqTxn <= getLastSeqTxn()) {
             int shift = (int) (committedSeqTxn - startSeqTxn + 1);
-            transactionMeta.removeIndexBlock(0, shift * TXN_METADATA_LONGS_SIZE);
-            startSeqTxn = committedSeqTxn + 1;
-            if (transactionMeta.size() > 0) {
-                transactionMeta.set(0, -1);
+            if (shift < 0) {
+                // This can happen after a rollback. In this case we have to clear everything.
+                transactionMeta.clear();
+                startSeqTxn = -1;
+            } else {
+                transactionMeta.removeIndexBlock(0, shift * TXN_METADATA_LONGS_SIZE);
+                startSeqTxn = committedSeqTxn + 1;
+                if (transactionMeta.size() > 0) {
+                    transactionMeta.set(0, -1);
+                }
             }
         } else {
             transactionMeta.clear();

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -8328,8 +8328,8 @@ public class IODispatcherTest extends AbstractTest {
         ObjList<String> ddls = new ObjList<>(
                 baseTable,
                 baseTable + " timestamp(ts)",
-                baseTable + " timestamp(ts) partition by DAY BYPASS WAL",
-                walTable
+                baseTable + " timestamp(ts) partition by DAY BYPASS WAL"
+                // walTable // TODO: ban cancellation of queries inside WAL Apply job
         );
 
         String createAsSelect = "create table new_tab as (select * from tab where sleep(120000))";
@@ -9052,7 +9052,7 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     private static class DelayedListener implements QueryRegistry.Listener {
-        private SOCountDownLatch queryFound = new SOCountDownLatch(1);
+        private final SOCountDownLatch queryFound = new SOCountDownLatch(1);
         private volatile CharSequence queryText;
 
         @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -2943,8 +2943,8 @@ if __name__ == "__main__":
         ObjList<String> ddls = new ObjList<>(
                 baseTable,
                 baseTable + " timestamp(ts)",
-                baseTable + " timestamp(ts) partition by DAY BYPASS WAL",
-                walTable
+                baseTable + " timestamp(ts) partition by DAY BYPASS WAL"
+                // walTable //TODO: ban WAL update cancellation
         );
 
         String createAsSelect = "create table new_tab as (select * from tab where sleep(120000))";
@@ -11629,7 +11629,7 @@ create table tab as (
     }
 
     private static class DelayedListener implements QueryRegistry.Listener {
-        private SOCountDownLatch queryFound = new SOCountDownLatch(1);
+        private final SOCountDownLatch queryFound = new SOCountDownLatch(1);
         private volatile CharSequence queryText;
 
         @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3127,8 +3127,12 @@ if __name__ == "__main__":
 
                             try (PreparedStatement stmt = connection.prepareStatement("cancel query " + queryId)) {
                                 stmt.executeUpdate();
+                            } catch (SQLException e) {
+                                // ignore errors showing that statement is completed
+                                if (!Chars.contains(e.getMessage(), "query to cancel not found in registry")) {
+                                    throw e;
+                                }
                             }
-
                             start = System.currentTimeMillis();
 
                             try (PreparedStatement stmt = connection.prepareStatement("select * from query_activity() where query_id = ?")) {


### PR DESCRIPTION
Related to #4154
TODO will be fixed as part of #4160
Removes unstable WAL cancellation test, #4151 will not be needed