### PR TITLE
fix(sql): fix a memory leak when using prepared statement and UUID columns

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/BindVariableServiceImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/BindVariableServiceImpl.java
@@ -91,6 +91,7 @@ public class BindVariableServiceImpl implements BindVariableService {
         charVarPool.clear();
         long256VarPool.clear();
         geoHashVarPool.clear();
+        uuidVarPool.clear();
     }
 
     @Override
@@ -878,7 +879,7 @@ public class BindVariableServiceImpl implements BindVariableService {
         }
     }
 
-    private static void setIPv40(Function function, int value, int index, @Nullable CharSequence name)  {
+    private static void setIPv40(Function function, int value, int index, @Nullable CharSequence name) {
         ((IPv4BindVariable) function).value = value;
     }
 


### PR DESCRIPTION
I'm not exactly sure how to test this without:
1. reliance on internals on the binding service
2. the test taking too long

I tried this:
``` java  
 @Test
    public void testUuidLeak() throws Exception {
        for (int i = 0; i < 100_000_000; i++) {
            bindVariableService.setUuid("uuid", 1, 1);
            bindVariableService.clear();
        }
    }
```

This worked locally, took around 2s on ARM Mac (after fix) and crashed without the fix. but I guess a point of such a test should be to detect when a new pool is added and not cleared on `clear()` and this wouldn't do it. ideas appreciated! 