### PR TITLE
feat(core): read snapshot id string from _snapshot.txt file in text format

### DIFF
--- a/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
+++ b/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
@@ -393,7 +393,7 @@ public class DatabaseSnapshotAgentImpl implements DatabaseSnapshotAgent, QuietCl
             CharSequence snapshotInstanceId = memFile.getStr(0);
             if (Chars.empty(snapshotInstanceId)) {
                 srcPath.trimTo(snapshotRootLen).concat(TableUtils.SNAPSHOT_META_FILE_NAME_TXT).$();
-                snapshotInstanceId = TableUtils.readText(ff, path);
+                snapshotInstanceId = TableUtils.readText(ff, srcPath);
             }
 
             if (Chars.empty(currentInstanceId) || Chars.empty(snapshotInstanceId) || Chars.equals(currentInstanceId, snapshotInstanceId)) {

--- a/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
@@ -37,6 +37,7 @@ import io.questdb.griffin.SqlUtil;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.SimpleWaitingLock;
 import io.questdb.std.*;
+import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
@@ -207,6 +208,58 @@ public class SnapshotTest extends AbstractCairoTest {
 
             // Dropped column should be there.
             assertSql(expectedAllColumns, "select * from " + tableName);
+        });
+    }
+
+    @Test
+    public void testRecoverSnapshotSupportsSnapshotTxtFile() throws Exception {
+        final int partitionCount = 10;
+        final String snapshotId = "id1";
+        final String restartedId = "id2";
+        assertMemoryLeak(() -> {
+            setProperty(PropertyKey.CAIRO_SNAPSHOT_INSTANCE_ID, "");
+            final String tableName = "t";
+            ddl(
+                    "create table " + tableName + " as " +
+                            "(select x, timestamp_sequence(0, 100000000000) ts from long_sequence(" + partitionCount + ")) timestamp(ts) partition by day"
+            );
+
+            ddl("snapshot prepare");
+
+            insert(
+                    "insert into " + tableName +
+                            " select x+20 x, timestamp_sequence(100000000000, 100000000000) ts from long_sequence(3)"
+            );
+
+            // Release all readers and writers, but keep the snapshot dir around.
+            engine.clear();
+
+            // create snapshot.txt file
+            var ff = configuration.getFilesFacade();
+            path.trimTo(rootLen).concat(TableUtils.SNAPSHOT_META_FILE_NAME_TXT);
+            int fd = ff.openRW(path.$(), configuration.getWriterFileOpenOpts());
+            Assert.assertTrue(fd > 0);
+
+            try {
+                try (DirectUtf8Sink utf8 = new DirectUtf8Sink(3)) {
+                    utf8.put(snapshotId);
+                    ff.write(fd, utf8.ptr(), utf8.size(), 0);
+                    ff.truncate(fd, utf8.size());
+                }
+            } finally {
+                ff.close(fd);
+            }
+            Assert.assertEquals(ff.length(path), restartedId.length());
+
+            setProperty(PropertyKey.CAIRO_SNAPSHOT_INSTANCE_ID, restartedId);
+            engine.recoverSnapshot();
+
+            // Data inserted after PREPARE SNAPSHOT should be discarded.
+            assertSql(
+                    "count\n" +
+                            partitionCount + "\n",
+                    "select count() from " + tableName
+            );
         });
     }
 


### PR DESCRIPTION
File `_snapshot` with instance id where the snapshot is created from has an inconvenient format, it's strictly saying a binary file.

This makes it hard to restore from the snapshots created by the instances where id was not set. This PR adds support of  `_snapshot.txt` file which will be used if file `_snapshot` is empty and it can be added as a text.