### PR TITLE
fix(sql): fix non-existing symbol bind variable initialization in indexed filter queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/DeferredSymbolIndexRowCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/DeferredSymbolIndexRowCursorFactory.java
@@ -90,9 +90,9 @@ public class DeferredSymbolIndexRowCursorFactory implements FunctionBasedRowCurs
     @Override
     public void prepareCursor(TableReader tableReader) {
         int symbolKey = tableReader.getSymbolMapReader(columnIndex).keyOf(symbol.getSymbol(null));
-        if (symbolKey != SymbolTable.VALUE_NOT_FOUND) {
-            this.symbolKey = TableUtils.toIndexKey(symbolKey);
-        }
+        this.symbolKey = symbolKey != SymbolTable.VALUE_NOT_FOUND
+                ? TableUtils.toIndexKey(symbolKey)
+                : SymbolTable.VALUE_NOT_FOUND;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -10744,25 +10744,52 @@ create table tab as (
 
                     // single key value in filter
 
-                    sink.clear();
                     try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id = ? and timestamp > ?")) {
-                        ps.setString(1, "d1");
-                        ps.setTimestamp(2, createTimestamp(1));
-                        try (ResultSet rs = ps.executeQuery()) {
-                            assertResultSet(
-                                    "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
-                                            "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
-                                    sink,
-                                    rs
-                            );
+                        for (int i = 0; i < 10; i++) {
+                            ps.setString(1, "d1");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // try querying non-existing symbol
+                            ps.setString(1, "foobar");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // and then an existing one
+                            ps.setString(1, "d2");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
                         }
                     }
 
-                    sink.clear();
                     try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id != ? and timestamp > ?")) {
                         ps.setString(1, "d1");
                         ps.setTimestamp(2, createTimestamp(1));
                         try (ResultSet rs = ps.executeQuery()) {
+                            sink.clear();
                             assertResultSet(
                                     "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
                                             "d2,c1,201.3,1970-01-01 00:00:00.000002\n",
@@ -10774,12 +10801,12 @@ create table tab as (
 
                     // multiple key values in filter
 
-                    sink.clear();
                     try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id in (?, ?) and timestamp > ? order by timestamp, value desc")) {
                         ps.setString(1, "d1");
                         ps.setString(2, "d2");
                         ps.setTimestamp(3, createTimestamp(0));
                         try (ResultSet rs = ps.executeQuery()) {
+                            sink.clear();
                             assertResultSet(
                                     "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
                                             "d2,c1,201.2,1970-01-01 00:00:00.000001\n" +
@@ -10792,12 +10819,12 @@ create table tab as (
                         }
                     }
 
-                    sink.clear();
                     try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id not in (?, ?) and timestamp > ?")) {
                         ps.setString(1, "d2");
                         ps.setString(2, "d3");
                         ps.setTimestamp(3, createTimestamp(0));
                         try (ResultSet rs = ps.executeQuery()) {
+                            sink.clear();
                             assertResultSet(
                                     "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
                                             "d1,c1,101.2,1970-01-01 00:00:00.000001\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -10744,8 +10744,8 @@ create table tab as (
 
                     // single key value in filter
 
-                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id = ? and timestamp > ?")) {
-                        for (int i = 0; i < 10; i++) {
+                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id = ? and timestamp > ? order by timestamp, value desc")) {
+                        for (int i = 0; i < 3; i++) {
                             ps.setString(1, "d1");
                             ps.setTimestamp(2, createTimestamp(1));
                             try (ResultSet rs = ps.executeQuery()) {
@@ -10785,53 +10785,142 @@ create table tab as (
                         }
                     }
 
-                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id != ? and timestamp > ?")) {
-                        ps.setString(1, "d1");
-                        ps.setTimestamp(2, createTimestamp(1));
-                        try (ResultSet rs = ps.executeQuery()) {
-                            sink.clear();
-                            assertResultSet(
-                                    "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
-                                            "d2,c1,201.3,1970-01-01 00:00:00.000002\n",
-                                    sink,
-                                    rs
-                            );
+                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id != ? and timestamp > ? order by timestamp, value desc")) {
+                        for (int i = 0; i < 3; i++) {
+                            ps.setString(1, "d1");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // try querying non-existing symbol
+                            ps.setString(1, "foobar");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // and then an existing one
+                            ps.setString(1, "d2");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
                         }
                     }
 
                     // multiple key values in filter
 
                     try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id in (?, ?) and timestamp > ? order by timestamp, value desc")) {
-                        ps.setString(1, "d1");
-                        ps.setString(2, "d2");
-                        ps.setTimestamp(3, createTimestamp(0));
-                        try (ResultSet rs = ps.executeQuery()) {
-                            sink.clear();
-                            assertResultSet(
-                                    "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
-                                            "d2,c1,201.2,1970-01-01 00:00:00.000001\n" +
-                                            "d1,c1,101.2,1970-01-01 00:00:00.000001\n" +
-                                            "d2,c1,201.3,1970-01-01 00:00:00.000002\n" +
-                                            "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
-                                    sink,
-                                    rs
-                            );
+                        for (int i = 0; i < 3; i++) {
+                            ps.setString(1, "d1");
+                            ps.setString(2, "d2");
+                            ps.setTimestamp(3, createTimestamp(0));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.2,1970-01-01 00:00:00.000001\n" +
+                                                "d1,c1,101.2,1970-01-01 00:00:00.000001\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // try querying non-existing symbols
+                            ps.setString(1, "foobar");
+                            ps.setString(2, "barbaz");
+                            ps.setTimestamp(3, createTimestamp(0));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // and then an existing duplicate one
+                            ps.setString(1, "d2");
+                            ps.setString(2, "d2");
+                            ps.setTimestamp(3, createTimestamp(0));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.2,1970-01-01 00:00:00.000001\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
                         }
                     }
 
-                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id not in (?, ?) and timestamp > ?")) {
-                        ps.setString(1, "d2");
-                        ps.setString(2, "d3");
-                        ps.setTimestamp(3, createTimestamp(0));
-                        try (ResultSet rs = ps.executeQuery()) {
-                            sink.clear();
-                            assertResultSet(
-                                    "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
-                                            "d1,c1,101.2,1970-01-01 00:00:00.000001\n" +
-                                            "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
-                                    sink,
-                                    rs
-                            );
+                    try (PreparedStatement ps = connection.prepareStatement("select * from x where device_id not in (?, ?) and timestamp > ? order by timestamp, value desc")) {
+                        for (int i = 0; i < 3; i++) {
+                            ps.setString(1, "d2");
+                            ps.setString(2, "d3");
+                            ps.setTimestamp(3, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // try querying non-existing symbols
+                            ps.setString(1, "foobar");
+                            ps.setString(2, "barbaz");
+                            ps.setTimestamp(3, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d2,c1,201.3,1970-01-01 00:00:00.000002\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
+
+                            // and then an existing duplicate one
+                            ps.setString(1, "d2");
+                            ps.setString(2, "d2");
+                            ps.setTimestamp(2, createTimestamp(1));
+                            try (ResultSet rs = ps.executeQuery()) {
+                                sink.clear();
+                                assertResultSet(
+                                        "device_id[VARCHAR],column_name[VARCHAR],value[DOUBLE],timestamp[TIMESTAMP]\n" +
+                                                "d1,c1,101.3,1970-01-01 00:00:00.000002\n",
+                                        sink,
+                                        rs
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Symbol key was not correctly initialized in `DeferredSymbolIndexRowCursorFactory` in case of non-existing symbols.

### Reproducer

```sql
CREATE TABLE 'one_min' (
  ticker SYMBOL capacity 256 CACHE index capacity 256,
  open INT,
  high INT,
  low INT,
  close INT,
  time TIMESTAMP
) TIMESTAMP (time) PARTITION BY YEAR WAL;

INSERT INTO one_min VALUES ('x', 1, 1, 1, 1, now());
```

Then `SELECT * FROM one_min WHERE ticker = ?;` query can be run for `x` and `foobar` (non-exiting) symbol values. The second execution would wrongly return results for the `x` symbol.