### PR TITLE
fix(sql): push down ORDER BY advice for DISTINCT queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2877,9 +2877,7 @@ public class SqlOptimiser implements Mutable {
         for (int i = 0, k = jm.size(); i < k; i++) {
             QueryModel qm = jm.getQuick(i).getNestedModel();
             if (qm != null) {
-                if (model.getGroupBy().size() == 0
-                        && model.getSampleBy() == null
-                        && model.getSelectModelType() != QueryModel.SELECT_MODEL_DISTINCT) { // order by should not copy through group by, sample by or distinct
+                if (model.getGroupBy().size() == 0 && model.getSampleBy() == null) { // order by should not copy through group by and sample by
                     qm.setOrderByAdviceMnemonic(orderByMnemonic);
                     qm.copyOrderByAdvice(orderByAdvice);
                     qm.copyOrderByDirectionAdvice(orderByDirectionAdvice);

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -785,13 +785,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di order by 1 desc limit 10",
-                "Sort light lo: 10\n" +
-                        "  keys: [ts desc]\n" +
+                "Limit lo: 10\n" +
                         "    DistinctTimeSeries\n" +
                         "      keys: ts\n" +
                         "        DataFrame\n" +
-                        "            Row forward scan\n" +
-                        "            Frame forward scan on: di\n"
+                        "            Row backward scan\n" +
+                        "            Frame backward scan on: di\n"
         );
     }
 


### PR DESCRIPTION
Fixes #4172.

Pushing down ORDER BY advice allows selecting a scanning order that matches the order direction specified in the ORDER BY clause. Consequently, for the query from the issue, we can avoid unnecessary sorting and utilize a record cursor factory available here:

https://github.com/questdb/questdb/blob/83cb7c358318f6028bb021742ab34dba03b867f6/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java#L2378-L2384.