### PR TITLE
test(core): fix edge case of snapshot restore failure when data copied under heavy ddl load

### DIFF
--- a/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
+++ b/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
@@ -477,6 +477,8 @@ public class DatabaseSnapshotAgentImpl implements DatabaseSnapshotAgent, QuietCl
                     copyOrError(srcPath, dstPath, ff, recoveredMetaFiles, TableUtils.META_FILE_NAME);
                     copyOrError(srcPath.trimTo(srcPathLen), dstPath.trimTo(dstPathLen), ff, recoveredTxnFiles, TableUtils.TXN_FILE_NAME);
                     copyOrError(srcPath.trimTo(srcPathLen), dstPath.trimTo(dstPathLen), ff, recoveredCVFiles, TableUtils.COLUMN_VERSION_FILE_NAME);
+                    // Reset _todo_ file otherwise TableWriter will start restoring metadata on open.
+                    TableUtils.resetTodoLog(ff, path, rootLen, memFile);
                     rebuildTableFiles(dstPath.trimTo(dstPathLen), symbolFilesCount);
 
                     // Go inside SEQ_DIR


### PR DESCRIPTION
Found by fuzz test. 

```
2024-02-18T05:28:05.862406Z I i.q.c.DatabaseSnapshotAgentImpl recovered _txn file [src=/tmp/junit10201576134088118831/dbRoot/snapshot/db/testSnapshotFullFuzz~2/_txn, dst=/tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2/_txn]
2024-02-18T05:28:05.862441Z I i.q.c.DatabaseSnapshotAgentImpl recovered _cv file [src=/tmp/junit10201576134088118831/dbRoot/snapshot/db/testSnapshotFullFuzz~2/_cv, dst=/tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2/_cv]
2024-02-18T05:28:05.862558Z I i.q.c.DatabaseSnapshotAgentImpl rebuilding symbol files [table=/tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2, column=c2, count=0]
2024-02-18T05:28:05.863398Z I i.q.c.DatabaseSnapshotAgentImpl rebuilding symbol files [table=/tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2, column=sym2, count=0]
2024-02-18T05:28:05.869140Z I i.q.c.DatabaseSnapshotAgentImpl recovered _meta file [src=/tmp/junit10201576134088118831/dbRoot/snapshot/db/testSnapshotFullFuzz~2/txn_seq, dst=/tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2/txn_seq]
2024-02-18T05:28:05.869152Z I i.q.c.DatabaseSnapshotAgentImpl snapshot recovery finished [metaFilesCount=2, txnFilesCount=2, cvFilesCount=2, walFilesCount=1, symbolFilesCount=5]
2024-02-18T05:28:05.871562Z I i.q.c.TableNameRegistryStore reloading tables file [path=/tmp/junit10201576134088118831/dbRoot/tables.d.0, threadId=1905]

...

2024-02-18T05:28:05.965244Z I i.q.c.p.WriterPool open [table=`testSnapshotFullFuzz~2`, thread=1905]
2024-02-18T05:28:05.965266Z I i.q.c.TableWriter open 'testSnapshotFullFuzz'
2024-02-18T05:28:05.965357Z I i.q.c.TableWriter Repairing metadata from: /tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2/_meta.prev
2024-02-18T05:28:05.966765Z I i.q.c.TableWriter closed 'testSnapshotFullFuzz'
2024-02-18T05:28:05.966824Z C i.q.c.w.ApplyWal2TableJob job failed, table suspended [table=testSnapshotFullFuzz~2, error=
java.lang.AssertionError
	at io.questdb.std.IntList.getQuick(IntList.java:139)
	at io.questdb.std.IntList.get(IntList.java:119)
	at io.questdb.cairo.TxReader.getSymbolValueCount(TxReader.java:338)
	at io.questdb.cairo.TableWriter.configureColumnMemory(TableWriter.java:3268)
	at io.questdb.cairo.TableWriter.<init>(TableWriter.java:344)
	at io.questdb.cairo.pool.WriterPool.createWriter(WriterPool.java:399)
	at io.questdb.cairo.pool.WriterPool.getWriterEntry(WriterPool.java:444)
	at io.questdb.cairo.pool.WriterPool.get(WriterPool.java:134)
	at io.questdb.cairo.CairoEngine.getWriterUnsafe(CairoEngine.java:740)
	at io.questdb.cairo.wal.ApplyWal2TableJob.applyWal(ApplyWal2TableJob.java:503)
	at io.questdb.cairo.wal.ApplyWal2TableJob.doRun(ApplyWal2TableJob.java:560)
	at io.questdb.mp.AbstractQueueConsumerJob.run(AbstractQueueConsumerJob.java:44)
	at io.questdb.mp.Job.run(Job.java:57)
	at io.questdb.test.griffin.wal.FuzzRunner.drainWalQueue(FuzzRunner.java:597)
	at io.questdb.test.griffin.wal.FuzzRunner.applyWal(FuzzRunner.java:280)
	at io.questdb.test.griffin.wal.SnapshotFuzzTest.lambda$runFuzzWithSnapshot$1(SnapshotFuzzTest.java:243)
	at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$7(AbstractCairoTest.java:917)
	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:619)
	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:914)
	at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:908)
	at io.questdb.test.griffin.wal.SnapshotFuzzTest.runFuzzWithSnapshot(SnapshotFuzzTest.java:202)
	at io.questdb.test.griffin.wal.SnapshotFuzzTest.testSnapshotFullFuzz(SnapshotFuzzTest.java:79)

```

The problem is metadata restore by TableWriter

```
I i.q.c.TableWriter Repairing metadata from: /tmp/junit10201576134088118831/dbRoot/testSnapshotFullFuzz~2/_meta.prev
```