### PR TITLE
fix(sql): potential incorrect results in non-keyed parallel GROUP BY query

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
@@ -198,8 +198,8 @@ class AsyncGroupByNotKeyedRecordCursor implements NoRandomAccessRecordCursor {
                 destValue.copy(srcValue);
             } else {
                 functionUpdater.merge(destValue, srcValue);
-                destValue.setNew(false);
             }
+            destValue.setNew(false);
         }
 
         isValueBuilt = true;

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -1255,6 +1255,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelNonKeyedGroupByWithNestedCaseFunction() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelStringKeyGroupBy(
+                "SELECT sum(CASE WHEN (key = 'k0') THEN 1 ELSE 0 END) FROM tab",
+                "sum\n" +
+                        "1600\n"
+        );
+    }
+
+    @Test
     public void testParallelNonKeyedGroupByWithNestedFilter() throws Exception {
         testParallelNonKeyedGroupBy(
                 "SELECT vwap(p, q), sum(ct) " +


### PR DESCRIPTION
Queries like the following one had a chance of returning incorrect results in the case when some of the worker threads (or machine's cores) are loaded:
```sql
SELECT sum(long_col) FROM tab;
```

In that case, some of the worker threads may not participate in the aggregation leading to the
```java
if (destValue.isNew()) {
    destValue.copy(srcValue);
}
```
branch in `AsyncGroupByNotKeyedRecordCursor`. The branch wasn't updating the new flag of `destValue`, hence some of the partial results may get ignored.