### PR TITLE
chore(core): add authentication to timings

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -75,6 +75,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     protected final byte httpHealthCheckAuthType;
     protected final byte httpStaticContentAuthType;
     private final ObjObjHashMap<ConfigPropertyKey, ConfigPropertyValue> allPairs = new ObjObjHashMap<>();
+    private final boolean allowTableRegistrySharedWrite;
     private final DateFormat backupDirTimestampFormat;
     private final int backupMkdirMode;
     private final String backupRoot;
@@ -117,6 +118,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final boolean defaultSymbolCacheFlag;
     private final int defaultSymbolCapacity;
     private final int detachedMkdirMode;
+    private final boolean enableTestFactories;
     private final int fileOperationRetryCount;
     private final FilesFacade filesFacade;
     private final FactoryProviderFactory fpf;
@@ -376,10 +378,8 @@ public class PropServerConfiguration implements ServerConfiguration {
     protected HttpServerConfiguration httpServerConfiguration = new PropHttpServerConfiguration();
     protected JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new PropJsonQueryProcessorConfiguration();
     protected StaticContentProcessorConfiguration staticContentProcessorConfiguration;
-    private boolean allowTableRegistrySharedWrite;
     protected long walSegmentRolloverSize;
     private long cairoSqlCopyMaxIndexChunkSize;
-    private boolean enableTestFactories;
     private FactoryProvider factoryProvider;
     private short floatDefaultColumnType;
     private int forceRecvFragmentationChunkSize;
@@ -492,7 +492,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     public PropServerConfiguration(
             String root,
             Properties properties,
-            @Nullable    Map<String, String> env,
+            @Nullable Map<String, String> env,
             Log log,
             final BuildInformation buildInformation
     ) throws ServerConfigurationException, JsonException {
@@ -2895,11 +2895,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public MillisecondClock getClock() {
-            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
-        }
-
-        @Override
         public int getConnectionPoolInitialCapacity() {
             return connectionPoolInitialCapacity;
         }
@@ -2935,6 +2930,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public MillisecondClock getMillisecondClock() {
+            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
         public int getMultipartHeaderBufferSize() {
             return multipartHeaderBufferSize;
         }
@@ -2942,6 +2942,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getMultipartIdleSpinCount() {
             return multipartIdleSpinCount;
+        }
+
+        @Override
+        public NanosecondClock getNanosecondClock() {
+            return httpFrozenClock ? StationaryNanosClock.INSTANCE : NanosecondClockImpl.INSTANCE;
         }
 
         @Override
@@ -3318,11 +3323,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     public class PropJsonQueryProcessorConfiguration implements JsonQueryProcessorConfiguration {
 
         @Override
-        public MillisecondClock getClock() {
-            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
-        }
-
-        @Override
         public int getConnectionCheckFrequency() {
             return jsonQueryConnectionCheckFrequency;
         }
@@ -3355,6 +3355,16 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getMaxQueryResponseRowLimit() {
             return maxHttpQueryResponseRowLimit;
+        }
+
+        @Override
+        public MillisecondClock getMillisecondClock() {
+            return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public NanosecondClock getNanosecondClock() {
+            return httpFrozenClock ? StationaryNanosClock.INSTANCE : NanosecondClockImpl.INSTANCE;
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
@@ -28,6 +28,8 @@ import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.NanosecondClock;
+import io.questdb.std.NanosecondClockImpl;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
@@ -40,11 +42,6 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     @Override
     public boolean areCookiesEnabled() {
         return true;
-    }
-
-    @Override
-    public MillisecondClock getClock() {
-        return MillisecondClockImpl.INSTANCE;
     }
 
     @Override
@@ -84,6 +81,11 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     }
 
     @Override
+    public MillisecondClock getMillisecondClock() {
+        return MillisecondClockImpl.INSTANCE;
+    }
+
+    @Override
     public int getMultipartHeaderBufferSize() {
         return 512;
     }
@@ -91,6 +93,11 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     @Override
     public long getMultipartIdleSpinCount() {
         return 10_000;
+    }
+
+    @Override
+    public NanosecondClock getNanosecondClock() {
+        return NanosecondClockImpl.INSTANCE;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -35,6 +35,7 @@ import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.NanosecondClock;
 import io.questdb.std.Numbers;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
@@ -201,11 +202,6 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
 
     public class DefaultJsonQueryProcessorConfiguration implements JsonQueryProcessorConfiguration {
         @Override
-        public MillisecondClock getClock() {
-            return httpContextConfiguration.getClock();
-        }
-
-        @Override
         public int getConnectionCheckFrequency() {
             return 1_000_000;
         }
@@ -238,6 +234,16 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
         @Override
         public long getMaxQueryResponseRowLimit() {
             return Long.MAX_VALUE;
+        }
+
+        @Override
+        public MillisecondClock getMillisecondClock() {
+            return httpContextConfiguration.getMillisecondClock();
+        }
+
+        @Override
+        public NanosecondClock getNanosecondClock() {
+            return httpContextConfiguration.getNanosecondClock();
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -446,10 +446,10 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
     }
 
     private boolean configureSecurityContext() {
-        final long authenticationStart = configuration.getNanosecondClock().getTicks();
         if (securityContext == DenyAllSecurityContext.INSTANCE) {
+            final long authenticationStart = configuration.getNanosecondClock().getTicks();
             if (!authenticator.authenticate(headerParser)) {
-                // authenticationNanos stays 0 when it fails, as it is probably irrelevant
+                // authenticationNanos stays 0, when it fails this value is irrelevant
                 return false;
             }
             securityContext = configuration.getFactoryProvider().getSecurityContextFactory().getInstance(
@@ -458,8 +458,8 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
                     authenticator.getAuthType(),
                     SecurityContextFactory.HTTP
             );
+            authenticationNanos = configuration.getNanosecondClock().getTicks() - authenticationStart;
         }
-        authenticationNanos = configuration.getNanosecondClock().getTicks() - authenticationStart;
         return true;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.http;
 
 import io.questdb.FactoryProvider;
 import io.questdb.network.NetworkFacade;
+import io.questdb.std.NanosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 
 public interface HttpContextConfiguration {
@@ -33,8 +34,6 @@ public interface HttpContextConfiguration {
     boolean allowDeflateBeforeSend();
 
     boolean areCookiesEnabled();
-
-    MillisecondClock getClock();
 
     int getConnectionPoolInitialCapacity();
 
@@ -50,9 +49,13 @@ public interface HttpContextConfiguration {
 
     String getHttpVersion();
 
+    MillisecondClock getMillisecondClock();
+
     int getMultipartHeaderBufferSize();
 
     long getMultipartIdleSpinCount();
+
+    NanosecondClock getNanosecondClock();
 
     NetworkFacade getNetworkFacade();
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -872,6 +872,7 @@ public class HttpResponseSink implements Closeable, Mutable {
         httpStatusMap.put(200, "OK");
         httpStatusMap.put(204, "OK");
         httpStatusMap.put(206, "Partial content");
+        httpStatusMap.put(302, "Temporarily Moved");
         httpStatusMap.put(304, "Not Modified");
         httpStatusMap.put(400, "Bad request");
         httpStatusMap.put(401, "Unauthorized");

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -77,7 +77,7 @@ public class HttpResponseSink implements Closeable, Mutable {
         this.nf = configuration.getNetworkFacade();
         this.buffer = new ChunkUtf8Sink(responseBufferSize);
         this.compressOutBuffer = new ChunkUtf8Sink(responseBufferSize);
-        this.headerImpl = new HttpResponseHeaderImpl(configuration.getClock());
+        this.headerImpl = new HttpResponseHeaderImpl(configuration.getMillisecondClock());
         this.dumpNetworkTraffic = configuration.getDumpNetworkTraffic();
         this.httpVersion = configuration.getHttpVersion();
         this.connectionCloseHeader = !configuration.getServerKeepAlive();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -131,7 +131,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         // Query types start with 1 instead of 0, so we have to add 1 to the expected size.
         assert this.queryExecutors.size() == (CompiledQuery.TYPES_COUNT + 1);
         this.sqlExecutionContext = sqlExecutionContext;
-        this.nanosecondClock = engine.getConfiguration().getNanosecondClock();
+        this.nanosecondClock = configuration.getNanosecondClock();
         this.maxSqlRecompileAttempts = engine.getConfiguration().getMaxSqlRecompileAttempts();
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(engine.getConfiguration().getCircuitBreakerConfiguration(), MemoryTag.NATIVE_CB3);
         this.metrics = engine.getMetrics();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorConfiguration.java
@@ -27,11 +27,10 @@ package io.questdb.cutlass.http.processors;
 import io.questdb.FactoryProvider;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.std.FilesFacade;
+import io.questdb.std.NanosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 
 public interface JsonQueryProcessorConfiguration {
-
-    MillisecondClock getClock();
 
     int getConnectionCheckFrequency();
 
@@ -46,6 +45,10 @@ public interface JsonQueryProcessorConfiguration {
     CharSequence getKeepAliveHeader();
 
     long getMaxQueryResponseRowLimit();
+
+    MillisecondClock getMillisecondClock();
+
+    NanosecondClock getNanosecondClock();
 
     default byte getRequiredAuthType() {
         return SecurityContext.AUTH_TYPE_CREDENTIALS;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -66,11 +66,11 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
     private final int doubleScale;
     private final CairoEngine engine;
     private final int floatScale;
+    private final int maxSqlRecompileAttempts;
     private final Metrics metrics;
     private final QueryLogger queryLogger;
     private final byte requiredAuthType;
     private final SqlExecutionContextImpl sqlExecutionContext;
-    private final int maxSqlRecompileAttempts;
 
     @TestOnly
     public TextQueryProcessor(
@@ -89,7 +89,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
     ) {
         this.configuration = configuration;
         this.floatScale = configuration.getFloatScale();
-        this.clock = configuration.getClock();
+        this.clock = configuration.getMillisecondClock();
         this.sqlExecutionContext = new SqlExecutionContextImpl(engine, workerCount, sharedWorkerCount);
         this.doubleScale = configuration.getDoubleScale();
         this.circuitBreaker = new NetworkSqlExecutionCircuitBreaker(engine.getConfiguration().getCircuitBreakerConfiguration(), MemoryTag.NATIVE_CB4);

--- a/core/src/main/java/io/questdb/std/StationaryNanosClock.java
+++ b/core/src/main/java/io/questdb/std/StationaryNanosClock.java
@@ -24,10 +24,8 @@
 
 package io.questdb.std;
 
-import io.questdb.std.datetime.millitime.MillisecondClock;
-
-public class StationaryMillisClock implements MillisecondClock {
-    public static final StationaryMillisClock INSTANCE = new StationaryMillisClock();
+public class StationaryNanosClock implements NanosecondClock {
+    public static final StationaryNanosClock INSTANCE = new StationaryNanosClock();
 
     @Override
     public long getTicks() {

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -264,7 +264,8 @@ public class PropServerConfigurationTest {
         // statics
         Assert.assertSame(FilesFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getFilesFacade());
         Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getClock());
-        Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getClock());
+        Assert.assertSame(MillisecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getMillisecondClock());
+        Assert.assertSame(NanosecondClockImpl.INSTANCE, configuration.getHttpServerConfiguration().getHttpContextConfiguration().getNanosecondClock());
         Assert.assertSame(NetworkFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getNetworkFacade());
         Assert.assertSame(EpollFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getEpollFacade());
         Assert.assertSame(SelectFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getDispatcherConfiguration().getSelectFacade());

--- a/core/src/test/java/io/questdb/test/TestServerConfiguration.java
+++ b/core/src/test/java/io/questdb/test/TestServerConfiguration.java
@@ -42,8 +42,10 @@ import io.questdb.cutlass.pgwire.DefaultPGWireConfiguration;
 import io.questdb.cutlass.pgwire.PGWireConfiguration;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.std.NanosecondClock;
 import io.questdb.std.Numbers;
 import io.questdb.std.StationaryMillisClock;
+import io.questdb.std.StationaryNanosClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
@@ -91,13 +93,18 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
     private final int workerCountHttp;
     private final HttpServerConfiguration confHttp = new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
         @Override
-        public MillisecondClock getClock() {
+        public FactoryProvider getFactoryProvider() {
+            return factoryProvider;
+        }
+
+        @Override
+        public MillisecondClock getMillisecondClock() {
             return StationaryMillisClock.INSTANCE;
         }
 
         @Override
-        public FactoryProvider getFactoryProvider() {
-            return factoryProvider;
+        public NanosecondClock getNanosecondClock() {
+            return StationaryNanosClock.INSTANCE;
         }
     }) {
         @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
@@ -44,9 +44,7 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.PlainSocketFactory;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.Misc;
-import io.questdb.std.ObjList;
+import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.mp.TestWorkerPool;
@@ -70,6 +68,7 @@ public class HttpQueryTestBuilder {
     private long maxWriterWaitTimeout = 30_000L;
     private Metrics metrics;
     private MicrosecondClock microsecondClock;
+    private NanosecondClock nanosecondClock = NanosecondClockImpl.INSTANCE;
     private QueryFutureUpdateListener queryFutureUpdateListener;
     private long queryTimeout = -1;
     private HttpServerConfigurationBuilder serverConfigBuilder;
@@ -100,6 +99,7 @@ public class HttpQueryTestBuilder {
                     .withFactoryProvider(factoryProvider)
                     .withStaticContentAuthRequired(httpStaticContentAuthType)
                     .withHealthCheckAuthRequired(httpHealthCheckAuthType)
+                    .withNanosClock(nanosecondClock)
                     .build();
             if (metrics == null) {
                 metrics = Metrics.enabled();
@@ -356,6 +356,11 @@ public class HttpQueryTestBuilder {
 
     public HttpQueryTestBuilder withMicrosecondClock(MicrosecondClock clock) {
         this.microsecondClock = clock;
+        return this;
+    }
+
+    public HttpQueryTestBuilder withNanosClock(NanosecondClock nanosecondClock) {
+        this.nanosecondClock = nanosecondClock;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
@@ -48,6 +48,7 @@ public class HttpServerConfigurationBuilder {
     private String httpProtocolVersion = "HTTP/1.1 ";
     private byte httpStaticContentAuthType = SecurityContext.AUTH_TYPE_NONE;
     private long multipartIdleSpinCount = -1;
+    private NanosecondClock nanosecondClock = StationaryNanosClock.INSTANCE;
     private NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
     private boolean pessimisticHealthCheck = false;
     private int port = -1;
@@ -120,7 +121,7 @@ public class HttpServerConfigurationBuilder {
 
                 @Override
                 public NanosecondClock getNanosecondClock() {
-                    return StationaryNanosClock.INSTANCE;
+                    return nanosecondClock;
                 }
             };
             private final StaticContentProcessorConfiguration staticContentProcessorConfiguration = new StaticContentProcessorConfiguration() {
@@ -196,7 +197,7 @@ public class HttpServerConfigurationBuilder {
 
                     @Override
                     public NanosecondClock getNanosecondClock() {
-                        return StationaryNanosClock.INSTANCE;
+                        return nanosecondClock;
                     }
 
                     @Override
@@ -315,6 +316,11 @@ public class HttpServerConfigurationBuilder {
 
     public HttpServerConfigurationBuilder withMultipartIdleSpinCount(long multipartIdleSpinCount) {
         this.multipartIdleSpinCount = multipartIdleSpinCount;
+        return this;
+    }
+
+    public HttpServerConfigurationBuilder withNanosClock(NanosecondClock nanosecondClock) {
+        this.nanosecondClock = nanosecondClock;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpServerConfigurationBuilder.java
@@ -33,9 +33,7 @@ import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.Numbers;
-import io.questdb.std.StationaryMillisClock;
+import io.questdb.std.*;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -81,11 +79,6 @@ public class HttpServerConfigurationBuilder {
         return new DefaultHttpServerConfiguration() {
             private final JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new JsonQueryProcessorConfiguration() {
                 @Override
-                public MillisecondClock getClock() {
-                    return () -> 0;
-                }
-
-                @Override
                 public int getConnectionCheckFrequency() {
                     return 1_000_000;
                 }
@@ -118,6 +111,16 @@ public class HttpServerConfigurationBuilder {
                 @Override
                 public long getMaxQueryResponseRowLimit() {
                     return configuredMaxQueryResponseRowLimit;
+                }
+
+                @Override
+                public MillisecondClock getMillisecondClock() {
+                    return StationaryMillisClock.INSTANCE;
+                }
+
+                @Override
+                public NanosecondClock getNanosecondClock() {
+                    return StationaryNanosClock.INSTANCE;
                 }
             };
             private final StaticContentProcessorConfiguration staticContentProcessorConfiguration = new StaticContentProcessorConfiguration() {
@@ -166,11 +169,6 @@ public class HttpServerConfigurationBuilder {
                     }
 
                     @Override
-                    public MillisecondClock getClock() {
-                        return StationaryMillisClock.INSTANCE;
-                    }
-
-                    @Override
                     public boolean getDumpNetworkTraffic() {
                         return dumpTraffic;
                     }
@@ -186,9 +184,19 @@ public class HttpServerConfigurationBuilder {
                     }
 
                     @Override
+                    public MillisecondClock getMillisecondClock() {
+                        return StationaryMillisClock.INSTANCE;
+                    }
+
+                    @Override
                     public long getMultipartIdleSpinCount() {
                         if (multipartIdleSpinCount < 0) return super.getMultipartIdleSpinCount();
                         return multipartIdleSpinCount;
+                    }
+
+                    @Override
+                    public NanosecondClock getNanosecondClock() {
+                        return StationaryNanosClock.INSTANCE;
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -967,8 +967,13 @@ public class IODispatcherTest extends AbstractTest {
                 HttpServer ignored = createHttpServer(
                         new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
                             @Override
-                            public MillisecondClock getClock() {
+                            public MillisecondClock getMillisecondClock() {
                                 return StationaryMillisClock.INSTANCE;
+                            }
+
+                            @Override
+                            public NanosecondClock getNanosecondClock() {
+                                return StationaryNanosClock.INSTANCE;
                             }
                         }),
                         cairoEngine,
@@ -1036,8 +1041,13 @@ public class IODispatcherTest extends AbstractTest {
                 HttpServer ignored = createHttpServer(
                         new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
                             @Override
-                            public MillisecondClock getClock() {
+                            public MillisecondClock getMillisecondClock() {
                                 return StationaryMillisClock.INSTANCE;
+                            }
+
+                            @Override
+                            public NanosecondClock getNanosecondClock() {
+                                return StationaryNanosClock.INSTANCE;
                             }
                         }),
                         cairoEngine,
@@ -6457,8 +6467,13 @@ public class IODispatcherTest extends AbstractTest {
             HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(
                     new DefaultHttpContextConfiguration() {
                         @Override
-                        public MillisecondClock getClock() {
-                            return () -> 0;
+                        public MillisecondClock getMillisecondClock() {
+                            return StationaryMillisClock.INSTANCE;
+                        }
+
+                        @Override
+                        public NanosecondClock getNanosecondClock() {
+                            return StationaryNanosClock.INSTANCE;
                         }
                     }
             );
@@ -7457,6 +7472,36 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testTimingsContainsAuthentication() throws Exception {
+
+        testJsonQuery(
+                10,
+                "GET /query?query=x%20where%20i%20%3D%20%27A%27&timings=true HTTP/1.1\r\n" +
+                        "Host: localhost:9001\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Cache-Control: max-age=0\r\n" +
+                        "Upgrade-Insecure-Requests: 1\r\n" +
+                        "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                        "Accept-Encoding: gzip, deflate, br\r\n" +
+                        "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                        "\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: questDB/1.0\r\n" +
+                        "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Content-Type: application/json; charset=utf-8\r\n" +
+                        "Keep-Alive: timeout=5, max=10000\r\n" +
+                        "\r\n" +
+                        "01ff\r\n" +
+                        "{\"query\":\"x where i = 'A'\",\"columns\":[{\"name\":\"a\",\"type\":\"BYTE\"},{\"name\":\"b\",\"type\":\"SHORT\"},{\"name\":\"c\",\"type\":\"INT\"},{\"name\":\"d\",\"type\":\"LONG\"},{\"name\":\"e\",\"type\":\"DATE\"},{\"name\":\"f\",\"type\":\"TIMESTAMP\"},{\"name\":\"g\",\"type\":\"FLOAT\"},{\"name\":\"h\",\"type\":\"DOUBLE\"},{\"name\":\"i\",\"type\":\"STRING\"},{\"name\":\"j\",\"type\":\"SYMBOL\"},{\"name\":\"k\",\"type\":\"BOOLEAN\"},{\"name\":\"l\",\"type\":\"BINARY\"},{\"name\":\"m\",\"type\":\"UUID\"}],\"timestamp\":-1,\"dataset\":[],\"count\":0," +
+                        "\"timings\":{\"authentication\":0,\"compiler\":0,\"execute\":0,\"count\":0}}\r\n" +
+                        "00\r\n" +
+                        "\r\n"
+        );
+    }
+
+    @Test
     public void testTriggerInternalCairoError() throws Exception {
         testJsonQuery0(1, engine -> {
             sendAndReceive(
@@ -7829,7 +7874,8 @@ public class IODispatcherTest extends AbstractTest {
                                 executionContext,
                                 "select count(*) from tab where b=false",
                                 sink,
-                                "count\n1000\n");
+                                "count\n1000\n"
+                        );
 
                     } finally {
                         engine.getQueryRegistry().setListener(null);

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -121,6 +121,7 @@ public class IODispatcherTest extends AbstractTest {
             .withLookingForStuckThread(true)
             .build();
     private long configuredMaxQueryResponseRowLimit = Long.MAX_VALUE;
+    private NanosecondClock nanosecondClock = NanosecondClockImpl.INSTANCE;
 
     @BeforeClass
     public static void setUpStatic() throws Exception {
@@ -6166,7 +6167,6 @@ public class IODispatcherTest extends AbstractTest {
                 try (Path path = new Path().of(baseDir).concat("questdb-temp.txt").$()) {
                     try {
                         Rnd rnd = new Rnd();
-                        final int diskBufferLen = 1024 * 1024;
 
                         writeRandomFile(path, rnd, 122222212222L);
 
@@ -7473,7 +7473,7 @@ public class IODispatcherTest extends AbstractTest {
 
     @Test
     public void testTimingsContainsAuthentication() throws Exception {
-
+        nanosecondClock = StationaryNanosClock.INSTANCE;
         testJsonQuery(
                 10,
                 "GET /query?query=x%20where%20i%20%3D%20%27A%27&timings=true HTTP/1.1\r\n" +
@@ -8942,6 +8942,7 @@ public class IODispatcherTest extends AbstractTest {
                 .withTelemetry(telemetry)
                 .withTempFolder(root)
                 .withJitMode(SqlJitMode.JIT_MODE_ENABLED)
+                .withNanosClock(nanosecondClock)
                 .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder()
                         .withServerKeepAlive(!http1)
                         .withSendBufferSize(16 * 1024)


### PR DESCRIPTION
Changes in this PR:
- measure latency caused by authentication, it is displayed in Web Console
- add 302 (Temporarily Moved) to the list of allowed HTTP status codes, used for redirects

required by https://github.com/questdb/questdb-enterprise/pull/365
