### PR TITLE
fix(sql): fix incorrect unordered map creation check

### DIFF
--- a/core/src/main/java/io/questdb/cairo/map/Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Map.java
@@ -61,10 +61,10 @@ public interface Map extends Mutable, Closeable, Reopenable {
     void merge(Map srcMap, MapValueMergeFunction mergeFunc);
 
     /**
-     * Reopens previously closed map with given key capacity and page size.
-     * Page size value is ignored if the map does not use heap to store keys and values.
+     * Reopens previously closed map with given key capacity and initial heap size.
+     * Heap size value is ignored if the map does not use heap to store keys and values.
      */
-    void reopen(int keyCapacity, int pageSize);
+    void reopen(int keyCapacity, int heapSize);
 
     void restoreInitialCapacity();
 

--- a/core/src/main/java/io/questdb/cairo/map/MapFactory.java
+++ b/core/src/main/java/io/questdb/cairo/map/MapFactory.java
@@ -103,7 +103,7 @@ public class MapFactory {
         final int maxEntrySize = configuration.getSqlUnorderedMapMaxEntrySize();
 
         final int keySize = totalSize(keyTypes);
-        final int valueSize = totalSize(keyTypes);
+        final int valueSize = totalSize(valueTypes);
         if (keySize > 0) {
             if (keySize <= Short.BYTES && valueSize <= maxEntrySize) {
                 return new Unordered2Map(keyTypes, valueTypes);
@@ -149,16 +149,19 @@ public class MapFactory {
      * or -1 if there is a var-size column in the given list.
      */
     private static int totalSize(ColumnTypes types) {
-        int keySize = 0;
+        if (types == null) {
+            return 0;
+        }
+        int totalSize = 0;
         for (int i = 0, n = types.getColumnCount(); i < n; i++) {
             final int columnType = types.getColumnType(i);
             final int size = ColumnType.sizeOf(columnType);
             if (size > 0) {
-                keySize += size;
+                totalSize += size;
             } else {
                 return -1;
             }
         }
-        return keySize;
+        return totalSize;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
@@ -98,8 +98,8 @@ public class OrderedMap implements Map, Reopenable {
     private long heapLimit; // Heap memory limit pointer.
     private long heapSize;
     private long heapStart; // Heap memory start pointer.
+    private int initialHeapSize;
     private int initialKeyCapacity;
-    private int initialPageSize;
     private long kPos;      // Current key-value memory pointer (contains searched key / pending key-value pair).
     private int keyCapacity;
     private int mask;
@@ -110,17 +110,17 @@ public class OrderedMap implements Map, Reopenable {
     private int size = 0;
 
     public OrderedMap(
-            int pageSize,
+            int heapSize,
             @Transient @NotNull ColumnTypes keyTypes,
             int keyCapacity,
             double loadFactor,
             int maxResizes
     ) {
-        this(pageSize, keyTypes, null, keyCapacity, loadFactor, maxResizes);
+        this(heapSize, keyTypes, null, keyCapacity, loadFactor, maxResizes);
     }
 
     public OrderedMap(
-            int pageSize,
+            int heapSize,
             @Transient @NotNull ColumnTypes keyTypes,
             @Transient @Nullable ColumnTypes valueTypes,
             int keyCapacity,
@@ -128,22 +128,22 @@ public class OrderedMap implements Map, Reopenable {
             int maxResizes,
             int memoryTag
     ) {
-        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, memoryTag, memoryTag);
+        this(heapSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, memoryTag, memoryTag);
     }
 
     public OrderedMap(
-            int pageSize,
+            int heapSize,
             @Transient @NotNull ColumnTypes keyTypes,
             @Transient @Nullable ColumnTypes valueTypes,
             int keyCapacity,
             double loadFactor,
             int maxResizes
     ) {
-        this(pageSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, MemoryTag.NATIVE_FAST_MAP, MemoryTag.NATIVE_FAST_MAP_INT_LIST);
+        this(heapSize, keyTypes, valueTypes, keyCapacity, loadFactor, maxResizes, MemoryTag.NATIVE_FAST_MAP, MemoryTag.NATIVE_FAST_MAP_INT_LIST);
     }
 
     OrderedMap(
-            int pageSize,
+            int heapSize,
             @NotNull @Transient ColumnTypes keyTypes,
             @Nullable @Transient ColumnTypes valueTypes,
             int keyCapacity,
@@ -152,15 +152,15 @@ public class OrderedMap implements Map, Reopenable {
             int heapMemoryTag,
             int listMemoryTag
     ) {
-        assert pageSize > 3;
+        assert heapSize > 3;
         assert loadFactor > 0 && loadFactor < 1d;
 
         this.heapMemoryTag = heapMemoryTag;
         this.listMemoryTag = listMemoryTag;
-        initialPageSize = pageSize;
+        initialHeapSize = heapSize;
         this.loadFactor = loadFactor;
-        heapStart = kPos = Unsafe.malloc(heapSize = pageSize, heapMemoryTag);
-        heapLimit = heapStart + pageSize;
+        heapStart = kPos = Unsafe.malloc(this.heapSize = heapSize, heapMemoryTag);
+        heapLimit = heapStart + heapSize;
         this.keyCapacity = (int) (keyCapacity / loadFactor);
         this.keyCapacity = this.initialKeyCapacity = Math.max(Numbers.ceilPow2(this.keyCapacity), MIN_KEY_CAPACITY);
         mask = this.keyCapacity - 1;
@@ -292,11 +292,11 @@ public class OrderedMap implements Map, Reopenable {
     }
 
     @Override
-    public void reopen(int keyCapacity, int pageSize) {
+    public void reopen(int keyCapacity, int heapSize) {
         if (heapStart == 0) {
             keyCapacity = (int) (keyCapacity / loadFactor);
             initialKeyCapacity = Math.max(Numbers.ceilPow2(keyCapacity), MIN_KEY_CAPACITY);
-            initialPageSize = pageSize;
+            initialHeapSize = heapSize;
             restoreInitialCapacity();
         }
     }
@@ -310,9 +310,9 @@ public class OrderedMap implements Map, Reopenable {
 
     @Override
     public void restoreInitialCapacity() {
-        if (heapSize != initialPageSize || keyCapacity != initialKeyCapacity) {
-            heapStart = kPos = Unsafe.realloc(heapStart, heapLimit - heapStart, heapSize = initialPageSize, heapMemoryTag);
-            heapLimit = heapStart + initialPageSize;
+        if (heapSize != initialHeapSize || keyCapacity != initialKeyCapacity) {
+            heapStart = kPos = Unsafe.realloc(heapStart, heapLimit - heapStart, heapSize = initialHeapSize, heapMemoryTag);
+            heapLimit = heapStart + initialHeapSize;
             keyCapacity = initialKeyCapacity;
             keyCapacity = keyCapacity < MIN_KEY_CAPACITY ? MIN_KEY_CAPACITY : Numbers.ceilPow2(keyCapacity);
             mask = keyCapacity - 1;

--- a/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
@@ -279,7 +279,7 @@ public class Unordered16Map implements Map, Reopenable {
     }
 
     @Override
-    public void reopen(int keyCapacity, int pageSize) {
+    public void reopen(int keyCapacity, int heapSize) {
         if (memStart == 0) {
             keyCapacity = (int) (keyCapacity / loadFactor);
             initialKeyCapacity = Math.max(Numbers.ceilPow2(keyCapacity), MIN_KEY_CAPACITY);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
@@ -215,7 +215,7 @@ public class Unordered2Map implements Map, Reopenable {
     }
 
     @Override
-    public void reopen(int keyCapacity, int pageSize) {
+    public void reopen(int keyCapacity, int heapSize) {
         reopen();
     }
 

--- a/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
@@ -275,7 +275,7 @@ public class Unordered4Map implements Map, Reopenable {
     }
 
     @Override
-    public void reopen(int keyCapacity, int pageSize) {
+    public void reopen(int keyCapacity, int heapSize) {
         if (memStart == 0) {
             keyCapacity = (int) (keyCapacity / loadFactor);
             initialKeyCapacity = Math.max(Numbers.ceilPow2(keyCapacity), MIN_KEY_CAPACITY);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -276,7 +276,7 @@ public class Unordered8Map implements Map, Reopenable {
     }
 
     @Override
-    public void reopen(int keyCapacity, int pageSize) {
+    public void reopen(int keyCapacity, int heapSize) {
         if (memStart == 0) {
             keyCapacity = (int) (keyCapacity / loadFactor);
             initialKeyCapacity = Math.max(Numbers.ceilPow2(keyCapacity), MIN_KEY_CAPACITY);

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -29,7 +29,8 @@ import io.questdb.std.str.Utf8String;
 
 public final class Hash {
 
-    private static final long M2 = 0x7a646e4d;
+    // Constant from Rust compiler's FxHasher.
+    private static final long M2 = 0x517cc1b727220a95L;
     private static final int MURMUR3_SEED = 95967;
     private static final long MURMUR3_X64_128_C1 = 0x87c37b91114253d5L;
     private static final long MURMUR3_X64_128_C2 = 0x4cf5ad432745937fL;

--- a/core/src/main/java/io/questdb/std/Vect.java
+++ b/core/src/main/java/io/questdb/std/Vect.java
@@ -319,7 +319,7 @@ public final class Vect {
     private static native void memcpy0(long src, long dst, long len);
 
     private static boolean memeq0(long a, long b, long len) {
-        int i = 0;
+        long i = 0;
         for (; i + 7 < len; i += 8) {
             if (Unsafe.getUnsafe().getLong(a + i) != Unsafe.getUnsafe().getLong(b + i)) {
                 return false;

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -345,7 +345,7 @@ query.timeout.sec=60
 #cairo.sql.groupby.allocator.max.chunk.size=4gb
 
 # threshold in bytes for switching from single memory buffer hash table (unordered) to a hash table with separate heap for entries (ordered)
-#cairo.sql.unordered.map.max.entry.size=24
+#cairo.sql.unordered.map.max.entry.size=32
 
 ## prevents stack overflow errors when evaluating complex nested SQLs
 ## the value is an approximate number of nested SELECT clauses.

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -330,7 +330,7 @@ query.timeout.sec=60
 #cairo.sql.groupby.allocator.max.chunk.size=4gb
 
 # threshold in bytes for switching from single memory buffer hash table (unordered) to a hash table with separate heap for entries (ordered)
-#cairo.sql.unordered.map.max.entry.size=24
+#cairo.sql.unordered.map.max.entry.size=32
 
 ## prevents stack overflow errors when evaluating complex nested SQLs
 ## the value is an approximate number of nested SELECT clauses.


### PR DESCRIPTION
`MapFactory#createUnorderedMap()` wasn't considering the size of the value correctly when deciding which map to create. This may have led to increased memory usage when running GROUP BY queries.

Other than that, fixes a few typos in comments and improves naming.