### PR TITLE
chore(ilp): implement min request throughput in Java ILP Sender

### DIFF
--- a/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
+++ b/core/src/main/java/io/questdb/cairo/DatabaseSnapshotAgentImpl.java
@@ -478,7 +478,7 @@ public class DatabaseSnapshotAgentImpl implements DatabaseSnapshotAgent, QuietCl
                     copyOrError(srcPath.trimTo(srcPathLen), dstPath.trimTo(dstPathLen), ff, recoveredTxnFiles, TableUtils.TXN_FILE_NAME);
                     copyOrError(srcPath.trimTo(srcPathLen), dstPath.trimTo(dstPathLen), ff, recoveredCVFiles, TableUtils.COLUMN_VERSION_FILE_NAME);
                     // Reset _todo_ file otherwise TableWriter will start restoring metadata on open.
-                    TableUtils.resetTodoLog(ff, path, rootLen, memFile);
+                    TableUtils.resetTodoLog(ff, dstPath, dstPathLen, memFile);
                     rebuildTableFiles(dstPath.trimTo(dstPathLen), symbolFilesCount);
 
                     // Go inside SEQ_DIR

--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -341,7 +341,7 @@ public interface Sender extends Closeable {
         private static final long DEFAULT_MIN_REQUEST_THROUGHPUT = 100 * 1024; // 100KB/s, keep in sync with the contract of the configuration method
         private static final int DEFAULT_BUFFER_CAPACITY = 64 * 1024;
         private static final int DEFAULT_HTTP_PORT = 9000;
-        private static final int DEFAULT_AUTO_FLUSH_INTERVAL_MILLIS = 1_000;
+        private static final int DEFAULT_AUTO_FLUSH_INTERVAL_MILLIS = 10_000;
         private static final int DEFAULT_HTTP_TIMEOUT = 30_000;
         private static final int DEFAULT_MAXIMUM_BUFFER_CAPACITY = 100 * 1024 * 1024;
         private static final long DEFAULT_MAX_RETRY_NANOS = TimeUnit.SECONDS.toNanos(10); // keep sync with the contract of the configuration method
@@ -494,7 +494,7 @@ public interface Sender extends Closeable {
 
 
         /**
-         * Set the interval at which the Sender automatically flushes its buffer.
+         * Set the interval in milliseconds at which the Sender automatically flushes its buffer.
          * <br>
          * It flushed the buffer even when the number of buffered rows is less than the value set by {@link #autoFlushRows(int)}.
          * This prevents rows from being locally buffered for too long when the rate of incoming data is low.
@@ -508,7 +508,7 @@ public interface Sender extends Closeable {
          * <br>
          * You cannot set this value when auto-flush is disabled. See {@link #disableAutoFlush()}.
          * <br>
-         * Default value is 1,000 milliseconds.
+         * Default value is 10,000 milliseconds.
          *
          * @param autoFlushIntervalMillis interval at which the Sender automatically flushes its buffer in milliseconds.
          * @return this instance for method chaining

--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -338,7 +338,7 @@ public interface Sender extends Closeable {
     final class LineSenderBuilder {
         private static final int AUTO_FLUSH_DISABLED = 0;
         private static final int DEFAULT_AUTO_FLUSH_ROWS = 600;
-        private static final long DEFAULT_MIN_REQUEST_THROUGHPUT = 100_000; // 100KB/s, keep in sync with the contract of the configuration method
+        private static final long DEFAULT_MIN_REQUEST_THROUGHPUT = 100 * 1024; // 100KB/s, keep in sync with the contract of the configuration method
         private static final int DEFAULT_BUFFER_CAPACITY = 64 * 1024;
         private static final int DEFAULT_HTTP_PORT = 9000;
         private static final int DEFAULT_HTTP_TIMEOUT = 30_000;

--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -496,7 +496,7 @@ public interface Sender extends Closeable {
         /**
          * Set the interval in milliseconds at which the Sender automatically flushes its buffer.
          * <br>
-         * It flushed the buffer even when the number of buffered rows is less than the value set by {@link #autoFlushRows(int)}.
+         * It flushes the buffer even when the number of buffered rows is less than the value set by {@link #autoFlushRows(int)}.
          * This prevents rows from being locally buffered for too long when the rate of incoming data is low.
          * <p>
          * <strong>Important:</strong>This option does not cause the Sender to flush the buffer at regular intervals.
@@ -508,7 +508,7 @@ public interface Sender extends Closeable {
          * <br>
          * You cannot set this value when auto-flush is disabled. See {@link #disableAutoFlush()}.
          * <br>
-         * Default value is 10,000 milliseconds.
+         * Default value is 10000 milliseconds.
          *
          * @param autoFlushIntervalMillis interval at which the Sender automatically flushes its buffer in milliseconds.
          * @return this instance for method chaining
@@ -756,10 +756,21 @@ public interface Sender extends Closeable {
                         port(protocol == PROTOCOL_TCP ? DEFAULT_TCP_PORT : DEFAULT_HTTP_PORT);
                     }
                 } else if (Chars.equals("user", sink)) {
+                    // deprecated key: user, new key: username
                     pos = getValue(configurationString, pos, sink, "user");
                     user = sink.toString();
+                } else if (Chars.equals("username", sink)) {
+                    pos = getValue(configurationString, pos, sink, "username");
+                    user = sink.toString();
                 } else if (Chars.equals("pass", sink)) {
+                    // deprecated key: pass, new key: password
                     pos = getValue(configurationString, pos, sink, "pass");
+                    if (protocol == PROTOCOL_TCP) {
+                        throw new LineSenderException("password is not supported for TCP protocol");
+                    }
+                    password = sink.toString();
+                } else if (Chars.equals("password", sink)) {
+                    pos = getValue(configurationString, pos, sink, "password");
                     if (protocol == PROTOCOL_TCP) {
                         throw new LineSenderException("password is not supported for TCP protocol");
                     }

--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -444,7 +444,7 @@ public abstract class HttpClient implements QuietCloseable {
             return this;
         }
 
-        public int getContentLen() {
+        public int getContentLength() {
             if (contentStart > -1) {
                 return (int) (ptr - contentStart);
             } else {

--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -438,6 +438,14 @@ public abstract class HttpClient implements QuietCloseable {
             return this;
         }
 
+        public int getContentLen() {
+            if (contentStart > -1) {
+                return (int) (ptr - contentStart);
+            } else {
+                return 0;
+            }
+        }
+
         public Request url(CharSequence url) {
             assert state == STATE_URL;
             state = STATE_URL_DONE;

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
@@ -341,7 +341,7 @@ public final class LineHttpSender implements Sender {
 
         long retryingDeadlineNanos = Long.MIN_VALUE;
         int retryBackoff = RETRY_INITIAL_BACKOFF_MS;
-        int contentLen = request.getContentLen();
+        int contentLen = request.getContentLength();
         int actualTimeoutMillis = baseTimeoutMillis;
         if (minRequestThroughput > 0) {
             long throughputTimeoutBonusMillis = (contentLen * 1_000L / minRequestThroughput);

--- a/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
+++ b/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
@@ -822,6 +822,30 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
+    public void testMinRequestThroughputCannotBeNegative() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                Sender.builder().address(LOCALHOST).http().minRequestThroughput(-100).build();
+                fail("minimum request throughput must not be negative");
+            } catch (LineSenderException e) {
+                TestUtils.assertContains(e.getMessage(), "minimum request throughput must not be negative [minRequestThroughput=-100]");
+            }
+        });
+    }
+
+    @Test
+    public void testMinRequestThroughputNotSupportedForTcp() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                Sender.builder().address(LOCALHOST).minRequestThroughput(1).build();
+                fail("min request throughput is not be supported for TCP and the builder should fail-fast");
+            } catch (LineSenderException e) {
+                TestUtils.assertContains(e.getMessage(), "minimum request throughput is not supported for TCP protocol");
+            }
+        });
+    }
+
+    @Test
     public void testUsernamePasswordAuthNotSupportedForTcp() throws Exception {
         assertMemoryLeak(() -> {
             try {

--- a/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
+++ b/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
@@ -249,10 +249,14 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrError("http::addr=localhost;tls_roots=/some/path;", "tls_roots was configured, but tls_roots_password is missing");
             assertConfStrError("http::addr=localhost;tls_roots_password=hunter123;", "tls_roots_password was configured, but tls_roots is missing");
             assertConfStrError("tcp::addr=localhost;user=foo;", "token cannot be empty nor null");
+            assertConfStrError("tcp::addr=localhost;username=foo;", "token cannot be empty nor null");
             assertConfStrError("tcp::addr=localhost;token=foo;", "TCP token is configured, but user is missing");
             assertConfStrError("http::addr=localhost;user=foo;", "password cannot be empty nor null");
+            assertConfStrError("http::addr=localhost;username=foo;", "password cannot be empty nor null");
             assertConfStrError("http::addr=localhost;pass=foo;", "HTTP password is configured, but username is missing");
+            assertConfStrError("http::addr=localhost;password=foo;", "HTTP password is configured, but username is missing");
             assertConfStrError("tcp::addr=localhost;pass=foo;", "password is not supported for TCP protocol");
+            assertConfStrError("tcp::addr=localhost;password=foo;", "password is not supported for TCP protocol");
             assertConfStrError("tcp::addr=localhost;retry_timeout=;", "retry_timeout cannot be empty");
             assertConfStrError("tcp::addr=localhost;max_buf_size=;", "max_buf_size cannot be empty");
             assertConfStrError("tcp::addr=localhost;init_buf_size=;", "init_buf_size cannot be empty");
@@ -261,6 +265,7 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrError("http::addr=localhost:8080;tls_verify=unsafe_off;", "TSL validation disabled, but TLS was not enabled");
             assertConfStrError("http::addr=localhost:8080;tls_verify=bad;", "invalid tls_verify [value=bad, allowed-values=[on, unsafe_off]]");
             assertConfStrError("tcps::addr=localhost;pass=unsafe_off;", "password is not supported for TCP protocol");
+            assertConfStrError("tcps::addr=localhost;password=unsafe_off;", "password is not supported for TCP protocol");
             assertConfStrError("http::addr=localhost:8080;max_buf_size=-32;", "maximum buffer capacity cannot be less than initial buffer capacity [maximumBufferCapacity=-32, initialBufferCapacity=65536]");
             assertConfStrError("http::addr=localhost:8080;max_buf_size=notanumber;", "invalid max_buf_size [value=notanumber]");
             assertConfStrError("http::addr=localhost:8080;init_buf_size=notanumber;", "invalid init_buf_size [value=notanumber]");

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderMockServerTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderMockServerTest.java
@@ -139,6 +139,20 @@ public class LineHttpSenderMockServerTest extends AbstractTest {
                     .symbol("sym", "bol")
                     .doubleColumn("x", 1.0)
                     .atNow();
+        }, port -> Sender.builder().fromConfig("http::addr=localhost:" + port + ";username=Aladdin;password=;;Open;;Sesame;;;;;")); // escaped semicolons in password
+    }
+
+    @Test
+    public void testConnectWithConfigString_deprecatedAuth() throws Exception {
+        MockHttpProcessor mockHttpProcessor = new MockHttpProcessor()
+                .withExpectedContent("test,sym=bol x=1.0\n")
+                .withExpectedHeader("Authorization", "Basic QWxhZGRpbjo7T3BlbjtTZXNhbWU7Ow==")
+                .replyWithStatus(204);
+        testWithMock(mockHttpProcessor, sender -> {
+            sender.table("test")
+                    .symbol("sym", "bol")
+                    .doubleColumn("x", 1.0)
+                    .atNow();
         }, port -> Sender.builder().fromConfig("http::addr=localhost:" + port + ";user=Aladdin;pass=;;Open;;Sesame;;;;;")); // escaped semicolons in password
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -128,7 +128,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
 
                 int totalCount = 100_000;
                 int autoFlushRows = 1000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, autoFlushRows, null, null, null, 0, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, autoFlushRows, null, null, null, 0, 0, Long.MAX_VALUE)) {
                     for (int i = 0; i < totalCount; i++) {
                         if (i != 0 && i % autoFlushRows == 0) {
                             serverMain.awaitTable("table with space");
@@ -198,7 +198,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 int httpPort = serverMain.getHttpServerPort();
 
                 int totalCount = 1_000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0, Long.MAX_VALUE)) {
                     for (int i = 0; i < totalCount; i++) {
                         sender.table("table")
                                 .longColumn("lcol1", i)
@@ -311,7 +311,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 int httpPort = serverMain.getHttpServerPort();
 
                 int totalCount = 1_000_000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0, Long.MAX_VALUE)) {
                     for (int i = 0; i < totalCount; i++) {
                         sender.table("table with space")
                                 .symbol("tag1", "value" + i % 10)
@@ -359,6 +359,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 .address("localhost:" + port)
                 .http()
                 .autoFlushRows(Integer.MAX_VALUE) // we want to flush manually
+                .autoFlushIntervalMillis(Integer.MAX_VALUE) // flush manually...
                 .build()
         ) {
             if (count / 2 > 0) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -128,7 +128,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
 
                 int totalCount = 100_000;
                 int autoFlushRows = 1000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, autoFlushRows, null, null, null, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, autoFlushRows, null, null, null, 0, 0)) {
                     for (int i = 0; i < totalCount; i++) {
                         if (i != 0 && i % autoFlushRows == 0) {
                             serverMain.awaitTable("table with space");
@@ -198,7 +198,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 int httpPort = serverMain.getHttpServerPort();
 
                 int totalCount = 1_000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0)) {
                     for (int i = 0; i < totalCount; i++) {
                         sender.table("table")
                                 .longColumn("lcol1", i)
@@ -311,7 +311,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 int httpPort = serverMain.getHttpServerPort();
 
                 int totalCount = 1_000_000;
-                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0)) {
+                try (LineHttpSender sender = new LineHttpSender("localhost", httpPort, DefaultHttpClientConfiguration.INSTANCE, null, 100_000, null, null, null, 0, 0)) {
                     for (int i = 0; i < totalCount; i++) {
                         sender.table("table with space")
                                 .symbol("tag1", "value" + i % 10)

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/MockHttpProcessor.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/MockHttpProcessor.java
@@ -75,6 +75,17 @@ final class MockHttpProcessor implements HttpRequestProcessor, HttpMultipartCont
         return this;
     }
 
+    public MockHttpProcessor keepReplyingWithStatus(int statusCode) {
+        Response response = new Response();
+        response.responseStatusCode = statusCode;
+        lastResortResponse = response;
+
+        expectedRequests.add(expectedRequest);
+        expectedRequest = new ExpectedRequest();
+
+        return this;
+    }
+
     public MockHttpProcessor keepReplyingWithContent(int statusCode, String responseContent, String contentType) {
         Response response = new Response();
         response.responseStatusCode = statusCode;

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/MockHttpProcessor.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/MockHttpProcessor.java
@@ -75,9 +75,11 @@ final class MockHttpProcessor implements HttpRequestProcessor, HttpMultipartCont
         return this;
     }
 
-    public MockHttpProcessor keepReplyingWithStatus(int statusCode) {
+    public MockHttpProcessor keepReplyingWithContent(int statusCode, String responseContent, String contentType) {
         Response response = new Response();
         response.responseStatusCode = statusCode;
+        response.responseContent = responseContent;
+        response.contentType = contentType;
         lastResortResponse = response;
 
         expectedRequests.add(expectedRequest);
@@ -86,11 +88,9 @@ final class MockHttpProcessor implements HttpRequestProcessor, HttpMultipartCont
         return this;
     }
 
-    public MockHttpProcessor keepReplyingWithContent(int statusCode, String responseContent, String contentType) {
+    public MockHttpProcessor keepReplyingWithStatus(int statusCode) {
         Response response = new Response();
         response.responseStatusCode = statusCode;
-        response.responseContent = responseContent;
-        response.contentType = contentType;
         lastResortResponse = response;
 
         expectedRequests.add(expectedRequest);


### PR DESCRIPTION
This patch introduces a new configuration option for the ILP@HTTP client: minimal request throughput. 

It enables the configuration of the HTTP request timeout to scale with request size. The feature calculates a dynamic timeout based on request size and adds this to the base timeout. This functionality is useful for occasionally sending large batches over slow links, where adding a large static timeout would be impractical.

This ensures the Java client remains in sync with other clients that also support this functionality.