### PR TITLE
feat(sql): parallel `sample by` implementation

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -311,6 +311,17 @@ public final class TableUtils {
 
     public static void createTable(
             CairoConfiguration configuration,
+            TableStructure structure,
+            int tableId,
+            CharSequence dirName
+    ) {
+        try (Path path = new Path(); MemoryMARW mem = Vm.getMARWInstance()) {
+            createTable(configuration, mem, path, structure, ColumnType.VERSION, tableId, dirName);
+        }
+    }
+
+    public static void createTable(
+            CairoConfiguration configuration,
             MemoryMARW memory,
             Path path,
             TableStructure structure,
@@ -336,6 +347,23 @@ public final class TableUtils {
             CharSequence dirName
     ) {
         createTable(ff, root, mkDirMode, memory, path, dirName, structure, tableVersion, tableId);
+    }
+
+    public static void createTable(
+            FilesFacade ff,
+            CharSequence root,
+            int mkDirMode,
+            TableStructure structure,
+            int tableVersion,
+            int tableId,
+            CharSequence dirName
+    ) {
+        try (
+                Path path = new Path();
+                MemoryMARW mem = Vm.getMARWInstance()
+        ) {
+            createTable(ff, root, mkDirMode, mem, path, dirName, structure, tableVersion, tableId);
+        }
     }
 
     public static void createTable(

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
@@ -71,7 +71,17 @@ public final class LineHttpSender implements Sender {
     private HttpClient.Request request;
     private RequestState state = RequestState.EMPTY;
 
-    public LineHttpSender(String host, int port, HttpClientConfiguration clientConfiguration, ClientTlsConfiguration tlsConfig, int autoFlushRows, String authToken, String username, String password, long maxRetriesNanos) {
+    public LineHttpSender(
+            String host,
+            int port,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            long maxRetriesNanos
+    ) {
         assert authToken == null || (username == null && password == null);
         this.maxRetriesNanos = maxRetriesNanos;
         this.host = host;

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -2353,6 +2353,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 listColumnFilterA.clear();
                 intHashSet.clear();
 
+                int orderedByTimestampIndex = -1;
                 // column index sign indicates direction
                 // therefore 0 index is not allowed
                 for (int i = 0; i < orderByColumnCount; i++) {
@@ -2380,6 +2381,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             listColumnFilterA.add(-index - 1);
                         } else {
                             listColumnFilterA.add(index + 1);
+                            if (i == 0 && metadata.getColumnType(index) == ColumnType.TIMESTAMP) {
+                                orderedByTimestampIndex = index;
+                            }
                         }
                     }
                 }
@@ -2415,9 +2419,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     orderedMetadata = GenericRecordMetadata.copyOf(metadata);
                 } else {
                     orderedMetadata = GenericRecordMetadata.copyOfSansTimestamp(metadata);
-                    if (model.isOrderByTimestamp()) {
-                        orderedMetadata.setTimestampIndex(firstOrderByColumnIndex);
-                    }
+                    orderedMetadata.setTimestampIndex(orderedByTimestampIndex);
                 }
                 final Function loFunc = getLoFunction(model, executionContext);
                 final Function hiFunc = getHiFunction(model, executionContext);

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -1251,7 +1251,7 @@ public class SqlKeywords {
                 && (tok.charAt(i++) | 32) == 't'
                 && (tok.charAt(i++) | 32) == 'e'
                 && (tok.charAt(i++) | 32) == 'r'
-                && (tok.charAt(i++) | 32) == 's';
+                && (tok.charAt(i) | 32) == 's';
     }
 
     public static boolean isPartitionKeyword(CharSequence tok) {
@@ -1686,6 +1686,16 @@ public class SqlKeywords {
                 && (tok.charAt(3) | 32) == 'e';
     }
 
+    public static boolean isUTC(CharSequence tok) {
+        return
+                tok.length() == 5
+                        && (tok.charAt(0)) == '\''
+                        && (tok.charAt(1) | 32) == 'u'
+                        && (tok.charAt(2) | 32) == 't'
+                        && (tok.charAt(3) | 32) == 'c'
+                        && (tok.charAt(4)) == '\'';
+    }
+
     public static boolean isUnboundedKeyword(CharSequence tok) {
         return tok.length() == 9
                 && (tok.charAt(0) | 32) == 'u'
@@ -1797,6 +1807,18 @@ public class SqlKeywords {
                 && (tok.charAt(1) | 32) == 'e'
                 && (tok.charAt(2) | 32) == 'a'
                 && (tok.charAt(3) | 32) == 'r';
+    }
+
+    public static boolean isZeroOffset(CharSequence tok) {
+        return
+                tok.length() == 7
+                        && tok.charAt(0) == '\''
+                        && tok.charAt(1) == '0'
+                        && tok.charAt(2) == '0'
+                        && tok.charAt(3) == ':'
+                        && tok.charAt(4) == '0'
+                        && tok.charAt(5) == '0'
+                        && tok.charAt(6) == '\'';
     }
 
     public static boolean isZoneKeyword(CharSequence tok) {

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -926,7 +926,6 @@ public class SqlOptimiser implements Mutable {
                         for (int i = 0; i < n; i++) {
                             _nested.addOrderBy(orderBy.getQuick(i), orderByDirection.getQuick(i));
                         }
-                        _nested.setOrderByTimestamp(un.isOrderByTimestamp());
                         orderBy.clear();
                         orderByDirection.clear();
 
@@ -3858,11 +3857,9 @@ public class SqlOptimiser implements Mutable {
                 if (orderBy.size() == 0) {
                     if (order != null) {
                         order.addOrderBy(nested.getTimestamp(), QueryModel.ORDER_DIRECTION_ASCENDING);
-                        order.setOrderByTimestamp(true);
                     }
 
                     nested.addOrderBy(nested.getTimestamp(), QueryModel.ORDER_DIRECTION_DESCENDING);
-                    nested.setOrderByTimestamp(true);
                 } else {
                     final IntList orderByDirection = nested.getOrderByDirection();
                     if (order != null) {
@@ -3877,7 +3874,6 @@ public class SqlOptimiser implements Mutable {
                             order.getAliasToColumnMap().put(orderByToken, nextColumn(orderByToken));
                         }
                         order.addOrderBy(orderByNode, orderByDirection.getQuick(0));
-                        order.setOrderByTimestamp(true);
                     }
 
                     int newOrder;
@@ -4102,7 +4098,6 @@ public class SqlOptimiser implements Mutable {
                 //order by can't be pushed through limit clause because it'll produce bad results
                 if (base != baseParent && base != limitModel) {
                     limitModel.addOrderBy(orderBy, base.getOrderByDirection().getQuick(i));
-                    limitModel.setOrderByTimestamp(base.isOrderByTimestamp());
                 }
             }
 
@@ -4281,9 +4276,8 @@ public class SqlOptimiser implements Mutable {
             if (
                     sampleBy != null
                             && timestamp != null
-                            && (sampleByOffset != null && Chars.equals(sampleByOffset.token, "'00:00'"))
+                            && (sampleByOffset != null && SqlKeywords.isZeroOffset(sampleByOffset.token) && (sampleByTimezoneName == null || SqlKeywords.isUTC(sampleByTimezoneName.token)))
                             && (sampleByFill.size() == 0 || (sampleByFill.size() == 1 && SqlKeywords.isNoneKeyword(sampleByFill.getQuick(0).token)))
-                            && sampleByTimezoneName == null
                             && sampleByUnit == null
             ) {
                 // When timestamp is not explicitly selected, we will
@@ -4398,7 +4392,6 @@ public class SqlOptimiser implements Mutable {
                     orderBy.type = CONSTANT;
                     nested.getOrderBy().add(orderBy);
                     nested.getOrderByDirection().add(0);
-                    nested.setOrderByTimestamp(true);
                     nested.setTimestamp(nextLiteral(timestamp.token));
                 }
 

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -163,6 +163,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     private int orderByAdviceMnemonic = OrderByMnemonic.ORDER_BY_UNKNOWN;
     // position of the order by clause token
     private int orderByPosition;
+    private boolean orderByTimestamp = false;
     private IntList orderedJoinModels = orderedJoinModels2;
     // Expression clause that is actually part of left/outer join but not in join model.
     // Inner join expressions
@@ -267,9 +268,12 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         final CharSequence alias = column.getAlias();
         final ExpressionNode ast = column.getAst();
         assert alias != null;
-        aliasToColumnNameMap.put(alias, ast.token);
+        int aliasKeyIndex = aliasToColumnNameMap.keyIndex(alias);
+        if (aliasKeyIndex > -1) {
+            aliasToColumnNameMap.putAt(aliasKeyIndex, alias, ast.token);
+            bottomUpColumnNames.add(alias);
+        }
         columnNameToAliasMap.put(ast.token, alias);
-        bottomUpColumnNames.add(alias);
         aliasToColumnMap.put(alias, column);
         columnAliasIndexes.put(alias, bottomUpColumnNames.size() - 1);
     }
@@ -416,6 +420,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         artificialStar = false;
         explicitTimestamp = false;
         showKind = -1;
+        orderByTimestamp = false;
     }
 
     public void clearColumnMapStructs() {
@@ -954,6 +959,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         return nestedModelIsSubQuery;
     }
 
+    public boolean isOrderByTimestamp() {
+        return orderByTimestamp;
+    }
+
     public boolean isOrderByTimestamp(CharSequence orderByToken) {
         if (Chars.equalsIgnoreCase(orderByToken, timestamp.token)) {
             return true;
@@ -1184,6 +1193,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public void setOrderByPosition(int orderByPosition) {
         this.orderByPosition = orderByPosition;
+    }
+
+    public void setOrderByTimestamp(boolean orderByTimestamp) {
+        this.orderByTimestamp = orderByTimestamp;
     }
 
     public void setOrderedJoinModels(IntList that) {

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -163,7 +163,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     private int orderByAdviceMnemonic = OrderByMnemonic.ORDER_BY_UNKNOWN;
     // position of the order by clause token
     private int orderByPosition;
-    private boolean orderByTimestamp = false;
     private IntList orderedJoinModels = orderedJoinModels2;
     // Expression clause that is actually part of left/outer join but not in join model.
     // Inner join expressions
@@ -432,7 +431,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         artificialStar = false;
         explicitTimestamp = false;
         showKind = -1;
-        orderByTimestamp = false;
     }
 
     public void clearColumnMapStructs() {
@@ -1023,10 +1021,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         return nestedModelIsSubQuery;
     }
 
-    public boolean isOrderByTimestamp() {
-        return orderByTimestamp;
-    }
-
     public boolean isOrderByTimestamp(CharSequence orderByToken) {
         if (Chars.equalsIgnoreCase(orderByToken, timestamp.token)) {
             return true;
@@ -1248,10 +1242,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public void setOrderByPosition(int orderByPosition) {
         this.orderByPosition = orderByPosition;
-    }
-
-    public void setOrderByTimestamp(boolean orderByTimestamp) {
-        this.orderByTimestamp = orderByTimestamp;
     }
 
     public void setOrderedJoinModels(IntList that) {

--- a/core/src/main/java/io/questdb/griffin/model/RuntimeIntrinsicIntervalModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/RuntimeIntrinsicIntervalModel.java
@@ -28,10 +28,9 @@ import io.questdb.griffin.Plannable;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.LongList;
+import io.questdb.std.QuietCloseable;
 
-import java.io.Closeable;
-
-public interface RuntimeIntrinsicIntervalModel extends Closeable, Plannable {
+public interface RuntimeIntrinsicIntervalModel extends QuietCloseable, Plannable {
     boolean allIntervalsHitOnePartition(int partitionBy);
 
     LongList calculateIntervals(SqlExecutionContext sqlContext) throws SqlException;

--- a/core/src/main/java/io/questdb/std/LowerCaseCharSequenceObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/LowerCaseCharSequenceObjHashMap.java
@@ -104,6 +104,10 @@ public class LowerCaseCharSequenceObjHashMap<T> extends AbstractLowerCaseCharSeq
         return hashCode;
     }
 
+    public CharSequence keyAt(int index) {
+        return index < 0 ? keys[-index - 1] : null;
+    }
+
     public boolean put(CharSequence key, T value) {
         return putAt(keyIndex(key), key, value);
     }

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -302,6 +302,10 @@ public abstract class AbstractCairoTest extends AbstractTest {
         node1.getConfigurationOverrides().setMangleTableDirNames(mangle);
     }
 
+    public static TableToken create(TableModel model) {
+        return TestUtils.create(model, engine);
+    }
+
     public static boolean doubleEquals(double a, double b, double epsilon) {
         return a == b || Math.abs(a - b) < epsilon;
     }
@@ -1140,7 +1144,7 @@ public abstract class AbstractCairoTest extends AbstractTest {
     }
 
     protected static TableToken createTable(TableModel model) {
-        return engine.createTable(securityContext, model.getMem(), model.getPath(), false, model, false);
+        return TestUtils.create(model, engine);
     }
 
     protected static ApplyWal2TableJob createWalApplyJob(QuestDBTestNode node) {

--- a/core/src/test/java/io/questdb/test/CreateTableTestUtils.java
+++ b/core/src/test/java/io/questdb/test/CreateTableTestUtils.java
@@ -33,26 +33,19 @@ import io.questdb.test.tools.TestUtils;
 
 public class CreateTableTestUtils {
 
-    public static TableToken create(TableModel model) {
-        return TestUtils.create(model, AbstractCairoTest.engine);
-    }
-
     public static void createAllTable(CairoEngine engine, int partitionBy) {
-        try (TableModel model = getAllTypesModel(engine.getConfiguration(), partitionBy)) {
-            TestUtils.create(model, engine);
-        }
+        TableModel model = getAllTypesModel(engine.getConfiguration(), partitionBy);
+        TestUtils.create(model, engine);
     }
 
     public static void createAllTableWithNewTypes(CairoEngine engine, int partitionBy) {
-        try (TableModel model = getAllTypesModelWithNewTypes(engine.getConfiguration(), partitionBy)) {
-            TestUtils.create(model, engine);
-        }
+        TableModel model = getAllTypesModelWithNewTypes(engine.getConfiguration(), partitionBy);
+        TestUtils.create(model, engine);
     }
 
     public static void createAllTableWithTimestamp(CairoEngine engine, int partitionBy) {
-        try (TableModel model = getAllTypesModel(engine.getConfiguration(), partitionBy).col("ts", ColumnType.TIMESTAMP).timestamp()) {
-            TestUtils.create(model, engine);
-        }
+        TableModel model = getAllTypesModel(engine.getConfiguration(), partitionBy).col("ts", ColumnType.TIMESTAMP).timestamp();
+        TestUtils.create(model, engine);
     }
 
     public static void createTableWithVersionAndId(TableModel model, CairoEngine engine, int version, int tableId) {
@@ -60,15 +53,7 @@ public class CreateTableTestUtils {
         if (tableToken == null) {
             throw CairoException.critical(0).put("table already exists: ").put(model.getTableName());
         }
-        TableUtils.createTable(
-                model.getConfiguration(),
-                model.getMem(),
-                model.getPath(),
-                model,
-                version,
-                tableId,
-                tableToken.getDirName()
-        );
+        TestUtils.createTable(model, model.getConfiguration(), version, tableId, tableToken);
         engine.registerTableToken(tableToken);
     }
 
@@ -78,23 +63,22 @@ public class CreateTableTestUtils {
 
     public static void createTestTable(CairoEngine engine, int n, Rnd rnd, TestRecord.ArrayBinarySequence binarySequence) {
         try {
-            try (TableModel model = new TableModel(engine.getConfiguration(), "x", PartitionBy.NONE)) {
-                model
-                        .col("a", ColumnType.BYTE)
-                        .col("b", ColumnType.SHORT)
-                        .col("c", ColumnType.INT)
-                        .col("d", ColumnType.LONG)
-                        .col("e", ColumnType.DATE)
-                        .col("f", ColumnType.TIMESTAMP)
-                        .col("g", ColumnType.FLOAT)
-                        .col("h", ColumnType.DOUBLE)
-                        .col("i", ColumnType.STRING)
-                        .col("j", ColumnType.SYMBOL)
-                        .col("k", ColumnType.BOOLEAN)
-                        .col("l", ColumnType.BINARY)
-                        .col("m", ColumnType.UUID);
-                TestUtils.create(model, engine);
-            }
+            TableModel model = new TableModel(engine.getConfiguration(), "x", PartitionBy.NONE);
+            model
+                    .col("a", ColumnType.BYTE)
+                    .col("b", ColumnType.SHORT)
+                    .col("c", ColumnType.INT)
+                    .col("d", ColumnType.LONG)
+                    .col("e", ColumnType.DATE)
+                    .col("f", ColumnType.TIMESTAMP)
+                    .col("g", ColumnType.FLOAT)
+                    .col("h", ColumnType.DOUBLE)
+                    .col("i", ColumnType.STRING)
+                    .col("j", ColumnType.SYMBOL)
+                    .col("k", ColumnType.BOOLEAN)
+                    .col("l", ColumnType.BINARY)
+                    .col("m", ColumnType.UUID);
+            TestUtils.create(model, engine);
         } catch (RuntimeException e) {
             if ("table already exists: x".equals(e.getMessage())) {
                 try (TableWriter writer = TestUtils.newOffPoolWriter(engine.getConfiguration(), engine.verifyTableName("x"))) {

--- a/core/src/test/java/io/questdb/test/PerformanceTest.java
+++ b/core/src/test/java/io/questdb/test/PerformanceTest.java
@@ -69,7 +69,7 @@ public class PerformanceTest extends AbstractCairoTest {
             long result;
 
             String[] symbols = {"AGK.L", "BP.L", "TLW.L", "ABF.L", "LLOY.L", "BT-A.L", "WTB.L", "RRS.L", "ADM.L", "GKN.L", "HSBA.L"};
-            try (TableModel model = new TableModel(configuration, "quote", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "quote", PartitionBy.NONE)
                     .timestamp()
                     .col("sym", ColumnType.SYMBOL)
                     .col("bid", ColumnType.DOUBLE)
@@ -77,9 +77,8 @@ public class PerformanceTest extends AbstractCairoTest {
                     .col("bidSize", ColumnType.INT)
                     .col("askSize", ColumnType.INT)
                     .col("mode", ColumnType.SYMBOL).symbolCapacity(2)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(2)) {
-                CreateTableTestUtils.create(model);
-            }
+                    .col("ex", ColumnType.SYMBOL).symbolCapacity(2);
+            AbstractCairoTest.create(model);
 
             try (TableWriter w = newOffPoolWriter(configuration, "quote", Metrics.disabled())) {
                 for (int i = -count; i < count; i++) {
@@ -155,7 +154,7 @@ public class PerformanceTest extends AbstractCairoTest {
 
     private double measureReloadSpeed(int reloadTableRowCount, int reloadCount, int txCount) {
         String[] symbols = {"AGK.L", "BP.L", "TLW.L", "ABF.L", "LLOY.L", "BT-A.L", "WTB.L", "RRS.L", "ADM.L", "GKN.L", "HSBA.L"};
-        try (TableModel model = new TableModel(configuration, "quote", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "quote", PartitionBy.DAY)
                 .timestamp()
                 .col("sym", ColumnType.SYMBOL)
                 .col("bid", ColumnType.DOUBLE)
@@ -163,9 +162,8 @@ public class PerformanceTest extends AbstractCairoTest {
                 .col("bidSize", ColumnType.INT)
                 .col("askSize", ColumnType.INT)
                 .col("mode", ColumnType.SYMBOL).symbolCapacity(2)
-                .col("ex", ColumnType.SYMBOL).symbolCapacity(2)) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(2);
+        AbstractCairoTest.create(model);
 
         SOCountDownLatch stopLatch = new SOCountDownLatch(2);
         SOCountDownLatch startLatch = new SOCountDownLatch(2);

--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -626,20 +626,17 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
         sink.put('\n');
         compiler.compile(sink.toString(), context);
 
-        try (
-                TableModel tableModel = new TableModel(engine.getConfiguration(), tableName, PartitionBy.DAY)
-                        .col("investmentMill", ColumnType.LONG)
-                        .col("ticketThous", ColumnType.INT)
-                        .col("broker", ColumnType.SYMBOL).symbolCapacity(32)
-                        .timestamp("ts")
-        ) {
-            // todo: replace with metadata
-            if (isWal) {
-                tableModel.wal();
-            }
-            CharSequence insert = insertFromSelectPopulateTableStmt(tableModel, 1000000, firstPartitionName, partitionCount);
-            compiler.compile(insert, context);
+        TableModel tableModel = new TableModel(engine.getConfiguration(), tableName, PartitionBy.DAY)
+                .col("investmentMill", ColumnType.LONG)
+                .col("ticketThous", ColumnType.INT)
+                .col("broker", ColumnType.SYMBOL).symbolCapacity(32)
+                .timestamp("ts");
+        // todo: replace with metadata
+        if (isWal) {
+            tableModel.wal();
         }
+        CharSequence insert = insertFromSelectPopulateTableStmt(tableModel, 1000000, firstPartitionName, partitionCount);
+        compiler.compile(insert, context);
         return engine.verifyTableName(tableName);
     }
 

--- a/core/src/test/java/io/questdb/test/ServerMainShowPartitionsTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainShowPartitionsTest.java
@@ -224,16 +224,13 @@ public class ServerMainShowPartitionsTest extends AbstractBootstrapTest {
             createTable += " WAL";
         }
         compiler.compile(createTable, context);
-        try (
-                TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
-                        .col("investmentMill", ColumnType.LONG)
-                        .col("ticketThous", ColumnType.INT)
-                        .col("broker", ColumnType.SYMBOL).symbolCapacity(32)
-                        .timestamp("ts")
-        ) {
-            CharSequence insert = insertFromSelectPopulateTableStmt(tableModel, 1000000, firstPartitionName, partitionCount);
-            compiler.compile(insert, context);
-        }
+        TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
+                .col("investmentMill", ColumnType.LONG)
+                .col("ticketThous", ColumnType.INT)
+                .col("broker", ColumnType.SYMBOL).symbolCapacity(32)
+                .timestamp("ts");
+        CharSequence insert = insertFromSelectPopulateTableStmt(tableModel, 1000000, firstPartitionName, partitionCount);
+        compiler.compile(insert, context);
         return engine.verifyTableName(tableName);
     }
 

--- a/core/src/test/java/io/questdb/test/ServerMainVectorGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainVectorGroupByTest.java
@@ -156,11 +156,11 @@ public class ServerMainVectorGroupByTest extends AbstractBootstrapTest {
         try (OperationFuture op = compiler.compile(sink.toString(), context).execute(null)) {
             op.await();
         }
+        TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
+                .col("l", ColumnType.LONG)
+                .col("s", ColumnType.SYMBOL)
+                .timestamp("ts");
         try (
-                TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
-                        .col("l", ColumnType.LONG)
-                        .col("s", ColumnType.SYMBOL)
-                        .timestamp("ts");
                 OperationFuture op = compiler.compile(insertFromSelectPopulateTableStmt(tableModel, 10000, "2020-01-01", 100), context).execute(null)
         ) {
             op.await();

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -35,7 +35,6 @@ import io.questdb.griffin.engine.table.LatestByArguments;
 import io.questdb.std.*;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
@@ -702,14 +701,12 @@ public class BitmapIndexTest extends AbstractCairoTest {
             final int N = 100;
             final int indexBlockCapacity = 32;
             // separate two symbol columns with primitive. It will make problems apparent if index does not shift correctly
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
                     col("a", ColumnType.STRING).
                     col("b", ColumnType.SYMBOL).indexed(true, indexBlockCapacity).
                     col("i", ColumnType.INT).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             final String[] symbols = new String[N];

--- a/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
@@ -68,7 +68,7 @@ public class CairoReadonlyEngineTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCannotCreateSecondWriteInsance() throws Exception {
+    public void testCannotCreateSecondWriteInstance() throws Exception {
         assertMemoryLeak(() -> {
             try (CairoEngine ignore = new CairoEngine(new DefaultTestCairoConfiguration(root) {
                 @Override
@@ -187,15 +187,14 @@ public class CairoReadonlyEngineTest extends AbstractCairoTest {
     }
 
     private static TableToken createTable(String tableName, CairoEngine cairoEngine) {
-        try (TableModel table1 = new TableModel(
+        TableModel table1 = new TableModel(
                 configuration,
                 tableName,
                 PartitionBy.NONE
-        )) {
-            table1.timestamp("ts")
-                    .col("x", ColumnType.INT)
-                    .col("y", ColumnType.STRING);
-            return TestUtils.create(table1, cairoEngine);
-        }
+        );
+        table1.timestamp("ts")
+                .col("x", ColumnType.INT)
+                .col("y", ColumnType.STRING);
+        return TestUtils.create(table1, cairoEngine);
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/DoubleReloadTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/DoubleReloadTest.java
@@ -29,21 +29,18 @@ import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableWriter;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class DoubleReloadTest extends AbstractCairoTest {
     @Test
     public void testSingleColumn() {
-        try (TableModel model = new TableModel(
+        TableModel model = new TableModel(
                 configuration,
                 "int_test",
                 PartitionBy.NONE
-        ).col("x", ColumnType.INT)) {
-            CreateTableTestUtils.create(model);
-        }
-
+        ).col("x", ColumnType.INT);
+        AbstractCairoTest.create(model);
 
         try (
                 TableReader reader = newOffPoolReader(configuration, "int_test");

--- a/core/src/test/java/io/questdb/test/cairo/FullBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/FullBwdDataFrameCursorTest.java
@@ -28,11 +28,10 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.DataFrameCursor;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
-import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.std.Rnd;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -66,13 +65,11 @@ public class FullBwdDataFrameCursorTest extends AbstractCairoTest {
                 "1530831067\t1904508147\t1975-01-01T00:00:00.000000Z\n";
         assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
                     col("a", ColumnType.INT).
                     col("b", ColumnType.INT).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
 
             Rnd rnd = new Rnd();

--- a/core/src/test/java/io/questdb/test/cairo/FullFwdDataFrameCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/FullFwdDataFrameCursorFactoryTest.java
@@ -28,10 +28,9 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.sql.DataFrame;
 import io.questdb.cairo.sql.DataFrameCursor;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
-import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.std.Rnd;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,15 +44,13 @@ public class FullFwdDataFrameCursorFactoryTest extends AbstractCairoTest {
             final int N = 100;
             TableToken tableToken;
             // separate two symbol columns with primitive. It will make problems apparent if index does not shift correctly
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
                     col("a", ColumnType.STRING).
                     col("b", ColumnType.SYMBOL).indexed(true, N / 4).
                     col("i", ColumnType.INT).
                     col("c", ColumnType.SYMBOL).indexed(true, N / 4).
-                    timestamp()
-            ) {
-                tableToken = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            tableToken = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             final String[] symbols = new String[N];

--- a/core/src/test/java/io/questdb/test/cairo/IntervalBwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IntervalBwdDataFrameCursorTest.java
@@ -26,7 +26,6 @@ package io.questdb.test.cairo;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
-import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.model.RuntimeIntervalModel;
 import io.questdb.std.LongList;
@@ -34,7 +33,7 @@ import io.questdb.std.Rnd;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -162,13 +161,11 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
     public void testClose() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
                     col("a", ColumnType.INT).
                     col("b", ColumnType.INT).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
             TableReader reader = newOffPoolReader(configuration, "x");
             IntervalBwdDataFrameCursor cursor = new IntervalBwdDataFrameCursor(
@@ -233,12 +230,10 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
     @Test
     public void testIntervalCursorNoTimestamp() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
-                    col("b", ColumnType.SYMBOL).indexed(true, 4)
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    col("b", ColumnType.SYMBOL).indexed(true, 4);
+            AbstractCairoTest.create(model);
         });
     }
 
@@ -354,13 +349,11 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
 
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, "x", partitionBy).
+            TableModel model = new TableModel(configuration, "x", partitionBy).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
                     col("b", ColumnType.SYMBOL).indexed(true, 4).
-                    timestamp()
-            ) {
-                tableToken = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            tableToken = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
@@ -584,13 +577,11 @@ public class IntervalBwdDataFrameCursorTest extends AbstractCairoTest {
     private void testIntervals(int partitionBy, long increment, int rowCount, CharSequence expected, long expectedCount) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", partitionBy).
+            TableModel model = new TableModel(configuration, "x", partitionBy).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
                     col("b", ColumnType.SYMBOL).indexed(true, 4).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");

--- a/core/src/test/java/io/questdb/test/cairo/IntervalFwdDataFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IntervalFwdDataFrameCursorTest.java
@@ -26,7 +26,6 @@ package io.questdb.test.cairo;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
-import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.model.RuntimeIntervalModel;
 import io.questdb.std.LongList;
@@ -34,7 +33,7 @@ import io.questdb.std.Rnd;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.cutlass.text.SqlExecutionContextStub;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,7 +51,7 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
         // 3 days
         int N = 36;
 
-        // single interval spanning all of the table
+        // single interval spanning all the table
         intervals.clear();
         intervals.add(TimestampFormatUtils.parseTimestamp("1979-01-01T00:00:00.000Z"));
         intervals.add(TimestampFormatUtils.parseTimestamp("1979-01-06T00:00:00.000Z"));
@@ -162,13 +161,11 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
     public void testClose() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).
                     col("a", ColumnType.INT).
                     col("b", ColumnType.INT).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
             TableReader reader = newOffPoolReader(configuration, "x");
             IntervalFwdDataFrameCursor cursor = new IntervalFwdDataFrameCursor(new RuntimeIntervalModel(intervals), reader.getMetadata().getTimestampIndex());
@@ -247,12 +244,10 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
     @Test
     public void testIntervalCursorNoTimestamp() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
-                    col("b", ColumnType.SYMBOL).indexed(true, 4)
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    col("b", ColumnType.SYMBOL).indexed(true, 4);
+            AbstractCairoTest.create(model);
         });
     }
 
@@ -386,13 +381,11 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
 
             TableToken x;
-            try (TableModel model = new TableModel(configuration, "x", partitionBy).
+            TableModel model = new TableModel(configuration, "x", partitionBy).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
                     col("b", ColumnType.SYMBOL).indexed(true, 4).
-                    timestamp()
-            ) {
-                x = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            x = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
@@ -609,13 +602,11 @@ public class IntervalFwdDataFrameCursorTest extends AbstractCairoTest {
     private void testIntervals(int partitionBy, long increment, int rowCount, CharSequence expected, long expectedCount) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", partitionBy).
+            TableModel model = new TableModel(configuration, "x", partitionBy).
                     col("a", ColumnType.SYMBOL).indexed(true, 4).
                     col("b", ColumnType.SYMBOL).indexed(true, 4).
-                    timestamp()
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");

--- a/core/src/test/java/io/questdb/test/cairo/TableModel.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableModel.java
@@ -34,7 +34,6 @@ import io.questdb.std.str.Path;
 
 import java.io.Closeable;
 
-// todo: remove native memory alloc from the model, we're leaking badly
 public class TableModel implements TableStructure, Closeable {
     private static final long COLUMN_FLAG_CACHED = 1L;
     private static final long COLUMN_FLAG_INDEXED = COLUMN_FLAG_CACHED << 1;
@@ -78,14 +77,6 @@ public class TableModel implements TableStructure, Closeable {
         columnNames.add(Chars.toString(name));
         // set default symbol capacity
         columnBits.add((128L << 32) | type, COLUMN_FLAG_CACHED);
-        return this;
-    }
-
-    public TableModel dedupKey() {
-        int pos = columnBits.size() - 1;
-        assert pos > 0;
-        long bits = columnBits.getQuick(pos);
-        columnBits.setQuick(pos, bits | COLUMN_FLAG_DEDUP_KEY);
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/TableModel.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableModel.java
@@ -34,6 +34,7 @@ import io.questdb.std.str.Path;
 
 import java.io.Closeable;
 
+// todo: remove native memory alloc from the model, we're leaking badly
 public class TableModel implements TableStructure, Closeable {
     private static final long COLUMN_FLAG_CACHED = 1L;
     private static final long COLUMN_FLAG_INDEXED = COLUMN_FLAG_CACHED << 1;

--- a/core/src/test/java/io/questdb/test/cairo/TableModel.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableModel.java
@@ -27,24 +27,20 @@ package io.questdb.test.cairo;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableStructure;
-import io.questdb.cairo.vm.Vm;
-import io.questdb.cairo.vm.api.MemoryMARW;
-import io.questdb.std.*;
-import io.questdb.std.str.Path;
+import io.questdb.std.Chars;
+import io.questdb.std.LongList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
 
-import java.io.Closeable;
-
-public class TableModel implements TableStructure, Closeable {
+public class TableModel implements TableStructure {
     private static final long COLUMN_FLAG_CACHED = 1L;
     private static final long COLUMN_FLAG_INDEXED = COLUMN_FLAG_CACHED << 1;
     private static final long COLUMN_FLAG_DEDUP_KEY = COLUMN_FLAG_INDEXED << 1;
     private final LongList columnBits = new LongList();
     private final ObjList<CharSequence> columnNames = new ObjList<>();
     private final CairoConfiguration configuration;
-    private final MemoryMARW mem = Vm.getMARWInstance();
     private final String name;
     private final int partitionBy;
-    private final Path path = new Path();
     private int timestampIndex = -1;
     private int walEnabled = -1;
 
@@ -65,12 +61,6 @@ public class TableModel implements TableStructure, Closeable {
             columnBits.setQuick(last, bits & ~COLUMN_FLAG_CACHED);
         }
         return this;
-    }
-
-    @Override
-    public void close() {
-        Misc.free(mem);
-        Misc.free(path);
     }
 
     public TableModel col(CharSequence name, int type) {
@@ -109,10 +99,6 @@ public class TableModel implements TableStructure, Closeable {
         return configuration.getMaxUncommittedRows();
     }
 
-    public MemoryMARW getMem() {
-        return mem;
-    }
-
     public String getName() {
         return name;
     }
@@ -125,10 +111,6 @@ public class TableModel implements TableStructure, Closeable {
     @Override
     public int getPartitionBy() {
         return partitionBy;
-    }
-
-    public Path getPath() {
-        return path;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -250,11 +250,9 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                 threads.getLast().start();
             }
 
-            try (
-                    TableModel tm = new TableModel(configuration, "abc", PartitionBy.DAY)
-                            .timestamp().col("c", ColumnType.TIMESTAMP);
-                    Path rmPath = new Path().of(configuration.getRoot())
-            ) {
+            try (Path rmPath = new Path().of(configuration.getRoot())) {
+                TableModel tm = new TableModel(configuration, "abc", PartitionBy.DAY)
+                        .timestamp().col("c", ColumnType.TIMESTAMP);
                 // Add / remove tables
                 engine.closeNameRegistry();
                 Rnd rnd = TestUtils.generateRandom(LOG);
@@ -273,7 +271,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                             TableToken tableToken = rw.lockTableName(tableName, tableName, iteration, true);
                             rw.registerName(tableToken);
                             addedTables.add(iteration);
-                            TableUtils.createTable(configuration, tm.getMem(), tm.getPath(), tm, iteration, tableName);
+                            TestUtils.createTable(tm, configuration, ColumnType.VERSION, iteration, tableToken);
                         } else if (addedTables.size() > 0) {
                             // Remove table
                             int tableId = addedTables.getLast();
@@ -543,13 +541,12 @@ public class TableNameRegistryTest extends AbstractCairoTest {
 
             }
 
-            try (TableModel model = new TableModel(configuration, "tab1", PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, "tab1", PartitionBy.DAY)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.INT)
                     .wal()
-                    .timestamp()) {
-                tt1 = createTable(model);
-            }
+                    .timestamp();
+            tt1 = createTable(model);
 
             Assert.assertTrue(engine.isWalTable(tt1));
 
@@ -701,13 +698,12 @@ public class TableNameRegistryTest extends AbstractCairoTest {
 
                 drainWalQueue();
 
-                try (TableModel model = new TableModel(configuration, "tab1", PartitionBy.DAY)
+                TableModel model = new TableModel(configuration, "tab1", PartitionBy.DAY)
                         .col("a", ColumnType.INT)
                         .col("b", ColumnType.INT)
                         .wal()
-                        .timestamp()) {
-                    tt1 = createTable(model);
-                }
+                        .timestamp();
+                tt1 = createTable(model);
             }
 
             simulateEngineRestart();
@@ -728,13 +724,12 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             Assert.assertTrue(engine.isWalTable(tt2));
 
             TableToken tt3;
-            try (TableModel model = new TableModel(configuration, "tab3", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "tab3", PartitionBy.NONE)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.INT)
                     .noWal()
-                    .timestamp()) {
-                tt3 = createTable(model);
-            }
+                    .timestamp();
+            tt3 = createTable(model);
             Assert.assertFalse(engine.isWalTable(tt3));
 
             try (MemoryMARW mem = Vm.getMARWInstance()) {
@@ -778,13 +773,12 @@ public class TableNameRegistryTest extends AbstractCairoTest {
     @NotNull
     private static TableToken createTableWal(String tab1) {
         TableToken tt1;
-        try (TableModel model = new TableModel(configuration, tab1, PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, tab1, PartitionBy.DAY)
                 .col("a", ColumnType.INT)
                 .col("b", ColumnType.INT)
                 .wal()
-                .timestamp()) {
-            tt1 = createTable(model);
-        }
+                .timestamp();
+        tt1 = createTable(model);
         return tt1;
     }
 
@@ -815,13 +809,12 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             Assert.assertTrue(engine.isWalTable(tt2));
 
             TableToken tt3;
-            try (TableModel model = new TableModel(configuration, "tab3", PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, "tab3", PartitionBy.DAY)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.INT)
                     .noWal()
-                    .timestamp()) {
-                tt3 = createTable(model);
-            }
+                    .timestamp();
+            tt3 = createTable(model);
             Assert.assertFalse(engine.isWalTable(tt3));
 
             ddl("alter table " + tt2.getTableName() + " set type bypass wal");

--- a/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
@@ -80,12 +80,11 @@ public class TableReadFailTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             node1.setProperty(PropertyKey.CAIRO_SPIN_LOCK_TIMEOUT, 1);
             String x = "x";
-            try (TableModel model = new TableModel(configuration, x, PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, x, PartitionBy.NONE)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.LONG)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (
                     Path path = new Path();
@@ -226,7 +225,7 @@ public class TableReadFailTest extends AbstractCairoTest {
                     public long getSpinLockTimeout() {
                         return 1;
                     }
-                }, "all");
+                }, "all").close();
                 Assert.fail();
             } catch (CairoException ignore) {
             }

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
@@ -36,10 +36,9 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
 
     @Test
     public void testReAddColumn() throws Exception {
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE)) {
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE);
+        model.timestamp();
+        AbstractCairoTest.create(model);
         final String expected = "int:INT\n" +
                 "short:SHORT\n" +
                 "byte:BYTE\n" +
@@ -60,7 +59,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
 
     @Test
     public void testRemoveColumnAfterTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
                 .col("int", ColumnType.INT)
                 .col("short", ColumnType.SHORT)
                 .col("byte", ColumnType.BYTE)
@@ -72,10 +71,9 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 .col("sym", ColumnType.SYMBOL)
                 .col("bool", ColumnType.BOOLEAN)
                 .col("bin", ColumnType.BINARY)
-                .col("date", ColumnType.DATE)) {
+                .col("date", ColumnType.DATE);
 
-            CreateTableTestUtils.create(model);
-        }
+        AbstractCairoTest.create(model);
 
         final String expected = "int:INT\n" +
                 "short:SHORT\n" +
@@ -93,10 +91,9 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
 
     @Test
     public void testRemoveColumnBeforeTimestamp() throws Exception {
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE)) {
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE);
+        model.timestamp();
+        AbstractCairoTest.create(model);
         final String expected = "int:INT\n" +
                 "short:SHORT\n" +
                 "byte:BYTE\n" +
@@ -113,7 +110,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
 
     @Test
     public void testRemoveFirstTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
                 .timestamp()
                 .col("int", ColumnType.INT)
                 .col("short", ColumnType.SHORT)
@@ -125,16 +122,14 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 .col("sym", ColumnType.SYMBOL)
                 .col("bool", ColumnType.BOOLEAN)
                 .col("bin", ColumnType.BINARY)
-                .col("date", ColumnType.DATE)) {
-
-            CreateTableTestUtils.create(model);
-        }
+                .col("date", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         assertThat(0);
     }
 
     @Test
     public void testRemoveMiddleTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
                 .col("int", ColumnType.INT)
                 .col("short", ColumnType.SHORT)
                 .col("byte", ColumnType.BYTE)
@@ -146,20 +141,16 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 .col("sym", ColumnType.SYMBOL)
                 .col("bool", ColumnType.BOOLEAN)
                 .col("bin", ColumnType.BINARY)
-                .col("date", ColumnType.DATE)) {
-
-            CreateTableTestUtils.create(model);
-        }
-
+                .col("date", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         assertThat(5);
     }
 
     @Test
     public void testRemoveTailTimestamp() throws Exception {
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.NONE)
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat(11);
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderReloadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderReloadFuzzTest.java
@@ -78,9 +78,8 @@ public class TableReaderReloadFuzzTest extends AbstractCairoTest {
     @Test
     public void testExplosion() throws SqlException {
         final String tableName = "exploding";
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).timestamp();
+        AbstractCairoTest.create(model);
 
         try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
             TableWriter.Row row = writer.newRow(0L);
@@ -157,10 +156,9 @@ public class TableReaderReloadFuzzTest extends AbstractCairoTest {
     }
 
     private void createTable() {
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.DAY)) {
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, PartitionBy.DAY);
+        model.timestamp();
+        AbstractCairoTest.create(model);
     }
 
     private ObjList<Column> extractLiveColumns(TableRecordMetadata metadata) {

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
@@ -149,10 +149,9 @@ public class TableReaderReloadTest extends AbstractCairoTest {
         final Rnd rnd = new Rnd();
         final int bufferSize = 1024;
         long buffer = Unsafe.malloc(bufferSize, MemoryTag.NATIVE_DEFAULT);
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, partitionBy)) {
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, partitionBy);
+        model.timestamp();
+        AbstractCairoTest.create(model);
 
         long timestamp = 0;
         try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
@@ -201,10 +200,9 @@ public class TableReaderReloadTest extends AbstractCairoTest {
         final Rnd rnd = new Rnd();
         final int bufferSize = 1024;
         long buffer = Unsafe.malloc(bufferSize, MemoryTag.NATIVE_DEFAULT);
-        try (TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, partitionBy)) {
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = CreateTableTestUtils.getAllTypesModel(configuration, partitionBy);
+        model.timestamp();
+        AbstractCairoTest.create(model);
 
         long timestamp = 0;
         try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -1460,28 +1460,26 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testAppendNullTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
-                .col("int", ColumnType.INT)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+                .col("int", ColumnType.INT);
 //                .timestamp("t") // cannot insert null as a timestamp on designated columns
-        ) {
-            CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
+        CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
 
-            TestUtils.assertMemoryLeak(() -> {
-                try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
-                    TableWriter.Row r = w.newRow(Numbers.LONG_NaN);
-                    r.putInt(0, 100);
-                    r.append();
-                    w.commit();
+        TestUtils.assertMemoryLeak(() -> {
+            try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
+                TableWriter.Row r = w.newRow(Numbers.LONG_NaN);
+                r.putInt(0, 100);
+                r.append();
+                w.commit();
 
-                    Assert.assertEquals(1, w.size());
-                }
+                Assert.assertEquals(1, w.size());
+            }
 
-                try (TableReader reader = newOffPoolReader(configuration, "all")) {
-                    Assert.assertEquals(1, reader.getPartitionCount());
-                    Assert.assertEquals(1, reader.openPartition(0));
-                }
-            });
-        }
+            try (TableReader reader = newOffPoolReader(configuration, "all")) {
+                Assert.assertEquals(1, reader.getPartitionCount());
+                Assert.assertEquals(1, reader.openPartition(0));
+            }
+        });
     }
 
     @Test
@@ -1515,11 +1513,10 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
 
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL)
-                    .col("b", ColumnType.SYMBOL)) {
-                CreateTableTestUtils.create(model);
-            }
+                    .col("b", ColumnType.SYMBOL);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -1592,11 +1589,10 @@ public class TableReaderTest extends AbstractCairoTest {
         TestFilesFacade ff = createColumnDeleteCounterFileFacade(counterRef, "b", "");
 
         // create table with two string columns
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("a", ColumnType.SYMBOL)
-                .col("b", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("b", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
 
         testRemoveSymbol(counterRef, ff, "b", 2);
     }
@@ -1607,11 +1603,10 @@ public class TableReaderTest extends AbstractCairoTest {
         TestFilesFacade ff = createColumnDeleteCounterFileFacade(counterRef, "c", ".0");
 
         // create table with two string columns
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("a", ColumnType.SYMBOL)
-                .col("b", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("b", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
 
         try (TableWriter tw = getWriter("x")) {
             tw.addColumn("c", ColumnType.SYMBOL);
@@ -1626,12 +1621,10 @@ public class TableReaderTest extends AbstractCairoTest {
         TestFilesFacade ff = createColumnDeleteCounterFileFacade(counterRef, "b", "");
 
         // create table with two string columns
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("a", ColumnType.SYMBOL)
-                .col("b", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-        }
-
+                .col("b", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
         testAsyncColumnRename(counterRef, ff, "b");
     }
 
@@ -1641,11 +1634,10 @@ public class TableReaderTest extends AbstractCairoTest {
         TestFilesFacade ff = createColumnDeleteCounterFileFacade(counterRef, "c", ".0");
 
         // create table with two string columns
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("a", ColumnType.SYMBOL)
-                .col("b", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("b", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
         try (TableWriter tw = getWriter("x")) {
             tw.addColumn("c", ColumnType.SYMBOL);
         }
@@ -1657,14 +1649,12 @@ public class TableReaderTest extends AbstractCairoTest {
     @Test
     public void testCharAsString() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-
-            try (TableModel model = new TableModel(
+            TableModel model = new TableModel(
                     configuration,
                     "char_test",
                     PartitionBy.NONE
-            ).col("cc", ColumnType.STRING)) {
-                CreateTableTestUtils.create(model);
-            }
+            ).col("cc", ColumnType.STRING);
+            AbstractCairoTest.create(model);
             char[] data = {'a', 'b', 'f', 'g'};
             try (TableWriter writer = newOffPoolWriter(configuration, "char_test", metrics)) {
 
@@ -1733,9 +1723,8 @@ public class TableReaderTest extends AbstractCairoTest {
             }
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG);
+            AbstractCairoTest.create(model);
 
             final int threads = 2;
             final CyclicBarrier startBarrier = new CyclicBarrier(threads);
@@ -1805,9 +1794,8 @@ public class TableReaderTest extends AbstractCairoTest {
         // and table reader would not be able to read data consistently
         TestUtils.assertMemoryLeak(() -> {
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.LONG256)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.LONG256);
+            AbstractCairoTest.create(model);
 
             try (TableWriter w = newOffPoolWriter(configuration, "x", metrics)) {
                 TableWriter.Row r = w.newRow();
@@ -2025,10 +2013,9 @@ public class TableReaderTest extends AbstractCairoTest {
     @Test
     public void testOver2GFile() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
-                    .col("a", ColumnType.LONG)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+                    .col("a", ColumnType.LONG);
+            AbstractCairoTest.create(model);
 
             long N = 280000000;
             Rnd rnd = new Rnd();
@@ -2146,9 +2133,8 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testReadLong256Four() {
-        try (TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp();
+        AbstractCairoTest.create(model);
 
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
@@ -2180,9 +2166,8 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testReadLong256One() {
-        try (TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp();
+        AbstractCairoTest.create(model);
 
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
@@ -2214,9 +2199,8 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testReadLong256Three() {
-        try (TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp();
+        AbstractCairoTest.create(model);
 
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
@@ -2248,9 +2232,8 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testReadLong256Two() {
-        try (TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG256).timestamp();
+        AbstractCairoTest.create(model);
 
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
@@ -2290,9 +2273,8 @@ public class TableReaderTest extends AbstractCairoTest {
     public void testReaderAndWriterRace() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
 
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-                CreateTableTestUtils.create(model.timestamp());
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE);
+            AbstractCairoTest.create(model.timestamp());
 
             SOCountDownLatch stopLatch = new SOCountDownLatch(2);
             CyclicBarrier barrier = new CyclicBarrier(2);
@@ -2358,27 +2340,27 @@ public class TableReaderTest extends AbstractCairoTest {
     @Test
     public void testReaderGoesToPoolWhenCommitHappen() throws Exception {
         assertMemoryLeak(() -> {
-            String tableName = "testReaderGoesToPoolWhenCommitHappen";
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).col("l", ColumnType.LONG)) {
-                TableToken tableToken = CreateTableTestUtils.create(model);
+                    String tableName = "testReaderGoesToPoolWhenCommitHappen";
+                    TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).col("l", ColumnType.LONG);
+                    TableToken tableToken = AbstractCairoTest.create(model);
 
-                int rowCount = 10;
-                try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
-                    try (TableReader ignore = getReader(tableToken)) {
-                        for (int i = 0; i < rowCount; i++) {
-                            TableWriter.Row row = writer.newRow();
-                            row.putLong(0, i);
-                            row.append();
+                    int rowCount = 10;
+                    try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+                        try (TableReader ignore = getReader(tableToken)) {
+                            for (int i = 0; i < rowCount; i++) {
+                                TableWriter.Row row = writer.newRow();
+                                row.putLong(0, i);
+                                row.append();
+                            }
+                            writer.commit();
                         }
-                        writer.commit();
+                    }
+
+                    try (TableReader reader = getReader(tableToken)) {
+                        Assert.assertEquals(rowCount, reader.size());
                     }
                 }
-
-                try (TableReader reader = getReader(tableToken)) {
-                    Assert.assertEquals(rowCount, reader.size());
-                }
-            }
-        });
+        );
 
     }
 
@@ -2391,9 +2373,8 @@ public class TableReaderTest extends AbstractCairoTest {
 
         node1.setProperty(PropertyKey.CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS, openPartitionsLimit);
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).col("i", ColumnType.INT).timestamp()) {
-            TestUtils.create(model, engine);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).col("i", ColumnType.INT).timestamp();
+        TestUtils.create(model, engine);
 
         try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
             for (int i = 0; i < rows; i++) {
@@ -2443,9 +2424,8 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(
                 () -> {
                     // model table
-                    try (TableModel model = new TableModel(configuration, "w", PartitionBy.HOUR).col("l", ColumnType.LONG).timestamp()) {
-                        CreateTableTestUtils.create(model);
-                    }
+                    TableModel model = new TableModel(configuration, "w", PartitionBy.HOUR).col("l", ColumnType.LONG).timestamp();
+                    AbstractCairoTest.create(model);
 
                     try (
                             TableWriter w = newOffPoolWriter(configuration, "w", metrics);
@@ -2525,11 +2505,10 @@ public class TableReaderTest extends AbstractCairoTest {
     @Test
     public void testReloadWithTrailingNullString() throws NumericException {
         final String tableName = "reload_test";
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-            model.col("str", ColumnType.STRING);
-            model.timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY);
+        model.col("str", ColumnType.STRING);
+        model.timestamp();
+        AbstractCairoTest.create(model);
 
         try (TableReader reader = newOffPoolReader(configuration, tableName)) {
 
@@ -2602,9 +2581,8 @@ public class TableReaderTest extends AbstractCairoTest {
     @Test
     public void testReloadWithoutData() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "tab", PartitionBy.DAY).col("x", ColumnType.SYMBOL).col("y", ColumnType.LONG)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "tab", PartitionBy.DAY).col("x", ColumnType.SYMBOL).col("y", ColumnType.LONG);
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "tab", metrics)) {
                 TableWriter.Row r = writer.newRow();
@@ -2654,9 +2632,8 @@ public class TableReaderTest extends AbstractCairoTest {
             int totalCount = 0;
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", PartitionBy.NONE).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", PartitionBy.NONE).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
 
@@ -2809,9 +2786,8 @@ public class TableReaderTest extends AbstractCairoTest {
             };
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
 
@@ -2907,38 +2883,36 @@ public class TableReaderTest extends AbstractCairoTest {
 
     @Test
     public void testScoreBoardOverflow() throws Throwable {
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.DAY)
                 .col("int", ColumnType.INT)
-                .timestamp("t")
-        ) {
-            CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
-            assertMemoryLeak(() -> {
+                .timestamp("t");
+        CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
+        assertMemoryLeak(() -> {
 
-                try (TableReader ignore = getReader("all")) {
-                    try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
-                        for (int i = 0; i < configuration.getTxnScoreboardEntryCount() + 1; i++) {
-                            TableWriter.Row r = w.newRow(1000);
-                            r.putInt(0, 100);
-                            r.append();
-                            w.commit();
-                        }
-                    }
-
-                    try (TableReader ignore2 = getReader("all")) {
-                        Assert.fail();
-                    } catch (CairoException ex) {
-                        TestUtils.assertContains(ex.getFlyweightMessage(), "max txn-inflight limit reached");
-                    }
-
-                    try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
-                        TableWriter.Row r = w.newRow(0);
+            try (TableReader ignore = getReader("all")) {
+                try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
+                    for (int i = 0; i < configuration.getTxnScoreboardEntryCount() + 1; i++) {
+                        TableWriter.Row r = w.newRow(1000);
                         r.putInt(0, 100);
                         r.append();
                         w.commit();
                     }
                 }
-            });
-        }
+
+                try (TableReader ignore2 = getReader("all")) {
+                    Assert.fail();
+                } catch (CairoException ex) {
+                    TestUtils.assertContains(ex.getFlyweightMessage(), "max txn-inflight limit reached");
+                }
+
+                try (TableWriter w = newOffPoolWriter(configuration, "all", metrics)) {
+                    TableWriter.Row r = w.newRow(0);
+                    r.putInt(0, 100);
+                    r.append();
+                    w.commit();
+                }
+            }
+        });
     }
 
     @Test
@@ -2947,11 +2921,9 @@ public class TableReaderTest extends AbstractCairoTest {
         TestFilesFacade ff = createColumnDeleteCounterFileFacade(counterRef, "b", "");
 
         assertMemoryLeak(ff, () -> {
-
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.STRING).col("b", ColumnType.STRING)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.STRING).col("b", ColumnType.STRING);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3012,12 +2984,11 @@ public class TableReaderTest extends AbstractCairoTest {
         String expected = "{\"columnCount\":3,\"columns\":[{\"index\":0,\"name\":\"a\",\"type\":\"SYMBOL\",\"indexed\":true,\"indexValueBlockCapacity\":2},{\"index\":1,\"name\":\"b\",\"type\":\"INT\"},{\"index\":2,\"name\":\"timestamp\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":2}";
 
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY)
                     .col("a", ColumnType.SYMBOL).indexed(true, 2)
                     .col("b", ColumnType.INT)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             int N = 1000;
             long ts = TimestampFormatUtils.parseTimestamp("2018-01-06T10:00:00.000Z");
@@ -3051,9 +3022,8 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
 
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.SYMBOL).col("b", ColumnType.STRING)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.SYMBOL).col("b", ColumnType.STRING);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3133,9 +3103,8 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
 
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.STRING).col("b", ColumnType.STRING)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.STRING).col("b", ColumnType.STRING);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3201,11 +3170,10 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
 
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL)
-                    .col("b", ColumnType.SYMBOL)) {
-                CreateTableTestUtils.create(model);
-            }
+                    .col("b", ColumnType.SYMBOL);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3273,11 +3241,10 @@ public class TableReaderTest extends AbstractCairoTest {
 
         assertMemoryLeak(ff, () -> {
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL)
-                    .col("b", ColumnType.SYMBOL).indexed(true, 256)) {
-                CreateTableTestUtils.create(model);
-            }
+                    .col("b", ColumnType.SYMBOL).indexed(true, 256);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3349,9 +3316,8 @@ public class TableReaderTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
 
             // create table with two string columns
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.SYMBOL).col("b", ColumnType.SYMBOL).indexed(true, 256)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.SYMBOL).col("b", ColumnType.SYMBOL).indexed(true, 256);
+            AbstractCairoTest.create(model);
 
             Rnd rnd = new Rnd();
             final int N = 1000;
@@ -3721,10 +3687,9 @@ public class TableReaderTest extends AbstractCairoTest {
     }
 
     private TableToken createTable(String tableName, int partitionBy) {
-        try (TableModel model = new TableModel(configuration, tableName, partitionBy)) {
-            model.timestamp();
-            return CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, tableName, partitionBy);
+        model.timestamp();
+        return AbstractCairoTest.create(model);
     }
 
     private long testAppend(TableWriter writer, Rnd rnd, long ts, int count, long inc, long blob, int testPartitionSwitch, FieldGenerator generator) {
@@ -3822,9 +3787,8 @@ public class TableReaderTest extends AbstractCairoTest {
             final int N = 1024_0000;
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             final int threads = 2;
             final CyclicBarrier startBarrier = new CyclicBarrier(threads);
@@ -4112,9 +4076,8 @@ public class TableReaderTest extends AbstractCairoTest {
             long timestampUs = TimestampFormatUtils.parseTimestamp("2017-12-11T00:00:00.000Z");
 
             // model table
-            try (TableModel model = new TableModel(configuration, tableName, partitionBy).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, tableName, partitionBy).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
 
@@ -4182,9 +4145,8 @@ public class TableReaderTest extends AbstractCairoTest {
             int totalCount = 0;
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
 
@@ -4252,9 +4214,8 @@ public class TableReaderTest extends AbstractCairoTest {
             int totalCount = 0;
 
             // model table
-            try (TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
 

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTxnScoreboardInteractionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTxnScoreboardInteractionTest.java
@@ -26,7 +26,6 @@ package io.questdb.test.cairo;
 
 import io.questdb.cairo.*;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -159,11 +158,10 @@ public class TableReaderTxnScoreboardInteractionTest extends AbstractCairoTest {
     }
 
     private static TableToken createTable() {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-            model
-                    .col("a", ColumnType.BYTE)
-                    .col("b", ColumnType.SHORT);
-            return CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE);
+        model
+                .col("a", ColumnType.BYTE)
+                .col("b", ColumnType.SHORT);
+        return AbstractCairoTest.create(model);
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -35,7 +35,6 @@ import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryARW;
 import io.questdb.cairo.vm.api.MemoryCMARW;
 import io.questdb.cairo.vm.api.MemoryMA;
-import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cairo.wal.WalUtils;
 import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
@@ -49,7 +48,10 @@ import io.questdb.std.datetime.DateLocaleFactory;
 import io.questdb.std.datetime.microtime.TimestampFormatCompiler;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
-import io.questdb.std.str.*;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Path;
+import io.questdb.std.str.Sinkable;
+import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -206,26 +208,18 @@ public class TableWriterTest extends AbstractCairoTest {
             setProperty(PropertyKey.CAIRO_WRITER_COMMAND_QUEUE_CAPACITY, Numbers.ceilPow2(2 * totalColAddCount));
             int tableId = 11;
             // Reduce disk space by for the test run.
-            setProperty(PropertyKey.CAIRO_WRITER_DATA_APPEND_PAGE_SIZE, 1<< 20); // 1MB
+            setProperty(PropertyKey.CAIRO_WRITER_DATA_APPEND_PAGE_SIZE, 1 << 20); // 1MB
 
             TableToken tableToken;
-            try (Path path = new Path()) {
-                try (
-                        MemoryMARW mem = Vm.getCMARWInstance();
-                        TableModel model = new TableModel(configuration, "testAddColumnConcurrentWithDataUpdates", PartitionBy.NONE)
-                ) {
-                    model.timestamp();
-                    tableToken = registerTableName(model.getTableName());
-                    TableUtils.createTable(
-                            configuration,
-                            mem,
-                            path,
-                            model,
-                            tableId,
-                            tableToken.getDirName()
-                    );
-                }
-            }
+            TableModel model = new TableModel(configuration, "testAddColumnConcurrentWithDataUpdates", PartitionBy.NONE);
+            model.timestamp();
+            tableToken = registerTableName(model.getTableName());
+            TableUtils.createTable(
+                    configuration,
+                    model,
+                    tableId,
+                    tableToken.getDirName()
+            );
 
             // Write data in a loop getting writer in and out of pool
             Thread writeDataThread = new Thread(() -> {
@@ -661,12 +655,11 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testAddUnsupportedIndex() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL).cached(true)
                     .col("b", ColumnType.STRING)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             final int N = 1000;
             try (TableWriter w = newOffPoolWriter(configuration, "x", metrics)) {
@@ -703,12 +696,11 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testAddUnsupportedIndexCapacity() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL).cached(true)
                     .col("b", ColumnType.STRING)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             final int N = 1000;
             try (TableWriter w = newOffPoolWriter(configuration, "x", metrics)) {
@@ -1814,14 +1806,13 @@ public class TableWriterTest extends AbstractCairoTest {
         int partitionBy = PartitionBy.DAY;
         int N = 1000;
         TableToken tableToken;
-        try (TableModel model = new TableModel(configuration, "test", partitionBy)) {
-            model.col("sym1", ColumnType.SYMBOL);
-            model.col("sym2", ColumnType.SYMBOL);
-            model.col("sym3", ColumnType.SYMBOL);
-            model.timestamp();
+        TableModel model = new TableModel(configuration, "test", partitionBy);
+        model.col("sym1", ColumnType.SYMBOL);
+        model.col("sym2", ColumnType.SYMBOL);
+        model.col("sym3", ColumnType.SYMBOL);
+        model.timestamp();
 
-            tableToken = CreateTableTestUtils.create(model);
-        }
+        tableToken = AbstractCairoTest.create(model);
 
         // insert data
         final Rnd rnd = new Rnd();
@@ -1926,11 +1917,10 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testO3AfterRowCancel() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "weather", PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, "weather", PartitionBy.DAY)
                     .col("windspeed", ColumnType.DOUBLE)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "weather", metrics)) {
                 TableWriter.Row r;
@@ -1974,68 +1964,65 @@ public class TableWriterTest extends AbstractCairoTest {
         final CairoConfiguration configuration = new DefaultTestCairoConfiguration(root);
         final String tableName = "testO3PartitionTruncate";
 
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                 .col("productId", ColumnType.LONG256)
-                .timestamp()
-        ) {
-            CreateTableTestUtils.create(model);
+                .timestamp();
+        AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), Metrics.disabled())) {
-                // Add 46 rows in partition 2020-07-13T00
-                long ts = IntervalUtils.parseFloorPartialTimestamp("2020-07-13");
-                long increment = Timestamps.SECOND_MICROS;
-                int rows = 46;
-                for (int i = 0; i < rows; i++) {
-                    TableWriter.Row row = writer.newRow(ts);
-                    row.putLong256(0, i, i, i, i);
-                    row.append();
-                    ts += increment;
-                }
-                writer.commit();
-
-                // Add 1 row in order in partition 2020-07-13T00
-                TableWriter.Row row = writer.newRow(ts + 2 * increment);
-                row.putLong256(0, 1, 1, 1, 1);
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), Metrics.disabled())) {
+            // Add 46 rows in partition 2020-07-13T00
+            long ts = IntervalUtils.parseFloorPartialTimestamp("2020-07-13");
+            long increment = Timestamps.SECOND_MICROS;
+            int rows = 46;
+            for (int i = 0; i < rows; i++) {
+                TableWriter.Row row = writer.newRow(ts);
+                row.putLong256(0, i, i, i, i);
                 row.append();
+                ts += increment;
+            }
+            writer.commit();
 
-                // Add 1 row ooo in partition 2020-07-13T00
-                row = writer.newRow(ts + 1);
-                row.putLong256(0, 1, 1, 1, 1);
-                row.append();
+            // Add 1 row in order in partition 2020-07-13T00
+            TableWriter.Row row = writer.newRow(ts + 2 * increment);
+            row.putLong256(0, 1, 1, 1, 1);
+            row.append();
 
-                // Add 1 row out of order in partition 2020-07-13T01
-                row = writer.newRow(ts + Timestamps.HOUR_MICROS);
-                row.putLong256(0, 2, 2, 2, 2);
-                row.append();
+            // Add 1 row ooo in partition 2020-07-13T00
+            row = writer.newRow(ts + 1);
+            row.putLong256(0, 1, 1, 1, 1);
+            row.append();
 
-                // Write rows to go beyond page in partition 2020-07-13T00
-                int rowCount = (int) (Files.PAGE_SIZE / 32);
-                for (int i = 0; i < rowCount; i++) {
-                    TableWriter.Row row2 = writer.newRow(ts);
-                    row2.putLong256(0, i, i, i, i);
-                    row2.append();
-                    ts += increment;
-                }
+            // Add 1 row out of order in partition 2020-07-13T01
+            row = writer.newRow(ts + Timestamps.HOUR_MICROS);
+            row.putLong256(0, 2, 2, 2, 2);
+            row.append();
 
-                writer.commit();
+            // Write rows to go beyond page in partition 2020-07-13T00
+            int rowCount = (int) (Files.PAGE_SIZE / 32);
+            for (int i = 0; i < rowCount; i++) {
+                TableWriter.Row row2 = writer.newRow(ts);
+                row2.putLong256(0, i, i, i, i);
+                row2.append();
+                ts += increment;
             }
 
-            try (TableReader rdr = newOffPoolReader(configuration, tableName)) {
-                RecordCursor cursor = rdr.getCursor();
-                RecordMetadata metadata = rdr.getMetadata();
-                println(metadata, cursor);
-            }
+            writer.commit();
+        }
+
+        try (TableReader rdr = newOffPoolReader(configuration, tableName)) {
+            RecordCursor cursor = rdr.getCursor();
+            RecordMetadata metadata = rdr.getMetadata();
+            println(metadata, cursor);
         }
     }
 
     @Test
     public void testO3WithCancelRow() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "weather", PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, "weather", PartitionBy.DAY)
                     .col("windspeed", ColumnType.DOUBLE)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             long[] tss = new long[]{
                     631150000000000L,
@@ -2083,13 +2070,12 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testOpenUnsupportedIndex() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                     .col("a", ColumnType.SYMBOL).cached(true)
                     .col("b", ColumnType.STRING)
                     .col("c", ColumnType.STRING).indexed(true, 1024)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try {
                 newOffPoolWriter(configuration, "x", metrics).close();
@@ -2119,41 +2105,38 @@ public class TableWriterTest extends AbstractCairoTest {
 
     @Test
     public void testRemoveColumnAfterTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .timestamp()
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
-                .col("price", ColumnType.DOUBLE)) {
-            testRemoveColumn(model);
-        }
+                .col("price", ColumnType.DOUBLE);
+        testRemoveColumn(model);
     }
 
     @Test
     public void testRemoveColumnBeforeTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
-                .timestamp()) {
-            testRemoveColumn(model);
-        }
+                .timestamp();
+        testRemoveColumn(model);
     }
 
     @Test
     public void testRemoveColumnBeforeTimestamp3Symbols() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
                 .col("productName", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
-                .timestamp()) {
-            testRemoveColumn(model);
-        }
+                .timestamp();
+        testRemoveColumn(model);
     }
 
     @Test
@@ -2316,50 +2299,47 @@ public class TableWriterTest extends AbstractCairoTest {
 
     @Test
     public void testRemoveTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.NONE)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
                 .timestamp()
-                .col("supplier", ColumnType.SYMBOL)
-        ) {
-            CreateTableTestUtils.create(model);
-            long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
+                .col("supplier", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
+        long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
-            Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        Rnd rnd = new Rnd();
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
 
-                append10KProducts(ts, rnd, writer);
+            append10KProducts(ts, rnd, writer);
 
-                writer.removeColumn("timestamp");
+            writer.removeColumn("timestamp");
 
-                append10KNoTimestamp(rnd, writer);
+            append10KNoTimestamp(rnd, writer);
 
-                writer.commit();
+            writer.commit();
 
-                Assert.assertEquals(20000, writer.size());
-            }
+            Assert.assertEquals(20000, writer.size());
+        }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
-                append10KNoTimestamp(rnd, writer);
-                writer.commit();
-                Assert.assertEquals(30000, writer.size());
-            }
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+            append10KNoTimestamp(rnd, writer);
+            writer.commit();
+            Assert.assertEquals(30000, writer.size());
         }
     }
 
     @Test
     public void testRemoveTimestampFromPartitionedTable() {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
                 .timestamp()
-                .col("supplier", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("supplier", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
 
         try (TableWriter writer = newOffPoolWriter(configuration, "ABC", metrics)) {
             try {
@@ -2372,28 +2352,26 @@ public class TableWriterTest extends AbstractCairoTest {
 
     @Test
     public void testRenameColumnAfterTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .timestamp()
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
-                .col("price", ColumnType.DOUBLE)) {
-            testRenameColumn(model);
-        }
+                .col("price", ColumnType.DOUBLE);
+        testRenameColumn(model);
     }
 
     @Test
     public void testRenameColumnBeforeTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
-                .timestamp()) {
-            testRenameColumn(model);
-        }
+                .timestamp();
+        testRenameColumn(model);
     }
 
     @Test
@@ -2556,70 +2534,67 @@ public class TableWriterTest extends AbstractCairoTest {
 
     @Test
     public void testRenameTimestamp() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.NONE)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
                 .timestamp()
-                .col("supplier", ColumnType.SYMBOL)
-        ) {
-            CreateTableTestUtils.create(model);
-            long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
+                .col("supplier", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
+        long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
-            Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        Rnd rnd = new Rnd();
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
 
-                append10KProducts(ts, rnd, writer);
+            append10KProducts(ts, rnd, writer);
 
-                writer.renameColumn("timestamp", "ts");
+            writer.renameColumn("timestamp", "ts");
 
-                append10KProducts(writer.getMaxTimestamp(), rnd, writer);
+            append10KProducts(writer.getMaxTimestamp(), rnd, writer);
 
-                writer.commit();
+            writer.commit();
 
-                Assert.assertEquals(20000, writer.size());
-            }
+            Assert.assertEquals(20000, writer.size());
+        }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
-                append10KProducts(writer.getMaxTimestamp(), rnd, writer);
-                writer.commit();
-                Assert.assertEquals(30000, writer.size());
-            }
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+            append10KProducts(writer.getMaxTimestamp(), rnd, writer);
+            writer.commit();
+            Assert.assertEquals(30000, writer.size());
         }
     }
 
     @Test
     public void testRenameTimestampFromPartitionedTable() throws Exception {
-        try (TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
+        TableModel model = new TableModel(configuration, "ABC", PartitionBy.DAY)
                 .col("productId", ColumnType.INT)
                 .col("productName", ColumnType.STRING)
                 .col("category", ColumnType.SYMBOL)
                 .col("price", ColumnType.DOUBLE)
                 .timestamp()
-                .col("supplier", ColumnType.SYMBOL)) {
-            CreateTableTestUtils.create(model);
-            long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
+                .col("supplier", ColumnType.SYMBOL);
+        AbstractCairoTest.create(model);
+        long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
-            Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        Rnd rnd = new Rnd();
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
 
-                append10KProducts(ts, rnd, writer);
+            append10KProducts(ts, rnd, writer);
 
-                writer.renameColumn("timestamp", "ts");
+            writer.renameColumn("timestamp", "ts");
 
-                append10KProducts(writer.getMaxTimestamp(), rnd, writer);
+            append10KProducts(writer.getMaxTimestamp(), rnd, writer);
 
-                writer.commit();
+            writer.commit();
 
-                Assert.assertEquals(20000, writer.size());
-            }
+            Assert.assertEquals(20000, writer.size());
+        }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
-                append10KProducts(writer.getMaxTimestamp(), rnd, writer);
-                writer.commit();
-                Assert.assertEquals(30000, writer.size());
-            }
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+            append10KProducts(writer.getMaxTimestamp(), rnd, writer);
+            writer.commit();
+            Assert.assertEquals(30000, writer.size());
         }
     }
 
@@ -2911,9 +2886,8 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(
                 () -> {
                     TableToken tableToken;
-                    try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.HOUR).col("x", ColumnType.LONG).timestamp()) {
-                        tableToken = TestUtils.create(model, engine);
-                    }
+                    TableModel model = new TableModel(configuration, "xyz", PartitionBy.HOUR).col("x", ColumnType.LONG).timestamp();
+                    tableToken = createTable(model);
 
                     final Rnd rnd = new Rnd();
                     final ObjList<String> timestampsReported = new ObjList<>();
@@ -3034,11 +3008,10 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testTwoByteUtf8() {
         String name = "соотечественник";
-        try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
                 .col("секьюрити", ColumnType.STRING)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         Rnd rnd = new Rnd();
         try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
@@ -3110,12 +3083,11 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testUtf8() {
         String name = "utf8";
-        try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
                 .col("str", ColumnType.STRING)
                 .col("sym", ColumnType.SYMBOL)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         String something = "Щось";
         String boring = "Таке-Сяке";
         try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
@@ -3317,10 +3289,9 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void assertGeoStr(String hash, int tableBits, long expected) {
         final String tableName = "geo1";
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-            model.col("g", ColumnType.getGeoHashTypeWithBits(tableBits));
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE);
+        model.col("g", ColumnType.getGeoHashTypeWithBits(tableBits));
+        AbstractCairoTest.create(model);
 
         try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
             TableWriter.Row r = writer.newRow();
@@ -3374,7 +3345,7 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     private void create(FilesFacade ff, int partitionBy, int N) {
-        try (TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
+        TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
             @Override
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
@@ -3389,9 +3360,8 @@ public class TableWriterTest extends AbstractCairoTest {
                 .col("locationShort", ColumnType.getGeoHashTypeWithBits(15))
                 .col("locationInt", ColumnType.getGeoHashTypeWithBits(30))
                 .col("locationLong", ColumnType.getGeoHashTypeWithBits(60))
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
     }
 
     private int getDirCount() {
@@ -3467,15 +3437,14 @@ public class TableWriterTest extends AbstractCairoTest {
     private void removeColumn(TestFilesFacade ff) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             String name = "ABC";
-            try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
                     .col("productId", ColumnType.INT)
                     .col("productName", ColumnType.STRING)
                     .col("supplier", ColumnType.SYMBOL)
                     .col("category", ColumnType.SYMBOL)
                     .col("price", ColumnType.DOUBLE)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -3513,15 +3482,14 @@ public class TableWriterTest extends AbstractCairoTest {
     private void renameColumn(TestFilesFacade ff) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             String name = "ABC";
-            try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, name, PartitionBy.NONE)
                     .col("productId", ColumnType.INT)
                     .col("productName", ColumnType.STRING)
                     .col("supplier", ColumnType.SYMBOL)
                     .col("category", ColumnType.SYMBOL)
                     .col("price", ColumnType.DOUBLE)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -3902,7 +3870,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testRemoveColumn(TableModel model) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            CreateTableTestUtils.create(model);
+            AbstractCairoTest.create(model);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
@@ -3979,7 +3947,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testRenameColumn(TableModel model) throws Exception {
         assertMemoryLeak(() -> {
-            CreateTableTestUtils.create(model);
+            AbstractCairoTest.create(model);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
@@ -4155,13 +4123,12 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     private void testSymbolCacheFlag(boolean cacheFlag) {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("a", ColumnType.SYMBOL).cached(cacheFlag)
                 .col("b", ColumnType.STRING)
                 .col("c", ColumnType.SYMBOL).cached(!cacheFlag)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         int N = 1000;
         Rnd rnd = new Rnd();
@@ -4197,91 +4164,90 @@ public class TableWriterTest extends AbstractCairoTest {
     private void testTruncate(TruncateModifier modifier) throws NumericException {
         int partitionBy = PartitionBy.DAY;
         int N = 1000;
-        try (TableModel model = new TableModel(configuration, "test", partitionBy)) {
-            model.col("sym1", ColumnType.SYMBOL);
-            model.col("sym2", ColumnType.SYMBOL);
-            model.col("sym3", ColumnType.SYMBOL);
-            model.timestamp();
+        TableModel model = new TableModel(configuration, "test", partitionBy);
+        model.col("sym1", ColumnType.SYMBOL);
+        model.col("sym2", ColumnType.SYMBOL);
+        model.col("sym3", ColumnType.SYMBOL);
+        model.timestamp();
 
-            TableToken tableToken = CreateTableTestUtils.create(model);
+        TableToken tableToken = AbstractCairoTest.create(model);
 
-            // insert data
-            final Rnd rnd = new Rnd();
-            long t = TimestampFormatUtils.parseTimestamp("2019-03-22T00:00:00.000000Z");
-            long increment = 2_000_000;
-            try (TableWriter w = getWriter(tableToken)) {
-                testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
-                w.commit();
+        // insert data
+        final Rnd rnd = new Rnd();
+        long t = TimestampFormatUtils.parseTimestamp("2019-03-22T00:00:00.000000Z");
+        long increment = 2_000_000;
+        try (TableWriter w = getWriter(tableToken)) {
+            testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
+            w.commit();
 
-                long t1 = t;
-                for (int i = 0; i < N / 2; i++) {
-                    TableWriter.Row r = w.newRow(t1);
-                    r.putSym(0, rnd.nextString(5));
-                    r.putSym(1, rnd.nextString(5));
-                    r.putSym(2, rnd.nextString(5));
-                    t1 += increment;
-                    r.append();
-                }
+            long t1 = t;
+            for (int i = 0; i < N / 2; i++) {
+                TableWriter.Row r = w.newRow(t1);
+                r.putSym(0, rnd.nextString(5));
+                r.putSym(1, rnd.nextString(5));
+                r.putSym(2, rnd.nextString(5));
+                t1 += increment;
+                r.append();
+            }
 
-                // modifier enters TableWriter in different states from which
-                // truncate() call must be able to recover
-                modifier.modify(w, rnd, t1, increment);
+            // modifier enters TableWriter in different states from which
+            // truncate() call must be able to recover
+            modifier.modify(w, rnd, t1, increment);
 
-                // truncate writer mid-row-append
+            // truncate writer mid-row-append
+            w.truncate();
+
+            // add a couple of indexes
+            w.addIndex("sym1", 1024);
+            w.addIndex("sym2", 1024);
+
+            Assert.assertTrue(w.getMetadata().isColumnIndexed(0));
+            Assert.assertTrue(w.getMetadata().isColumnIndexed(1));
+            Assert.assertFalse(w.getMetadata().isColumnIndexed(2));
+
+            // here we reset random to ensure we re-insert the same values
+            rnd.reset();
+
+            testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
+            w.commit();
+
+            Assert.assertEquals(1, w.getPartitionCount());
+
+            // ensure indexes can be read
+            try (TableReader reader = getReader(tableToken)) {
+                final TableReaderRecord record = (TableReaderRecord) reader.getCursor().getRecord();
+                assertIndex(reader, record, 0);
+                assertIndex(reader, record, 1);
+
+                // check if we can still truncate the writer
                 w.truncate();
+                Assert.assertEquals(0, w.size());
+                Assert.assertTrue(reader.reload());
+                Assert.assertEquals(0, reader.size());
+            }
 
-                // add a couple of indexes
-                w.addIndex("sym1", 1024);
-                w.addIndex("sym2", 1024);
+            // truncate again with indexers present
+            w.truncate();
 
-                Assert.assertTrue(w.getMetadata().isColumnIndexed(0));
-                Assert.assertTrue(w.getMetadata().isColumnIndexed(1));
-                Assert.assertFalse(w.getMetadata().isColumnIndexed(2));
+            // add the same data again and check indexes
+            rnd.reset();
 
-                // here we reset random to ensure we re-insert the same values
-                rnd.reset();
+            testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
+            w.commit();
 
-                testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
-                w.commit();
+            Assert.assertEquals(1, w.getPartitionCount());
 
-                Assert.assertEquals(1, w.getPartitionCount());
+            // ensure indexes can be read
+            try (TableReader reader = getReader(tableToken)) {
+                final TableReaderRecord record = (TableReaderRecord) reader.getCursor().getRecord();
+                assertIndex(reader, record, 0);
+                assertIndex(reader, record, 1);
 
-                // ensure indexes can be read
-                try (TableReader reader = getReader(tableToken)) {
-                    final TableReaderRecord record = (TableReaderRecord) reader.getCursor().getRecord();
-                    assertIndex(reader, record, 0);
-                    assertIndex(reader, record, 1);
-
-                    // check if we can still truncate the writer
-                    w.truncate();
-                    Assert.assertEquals(0, w.size());
-                    Assert.assertTrue(reader.reload());
-                    Assert.assertEquals(0, reader.size());
-                }
-
-                // truncate again with indexers present
+                // check if we can still truncate the writer
                 w.truncate();
-
-                // add the same data again and check indexes
-                rnd.reset();
-
-                testIndexIsAddedToTableAppendData(N, rnd, t, increment, w);
-                w.commit();
-
-                Assert.assertEquals(1, w.getPartitionCount());
-
-                // ensure indexes can be read
-                try (TableReader reader = getReader(tableToken)) {
-                    final TableReaderRecord record = (TableReaderRecord) reader.getCursor().getRecord();
-                    assertIndex(reader, record, 0);
-                    assertIndex(reader, record, 1);
-
-                    // check if we can still truncate the writer
-                    w.truncate();
-                    Assert.assertEquals(0, w.size());
-                    Assert.assertTrue(reader.reload());
-                    Assert.assertEquals(0, reader.size());
-                }
+                Assert.assertEquals(0, w.size());
+                Assert.assertTrue(reader.reload());
+                Assert.assertEquals(0, reader.size());
             }
         }
     }

--- a/core/src/test/java/io/questdb/test/cairo/TxnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TxnTest.java
@@ -33,7 +33,6 @@ import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
@@ -63,12 +62,9 @@ public class TxnTest extends AbstractCairoTest {
             assertMemoryLeak(() -> {
 
                 String tableName = "txntest";
-                try (
-                        TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
-                ) {
-                    model.timestamp();
-                    CreateTableTestUtils.create(model);
-                }
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY);
+                model.timestamp();
+                AbstractCairoTest.create(model);
 
                 try (Path path = new Path()) {
                     TableToken tableToken = engine.verifyTableName(tableName);
@@ -131,10 +127,9 @@ public class TxnTest extends AbstractCairoTest {
             int maxSymbolCount = (int) (Files.PAGE_SIZE / 8 / 4);
             AtomicInteger partitionCountCheck = new AtomicInteger();
 
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)) {
-                model.timestamp();
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR);
+            model.timestamp();
+            AbstractCairoTest.create(model);
             int truncateIteration = 33;
             Thread writerThread = createWriterThread(
                     start,
@@ -202,7 +197,7 @@ public class TxnTest extends AbstractCairoTest {
                 readers[th].join();
             }
 
-            if (exceptions.size() != 0) {
+            if (!exceptions.isEmpty()) {
                 Assert.fail(exceptions.poll().toString());
             }
             Assert.assertTrue(reloadCount.get() > 10);
@@ -228,10 +223,9 @@ public class TxnTest extends AbstractCairoTest {
             int maxSymbolCount = (int) (Files.PAGE_SIZE / 8 / 4);
             AtomicInteger partitionCountCheck = new AtomicInteger();
 
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)) {
-                model.timestamp();
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR);
+            model.timestamp();
+            AbstractCairoTest.create(model);
             Thread writerThread = createWriterThread(
                     start,
                     done,
@@ -318,7 +312,7 @@ public class TxnTest extends AbstractCairoTest {
                 readers[th].join();
             }
 
-            if (exceptions.size() != 0) {
+            if (!exceptions.isEmpty()) {
                 Assert.fail(exceptions.poll().toString());
             }
             Assert.assertTrue(reloadCount.get() > 10);
@@ -412,7 +406,7 @@ public class TxnTest extends AbstractCairoTest {
                         txWriter.ofRW(path, PartitionBy.HOUR);
                     }
 
-                    if (exceptions.size() > 0) {
+                    if (!exceptions.isEmpty()) {
                         break;
                     }
                 }

--- a/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.std.*;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.cairo.TestRecord;
 import io.questdb.test.tools.TestUtils;
@@ -824,10 +823,9 @@ public class OrderedMapTest extends AbstractCairoTest {
             int geohashType = ColumnType.getGeoHashTypeWithBits(precisionBits);
 
             BytecodeAssembler asm = new BytecodeAssembler();
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-                model.col("a", ColumnType.LONG).col("b", geohashType);
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE);
+            model.col("a", ColumnType.LONG).col("b", geohashType);
+            AbstractCairoTest.create(model);
 
             try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
                 for (int i = 0; i < N; i++) {
@@ -2019,23 +2017,22 @@ public class OrderedMapTest extends AbstractCairoTest {
     }
 
     private void createTestTable(int n, Rnd rnd, TestRecord.ArrayBinarySequence binarySequence) {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-            model
-                    .col("a", ColumnType.BYTE)
-                    .col("b", ColumnType.SHORT)
-                    .col("c", ColumnType.INT)
-                    .col("d", ColumnType.LONG)
-                    .col("e", ColumnType.DATE)
-                    .col("f", ColumnType.TIMESTAMP)
-                    .col("g", ColumnType.FLOAT)
-                    .col("h", ColumnType.DOUBLE)
-                    .col("i", ColumnType.STRING)
-                    .col("j", ColumnType.SYMBOL)
-                    .col("k", ColumnType.BOOLEAN)
-                    .col("l", ColumnType.BINARY)
-                    .col("m", ColumnType.UUID);
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE);
+        model
+                .col("a", ColumnType.BYTE)
+                .col("b", ColumnType.SHORT)
+                .col("c", ColumnType.INT)
+                .col("d", ColumnType.LONG)
+                .col("e", ColumnType.DATE)
+                .col("f", ColumnType.TIMESTAMP)
+                .col("g", ColumnType.FLOAT)
+                .col("h", ColumnType.DOUBLE)
+                .col("i", ColumnType.STRING)
+                .col("j", ColumnType.SYMBOL)
+                .col("k", ColumnType.BOOLEAN)
+                .col("l", ColumnType.BINARY)
+                .col("m", ColumnType.UUID);
+        AbstractCairoTest.create(model);
 
         try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
             for (int i = 0; i < n; i++) {

--- a/core/src/test/java/io/questdb/test/cairo/map/RecordValueSinkFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/RecordValueSinkFactoryTest.java
@@ -33,7 +33,6 @@ import io.questdb.std.BytecodeAssembler;
 import io.questdb.std.Numbers;
 import io.questdb.std.Rnd;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,7 +42,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
     @Test
     public void testAllSupportedTypes() {
         SingleColumnType keyTypes = new SingleColumnType(ColumnType.INT);
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
                 .col("int", ColumnType.INT)
                 .col("short", ColumnType.SHORT)
                 .col("byte", ColumnType.BYTE)
@@ -54,10 +53,8 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
                 .col("bool", ColumnType.BOOLEAN)
                 .col("date", ColumnType.DATE)
                 .col("ts", ColumnType.TIMESTAMP)
-                .col("ipv4", ColumnType.IPv4)
-        ) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("ipv4", ColumnType.IPv4);
+        AbstractCairoTest.create(model);
 
         final int N = 1024;
         final Rnd rnd = new Rnd();
@@ -128,7 +125,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
     @Test
     public void testSubset() {
         SingleColumnType keyTypes = new SingleColumnType(ColumnType.INT);
-        try (TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "all", PartitionBy.NONE)
                 .col("int", ColumnType.INT)
                 .col("short", ColumnType.SHORT)
                 .col("byte", ColumnType.BYTE)
@@ -139,10 +136,8 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
                 .col("bool", ColumnType.BOOLEAN)
                 .col("date", ColumnType.DATE)
                 .col("ts", ColumnType.TIMESTAMP)
-                .col("IPv4", ColumnType.IPv4)
-        ) {
-            CreateTableTestUtils.create(model);
-        }
+                .col("IPv4", ColumnType.IPv4);
+        AbstractCairoTest.create(model);
 
         final int N = 1024;
         final Rnd rnd = new Rnd();

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -35,7 +35,6 @@ import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.cairo.TestFilesFacade;
@@ -59,9 +58,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
     @Before
     public void setUpInstance() {
-        try (TableModel model = new TableModel(configuration, "u", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "u", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         uTableToken = engine.verifyTableName("u");
     }
 
@@ -162,9 +160,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     @Test
     public void testBasicCharSequence() throws Exception {
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         sink.clear();
         sink.put("x");
         TableToken xTableToken = engine.verifyTableName(sink);
@@ -189,9 +186,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     @Test
     public void testClosePoolWhenReaderIsOut() throws Exception {
         assertWithPool(pool -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+            AbstractCairoTest.create(model);
 
             try (TableReader reader = pool.get(engine.verifyTableName("x"))) {
                 Assert.assertNotNull(reader);
@@ -262,9 +258,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
         final TableToken[] names = new TableToken[readerCount];
         for (int i = 0; i < readerCount; i++) {
             String name = "x" + i;
-            try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, name, PartitionBy.NONE).col("ts", ColumnType.DATE);
+            AbstractCairoTest.create(model);
             names[i] = engine.verifyTableName(name);
         }
 
@@ -315,9 +310,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
         for (int i = 0; i < readerCount; i++) {
             String name = "x" + i;
-            try (TableModel model = new TableModel(configuration, name, PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, name, PartitionBy.NONE).col("ts", ColumnType.DATE);
+            AbstractCairoTest.create(model);
 
             try (TableWriter w = newOffPoolWriter(configuration, name, metrics)) {
                 for (int k = 0; k < 10; k++) {
@@ -418,9 +412,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
     @Test
     public void testDoubleLock() throws Exception {
-        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         TableToken xyzTableToken = engine.verifyTableName("xyz");
 
         assertWithPool(pool -> {
@@ -443,9 +436,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
     @Test
     public void testGetAndCloseRace() throws Exception {
-        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         TableToken xyzTableToken = engine.verifyTableName("xyz");
 
         for (int i = 0; i < 100; i++) {
@@ -612,9 +604,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
             @Override
             public void run(ReaderPool pool) throws Exception {
-                try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                    CreateTableTestUtils.create(model);
-                }
+                TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+                AbstractCairoTest.create(model);
                 final TableToken nameX = engine.verifyTableName("x");
 
                 final int N = 10_000;
@@ -738,9 +729,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     @Test
     public void testLockRaceAgainstGet() throws Exception {
         assertWithPool(pool -> {
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+            AbstractCairoTest.create(model);
 
             TableToken xTableToken = engine.verifyTableName("x");
             for (int k = 0; k < 10; k++) {
@@ -788,14 +778,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     @Test
     public void testLockUnlock() throws Exception {
         // create tables
-
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
-
-        try (TableModel model = new TableModel(configuration, "y", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        AbstractCairoTest.create(new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE));
+        AbstractCairoTest.create(new TableModel(configuration, "y", PartitionBy.NONE).col("ts", ColumnType.DATE));
 
         assertWithPool(pool -> {
             TableReader x, y;

--- a/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
@@ -36,7 +36,6 @@ import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.cairo.TestFilesFacade;
@@ -58,9 +57,8 @@ public class WriterPoolTest extends AbstractCairoTest {
 
     @Before
     public void setUpInstance() {
-        try (TableModel model = new TableModel(configuration, "z", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "z", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
         zTableToken = engine.verifyTableName("z");
     }
 
@@ -123,9 +121,8 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testBasicCharSequence() throws Exception {
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         assertWithPool(pool -> {
             sink.clear();
@@ -198,7 +195,6 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             // check that we can't create standalone writer either
             try {
-                //noinspection resource
                 newOffPoolWriter(configuration, "z", metrics);
                 Assert.fail();
             } catch (CairoException ignored) {
@@ -270,9 +266,8 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testGetAndCloseRace() throws Exception {
 
-        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         TableToken xyzTableToken = engine.verifyTableName("xyz");
         for (int i = 0; i < 100; i++) {
@@ -324,9 +319,8 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testGetAndReleaseRace() throws Exception {
 
-        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         TableToken xyzTableName = engine.verifyTableName("xyz");
         for (int i = 0; i < 100; i++) {
@@ -396,13 +390,11 @@ public class WriterPoolTest extends AbstractCairoTest {
 
     @Test
     public void testLockUnlock() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
-        try (TableModel model = new TableModel(configuration, "y", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        model = new TableModel(configuration, "y", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         TableToken xTableToken = engine.verifyTableName("x");
         TableToken yTableToken = engine.verifyTableName("y");
@@ -470,9 +462,8 @@ public class WriterPoolTest extends AbstractCairoTest {
     @Test
     public void testLockUnlockAndReleaseRace() throws Exception {
 
-        try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "xyz", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         TableToken xyzTableToken = engine.verifyTableName("xyz");
         for (int i = 0; i < 100; i++) {
@@ -523,9 +514,8 @@ public class WriterPoolTest extends AbstractCairoTest {
 
     @Test
     public void testLockWorkflow() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("ts", ColumnType.DATE);
+        AbstractCairoTest.create(model);
 
         assertWithPool(pool -> {
             TableToken xTableToken = engine.verifyTableName("x");
@@ -654,9 +644,8 @@ public class WriterPoolTest extends AbstractCairoTest {
     public void testReplaceWriterAfterUnlock() throws Exception {
         assertWithPool(pool -> {
             String x = "x";
-            try (TableModel model = new TableModel(configuration, x, PartitionBy.NONE).col("ts", ColumnType.DATE)) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, x, PartitionBy.NONE).col("ts", ColumnType.DATE);
+            AbstractCairoTest.create(model);
 
             TableToken tableToken = engine.verifyTableName(x);
             Assert.assertEquals(WriterPool.OWNERSHIP_REASON_NONE, pool.lock(tableToken, "testing"));

--- a/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
@@ -178,12 +178,11 @@ public class TableSequencerImplTest extends AbstractCairoTest {
 
     private void runAddColumnRace(CyclicBarrier barrier, String tableName, int iterations, int readerThreads, AtomicReference<Throwable> exception, Runnable runnable) throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("int", ColumnType.INT)
                     .timestamp("ts")
-                    .wal()) {
-                createTable(model);
-            }
+                    .wal();
+            createTable(model);
             ObjList<Thread> readerThreadList = new ObjList<>();
             for (int i = 0; i < readerThreads; i++) {
                 Thread t = new Thread(runnable);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
@@ -58,7 +58,7 @@ public class WalListenerTest extends AbstractCairoTest {
     }
 
     @AfterClass
-    public static void tearDownStatic()  {
+    public static void tearDownStatic() {
         engine.setWalListener(DefaultWalListener.INSTANCE);
         if (!listener.events.isEmpty()) {
             System.err.println("Unexpected or unasserted WalListener events:");
@@ -207,13 +207,12 @@ public class WalListenerTest extends AbstractCairoTest {
     }
 
     static TableToken createTable(String tableName) {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                 .col("a", ColumnType.BYTE)
                 .col("b", ColumnType.STRING)
                 .timestamp("ts")
-                .wal()) {
-            return createTable(model);
-        }
+                .wal();
+        return createTable(model);
     }
 
     enum WalListenerEventType {

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
@@ -98,41 +98,38 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
     public void testOutOfOrderDuplicateTimestamps() throws Exception {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
-            try (
-                    TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
-                            .col("i", ColumnType.INT)
-                            .timestamp("ts")
-                            .wal()
-            ) {
-                TableToken tt = createTable(model);
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                    .col("i", ColumnType.INT)
+                    .timestamp("ts")
+                    .wal();
+            TableToken tt = createTable(model);
 
-                try (WalWriter walWriter = engine.getWalWriter(tt)) {
-                    TableWriter.Row row = walWriter.newRow(1000);
-                    row.putInt(0, 1);
-                    row.append();
-                    // second row is out-of-order
-                    row = walWriter.newRow(500);
-                    row.putInt(0, 2);
-                    row.append();
-                    // third row is in-order
-                    row = walWriter.newRow(1500);
-                    row.putInt(0, 3);
-                    row.append();
-                    // forth row is in-order with duplicate timestamp
-                    row = walWriter.newRow(1500);
-                    row.putInt(0, 4);
-                    row.append();
-                    walWriter.commit();
+            try (WalWriter walWriter = engine.getWalWriter(tt)) {
+                TableWriter.Row row = walWriter.newRow(1000);
+                row.putInt(0, 1);
+                row.append();
+                // second row is out-of-order
+                row = walWriter.newRow(500);
+                row.putInt(0, 2);
+                row.append();
+                // third row is in-order
+                row = walWriter.newRow(1500);
+                row.putInt(0, 3);
+                row.append();
+                // forth row is in-order with duplicate timestamp
+                row = walWriter.newRow(1500);
+                row.putInt(0, 4);
+                row.append();
+                walWriter.commit();
 
-                    drainWalQueue();
-                }
-
-                assertSql("i\tts\n" +
-                        "2\t1970-01-01T00:00:00.000500Z\n" +
-                        "1\t1970-01-01T00:00:00.001000Z\n" +
-                        "3\t1970-01-01T00:00:00.001500Z\n" +
-                        "4\t1970-01-01T00:00:00.001500Z\n", tableName);
+                drainWalQueue();
             }
+
+            assertSql("i\tts\n" +
+                    "2\t1970-01-01T00:00:00.000500Z\n" +
+                    "1\t1970-01-01T00:00:00.001000Z\n" +
+                    "3\t1970-01-01T00:00:00.001500Z\n" +
+                    "4\t1970-01-01T00:00:00.001500Z\n", tableName);
         });
     }
 
@@ -393,32 +390,30 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
     public void testUpdateViaWal_CopyIntoDeletedColumn() throws Exception {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.INT)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                TableToken tableToken = createTable(model);
+                    .wal();
+            TableToken tableToken = createTable(model);
 
-                try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
-                    TableWriter.Row row = walWriter.newRow(0);
-                    row.putInt(0, 10);
-                    row.append();
-                    row = walWriter.newRow(0);
-                    row.putInt(0, 11);
-                    row.append();
-                    row = walWriter.newRow(0);
-                    row.putInt(0, 12);
-                    row.append();
-                    walWriter.commit();
+            try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
+                TableWriter.Row row = walWriter.newRow(0);
+                row.putInt(0, 10);
+                row.append();
+                row = walWriter.newRow(0);
+                row.putInt(0, 11);
+                row.append();
+                row = walWriter.newRow(0);
+                row.putInt(0, 12);
+                row.append();
+                walWriter.commit();
 
-                    WalWriterTest.removeColumn(walWriter, "b");
+                WalWriterTest.removeColumn(walWriter, "b");
 
-                    assertException("UPDATE " + tableName + " SET b = a");
-                } catch (Exception e) {
-                    assertTrue(e.getMessage().endsWith("Invalid column: b"));
-                }
+                assertException("UPDATE " + tableName + " SET b = a");
+            } catch (Exception e) {
+                assertTrue(e.getMessage().endsWith("Invalid column: b"));
             }
         });
     }
@@ -427,39 +422,37 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
     public void testUpdateViaWal_CopyIntoNewColumn() throws Exception {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.INT)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                TableToken tableToken = createTable(model);
+                    .wal();
+            TableToken tableToken = createTable(model);
 
-                try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
-                    TableWriter.Row row = walWriter.newRow(0);
-                    row.putInt(0, 10);
-                    row.append();
-                    row = walWriter.newRow(0);
-                    row.putInt(0, 11);
-                    row.append();
-                    row = walWriter.newRow(0);
-                    row.putInt(0, 12);
-                    row.append();
-                    walWriter.commit();
+            try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
+                TableWriter.Row row = walWriter.newRow(0);
+                row.putInt(0, 10);
+                row.append();
+                row = walWriter.newRow(0);
+                row.putInt(0, 11);
+                row.append();
+                row = walWriter.newRow(0);
+                row.putInt(0, 12);
+                row.append();
+                walWriter.commit();
 
-                    addColumn(walWriter, "c", ColumnType.INT);
-                    drainWalQueue();
+                addColumn(walWriter, "c", ColumnType.INT);
+                drainWalQueue();
 
-                    update("UPDATE " + tableName + " SET b = a");
-                    update("UPDATE " + tableName + " SET c = a");
-                    drainWalQueue();
-                }
-
-                assertSql("a\tb\tts\tc\n" +
-                        "10\t10\t1970-01-01T00:00:00.000000Z\t10\n" +
-                        "11\t11\t1970-01-01T00:00:00.000000Z\t11\n" +
-                        "12\t12\t1970-01-01T00:00:00.000000Z\t12\n", tableName);
+                update("UPDATE " + tableName + " SET b = a");
+                update("UPDATE " + tableName + " SET c = a");
+                drainWalQueue();
             }
+
+            assertSql("a\tb\tts\tc\n" +
+                    "10\t10\t1970-01-01T00:00:00.000000Z\t10\n" +
+                    "11\t11\t1970-01-01T00:00:00.000000Z\t11\n" +
+                    "12\t12\t1970-01-01T00:00:00.000000Z\t12\n", tableName);
         });
     }
 
@@ -965,20 +958,16 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
     private TableToken createTableAndCopy(String tableName, String tableCopyName) {
         AtomicReference<TableToken> tableToken = new AtomicReference<>();
         // tableName is WAL enabled
-        try (TableModel model = createTableModel(tableName).wal()) {
-            forEachNode(node -> tableToken.set(TestUtils.create(model, node.getEngine()))
-            );
-        }
+        final TableModel model = createTableModel(tableName).wal();
+        forEachNode(node -> tableToken.set(TestUtils.create(model, node.getEngine()))
+        );
 
         // tableCopyName is not WAL enabled
-        try (TableModel model = createTableModel(tableCopyName).noWal()) {
-            createTable(model);
-        }
+        createTable(createTableModel(tableCopyName).noWal());
         return tableToken.get();
     }
 
     private TableModel createTableModel(String tableName) {
-        //noinspection resource
         return new TableModel(configuration, tableName, PartitionBy.HOUR)
                 .col("int", ColumnType.INT)
                 .col("byte", ColumnType.BYTE)

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -92,132 +92,131 @@ public class WalWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableModel model = defaultModel(tableToken.getTableName())) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableToken.getTableName());
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    Assert.assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                Assert.assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                model.col("c", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            model.col("c", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(110, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(110, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(100, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(100, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -249,105 +248,104 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableToken.getTableName())) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableToken.getTableName());
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                model.col("c", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            model.col("c", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(Integer.MIN_VALUE, record.getInt(3));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(Integer.MIN_VALUE, record.getInt(3));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                model.col("d", ColumnType.SHORT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2, 1)) {
-                    assertEquals(5, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            model.col("d", ColumnType.SHORT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2, 1)) {
+                assertEquals(5, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(100, record.getByte(0));
-                    assertEquals(1000, record.getShort(4));
-                    assertNull(record.getStr(1));
-                    assertEquals(Integer.MIN_VALUE, record.getInt(3));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(100, record.getByte(0));
+                assertEquals(1000, record.getShort(4));
+                assertNull(record.getStr(1));
+                assertEquals(Integer.MIN_VALUE, record.getInt(3));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -367,38 +365,37 @@ public class WalWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableModel model = defaultModel(tableToken.getTableName())) {
-                model.col("c", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 0)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(0, reader.size());
+            TableModel model = defaultModel(tableToken.getTableName());
+            model.col("c", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 0)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(0, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertFalse(eventCursor.hasNext());
-                }
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertFalse(eventCursor.hasNext());
+            }
 
-                model.col("d", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 0)) {
-                    assertEquals(5, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableToken.getTableName(), reader.getTableName());
-                    assertEquals(0, reader.size());
+            model.col("d", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 0)) {
+                assertEquals(5, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableToken.getTableName(), reader.getTableName());
+                assertEquals(0, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertFalse(eventCursor.hasNext());
-                }
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -424,54 +421,53 @@ public class WalWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                model.col("c", ColumnType.INT);
-                model.col("d", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
-                    assertEquals(5, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            model.col("c", ColumnType.INT);
+            model.col("d", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
+                assertEquals(5, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 0)) {
-                    assertEquals(5, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(0, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 0)) {
+                assertEquals(5, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(0, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertFalse(eventCursor.hasNext());
-                }
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -509,99 +505,98 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                model.col("c", ColumnType.INT);
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 2)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(2, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            model.col("c", ColumnType.INT);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 2)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(2, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(Integer.MIN_VALUE, record.getInt(3));
-                    assertEquals(0, record.getRowId());
-                    assertTrue(cursor.hasNext());
-                    assertEquals(100, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(Integer.MIN_VALUE, record.getInt(3));
-                    assertEquals(1, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(Integer.MIN_VALUE, record.getInt(3));
+                assertEquals(0, record.getRowId());
+                assertTrue(cursor.hasNext());
+                assertEquals(100, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(Integer.MIN_VALUE, record.getInt(3));
+                assertEquals(1, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(1, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                assertTrue(eventCursor.hasNext());
+                assertEquals(1, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(1, dataInfo.getStartRowID());
-                    assertEquals(2, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(1, dataInfo.getStartRowID());
+                assertEquals(2, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
+            }
 
-                try {
-                    engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2, 1);
-                    assertException("Segment 2 should not exist");
-                } catch (CairoException e) {
-                    assertTrue(e.getMessage().endsWith("could not open read-only [file=" + engine.getConfiguration().getRoot() +
-                            File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
-                            File.separatorChar + walName +
-                            File.separatorChar + "2" +
-                            File.separatorChar + TableUtils.META_FILE_NAME + "]"));
-                }
+            try {
+                engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2, 1);
+                assertException("Segment 2 should not exist");
+            } catch (CairoException e) {
+                assertTrue(e.getMessage().endsWith("could not open read-only [file=" + engine.getConfiguration().getRoot() +
+                        File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
+                        File.separatorChar + walName +
+                        File.separatorChar + "2" +
+                        File.separatorChar + TableUtils.META_FILE_NAME + "]"));
             }
         });
     }
@@ -622,38 +617,37 @@ public class WalWriterTest extends AbstractCairoTest {
                 addColumn(walWriter, "c", ColumnType.SYMBOL);
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(125, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(125, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -762,33 +756,32 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 3)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(3, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 3)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(3, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
 
-                    assertTrue(cursor.hasNext());
-                    assertEquals(11, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(1, record.getRowId());
+                assertTrue(cursor.hasNext());
+                assertEquals(11, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(1, record.getRowId());
 
-                    assertTrue(cursor.hasNext());
-                    assertEquals(112, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(2, record.getRowId());
+                assertTrue(cursor.hasNext());
+                assertEquals(112, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(2, record.getRowId());
 
-                    assertFalse(cursor.hasNext());
-                    assertColumnMetadata(model, reader);
-                }
+                assertFalse(cursor.hasNext());
+                assertColumnMetadata(model, reader);
             }
 
             try (Path path = new Path().of(configuration.getRoot())) {
@@ -840,99 +833,98 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 44)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(44, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 44)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(44, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(44, i);
-
-                    assertColumnMetadata(model, reader);
-
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(18, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(1, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(18, dataInfo.getStartRowID());
-                    assertEquals(24, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(2, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(24, dataInfo.getStartRowID());
-                    assertEquals(44, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 7)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(7, reader.size());
+                assertEquals(44, i);
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i, record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(7, i);
+                assertColumnMetadata(model, reader);
 
-                    assertColumnMetadata(model, reader);
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(18, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(7, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                assertTrue(eventCursor.hasNext());
+                assertEquals(1, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    assertFalse(eventCursor.hasNext());
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(18, dataInfo.getStartRowID());
+                assertEquals(24, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertTrue(eventCursor.hasNext());
+                assertEquals(2, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(24, dataInfo.getStartRowID());
+                assertEquals(44, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 7)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(7, reader.size());
+
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i, record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
+                assertEquals(7, i);
+
+                assertColumnMetadata(model, reader);
+
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(7, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -1006,74 +998,73 @@ public class WalWriterTest extends AbstractCairoTest {
             final LongHashSet txnSet = new LongHashSet(numOfThreads);
             final IntList symbolCounts = new IntList();
             symbolCounts.add(numOfRows);
-            try (TableModel model = defaultModel(tableName)) {
-                for (Map.Entry<Integer, AtomicInteger> counterEntry : counters.entrySet()) {
-                    final int walId = counterEntry.getKey();
-                    final int count = counterEntry.getValue().get();
-                    final String walName = WAL_NAME_BASE + walId;
+            TableModel model = defaultModel(tableName);
+            for (Map.Entry<Integer, AtomicInteger> counterEntry : counters.entrySet()) {
+                final int walId = counterEntry.getKey();
+                final int count = counterEntry.getValue().get();
+                final String walName = WAL_NAME_BASE + walId;
 
-                    for (int i = 0; i < count; i++) {
-                        try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2 * i, numOfRows)) {
-                            assertEquals(3, reader.getRealColumnCount());
-                            assertEquals(walName, reader.getWalName());
-                            assertEquals(tableName, reader.getTableName());
-                            assertEquals(numOfRows, reader.size());
+                for (int i = 0; i < count; i++) {
+                    try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2 * i, numOfRows)) {
+                        assertEquals(3, reader.getRealColumnCount());
+                        assertEquals(walName, reader.getWalName());
+                        assertEquals(tableName, reader.getTableName());
+                        assertEquals(numOfRows, reader.size());
 
-                            final RecordCursor cursor = reader.getDataCursor();
-                            final Record record = cursor.getRecord();
-                            int n = 0;
-                            while (cursor.hasNext()) {
-                                assertEquals(1, record.getByte(0));
-                                assertEquals("test" + n, record.getStr(1).toString());
-                                assertEquals(n, record.getRowId());
-                                n++;
-                            }
-                            assertEquals(numOfRows, n);
-
-                            assertColumnMetadata(model, reader);
-
-                            final WalEventCursor eventCursor = reader.getEventCursor();
-                            assertTrue(eventCursor.hasNext());
-                            assertEquals(WalTxnType.DATA, eventCursor.getType());
-                            txnSet.add(Numbers.encodeLowHighInts(walId * 10 + i, (int) eventCursor.getTxn()));
-
-                            final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                            assertEquals(0, dataInfo.getStartRowID());
-                            assertEquals(numOfRows, dataInfo.getEndRowID());
-                            assertEquals(0, dataInfo.getMinTimestamp());
-                            assertEquals(0, dataInfo.getMaxTimestamp());
-                            assertFalse(dataInfo.isOutOfOrder());
-
-                            assertNull(dataInfo.nextSymbolMapDiff());
-
-                            assertFalse(eventCursor.hasNext());
+                        final RecordCursor cursor = reader.getDataCursor();
+                        final Record record = cursor.getRecord();
+                        int n = 0;
+                        while (cursor.hasNext()) {
+                            assertEquals(1, record.getByte(0));
+                            assertEquals("test" + n, record.getStr(1).toString());
+                            assertEquals(n, record.getRowId());
+                            n++;
                         }
+                        assertEquals(numOfRows, n);
 
-                        try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2 * i + 1, 0)) {
-                            assertEquals(3, reader.getRealColumnCount());
-                            assertEquals(walName, reader.getWalName());
-                            assertEquals(tableName, reader.getTableName());
-                            assertEquals(0, reader.size());
+                        assertColumnMetadata(model, reader);
 
-                            final RecordCursor cursor = reader.getDataCursor();
-                            assertFalse(cursor.hasNext());
+                        final WalEventCursor eventCursor = reader.getEventCursor();
+                        assertTrue(eventCursor.hasNext());
+                        assertEquals(WalTxnType.DATA, eventCursor.getType());
+                        txnSet.add(Numbers.encodeLowHighInts(walId * 10 + i, (int) eventCursor.getTxn()));
 
-                            assertColumnMetadata(model, reader);
+                        final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                        assertEquals(0, dataInfo.getStartRowID());
+                        assertEquals(numOfRows, dataInfo.getEndRowID());
+                        assertEquals(0, dataInfo.getMinTimestamp());
+                        assertEquals(0, dataInfo.getMaxTimestamp());
+                        assertFalse(dataInfo.isOutOfOrder());
 
-                            final WalEventCursor eventCursor = reader.getEventCursor();
-                            assertFalse(eventCursor.hasNext());
-                        }
+                        assertNull(dataInfo.nextSymbolMapDiff());
 
-                        try (Path path = new Path().of(configuration.getRoot())) {
-                            assertWalFileExist(path, tableToken, walName, 0, "_meta");
-                            assertWalFileExist(path, tableToken, walName, 0, "_event");
-                            assertWalFileExist(path, tableToken, walName, 0, "a.d");
-                            assertWalFileExist(path, tableToken, walName, 0, "b.d");
-                            assertWalFileExist(path, tableToken, walName, 1, "_meta");
-                            assertWalFileExist(path, tableToken, walName, 1, "_event");
-                            assertWalFileExist(path, tableToken, walName, 1, "a.d");
-                            assertWalFileExist(path, tableToken, walName, 1, "b.d");
-                        }
+                        assertFalse(eventCursor.hasNext());
+                    }
+
+                    try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 2 * i + 1, 0)) {
+                        assertEquals(3, reader.getRealColumnCount());
+                        assertEquals(walName, reader.getWalName());
+                        assertEquals(tableName, reader.getTableName());
+                        assertEquals(0, reader.size());
+
+                        final RecordCursor cursor = reader.getDataCursor();
+                        assertFalse(cursor.hasNext());
+
+                        assertColumnMetadata(model, reader);
+
+                        final WalEventCursor eventCursor = reader.getEventCursor();
+                        assertFalse(eventCursor.hasNext());
+                    }
+
+                    try (Path path = new Path().of(configuration.getRoot())) {
+                        assertWalFileExist(path, tableToken, walName, 0, "_meta");
+                        assertWalFileExist(path, tableToken, walName, 0, "_event");
+                        assertWalFileExist(path, tableToken, walName, 0, "a.d");
+                        assertWalFileExist(path, tableToken, walName, 0, "b.d");
+                        assertWalFileExist(path, tableToken, walName, 1, "_meta");
+                        assertWalFileExist(path, tableToken, walName, 1, "_event");
+                        assertWalFileExist(path, tableToken, walName, 1, "a.d");
+                        assertWalFileExist(path, tableToken, walName, 1, "b.d");
                     }
                 }
             }
@@ -1087,14 +1078,12 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = "testTable";
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             final int numOfRows = 4000;
             final int maxRowCount = 500;
@@ -1153,71 +1142,69 @@ public class WalWriterTest extends AbstractCairoTest {
             final LongHashSet txnSet = new LongHashSet(numOfTxn);
             final IntList symbolCounts = new IntList();
             symbolCounts.add(numOfRows);
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                for (Map.Entry<Integer, AtomicInteger> counterEntry : counters.entrySet()) {
-                    final int walId = counterEntry.getKey();
-                    final int count = counterEntry.getValue().get();
-                    final String walName = WAL_NAME_BASE + walId;
+                    .wal();
+            for (Map.Entry<Integer, AtomicInteger> counterEntry : counters.entrySet()) {
+                final int walId = counterEntry.getKey();
+                final int count = counterEntry.getValue().get();
+                final String walName = WAL_NAME_BASE + walId;
 
-                    for (int segmentId = 0; segmentId < count * numOfSegments; segmentId++) {
-                        try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, segmentId, maxRowCount)) {
-                            assertEquals(3, reader.getColumnCount());
-                            assertEquals(walName, reader.getWalName());
-                            assertEquals(tableName, reader.getTableName());
-                            assertEquals(maxRowCount, reader.size());
+                for (int segmentId = 0; segmentId < count * numOfSegments; segmentId++) {
+                    try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, segmentId, maxRowCount)) {
+                        assertEquals(3, reader.getColumnCount());
+                        assertEquals(walName, reader.getWalName());
+                        assertEquals(tableName, reader.getTableName());
+                        assertEquals(maxRowCount, reader.size());
 
-                            final RecordCursor cursor = reader.getDataCursor();
-                            final Record record = cursor.getRecord();
-                            int n = 0;
-                            while (cursor.hasNext()) {
-                                assertEquals((segmentId % numOfSegments) * maxRowCount + n, record.getInt(0));
-                                assertEquals(n, record.getInt(1)); // New symbol value every row
-                                assertEquals("test" + ((segmentId % numOfSegments) * maxRowCount + n), record.getSym(1));
-                                assertEquals(n, record.getRowId());
-                                n++;
-                            }
-                            assertEquals(maxRowCount, n);
-
-                            assertColumnMetadata(model, reader);
-
-                            final WalEventCursor eventCursor = reader.getEventCursor();
-                            assertTrue(eventCursor.hasNext());
-                            assertEquals(WalTxnType.DATA, eventCursor.getType());
-                            txnSet.add(Numbers.encodeLowHighInts(walId, segmentId * 1000 + (int) eventCursor.getTxn()));
-
-                            final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                            assertEquals(0, dataInfo.getStartRowID());
-                            assertEquals(maxRowCount, dataInfo.getEndRowID());
-                            assertEquals(0, dataInfo.getMinTimestamp());
-                            assertEquals(0, dataInfo.getMaxTimestamp());
-                            assertFalse(dataInfo.isOutOfOrder());
-
-                            final SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
-                            assertEquals(1, symbolMapDiff.getColumnIndex());
-                            int expectedKey = 0;
-                            SymbolMapDiffEntry entry;
-                            while ((entry = symbolMapDiff.nextEntry()) != null) {
-                                assertEquals("test" + ((segmentId % numOfSegments) * maxRowCount + expectedKey), entry.getSymbol().toString());
-                                expectedKey++;
-                            }
-                            assertEquals(maxRowCount, expectedKey);
-                            assertNull(dataInfo.nextSymbolMapDiff());
-
-                            assertFalse(eventCursor.hasNext());
+                        final RecordCursor cursor = reader.getDataCursor();
+                        final Record record = cursor.getRecord();
+                        int n = 0;
+                        while (cursor.hasNext()) {
+                            assertEquals((segmentId % numOfSegments) * maxRowCount + n, record.getInt(0));
+                            assertEquals(n, record.getInt(1)); // New symbol value every row
+                            assertEquals("test" + ((segmentId % numOfSegments) * maxRowCount + n), record.getSym(1));
+                            assertEquals(n, record.getRowId());
+                            n++;
                         }
+                        assertEquals(maxRowCount, n);
 
-                        try (Path path = new Path().of(configuration.getRoot())) {
-                            assertWalFileExist(path, tableToken, walName, segmentId, "_meta");
-                            assertWalFileExist(path, tableToken, walName, segmentId, "_event");
-                            assertWalFileExist(path, tableToken, walName, segmentId, "a.d");
-                            assertWalFileExist(path, tableToken, walName, segmentId, "b.d");
-                            assertWalFileExist(path, tableToken, walName, segmentId, "ts.d");
+                        assertColumnMetadata(model, reader);
+
+                        final WalEventCursor eventCursor = reader.getEventCursor();
+                        assertTrue(eventCursor.hasNext());
+                        assertEquals(WalTxnType.DATA, eventCursor.getType());
+                        txnSet.add(Numbers.encodeLowHighInts(walId, segmentId * 1000 + (int) eventCursor.getTxn()));
+
+                        final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                        assertEquals(0, dataInfo.getStartRowID());
+                        assertEquals(maxRowCount, dataInfo.getEndRowID());
+                        assertEquals(0, dataInfo.getMinTimestamp());
+                        assertEquals(0, dataInfo.getMaxTimestamp());
+                        assertFalse(dataInfo.isOutOfOrder());
+
+                        final SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
+                        assertEquals(1, symbolMapDiff.getColumnIndex());
+                        int expectedKey = 0;
+                        SymbolMapDiffEntry entry;
+                        while ((entry = symbolMapDiff.nextEntry()) != null) {
+                            assertEquals("test" + ((segmentId % numOfSegments) * maxRowCount + expectedKey), entry.getSymbol().toString());
+                            expectedKey++;
                         }
+                        assertEquals(maxRowCount, expectedKey);
+                        assertNull(dataInfo.nextSymbolMapDiff());
+
+                        assertFalse(eventCursor.hasNext());
+                    }
+
+                    try (Path path = new Path().of(configuration.getRoot())) {
+                        assertWalFileExist(path, tableToken, walName, segmentId, "_meta");
+                        assertWalFileExist(path, tableToken, walName, segmentId, "_event");
+                        assertWalFileExist(path, tableToken, walName, segmentId, "a.d");
+                        assertWalFileExist(path, tableToken, walName, segmentId, "b.d");
+                        assertWalFileExist(path, tableToken, walName, segmentId, "ts.d");
                     }
                 }
             }
@@ -1335,13 +1322,11 @@ public class WalWriterTest extends AbstractCairoTest {
             String tableName = testName.getMethodName();
             TableToken tableToken;
             // Schema with 8 columns, 8 bytes each = 64 bytes per row
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
                     .timestamp("ts")
                     .col("a", ColumnType.LONG)
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
                 final RowInserter ins = new RowInserter() {
@@ -1551,7 +1536,7 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = "testTableAllTypes";
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("int", ColumnType.INT)
                     .col("byte", ColumnType.BYTE)
                     .col("long", ColumnType.LONG)
@@ -1584,10 +1569,8 @@ public class WalWriterTest extends AbstractCairoTest {
                     .col("uuidb", ColumnType.UUID) // putUUID(int columnIndex, CharSequence value)
                     .col("IPv4", ColumnType.IPv4)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             final int rowsToInsertTotal = 100;
             final long pointer = Unsafe.getUnsafe().allocateMemory(rowsToInsertTotal);
@@ -1799,137 +1782,134 @@ public class WalWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
-
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
-
-                    assertColumnMetadata(model, reader);
-
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
+
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
+
+                assertColumnMetadata(model, reader);
+
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
+            }
+            model = new TableModel(configuration, tableName, PartitionBy.NONE)
                     .col("a", ColumnType.BYTE)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(2, reader.getRealColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                    .wal();
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(2, reader.getRealColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(110, record.getByte(0));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(110, record.getByte(0));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(2, reader.getRealColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(2, reader.getRealColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(100, record.getByte(0));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(100, record.getByte(0));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -1950,49 +1930,48 @@ public class WalWriterTest extends AbstractCairoTest {
                 removeColumn(walWriter, "a");
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
+            }
 
-                try {
-                    engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 0);
-                    assertException("Segment 1 should not exist");
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not open read-only [file=" + engine.getConfiguration().getRoot() +
-                            File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
-                            File.separatorChar + walName +
-                            File.separatorChar + "1" +
-                            File.separatorChar + TableUtils.META_FILE_NAME + "]");
-                }
+            try {
+                engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 0);
+                assertException("Segment 1 should not exist");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "could not open read-only [file=" + engine.getConfiguration().getRoot() +
+                        File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
+                        File.separatorChar + walName +
+                        File.separatorChar + "1" +
+                        File.separatorChar + TableUtils.META_FILE_NAME + "]");
             }
         });
     }
@@ -2024,54 +2003,53 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 2)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(2, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 2)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(2, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(1, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(1, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(1, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                assertTrue(eventCursor.hasNext());
+                assertEquals(1, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(1, dataInfo.getStartRowID());
-                    assertEquals(2, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(1, dataInfo.getStartRowID());
+                assertEquals(2, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -2081,15 +2059,13 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
                     .col("c", ColumnType.SYMBOL)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             final String walName;
             try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
@@ -2121,104 +2097,100 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
+            model = new TableModel(configuration, tableName, PartitionBy.NONE)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
                     .col("c", ColumnType.SYMBOL)
-                    .timestamp("ts")
-            ) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                    .timestamp("ts");
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 1)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(12, record.getInt(0));
-                    assertEquals("symb", record.getSym(1));
-                    assertEquals("symc", record.getSym(2));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(12, record.getInt(0));
+                assertEquals("symb", record.getSym(1));
+                assertEquals("symc", record.getSym(2));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
 
-                    SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
-                    assertEquals(1, symbolMapDiff.getColumnIndex());
-                    int expectedKey = 0;
-                    SymbolMapDiffEntry entry;
-                    while ((entry = symbolMapDiff.nextEntry()) != null) {
-                        assertEquals(expectedKey, entry.getKey());
-                        assertEquals("symb", entry.getSymbol().toString());
-                        expectedKey++;
-                    }
-                    assertEquals(1, expectedKey);
-                    symbolMapDiff = dataInfo.nextSymbolMapDiff();
-                    assertEquals(2, symbolMapDiff.getColumnIndex());
-                    expectedKey = 0;
-                    while ((entry = symbolMapDiff.nextEntry()) != null) {
-                        assertEquals(expectedKey, entry.getKey());
-                        assertEquals("symc", entry.getSymbol().toString());
-                        expectedKey++;
-                    }
-                    assertEquals(1, expectedKey);
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
+                SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
+                assertEquals(1, symbolMapDiff.getColumnIndex());
+                int expectedKey = 0;
+                SymbolMapDiffEntry entry;
+                while ((entry = symbolMapDiff.nextEntry()) != null) {
+                    assertEquals(expectedKey, entry.getKey());
+                    assertEquals("symb", entry.getSymbol().toString());
+                    expectedKey++;
                 }
+                assertEquals(1, expectedKey);
+                symbolMapDiff = dataInfo.nextSymbolMapDiff();
+                assertEquals(2, symbolMapDiff.getColumnIndex());
+                expectedKey = 0;
+                while ((entry = symbolMapDiff.nextEntry()) != null) {
+                    assertEquals(expectedKey, entry.getKey());
+                    assertEquals("symc", entry.getSymbol().toString());
+                    expectedKey++;
+                }
+                assertEquals(1, expectedKey);
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
             }
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
+            model = new TableModel(configuration, tableName, PartitionBy.NONE)
                     .col("a", ColumnType.INT)
                     .col("c", ColumnType.SYMBOL)
-                    .timestamp("ts")
-            ) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
-                    assertEquals(4, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                    .timestamp("ts");
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
+                assertEquals(4, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(133, record.getInt(0));
-                    assertEquals("Таке-Сяке", record.getSym(2));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(133, record.getInt(0));
+                assertEquals("Таке-Сяке", record.getSym(2));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
-                    assertEquals(1, symbolMapDiff.getSize());
-                    assertEquals(2, symbolMapDiff.getColumnIndex());
-                    assertEquals(0, symbolMapDiff.getCleanSymbolCount());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                SymbolMapDiff symbolMapDiff = dataInfo.nextSymbolMapDiff();
+                assertEquals(1, symbolMapDiff.getSize());
+                assertEquals(2, symbolMapDiff.getColumnIndex());
+                assertEquals(0, symbolMapDiff.getCleanSymbolCount());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -2260,138 +2232,135 @@ public class WalWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
-
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(10, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
-
-                    assertColumnMetadata(model, reader);
-
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 0, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
+
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(10, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
+
+                assertColumnMetadata(model, reader);
+
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
+            }
+            model = new TableModel(configuration, tableName, PartitionBy.NONE)
                     .col("a", ColumnType.BYTE)
                     .col("c", ColumnType.STRING)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName1, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                    .wal();
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName1, 1, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName1, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(110, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(110, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName2, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName2, 1, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName2, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(100, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(100, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -2425,71 +2394,70 @@ public class WalWriterTest extends AbstractCairoTest {
                 assertEquals(1, walWriter.getSegmentRowCount());
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 2)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(2, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 0, 2)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(2, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(1, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertTrue(cursor.hasNext());
-                    assertEquals(11, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(1, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(1, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertTrue(cursor.hasNext());
+                assertEquals(11, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(1, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(2, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(2, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
 
-                    assertFalse(eventCursor.hasNext());
-                }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(walName, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(1, reader.size());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 1)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(walName, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(1, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    assertTrue(cursor.hasNext());
-                    assertEquals(112, record.getByte(0));
-                    assertNull(record.getStr(1));
-                    assertEquals(0, record.getRowId());
-                    assertFalse(cursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                assertTrue(cursor.hasNext());
+                assertEquals(112, record.getByte(0));
+                assertNull(record.getStr(1));
+                assertEquals(0, record.getRowId());
+                assertFalse(cursor.hasNext());
 
-                    assertColumnMetadata(model, reader);
+                assertColumnMetadata(model, reader);
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(1, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(1, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
 
-                    assertFalse(eventCursor.hasNext());
-                }
+                assertFalse(eventCursor.hasNext());
             }
 
             try (Path path = new Path().of(configuration.getRoot())) {
@@ -2512,13 +2480,11 @@ public class WalWriterTest extends AbstractCairoTest {
             assertMemoryLeak(() -> {
                 final String tableName = testName.getMethodName();
                 final TableToken tableToken;
-                try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
                         .col("a", colType)
                         .timestamp("ts")
-                        .wal()
-                ) {
-                    tableToken = createTable(model);
-                }
+                        .wal();
+                tableToken = createTable(model);
 
                 final long rolloverSize = 1024;
                 // 1 KiB
@@ -2709,191 +2675,190 @@ public class WalWriterTest extends AbstractCairoTest {
                 walWriter.commit();
             }
 
-            try (TableModel model = defaultModel(tableName)) {
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal1Name, 0, 44)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(wal1Name, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(44, reader.size());
+            TableModel model = defaultModel(tableName);
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal1Name, 0, 44)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(wal1Name, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(44, reader.size());
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(44, i);
-
-                    assertColumnMetadata(model, reader);
-
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(18, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(1, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(18, dataInfo.getStartRowID());
-                    assertEquals(24, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(2, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(24, dataInfo.getStartRowID());
-                    assertEquals(44, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal1Name, 1, 7)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(wal1Name, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(7, reader.size());
+                assertEquals(44, i);
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i, record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(7, i);
+                assertColumnMetadata(model, reader);
 
-                    assertColumnMetadata(model, reader);
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(18, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(7, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                assertTrue(eventCursor.hasNext());
+                assertEquals(1, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    assertFalse(eventCursor.hasNext());
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(18, dataInfo.getStartRowID());
+                assertEquals(24, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertTrue(eventCursor.hasNext());
+                assertEquals(2, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(24, dataInfo.getStartRowID());
+                assertEquals(44, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal1Name, 1, 7)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(wal1Name, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(7, reader.size());
+
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i, record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal2Name, 0, 34)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(wal2Name, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(34, reader.size());
+                assertEquals(7, i);
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(34, i);
+                assertColumnMetadata(model, reader);
 
-                    assertColumnMetadata(model, reader);
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(7, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(18, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal2Name, 0, 34)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(wal2Name, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(34, reader.size());
 
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(1, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(18, dataInfo.getStartRowID());
-                    assertEquals(24, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(2, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
-
-                    dataInfo = eventCursor.getDataInfo();
-                    assertEquals(24, dataInfo.getStartRowID());
-                    assertEquals(34, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
-
-                    assertFalse(eventCursor.hasNext());
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i > 23 ? i - 24 : (i > 17 ? i - 18 : i), record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
-                try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal2Name, 1, 7)) {
-                    assertEquals(3, reader.getColumnCount());
-                    assertEquals(wal2Name, reader.getWalName());
-                    assertEquals(tableName, reader.getTableName());
-                    assertEquals(7, reader.size());
+                assertEquals(34, i);
 
-                    final RecordCursor cursor = reader.getDataCursor();
-                    final Record record = cursor.getRecord();
-                    int i = 0;
-                    while (cursor.hasNext()) {
-                        assertEquals(i, record.getByte(0));
-                        assertNull(record.getStr(1));
-                        assertEquals(i, record.getRowId());
-                        i++;
-                    }
-                    assertEquals(7, i);
+                assertColumnMetadata(model, reader);
 
-                    assertColumnMetadata(model, reader);
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    final WalEventCursor eventCursor = reader.getEventCursor();
-                    assertTrue(eventCursor.hasNext());
-                    assertEquals(0, eventCursor.getTxn());
-                    assertEquals(WalTxnType.DATA, eventCursor.getType());
+                WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(18, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
 
-                    final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
-                    assertEquals(0, dataInfo.getStartRowID());
-                    assertEquals(7, dataInfo.getEndRowID());
-                    assertEquals(0, dataInfo.getMinTimestamp());
-                    assertEquals(0, dataInfo.getMaxTimestamp());
-                    assertFalse(dataInfo.isOutOfOrder());
-                    assertNull(dataInfo.nextSymbolMapDiff());
+                assertTrue(eventCursor.hasNext());
+                assertEquals(1, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
 
-                    assertFalse(eventCursor.hasNext());
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(18, dataInfo.getStartRowID());
+                assertEquals(24, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertTrue(eventCursor.hasNext());
+                assertEquals(2, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                dataInfo = eventCursor.getDataInfo();
+                assertEquals(24, dataInfo.getStartRowID());
+                assertEquals(34, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
+            }
+            try (WalReader reader = engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, wal2Name, 1, 7)) {
+                assertEquals(3, reader.getColumnCount());
+                assertEquals(wal2Name, reader.getWalName());
+                assertEquals(tableName, reader.getTableName());
+                assertEquals(7, reader.size());
+
+                final RecordCursor cursor = reader.getDataCursor();
+                final Record record = cursor.getRecord();
+                int i = 0;
+                while (cursor.hasNext()) {
+                    assertEquals(i, record.getByte(0));
+                    assertNull(record.getStr(1));
+                    assertEquals(i, record.getRowId());
+                    i++;
                 }
+                assertEquals(7, i);
+
+                assertColumnMetadata(model, reader);
+
+                final WalEventCursor eventCursor = reader.getEventCursor();
+                assertTrue(eventCursor.hasNext());
+                assertEquals(0, eventCursor.getTxn());
+                assertEquals(WalTxnType.DATA, eventCursor.getType());
+
+                final WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
+                assertEquals(0, dataInfo.getStartRowID());
+                assertEquals(7, dataInfo.getEndRowID());
+                assertEquals(0, dataInfo.getMinTimestamp());
+                assertEquals(0, dataInfo.getMaxTimestamp());
+                assertFalse(dataInfo.isOutOfOrder());
+                assertNull(dataInfo.nextSymbolMapDiff());
+
+                assertFalse(eventCursor.hasNext());
             }
         });
     }
@@ -2903,16 +2868,14 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = "testSymTable";
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
                     .col("a", ColumnType.BYTE)
                     .col("b", ColumnType.SYMBOL)
                     .col("c", ColumnType.SYMBOL)
                     .col("d", ColumnType.SYMBOL)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             try (TableWriter tableWriter = getWriter(tableToken)) {
                 for (int i = 0; i < 5; i++) {
@@ -3117,14 +3080,12 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(ff, () -> {
             final String tableName = testName.getMethodName();
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             WalWriter walWriter = engine.getWalWriter(tableToken);
             TableWriter.Row row = walWriter.newRow(0);
@@ -3152,13 +3113,11 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = "testWalSegmentInit";
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
                     .col("a", ColumnType.BYTE)
                     .timestamp("ts")
-                    .wal()
-            ) {
-                tableToken = createTable(model);
-            }
+                    .wal();
+            tableToken = createTable(model);
 
             assertTableExistence(true, tableToken);
 
@@ -3213,13 +3172,11 @@ public class WalWriterTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                     .col("a", ColumnType.INT)
                     .col("b", ColumnType.SYMBOL)
-                    .timestamp("ts") // not a WAL table
-            ) {
-                tableToken = createTable(model);
-            }
+                    .timestamp("ts"); // not a WAL table
+            tableToken = createTable(model);
             try (WalWriter ignored = engine.getWalWriter(tableToken)) {
                 Assert.fail();
             } catch (CairoException e) {
@@ -3235,7 +3192,6 @@ public class WalWriterTest extends AbstractCairoTest {
                 : path.concat(tableName).slash().concat(walName).slash().put(segment).slash().concat(fileName).$();
     }
 
-    @SuppressWarnings("resource")
     private static TableModel defaultModel(String tableName) {
         return new TableModel(configuration, tableName, PartitionBy.HOUR)
                 .col("a", ColumnType.BYTE)
@@ -3332,9 +3288,8 @@ public class WalWriterTest extends AbstractCairoTest {
                 assertEquals(2, ((WalDataRecord) record).getDesignatedTimestampRowId(2));
                 assertFalse(cursor.hasNext());
 
-                try (TableModel model = defaultModel(tableName)) {
-                    assertColumnMetadata(model, reader);
-                }
+                TableModel model = defaultModel(tableName);
+                assertColumnMetadata(model, reader);
 
                 final WalEventCursor eventCursor = reader.getEventCursor();
                 assertTrue(eventCursor.hasNext());
@@ -3373,15 +3328,11 @@ public class WalWriterTest extends AbstractCairoTest {
     }
 
     static TableToken createTable(String tableName) {
-        try (TableModel model = defaultModel(tableName)) {
-            return createTable(model);
-        }
+        return createTable(defaultModel(tableName));
     }
 
     static TableToken createTable() {
-        try (TableModel model = defaultModel("testTable")) {
-            return createTable(model);
-        }
+        return createTable(defaultModel("testTable"));
     }
 
     static void prepareBinPayload(long pointer, int limit) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
@@ -40,7 +40,6 @@ import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -52,7 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DispatcherWriterQueueTest extends AbstractCairoTest {
-    private static final String UTF_8 = "UTF-8";
     @Rule
     public Timeout timeout = Timeout.builder()
             .withTimeout(10 * 60 * 1000, TimeUnit.MILLISECONDS)
@@ -270,41 +268,6 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 "alter+table+<x>+drop+column+s");
     }
 
-    @Ignore// update statements don't time out anymore but can be cancelled manually
-    @Test
-    public void testRestUpdateTimeout() throws Exception {
-        HttpQueryTestBuilder queryTestBuilder = new HttpQueryTestBuilder()
-                .withTempFolder(root)
-                .withWorkerCount(1)
-                .withHttpServerConfigBuilder(
-                        new HttpServerConfigurationBuilder().withReceiveBufferSize(50)
-                )
-                .withAlterTableStartWaitTimeout(30_000)
-                .withFilesFacade(new TestFilesFacadeImpl() {
-                    @Override
-                    public int openRW(LPSZ name, long opts) {
-                        if (Utf8s.endsWithAscii(name, "x.d.1")) {
-                            Os.sleep(50);
-                        }
-                        return super.openRW(name, opts);
-                    }
-                });
-
-        runUpdateOnBusyTable((writer, rdr) -> {
-                    // Test no resources leak, update can go through or not, it is not deterministic
-                },
-                writer -> {
-                },
-                1,
-                queryTestBuilder,
-                null,
-                null,
-                1,
-                3,
-                URLEncoder.encode("update x set x=1 from tables() where s = 'a'", UTF_8)
-        );
-    }
-
     @Test
     public void testUpdateBusyTable() throws Exception {
         HttpQueryTestBuilder queryTestBuilder = new HttpQueryTestBuilder()
@@ -338,8 +301,8 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 null,
                 -1L,
                 3,
-                URLEncoder.encode("update x set x=1 where s = 'a'", UTF_8),
-                URLEncoder.encode("update x set x=10 where s = 'b'", UTF_8)
+                URLEncoder.encode("update x set x=1 where s = 'a'", StandardCharsets.UTF_8),
+                URLEncoder.encode("update x set x=10 where s = 'b'", StandardCharsets.UTF_8)
         );
     }
 
@@ -375,7 +338,7 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 null,
                 1000,
                 0,
-                URLEncoder.encode("update x set x=1 from tables()", UTF_8)
+                URLEncoder.encode("update x set x=1 from tables()", StandardCharsets.UTF_8)
         );
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
@@ -40,6 +40,7 @@ import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -51,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DispatcherWriterQueueTest extends AbstractCairoTest {
+    private static final String UTF_8 = "UTF-8";
     @Rule
     public Timeout timeout = Timeout.builder()
             .withTimeout(10 * 60 * 1000, TimeUnit.MILLISECONDS)
@@ -268,6 +270,41 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 "alter+table+<x>+drop+column+s");
     }
 
+    @Ignore// update statements don't time out anymore but can be cancelled manually
+    @Test
+    public void testRestUpdateTimeout() throws Exception {
+        HttpQueryTestBuilder queryTestBuilder = new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(
+                        new HttpServerConfigurationBuilder().withReceiveBufferSize(50)
+                )
+                .withAlterTableStartWaitTimeout(30_000)
+                .withFilesFacade(new TestFilesFacadeImpl() {
+                    @Override
+                    public int openRW(LPSZ name, long opts) {
+                        if (Utf8s.endsWithAscii(name, "x.d.1")) {
+                            Os.sleep(50);
+                        }
+                        return super.openRW(name, opts);
+                    }
+                });
+
+        runUpdateOnBusyTable((writer, rdr) -> {
+                    // Test no resources leak, update can go through or not, it is not deterministic
+                },
+                writer -> {
+                },
+                1,
+                queryTestBuilder,
+                null,
+                null,
+                1,
+                3,
+                URLEncoder.encode("update x set x=1 from tables() where s = 'a'", UTF_8)
+        );
+    }
+
     @Test
     public void testUpdateBusyTable() throws Exception {
         HttpQueryTestBuilder queryTestBuilder = new HttpQueryTestBuilder()
@@ -301,8 +338,8 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 null,
                 -1L,
                 3,
-                URLEncoder.encode("update x set x=1 where s = 'a'", StandardCharsets.UTF_8),
-                URLEncoder.encode("update x set x=10 where s = 'b'", StandardCharsets.UTF_8)
+                URLEncoder.encode("update x set x=1 where s = 'a'", UTF_8),
+                URLEncoder.encode("update x set x=10 where s = 'b'", UTF_8)
         );
     }
 
@@ -338,7 +375,7 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
                 null,
                 1000,
                 0,
-                URLEncoder.encode("update x set x=1 from tables()", StandardCharsets.UTF_8)
+                URLEncoder.encode("update x set x=1 from tables()", UTF_8)
         );
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -8194,10 +8194,9 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     private static void createTestTable(CairoEngine engine) {
-        try (TableModel model = new TableModel(engine.getConfiguration(), "y", PartitionBy.NONE)) {
-            model.col("j", ColumnType.SYMBOL);
-            TestUtils.create(model, engine);
-        }
+        TableModel model = new TableModel(engine.getConfiguration(), "y", PartitionBy.NONE);
+        model.col("j", ColumnType.SYMBOL);
+        TestUtils.create(model, engine);
 
         try (TableWriter writer = TestUtils.newOffPoolWriter(engine.getConfiguration(), engine.verifyTableName("y"))) {
             for (int i = 0; i < 20; i++) {
@@ -8523,11 +8522,10 @@ public class IODispatcherTest extends AbstractTest {
                 false,
                 1,
                 engine -> {
-                    try (TableModel model = new TableModel(configuration, tableName, partitionBy)
+                    TableModel model = new TableModel(configuration, tableName, partitionBy)
                             .timestamp("ts")
-                            .col("int", ColumnType.INT)) {
-                        TestUtils.create(model, engine);
-                    }
+                            .col("int", ColumnType.INT);
+                    TestUtils.create(model, engine);
                 }
         );
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -2709,6 +2709,38 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testInvalidRequestIsHandled() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(2)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((engine) -> {
+                    final String request = " /query?query=drop%20table%20x HTTP/1.1\r\n" +
+                            "Host: localhost:9001\r\n" +
+                            "Connection: keep-alive\r\n" +
+                            "Cache-Control: max-age=0\r\n" +
+                            "Upgrade-Insecure-Requests: 1\r\n" +
+                            "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36\r\n" +
+                            "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3\r\n" +
+                            "Accept-Encoding: gzip, deflate, br\r\n" +
+                            "Accept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\n" +
+                            "\r\n";
+                    new SendAndReceiveRequestBuilder().execute(request,
+                            "HTTP/1.1 400 Bad request\r\n" +
+                                    "Server: questDB/1.0\r\n" +
+                                    "Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n" +
+                                    "Transfer-Encoding: chunked\r\n" +
+                                    "Content-Type: text/plain; charset=utf-8\r\n" +
+                                    "\r\n" +
+                                    "16\r\n" +
+                                    "Method not supported\r\n" +
+                                    "\r\n" +
+                                    "00\r\n");
+                });
+    }
+
+    @Test
     public void testJsonImplicitCastException() throws Exception {
         testJsonQuery(
                 0,

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -83,6 +83,7 @@ public class MetricsIODispatcherTest {
     }
 
     @Test
+    @Ignore
     public void testLotsOfConnections() throws Exception {
         // In this scenario we want to test pool reuse.
         // This is dependent on thread scheduling so some runs may not achieve

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -116,6 +116,7 @@ public class MetricsIODispatcherTest {
     }
 
     @Test
+    @Ignore
     public void testMultipleChunksPeerIsSlowToReadPar() throws Exception {
         testPrometheusScenario(10_000, 1024, 256, PARALLEL_REQUESTS);
     }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
@@ -41,7 +41,7 @@ import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -158,13 +158,12 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         runInContext((server) -> {
             long day1 = IntervalUtils.parseFloorPartialTimestamp("2023-02-27") * 1000; // <-- last partition
 
-            try (TableModel tm = new TableModel(configuration, "plug", PartitionBy.DAY)) {
-                tm.col("room", ColumnType.SYMBOL);
-                tm.col("watts", ColumnType.LONG);
-                tm.timestamp();
+            TableModel tm = new TableModel(configuration, "plug", PartitionBy.DAY);
+            tm.col("room", ColumnType.SYMBOL);
+            tm.col("watts", ColumnType.LONG);
+            tm.timestamp();
 
-                CreateTableTestUtils.create(tm);
-            }
+            AbstractCairoTest.create(tm);
 
             try (TableWriterAPI writer = getTableWriterAPI("plug")) {
                 TableWriter.Row row = writer.newRow(day1 / 1000);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
@@ -164,13 +164,12 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
         runInContext((server) -> {
             long day1 = IntervalUtils.parseFloorPartialTimestamp("2023-02-27") * 1000; // <-- last partition
 
-            try (TableModel tm = new TableModel(configuration, "plug", PartitionBy.DAY)) {
-                tm.col("room", ColumnType.SYMBOL);
-                tm.col("watts", ColumnType.LONG);
-                tm.timestamp();
-                tm.wal();
-                TableToken ignored = TestUtils.create(tm, engine);
-            }
+            TableModel tm = new TableModel(configuration, "plug", PartitionBy.DAY);
+            tm.col("room", ColumnType.SYMBOL);
+            tm.col("watts", ColumnType.LONG);
+            tm.timestamp();
+            tm.wal();
+            TableToken ignored = TestUtils.create(tm, engine);
 
             try (TableWriterAPI writer = getTableWriterAPI("plug")) {
                 TableWriter.Row row = writer.newRow(day1 / 1000);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpInsertGeoHashTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/BaseLineTcpInsertGeoHashTest.java
@@ -25,7 +25,10 @@
 package io.questdb.test.cutlass.line.tcp;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableReaderMetadata;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -98,13 +101,12 @@ abstract class BaseLineTcpInsertGeoHashTest extends BaseLineTcpContextTest {
                                  String expected,
                                  String... expectedExtraStringColumns) throws Exception {
         runInContext(() -> {
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                model.col(targetColumnName, ColumnType.getGeoHashTypeWithBits(columnBits)).timestamp();
-                if (walEnabled) {
-                    model.wal();
-                }
-                TestUtils.create(model, engine);
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY);
+            model.col(targetColumnName, ColumnType.getGeoHashTypeWithBits(columnBits)).timestamp();
+            if (walEnabled) {
+                model.wal();
             }
+            TestUtils.create(model, engine);
             if (walEnabled) {
                 Assert.assertTrue(isWalTable(tableName));
             }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpConnectionContextTest.java
@@ -33,7 +33,7 @@ import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
@@ -552,22 +552,19 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     @Test
     public void testColumnConversion1() throws Exception {
         runInContext(() -> {
-            try (
-                    TableModel model = new TableModel(configuration, "t_ilp21", PartitionBy.DAY)
-                            .col("event", ColumnType.SHORT)
-                            .col("id", ColumnType.LONG256)
-                            .col("ts", ColumnType.TIMESTAMP)
-                            .col("float1", ColumnType.FLOAT)
-                            .col("int1", ColumnType.INT)
-                            .col("date1", ColumnType.DATE)
-                            .col("byte1", ColumnType.BYTE)
-                            .timestamp()
-            ) {
-                if (walEnabled) {
-                    model.wal();
-                }
-                CreateTableTestUtils.create(model);
+            TableModel model = new TableModel(configuration, "t_ilp21", PartitionBy.DAY)
+                    .col("event", ColumnType.SHORT)
+                    .col("id", ColumnType.LONG256)
+                    .col("ts", ColumnType.TIMESTAMP)
+                    .col("float1", ColumnType.FLOAT)
+                    .col("int1", ColumnType.INT)
+                    .col("date1", ColumnType.DATE)
+                    .col("byte1", ColumnType.BYTE)
+                    .timestamp();
+            if (walEnabled) {
+                model.wal();
             }
+            AbstractCairoTest.create(model);
             microSecondTicks = 1465839830102800L;
             recvBuffer = "t_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i\n" +
                     "t_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i\n";
@@ -585,11 +582,8 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     public void testColumnConversion2() throws Exception {
         assumeFalse(walEnabled); // Wal needs partitioning
         runInContext(() -> {
-            try (
-                    TableModel model = new TableModel(configuration, "t_ilp21", PartitionBy.NONE).col("l", ColumnType.LONG)
-            ) {
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "t_ilp21", PartitionBy.NONE).col("l", ColumnType.LONG);
+            AbstractCairoTest.create(model);
             microSecondTicks = 1465839830102800L;
             recvBuffer = "t_ilp21 l=843530699759026177i\n" +
                     "t_ilp21 l=\"843530699759026178\"\n" +
@@ -1916,17 +1910,14 @@ public class LineTcpConnectionContextTest extends BaseLineTcpContextTest {
     }
 
     private void addTable(String table) {
-        try (
-                TableModel model = new TableModel(configuration, table, walEnabled ? PartitionBy.DAY : PartitionBy.NONE)
-                        .col("location", ColumnType.SYMBOL)
-                        .col("temperature", ColumnType.DOUBLE)
-                        .timestamp()
-        ) {
-            if (walEnabled) {
-                model.wal();
-            }
-            CreateTableTestUtils.create(model);
+        TableModel model = new TableModel(configuration, table, walEnabled ? PartitionBy.DAY : PartitionBy.NONE)
+                .col("location", ColumnType.SYMBOL)
+                .col("temperature", ColumnType.DOUBLE)
+                .timestamp();
+        if (walEnabled) {
+            model.wal();
         }
+        AbstractCairoTest.create(model);
         engine.releaseInactive();
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpInsertOtherTypesTest.java
@@ -27,7 +27,6 @@ package io.questdb.test.cutlass.line.tcp;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.cairo.SqlWalMode;
 import io.questdb.cairo.TableReader;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.cairo.TableModel;
@@ -997,9 +996,8 @@ public class LineTcpInsertOtherTypesTest extends BaseLineTcpContextTest {
     private void assertType(int columnType, String expected, CharSequence[] values, boolean isTag) throws Exception {
         runInContext(() -> {
             if (columnType != ColumnType.UNDEFINED) {
-                try (TableModel model = new TableModel(configuration, TABLE, PartitionBy.DAY)) {
-                    TestUtils.create(model.col(TARGET_COLUMN_NAME, columnType).timestamp(), engine);
-                }
+                TableModel model = new TableModel(configuration, TABLE, PartitionBy.DAY);
+                TestUtils.create(model.col(TARGET_COLUMN_NAME, columnType).timestamp(), engine);
                 if (walEnabled) {
                     Assert.assertTrue(isWalTable(TABLE));
                 }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpPartitionReadOnlyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpPartitionReadOnlyTest.java
@@ -202,16 +202,13 @@ public class LineTcpPartitionReadOnlyTest extends AbstractLinePartitionReadOnlyT
                 // create a table with 4 partitions and 1111 rows
                 CairoConfiguration cairoConfig = qdb.getConfiguration().getCairoConfiguration();
 
-                try (
-                        TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
-                                .col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL).symbolCapacity(32)
-                                .timestamp("ts")
-                ) {
-                    engine.ddl("create table " + tableName + " (l long, i int, s symbol, ts timestamp) timestamp(ts) partition by day bypass wal", context);
-                    engine.insert(insertFromSelectPopulateTableStmt(tableModel, 1111, firstPartitionName, 4), context);
-                }
+                TableModel tableModel = new TableModel(cairoConfig, tableName, PartitionBy.DAY)
+                        .col("l", ColumnType.LONG)
+                        .col("i", ColumnType.INT)
+                        .col("s", ColumnType.SYMBOL).symbolCapacity(32)
+                        .timestamp("ts");
+                engine.ddl("create table " + tableName + " (l long, i int, s symbol, ts timestamp) timestamp(ts) partition by day bypass wal", context);
+                engine.insert(insertFromSelectPopulateTableStmt(tableModel, 1111, firstPartitionName, 4), context);
 
                 // set partition read-only state
                 TableToken tableToken = engine.getTableTokenIfExists(tableName);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -28,8 +28,10 @@ import io.questdb.PropertyKey;
 import io.questdb.cairo.*;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cairo.pool.ex.EntryLockedException;
-import io.questdb.cairo.sql.*;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cutlass.line.AbstractLineSender;
@@ -48,8 +50,11 @@ import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
-import io.questdb.std.str.*;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Path;
+import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8s;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -177,11 +182,10 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         final String tableName = "weather";
         final int numOfRows = 2000;
 
-        try (TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-            m.col("abcdef", ColumnType.SYMBOL).timestamp("ts");
-            CreateTableTestUtils.create(m);
-            engine.releaseInactive();
-        }
+        TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY);
+        m.col("abcdef", ColumnType.SYMBOL).timestamp("ts");
+        AbstractCairoTest.create(m);
+        engine.releaseInactive();
 
         final SOCountDownLatch dataSent = new SOCountDownLatch(1);
         final SOCountDownLatch dataConsumed = new SOCountDownLatch(1);
@@ -248,10 +252,9 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         runInContext((receiver) -> {
             // Pre-create a partitioned table, so we can wait until it's created.
-            try (TableModel m = new TableModel(configuration, tablePartitioned, PartitionBy.DAY)) {
-                m.timestamp("ts").wal();
-                TestUtils.create(m, engine);
-            }
+            TableModel m = new TableModel(configuration, tablePartitioned, PartitionBy.DAY);
+            m.timestamp("ts").wal();
+            TestUtils.create(m, engine);
 
             // Send non-partitioned table rows before the partitioned table ones.
             final String lineData = tableNonPartitioned + " windspeed=2.0 631150000000000000\n" +
@@ -316,10 +319,9 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         runInContext((receiver) -> {
             // Pre-create a partitioned table, so we can wait until it's created.
-            try (TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                m.timestamp("ts").col("dt", ColumnType.DATE).noWal();
-                CreateTableTestUtils.create(m);
-            }
+            TableModel m = new TableModel(configuration, tableName, PartitionBy.DAY);
+            m.timestamp("ts").col("dt", ColumnType.DATE).noWal();
+            AbstractCairoTest.create(m);
 
             final String lineData = tableName + " dt=631150000000000t 631150000000000000\n" +
                     tableName + " dt=631160000000000t 631160000000000000\n";
@@ -409,10 +411,9 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         // WAL is not supported on non-partitioned tables
         Assume.assumeFalse(walEnabled);
 
-        try (TableModel m = new TableModel(configuration, "weather", PartitionBy.NONE)) {
-            m.col("windspeed", ColumnType.DOUBLE).timestamp();
-            CreateTableTestUtils.create(m);
-        }
+        TableModel m = new TableModel(configuration, "weather", PartitionBy.NONE);
+        m.col("windspeed", ColumnType.DOUBLE).timestamp();
+        AbstractCairoTest.create(m);
 
         String lineData =
                 "weather windspeed=2.0 631150000000000000\n" +
@@ -637,13 +638,12 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         autoCreateNewColumns = false;
         runInContext((receiver) -> {
             // First, create a table and insert a few rows into it, so that we get some existing symbol keys.
-            try (TableModel m = new TableModel(configuration, "up", PartitionBy.MONTH)) {
-                m.timestamp("ts").col("sym", ColumnType.SYMBOL);
-                if (walEnabled) {
-                    m.wal();
-                }
-                createTable(m);
+            TableModel m = new TableModel(configuration, "up", PartitionBy.MONTH);
+            m.timestamp("ts").col("sym", ColumnType.SYMBOL);
+            if (walEnabled) {
+                m.wal();
             }
+            createTable(m);
 
             String lineData =
                     "up out=1.0 631150000000000000\n" +
@@ -1348,15 +1348,14 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         byte[] utf8Bytes = "ल".getBytes(Files.UTF_8);
         Assert.assertEquals(3, utf8Bytes.length);
 
-        try (TableModel m = new TableModel(configuration, "लаблअца", PartitionBy.DAY)) {
-            m.col("символ", ColumnType.SYMBOL).indexed(true, 256)
-                    .col("поле", ColumnType.STRING)
-                    .timestamp("время");
-            if (walEnabled) {
-                m.wal();
-            }
-            TestUtils.create(m, engine);
+        TableModel m = new TableModel(configuration, "लаблअца", PartitionBy.DAY);
+        m.col("символ", ColumnType.SYMBOL).indexed(true, 256)
+                .col("поле", ColumnType.STRING)
+                .timestamp("время");
+        if (walEnabled) {
+            m.wal();
         }
+        TestUtils.create(m, engine);
 
         engine.releaseInactive();
         runInContext((receiver) -> {
@@ -1401,16 +1400,15 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
 
         runInContext((receiver) -> {
-            try (TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY)) {
-                m.timestamp("ReceiveTime")
-                        .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
-                        .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
-                        .col("Length", ColumnType.INT);
-                if (walEnabled) {
-                    m.wal();
-                }
-                TestUtils.create(m, engine);
+            TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY);
+            m.timestamp("ReceiveTime")
+                    .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("Length", ColumnType.INT);
+            if (walEnabled) {
+                m.wal();
             }
+            TestUtils.create(m, engine);
 
             sendLinger(lineData, "table_a");
 
@@ -1527,18 +1525,17 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
         currentMicros = 1;
         String lineData = "messages id=843530699759026177i,author=820703963477180437i,guild=820704412095479830i,channel=820704412095479833i,flags=6i\n";
         runInContext((receiver) -> {
-            try (TableModel m = new TableModel(configuration, "messages", PartitionBy.MONTH)) {
-                m.timestamp("ts")
-                        .col("id", ColumnType.LONG)
-                        .col("author", ColumnType.LONG)
-                        .col("guild", ColumnType.LONG)
-                        .col("channel", ColumnType.LONG)
-                        .col("flags", ColumnType.BYTE);
-                if (walEnabled) {
-                    m.wal();
-                }
-                TestUtils.create(m, engine);
+            TableModel m = new TableModel(configuration, "messages", PartitionBy.MONTH);
+            m.timestamp("ts")
+                    .col("id", ColumnType.LONG)
+                    .col("author", ColumnType.LONG)
+                    .col("guild", ColumnType.LONG)
+                    .col("channel", ColumnType.LONG)
+                    .col("flags", ColumnType.BYTE);
+            if (walEnabled) {
+                m.wal();
             }
+            TestUtils.create(m, engine);
 
             send(lineData, "messages");
             String expected = "ts\tid\tauthor\tguild\tchannel\tflags\n" +
@@ -1565,13 +1562,12 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                 }
             };
 
-            try (TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY)) {
-                m.timestamp("ReceiveTime")
-                        .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
-                        .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
-                        .col("Length", ColumnType.INT);
-                CreateTableTestUtils.create(m);
-            }
+            TableModel m = new TableModel(configuration, "table_a", PartitionBy.DAY);
+            m.timestamp("ReceiveTime")
+                    .col("SequenceNumber", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("MessageType", ColumnType.SYMBOL).indexed(true, 256)
+                    .col("Length", ColumnType.INT);
+            AbstractCairoTest.create(m);
 
             String lineData = "table_a,MessageType=B,SequenceNumber=1 Length=92i,test=1.5 1465839830100400000\n";
             sendLinger(lineData, "table_a");
@@ -1592,10 +1588,9 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
         runInContext((receiver) -> {
             // First, create a table and insert a few rows into it, so that we get some existing symbol keys.
-            try (TableModel m = new TableModel(configuration, tableName, PartitionBy.MONTH)) {
-                m.timestamp("ts").col("sym", ColumnType.SYMBOL).wal();
-                CreateTableTestUtils.create(m);
-            }
+            TableModel m = new TableModel(configuration, tableName, PartitionBy.MONTH);
+            m.timestamp("ts").col("sym", ColumnType.SYMBOL).wal();
+            AbstractCairoTest.create(m);
 
             // Next, start inserting symbols on a background thread.
             final CountDownLatch halfDoneLatch = new CountDownLatch(1);

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpSenderTest.java
@@ -39,7 +39,7 @@ import io.questdb.std.Os;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.StringSink;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
@@ -302,12 +302,11 @@ public class LineTcpSenderTest extends AbstractLineTcpReceiverTest {
         // this is to check that a non-ASCII string will not prevent
         // parsing a subsequent UUID
         runInContext(r -> {
-            try (TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
                     .col("s", ColumnType.STRING)
                     .col("u", ColumnType.UUID)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (Sender sender = Sender.builder()
                     .address("127.0.0.1")
@@ -340,13 +339,12 @@ public class LineTcpSenderTest extends AbstractLineTcpReceiverTest {
     public void testInsertStringIntoUuidColumn() throws Exception {
         runInContext(r -> {
             // create table with UUID column
-            try (TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
                     .col("u1", ColumnType.UUID)
                     .col("u2", ColumnType.UUID)
                     .col("u3", ColumnType.UUID)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (Sender sender = Sender.builder()
                     .address("127.0.0.1")
@@ -373,11 +371,10 @@ public class LineTcpSenderTest extends AbstractLineTcpReceiverTest {
     @Test
     public void testInsertTimestampAsInstant() throws Exception {
         runInContext(r -> {
-            try (TableModel model = new TableModel(configuration, "mytable", PartitionBy.YEAR)
+            TableModel model = new TableModel(configuration, "mytable", PartitionBy.YEAR)
                     .col("ts_col", ColumnType.TIMESTAMP)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (Sender sender = Sender.builder()
                     .address("127.0.0.1")
@@ -401,12 +398,11 @@ public class LineTcpSenderTest extends AbstractLineTcpReceiverTest {
     @Test
     public void testInsertTimestampMiscUnits() throws Exception {
         runInContext(r -> {
-            try (TableModel model = new TableModel(configuration, "mytable", PartitionBy.YEAR)
+            TableModel model = new TableModel(configuration, "mytable", PartitionBy.YEAR)
                     .col("unit", ColumnType.STRING)
                     .col("ts", ColumnType.TIMESTAMP)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             try (Sender sender = Sender.builder()
                     .address("127.0.0.1")
@@ -696,11 +692,10 @@ public class LineTcpSenderTest extends AbstractLineTcpReceiverTest {
     private void testValueCannotBeInsertedToUuidColumn(String value) throws Exception {
         runInContext(r -> {
             // create table with UUID column
-            try (TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
+            TableModel model = new TableModel(configuration, "mytable", PartitionBy.NONE)
                     .col("u1", ColumnType.UUID)
-                    .timestamp()) {
-                CreateTableTestUtils.create(model);
-            }
+                    .timestamp();
+            AbstractCairoTest.create(model);
 
             // this sender fails as the string is not UUID
             try (Sender sender = Sender.builder()

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
@@ -43,7 +43,6 @@ import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.DirectUtf8String;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
@@ -186,8 +185,6 @@ public class SymbolCacheTest extends AbstractCairoTest {
 
         TestUtils.assertMemoryLeak(() -> {
             try (Path path = new Path();
-                 TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
-                         .col("symCol", ColumnType.SYMBOL);
                  SymbolCache cache = new SymbolCache(new DefaultLineTcpReceiverConfiguration() {
                      @Override
                      public long getSymbolCacheWaitUsBeforeReload() {
@@ -195,7 +192,9 @@ public class SymbolCacheTest extends AbstractCairoTest {
                      }
                  })
             ) {
-                CreateTableTestUtils.create(model);
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+                        .col("symCol", ColumnType.SYMBOL);
+                AbstractCairoTest.create(model);
                 DirectUtf8String dus = new DirectUtf8String();
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 TableToken tableToken = engine.verifyTableName(tableName);
@@ -367,8 +366,6 @@ public class SymbolCacheTest extends AbstractCairoTest {
 
         TestUtils.assertMemoryLeak(() -> {
             try (Path path = new Path();
-                 TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
-                         .col("symCol", ColumnType.SYMBOL);
                  SymbolCache cache = new SymbolCache(new DefaultLineTcpReceiverConfiguration() {
                      @Override
                      public long getSymbolCacheWaitUsBeforeReload() {
@@ -376,7 +373,9 @@ public class SymbolCacheTest extends AbstractCairoTest {
                      }
                  })
             ) {
-                CreateTableTestUtils.create(model);
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+                        .col("symCol", ColumnType.SYMBOL);
+                AbstractCairoTest.create(model);
                 DirectUtf8String dus = new DirectUtf8String();
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 TableToken tableToken = engine.verifyTableName(tableName);
@@ -430,9 +429,6 @@ public class SymbolCacheTest extends AbstractCairoTest {
         FilesFacade ff = new TestFilesFacadeImpl();
         TestUtils.assertMemoryLeak(() -> {
             try (Path path = new Path();
-                 TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
-                         .col("symCol1", ColumnType.SYMBOL)
-                         .col("symCol2", ColumnType.SYMBOL);
                  SymbolCache cache = new SymbolCache(new DefaultLineTcpReceiverConfiguration() {
                      @Override
                      public long getSymbolCacheWaitUsBeforeReload() {
@@ -440,7 +436,10 @@ public class SymbolCacheTest extends AbstractCairoTest {
                      }
                  })
             ) {
-                CreateTableTestUtils.create(model);
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                        .col("symCol1", ColumnType.SYMBOL)
+                        .col("symCol2", ColumnType.SYMBOL);
+                AbstractCairoTest.create(model);
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
@@ -590,8 +589,6 @@ public class SymbolCacheTest extends AbstractCairoTest {
         FilesFacade ff = new TestFilesFacadeImpl();
         TestUtils.assertMemoryLeak(() -> {
             try (Path path = new Path();
-                 TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
-                         .col("symCol", ColumnType.SYMBOL);
                  SymbolCache cache = new SymbolCache(new DefaultLineTcpReceiverConfiguration() {
                      @Override
                      public long getSymbolCacheWaitUsBeforeReload() {
@@ -599,7 +596,9 @@ public class SymbolCacheTest extends AbstractCairoTest {
                      }
                  })
             ) {
-                CreateTableTestUtils.create(model);
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                        .col("symCol", ColumnType.SYMBOL);
+                AbstractCairoTest.create(model);
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
@@ -673,8 +672,6 @@ public class SymbolCacheTest extends AbstractCairoTest {
         FilesFacade ff = new TestFilesFacadeImpl();
         TestUtils.assertMemoryLeak(() -> {
             try (Path path = new Path();
-                 TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
-                         .col("symCol", ColumnType.SYMBOL);
                  SymbolCache cache = new SymbolCache(new DefaultLineTcpReceiverConfiguration() {
                      @Override
                      public long getSymbolCacheWaitUsBeforeReload() {
@@ -682,7 +679,9 @@ public class SymbolCacheTest extends AbstractCairoTest {
                      }
                  })
             ) {
-                CreateTableTestUtils.create(model);
+                TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                        .col("symCol", ColumnType.SYMBOL);
+                AbstractCairoTest.create(model);
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
@@ -744,10 +743,9 @@ public class SymbolCacheTest extends AbstractCairoTest {
     }
 
     private void createTable(String tableName) {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-            model.timestamp();
-            TestUtils.create(model, engine);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY);
+        model.timestamp();
+        TestUtils.create(model, engine);
     }
 
     private static class Holder implements Mutable {

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpInsertTest.java
@@ -84,9 +84,8 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                 });
                 try (AbstractLineProtoUdpReceiver receiver = createLineProtoReceiver(engine)) {
                     if (columnType != ColumnType.UNDEFINED) {
-                        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                            TestUtils.create(model.col(targetColumnName, columnType).timestamp(), engine);
-                        }
+                        TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE);
+                        TestUtils.create(model.col(targetColumnName, columnType).timestamp(), engine);
                     }
                     receiver.start();
                     try (AbstractLineSender sender = createLineProtoSender()) {

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserImplTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserImplTest.java
@@ -35,7 +35,6 @@ import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.cairo.TestFilesFacade;
@@ -101,16 +100,15 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
                 "1.6\t15\ttrue\t\txyz\tstring1\t2017-10-03T10:00:00.000000Z\n" +
                 "1.3\t11\tfalse\tabc\t\tstring2\t2017-10-03T10:00:00.010000Z\n";
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("double", ColumnType.DOUBLE)
                 .col("int", ColumnType.LONG)
                 .col("bool", ColumnType.BOOLEAN)
                 .col("sym1", ColumnType.SYMBOL)
                 .col("sym2", ColumnType.SYMBOL)
                 .col("str", ColumnType.STRING)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         String lines = "x,sym2=xyz double=1.6,int=15i,bool=true,str=\"string1\"\n" +
                 "x,sym1=abc double=1.3,int=11i,bool=false,str=\"string2\"\n";
@@ -279,11 +277,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testBinary() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("bin", ColumnType.BINARY)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("bin\ttimestamp\n",
                 "x bin=b10101010101\n",
                 "x",
@@ -298,18 +295,15 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
     @Test
     public void testBusyTable() throws Exception {
         final String expected = "double\tint\tbool\tsym1\tsym2\tstr\ttimestamp\n";
-
-
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("double", ColumnType.DOUBLE)
                 .col("int", ColumnType.INT)
                 .col("bool", ColumnType.BOOLEAN)
                 .col("sym1", ColumnType.SYMBOL)
                 .col("sym2", ColumnType.SYMBOL)
                 .col("str", ColumnType.STRING)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         String lines = "x,sym2=xyz double=1.6,int=15i,bool=true,str=\"string1\"\n" +
                 "x,sym1=abc double=1.3,int=11i,bool=false,str=\"string2\"\n";
@@ -414,11 +408,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testCharMissing() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("char", ColumnType.CHAR)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("char\ttimestamp\n" +
                         "\t1970-01-01T00:00:00.000000Z\n",
                 "x char=\n",
@@ -433,11 +426,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testCharNull() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("char", ColumnType.CHAR)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("char\ttimestamp\n" +
                         "\t1970-01-01T00:00:00.000000Z\n",
                 "x char=\"\"\n",
@@ -452,11 +444,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testCharSingleChar() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("char", ColumnType.CHAR)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("char\ttimestamp\n" +
                         "c\t1970-01-01T00:00:00.000000Z\n",
                 "x char=\"c\"\n",
@@ -471,11 +462,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testCharSingleQuote() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("char", ColumnType.CHAR)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("char\ttimestamp\n",
                 "x char=''\n",
                 "x",
@@ -489,11 +479,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testCharStringIsProvided() throws Exception {
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)
                 .col("char", ColumnType.CHAR)
-                .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+                .timestamp();
+        AbstractCairoTest.create(model);
         assertThat("char\ttimestamp\n" +
                         "c\t1970-01-01T00:00:00.000000Z\n",
                 "x char=\"coconut\"\n",
@@ -508,12 +497,10 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testColumnConversion1() throws Exception {
-        try (
-                TableModel model = new TableModel(configuration, "t_ilp21",
-                        PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT)
-                        .col("int1", ColumnType.INT).col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "t_ilp21",
+                PartitionBy.NONE).col("event", ColumnType.SHORT).col("id", ColumnType.LONG256).col("ts", ColumnType.TIMESTAMP).col("float1", ColumnType.FLOAT)
+                .col("int1", ColumnType.INT).col("date1", ColumnType.DATE).col("byte1", ColumnType.BYTE).timestamp();
+        AbstractCairoTest.create(model);
         String lines = "t_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i 1465839830102800000\n" +
                 "t_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i 1465839830102800000\n";
         String expected = "event\tid\tts\tfloat1\tint1\tdate1\tbyte1\ttimestamp\n" +
@@ -567,19 +554,17 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testExistingTableRemovedColumn() throws Exception {
-        try (
-                TableModel model = new TableModel(configuration, "t_ilp21",
-                        PartitionBy.NONE)
-                        .col("event", ColumnType.SHORT)
-                        .col("id", ColumnType.LONG256)
-                        .col("ts", ColumnType.TIMESTAMP)
-                        .col("float1", ColumnType.FLOAT)
-                        .col("int1", ColumnType.INT)
-                        .col("date1", ColumnType.DATE)
-                        .col("byte1", ColumnType.BYTE)
-                        .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "t_ilp21",
+                PartitionBy.NONE)
+                .col("event", ColumnType.SHORT)
+                .col("id", ColumnType.LONG256)
+                .col("ts", ColumnType.TIMESTAMP)
+                .col("float1", ColumnType.FLOAT)
+                .col("int1", ColumnType.INT)
+                .col("date1", ColumnType.DATE)
+                .col("byte1", ColumnType.BYTE)
+                .timestamp();
+        AbstractCairoTest.create(model);
         try (TableWriter writer = getWriter("t_ilp21")) {
             writer.removeColumn("event");
         }
@@ -595,19 +580,17 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testExistingTableRemovedColumnAndAddedBack() throws Exception {
-        try (
-                TableModel model = new TableModel(configuration, "t_ilp21",
-                        PartitionBy.NONE)
-                        .col("event", ColumnType.SHORT)
-                        .col("id", ColumnType.LONG256)
-                        .col("ts", ColumnType.TIMESTAMP)
-                        .col("float1", ColumnType.FLOAT)
-                        .col("int1", ColumnType.INT)
-                        .col("date1", ColumnType.DATE)
-                        .col("byte1", ColumnType.BYTE)
-                        .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "t_ilp21",
+                PartitionBy.NONE)
+                .col("event", ColumnType.SHORT)
+                .col("id", ColumnType.LONG256)
+                .col("ts", ColumnType.TIMESTAMP)
+                .col("float1", ColumnType.FLOAT)
+                .col("int1", ColumnType.INT)
+                .col("date1", ColumnType.DATE)
+                .col("byte1", ColumnType.BYTE)
+                .timestamp();
+        AbstractCairoTest.create(model);
         try (TableWriter writer = getWriter("t_ilp21")) {
             writer.removeColumn("event");
             writer.addColumn("event", ColumnType.SHORT);
@@ -624,19 +607,17 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testExistingTableWhenAddingNewTablesAndColumnsDisabled() throws Exception {
-        try (
-                TableModel model = new TableModel(configuration, "t_ilp21",
-                        PartitionBy.NONE)
-                        .col("event", ColumnType.SHORT)
-                        .col("id", ColumnType.LONG256)
-                        .col("ts", ColumnType.TIMESTAMP)
-                        .col("float1", ColumnType.FLOAT)
-                        .col("int1", ColumnType.INT)
-                        .col("date1", ColumnType.DATE)
-                        .col("byte1", ColumnType.BYTE)
-                        .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "t_ilp21",
+                PartitionBy.NONE)
+                .col("event", ColumnType.SHORT)
+                .col("id", ColumnType.LONG256)
+                .col("ts", ColumnType.TIMESTAMP)
+                .col("float1", ColumnType.FLOAT)
+                .col("int1", ColumnType.INT)
+                .col("date1", ColumnType.DATE)
+                .col("byte1", ColumnType.BYTE)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         String lines = "t_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i 1465839830102800000\n" +
                 "t_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i 1465839830102800000\n";
@@ -658,18 +639,16 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
 
     @Test
     public void testFailsToAddAColumnWhenAutoColumnAddDisabled() throws Exception {
-        try (
-                TableModel model = new TableModel(configuration, "t_ilp21",
-                        PartitionBy.NONE)
-                        .col("event", ColumnType.SHORT)
-                        .col("id", ColumnType.LONG256)
-                        .col("ts", ColumnType.TIMESTAMP)
-                        .col("float1", ColumnType.FLOAT)
-                        .col("int1", ColumnType.INT)
-                        .col("date1", ColumnType.DATE)
-                        .timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "t_ilp21",
+                PartitionBy.NONE)
+                .col("event", ColumnType.SHORT)
+                .col("id", ColumnType.LONG256)
+                .col("ts", ColumnType.TIMESTAMP)
+                .col("float1", ColumnType.FLOAT)
+                .col("int1", ColumnType.INT)
+                .col("date1", ColumnType.DATE)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         String lines = "t_ilp21 event=12i,id=0x05a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1.2,int1=23i,date1=1465839830102i,byte1=-7i 1465839830102800000\n" +
                 "t_ilp21 event=12i,id=0x5a9796963abad00001e5f6bbdb38i,ts=1465839830102400i,float1=1e3,int1=-500000i,date1=1465839830102i,byte1=3i 1465839830102800000\n";

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserSupportTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserSupportTest.java
@@ -24,7 +24,9 @@
 
 package io.questdb.test.cutlass.line.udp;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.cutlass.line.udp.AbstractLineProtoUdpReceiver;
@@ -315,13 +317,12 @@ public class LineUdpParserSupportTest extends LineUdpInsertTest {
                     }
                 });
                 try (AbstractLineProtoUdpReceiver receiver = createLineProtoReceiver(engine)) {
-                    try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                        TestUtils.create(model
-                                        .col(targetColumnName, columnType)
-                                        .col(locationColumnName, ColumnType.getGeoHashTypeWithBits(30))
-                                        .timestamp(),
-                                engine);
-                    }
+                    TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE);
+                    TestUtils.create(model
+                                    .col(targetColumnName, columnType)
+                                    .col(locationColumnName, ColumnType.getGeoHashTypeWithBits(30))
+                                    .timestamp(),
+                            engine);
                     receiver.start();
                     try (AbstractLineSender sender = createLineProtoSender()) {
                         senderConsumer.accept(sender);

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
@@ -242,13 +242,12 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
                 try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, 0, null, null, metrics)) {
                     // create table
                     String tableName = "tab";
-                    try (TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
+                    TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
                             .col("colour", ColumnType.SYMBOL)
                             .col("shape", ColumnType.SYMBOL)
                             .col("size", ColumnType.DOUBLE)
-                            .timestamp()) {
-                        TestUtils.create(model, engine);
-                    }
+                            .timestamp();
+                    TestUtils.create(model, engine);
 
                     // warm writer up
                     try (TableWriter w = getWriter(engine, tableName)) {

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -11019,6 +11019,8 @@ create table tab as (
                     assertEquals(testSize, stmt.getFetchSize());
 
                     try {
+                        // sleep to allow disconnect timer to trigger.
+                        Os.sleep(500);
                         stmt.executeQuery();
                         Assert.fail();
                     } catch (PSQLException ex) {

--- a/core/src/test/java/io/questdb/test/griffin/AbstractSqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AbstractSqlParserTest.java
@@ -195,10 +195,10 @@ public class AbstractSqlParserTest extends AbstractCairoTest {
             for (int i = 0, n = nested.getJoinModels().size(); i < n; i++) {
                 LowerCaseCharSequenceHashSet set = new LowerCaseCharSequenceHashSet();
                 final QueryModel m = nested.getJoinModels().getQuick(i);
+                // validate uniqueness of top-down column names.
                 final ObjList<QueryColumn> cols = m.getTopDownColumns();
                 for (int j = 0, k = cols.size(); j < k; j++) {
-                    QueryColumn qc = cols.getQuick(j);
-                    Assert.assertTrue(set.add(qc.getName()));
+                    Assert.assertTrue(set.add(cols.getQuick(j).getName()));
                 }
                 nameSets.add(set);
             }

--- a/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
@@ -39,7 +39,6 @@ import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.*;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
@@ -103,10 +102,9 @@ public class AggregateTest extends AbstractCairoTest {
 
     @Test
     public void testCountAggregationWithConst() throws Exception {
-        try (TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.DAY)) {
-            tt1.col("tts", ColumnType.LONG).timestamp("ts");
-            createPopulateTable(tt1, 100, "2020-01-01", 2);
-        }
+        TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.DAY);
+        tt1.col("tts", ColumnType.LONG).timestamp("ts");
+        createPopulateTable(tt1, 100, "2020-01-01", 2);
 
         String expected = "ts\tcount\n" +
                 "2020-01-01T00:28:47.990000Z:TIMESTAMP\t51:LONG\n" +
@@ -119,10 +117,9 @@ public class AggregateTest extends AbstractCairoTest {
 
     @Test
     public void testCountAggregations() throws Exception {
-        try (TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.NONE)) {
-            tt1.col("tts", ColumnType.LONG);
-            CreateTableTestUtils.create(tt1);
-        }
+        TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.NONE);
+        tt1.col("tts", ColumnType.LONG);
+        AbstractCairoTest.create(tt1);
 
         String expected = "max\tcount\n" +
                 "NaN:LONG\t0:LONG\n";
@@ -162,11 +159,10 @@ public class AggregateTest extends AbstractCairoTest {
 
     @Test
     public void testCountCaseInsensitive() throws Exception {
-        try (TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.DAY)) {
-            tt1.col("tts", ColumnType.LONG).timestamp("ts")
-                    .col("ID", ColumnType.LONG);
-            createPopulateTable(tt1, 100, "2020-01-01", 2);
-        }
+        TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.DAY);
+        tt1.col("tts", ColumnType.LONG).timestamp("ts")
+                .col("ID", ColumnType.LONG);
+        createPopulateTable(tt1, 100, "2020-01-01", 2);
 
         String expected = "ts\tcount\n" +
                 "2020-01-01T00:28:47.990000Z:TIMESTAMP\t1:LONG\n" +
@@ -2070,12 +2066,11 @@ public class AggregateTest extends AbstractCairoTest {
     }
 
     private void testAggregations(String[] aggregateFunctions, TypeVal[] aggregateColTypes) throws SqlException {
-        try (TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.NONE)) {
-            for (TypeVal colType : aggregateColTypes) {
-                tt1.col(colType.colName, colType.columnType);
-            }
-            CreateTableTestUtils.create(tt1);
+        TableModel tt1 = new TableModel(configuration, "tt1", PartitionBy.NONE);
+        for (TypeVal colType : aggregateColTypes) {
+            tt1.col(colType.colName, colType.columnType);
         }
+        AbstractCairoTest.create(tt1);
 
         // Insert a lot of empty rows to test function's merge correctness.
         try (TableWriter writer = TestUtils.newOffPoolWriter(engine.getConfiguration(), engine.verifyTableName("tt1"))) {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionFromSoftLinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionFromSoftLinkTest.java
@@ -710,18 +710,17 @@ public class AlterTableAttachPartitionFromSoftLinkTest extends AbstractAlterTabl
             String otherLocation = "CON-CHIN-CHINA";
             int txn = 0;
             TableToken tableToken;
-            try (TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                tableToken = createPopulateTable(
-                        1,
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 32)
-                                .timestamp("ts"),
-                        10000,
-                        partitionName[0],
-                        partitionCount
-                );
-            }
+            TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY);
+            tableToken = createPopulateTable(
+                    1,
+                    src.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .col("s", ColumnType.SYMBOL).indexed(true, 32)
+                            .timestamp("ts"),
+                    10000,
+                    partitionName[0],
+                    partitionCount
+            );
             txn++;
             assertSql("min\tmax\tcount\n" +
                     expectedMinTimestamp + "\t" + expectedMaxTimestamp + "\t10000\n", "SELECT min(ts), max(ts), count() FROM " + tableName
@@ -1162,18 +1161,17 @@ public class AlterTableAttachPartitionFromSoftLinkTest extends AbstractAlterTabl
 
     private TableToken createPopulateTable(String tableName, int partitionCount) throws Exception {
         TableToken tableToken;
-        try (TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-            tableToken = createPopulateTable(
-                    1,
-                    src.col("l", ColumnType.LONG)
-                            .col("i", ColumnType.INT)
-                            .col("s", ColumnType.SYMBOL).indexed(true, 32)
-                            .timestamp("ts"),
-                    10000,
-                    "2022-10-17",
-                    partitionCount
-            );
-        }
+        TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY);
+        tableToken = createPopulateTable(
+                1,
+                src.col("l", ColumnType.LONG)
+                        .col("i", ColumnType.INT)
+                        .col("s", ColumnType.SYMBOL).indexed(true, 32)
+                        .timestamp("ts"),
+                10000,
+                "2022-10-17",
+                partitionCount
+        );
         return tableToken;
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionTest.java
@@ -32,7 +32,7 @@ import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Utf8s;
-import io.questdb.test.CreateTableTestUtils;
+import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
@@ -49,291 +49,289 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
     @Test
     public void testAttach2Partitions() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src1", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst1", PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2020-01-01",
-                        12);
+                    TableModel src = new TableModel(configuration, "src1", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst1", PartitionBy.DAY);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2020-01-01",
+                            12);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                attachFromSrcIntoDst(src, dst, "2020-01-09", "2020-01-10");
-            }
-        });
+                    attachFromSrcIntoDst(src, dst, "2020-01-09", "2020-01-10");
+                }
+        );
     }
 
     @Test
     public void testAttachActive2PartitionsOneByOneInDescOrder() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src2", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst2", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src2", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst2", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2020-01-01",
-                        12);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2020-01-01",
+                            12);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                attachFromSrcIntoDst(src, dst, "2020-01-10");
-                attachFromSrcIntoDst(src, dst, "2020-01-09");
-            }
-        });
+                    attachFromSrcIntoDst(src, dst, "2020-01-10");
+                    attachFromSrcIntoDst(src, dst, "2020-01-09");
+                }
+        );
     }
 
     @Test
     public void testAttachActive3Partitions() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src3", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst3", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src3", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst3", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2020-01-01",
-                        12);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2020-01-01",
+                            12);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                // 3 partitions unordered
-                attachFromSrcIntoDst(src, dst, "2020-01-09", "2020-01-10", "2020-01-01");
-            }
-        });
+                    // 3 partitions unordered
+                    attachFromSrcIntoDst(src, dst, "2020-01-09", "2020-01-10", "2020-01-01");
+                }
+        );
     }
 
     @Test
     public void testAttachActiveWrittenPartition() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src4", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst4", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src4", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst4", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2020-01-01",
-                        11);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2020-01-01",
+                            11);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                attachFromSrcIntoDst(src, dst, "2020-01-10");
-            }
-        });
+                    attachFromSrcIntoDst(src, dst, "2020-01-10");
+                }
+        );
     }
 
     @Test
     public void testAttachFailsInvalidFormat() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst5", PartitionBy.MONTH)) {
+                    TableModel dst = new TableModel(configuration, "dst5", PartitionBy.MONTH);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '202A-01'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[39] 'yyyy-MM' expected, found [ts=202A-01]", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '202A-01'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[39] 'yyyy-MM' expected, found [ts=202A-01]", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachFailsInvalidFormatPartitionsAnnually0() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst6a", PartitionBy.YEAR)) {
+                    TableModel dst = new TableModel(configuration, "dst6a", PartitionBy.YEAR);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST 'nono'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[40] 'yyyy' expected, found [ts=nono]", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST 'nono'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[40] 'yyyy' expected, found [ts=nono]", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachFailsInvalidFormatPartitionsAnnually1() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst6b", PartitionBy.YEAR)) {
+                    TableModel dst = new TableModel(configuration, "dst6b", PartitionBy.YEAR);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '202'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[40] 'yyyy' expected, found [ts=202]", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '202'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[40] 'yyyy' expected, found [ts=202]", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachFailsInvalidFormatPartitionsMonthly0() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst7a", PartitionBy.MONTH)) {
+                    TableModel dst = new TableModel(configuration, "dst7a", PartitionBy.MONTH);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-no'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[40] 'yyyy-MM' expected, found [ts=2020-no]", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-no'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[40] 'yyyy-MM' expected, found [ts=2020-no]", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachFailsInvalidFormatPartitionsMonthly1() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst7b", PartitionBy.MONTH)) {
+                    TableModel dst = new TableModel(configuration, "dst7b", PartitionBy.MONTH);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[40] 'yyyy-MM' expected, found [ts=2020]", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[40] 'yyyy-MM' expected, found [ts=2020]", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachFailsInvalidSeparatorFormat() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst8", PartitionBy.MONTH)) {
+                    TableModel dst = new TableModel(configuration, "dst8", PartitionBy.MONTH);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01'.'2020-02'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (SqlException e) {
-                    Assert.assertEquals("[48] ',' expected", e.getMessage());
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01'.'2020-02'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        Assert.assertEquals("[48] ',' expected", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachMissingPartition() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst9", PartitionBy.DAY)) {
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    TableModel dst = new TableModel(configuration, "dst9", PartitionBy.DAY);
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-01'";
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-01'";
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachNonExisting() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel dst = new TableModel(configuration, "dst10", PartitionBy.DAY)) {
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    TableModel dst = new TableModel(configuration, "dst10", PartitionBy.DAY);
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-01'";
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-01'";
 
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionInWrongDirectoryName() throws Exception {
         assertMemoryLeak(() -> {
-            try (
                     TableModel src = new TableModel(configuration, "src11", PartitionBy.DAY);
-                    TableModel dst = new TableModel(configuration, "dst11", PartitionBy.DAY)
-            ) {
+                    TableModel dst = new TableModel(configuration, "dst11", PartitionBy.DAY);
 
-                TableToken srcTableToken = createPopulateTable(
-                        1,
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        10000,
-                        "2020-01-01",
-                        1);
+                    TableToken srcTableToken = createPopulateTable(
+                            1,
+                            src.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .timestamp("ts"),
+                            10000,
+                            "2020-01-01",
+                            1);
 
-                CreateTableTestUtils.create(
-                        dst.col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .timestamp("ts"));
+                    AbstractCairoTest.create(
+                            dst.col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .timestamp("ts"));
 
-                copyPartitionToAttachable(srcTableToken, "2020-01-01", dst.getName(), "COCONUTS");
+                    copyPartitionToAttachable(srcTableToken, "2020-01-01", dst.getName(), "COCONUTS");
 
-                try {
-                    ddl("ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-02'", sqlExecutionContext);
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    try {
+                        ddl("ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2020-01-02'", sqlExecutionContext);
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -416,20 +414,20 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
     @Test
     public void testAttachPartitionSymbolFileNegativeValue() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src31", PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("l", ColumnType.LONG)
-                                .col("sym", ColumnType.SYMBOL)
-                                .col("i", ColumnType.INT),
-                        10000,
-                        "2022-08-01",
-                        3);
+                    TableModel src = new TableModel(configuration, "src31", PartitionBy.DAY);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("l", ColumnType.LONG)
+                                    .col("sym", ColumnType.SYMBOL)
+                                    .col("i", ColumnType.INT),
+                            10000,
+                            "2022-08-01",
+                            3);
 
-                writeToStrIndexFile(src, "2022-08-02", "sym.d", -1L, 4L);
+                    writeToStrIndexFile(src, "2022-08-02", "sym.d", -1L, 4L);
 
-                try (TableModel dst = new TableModel(configuration, "dst31", PartitionBy.DAY)) {
+                    TableModel dst = new TableModel(configuration, "dst31", PartitionBy.DAY);
                     createPopulateTable(
                             1,
                             dst.timestamp("ts")
@@ -447,8 +445,7 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
                         TestUtils.assertContains(e.getFlyweightMessage(), "Symbol file does not match symbol column, invalid key");
                     }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -483,35 +480,35 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
     @Test
     public void testAttachPartitionWhereTimestampColumnNameIsOtherThanTimestamp() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src33", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst33", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src33", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst33", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                CreateTableTestUtils.create(dst.timestamp("ts1")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts1")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                try {
-                    attachFromSrcIntoDst(src, dst, "2022-08-01");
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(),
-                            "could not open read-only"
-                    );
-                    TestUtils.assertContains(e.getFlyweightMessage(),
-                            "ts1.d"
-                    );
+                    try {
+                        attachFromSrcIntoDst(src, dst, "2022-08-01");
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(),
+                                "could not open read-only"
+                        );
+                        TestUtils.assertContains(e.getFlyweightMessage(),
+                                "ts1.d"
+                        );
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -541,410 +538,410 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
     @Test
     public void testAttachPartitionsDeletedColumnFromSrc() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, testName.getMethodName() + "_src", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, testName.getMethodName() + "_dst", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, testName.getMethodName() + "_src", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, testName.getMethodName() + "_dst", PartitionBy.DAY);
 
-                TableToken srcTableToken = createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 128)
-                                .col("str", ColumnType.STRING),
-                        8,
-                        "2022-08-01",
-                        4);
-                try (TableWriter writer = getWriter(src.getName())) {
-                    writer.removeColumn("s");
-                    writer.removeColumn("str");
-                    writer.removeColumn("i");
+                    TableToken srcTableToken = createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL).indexed(true, 128)
+                                    .col("str", ColumnType.STRING),
+                            8,
+                            "2022-08-01",
+                            4);
+                    try (TableWriter writer = getWriter(src.getName())) {
+                        writer.removeColumn("s");
+                        writer.removeColumn("str");
+                        writer.removeColumn("i");
+                    }
+
+                    TableToken dstTableToken = AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s", ColumnType.SYMBOL).indexed(true, 128)
+                            .col("str", ColumnType.STRING)
+                    );
+
+                    copyPartitionToAttachable(srcTableToken, "2022-08-02", dstTableToken.getDirName(), "2022-08-02");
+                    ddl("ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2022-08-02'", sqlExecutionContext);
+
+                    engine.clear();
+                    assertQuery(
+                            "ts\ti\tl\ts\tstr\n" +
+                                    "2022-08-02T11:59:59.625000Z\tNaN\t3\t\t\n" +
+                                    "2022-08-02T23:59:59.500000Z\tNaN\t4\t\t\n",
+                            dst.getName(),
+                            "ts",
+                            true,
+                            true
+                    );
                 }
-
-                TableToken dstTableToken = CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG)
-                        .col("s", ColumnType.SYMBOL).indexed(true, 128)
-                        .col("str", ColumnType.STRING)
-                );
-
-                copyPartitionToAttachable(srcTableToken, "2022-08-02", dstTableToken.getDirName(), "2022-08-02");
-                ddl("ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2022-08-02'", sqlExecutionContext);
-
-                engine.clear();
-                assertQuery(
-                        "ts\ti\tl\ts\tstr\n" +
-                                "2022-08-02T11:59:59.625000Z\tNaN\t3\t\t\n" +
-                                "2022-08-02T23:59:59.500000Z\tNaN\t4\t\t\n",
-                        dst.getName(),
-                        "ts",
-                        true,
-                        true
-                );
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionsDetachedHasExtraColumn() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src48", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst48", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src48", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst48", PartitionBy.DAY);
 
-                int partitionRowCount = 11;
-                TableToken srcTableToken = createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 128),
-                        partitionRowCount,
-                        "2022-08-01",
-                        4);
+                    int partitionRowCount = 11;
+                    TableToken srcTableToken = createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL).indexed(true, 128),
+                            partitionRowCount,
+                            "2022-08-01",
+                            4);
 
-                TableToken dstTableToken = CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    TableToken dstTableToken = AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                copyPartitionToAttachable(srcTableToken, "2022-08-01", dstTableToken.getDirName(), "2022-08-01");
+                    copyPartitionToAttachable(srcTableToken, "2022-08-01", dstTableToken.getDirName(), "2022-08-01");
 
-                long timestamp = TimestampFormatUtils.parseTimestamp("2022-08-01T00:00:00.000z");
-                long txn;
-                try (TableWriter writer = getWriter(dst.getName())) {
-                    txn = writer.getTxn();
-                    writer.attachPartition(timestamp);
+                    long timestamp = TimestampFormatUtils.parseTimestamp("2022-08-01T00:00:00.000z");
+                    long txn;
+                    try (TableWriter writer = getWriter(dst.getName())) {
+                        txn = writer.getTxn();
+                        writer.attachPartition(timestamp);
+                    }
+                    path.of(configuration.getRoot()).concat(dstTableToken);
+                    TableUtils.setPathForPartition(path, PartitionBy.DAY, IntervalUtils.parseFloorPartialTimestamp("2022-08-01"), txn);
+                    int pathLen = path.size();
+
+                    // Extra columns not deleted
+                    Assert.assertTrue(Files.exists(path.concat("s.d").$()));
+                    Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("s.k").$()));
+                    Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("s.v").$()));
+                    Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("l.d").$()));
+
+                    engine.clear();
+                    assertQuery(
+                            "ts\ti\tl\n" +
+                                    "2022-08-01T08:43:38.090909Z\t1\t1\n" +
+                                    "2022-08-01T17:27:16.181818Z\t2\t2\n",
+                            dst.getName(),
+                            "ts",
+                            true,
+                            true
+                    );
                 }
-                path.of(configuration.getRoot()).concat(dstTableToken);
-                TableUtils.setPathForPartition(path, PartitionBy.DAY, IntervalUtils.parseFloorPartialTimestamp("2022-08-01"), txn);
-                int pathLen = path.size();
-
-                // Extra columns not deleted
-                Assert.assertTrue(Files.exists(path.concat("s.d").$()));
-                Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("s.k").$()));
-                Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("s.v").$()));
-                Assert.assertTrue(Files.exists(path.trimTo(pathLen).concat("l.d").$()));
-
-                engine.clear();
-                assertQuery(
-                        "ts\ti\tl\n" +
-                                "2022-08-01T08:43:38.090909Z\t1\t1\n" +
-                                "2022-08-01T17:27:16.181818Z\t2\t2\n",
-                        dst.getName(),
-                        "ts",
-                        true,
-                        true
-                );
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionsNonPartitioned() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src35", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst35", PartitionBy.NONE)) {
+                    TableModel src = new TableModel(configuration, "src35", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst35", PartitionBy.NONE);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                try {
-                    attachFromSrcIntoDst(src, dst, "2022-08-01");
-                    Assert.fail();
-                } catch (SqlException e) {
-                    TestUtils.assertEquals("[25] table is not partitioned", e.getMessage());
+                    try {
+                        attachFromSrcIntoDst(src, dst, "2022-08-01");
+                        Assert.fail();
+                    } catch (SqlException e) {
+                        TestUtils.assertEquals("[25] table is not partitioned", e.getMessage());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionsTableInTransaction() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src36", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst36", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src36", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst36", PartitionBy.DAY);
 
-                int partitionRowCount = 111;
-                TableToken srcTableToken = createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        partitionRowCount,
-                        "2022-08-01",
-                        1);
+                    int partitionRowCount = 111;
+                    TableToken srcTableToken = createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            partitionRowCount,
+                            "2022-08-01",
+                            1);
 
-                TableToken dstTableToken = CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    TableToken dstTableToken = AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                copyPartitionToAttachable(srcTableToken, "2022-08-01", dstTableToken.getDirName(), "2022-08-01");
+                    copyPartitionToAttachable(srcTableToken, "2022-08-01", dstTableToken.getDirName(), "2022-08-01");
 
-                // Add 1 row without commit
-                long timestamp = TimestampFormatUtils.parseTimestamp("2022-08-01T00:00:00.000z");
-                try (TableWriter writer = getWriter(dst.getName())) {
-                    long insertTs = TimestampFormatUtils.parseTimestamp("2022-08-01T23:59:59.999z");
-                    TableWriter.Row row = writer.newRow(insertTs + 1000L);
-                    row.putLong(0, 1L);
-                    row.putInt(1, 1);
-                    row.append();
+                    // Add 1 row without commit
+                    long timestamp = TimestampFormatUtils.parseTimestamp("2022-08-01T00:00:00.000z");
+                    try (TableWriter writer = getWriter(dst.getName())) {
+                        long insertTs = TimestampFormatUtils.parseTimestamp("2022-08-01T23:59:59.999z");
+                        TableWriter.Row row = writer.newRow(insertTs + 1000L);
+                        row.putLong(0, 1L);
+                        row.putInt(1, 1);
+                        row.append();
 
-                    Assert.assertTrue(writer.inTransaction());
+                        Assert.assertTrue(writer.inTransaction());
 
-                    // This commits the append before attaching
-                    writer.attachPartition(timestamp);
-                    Assert.assertEquals(partitionRowCount + 1, writer.size());
+                        // This commits the append before attaching
+                        writer.attachPartition(timestamp);
+                        Assert.assertEquals(partitionRowCount + 1, writer.size());
 
-                    Assert.assertFalse(writer.inTransaction());
+                        Assert.assertFalse(writer.inTransaction());
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionsWithExtraCharsInPartitionNameByDay() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src3a", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst3a", PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2020-01-01",
-                        12);
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
-                attachFromSrcIntoDst(src, dst, "2020-01-09.10", "2020-01-10T19", "2020-01-01T20:22:24.262829Z");
-            }
-        });
+                    TableModel src = new TableModel(configuration, "src3a", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst3a", PartitionBy.DAY);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2020-01-01",
+                            12);
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
+                    attachFromSrcIntoDst(src, dst, "2020-01-09.10", "2020-01-10T19", "2020-01-01T20:22:24.262829Z");
+                }
+        );
     }
 
     @Test
     public void testAttachPartitionsWithIndexedSymbolsValueMatch() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src37", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst37", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src37", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst37", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s", ColumnType.SYMBOL).indexed(false, 4096),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL).indexed(false, 4096),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                // Make sure nulls are included in the partition to be attached
-                assertSql("count\n302\n", "select count() from " + src.getName() + " where ts in '2022-08-09' and s = null");
+                    // Make sure nulls are included in the partition to be attached
+                    assertSql("count\n302\n", "select count() from " + src.getName() + " where ts in '2022-08-09' and s = null");
 
-                createPopulateTable(
-                        1,
-                        dst.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s", ColumnType.SYMBOL).indexed(false, 4096),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            dst.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL).indexed(false, 4096),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
+                    compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
 
-                attachFromSrcIntoDst(src, dst, "2022-08-09");
-            }
-        });
+                    attachFromSrcIntoDst(src, dst, "2022-08-09");
+                }
+        );
     }
 
     @Test
     public void testAttachPartitionsWithSymbolsValueDoesNotMatch() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src38", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst38", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src38", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst38", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("s2", ColumnType.SYMBOL)
-                                .col("l", ColumnType.LONG),
-                        20,
-                        "2022-08-01",
-                        3);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("s2", ColumnType.SYMBOL)
+                                    .col("l", ColumnType.LONG),
+                            20,
+                            "2022-08-01",
+                            3);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("s", ColumnType.SYMBOL)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("s", ColumnType.SYMBOL)
+                            .col("l", ColumnType.LONG));
 
-                attachFromSrcIntoDst(src, dst, "2022-08-01", "2022-08-02");
+                    attachFromSrcIntoDst(src, dst, "2022-08-01", "2022-08-02");
 
-                // s2 column files from the attached partitions should be ignored
-                // and coltops for s column should be created instead.
-                assertSql("count\n0\n", "select count() from " + dst.getName() + " where s is not null");
-            }
-        });
+                    // s2 column files from the attached partitions should be ignored
+                    // and coltops for s column should be created instead.
+                    assertSql("count\n0\n", "select count() from " + dst.getName() + " where s is not null");
+                }
+        );
     }
 
     @Test
     public void testAttachPartitionsWithSymbolsValueMatch() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src39", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst39", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src39", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst39", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                // Make sure nulls are included in the partition to be attached
-                assertSql("count\n302\n", "select count() from " + src.getName() + " where ts in '2022-08-09' and s = null");
+                    // Make sure nulls are included in the partition to be attached
+                    assertSql("count\n302\n", "select count() from " + src.getName() + " where ts in '2022-08-09' and s = null");
 
-                createPopulateTable(
-                        1,
-                        dst.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            dst.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
+                    compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
 
-                attachFromSrcIntoDst(src, dst, "2022-08-09");
-            }
-        });
+                    attachFromSrcIntoDst(src, dst, "2022-08-09");
+                }
+        );
     }
 
     @Test
     public void testAttachPartitionsWithSymbolsValueMatchWithNoIndex() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src40", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst40", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src40", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst40", PartitionBy.DAY);
 
-                createPopulateTable(
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            src.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                createPopulateTable(
-                        1,
-                        dst.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 4096)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            dst.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL).indexed(true, 4096)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
+                    compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
 
-                try {
-                    attachFromSrcIntoDst(src, dst, "2022-08-09");
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(),
-                            "Symbol index value file does not exist"
-                    );
+                    try {
+                        attachFromSrcIntoDst(src, dst, "2022-08-09");
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(),
+                                "Symbol index value file does not exist"
+                        );
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachPartitionsWithSymbolsValueMatchWithNoIndexKeyFile() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src41", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst41", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src41", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst41", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 4096)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL).indexed(true, 4096)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                createPopulateTable(
-                        1,
-                        dst.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("s", ColumnType.SYMBOL).indexed(true, 4096)
-                                .timestamp("ts"),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            dst.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("s", ColumnType.SYMBOL).indexed(true, 4096)
+                                    .timestamp("ts"),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
+                    compile("alter table " + dst.getName() + " drop partition list '2022-08-09'");
 
-                // remove .k
-                engine.clear();
-                TableToken tableToken = engine.verifyTableName(src.getName());
-                path.of(configuration.getRoot()).concat(tableToken).concat("2022-08-09").concat("s.k").$();
-                Assert.assertTrue(Files.remove(path));
-                try {
-                    attachFromSrcIntoDst(src, dst, "2022-08-09");
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "Symbol index key file does not exist");
+                    // remove .k
+                    engine.clear();
+                    TableToken tableToken = engine.verifyTableName(src.getName());
+                    path.of(configuration.getRoot()).concat(tableToken).concat("2022-08-09").concat("s.k").$();
+                    Assert.assertTrue(Files.remove(path));
+                    try {
+                        attachFromSrcIntoDst(src, dst, "2022-08-09");
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "Symbol index key file does not exist");
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
     public void testAttachSamePartitionTwice() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src42", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst42", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src42", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst42", PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                attachFromSrcIntoDst(src, dst, "2022-08-09");
+                    attachFromSrcIntoDst(src, dst, "2022-08-09");
 
-                String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2022-08-09'";
+                    String alterCommand = "ALTER TABLE " + dst.getName() + " ATTACH PARTITION LIST '2022-08-09'";
 
-                try {
-                    ddl(alterCommand, sqlExecutionContext);
-                    Assert.fail();
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    try {
+                        ddl(alterCommand, sqlExecutionContext);
+                        Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "could not attach partition");
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -1046,67 +1043,67 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
         }
 
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "src47", PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dst47", PartitionBy.DAY)) {
+                    TableModel src = new TableModel(configuration, "src47", PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dst47", PartitionBy.DAY);
 
-                int partitionRowCount = 5;
-                TableToken srcTableToken = createPopulateTable(
-                        1,
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("str", ColumnType.STRING)
-                                .timestamp("ts"),
-                        partitionRowCount,
-                        "2020-01-09",
-                        2);
+                    int partitionRowCount = 5;
+                    TableToken srcTableToken = createPopulateTable(
+                            1,
+                            src.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("str", ColumnType.STRING)
+                                    .timestamp("ts"),
+                            partitionRowCount,
+                            "2020-01-09",
+                            2);
 
-                TableToken dstTableToken = createPopulateTable(
-                        1,
-                        dst.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .col("str", ColumnType.STRING)
-                                .timestamp("ts"),
-                        partitionRowCount - 3,
-                        "2020-01-09",
-                        2);
+                    TableToken dstTableToken = createPopulateTable(
+                            1,
+                            dst.col("l", ColumnType.LONG)
+                                    .col("i", ColumnType.INT)
+                                    .col("str", ColumnType.STRING)
+                                    .timestamp("ts"),
+                            partitionRowCount - 3,
+                            "2020-01-09",
+                            2);
 
-                try (TableReader dstReader = newOffPoolReader(configuration, dst.getTableName())) {
-                    dstReader.openPartition(0);
-                    dstReader.openPartition(1);
-                    dstReader.goPassive();
+                    try (TableReader dstReader = newOffPoolReader(configuration, dst.getTableName())) {
+                        dstReader.openPartition(0);
+                        dstReader.openPartition(1);
+                        dstReader.goPassive();
 
-                    long timestamp = TimestampFormatUtils.parseTimestamp("2020-01-09T00:00:00.000z");
+                        long timestamp = TimestampFormatUtils.parseTimestamp("2020-01-09T00:00:00.000z");
 
-                    try (TableWriter writer = getWriter(dst.getTableName())) {
-                        writer.removePartition(timestamp);
-                        copyPartitionToAttachable(srcTableToken, "2020-01-09", dstTableToken.getDirName(), "2020-01-09");
-                        Assert.assertEquals(AttachDetachStatus.OK, writer.attachPartition(timestamp));
-                    }
+                        try (TableWriter writer = getWriter(dst.getTableName())) {
+                            writer.removePartition(timestamp);
+                            copyPartitionToAttachable(srcTableToken, "2020-01-09", dstTableToken.getDirName(), "2020-01-09");
+                            Assert.assertEquals(AttachDetachStatus.OK, writer.attachPartition(timestamp));
+                        }
 
-                    // Go active
-                    Assert.assertTrue(dstReader.reload());
-                    try (TableReader srcReader = getReader(src.getTableName())) {
-                        String expected =
-                                "l\ti\tstr\tts\n" +
-                                        "1\t1\t1\t2020-01-09T09:35:59.800000Z\n" +
-                                        "2\t2\t2\t2020-01-09T19:11:59.600000Z\n" +
-                                        "3\t3\t3\t2020-01-10T04:47:59.400000Z\n" +
-                                        "4\t4\t4\t2020-01-10T14:23:59.200000Z\n" +
-                                        "5\t5\t5\t2020-01-10T23:59:59.000000Z\n";
-                        assertCursor(expected, srcReader.getCursor(), srcReader.getMetadata(), true);
+                        // Go active
+                        Assert.assertTrue(dstReader.reload());
+                        try (TableReader srcReader = getReader(src.getTableName())) {
+                            String expected =
+                                    "l\ti\tstr\tts\n" +
+                                            "1\t1\t1\t2020-01-09T09:35:59.800000Z\n" +
+                                            "2\t2\t2\t2020-01-09T19:11:59.600000Z\n" +
+                                            "3\t3\t3\t2020-01-10T04:47:59.400000Z\n" +
+                                            "4\t4\t4\t2020-01-10T14:23:59.200000Z\n" +
+                                            "5\t5\t5\t2020-01-10T23:59:59.000000Z\n";
+                            assertCursor(expected, srcReader.getCursor(), srcReader.getMetadata(), true);
 
-                        // Check that first 2 lines of partition 2020-01-09 match for src and dst tables
-                        assertCursor("l\ti\tstr\tts\n" +
-                                        "1\t1\t1\t2020-01-09T09:35:59.800000Z\n" +
-                                        "2\t2\t2\t2020-01-09T19:11:59.600000Z\n" +
-                                        "2\t2\t2\t2020-01-10T23:59:59.000000Z\n",
-                                dstReader.getCursor(),
-                                dstReader.getMetadata(),
-                                true);
+                            // Check that first 2 lines of partition 2020-01-09 match for src and dst tables
+                            assertCursor("l\ti\tstr\tts\n" +
+                                            "1\t1\t1\t2020-01-09T09:35:59.800000Z\n" +
+                                            "2\t2\t2\t2020-01-09T19:11:59.600000Z\n" +
+                                            "2\t2\t2\t2020-01-10T23:59:59.000000Z\n",
+                                    dstReader.getCursor(),
+                                    dstReader.getMetadata(),
+                                    true);
+                        }
                     }
                 }
-            }
-        });
+        );
     }
 
     private void assertSchemaMatch(AddColumn tm, int idx) throws Exception {
@@ -1114,28 +1111,28 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
             setUp();
         }
         assertMemoryLeak(() -> {
-            try (TableModel src = new TableModel(configuration, "srcCM" + idx, PartitionBy.DAY);
-                 TableModel dst = new TableModel(configuration, "dstCM" + idx, PartitionBy.DAY)) {
-                src.col("l", ColumnType.LONG)
-                        .col("i", ColumnType.INT)
-                        .timestamp("ts");
-                tm.add(src);
+                    TableModel src = new TableModel(configuration, "srcCM" + idx, PartitionBy.DAY);
+                    TableModel dst = new TableModel(configuration, "dstCM" + idx, PartitionBy.DAY);
+                    src.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts");
+                    tm.add(src);
 
-                createPopulateTable(
-                        src,
-                        10000,
-                        "2022-08-01",
-                        10);
+                    createPopulateTable(
+                            src,
+                            10000,
+                            "2022-08-01",
+                            10);
 
-                dst.col("l", ColumnType.LONG)
-                        .col("i", ColumnType.INT)
-                        .timestamp("ts");
-                tm.add(dst);
+                    dst.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts");
+                    tm.add(dst);
 
-                CreateTableTestUtils.create(dst);
-                attachFromSrcIntoDst(src, dst, "2022-08-01");
-            }
-        });
+                    AbstractCairoTest.create(dst);
+                    attachFromSrcIntoDst(src, dst, "2022-08-01");
+                }
+        );
         if (idx > 0) {
             tearDown();
         }
@@ -1149,48 +1146,45 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
             AddColumn afterCreateSrc,
             String errorMessage
     ) throws Exception {
-        try (
-                TableModel src = new TableModel(configuration, srcTableName, PartitionBy.DAY);
-                TableModel dst = new TableModel(configuration, dstTableName, PartitionBy.DAY)
-        ) {
-            srcTransform.add(src);
-            createPopulateTable(
-                    1,
-                    src,
-                    45000,
-                    "2022-08-01",
-                    10
-            );
+        TableModel src = new TableModel(configuration, srcTableName, PartitionBy.DAY);
+        TableModel dst = new TableModel(configuration, dstTableName, PartitionBy.DAY);
+        srcTransform.add(src);
+        createPopulateTable(
+                1,
+                src,
+                45000,
+                "2022-08-01",
+                10
+        );
 
-            if (afterCreateSrc != null) {
-                afterCreateSrc.add(src);
-            }
-
-            // make dst a copy of src
-            int tsIdx = src.getTimestampIndex();
-            for (int i = 0, limit = src.getColumnCount(); i < limit; i++) {
-                if (i != tsIdx) {
-                    dst.col(src.getColumnName(i), src.getColumnType(i));
-                    if (src.isIndexed(i)) {
-                        dst.indexed(true, src.getIndexBlockCapacity(i));
-                    }
-                } else {
-                    dst.timestamp(src.getColumnName(i));
-                }
-            }
-
-            // apply transform to dst and create table
-            dstTransform.add(dst);
-            CreateTableTestUtils.create(dst);
-            try {
-                attachFromSrcIntoDst(src, dst, "2022-08-01");
-                Assert.fail("Expected exception with '" + errorMessage + "' message");
-            } catch (CairoException e) {
-                TestUtils.assertContains(e.getFlyweightMessage(), errorMessage);
-            }
-            TableToken tableToken = engine.verifyTableName(dstTableName);
-            Files.rmdir(path.of(root).concat(tableToken).concat("2022-08-01").put(configuration.getAttachPartitionSuffix()).$(), true);
+        if (afterCreateSrc != null) {
+            afterCreateSrc.add(src);
         }
+
+        // make dst a copy of src
+        int tsIdx = src.getTimestampIndex();
+        for (int i = 0, limit = src.getColumnCount(); i < limit; i++) {
+            if (i != tsIdx) {
+                dst.col(src.getColumnName(i), src.getColumnType(i));
+                if (src.isIndexed(i)) {
+                    dst.indexed(true, src.getIndexBlockCapacity(i));
+                }
+            } else {
+                dst.timestamp(src.getColumnName(i));
+            }
+        }
+
+        // apply transform to dst and create table
+        dstTransform.add(dst);
+        AbstractCairoTest.create(dst);
+        try {
+            attachFromSrcIntoDst(src, dst, "2022-08-01");
+            Assert.fail("Expected exception with '" + errorMessage + "' message");
+        } catch (CairoException e) {
+            TestUtils.assertContains(e.getFlyweightMessage(), errorMessage);
+        }
+        TableToken tableToken = engine.verifyTableName(dstTableName);
+        Files.rmdir(path.of(root).concat(tableToken).concat("2022-08-01").put(configuration.getAttachPartitionSuffix()).$(), true);
     }
 
     private void attachFromSrcIntoDst(TableModel src, TableModel dst, String... partitionList) throws SqlException, NumericException {
@@ -1342,45 +1336,43 @@ public class AlterTableAttachPartitionTest extends AbstractAlterTableAttachParti
             String... errorContains
     ) throws Exception {
         assertMemoryLeak(ff, () -> {
-            try (
                     TableModel src = new TableModel(configuration, srcTableName, PartitionBy.DAY);
-                    TableModel dst = new TableModel(configuration, dstTableName, PartitionBy.DAY)
-            ) {
+                    TableModel dst = new TableModel(configuration, dstTableName, PartitionBy.DAY);
 
-                createPopulateTable(
-                        1,
-                        src.timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG),
-                        100,
-                        "2020-01-01",
-                        3);
+                    createPopulateTable(
+                            1,
+                            src.timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            100,
+                            "2020-01-01",
+                            3);
 
-                CreateTableTestUtils.create(dst.timestamp("ts")
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG));
+                    AbstractCairoTest.create(dst.timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG));
 
-                try {
-                    attachFromSrcIntoDst(src, dst, "2020-01-01");
-                    Assert.fail();
-                } catch (CairoException | SqlException e) {
-                    for (String error : errorContains) {
-                        TestUtils.assertContains(e.getFlyweightMessage(), error);
-                    }
-                } catch (Throwable e) {
-                    if (catchAll) {
+                    try {
+                        attachFromSrcIntoDst(src, dst, "2020-01-01");
+                        Assert.fail();
+                    } catch (CairoException | SqlException e) {
                         for (String error : errorContains) {
-                            TestUtils.assertContains(e.getMessage(), error);
+                            TestUtils.assertContains(e.getFlyweightMessage(), error);
                         }
-                    } else {
-                        throw e;
+                    } catch (Throwable e) {
+                        if (catchAll) {
+                            for (String error : errorContains) {
+                                TestUtils.assertContains(e.getMessage(), error);
+                            }
+                        } else {
+                            throw e;
+                        }
                     }
-                }
 
-                // second attempt without FilesFacade override should work ok
-                attachFromSrcIntoDst(src, dst, "2020-01-02");
-            }
-        });
+                    // second attempt without FilesFacade override should work ok
+                    attachFromSrcIntoDst(src, dst, "2020-01-02");
+                }
+        );
     }
 
     private void writeToStrIndexFile(TableModel src, String partition, String columnFileName, long value, long offset) {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -38,7 +38,6 @@ import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.Overrides;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -123,29 +122,28 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                 }
             };
 
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                assertSql(
-                        "first\tts\n" +
-                                "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
 
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                        ATTACH_ERR_COPY.name()
-                );
-            }
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                    ATTACH_ERR_COPY.name()
+            );
         });
     }
 
@@ -172,36 +170,35 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(ff1, () -> {
             String tableName = testName.getMethodName();
 
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                assertSql(
-                        "first\tts\n" +
-                                "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
 
-                compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                assertFailure("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", DETACH_ERR_COPY_META.name());
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertFailure("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", DETACH_ERR_COPY_META.name());
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
 
-                assertSql(
-                        "first\tts\n" +
-                                "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
-                                "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
-                                "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                );
-            }
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
+                            "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
+                            "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
         });
     }
 
@@ -226,41 +223,40 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                     DETACHED_DIR_MARKER
             );
 
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                assertSql(
-                        "first\tts\n" +
-                                "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
 
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                        "could not attach partition"
-                );
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                        "could not attach partition"
-                );
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                    "could not attach partition"
+            );
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                    "could not attach partition"
+            );
 
-                compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                assertSql(
-                        "first\tts\n" +
-                                "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
-                                "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
-                                "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                );
-            }
+            compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
+                            "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
+                            "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
         });
     }
 
@@ -268,39 +264,38 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachPartitionAfterTruncate() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        src.col("sym", ColumnType.SYMBOL).timestamp("ts"),
-                        3,
-                        "2020-01-01",
-                        1
-                );
+            TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    src.col("sym", ColumnType.SYMBOL).timestamp("ts"),
+                    3,
+                    "2020-01-01",
+                    1
+            );
 
-                insert("insert into " + tableName + " values ('foobar', '2020-01-02T23:59:59')");
+            insert("insert into " + tableName + " values ('foobar', '2020-01-02T23:59:59')");
 
-                assertSql(
-                        "first\tsym\n" +
-                                "2020-01-01T07:59:59.666666Z\tCPSW\n" +
-                                "2020-01-01T15:59:59.333332Z\tHYRX\n" +
-                                "2020-01-01T23:59:58.999998Z\t\n" +
-                                "2020-01-02T23:59:59.000000Z\tfoobar\n", "select first(ts), sym from " + tableName + " sample by 1d"
-                );
+            assertSql(
+                    "first\tsym\n" +
+                            "2020-01-01T07:59:59.666666Z\tCPSW\n" +
+                            "2020-01-01T15:59:59.333332Z\tHYRX\n" +
+                            "2020-01-01T23:59:58.999998Z\t\n" +
+                            "2020-01-02T23:59:59.000000Z\tfoobar\n", "select first(ts), sym from " + tableName + " sample by 1d"
+            );
 
-                compile("alter table " + tableName + " detach partition list '2020-01-01'");
+            compile("alter table " + tableName + " detach partition list '2020-01-01'");
 
-                compile("truncate table " + tableName);
+            compile("truncate table " + tableName);
 
-                renameDetachedToAttachable(tableName, "2020-01-01");
-                compile("alter table " + tableName + " attach partition list '2020-01-01'");
+            renameDetachedToAttachable(tableName, "2020-01-01");
+            compile("alter table " + tableName + " attach partition list '2020-01-01'");
 
-                // No symbols are present.
-                assertSql(
-                        "first\tsym\n" +
-                                "2020-01-01T07:59:59.666666Z\t\n" +
-                                "2020-01-01T15:59:59.333332Z\t\n" +
-                                "2020-01-01T23:59:58.999998Z\t\n", "select first(ts), sym from " + tableName + " sample by 1d"
-                );
-            }
+            // No symbols are present.
+            assertSql(
+                    "first\tsym\n" +
+                            "2020-01-01T07:59:59.666666Z\t\n" +
+                            "2020-01-01T15:59:59.333332Z\t\n" +
+                            "2020-01-01T23:59:58.999998Z\t\n", "select first(ts), sym from " + tableName + " sample by 1d"
+            );
         });
     }
 
@@ -308,41 +303,40 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachPartitionAfterTruncateKeepSymbolTables() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                // It's important to have a symbol column here to make sure
-                // that we don't wipe symbol tables on TRUNCATE.
-                createPopulateTable(
-                        src.col("sym", ColumnType.SYMBOL).timestamp("ts"),
-                        3,
-                        "2020-01-01",
-                        1
-                );
+            TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY);
+            // It's important to have a symbol column here to make sure
+            // that we don't wipe symbol tables on TRUNCATE.
+            createPopulateTable(
+                    src.col("sym", ColumnType.SYMBOL).timestamp("ts"),
+                    3,
+                    "2020-01-01",
+                    1
+            );
 
-                insert("insert into " + tableName + " values ('foobar', '2020-01-02T23:59:59')");
+            insert("insert into " + tableName + " values ('foobar', '2020-01-02T23:59:59')");
 
-                assertSql(
-                        "first\tsym\n" +
-                                "2020-01-01T07:59:59.666666Z\tCPSW\n" +
-                                "2020-01-01T15:59:59.333332Z\tHYRX\n" +
-                                "2020-01-01T23:59:58.999998Z\t\n" +
-                                "2020-01-02T23:59:59.000000Z\tfoobar\n", "select first(ts), sym from " + tableName + " sample by 1d"
-                );
+            assertSql(
+                    "first\tsym\n" +
+                            "2020-01-01T07:59:59.666666Z\tCPSW\n" +
+                            "2020-01-01T15:59:59.333332Z\tHYRX\n" +
+                            "2020-01-01T23:59:58.999998Z\t\n" +
+                            "2020-01-02T23:59:59.000000Z\tfoobar\n", "select first(ts), sym from " + tableName + " sample by 1d"
+            );
 
-                compile("alter table " + tableName + " detach partition list '2020-01-01'");
+            compile("alter table " + tableName + " detach partition list '2020-01-01'");
 
-                compile("truncate table " + tableName + " keep symbol maps");
+            compile("truncate table " + tableName + " keep symbol maps");
 
-                renameDetachedToAttachable(tableName, "2020-01-01");
-                compile("alter table " + tableName + " attach partition list '2020-01-01'");
+            renameDetachedToAttachable(tableName, "2020-01-01");
+            compile("alter table " + tableName + " attach partition list '2020-01-01'");
 
-                // All symbols are kept.
-                assertSql(
-                        "first\tsym\n" +
-                                "2020-01-01T07:59:59.666666Z\tCPSW\n" +
-                                "2020-01-01T15:59:59.333332Z\tHYRX\n" +
-                                "2020-01-01T23:59:58.999998Z\t\n", "select first(ts), sym from " + tableName + " sample by 1d"
-                );
-            }
+            // All symbols are kept.
+            assertSql(
+                    "first\tsym\n" +
+                            "2020-01-01T07:59:59.666666Z\tCPSW\n" +
+                            "2020-01-01T15:59:59.333332Z\tHYRX\n" +
+                            "2020-01-01T23:59:58.999998Z\t\n", "select first(ts), sym from " + tableName + " sample by 1d"
+            );
         });
     }
 
@@ -350,45 +344,44 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachPartitionCommits() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        5,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    5,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-02";
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            String timestampDay = "2022-06-02";
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
 
-                renameDetachedToAttachable(tableName, timestampDay);
+            renameDetachedToAttachable(tableName, timestampDay);
 
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
 
-                    TableWriter.Row row = writer.newRow(IntervalUtils.parseFloorPartialTimestamp("2022-06-03T12:00:00.000000Z"));
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.append();
+                TableWriter.Row row = writer.newRow(IntervalUtils.parseFloorPartialTimestamp("2022-06-03T12:00:00.000000Z"));
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.append();
 
-                    Assert.assertEquals(AttachDetachStatus.OK, writer.attachPartition(IntervalUtils.parseFloorPartialTimestamp(timestampDay)));
-                }
-
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
-                                "2\t2\t2022-06-02T14:23:59.600000Z\tNaN\n" +
-                                "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
-                                "33\t33\t2022-06-03T12:00:00.000000Z\tNaN\n" +
-                                "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
-                                "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
-                        tableName
-                );
+                Assert.assertEquals(AttachDetachStatus.OK, writer.attachPartition(IntervalUtils.parseFloorPartialTimestamp(timestampDay)));
             }
+
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
+                            "2\t2\t2022-06-02T14:23:59.600000Z\tNaN\n" +
+                            "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
+                            "33\t33\t2022-06-03T12:00:00.000000Z\tNaN\n" +
+                            "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
+                            "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -396,45 +389,44 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachPartitionCommitsToSamePartition() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        5,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    5,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-02";
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            String timestampDay = "2022-06-02";
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
 
-                renameDetachedToAttachable(tableName, timestampDay);
+            renameDetachedToAttachable(tableName, timestampDay);
 
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T22:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T22:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
 
-                    TableWriter.Row row = writer.newRow(timestamp);
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.append();
+                TableWriter.Row row = writer.newRow(timestamp);
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.append();
 
-                    Assert.assertEquals(AttachDetachStatus.ATTACH_ERR_PARTITION_EXISTS, writer.attachPartition(IntervalUtils.parseFloorPartialTimestamp(timestampDay)));
-                }
-
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
-                                "33\t33\t2022-06-02T22:00:00.000000Z\tNaN\n" +
-                                "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
-                                "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
-                                "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
-                        tableName
-                );
+                Assert.assertEquals(AttachDetachStatus.ATTACH_ERR_PARTITION_EXISTS, writer.attachPartition(IntervalUtils.parseFloorPartialTimestamp(timestampDay)));
             }
+
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
+                            "33\t33\t2022-06-02T22:00:00.000000Z\tNaN\n" +
+                            "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
+                            "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
+                            "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -442,53 +434,52 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachPartitionWithColumnTops() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY)) {
+            TableModel src = new TableModel(configuration, tableName, PartitionBy.DAY);
 
-                createPopulateTable(
-                        src.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        100,
-                        "2020-01-01",
-                        2
-                );
+            createPopulateTable(
+                    src.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    100,
+                    "2020-01-01",
+                    2
+            );
 
-                compile("alter table " + tableName + " add column str string");
+            compile("alter table " + tableName + " add column str string");
 
-                compile("insert into " + tableName +
-                        " select x, rnd_int(), timestamp_sequence('2020-01-02T23:59:59', 1000000L * 60 * 20), rnd_str('a', 'b', 'c', null)" +
-                        " from long_sequence(100)");
+            compile("insert into " + tableName +
+                    " select x, rnd_int(), timestamp_sequence('2020-01-02T23:59:59', 1000000L * 60 * 20), rnd_str('a', 'b', 'c', null)" +
+                    " from long_sequence(100)");
 
-                compile("alter table " + tableName + " detach partition list '2020-01-02', '2020-01-03'");
+            compile("alter table " + tableName + " detach partition list '2020-01-02', '2020-01-03'");
 
-                assertSql(
-                        "first\tstr\n" +
-                                "2020-01-01T00:28:47.990000Z\t\n" +
-                                "2020-01-04T00:19:59.000000Z\ta\n" +
-                                "2020-01-04T00:39:59.000000Z\tc\n" +
-                                "2020-01-04T01:19:59.000000Z\tb\n" +
-                                "2020-01-04T01:39:59.000000Z\t\n" +
-                                "2020-01-04T01:59:59.000000Z\ta\n", "select first(ts), str from " + tableName + " sample by 1d"
-                );
+            assertSql(
+                    "first\tstr\n" +
+                            "2020-01-01T00:28:47.990000Z\t\n" +
+                            "2020-01-04T00:19:59.000000Z\ta\n" +
+                            "2020-01-04T00:39:59.000000Z\tc\n" +
+                            "2020-01-04T01:19:59.000000Z\tb\n" +
+                            "2020-01-04T01:39:59.000000Z\t\n" +
+                            "2020-01-04T01:59:59.000000Z\ta\n", "select first(ts), str from " + tableName + " sample by 1d"
+            );
 
-                renameDetachedToAttachable(tableName, "2020-01-02", "2020-01-03");
-                compile("alter table " + tableName + " attach partition list '2020-01-02', '2020-01-03'");
+            renameDetachedToAttachable(tableName, "2020-01-02", "2020-01-03");
+            compile("alter table " + tableName + " attach partition list '2020-01-02', '2020-01-03'");
 
-                assertSql(
-                        "first\tstr\n" +
-                                "2020-01-01T00:28:47.990000Z\t\n" +
-                                "2020-01-02T00:57:35.480000Z\t\n" +
-                                "2020-01-02T23:59:59.000000Z\tc\n" +
-                                "2020-01-03T00:39:59.000000Z\t\n" +
-                                "2020-01-03T01:19:59.000000Z\ta\n" +
-                                "2020-01-03T02:39:59.000000Z\tb\n" +
-                                "2020-01-03T02:59:59.000000Z\tc\n" +
-                                "2020-01-04T00:39:59.000000Z\tc\n" +
-                                "2020-01-04T01:19:59.000000Z\tb\n" +
-                                "2020-01-04T01:39:59.000000Z\t\n" +
-                                "2020-01-04T01:59:59.000000Z\ta\n", "select first(ts), str from " + tableName + " sample by 1d"
-                );
-            }
+            assertSql(
+                    "first\tstr\n" +
+                            "2020-01-01T00:28:47.990000Z\t\n" +
+                            "2020-01-02T00:57:35.480000Z\t\n" +
+                            "2020-01-02T23:59:59.000000Z\tc\n" +
+                            "2020-01-03T00:39:59.000000Z\t\n" +
+                            "2020-01-03T01:19:59.000000Z\ta\n" +
+                            "2020-01-03T02:39:59.000000Z\tb\n" +
+                            "2020-01-03T02:59:59.000000Z\tc\n" +
+                            "2020-01-04T00:39:59.000000Z\tc\n" +
+                            "2020-01-04T01:19:59.000000Z\tb\n" +
+                            "2020-01-04T01:39:59.000000Z\t\n" +
+                            "2020-01-04T01:59:59.000000Z\ta\n", "select first(ts), str from " + tableName + " sample by 1d"
+            );
         });
     }
 
@@ -496,66 +487,65 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testAttachWillFailIfThePartitionWasRecreated() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabTimeTravel2";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                String timestampDay = "2022-06-01";
-                createPopulateTable(
-                        tab
-                                .col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        timestampDay,
-                        4
-                );
-                assertContent(
-                        "l\ti\tts\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\n",
-                        tableName
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            String timestampDay = "2022-06-01";
+            createPopulateTable(
+                    tab
+                            .col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    timestampDay,
+                    4
+            );
+            assertContent(
+                    "l\ti\tts\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\n",
+                    tableName
+            );
 
-                // drop the partition
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            // drop the partition
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
 
-                // insert data, which will create the partition again
-                engine.clear();
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T09:59:59.999999Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    TableWriter.Row row = writer.newRow(timestamp);
-                    row.putLong(0, 137L);
-                    row.putInt(1, 137);
-                    row.append();
-                    writer.commit();
-                }
-                String expected = "l\ti\tts\n" +
-                        "137\t137\t2022-06-01T09:59:59.999999Z\n" +
-                        "4\t4\t2022-06-02T07:59:59.666664Z\n" +
-                        "5\t5\t2022-06-02T15:59:59.583330Z\n" +
-                        "6\t6\t2022-06-02T23:59:59.499996Z\n" +
-                        "7\t7\t2022-06-03T07:59:59.416662Z\n" +
-                        "8\t8\t2022-06-03T15:59:59.333328Z\n" +
-                        "9\t9\t2022-06-03T23:59:59.249994Z\n" +
-                        "10\t10\t2022-06-04T07:59:59.166660Z\n" +
-                        "11\t11\t2022-06-04T15:59:59.083326Z\n" +
-                        "12\t12\t2022-06-04T23:59:58.999992Z\n";
-                assertContent(expected, tableName);
-                renameDetachedToAttachable(tableName, timestampDay);
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'",
-                        "could not attach partition [table=tabTimeTravel2, detachStatus=ATTACH_ERR_PARTITION_EXISTS"
-                );
-                assertContent(expected, tableName);
+            // insert data, which will create the partition again
+            engine.clear();
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T09:59:59.999999Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                TableWriter.Row row = writer.newRow(timestamp);
+                row.putLong(0, 137L);
+                row.putInt(1, 137);
+                row.append();
+                writer.commit();
             }
+            String expected = "l\ti\tts\n" +
+                    "137\t137\t2022-06-01T09:59:59.999999Z\n" +
+                    "4\t4\t2022-06-02T07:59:59.666664Z\n" +
+                    "5\t5\t2022-06-02T15:59:59.583330Z\n" +
+                    "6\t6\t2022-06-02T23:59:59.499996Z\n" +
+                    "7\t7\t2022-06-03T07:59:59.416662Z\n" +
+                    "8\t8\t2022-06-03T15:59:59.333328Z\n" +
+                    "9\t9\t2022-06-03T23:59:59.249994Z\n" +
+                    "10\t10\t2022-06-04T07:59:59.166660Z\n" +
+                    "11\t11\t2022-06-04T15:59:59.083326Z\n" +
+                    "12\t12\t2022-06-04T23:59:58.999992Z\n";
+            assertContent(expected, tableName);
+            renameDetachedToAttachable(tableName, timestampDay);
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'",
+                    "could not attach partition [table=tabTimeTravel2, detachStatus=ATTACH_ERR_PARTITION_EXISTS"
+            );
+            assertContent(expected, tableName);
         });
     }
 
@@ -600,19 +590,18 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
 
         assertMemoryLeak(ff, () -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        100,
-                        "2022-06-01",
-                        5
-                );
-            }
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    100,
+                    "2022-06-01",
+                    5
+            );
 
             compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-03'");
 
@@ -645,36 +634,35 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                 ff1,
                 () -> {
                     String tableName = "tabUndoRenameCopyMeta";
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        createPopulateTable(
-                                tab
-                                        .timestamp("ts")
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG),
-                                10,
-                                "2022-06-01",
-                                4
-                        );
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            tab
+                                    .timestamp("ts")
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG),
+                            10,
+                            "2022-06-01",
+                            4
+                    );
 
 
-                        engine.clear();
-                        long timestamp = TimestampFormatUtils.parseTimestamp("2022-06-01T00:00:00.000000Z");
-                        try (TableWriter writer = getWriter(tableName)) {
-                            AttachDetachStatus attachDetachStatus = writer.detachPartition(timestamp);
-                            Assert.assertEquals(DETACH_ERR_COPY_META, attachDetachStatus);
-                        }
-                        assertContent("ts\ti\tl\n" +
-                                "2022-06-01T09:35:59.900000Z\t1\t1\n" +
-                                "2022-06-01T19:11:59.800000Z\t2\t2\n" +
-                                "2022-06-02T04:47:59.700000Z\t3\t3\n" +
-                                "2022-06-02T14:23:59.600000Z\t4\t4\n" +
-                                "2022-06-02T23:59:59.500000Z\t5\t5\n" +
-                                "2022-06-03T09:35:59.400000Z\t6\t6\n" +
-                                "2022-06-03T19:11:59.300000Z\t7\t7\n" +
-                                "2022-06-04T04:47:59.200000Z\t8\t8\n" +
-                                "2022-06-04T14:23:59.100000Z\t9\t9\n" +
-                                "2022-06-04T23:59:59.000000Z\t10\t10\n", tableName);
+                    engine.clear();
+                    long timestamp = TimestampFormatUtils.parseTimestamp("2022-06-01T00:00:00.000000Z");
+                    try (TableWriter writer = getWriter(tableName)) {
+                        AttachDetachStatus attachDetachStatus = writer.detachPartition(timestamp);
+                        Assert.assertEquals(DETACH_ERR_COPY_META, attachDetachStatus);
                     }
+                    assertContent("ts\ti\tl\n" +
+                            "2022-06-01T09:35:59.900000Z\t1\t1\n" +
+                            "2022-06-01T19:11:59.800000Z\t2\t2\n" +
+                            "2022-06-02T04:47:59.700000Z\t3\t3\n" +
+                            "2022-06-02T14:23:59.600000Z\t4\t4\n" +
+                            "2022-06-02T23:59:59.500000Z\t5\t5\n" +
+                            "2022-06-03T09:35:59.400000Z\t6\t6\n" +
+                            "2022-06-03T19:11:59.300000Z\t7\t7\n" +
+                            "2022-06-04T04:47:59.200000Z\t8\t8\n" +
+                            "2022-06-04T14:23:59.100000Z\t9\t9\n" +
+                            "2022-06-04T23:59:59.000000Z\t10\t10\n", tableName);
                 }
         );
     }
@@ -702,35 +690,34 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                             DETACHED_DIR_MARKER
                     );
 
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        createPopulateTable(
-                                tab
-                                        .timestamp("ts")
-                                        .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s2", ColumnType.SYMBOL),
-                                10,
-                                "2022-06-01",
-                                3
-                        );
-                        compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            tab
+                                    .timestamp("ts")
+                                    .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s2", ColumnType.SYMBOL),
+                            10,
+                            "2022-06-01",
+                            3
+                    );
+                    compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+                    assertSql(
+                            "first\tts\n" +
+                                    "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+                    );
+
+                    for (int i = 0; i < 2; i++) {
+                        compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
                         assertSql(
                                 "first\tts\n" +
-                                        "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+                                        "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
+                                        "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
+                                        "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
                         );
+                        compile("ALTER TABLE " + tableName + " DROP PARTITION LIST '2022-06-01', '2022-06-02'");
 
-                        for (int i = 0; i < 2; i++) {
-                            compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                            assertSql(
-                                    "first\tts\n" +
-                                            "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
-                                            "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
-                                            "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                            );
-                            compile("ALTER TABLE " + tableName + " DROP PARTITION LIST '2022-06-01', '2022-06-02'");
-
-                        }
                     }
                 }
         );
@@ -764,23 +751,22 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                             DETACHED_DIR_MARKER
                     );
 
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        createPopulateTable(
-                                tab
-                                        .timestamp("ts")
-                                        .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s2", ColumnType.SYMBOL),
-                                10,
-                                "2022-06-01",
-                                3
-                        );
-                        assertFailure(
-                                "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                                DETACH_ERR_COPY.name()
-                        );
-                    }
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            tab
+                                    .timestamp("ts")
+                                    .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s2", ColumnType.SYMBOL),
+                            10,
+                            "2022-06-01",
+                            3
+                    );
+                    assertFailure(
+                            "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                            DETACH_ERR_COPY.name()
+                    );
                 }
         );
     }
@@ -798,23 +784,22 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                 ff1,
                 () -> {
                     String tableName = testName.getMethodName();
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        createPopulateTable(
-                                tab
-                                        .timestamp("ts")
-                                        .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s2", ColumnType.SYMBOL),
-                                10,
-                                "2022-06-01",
-                                3
-                        );
-                        assertFailure(
-                                "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                                DETACH_ERR_HARD_LINK.name()
-                        );
-                    }
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            tab
+                                    .timestamp("ts")
+                                    .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s2", ColumnType.SYMBOL),
+                            10,
+                            "2022-06-01",
+                            3
+                    );
+                    assertFailure(
+                            "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                            DETACH_ERR_HARD_LINK.name()
+                    );
                 }
         );
     }
@@ -824,45 +809,44 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(
                 () -> {
                     String tableName = testName.getMethodName();
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        createPopulateTable(
-                                1,
-                                tab.timestamp("ts")
-                                        .col("si", ColumnType.SYMBOL).indexed(true, 250)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s", ColumnType.SYMBOL),
-                                10,
-                                "2022-06-01",
-                                2
-                        );
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            1,
+                            tab.timestamp("ts")
+                                    .col("si", ColumnType.SYMBOL).indexed(true, 250)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL),
+                            10,
+                            "2022-06-01",
+                            2
+                    );
 
-                        String expected = "ts\tsi\ti\tl\ts\n" +
-                                "2022-06-01T04:47:59.900000Z\tPEHN\t1\t1\tSXUX\n" +
-                                "2022-06-01T09:35:59.800000Z\tVTJW\t2\t2\t\n" +
-                                "2022-06-01T14:23:59.700000Z\t\t3\t3\tSXUX\n" +
-                                "2022-06-01T19:11:59.600000Z\t\t4\t4\t\n" +
-                                "2022-06-01T23:59:59.500000Z\t\t5\t5\tGPGW\n" +
-                                "2022-06-02T04:47:59.400000Z\tPEHN\t6\t6\tRXGZ\n" +
-                                "2022-06-02T09:35:59.300000Z\tCPSW\t7\t7\t\n" +
-                                "2022-06-02T14:23:59.200000Z\t\t8\t8\t\n" +
-                                "2022-06-02T19:11:59.100000Z\tPEHN\t9\t9\tRXGZ\n" +
-                                "2022-06-02T23:59:59.000000Z\tVTJW\t10\t10\tIBBT\n";
+                    String expected = "ts\tsi\ti\tl\ts\n" +
+                            "2022-06-01T04:47:59.900000Z\tPEHN\t1\t1\tSXUX\n" +
+                            "2022-06-01T09:35:59.800000Z\tVTJW\t2\t2\t\n" +
+                            "2022-06-01T14:23:59.700000Z\t\t3\t3\tSXUX\n" +
+                            "2022-06-01T19:11:59.600000Z\t\t4\t4\t\n" +
+                            "2022-06-01T23:59:59.500000Z\t\t5\t5\tGPGW\n" +
+                            "2022-06-02T04:47:59.400000Z\tPEHN\t6\t6\tRXGZ\n" +
+                            "2022-06-02T09:35:59.300000Z\tCPSW\t7\t7\t\n" +
+                            "2022-06-02T14:23:59.200000Z\t\t8\t8\t\n" +
+                            "2022-06-02T19:11:59.100000Z\tPEHN\t9\t9\tRXGZ\n" +
+                            "2022-06-02T23:59:59.000000Z\tVTJW\t10\t10\tIBBT\n";
 
-                        assertContent(expected, tableName);
+                    assertContent(expected, tableName);
 
-                        engine.clear();
-                        ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
-                        renameDetachedToAttachable(tableName, "2022-06-01");
-                        ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    engine.clear();
+                    ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    renameDetachedToAttachable(tableName, "2022-06-01");
+                    ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
 
-                        engine.clear();
-                        ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
-                        renameDetachedToAttachable(tableName, "2022-06-01");
-                        ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    engine.clear();
+                    ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    renameDetachedToAttachable(tableName, "2022-06-01");
+                    ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
 
-                        assertContent(expected, tableName);
-                    }
+                    assertContent(expected, tableName);
                 });
     }
 
@@ -871,9 +855,9 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(() -> {
             String tableName = "tabBrokenColType";
             String brokenTableName = "tabBrokenColType2";
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
-                    TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
                     MemoryMARW mem = Vm.getMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
@@ -970,25 +954,24 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachAttachPartitionFailsYouDidNotRenameTheFolderToAttachable() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabDetachAttachNotAttachable";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("si", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("si", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
 
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                        "could not attach partition [table=tabDetachAttachNotAttachable, detachStatus=ATTACH_ERR_MISSING_PARTITION"
-                );
-            }
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                    "could not attach partition [table=tabDetachAttachNotAttachable, detachStatus=ATTACH_ERR_MISSING_PARTITION"
+            );
         });
     }
 
@@ -996,48 +979,47 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachAttachPartitionMissingMetadata() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabDetachAttachMissingMeta";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
 
-                // remove _meta.detached simply prevents metadata checking, all else is the same
-                TableToken tableToken = engine.verifyTableName(tableName);
-                path.of(configuration.getRoot())
-                        .concat(tableToken)
-                        .concat("2022-06-02")
-                        .put(DETACHED_DIR_MARKER)
-                        .concat(META_FILE_NAME)
-                        .$();
-                Assert.assertTrue(Files.remove(path));
-                path.parent().concat(COLUMN_VERSION_FILE_NAME).$();
-                Assert.assertTrue(Files.remove(path));
-                renameDetachedToAttachable(tableName, "2022-06-01", "2022-06-02");
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
-                assertContent(
-                        "ts\ts1\ti\tl\ts2\n" +
-                                "2022-06-01T07:11:59.900000Z\tPEHN\t1\t1\tSXUX\n" +
-                                "2022-06-01T14:23:59.800000Z\tVTJW\t2\t2\t\n" +
-                                "2022-06-01T21:35:59.700000Z\t\t3\t3\tSXUX\n" +
-                                "2022-06-02T04:47:59.600000Z\t\t4\t4\t\n" +
-                                "2022-06-02T11:59:59.500000Z\t\t5\t5\tGPGW\n" +
-                                "2022-06-02T19:11:59.400000Z\tPEHN\t6\t6\tRXGZ\n" +
-                                "2022-06-03T02:23:59.300000Z\tCPSW\t7\t7\t\n" +
-                                "2022-06-03T09:35:59.200000Z\t\t8\t8\t\n" +
-                                "2022-06-03T16:47:59.100000Z\tPEHN\t9\t9\tRXGZ\n" +
-                                "2022-06-03T23:59:59.000000Z\tVTJW\t10\t10\tIBBT\n",
-                        tableName
-                );
-            }
+            // remove _meta.detached simply prevents metadata checking, all else is the same
+            TableToken tableToken = engine.verifyTableName(tableName);
+            path.of(configuration.getRoot())
+                    .concat(tableToken)
+                    .concat("2022-06-02")
+                    .put(DETACHED_DIR_MARKER)
+                    .concat(META_FILE_NAME)
+                    .$();
+            Assert.assertTrue(Files.remove(path));
+            path.parent().concat(COLUMN_VERSION_FILE_NAME).$();
+            Assert.assertTrue(Files.remove(path));
+            renameDetachedToAttachable(tableName, "2022-06-01", "2022-06-02");
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'", sqlExecutionContext);
+            assertContent(
+                    "ts\ts1\ti\tl\ts2\n" +
+                            "2022-06-01T07:11:59.900000Z\tPEHN\t1\t1\tSXUX\n" +
+                            "2022-06-01T14:23:59.800000Z\tVTJW\t2\t2\t\n" +
+                            "2022-06-01T21:35:59.700000Z\t\t3\t3\tSXUX\n" +
+                            "2022-06-02T04:47:59.600000Z\t\t4\t4\t\n" +
+                            "2022-06-02T11:59:59.500000Z\t\t5\t5\tGPGW\n" +
+                            "2022-06-02T19:11:59.400000Z\tPEHN\t6\t6\tRXGZ\n" +
+                            "2022-06-03T02:23:59.300000Z\tCPSW\t7\t7\t\n" +
+                            "2022-06-03T09:35:59.200000Z\t\t8\t8\t\n" +
+                            "2022-06-03T16:47:59.100000Z\tPEHN\t9\t9\tRXGZ\n" +
+                            "2022-06-03T23:59:59.000000Z\tVTJW\t10\t10\tIBBT\n",
+                    tableName
+            );
         });
     }
 
@@ -1046,18 +1028,17 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
         assertMemoryLeak(() -> {
             String tableName = "tabPingPong";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab.timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-            }
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab.timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
 
             CyclicBarrier start = new CyclicBarrier(2);
             CountDownLatch end = new CountDownLatch(2);
@@ -1153,35 +1134,34 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                 }
             };
 
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        3
-                );
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    3
+            );
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'");
+            assertSql(
+                    "first\tts\n" +
+                            "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+            );
+
+            for (int i = 0; i < 2; i++) {
+                compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
                 assertSql(
                         "first\tts\n" +
-                                "2022-06-03T02:23:59.300000Z\t2022-06-03T02:23:59.300000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
+                                "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
+                                "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
+                                "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
                 );
+                compile("ALTER TABLE " + tableName + " DROP PARTITION LIST '2022-06-01', '2022-06-02'");
 
-                for (int i = 0; i < 2; i++) {
-                    compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01', '2022-06-02'");
-                    assertSql(
-                            "first\tts\n" +
-                                    "2022-06-01T07:11:59.900000Z\t2022-06-01T07:11:59.900000Z\n" +
-                                    "2022-06-02T11:59:59.500000Z\t2022-06-02T07:11:59.900000Z\n" +
-                                    "2022-06-03T09:35:59.200000Z\t2022-06-03T07:11:59.900000Z\n", "select first(ts), ts from " + tableName + " sample by 1d"
-                    );
-                    compile("ALTER TABLE " + tableName + " DROP PARTITION LIST '2022-06-01', '2022-06-02'");
-
-                }
             }
         });
     }
@@ -1193,36 +1173,35 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                     String tableName = testName.getMethodName();
                     Overrides overrides = node1.getConfigurationOverrides();
                     overrides.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 300);
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                        TableToken token = createPopulateTable(
-                                1,
-                                tab.timestamp("ts")
-                                        .col("si", ColumnType.SYMBOL).indexed(true, 250)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s", ColumnType.SYMBOL),
-                                1000,
-                                "2022-06-01",
-                                2
-                        );
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    TableToken token = createPopulateTable(
+                            1,
+                            tab.timestamp("ts")
+                                    .col("si", ColumnType.SYMBOL).indexed(true, 250)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL),
+                            1000,
+                            "2022-06-01",
+                            2
+                    );
 
-                        try (TableReader ignore = getReader(token)) {
-                            // Split partition by committing O3 to "2022-06-01"
-                            ddl("insert into " + tableName + "(ts) select ts + 20 * 60 * 60 * 1000000L from " + tableName, sqlExecutionContext);
+                    try (TableReader ignore = getReader(token)) {
+                        // Split partition by committing O3 to "2022-06-01"
+                        ddl("insert into " + tableName + "(ts) select ts + 20 * 60 * 60 * 1000000L from " + tableName, sqlExecutionContext);
 
-                            //noinspection resource
-                            Path path = Path.getThreadLocal(configuration.getRoot()).concat(token).concat("2022-06-01T200057-183001.1").concat("ts.d");
-                            FilesFacade ff = configuration.getFilesFacade();
-                            Assert.assertTrue(ff.exists(path.$()));
+                        //noinspection resource
+                        Path path = Path.getThreadLocal(configuration.getRoot()).concat(token).concat("2022-06-01T200057-183001.1").concat("ts.d");
+                        FilesFacade ff = configuration.getFilesFacade();
+                        Assert.assertTrue(ff.exists(path.$()));
 
-                            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
-                        }
-
-                        renameDetachedToAttachable(tableName, "2022-06-01");
-                        ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
-                        assertSql("min\n" +
-                                "2022-06-01T00:02:52.799000Z\n", "select min(ts) from " + tableName);
+                        ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
                     }
+
+                    renameDetachedToAttachable(tableName, "2022-06-01");
+                    ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    assertSql("min\n" +
+                            "2022-06-01T00:02:52.799000Z\n", "select min(ts) from " + tableName);
                 });
     }
 
@@ -1231,23 +1210,22 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(
                 () -> {
                     String tableName = testName.getMethodName();
-                    try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                        createPopulateTable(
-                                tab
-                                        .timestamp("ts")
-                                        .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                        .col("i", ColumnType.INT)
-                                        .col("l", ColumnType.LONG)
-                                        .col("s2", ColumnType.SYMBOL),
-                                10,
-                                "2022-06-01",
-                                1
-                        );
-                        assertFailure(
-                                "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
-                                "table is not partitioned"
-                        );
-                    }
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.NONE);
+                    createPopulateTable(
+                            tab
+                                    .timestamp("ts")
+                                    .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s2", ColumnType.SYMBOL),
+                            10,
+                            "2022-06-01",
+                            1
+                    );
+                    assertFailure(
+                            "ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01', '2022-06-02'",
+                            "table is not partitioned"
+                    );
                 });
     }
 
@@ -1255,45 +1233,44 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionCommits() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        5,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    5,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-02";
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
+            String timestampDay = "2022-06-02";
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
 
-                    TableWriter.Row row = writer.newRow(IntervalUtils.parseFloorPartialTimestamp("2022-05-03T12:00:00.000000Z"));
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.append();
+                TableWriter.Row row = writer.newRow(IntervalUtils.parseFloorPartialTimestamp("2022-05-03T12:00:00.000000Z"));
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.append();
 
-                    Assert.assertEquals(AttachDetachStatus.OK, writer.detachPartition((IntervalUtils.parseFloorPartialTimestamp(timestampDay))));
-                }
-
-                renameDetachedToAttachable(tableName, timestampDay);
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-
-                // attach the partition
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "33\t33\t2022-05-03T12:00:00.000000Z\tNaN\n" +
-                                "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
-                                "2\t2\t2022-06-02T14:23:59.600000Z\tNaN\n" +
-                                "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
-                                "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
-                                "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
-                        tableName
-                );
+                Assert.assertEquals(AttachDetachStatus.OK, writer.detachPartition((IntervalUtils.parseFloorPartialTimestamp(timestampDay))));
             }
+
+            renameDetachedToAttachable(tableName, timestampDay);
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+
+            // attach the partition
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "33\t33\t2022-05-03T12:00:00.000000Z\tNaN\n" +
+                            "1\t1\t2022-06-01T19:11:59.800000Z\tNaN\n" +
+                            "2\t2\t2022-06-02T14:23:59.600000Z\tNaN\n" +
+                            "3\t3\t2022-06-03T09:35:59.400000Z\tNaN\n" +
+                            "4\t4\t2022-06-04T04:47:59.200000Z\tNaN\n" +
+                            "5\t5\t2022-06-04T23:59:59.000000Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1302,10 +1279,9 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(() -> {
             String tableName = "tabIndexFilesIndex";
             String brokenTableName = "tabIndexFilesIndex2";
-
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
-                    TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
                     MemoryMARW mem = Vm.getMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
@@ -1377,10 +1353,10 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(() -> {
             String tableName = "tabIndexFilesReIndex";
             String brokenTableName = "tabIndexFilesReIndex2";
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
 
             try (
-                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
-                    TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
                     MemoryMARW mem = Vm.getMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
@@ -1453,10 +1429,10 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
         assertMemoryLeak(() -> {
             String tableName = "tabIndexFiles";
             String brokenTableName = "tabIndexFiles2";
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
 
             try (
-                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
-                    TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
                     MemoryMARW mem = Vm.getMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
@@ -1541,33 +1517,32 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionLongerName() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        5,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    5,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-02";
-                try (TableWriter writer = getWriter(tableName)) {
-                    Assert.assertEquals(AttachDetachStatus.OK, writer.detachPartition((IntervalUtils.parseFloorPartialTimestamp(timestampDay))));
-                }
-                renameDetachedToAttachable(tableName, timestampDay);
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "T23:59:59.000000Z'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\n" +
-                                "1\t1\t2022-06-01T19:11:59.800000Z\n" +
-                                "2\t2\t2022-06-02T14:23:59.600000Z\n" +
-                                "3\t3\t2022-06-03T09:35:59.400000Z\n" +
-                                "4\t4\t2022-06-04T04:47:59.200000Z\n" +
-                                "5\t5\t2022-06-04T23:59:59.000000Z\n",
-                        tableName
-                );
+            String timestampDay = "2022-06-02";
+            try (TableWriter writer = getWriter(tableName)) {
+                Assert.assertEquals(AttachDetachStatus.OK, writer.detachPartition((IntervalUtils.parseFloorPartialTimestamp(timestampDay))));
             }
+            renameDetachedToAttachable(tableName, timestampDay);
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "T23:59:59.000000Z'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\n" +
+                            "1\t1\t2022-06-01T19:11:59.800000Z\n" +
+                            "2\t2\t2022-06-02T14:23:59.600000Z\n" +
+                            "3\t3\t2022-06-03T09:35:59.400000Z\n" +
+                            "4\t4\t2022-06-04T04:47:59.200000Z\n" +
+                            "5\t5\t2022-06-04T23:59:59.000000Z\n",
+                    tableName
+            );
         });
     }
 
@@ -1575,114 +1550,113 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsColumnTops() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabColumnTops";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-02";
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T22:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
+            String timestampDay = "2022-06-02";
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T22:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
 
-                    TableWriter.Row row = writer.newRow(timestamp);
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.putInt(3, 33);
-                    row.append();
+                TableWriter.Row row = writer.newRow(timestamp);
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.putInt(3, 33);
+                row.append();
 
-                    writer.commit();
-                }
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "33\t33\t2022-06-02T22:00:00.000000Z\t33\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
-
-                // detach the partition
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
-
-                // insert data, which will create the partition again
-                engine.clear();
-                try (TableWriter writer = getWriter(tableName)) {
-                    TableWriter.Row row = writer.newRow(timestamp);
-                    row.putLong(0, 25160L);
-                    row.putInt(1, 25160);
-                    row.putInt(3, 25160);
-                    row.append();
-                    writer.commit();
-                }
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "25160\t25160\t2022-06-02T22:00:00.000000Z\t25160\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
-
-                dropCurrentVersionOfPartition(tableName, timestampDay);
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                // reattach old version
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "33\t33\t2022-06-02T22:00:00.000000Z\t33\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
+                writer.commit();
             }
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "33\t33\t2022-06-02T22:00:00.000000Z\t33\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
+
+            // detach the partition
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
+
+            // insert data, which will create the partition again
+            engine.clear();
+            try (TableWriter writer = getWriter(tableName)) {
+                TableWriter.Row row = writer.newRow(timestamp);
+                row.putLong(0, 25160L);
+                row.putInt(1, 25160);
+                row.putInt(3, 25160);
+                row.append();
+                writer.commit();
+            }
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "25160\t25160\t2022-06-02T22:00:00.000000Z\t25160\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
+
+            dropCurrentVersionOfPartition(tableName, timestampDay);
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            // reattach old version
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "33\t33\t2022-06-02T22:00:00.000000Z\t33\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1711,47 +1685,46 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTableAddColumn() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabInAddColumn";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                engine.clear();
-                String timestampDay = "2022-06-01";
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
-                    writer.detachPartition(timestamp);
-                    Assert.assertEquals(9, writer.size());
-                }
-
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
+            engine.clear();
+            String timestampDay = "2022-06-01";
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
+                writer.detachPartition(timestamp);
+                Assert.assertEquals(9, writer.size());
             }
+
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1759,47 +1732,46 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTableAddColumn2() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabInAddColumn2";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                engine.clear();
-                String timestampDay = "2022-06-01";
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    writer.detachPartition(timestamp);
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
-                    Assert.assertEquals(9, writer.size());
-                }
-
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
+            engine.clear();
+            String timestampDay = "2022-06-01";
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                writer.detachPartition(timestamp);
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
+                Assert.assertEquals(9, writer.size());
             }
+
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1807,52 +1779,51 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTableAddColumnAndData() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabInAddColumnAndData";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                engine.clear();
-                String timestampDay = "2022-06-01";
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
-                    TableWriter.Row row = writer.newRow(timestamp);
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.append();
-                    writer.detachPartition(timestamp);
-                    Assert.assertEquals(9, writer.size());
-                }
-
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "33\t33\t2022-06-01T00:00:00.000000Z\tNaN\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
+            engine.clear();
+            String timestampDay = "2022-06-01";
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
+                TableWriter.Row row = writer.newRow(timestamp);
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.append();
+                writer.detachPartition(timestamp);
+                Assert.assertEquals(9, writer.size());
             }
+
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "33\t33\t2022-06-01T00:00:00.000000Z\tNaN\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1860,57 +1831,56 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTableAddColumnAndData2() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabInAddColumn2";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                engine.clear();
-                String timestampDay = "2022-06-01";
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    writer.detachPartition(timestamp);
+            engine.clear();
+            String timestampDay = "2022-06-01";
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                writer.detachPartition(timestamp);
 
-                    // structural change
-                    writer.addColumn("new_column", ColumnType.INT);
+                // structural change
+                writer.addColumn("new_column", ColumnType.INT);
 
-                    TableWriter.Row row = writer.newRow(TimestampFormatUtils.parseTimestamp("2022-06-02T00:00:00.000000Z"));
-                    row.putLong(0, 33L);
-                    row.putInt(1, 33);
-                    row.putInt(3, 333);
-                    row.append();
+                TableWriter.Row row = writer.newRow(TimestampFormatUtils.parseTimestamp("2022-06-02T00:00:00.000000Z"));
+                row.putLong(0, 33L);
+                row.putInt(1, 33);
+                row.putInt(3, 333);
+                row.append();
 
-                    Assert.assertEquals(10, writer.size());
-                    writer.commit();
-                }
-
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
-                assertContent(
-                        "l\ti\tts\tnew_column\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
-                                "33\t33\t2022-06-02T00:00:00.000000Z\t333\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
-                        tableName
-                );
+                Assert.assertEquals(10, writer.size());
+                writer.commit();
             }
+
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            assertContent(
+                    "l\ti\tts\tnew_column\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\tNaN\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\tNaN\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\tNaN\n" +
+                            "33\t33\t2022-06-02T00:00:00.000000Z\t333\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\tNaN\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\tNaN\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\tNaN\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\tNaN\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\tNaN\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\tNaN\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\tNaN\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\tNaN\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\tNaN\n",
+                    tableName
+            );
         });
     }
 
@@ -1918,93 +1888,92 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTimeTravel() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabTimeTravel";
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                String timestampDay = "2022-06-01";
-                createPopulateTable(
-                        tab
-                                .col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        timestampDay,
-                        4
-                );
-                assertContent(
-                        "l\ti\tts\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\n",
-                        tableName
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            String timestampDay = "2022-06-01";
+            createPopulateTable(
+                    tab
+                            .col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    timestampDay,
+                    4
+            );
+            assertContent(
+                    "l\ti\tts\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\n",
+                    tableName
+            );
 
-                // drop the partition
-                ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
+            // drop the partition
+            ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "'", sqlExecutionContext);
 
-                // insert data, which will create the partition again
-                engine.clear();
-                long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
-                long timestamp2 = TimestampFormatUtils.parseTimestamp("2022-06-01T09:59:59.999999Z");
-                try (TableWriter writer = getWriter(tableName)) {
+            // insert data, which will create the partition again
+            engine.clear();
+            long timestamp = TimestampFormatUtils.parseTimestamp(timestampDay + "T00:00:00.000000Z");
+            long timestamp2 = TimestampFormatUtils.parseTimestamp("2022-06-01T09:59:59.999999Z");
+            try (TableWriter writer = getWriter(tableName)) {
 
-                    TableWriter.Row row = writer.newRow(timestamp2);
-                    row.putLong(0, 137L);
-                    row.putInt(1, 137);
-                    row.append(); // O3 append
+                TableWriter.Row row = writer.newRow(timestamp2);
+                row.putLong(0, 137L);
+                row.putInt(1, 137);
+                row.append(); // O3 append
 
-                    row = writer.newRow(timestamp);
-                    row.putLong(0, 2802L);
-                    row.putInt(1, 2802);
-                    row.append(); // O3 append
+                row = writer.newRow(timestamp);
+                row.putLong(0, 2802L);
+                row.putInt(1, 2802);
+                row.append(); // O3 append
 
-                    writer.commit();
-                }
-                assertContent(
-                        "l\ti\tts\n" +
-                                "2802\t2802\t2022-06-01T00:00:00.000000Z\n" +
-                                "137\t137\t2022-06-01T09:59:59.999999Z\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\n",
-                        tableName
-                );
-
-                dropCurrentVersionOfPartition(tableName, timestampDay);
-                renameDetachedToAttachable(tableName, timestampDay);
-
-                // reattach old version
-                compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'");
-                assertContent(
-                        "l\ti\tts\n" +
-                                "1\t1\t2022-06-01T07:59:59.916666Z\n" +
-                                "2\t2\t2022-06-01T15:59:59.833332Z\n" +
-                                "3\t3\t2022-06-01T23:59:59.749998Z\n" +
-                                "4\t4\t2022-06-02T07:59:59.666664Z\n" +
-                                "5\t5\t2022-06-02T15:59:59.583330Z\n" +
-                                "6\t6\t2022-06-02T23:59:59.499996Z\n" +
-                                "7\t7\t2022-06-03T07:59:59.416662Z\n" +
-                                "8\t8\t2022-06-03T15:59:59.333328Z\n" +
-                                "9\t9\t2022-06-03T23:59:59.249994Z\n" +
-                                "10\t10\t2022-06-04T07:59:59.166660Z\n" +
-                                "11\t11\t2022-06-04T15:59:59.083326Z\n" +
-                                "12\t12\t2022-06-04T23:59:58.999992Z\n",
-                        tableName
-                );
+                writer.commit();
             }
+            assertContent(
+                    "l\ti\tts\n" +
+                            "2802\t2802\t2022-06-01T00:00:00.000000Z\n" +
+                            "137\t137\t2022-06-01T09:59:59.999999Z\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\n",
+                    tableName
+            );
+
+            dropCurrentVersionOfPartition(tableName, timestampDay);
+            renameDetachedToAttachable(tableName, timestampDay);
+
+            // reattach old version
+            compile("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'");
+            assertContent(
+                    "l\ti\tts\n" +
+                            "1\t1\t2022-06-01T07:59:59.916666Z\n" +
+                            "2\t2\t2022-06-01T15:59:59.833332Z\n" +
+                            "3\t3\t2022-06-01T23:59:59.749998Z\n" +
+                            "4\t4\t2022-06-02T07:59:59.666664Z\n" +
+                            "5\t5\t2022-06-02T15:59:59.583330Z\n" +
+                            "6\t6\t2022-06-02T23:59:59.499996Z\n" +
+                            "7\t7\t2022-06-03T07:59:59.416662Z\n" +
+                            "8\t8\t2022-06-03T15:59:59.333328Z\n" +
+                            "9\t9\t2022-06-03T23:59:59.249994Z\n" +
+                            "10\t10\t2022-06-04T07:59:59.166660Z\n" +
+                            "11\t11\t2022-06-04T15:59:59.083326Z\n" +
+                            "12\t12\t2022-06-04T23:59:58.999992Z\n",
+                    tableName
+            );
         });
     }
 
@@ -2012,39 +1981,38 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsTimestampColumnTooShort() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-01";
-                String timestampWrongDay2 = "2022-06-02";
+            String timestampDay = "2022-06-01";
+            String timestampWrongDay2 = "2022-06-02";
 
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "','" + timestampWrongDay2 + "'");
-                renameDetachedToAttachable(tableName, timestampDay);
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "','" + timestampWrongDay2 + "'");
+            renameDetachedToAttachable(tableName, timestampDay);
 
-                TableToken tableToken = engine.verifyTableName(tableName);
-                Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
-                FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
-                dFile(src.$(), "ts", -1);
-                int fd = TableUtils.openRW(ff, src.$(), LOG, configuration.getWriterFileOpenOpts());
-                try {
-                    ff.truncate(fd, 8);
-                } finally {
-                    ff.close(fd);
-                }
-
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'",
-                        "cannot read min, max timestamp from the column"
-                );
+            TableToken tableToken = engine.verifyTableName(tableName);
+            Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
+            FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
+            dFile(src.$(), "ts", -1);
+            int fd = TableUtils.openRW(ff, src.$(), LOG, configuration.getWriterFileOpenOpts());
+            try {
+                ff.truncate(fd, 8);
+            } finally {
+                ff.close(fd);
             }
+
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'",
+                    "cannot read min, max timestamp from the column"
+            );
         });
     }
 
@@ -2052,75 +2020,72 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     public void testDetachPartitionsWrongFolderName() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        1,
-                        tab.col("l", ColumnType.LONG)
-                                .col("i", ColumnType.INT)
-                                .timestamp("ts"),
-                        12,
-                        "2022-06-01",
-                        4
-                );
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    tab.col("l", ColumnType.LONG)
+                            .col("i", ColumnType.INT)
+                            .timestamp("ts"),
+                    12,
+                    "2022-06-01",
+                    4
+            );
 
-                String timestampDay = "2022-06-01";
-                String timestampWrongDay2 = "2022-06-02";
+            String timestampDay = "2022-06-01";
+            String timestampWrongDay2 = "2022-06-02";
 
-                compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "','" + timestampWrongDay2 + "'");
-                renameDetachedToAttachable(tableName, timestampDay);
+            compile("ALTER TABLE " + tableName + " DETACH PARTITION LIST '" + timestampDay + "','" + timestampWrongDay2 + "'");
+            renameDetachedToAttachable(tableName, timestampDay);
 
-                String timestampWrongDay = "2021-06-01";
+            String timestampWrongDay = "2021-06-01";
 
-                // Partition does not exist in copied _dtxn
-                TableToken tableToken = engine.verifyTableName(tableName);
-                Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
-                Path dst = Path.PATH2.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
+            // Partition does not exist in copied _dtxn
+            TableToken tableToken = engine.verifyTableName(tableName);
+            Path src = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampDay).put(configuration.getAttachPartitionSuffix()).slash$();
+            Path dst = Path.PATH2.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
 
-                FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
-                Assert.assertEquals(0, ff.rename(src, dst));
-                assertFailure("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay + "'", "partition is not preset in detached txn file");
+            FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
+            Assert.assertEquals(0, ff.rename(src, dst));
+            assertFailure("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay + "'", "partition is not preset in detached txn file");
 
-                // Existing partition but wrong folder name
-                dst = Path.PATH2.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
-                Path dst2 = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay2).put(configuration.getAttachPartitionSuffix()).slash$();
-                Assert.assertEquals(0, ff.rename(dst, dst2));
+            // Existing partition but wrong folder name
+            dst = Path.PATH2.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay).put(configuration.getAttachPartitionSuffix()).slash$();
+            Path dst2 = Path.PATH.get().of(configuration.getRoot()).concat(tableToken).concat(timestampWrongDay2).put(configuration.getAttachPartitionSuffix()).slash$();
+            Assert.assertEquals(0, ff.rename(dst, dst2));
 
-                assertFailure(
-                        "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay2 + "'",
-                        "invalid timestamp column data in detached partition, data does not match partition directory name"
-                );
-            }
+            assertFailure(
+                    "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay2 + "'",
+                    "invalid timestamp column data in detached partition, data does not match partition directory name"
+            );
         });
     }
 
     @Test
     public void testNoDesignatedTimestamp() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tab = new TableModel(configuration, "tab0", PartitionBy.DAY)) {
-                CreateTableTestUtils.create(tab
-                        .col("i", ColumnType.INT)
-                        .col("l", ColumnType.LONG)
-                );
-                try {
-                    ddl("ALTER TABLE tab0 DETACH PARTITION LIST '2022-06-27'", sqlExecutionContext);
-                    Assert.fail();
-                } catch (AssertionError e) {
-                    Assert.assertEquals(-1, tab.getTimestampIndex());
-                }
+            TableModel tab = new TableModel(configuration, "tab0", PartitionBy.DAY);
+            AbstractCairoTest.create(tab
+                    .col("i", ColumnType.INT)
+                    .col("l", ColumnType.LONG)
+            );
+            try {
+                ddl("ALTER TABLE tab0 DETACH PARTITION LIST '2022-06-27'", sqlExecutionContext);
+                Assert.fail();
+            } catch (AssertionError e) {
+                Assert.assertEquals(-1, tab.getTimestampIndex());
             }
         });
     }
 
     @Test
     public void testNotPartitioned() throws Exception {
-        try (TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.NONE).timestamp()) {
-            AbstractSqlParserTest.assertSyntaxError(
-                    "ALTER TABLE tab DETACH PARTITION LIST '2022-06-27'",
-                    23,
-                    "table is not partitioned",
-                    tableModel
-            );
-        }
+        TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.NONE).timestamp();
+        AbstractSqlParserTest.assertSyntaxError(
+                "ALTER TABLE tab DETACH PARTITION LIST '2022-06-27'",
+                23,
+                "table is not partitioned",
+                tableModel
+        );
     }
 
     @Test
@@ -2152,50 +2117,46 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
 
     @Test
     public void testSyntaxErrorListOrWhereExpected() throws Exception {
-        try (TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp()) {
-            AbstractSqlParserTest.assertSyntaxError(
-                    "ALTER TABLE tab DETACH PARTITION",
-                    32,
-                    "'list' or 'where' expected",
-                    tableModel
-            );
-        }
+        TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp();
+        AbstractSqlParserTest.assertSyntaxError(
+                "ALTER TABLE tab DETACH PARTITION",
+                32,
+                "'list' or 'where' expected",
+                tableModel
+        );
     }
 
     @Test
     public void testSyntaxErrorPartitionMissing() throws Exception {
-        try (TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp()) {
-            AbstractSqlParserTest.assertSyntaxError(
-                    "ALTER TABLE tab DETACH '2022-06-27'",
-                    23,
-                    "'partition' expected",
-                    tableModel
-            );
-        }
+        TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp();
+        AbstractSqlParserTest.assertSyntaxError(
+                "ALTER TABLE tab DETACH '2022-06-27'",
+                23,
+                "'partition' expected",
+                tableModel
+        );
     }
 
     @Test
     public void testSyntaxErrorPartitionNameExpected() throws Exception {
-        try (TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp()) {
-            AbstractSqlParserTest.assertSyntaxError(
-                    "ALTER TABLE tab DETACH PARTITION LIST",
-                    37,
-                    "partition name expected",
-                    tableModel
-            );
-        }
+        TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp();
+        AbstractSqlParserTest.assertSyntaxError(
+                "ALTER TABLE tab DETACH PARTITION LIST",
+                37,
+                "partition name expected",
+                tableModel
+        );
     }
 
     @Test
     public void testSyntaxErrorUnknownKeyword() throws Exception {
-        try (TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp()) {
-            AbstractSqlParserTest.assertSyntaxError(
-                    "ALTER TABLE tab foobar",
-                    16,
-                    "'add', 'alter', 'attach', 'detach', 'drop', 'resume', 'rename', 'set' or 'squash' expected",
-                    tableModel
-            );
-        }
+        TableModel tableModel = new TableModel(configuration, "tab", PartitionBy.DAY).timestamp();
+        AbstractSqlParserTest.assertSyntaxError(
+                "ALTER TABLE tab foobar",
+                16,
+                "'add', 'alter', 'attach', 'detach', 'drop', 'resume', 'rename', 'set' or 'squash' expected",
+                tableModel
+        );
     }
 
     private static void assertContent(String expected, String tableName) throws Exception {
@@ -2205,57 +2166,56 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
 
     private void assertCannotCopyMeta(String tableName, int copyCallId) throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("i", ColumnType.INT)
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        10,
-                        "2022-06-01",
-                        4
-                );
-                String expected = "ts\ti\ts1\tl\ts2\n" +
-                        "2022-06-01T09:35:59.900000Z\t1\tPEHN\t1\tSXUX\n" +
-                        "2022-06-01T19:11:59.800000Z\t2\tVTJW\t2\t\n" +
-                        "2022-06-02T04:47:59.700000Z\t3\t\t3\tSXUX\n" +
-                        "2022-06-02T14:23:59.600000Z\t4\t\t4\t\n" +
-                        "2022-06-02T23:59:59.500000Z\t5\t\t5\tGPGW\n" +
-                        "2022-06-03T09:35:59.400000Z\t6\tPEHN\t6\tRXGZ\n" +
-                        "2022-06-03T19:11:59.300000Z\t7\tCPSW\t7\t\n" +
-                        "2022-06-04T04:47:59.200000Z\t8\t\t8\t\n" +
-                        "2022-06-04T14:23:59.100000Z\t9\tPEHN\t9\tRXGZ\n" +
-                        "2022-06-04T23:59:59.000000Z\t10\tVTJW\t10\tIBBT\n";
-                assertContent(expected, tableName);
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("i", ColumnType.INT)
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    10,
+                    "2022-06-01",
+                    4
+            );
+            String expected = "ts\ti\ts1\tl\ts2\n" +
+                    "2022-06-01T09:35:59.900000Z\t1\tPEHN\t1\tSXUX\n" +
+                    "2022-06-01T19:11:59.800000Z\t2\tVTJW\t2\t\n" +
+                    "2022-06-02T04:47:59.700000Z\t3\t\t3\tSXUX\n" +
+                    "2022-06-02T14:23:59.600000Z\t4\t\t4\t\n" +
+                    "2022-06-02T23:59:59.500000Z\t5\t\t5\tGPGW\n" +
+                    "2022-06-03T09:35:59.400000Z\t6\tPEHN\t6\tRXGZ\n" +
+                    "2022-06-03T19:11:59.300000Z\t7\tCPSW\t7\t\n" +
+                    "2022-06-04T04:47:59.200000Z\t8\t\t8\t\n" +
+                    "2022-06-04T14:23:59.100000Z\t9\tPEHN\t9\tRXGZ\n" +
+                    "2022-06-04T23:59:59.000000Z\t10\tVTJW\t10\tIBBT\n";
+            assertContent(expected, tableName);
 
-                AbstractCairoTest.ff = new TestFilesFacadeImpl() {
-                    private int copyCallCount = 0;
+            AbstractCairoTest.ff = new TestFilesFacadeImpl() {
+                private int copyCallCount = 0;
 
-                    public int copy(LPSZ from, LPSZ to) {
-                        return ++copyCallCount == copyCallId ? -1 : super.copy(from, to);
-                    }
-                };
-                engine.clear(); // to recreate the writer with the new ff
-                long timestamp = TimestampFormatUtils.parseTimestamp("2022-06-01T00:00:00.000000Z");
-                try (TableWriter writer = getWriter(tableName)) {
-                    AttachDetachStatus attachDetachStatus = writer.detachPartition(timestamp);
-                    Assert.assertEquals(DETACH_ERR_COPY_META, attachDetachStatus);
+                public int copy(LPSZ from, LPSZ to) {
+                    return ++copyCallCount == copyCallId ? -1 : super.copy(from, to);
                 }
-
-                assertContent(expected, tableName);
-
-                // check no metadata files were left behind
-                TableToken tableToken = engine.verifyTableName(tableName);
-                path.of(configuration.getRoot())
-                        .concat(tableToken)
-                        .concat("2022-06-01").concat(META_FILE_NAME)
-                        .$();
-                Assert.assertFalse(Files.exists(path));
-                path.parent().concat(COLUMN_VERSION_FILE_NAME).$();
-                Assert.assertFalse(Files.exists(path));
+            };
+            engine.clear(); // to recreate the writer with the new ff
+            long timestamp = TimestampFormatUtils.parseTimestamp("2022-06-01T00:00:00.000000Z");
+            try (TableWriter writer = getWriter(tableName)) {
+                AttachDetachStatus attachDetachStatus = writer.detachPartition(timestamp);
+                Assert.assertEquals(DETACH_ERR_COPY_META, attachDetachStatus);
             }
+
+            assertContent(expected, tableName);
+
+            // check no metadata files were left behind
+            TableToken tableToken = engine.verifyTableName(tableName);
+            path.of(configuration.getRoot())
+                    .concat(tableToken)
+                    .concat("2022-06-01").concat(META_FILE_NAME)
+                    .$();
+            Assert.assertFalse(Files.exists(path));
+            path.parent().concat(COLUMN_VERSION_FILE_NAME).$();
+            Assert.assertFalse(Files.exists(path));
         });
     }
 
@@ -2269,9 +2229,9 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             String expectedErrorMessage
     ) throws Exception {
         assertMemoryLeak(() -> {
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
-                    TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
                     MemoryMARW mem = Vm.getMARWInstance()
             ) {
                 createPopulateTable(
@@ -2361,23 +2321,22 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             @Nullable Runnable mutator
     ) throws Exception {
         assertMemoryLeak(ff, () -> {
-            try (TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY)) {
-                createPopulateTable(
-                        tab
-                                .timestamp("ts")
-                                .col("s1", ColumnType.SYMBOL).indexed(true, 32)
-                                .col("i", ColumnType.INT)
-                                .col("l", ColumnType.LONG)
-                                .col("s2", ColumnType.SYMBOL),
-                        100,
-                        "2022-06-01",
-                        5
-                );
-                if (mutator != null) {
-                    mutator.run();
-                }
-                assertFailure(operation, errorMsg);
+            TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+            createPopulateTable(
+                    tab
+                            .timestamp("ts")
+                            .col("s1", ColumnType.SYMBOL).indexed(true, 32)
+                            .col("i", ColumnType.INT)
+                            .col("l", ColumnType.LONG)
+                            .col("s2", ColumnType.SYMBOL),
+                    100,
+                    "2022-06-01",
+                    5
+            );
+            if (mutator != null) {
+                mutator.run();
             }
+            assertFailure(operation, errorMsg);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDropActivePartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDropActivePartitionTest.java
@@ -35,7 +35,6 @@ import io.questdb.std.Misc;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -182,7 +181,7 @@ public class AlterTableDropActivePartitionTest extends AbstractCairoTest {
                     dropPartition(tableName, LastPartitionTs);
                     assertTableX(tableName, TableHeader, EmptyTableMinMaxCount);
                     insert("insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')");
-                    insert("insert into " + tableName + " values(1, '2023-10-16T00:00:00.000000Z')"); // spureous row from the future
+                    insert("insert into " + tableName + " values(1, '2023-10-16T00:00:00.000000Z')"); // spurious row from the future
                     assertSql(TableHeader +
                             "5\t2023-10-15T00:00:00.000000Z\n" +
                             "1\t2023-10-16T00:00:00.000000Z\n", tableName); // new active partition
@@ -747,7 +746,7 @@ public class AlterTableDropActivePartitionTest extends AbstractCairoTest {
                             "insert into " + tableName + " values(5, '2023-10-15T00:00:00.000000Z')",
                             "insert into " + tableName + " values(111, '2023-10-15T11:11:11.111111Z')");
 
-                    final String expectedTableInTracsaction = TableHeader +
+                    final String expectedTableInTransaction = TableHeader +
                             "777\t2023-10-13T00:10:00.000000Z\n" +
                             "5\t2023-10-15T00:00:00.000000Z\n" +
                             "888\t2023-10-15T00:00:00.000000Z\n" +
@@ -762,7 +761,7 @@ public class AlterTableDropActivePartitionTest extends AbstractCairoTest {
 
                             Assert.assertEquals(2, reader0.size());
                             Assert.assertEquals(3, reader1.size());
-                            assertSql(expectedTableInTracsaction, tableName);
+                            assertSql(expectedTableInTransaction, tableName);
 
                             dropPartition(tableName, LastPartitionTs);
 
@@ -889,9 +888,8 @@ public class AlterTableDropActivePartitionTest extends AbstractCairoTest {
     }
 
     private void createTableX(String tableName, String expected, String... insertStmt) throws SqlException {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).col("id", ColumnType.INT).timestamp()) {
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).col("id", ColumnType.INT).timestamp();
+        AbstractCairoTest.create(model);
         txn = 0;
         //noinspection ForLoopReplaceableByForEach
         for (int i = 0, n = insertStmt.length; i < n; i++) {

--- a/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
@@ -92,11 +92,10 @@ public class DropIndexTest extends AbstractCairoTest {
 
     @Test
     public void dropIndexColumnTop() throws SqlException, NumericException {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)) {
-            model.col("a", ColumnType.INT);
-            model.timestamp("ts");
-            createPopulateTable(model, 5, "2022-02-24", 2);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR);
+        model.col("a", ColumnType.INT);
+        model.timestamp("ts");
+        createPopulateTable(model, 5, "2022-02-24", 2);
         compile("alter table " + tableName + " add column sym symbol index");
         compile("insert into " + tableName +
                 " select x, timestamp_sequence('2022-02-24T01:30', 1000000000), rnd_symbol('A', 'B', 'C') from long_sequence(5)");
@@ -149,11 +148,10 @@ public class DropIndexTest extends AbstractCairoTest {
 
     @Test
     public void dropIndexColumnTopLastPartition() throws SqlException, NumericException {
-        try (TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)) {
-            model.col("a", ColumnType.INT);
-            model.timestamp("ts");
-            createPopulateTable(model, 5, "2022-02-24", 2);
-        }
+        TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR);
+        model.col("a", ColumnType.INT);
+        model.timestamp("ts");
+        createPopulateTable(model, 5, "2022-02-24", 2);
         compile("alter table " + tableName + " add column sym symbol index");
 
         assertSql("a\tts\tsym\n" +

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -1266,13 +1266,15 @@ public class ExplainPlanTest extends AbstractCairoTest {
                             "  from tab\n" +
                             "  where id = 'XXX' \n" +
                             "  sample by 15m ALIGN to CALENDAR\n",
-                    "SampleByFirstLast\n" +
-                            "  keys: [ts, id]\n" +
-                            "  values: [last(val)]\n" +
-                            "    DeferredSingleSymbolFilterDataFrame\n" +
-                            "        Index forward scan on: id\n" +
-                            "          filter: id=1\n" +
-                            "        Frame forward scan on: tab\n"
+                    "Sort light\n" +
+                            "  keys: [ts]\n" +
+                            "    GroupBy vectorized: false\n" +
+                            "      keys: [ts,id]\n" +
+                            "      values: [last(val)]\n" +
+                            "        DeferredSingleSymbolFilterDataFrame\n" +
+                            "            Index forward scan on: id\n" +
+                            "              filter: id=1\n" +
+                            "            Frame forward scan on: tab\n"
             );
 
         });
@@ -2116,7 +2118,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
 
         final StringSink sink = new StringSink();
 
-        IntObjHashMap<ObjList<Function>> constFuncs = new IntObjHashMap<ObjList<Function>>();
+        IntObjHashMap<ObjList<Function>> constFuncs = new IntObjHashMap<>();
         constFuncs.put(ColumnType.BOOLEAN, list(BooleanConstant.TRUE, BooleanConstant.FALSE));
         constFuncs.put(ColumnType.BYTE, list(new ByteConstant((byte) 1)));
         constFuncs.put(ColumnType.SHORT, list(new ShortConstant((short) 2)));
@@ -2337,7 +2339,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         if (factory.isWindow()) {
                             sqlExecutionContext.configureWindowContext(null, null, null, false, DataFrameRecordCursorFactory.SCAN_DIRECTION_FORWARD, -1, true, WindowColumn.FRAMING_RANGE, Long.MIN_VALUE, 10, 0, 20, WindowColumn.EXCLUDE_NO_OTHERS, 0, -1);
                         }
-                        Function function = null;
+                        Function function;
                         try {
                             function = factory.newInstance(0, args, argPositions, engine.getConfiguration(), sqlExecutionContext);
                             function.toPlan(planSink);
@@ -10072,7 +10074,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
     }
 
     private <T> ObjList<T> list(T... values) {
-        return new ObjList<T>(values);
+        return new ObjList<>(values);
     }
 
     private void test2686Prepare() throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -5359,20 +5359,19 @@ public class ExplainPlanTest extends AbstractCairoTest {
                     "select * " +
                     "from full_range";
 
-            String expectedPlan = "SelectedRecord\n" +
-                    "    Sort\n" +
-                    "      keys: [timestamp]\n" +
+            String expectedPlan = "Sort\n" +
+                    "  keys: [timestamp]\n" +
+                    "    Union\n" +
                     "        Union\n" +
-                    "            Union\n" +
-                    "                DataFrame\n" +
-                    "                    Row forward scan\n" +
-                    "                    Frame forward scan on: gas_prices\n" +
-                    "                VirtualRecord\n" +
-                    "                  functions: [915148800000000,null]\n" +
-                    "                    long_sequence count: 1\n" +
+                    "            DataFrame\n" +
+                    "                Row forward scan\n" +
+                    "                Frame forward scan on: gas_prices\n" +
                     "            VirtualRecord\n" +
-                    "              functions: [1676851200000000,null]\n" +
-                    "                long_sequence count: 1\n";
+                    "              functions: [915148800000000,null]\n" +
+                    "                long_sequence count: 1\n" +
+                    "        VirtualRecord\n" +
+                    "          functions: [1676851200000000,null]\n" +
+                    "            long_sequence count: 1\n";
             assertPlan(query, expectedPlan);
             assertPlan(query + " order by timestamp", expectedPlan);
         });

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -3773,12 +3773,11 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select * from (select ts, i as i1, i as i2 from a ) where 0 < i1 and i2 < 10 latest on ts partition by i1",
                 "LatestBy light order_by_timestamp: true\n" +
                         "    SelectedRecord\n" +
-                        "        SelectedRecord\n" +
-                        "            Async JIT Filter workers: 1\n" +
-                        "              filter: (0<i and i<10)\n" +
-                        "                DataFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: a\n"
+                        "        Async JIT Filter workers: 1\n" +
+                        "          filter: (0<i and i<10)\n" +
+                        "            DataFrame\n" +
+                        "                Row forward scan\n" +
+                        "                Frame forward scan on: a\n"
         );
     }
 
@@ -3788,11 +3787,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table a ( i int, ts timestamp) timestamp(ts);",
                 "select ts, i as i1, i as i2 from a where 0 < i and i < 10 latest on ts partition by i",
                 "SelectedRecord\n" +
-                        "    SelectedRecord\n" +
-                        "        LatestByAllFiltered\n" +
-                        "            Row backward scan\n" +
-                        "              filter: (0<i and i<10)\n" +
-                        "            Frame backward scan on: a\n"
+                        "    LatestByAllFiltered\n" +
+                        "        Row backward scan\n" +
+                        "          filter: (0<i and i<10)\n" +
+                        "        Frame backward scan on: a\n"
         );
     }
 
@@ -8839,13 +8837,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "SelectedRecord\n" +
                         "    Filter filter: l1*i2!=0\n" +
                         "        SelectedRecord\n" +
-                        "            SelectedRecord\n" +
-                        "                Async Filter workers: 1\n" +
-                        "                  limit: 100\n" +
-                        "                  filter: l::short<i\n" +
-                        "                    DataFrame\n" +
-                        "                        Row forward scan\n" +
-                        "                        Frame forward scan on: a\n"
+                        "            Async Filter workers: 1\n" +
+                        "              limit: 100\n" +
+                        "              filter: l::short<i\n" +
+                        "                DataFrame\n" +
+                        "                    Row forward scan\n" +
+                        "                    Frame forward scan on: a\n"
         );
     }
 
@@ -8864,10 +8861,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         "        Sort light lo: 100 partiallySorted: true\n" +
                         "          keys: [ts1, l1]\n" +
                         "            SelectedRecord\n" +
-                        "                SelectedRecord\n" +
-                        "                    DataFrame\n" +
-                        "                        Row forward scan\n" +
-                        "                        Frame forward scan on: a\n"
+                        "                DataFrame\n" +
+                        "                    Row forward scan\n" +
+                        "                    Frame forward scan on: a\n"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/GroupByFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByFunctionTest.java
@@ -141,7 +141,7 @@ public class GroupByFunctionTest extends AbstractCairoTest {
                         " rnd_double() volume_mw" +
                         " from long_sequence(100)" +
                         "), index(seller), index(buyer) timestamp(delivery_start_utc)",
-                null,
+                "y_utc_15m",
                 true,
                 true
         );

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -482,7 +482,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t3\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -515,7 +515,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t3\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -549,7 +549,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t3\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -586,7 +586,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t1970-01-02T00:00:00.000000Z\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t1970-01-03T00:00:00.000000Z\t3\n",
                     query,
-                    null,
+                    "date_report1",
                     true,
                     true
             );
@@ -624,7 +624,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t1970-01-01T00:00:00.000000Z\t1970-01-03T00:00:00.000000Z\t1864000000003\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t1970-01-02T00:00:00.000000Z\t1970-01-04T00:00:00.000000Z\t11728000000003\t3\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -662,7 +662,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-02T00:00:00.000000Z\t02.01.1970\t1970-01-03T00:00:00.000000Z\t1970-01-01T00:00:00.000000Z\t4\n" +
                             "1970-01-03T00:00:00.000000Z\t03.01.1970\t1970-01-04T00:00:00.000000Z\t1970-01-02T00:00:00.000000Z\t3\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -713,7 +713,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "1970-01-12T00:00:00.000000Z\t12.01.1970\t1970-01-13T00:00:00.000000Z\t1\t4\t1970-01-01T00:00:00.000000Z\n" +
                             "1970-01-13T00:00:00.000000Z\t13.01.1970\t1970-01-14T00:00:00.000000Z\t2\t3\t1970-01-02T00:00:00.000000Z\n",
                     query,
-                    null,
+                    "date_report",
                     true,
                     true
             );
@@ -1596,8 +1596,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "    DataFrame\n" +
                             "        Row forward scan\n" +
                             "        Frame forward scan on: x\n");
-            assertQuery("" +
-                            "a\tB\tz\tviews\n" +
+            assertQuery("a\tB\tz\tviews\n" +
                             "1\t2\t3\t1\n",
                     query,
                     null,
@@ -1657,8 +1656,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "    DataFrame\n" +
                             "        Row forward scan\n" +
                             "        Frame forward scan on: x\n");
-            assertQuery("" +
-                            "a\tb\tc\tviews\n" +
+            assertQuery("a\tb\tc\tviews\n" +
                             "1\t2\t3\t1\n",
                     query,
                     null,
@@ -1779,7 +1777,7 @@ public class GroupByTest extends AbstractCairoTest {
 
             assertQuery(expected,
                     query,
-                    null,
+                    "y_utc_15m",
                     true,
                     true
             );
@@ -1830,8 +1828,7 @@ public class GroupByTest extends AbstractCairoTest {
                             "                DataFrame\n" +
                             "                    Row forward scan\n" +
                             "                    Frame forward scan on: x\n");
-            assertQuery("" +
-                            "a\tsum\tz\tviews\n" +
+            assertQuery("a\tsum\tz\tviews\n" +
                             "1\t2\t3\t1\n" +
                             "1\t3\t1\t1\n" +
                             "1\t5\t4\t1\n",
@@ -2081,7 +2078,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "FROM tst " +
                         "GROUP BY ts " +
                         "ORDER BY ts",
-                "",
+                "ref0",
                 true,
                 true
         );
@@ -2092,7 +2089,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "FROM tst " +
                         "GROUP BY tst.ts " +
                         "ORDER BY tst.ts",
-                "",
+                "ref0",
                 true,
                 true
         );
@@ -2103,7 +2100,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "FROM tst " +
                         "GROUP BY ts " +
                         "ORDER BY tst.ts",
-                "",
+                "ref0",
                 true,
                 true
         );
@@ -2114,7 +2111,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "FROM tst " +
                         "GROUP BY tst.ts " +
                         "ORDER BY ts",
-                "",
+                "ref0",
                 true,
                 true
         );
@@ -2128,7 +2125,7 @@ public class GroupByTest extends AbstractCairoTest {
                             join +
                             "GROUP BY tst.ts, data.dts " +
                             "ORDER BY ts",
-                    "",
+                    "ref0",
                     true,
                     true
             );
@@ -2140,7 +2137,7 @@ public class GroupByTest extends AbstractCairoTest {
                             join +
                             "GROUP BY ts, data.dts " +
                             "ORDER BY tst.ts",
-                    "",
+                    "ref0",
                     true,
                     true
             );
@@ -2181,7 +2178,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "1970-01-01T00:00:00.000002Z\n" +
                         "1970-01-01T00:00:00.000003Z\n",
                 query,
-                null,
+                "ref0",
                 true,
                 false
         );
@@ -2221,7 +2218,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "1970-01-01T01:00:00.000002Z\n" +
                         "1970-01-01T01:00:00.000003Z\n",
                 query,
-                null,
+                "ref0",
                 true,
                 false
         );
@@ -2259,7 +2256,7 @@ public class GroupByTest extends AbstractCairoTest {
                         "1970-01-01T00:00:00.000002Z\n" +
                         "1970-01-01T00:00:00.000003Z\n",
                 query,
-                null,
+                "created",
                 true,
                 false
         );

--- a/core/src/test/java/io/questdb/test/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/InsertTest.java
@@ -42,7 +42,6 @@ import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.griffin.engine.TestBinarySequence;
 import io.questdb.test.tools.TestUtils;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -138,9 +137,8 @@ public class InsertTest extends AbstractCairoTest {
         };
 
         assertMemoryLeak(() -> {
-            try (TableModel model = CreateTableTestUtils.getGeoHashTypesModelWithNewTypes(configuration, PartitionBy.YEAR)) {
-                TestUtils.create(model, engine);
-            }
+            TableModel model = CreateTableTestUtils.getGeoHashTypesModelWithNewTypes(configuration, PartitionBy.YEAR);
+            TestUtils.create(model, engine);
             Rnd rnd = new Rnd();
 
             final String sql;

--- a/core/src/test/java/io/questdb/test/griffin/JoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JoinTest.java
@@ -4043,9 +4043,9 @@ public class JoinTest extends AbstractCairoTest {
                     "  SELECT ts, SUM(price * qty) / SUM(qty) vwap\n" +
                     "  FROM trade\n" +
                     "  WHERE instrument = 'A'\n" +
-                    "  SAMPLE by 5m ALIGN TO CALENDAR\n" +
+                    "  SAMPLE by 5m ALIGN TO FIRST OBSERVATION\n" +
                     ") \n" +
-                    "SPLICE JOIN trade ", "left side of splice join doesn't support random access", 137);
+                    "SPLICE JOIN trade ", "left side of splice join doesn't support random access", 146);
 
             assertFailure("SELECT *\n" +
                     "FROM trade " +
@@ -4054,7 +4054,7 @@ public class JoinTest extends AbstractCairoTest {
                     "  SELECT ts, SUM(price * qty) / SUM(qty) vwap\n" +
                     "  FROM trade\n" +
                     "  WHERE instrument = 'A'\n" +
-                    "  SAMPLE BY 5m ALIGN TO CALENDAR\n" +
+                    "  SAMPLE BY 5m ALIGN TO FIRST OBSERVATION\n" +
                     ") \n", "right side of splice join doesn't support random access", 20);
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/O3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3MaxLagTest.java
@@ -47,38 +47,35 @@ public class O3MaxLagTest extends AbstractO3Test {
     @Test
     public void testBigUncommittedCheckStrColFixedAndVarMappedSizes() throws Exception {
         executeWithPool(0, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY)) {
-                tableModel
-                        .col("id", ColumnType.STRING)
-                        .timestamp("ts");
-                testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
-            }
+            TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY);
+            tableModel
+                    .col("id", ColumnType.STRING)
+                    .timestamp("ts");
+            testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
         });
     }
 
     @Test
     public void testBigUncommittedMovesTimestampOnEdge() throws Exception {
         executeWithPool(0, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY)) {
-                tableModel
-                        .col("id", ColumnType.LONG)
-                        .timestamp("ts");
-                testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
-            }
+            TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY);
+            tableModel
+                    .col("id", ColumnType.LONG)
+                    .timestamp("ts");
+            testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
         });
     }
 
     @Test
     public void testBigUncommittedToMove() throws Exception {
         executeWithPool(0, (CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) -> {
-            try (TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY)) {
-                tableModel
-                        .col("id", ColumnType.LONG)
-                        .col("ok", ColumnType.FLOAT)
-                        .col("str", ColumnType.STRING)
-                        .timestamp("ts");
-                testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
-            }
+            TableModel tableModel = new TableModel(engine.getConfiguration(), "table", PartitionBy.DAY);
+            tableModel
+                    .col("id", ColumnType.LONG)
+                    .col("ok", ColumnType.FLOAT)
+                    .col("str", ColumnType.STRING)
+                    .timestamp("ts");
+            testBigUncommittedMove1(engine, compiler, sqlExecutionContext, tableModel);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
@@ -403,10 +403,9 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
             overrides.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 100);
 
             TableToken token;
-            try (TableModel tm = new TableModel(configuration, "tbl", PartitionBy.DAY)
-                    .col("x", ColumnType.INT).timestamp()) {
-                token = createPopulateTable(1, tm, 2000, "2022-02-24T04", 2);
-            }
+            TableModel tm = new TableModel(configuration, "tbl", PartitionBy.DAY)
+                    .col("x", ColumnType.INT).timestamp();
+            token = createPopulateTable(1, tm, 2000, "2022-02-24T04", 2);
 
             Path path = Path.getThreadLocal("");
 

--- a/core/src/test/java/io/questdb/test/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3Test.java
@@ -98,17 +98,15 @@ public class O3Test extends AbstractO3Test {
         executeWithPool(0, (engine, compiler, sqlExecutionContext) -> {
             final CairoConfiguration configuration = new DefaultTestCairoConfiguration(root);
             final String tableName = "ABC";
-            try (TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
                     .col("productId", ColumnType.INT)
                     .col("productName", ColumnType.STRING)
                     .col("category", ColumnType.SYMBOL)
                     .col("price", ColumnType.DOUBLE)
                     .timestamp()
-                    .col("supplier", ColumnType.SYMBOL)
-            ) {
+                    .col("supplier", ColumnType.SYMBOL);
 
-                TestUtils.create(model, engine);
-            }
+            TestUtils.create(model, engine);
 
             AtomicInteger errorCount = new AtomicInteger();
             short[] columnTypes = new short[]{ColumnType.INT, ColumnType.STRING, ColumnType.SYMBOL, ColumnType.DOUBLE};
@@ -7639,33 +7637,32 @@ public class O3Test extends AbstractO3Test {
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException, NumericException {
         CairoConfiguration configuration = engine.getConfiguration();
-        try (TableModel x = new TableModel(configuration, "x", PartitionBy.DAY)) {
-            TestUtils.createPopulateTable(
-                    compiler,
-                    sqlExecutionContext,
-                    x.col("id", ColumnType.LONG)
-                            .col("ok", ColumnType.DOUBLE)
-                            .timestamp("ts"),
-                    10,
-                    "2020-01-01",
-                    1
-            );
+        TableModel x = new TableModel(configuration, "x", PartitionBy.DAY);
+        TestUtils.createPopulateTable(
+                compiler,
+                sqlExecutionContext,
+                x.col("id", ColumnType.LONG)
+                        .col("ok", ColumnType.DOUBLE)
+                        .timestamp("ts"),
+                10,
+                "2020-01-01",
+                1
+        );
 
-            // Insert OOO to create partition dir 2020-01-01.1
-            CairoEngine.insert(compiler, "insert into x values(1, 100.0, '2020-01-01T00:01:00')", sqlExecutionContext);
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
-                    "count\n" +
-                            "11\n"
-            );
+        // Insert OOO to create partition dir 2020-01-01.1
+        CairoEngine.insert(compiler, "insert into x values(1, 100.0, '2020-01-01T00:01:00')", sqlExecutionContext);
+        TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
+                "count\n" +
+                        "11\n"
+        );
 
-            // Close and open writer. Partition dir 2020-01-01.1 should not be purged
-            engine.releaseAllWriters();
-            CairoEngine.insert(compiler, "insert into x values(2, 101.0, '2020-01-01T00:02:00')", sqlExecutionContext);
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
-                    "count\n" +
-                            "12\n"
-            );
-        }
+        // Close and open writer. Partition dir 2020-01-01.1 should not be purged
+        engine.releaseAllWriters();
+        CairoEngine.insert(compiler, "insert into x values(2, 101.0, '2020-01-01T00:02:00')", sqlExecutionContext);
+        TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
+                "count\n" +
+                        "12\n"
+        );
     }
 
     private static void testWriterOpensUnmappedPage(
@@ -7674,88 +7671,87 @@ public class O3Test extends AbstractO3Test {
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException, NumericException {
         CairoConfiguration configuration = engine.getConfiguration();
-        try (TableModel tableModel = new TableModel(configuration, "x", PartitionBy.DAY)) {
-            tableModel
-                    .col("id", ColumnType.LONG)
-                    .col("str", ColumnType.STRING)
-                    .col("sym", ColumnType.SYMBOL).indexed(true, 2)
-                    .timestamp("ts");
+        TableModel tableModel = new TableModel(configuration, "x", PartitionBy.DAY);
+        tableModel
+                .col("id", ColumnType.LONG)
+                .col("str", ColumnType.STRING)
+                .col("sym", ColumnType.SYMBOL).indexed(true, 2)
+                .timestamp("ts");
 
-            TestUtils.createPopulateTable(
-                    "x",
-                    compiler,
-                    sqlExecutionContext,
-                    tableModel,
-                    0,
-                    "2021-10-09",
-                    0
-            );
+        TestUtils.createPopulateTable(
+                "x",
+                compiler,
+                sqlExecutionContext,
+                tableModel,
+                0,
+                "2021-10-09",
+                0
+        );
 
-            int longColIndex = -1;
-            int symColIndex = -1;
-            int strColIndex = -1;
-            for (int i = 0; i < tableModel.getColumnCount(); i++) {
-                switch (ColumnType.tagOf(tableModel.getColumnType(i))) {
-                    case ColumnType.LONG:
-                        longColIndex = i;
-                        break;
-                    case ColumnType.SYMBOL:
-                        symColIndex = i;
-                        break;
-                    case ColumnType.STRING:
-                        strColIndex = i;
-                        break;
+        int longColIndex = -1;
+        int symColIndex = -1;
+        int strColIndex = -1;
+        for (int i = 0; i < tableModel.getColumnCount(); i++) {
+            switch (ColumnType.tagOf(tableModel.getColumnType(i))) {
+                case ColumnType.LONG:
+                    longColIndex = i;
+                    break;
+                case ColumnType.SYMBOL:
+                    symColIndex = i;
+                    break;
+                case ColumnType.STRING:
+                    strColIndex = i;
+                    break;
+            }
+        }
+
+        int idBatchSize = 3 * 1024 * 1024 + 1;
+        long batchOnDiskSize = (long) ColumnType.sizeOf(ColumnType.LONG) * idBatchSize;
+        long mappedPageSize = configuration.getDataAppendPageSize();
+        Assert.assertTrue("Batch size must be greater than mapped page size", batchOnDiskSize > mappedPageSize);
+        long pageSize = configuration.getMiscAppendPageSize();
+        Assert.assertNotEquals("Batch size must be unaligned with page size", 0, batchOnDiskSize % pageSize);
+
+        long start = IntervalUtils.parseFloorPartialTimestamp("2021-10-09T10:00:00");
+        String[] varCol = new String[]{"aldfjkasdlfkj", "2021-10-10T12:00:00", "12345678901234578"};
+
+        // Add 2 batches
+        int iterations = 2;
+        try (TableWriter o3 = TestUtils.getWriter(engine, "x")) {
+            for (int i = 0; i < iterations; i++) {
+                for (int id = 0; id < idBatchSize; id++) {
+                    // We leave start + idBatchSize out to insert it O3 later
+                    long timestamp = start + i * idBatchSize + id + i;
+                    TableWriter.Row row = o3.newRow(timestamp);
+                    row.putLong(longColIndex, timestamp);
+                    row.putSym(symColIndex, "test");
+                    row.putStr(strColIndex, varCol[id % varCol.length]);
+                    row.append();
+                }
+
+                // Commit only the first batch
+                if (i == 0) {
+                    o3.commit();
                 }
             }
 
-            int idBatchSize = 3 * 1024 * 1024 + 1;
-            long batchOnDiskSize = (long) ColumnType.sizeOf(ColumnType.LONG) * idBatchSize;
-            long mappedPageSize = configuration.getDataAppendPageSize();
-            Assert.assertTrue("Batch size must be greater than mapped page size", batchOnDiskSize > mappedPageSize);
-            long pageSize = configuration.getMiscAppendPageSize();
-            Assert.assertNotEquals("Batch size must be unaligned with page size", 0, batchOnDiskSize % pageSize);
+            // Append one more row out of order
+            long timestamp = start + idBatchSize;
+            TableWriter.Row row = o3.newRow(timestamp);
+            row.putLong(longColIndex, timestamp);
+            row.putSym(symColIndex, "test");
+            row.putStr(strColIndex, varCol[0]);
+            row.append();
 
-            long start = IntervalUtils.parseFloorPartialTimestamp("2021-10-09T10:00:00");
-            String[] varCol = new String[]{"aldfjkasdlfkj", "2021-10-10T12:00:00", "12345678901234578"};
+            o3.commit();
+        }
 
-            // Add 2 batches
-            int iterations = 2;
-            try (TableWriter o3 = TestUtils.getWriter(engine, "x")) {
-                for (int i = 0; i < iterations; i++) {
-                    for (int id = 0; id < idBatchSize; id++) {
-                        // We leave start + idBatchSize out to insert it O3 later
-                        long timestamp = start + i * idBatchSize + id + i;
-                        TableWriter.Row row = o3.newRow(timestamp);
-                        row.putLong(longColIndex, timestamp);
-                        row.putSym(symColIndex, "test");
-                        row.putStr(strColIndex, varCol[id % varCol.length]);
-                        row.append();
-                    }
-
-                    // Commit only the first batch
-                    if (i == 0) {
-                        o3.commit();
-                    }
-                }
-
-                // Append one more row out of order
-                long timestamp = start + idBatchSize;
-                TableWriter.Row row = o3.newRow(timestamp);
-                row.putLong(longColIndex, timestamp);
-                row.putSym(symColIndex, "test");
-                row.putStr(strColIndex, varCol[0]);
-                row.append();
-
-                o3.commit();
-            }
-
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
-                    "count\n" + (2 * idBatchSize + 1) + "\n"
-            );
-            engine.releaseAllReaders();
-            try (TableWriter o3 = TestUtils.getWriter(engine, "x")) {
-                o3.truncate();
-            }
+        TestUtils.assertSql(compiler, sqlExecutionContext, "select count() from x", sink,
+                "count\n" + (2 * idBatchSize + 1) + "\n"
+        );
+        engine.releaseAllReaders();
+        try (TableWriter o3 = TestUtils.getWriter(engine, "x")) {
+            o3.truncate();
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -47,6 +47,58 @@ public class OrderByAdviceTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateDesignatedTimestampFromMultipleOrderBy() throws Exception {
+        assertQuery(
+                "a\tt\n" +
+                        "1\t1970-01-01T00:00:00.000000Z\n" +
+                        "2\t1970-01-01T00:00:00.001000Z\n" +
+                        "3\t1970-01-01T00:00:00.002000Z\n" +
+                        "4\t1970-01-01T00:00:00.003000Z\n" +
+                        "5\t1970-01-01T00:00:00.004000Z\n" +
+                        "6\t1970-01-01T00:00:00.005000Z\n" +
+                        "7\t1970-01-01T00:00:00.006000Z\n" +
+                        "8\t1970-01-01T00:00:00.007000Z\n" +
+                        "9\t1970-01-01T00:00:00.008000Z\n",
+                "select * from x order by t, a",
+                "create table x as (" +
+                        "select" +
+                        " x a," +
+                        " timestamp_sequence(0, 1000) t" +
+                        " from long_sequence(9)" +
+                        ")",
+                "t",
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testSkipDesignatedTimestampFromMultipleOrderBy() throws Exception {
+        assertQuery(
+                "a\tt\n" +
+                        "-1148479920\t1970-01-01T00:00:00.000000Z\n" +
+                        "-948263339\t1970-01-01T00:00:00.005000Z\n" +
+                        "-727724771\t1970-01-01T00:00:00.003000Z\n" +
+                        "73575701\t1970-01-01T00:00:00.004000Z\n" +
+                        "315515118\t1970-01-01T00:00:00.001000Z\n" +
+                        "592859671\t1970-01-01T00:00:00.007000Z\n" +
+                        "1326447242\t1970-01-01T00:00:00.006000Z\n" +
+                        "1548800833\t1970-01-01T00:00:00.002000Z\n" +
+                        "1868723706\t1970-01-01T00:00:00.008000Z\n",
+                "select * from x order by a, t",
+                "create table x as (" +
+                        "select" +
+                        " rnd_int() a," +
+                        " timestamp_sequence(0, 1000) t" +
+                        " from long_sequence(9)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testDistinctWithOrderByAnotherColumn() throws Exception {
         ddl(
                 "create table x as (" +

--- a/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
@@ -830,7 +830,7 @@ public class OrderByWithFilterTest extends AbstractCairoTest {
                         "order by ts",
                 "create table weather as " +
                         "(select cast(x*36000000000 as timestamp) ts, \n" +
-                        "  rnd_float(0)*100 temp from long_sequence(1000));", null
+                        "  rnd_float(0)*100 temp from long_sequence(1000));", "ts"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/ReaderPoolTableFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ReaderPoolTableFunctionTest.java
@@ -106,14 +106,12 @@ public class ReaderPoolTableFunctionTest extends AbstractCairoTest {
     public void testMultipleTables() throws Exception {
         assertMemoryLeak(() -> {
             // create a table
-            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
-            try (TableModel tm = new TableModel(configuration, "tab2", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
+            TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
+            tm = new TableModel(configuration, "tab2", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
 
             int readerAcquisitionCount = ReaderPool.ENTRY_SIZE * 2;
             long startTime = MicrosecondClockImpl.INSTANCE.getTicks();
@@ -172,10 +170,9 @@ public class ReaderPoolTableFunctionTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             String tableName = "tab1";
             // create a table
-            try (TableModel tm = new TableModel(configuration, tableName, PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
+            TableModel tm = new TableModel(configuration, tableName, PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
 
             // add 3 more transactions
             for (int i = 0; i < 3; i++) {
@@ -199,10 +196,9 @@ public class ReaderPoolTableFunctionTest extends AbstractCairoTest {
     public void testReleaseAcquisitionTimeRecorded() throws Exception {
         assertMemoryLeak(() -> {
             // create a table
-            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
+            TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
 
             long startTime = MicrosecondClockImpl.INSTANCE.getTicks();
             long threadId = Thread.currentThread().getId();
@@ -230,10 +226,9 @@ public class ReaderPoolTableFunctionTest extends AbstractCairoTest {
     @Test
     public void testSmoke() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 2, "2020-01-01", 1);
-            }
+            TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 2, "2020-01-01", 1);
 
             assertSql("ts\tID\n" +
                     "2020-01-01T00:00:00.000000Z\t1\n" +
@@ -247,10 +242,9 @@ public class ReaderPoolTableFunctionTest extends AbstractCairoTest {
     @Test
     public void testToTop() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
+            TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
 
             try (TableReader ignored = getReader("tab1");
                  RecordCursorFactory readerPoolFactory = new ReaderPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());

--- a/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
@@ -164,7 +164,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAlignToCalendarWithTimeZoneAndLimit() throws SqlException {
         assertQuery(
-                "select-group-by a, sum(a) sum from (select [a] from x timestamp (timestamp)) sample by 1h align to calendar time zone 'UTC' with offset '00:00' limit 1",
+                "select-choose a, sum from (select-group-by [a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp] a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp from (select [a, timestamp] from x timestamp (timestamp)) order by timestamp limit 1)",
                 "select a, sum(a) from x sample by 1h align to calendar time zone 'UTC' limit 1;",
                 model()
         );
@@ -173,7 +173,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAlignToCalendarWithTimeZoneAndOrderBy() throws SqlException {
         assertQuery(
-                "select-group-by a, sum(a) sum from (select [a] from x timestamp (timestamp)) sample by 1h align to calendar time zone 'UTC' with offset '00:00' order by a desc",
+                "select-choose a, sum from (select-group-by [a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp] a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp from (select [a, timestamp] from x timestamp (timestamp)) order by a desc)",
                 "select a, sum(a) from x sample by 1h align to calendar time zone 'UTC' order by a desc;",
                 model()
         );
@@ -182,7 +182,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAlignToCalendarWithTimeZoneEndingWithSemicolon() throws SqlException {
         assertQuery(
-                "select-group-by a, sum(a) sum from (select [a] from x timestamp (timestamp)) sample by 1h align to calendar time zone 'UTC' with offset '00:00'",
+                "select-choose a, sum from (select-group-by [a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp] a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp from (select [a, timestamp] from x timestamp (timestamp)) order by timestamp)",
                 "select a, sum(a) from x sample by 1h align to calendar time zone 'UTC';",
                 model()
         );

--- a/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
@@ -210,7 +210,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCalendar() throws SqlException {
         assertQuery(
-                "select-choose b, sum, k1, k from (select-group-by [b, sum(a) sum, k1 k, k, timestamp_floor('3h',timestamp) timestamp] b, sum(a) sum, k1 k, k, timestamp_floor('3h',timestamp) timestamp from (select [b, a, k, timestamp] from x y timestamp (timestamp)) y order by timestamp)",
+                "select-choose b, sum, k1, k from (select-group-by [b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp] b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp from (select [b, a, k, timestamp] from x y timestamp (timestamp)) y order by timestamp)",
                 "select b, sum(a), k k1, k from x y sample by 3h align to calendar",
                 model()
         );

--- a/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SampleBySqlParserTest.java
@@ -191,7 +191,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAlignToCalendarWithoutTimezoneNorOffsetAndLimit() throws SqlException {
         assertQuery(
-                "select-group-by a, sum(a) sum from (select [a] from x timestamp (timestamp)) sample by 1h align to calendar with offset '00:00' limit 1",
+                "select-choose a, sum from (select-group-by [a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp] a, sum(a) sum, timestamp_floor('1h',timestamp) timestamp from (select [a, timestamp] from x timestamp (timestamp)) order by timestamp limit 1)",
                 "select a, sum(a) from x sample by 1h align to calendar limit 1;",
                 model()
         );
@@ -210,7 +210,7 @@ public class SampleBySqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testCalendar() throws SqlException {
         assertQuery(
-                "select-group-by b, sum(a) sum, k1, k1 k from (select-choose [b, a, k k1] b, a, k k1, timestamp from (select [b, a, k] from x y timestamp (timestamp)) y) y sample by 3h align to calendar with offset '00:00'",
+                "select-choose b, sum, k1, k from (select-group-by [b, sum(a) sum, k1 k, k, timestamp_floor('3h',timestamp) timestamp] b, sum(a) sum, k1 k, k, timestamp_floor('3h',timestamp) timestamp from (select [b, a, k, timestamp] from x y timestamp (timestamp)) y order by timestamp)",
                 "select b, sum(a), k k1, k from x y sample by 3h align to calendar",
                 model()
         );

--- a/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
@@ -109,9 +109,9 @@ public class ShowPartitionsTest extends AbstractCairoTest {
         String tabName = testTableName(testName.getMethodName());
         String tab2Name = tabName + "_fubar";
         assertMemoryLeak(() -> {
+            TableModel tab = new TableModel(configuration, tabName, PartitionBy.DAY);
+            TableModel tab2 = new TableModel(configuration, tab2Name, PartitionBy.MONTH);
             try (
-                    TableModel tab = new TableModel(configuration, tabName, PartitionBy.DAY);
-                    TableModel tab2 = new TableModel(configuration, tab2Name, PartitionBy.MONTH);
                     Path dstPath = new Path();
                     Path srcPath = new Path()
             ) {
@@ -165,9 +165,9 @@ public class ShowPartitionsTest extends AbstractCairoTest {
         String tabName = testTableName(testName.getMethodName());
         String tab2Name = tabName + "_fubar";
         assertMemoryLeak(() -> {
+            TableModel tab = new TableModel(configuration, tabName, PartitionBy.DAY);
+            TableModel tab2 = new TableModel(configuration, tab2Name, PartitionBy.DAY);
             try (
-                    TableModel tab = new TableModel(configuration, tabName, PartitionBy.DAY);
-                    TableModel tab2 = new TableModel(configuration, tab2Name, PartitionBy.DAY);
                     Path dstPath = new Path();
                     Path srcPath = new Path()
             ) {

--- a/core/src/test/java/io/questdb/test/griffin/SimpleTableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SimpleTableTest.java
@@ -69,10 +69,9 @@ public class SimpleTableTest extends AbstractCairoTest {
 
     @Test
     public void testWhereIsColumnNameInsensitive() throws SqlException, NumericException {
-        try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-            tm.timestamp("ts").col("ID", ColumnType.INT);
-            createPopulateTable(tm, 2, "2020-01-01", 1);
-        }
+        TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+        tm.timestamp("ts").col("ID", ColumnType.INT);
+        createPopulateTable(tm, 2, "2020-01-01", 1);
 
         assertSql("ts\n" +
                 "2020-01-01T00:00:00.000000Z\n", "select ts from tab1 where id > 1");

--- a/core/src/test/java/io/questdb/test/griffin/SqlKeywordsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlKeywordsTest.java
@@ -224,5 +224,7 @@ public class SqlKeywordsTest {
         specialCases.put("isEmptyAlias", "''");
         specialCases.put("isKeyword", "select");
         specialCases.put("isServerVersionKeyword", "server_version");
+        specialCases.put("isUTC", "'UTC'");
+        specialCases.put("isZeroOffset", "'00:00'");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -4037,6 +4037,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
                 "select-virtual customerId + 1 column, name, count from (select-group-by [customerId, customerName name, count() count] customerId, customerName name, count() count from (select [customerId, customerName] from customers where customerName = 'X'))",
                 "select customerId+1, name, count from (select customerId, customerName name, count() count from customers) where name = 'X'",
                 modelOf("customers").col("customerId", ColumnType.INT).col("customerName", ColumnType.STRING),
+                // todo: is this a leak?
                 modelOf("orders").col("orderId", ColumnType.INT).col("customerId", ColumnType.INT)
         );
     }

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -3540,6 +3540,19 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testSampleByUnionAll() throws SqlException {
+        assertQuery(
+                "select-choose b, sum, k1, k from (select-group-by [b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp] b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp from (select [b, a, k, timestamp] from x y timestamp (timestamp)) y order by timestamp) union all select-choose b, sum, k1, k from (select-group-by [b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp] b, sum(a) sum, k k1, k, timestamp_floor('3h',timestamp) timestamp from (select [b, a, k, timestamp] from x y timestamp (timestamp)) y order by timestamp)",
+                "select b, sum(a), k k1, k from x y sample by 3h align to calendar" +
+                        " union all " +
+                        "select b, sum(a), k k1, k from x y sample by 3h align to calendar",
+                modelOf("x").col("a", ColumnType.DOUBLE).col("b", ColumnType.SYMBOL).col("k", ColumnType.TIMESTAMP).timestamp()
+        );
+    }
+
+
+
+    @Test
     public void testDuplicateColumnsBasicSelect() throws SqlException {
         assertQuery(
                 "select-choose b, a, k1, k1 k from (select-choose [b, a, k k1] b, a, k k1 from (select [b, a, k] from x timestamp (timestamp)))",

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -883,7 +883,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAliasWithWildcard1() throws SqlException {
         assertQuery(
-                "select-choose a1, a1 a, b from (select-choose [a a1, b] a a1, b from (select [a, b] from x))",
+                "select-choose a a1, a, b from (select [a, b] from x)",
                 "select a as a1, * from x",
                 modelOf("x").col("a", ColumnType.INT).col("b", ColumnType.INT)
         );
@@ -3555,7 +3555,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testDuplicateColumnsBasicSelect() throws SqlException {
         assertQuery(
-                "select-choose b, a, k1, k1 k from (select-choose [b, a, k k1] b, a, k k1 from (select [b, a, k] from x timestamp (timestamp)))",
+                "select-choose b, a, k k1, k from (select [b, a, k] from x timestamp (timestamp))",
                 "select b, a, k k1, k from x",
                 modelOf("x").col("a", ColumnType.DOUBLE).col("b", ColumnType.SYMBOL).col("k", ColumnType.TIMESTAMP).timestamp()
         );

--- a/core/src/test/java/io/questdb/test/griffin/TableWriterInteractionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableWriterInteractionTest.java
@@ -29,7 +29,6 @@ import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableWriter;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
@@ -38,11 +37,10 @@ public class TableWriterInteractionTest extends AbstractCairoTest {
     @Test
     public void testRowCancelRowIndexUpdate() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel model = new TableModel(configuration, "xyz", PartitionBy.DAY)) {
-                model.timestamp();
-                model.col("x", ColumnType.SYMBOL).indexed(true, 256);
-                CreateTableTestUtils.create(model);
-            }
+            TableModel model = new TableModel(configuration, "xyz", PartitionBy.DAY);
+            model.timestamp();
+            model.col("x", ColumnType.SYMBOL).indexed(true, 256);
+            AbstractCairoTest.create(model);
 
             long ts = TimestampFormatUtils.parseTimestamp("2019-04-29T12:00:04.877721Z");
             try (TableWriter w = getWriter("xyz")) {

--- a/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
@@ -81,8 +81,8 @@ public class TimestampQueryTest extends AbstractCairoTest {
     public void testDesignatedTimestampOpSymbolColumns() throws Exception {
         assertQuery(
                 "a\tdk\tk\n" +
-                "1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.030000Z\t1970-01-01T00:00:00.030000Z\n" +
-                "1970-01-01T00:00:00.050000Z\t1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.040000Z\n",
+                        "1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.030000Z\t1970-01-01T00:00:00.030000Z\n" +
+                        "1970-01-01T00:00:00.050000Z\t1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.040000Z\n",
                 "select a, dk, k from x where dk < cast(a as timestamp)",
                 "create table x as (select cast(concat('1970-01-01T00:00:00.0', (case when x > 3 then x else x - 1 end), '0000Z') as symbol) a, timestamp_sequence(0, 10000) dk, timestamp_sequence(0, 10000) k from long_sequence(5)) timestamp(k)",
                 "k",
@@ -728,29 +728,28 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampConversion() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel m = new TableModel(configuration, "tt", PartitionBy.DAY)) {
-                m.timestamp("dts")
-                        .col("ts", ColumnType.TIMESTAMP);
-                createPopulateTable(m, 31, "2021-03-14", 31);
-                String expected = "dts\tts\n" +
-                        "2021-04-02T23:59:59.354820Z\t2021-04-02T23:59:59.354820Z\n";
+            TableModel m = new TableModel(configuration, "tt", PartitionBy.DAY);
+            m.timestamp("dts")
+                    .col("ts", ColumnType.TIMESTAMP);
+            createPopulateTable(m, 31, "2021-03-14", 31);
+            String expected = "dts\tts\n" +
+                    "2021-04-02T23:59:59.354820Z\t2021-04-02T23:59:59.354820Z\n";
 
-                assertQuery(
-                        expected,
-                        "tt where dts > '2021-04-02T13:45:49.207Z' and dts < '2021-04-03 13:45:49.207'",
-                        "dts",
-                        true,
-                        true
-                );
+            assertQuery(
+                    expected,
+                    "tt where dts > '2021-04-02T13:45:49.207Z' and dts < '2021-04-03 13:45:49.207'",
+                    "dts",
+                    true,
+                    true
+            );
 
-                assertQuery(
-                        expected,
-                        "tt where ts > '2021-04-02T13:45:49.207Z' and ts < '2021-04-03 13:45:49.207'",
-                        "dts",
-                        true,
-                        false
-                );
-            }
+            assertQuery(
+                    expected,
+                    "tt where ts > '2021-04-02T13:45:49.207Z' and ts < '2021-04-03 13:45:49.207'",
+                    "dts",
+                    true,
+                    false
+            );
         });
     }
 
@@ -1352,29 +1351,28 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampSymbolConversion() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel m = new TableModel(configuration, "tt", PartitionBy.DAY)) {
-                m.timestamp("dts")
-                        .col("ts", ColumnType.TIMESTAMP);
-                createPopulateTable(m, 31, "2021-03-14", 31);
-                String expected = "dts\tts\n" +
-                        "2021-04-02T23:59:59.354820Z\t2021-04-02T23:59:59.354820Z\n";
+            TableModel m = new TableModel(configuration, "tt", PartitionBy.DAY);
+            m.timestamp("dts")
+                    .col("ts", ColumnType.TIMESTAMP);
+            createPopulateTable(m, 31, "2021-03-14", 31);
+            String expected = "dts\tts\n" +
+                    "2021-04-02T23:59:59.354820Z\t2021-04-02T23:59:59.354820Z\n";
 
-                assertQuery(
-                        expected,
-                        "tt where dts > cast('2021-04-02T13:45:49.207Z' as symbol) and dts < cast('2021-04-03 13:45:49.207' as symbol)",
-                        "dts",
-                        true,
-                        true
-                );
+            assertQuery(
+                    expected,
+                    "tt where dts > cast('2021-04-02T13:45:49.207Z' as symbol) and dts < cast('2021-04-03 13:45:49.207' as symbol)",
+                    "dts",
+                    true,
+                    true
+            );
 
-                assertQuery(
-                        expected,
-                        "tt where ts > cast('2021-04-02T13:45:49.207Z' as symbol) and ts < cast('2021-04-03 13:45:49.207' as symbol)",
-                        "dts",
-                        true,
-                        false
-                );
-            }
+            assertQuery(
+                    expected,
+                    "tt where ts > cast('2021-04-02T13:45:49.207Z' as symbol) and ts < cast('2021-04-03 13:45:49.207' as symbol)",
+                    "dts",
+                    true,
+                    false
+            );
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/UpdateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UpdateTest.java
@@ -1112,13 +1112,12 @@ public class UpdateTest extends AbstractCairoTest {
     @Test
     public void testUpdateMultiPartitionedTableSamePartitionManyFrames() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tml = new TableModel(configuration, "up", PartitionBy.DAY)) {
-                tml.col("xint", ColumnType.INT).col("xsym", ColumnType.SYMBOL).indexed(true, 256).timestamp("ts");
-                if (walEnabled) {
-                    tml.wal();
-                }
-                createPopulateTable(tml, 10, "2020-01-01", 2);
+            TableModel tml = new TableModel(configuration, "up", PartitionBy.DAY);
+            tml.col("xint", ColumnType.INT).col("xsym", ColumnType.SYMBOL).indexed(true, 256).timestamp("ts");
+            if (walEnabled) {
+                tml.wal();
             }
+            createPopulateTable(tml, 10, "2020-01-01", 2);
 
             update("UPDATE up SET xint = -1000 WHERE ts in '2020-01-01T00;6h;12h;24'");
             assertSql("xint\txsym\tts\n" +
@@ -1194,13 +1193,12 @@ public class UpdateTest extends AbstractCairoTest {
     @Test
     public void testUpdateMultipartitionedTable() throws Exception {
         assertMemoryLeak(() -> {
-            try (TableModel tml = new TableModel(configuration, "up", PartitionBy.DAY)) {
-                tml.col("xint", ColumnType.INT).col("xsym", ColumnType.SYMBOL).indexed(true, 256).timestamp("ts");
-                if (walEnabled) {
-                    tml.wal();
-                }
-                createPopulateTable(tml, 5, "2020-01-01", 2);
+            TableModel tml = new TableModel(configuration, "up", PartitionBy.DAY);
+            tml.col("xint", ColumnType.INT).col("xsym", ColumnType.SYMBOL).indexed(true, 256).timestamp("ts");
+            if (walEnabled) {
+                tml.wal();
             }
+            createPopulateTable(tml, 5, "2020-01-01", 2);
 
             update("UPDATE up SET xint = -1000 WHERE ts > '2020-01-02T14'");
             assertSql("xint\txsym\tts\n" +

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -36,7 +36,6 @@ import io.questdb.griffin.*;
 import io.questdb.griffin.model.*;
 import io.questdb.std.*;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.AfterClass;
@@ -71,64 +70,59 @@ public class WhereClauseParserTest extends AbstractCairoTest {
         AbstractCairoTest.setUpStatic();
 
         // same as x but with different number of values in symbol maps
-        try (TableModel model = new TableModel(configuration, "v", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
-                    .timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "v", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
-        try (TableModel model = new TableModel(configuration, "w", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL)
-                    .col("ex", ColumnType.SYMBOL)
-                    .col("timestamp", ColumnType.TIMESTAMP);
-            CreateTableTestUtils.create(model);
-        }
+        model = new TableModel(configuration, "w", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL)
+                .col("ex", ColumnType.SYMBOL)
+                .col("timestamp", ColumnType.TIMESTAMP);
+        AbstractCairoTest.create(model);
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
-                    .timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        model = new TableModel(configuration, "x", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
-        try (TableModel model = new TableModel(configuration, "y", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4);
-            CreateTableTestUtils.create(model);
-        }
+        model = new TableModel(configuration, "y", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL).symbolCapacity(1).indexed(true, 16)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL).symbolCapacity(4).indexed(true, 4)
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4);
+        AbstractCairoTest.create(model);
 
-        try (TableModel model = new TableModel(configuration, "z", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
-                    .timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        model = new TableModel(configuration, "z", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL)
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(5).indexed(true, 4)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         try (TableWriter writer = newOffPoolWriter(configuration, "v", Metrics.disabled())) {
             TableWriter.Row row = writer.newRow(0);
@@ -2453,8 +2447,10 @@ public class WhereClauseParserTest extends AbstractCairoTest {
         // because 'systimestamp' is neither constant/runtime-constant, so the latter AND is not intrinsic and thus is out of the intervals model
         String whereExpression = "timestamp >= '2022-03-23T08:00:00.000000Z' AND timestamp < '2022-03-25T10:00:00.000000Z' AND timestamp > dateadd('d', -10, systimestamp())";
         currentMicros = 1649186452792000L; // '2022-04-05T19:20:52.792Z'
-        LongList intervals = modelOf(whereExpression).buildIntervalModel().calculateIntervals(sqlExecutionContext);
-        Assert.assertEquals("[1648022400000000,1648202399999999]", intervals.toString());
+        try (RuntimeIntrinsicIntervalModel intervalModel = modelOf(whereExpression).buildIntervalModel()) {
+            LongList intervals = intervalModel.calculateIntervals(sqlExecutionContext);
+            Assert.assertEquals("[1648022400000000,1648202399999999]", intervals.toString());
+        }
     }
 
     @Test
@@ -2933,8 +2929,9 @@ public class WhereClauseParserTest extends AbstractCairoTest {
         if (!model.hasIntervalFilters()) {
             return "";
         }
-        RuntimeIntrinsicIntervalModel sm = model.buildIntervalModel();
-        return GriffinParserTestUtils.intervalToString(sm.calculateIntervals(sqlExecutionContext));
+        try (RuntimeIntrinsicIntervalModel sm = model.buildIntervalModel()) {
+            return GriffinParserTestUtils.intervalToString(sm.calculateIntervals(sqlExecutionContext));
+        }
     }
 
     private String keyValueFuncsToString(ObjList<Function> keyValueFuncs) {
@@ -3088,13 +3085,12 @@ public class WhereClauseParserTest extends AbstractCairoTest {
             }
             sink.clear(sink.length() - separator.length());
             String expression = sink.toString();
-            Assert.assertEquals(
-                    expected,
-                    modelOf(expression)
-                            .buildIntervalModel()
-                            .calculateIntervals(sqlExecutionContext)
-                            .toString()
-            );
+            try (RuntimeIntrinsicIntervalModel intervalModel = modelOf(expression).buildIntervalModel()) {
+                Assert.assertEquals(
+                        expected,
+                        intervalModel.calculateIntervals(sqlExecutionContext).toString()
+                );
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseSymbolEstimatorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseSymbolEstimatorTest.java
@@ -35,7 +35,6 @@ import io.questdb.griffin.model.QueryModel;
 import io.questdb.std.IntList;
 import io.questdb.std.Misc;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.AfterClass;
@@ -54,17 +53,16 @@ public class WhereClauseSymbolEstimatorTest extends AbstractCairoTest {
     public static void setUpStatic() throws Exception {
         AbstractCairoTest.setUpStatic();
 
-        try (TableModel model = new TableModel(configuration, "x", PartitionBy.NONE)) {
-            model.col("sym", ColumnType.SYMBOL).symbolCapacity(1)
-                    .col("bid", ColumnType.DOUBLE)
-                    .col("ask", ColumnType.DOUBLE)
-                    .col("bidSize", ColumnType.INT)
-                    .col("askSize", ColumnType.INT)
-                    .col("mode", ColumnType.SYMBOL).symbolCapacity(4)
-                    .col("ex", ColumnType.SYMBOL).symbolCapacity(5)
-                    .timestamp();
-            CreateTableTestUtils.create(model);
-        }
+        TableModel model = new TableModel(configuration, "x", PartitionBy.NONE);
+        model.col("sym", ColumnType.SYMBOL).symbolCapacity(1)
+                .col("bid", ColumnType.DOUBLE)
+                .col("ask", ColumnType.DOUBLE)
+                .col("bidSize", ColumnType.INT)
+                .col("askSize", ColumnType.INT)
+                .col("mode", ColumnType.SYMBOL).symbolCapacity(4)
+                .col("ex", ColumnType.SYMBOL).symbolCapacity(5)
+                .timestamp();
+        AbstractCairoTest.create(model);
 
         reader = newOffPoolReader(configuration, "x");
         metadata = reader.getMetadata();

--- a/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
@@ -97,6 +97,55 @@ public class WriterPoolTableFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testRandomAccessUnsupported() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
+            ) {
+                Record record = readerPoolCursor.getRecord();
+                readerPoolCursor.recordAt(record, 0);
+                Assert.fail("Random access is not expected to be implemented");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        });
+    }
+
+    @Test
+    public void testRecordBNotImplemented() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
+            ) {
+                readerPoolCursor.getRecordB();
+                Assert.fail("RecordB is not expected to be implemented");
+            } catch (UnsupportedOperationException ignored) {
+            }
+        });
+    }
+
+    @Test
+    public void testToTop() throws Exception {
+        assertMemoryLeak(() -> {
+            TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+            tm.timestamp("ts").col("ID", ColumnType.INT);
+            createPopulateTable(tm, 20, "2020-01-01", 1);
+
+            try (TableReader ignored = getReader("tab1");
+                 RecordCursorFactory readerPoolFactory = new ReaderPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
+                 RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)) {
+                // scroll cursor ignoring its contents
+                //noinspection StatementWithEmptyBody
+                while (readerPoolCursor.hasNext()) {
+                }
+                readerPoolCursor.toTop();
+                assertTrue(readerPoolCursor.hasNext());
+            }
+        });
+    }
+
+    @Test
     public void testWriterList() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table a(u int)");
@@ -148,56 +197,6 @@ public class WriterPoolTableFunctionTest extends AbstractCairoTest {
                             "a\t\n",
                     "select table_name,ownership_reason from writer_pool order by 1 desc"
             );
-        });
-    }
-
-    @Test
-    public void testRandomAccessUnsupported() throws Exception {
-        assertMemoryLeak(() -> {
-            try (
-                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
-                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
-            ) {
-                Record record = readerPoolCursor.getRecord();
-                readerPoolCursor.recordAt(record, 0);
-                Assert.fail("Random access is not expected to be implemented");
-            } catch (UnsupportedOperationException ignored) {
-            }
-        });
-    }
-
-    @Test
-    public void testRecordBNotImplemented() throws Exception {
-        assertMemoryLeak(() -> {
-            try (
-                    RecordCursorFactory readerPoolFactory = new WriterPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
-                    RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)
-            ) {
-                readerPoolCursor.getRecordB();
-                Assert.fail("RecordB is not expected to be implemented");
-            } catch (UnsupportedOperationException ignored) {
-            }
-        });
-    }
-
-    @Test
-    public void testToTop() throws Exception {
-        assertMemoryLeak(() -> {
-            try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-                tm.timestamp("ts").col("ID", ColumnType.INT);
-                createPopulateTable(tm, 20, "2020-01-01", 1);
-            }
-
-            try (TableReader ignored = getReader("tab1");
-                 RecordCursorFactory readerPoolFactory = new ReaderPoolRecordCursorFactory(sqlExecutionContext.getCairoEngine());
-                 RecordCursor readerPoolCursor = readerPoolFactory.getCursor(sqlExecutionContext)) {
-                // scroll cursor ignoring its contents
-                //noinspection StatementWithEmptyBody
-                while (readerPoolCursor.hasNext()) {
-                }
-                readerPoolCursor.toTop();
-                assertTrue(readerPoolCursor.hasNext());
-            }
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/BrokenIntReadTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/BrokenIntReadTest.java
@@ -140,7 +140,7 @@ public class BrokenIntReadTest extends AbstractCairoTest {
     }
 
     private void createTables(FilesFacade ff) {
-        try (TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
+        TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
             @Override
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
@@ -150,11 +150,10 @@ public class BrokenIntReadTest extends AbstractCairoTest {
                 .col("productName", ColumnType.STRING)
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
-                .timestamp()) {
-            CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
-        }
+                .timestamp();
+        CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
 
-        try (TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
+        model = new TableModel(new DefaultTestCairoConfiguration(root) {
             @Override
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
@@ -165,11 +164,10 @@ public class BrokenIntReadTest extends AbstractCairoTest {
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
 
-                .timestamp()) {
-            CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
-        }
+                .timestamp();
+        CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
 
-        try (TableModel model = new TableModel(new DefaultTestCairoConfiguration(root) {
+        model = new TableModel(new DefaultTestCairoConfiguration(root) {
             @Override
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
@@ -179,9 +177,8 @@ public class BrokenIntReadTest extends AbstractCairoTest {
                 .col("productName", ColumnType.STRING)
                 .col("supplier", ColumnType.SYMBOL)
                 .col("category", ColumnType.SYMBOL)
-                .timestamp()) {
-            CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
-        }
+                .timestamp();
+        CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 2);
     }
 
     private void testFailOnRead(int i, String expected) throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/ShowTablesFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/ShowTablesFunctionFactoryTest.java
@@ -27,11 +27,11 @@ package io.questdb.test.griffin.engine.functions.catalogue;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.cairo.TableModel;
 import io.questdb.cairo.TableToken;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.str.Path;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
 import org.junit.Test;
 
 import static io.questdb.cairo.TableUtils.META_FILE_NAME;
@@ -39,15 +39,13 @@ import static io.questdb.cairo.TableUtils.META_FILE_NAME;
 public class ShowTablesFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testMetadataQuery() throws Exception {
-        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
-            tm1.col("abc", ColumnType.STRING);
-            tm1.timestamp("ts1");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
-        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
-            tm1.timestamp("ts2");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
+        TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY);
+        tm1.col("abc", ColumnType.STRING);
+        tm1.timestamp("ts1");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
+        tm1 = new TableModel(configuration, "table2", PartitionBy.NONE);
+        tm1.timestamp("ts2");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
 
         assertSql(
                 "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\n" +
@@ -61,11 +59,10 @@ public class ShowTablesFunctionFactoryTest extends AbstractCairoTest {
         node1.setProperty(PropertyKey.CAIRO_MAX_UNCOMMITTED_ROWS, 83737);
         node1.setProperty(PropertyKey.CAIRO_O3_MAX_LAG, 28);
 
-        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
-            tm1.col("abc", ColumnType.STRING);
-            tm1.timestamp("ts1");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
+        TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY);
+        tm1.col("abc", ColumnType.STRING);
+        tm1.timestamp("ts1");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
 
         assertSql(
                 "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\n" +
@@ -75,15 +72,13 @@ public class ShowTablesFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testMetadataQueryMissingMetaFile() throws Exception {
-        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
-            tm1.col("abc", ColumnType.STRING);
-            tm1.timestamp("ts1");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
-        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
-            tm1.timestamp("ts2");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
+        TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY);
+        tm1.col("abc", ColumnType.STRING);
+        tm1.timestamp("ts1");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
+        tm1 = new TableModel(configuration, "table2", PartitionBy.NONE);
+        tm1.timestamp("ts2");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
 
         engine.releaseAllWriters();
         engine.releaseAllReaders();
@@ -104,15 +99,13 @@ public class ShowTablesFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testMetadataQueryWithWhere() throws Exception {
-        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
-            tm1.col("abc", ColumnType.STRING);
-            tm1.timestamp("ts1");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
-        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
-            tm1.timestamp("ts2");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
+        TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY);
+        tm1.col("abc", ColumnType.STRING);
+        tm1.timestamp("ts1");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
+        tm1 = new TableModel(configuration, "table2", PartitionBy.NONE);
+        tm1.timestamp("ts2");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
 
         assertSql(
                 "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\n" +
@@ -122,15 +115,13 @@ public class ShowTablesFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testMetadataQueryWithWhereAndSelect() throws Exception {
-        try (TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY)) {
-            tm1.col("abc", ColumnType.STRING);
-            tm1.timestamp("ts1");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
-        try (TableModel tm1 = new TableModel(configuration, "table2", PartitionBy.NONE)) {
-            tm1.timestamp("ts2");
-            createPopulateTable(tm1, 0, "2020-01-01", 0);
-        }
+        TableModel tm1 = new TableModel(configuration, "table1", PartitionBy.DAY);
+        tm1.col("abc", ColumnType.STRING);
+        tm1.timestamp("ts1");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
+        tm1 = new TableModel(configuration, "table2", PartitionBy.NONE);
+        tm1.timestamp("ts2");
+        createPopulateTable(tm1, 0, "2020-01-01", 0);
 
         assertSql(
                 "designatedTimestamp\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CharGroupByFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CharGroupByFunctionTest.java
@@ -26,11 +26,11 @@ package io.questdb.test.griffin.engine.functions.groupby;
 
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.cairo.TableModel;
 import io.questdb.griffin.SqlException;
 import io.questdb.std.NumericException;
 import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
 import org.junit.Test;
 
 public class CharGroupByFunctionTest extends AbstractCairoTest {
@@ -58,10 +58,9 @@ public class CharGroupByFunctionTest extends AbstractCairoTest {
 
     @Test
     public void testSampleBy() throws SqlException, NumericException {
-        try (TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY)) {
-            tm.timestamp("ts").col("ch", ColumnType.CHAR);
-            createPopulateTable(tm, 100, "2020-01-01", 2);
-        }
+        TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY);
+        tm.timestamp("ts").col("ch", ColumnType.CHAR);
+        createPopulateTable(tm, 100, "2020-01-01", 2);
 
         assertSql("ts\tmin\tmax\tfirst\tlast\tcount\n" +
                 "2020-01-01T00:28:47.990000Z\t\u0001\t3\t\u0001\t3\t51\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FloatGroupByFunctionsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FloatGroupByFunctionsTest.java
@@ -26,21 +26,20 @@ package io.questdb.test.griffin.engine.functions.groupby;
 
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.cairo.TableModel;
 import io.questdb.griffin.SqlException;
 import io.questdb.std.NumericException;
 import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
 import org.junit.Test;
 
 public class FloatGroupByFunctionsTest extends AbstractCairoTest {
     @Test
     public void testSampleBy() throws SqlException, NumericException {
         sqlExecutionContext.setRandom(new Rnd());
-        try (TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY)) {
-            tm.timestamp("ts").col("ch", ColumnType.FLOAT);
-            createPopulateTable(tm, 100, "2020-01-01", 2);
-        }
+        TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY);
+        tm.timestamp("ts").col("ch", ColumnType.FLOAT);
+        createPopulateTable(tm, 100, "2020-01-01", 2);
 
         assertSql("ts\tmin\tmax\tfirst\tlast\tcount\n" +
                 "2020-01-01T00:28:47.990000Z\t0.0010\t0.0510\t0.0010\t0.0510\t51\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MaxFloatGroupByFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MaxFloatGroupByFunctionTest.java
@@ -26,19 +26,18 @@ package io.questdb.test.griffin.engine.functions.groupby;
 
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.cairo.TableModel;
 import io.questdb.griffin.SqlException;
 import io.questdb.std.NumericException;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
 import org.junit.Test;
 
 public class MaxFloatGroupByFunctionTest extends AbstractCairoTest {
     @Test
     public void testSampleByWithFill() throws SqlException, NumericException {
-        try (TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY)) {
-            tm.timestamp("ts").col("ch", ColumnType.FLOAT);
-            createPopulateTable(tm, 100, "2020-01-01", 2);
-        }
+        TableModel tm = new TableModel(configuration, "tab", PartitionBy.DAY);
+        tm.timestamp("ts").col("ch", ColumnType.FLOAT);
+        createPopulateTable(tm, 100, "2020-01-01", 2);
 
         assertSql(
                 "ts\tmin\tmax\tfirst\tlast\tcount\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionCaseTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionCaseTest.java
@@ -223,12 +223,13 @@ public class GroupByFunctionCaseTest extends AbstractCairoTest {
                             "    AND venue in ('CBS', 'FUS', 'LMX', 'BTS')\n" +
                             "  SAMPLE BY 1h \n" +
                             "  ALIGN TO CALENDAR TIME ZONE 'UTC'",
-                    "VirtualRecord\n" +
-                            "  functions: [candle_st,venue,num_ticks,quote_volume,quote_volume/SUM]\n" +
-                            "    SampleBy\n" +
-                            "      keys: [candle_st,venue]\n" +
-                            "      values: [count(*),sum(qty*price),sum(qty)]\n" +
-                            "        SelectedRecord\n" +
+                    "Sort light\n" +
+                            "  keys: [candle_st]\n" +
+                            "    VirtualRecord\n" +
+                            "      functions: [candle_st,venue,num_ticks,quote_volume,quote_volume/SUM]\n" +
+                            "        GroupBy vectorized: false\n" +
+                            "          keys: [candle_st,venue]\n" +
+                            "          values: [count(*),sum(qty*price),sum(qty)]\n" +
                             "            Async Filter workers: 1\n" +
                             "              filter: (instrument_key ~ ETH.USD.S..*? and venue in [CBS,FUS,LMX,BTS])\n" +
                             "                DataFrame\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/DataFrameRecordCursorImplFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/DataFrameRecordCursorImplFactoryTest.java
@@ -38,7 +38,6 @@ import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.DirectString;
 import io.questdb.test.AbstractCairoTest;
-import io.questdb.test.CreateTableTestUtils;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -55,15 +54,13 @@ public class DataFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
             final int N = 100;
             // separate two symbol columns with primitive. It will make problems apparent if index does not shift correctly
             TableToken tableToken;
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
                     col("a", ColumnType.STRING).
                     col("b", ColumnType.SYMBOL).indexed(true, N / 4).
                     col("i", ColumnType.INT).
                     col("c", ColumnType.SYMBOL).indexed(true, N / 4).
-                    timestamp()
-            ) {
-                tableToken = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            tableToken = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             final String[] symbols = new String[N];
@@ -190,13 +187,11 @@ public class DataFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
         setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, maxSize);
 
         TestUtils.assertMemoryLeak(() -> {
-            TableToken tableToekn;
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).
+            TableToken tableToken;
+            TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).
                     col("i", ColumnType.INT).
-                    timestamp()
-            ) {
-                tableToekn = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            tableToken = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             final long increment = 1000000 * 60L * 4;
@@ -244,7 +239,7 @@ public class DataFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
                 final IntList columnSizes = new IntList();
                 populateColumnTypes(metadata, columnIndexes, columnSizes);
 
-                try (FullFwdDataFrameCursorFactory dataFrameFactory = new FullFwdDataFrameCursorFactory(tableToekn, TableUtils.ANY_TABLE_VERSION, metadata)) {
+                try (FullFwdDataFrameCursorFactory dataFrameFactory = new FullFwdDataFrameCursorFactory(tableToken, TableUtils.ANY_TABLE_VERSION, metadata)) {
                     DataFrameRowCursorFactory rowCursorFactory = new DataFrameRowCursorFactory(); // stub RowCursorFactory
                     DataFrameRecordCursorFactory factory = new DataFrameRecordCursorFactory(
                             configuration,
@@ -309,12 +304,10 @@ public class DataFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
 
         TestUtils.assertMemoryLeak(() -> {
             TableToken tt;
-            try (TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).
+            TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).
                     col("i", ColumnType.INT).
-                    timestamp()
-            ) {
-                tt = CreateTableTestUtils.create(model);
-            }
+                    timestamp();
+            tt = AbstractCairoTest.create(model);
 
             final Rnd rnd = new Rnd();
             final long increment = 1000000 * 60L * 4;

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.griffin.SqlCompiler;
-import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.table.TableWriterMetricsRecordCursorFactory;
 import io.questdb.std.str.StringSink;
@@ -82,10 +81,9 @@ public class TableWriterMetricsRecordCursorFactoryTest extends AbstractCairoTest
         MetricsSnapshot metricsBefore = snapshotMetrics();
         assertMetricsCursorEquals(metricsBefore);
 
-        try (TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE)) {
-            tm.timestamp("ts").col("ID", ColumnType.INT);
-            createPopulateTable(tm, 1, "2020-01-01", 1);
-        }
+        TableModel tm = new TableModel(configuration, "tab1", PartitionBy.NONE);
+        tm.timestamp("ts").col("ID", ColumnType.INT);
+        createPopulateTable(tm, 1, "2020-01-01", 1);
         MetricsSnapshot metricsAfter = snapshotMetrics();
         assertNotEquals(metricsBefore, metricsAfter);
 
@@ -114,7 +112,7 @@ public class TableWriterMetricsRecordCursorFactoryTest extends AbstractCairoTest
     }
 
     @Test
-    public void testSanity() throws SqlException {
+    public void testSanity() {
         // we want to make sure metrics in tests are enabled by default
         assertTrue(metrics.isEnabled());
         assertTrue(engine.getMetrics().isEnabled());

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -24,7 +24,10 @@
 
 package io.questdb.test.tools;
 
-import io.questdb.*;
+import io.questdb.MessageBus;
+import io.questdb.MessageBusImpl;
+import io.questdb.Metrics;
+import io.questdb.ServerMain;
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
@@ -50,8 +53,6 @@ import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.*;
 import io.questdb.test.QuestDBTestNode;
-import io.questdb.cairo.LogRecordSinkAdapter;
-import io.questdb.cairo.CursorPrinter;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.griffin.CustomisableRunnable;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -849,15 +850,7 @@ public final class TestUtils {
         if (tableToken == null) {
             throw new RuntimeException("table already exists: " + model.getTableName());
         }
-        TableUtils.createTable(
-                engine.getConfiguration(),
-                model.getMem(),
-                model.getPath(),
-                model,
-                ColumnType.VERSION,
-                tableId,
-                tableToken.getDirName()
-        );
+        createTable(model, engine.getConfiguration(), ColumnType.VERSION, tableId, tableToken);
         engine.registerTableToken(tableToken);
         if (model.isWalEnabled()) {
             engine.getTableSequencerAPI().registerTable(tableId, model, tableToken);
@@ -1669,6 +1662,23 @@ public final class TestUtils {
                 || expected.getLong2() != actual.getLong2()
                 || expected.getLong3() != actual.getLong3()) {
             Assert.assertEquals(toHexString(expected), toHexString(actual));
+        }
+    }
+
+    public static void createTable(TableModel model, CairoConfiguration configuration, int tableVersion, int tableId, TableToken tableToken) {
+        try (
+                Path path = new Path();
+                MemoryMARW mem = Vm.getMARWInstance()
+        ) {
+            TableUtils.createTable(
+                    configuration,
+                    mem,
+                    path,
+                    model,
+                    tableVersion,
+                    tableId,
+                    tableToken.getDirName()
+            );
         }
     }
 

--- a/core/src/test/java/io/questdb/test/wal/WalTxnDetailsFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/wal/WalTxnDetailsFuzzTest.java
@@ -28,7 +28,6 @@ import io.questdb.PropertyKey;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableWriter;
-import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.wal.WalTxnDetails;
 import io.questdb.cairo.wal.WalWriter;
 import io.questdb.cairo.wal.seq.TransactionLogCursor;
@@ -250,7 +249,6 @@ public class WalTxnDetailsFuzzTest extends AbstractCairoTest {
         }
     }
 
-    @SuppressWarnings("resource")
     private static TableModel defaultModel(String tableName) {
         return new TableModel(configuration, tableName, PartitionBy.DAY)
                 .timestamp("ts")
@@ -293,15 +291,7 @@ public class WalTxnDetailsFuzzTest extends AbstractCairoTest {
     }
 
     static TableToken createTable(String tableName) {
-        try (TableModel model = defaultModel(tableName)) {
-            return engine.createTable(
-                    AllowAllSecurityContext.INSTANCE,
-                    model.getMem(),
-                    model.getPath(),
-                    false,
-                    model,
-                    false
-            );
-        }
+        TableModel model = defaultModel(tableName);
+        return TestUtils.create(model, engine);
     }
 }


### PR DESCRIPTION
This PR also fixes SQL issue:

- incorrect "duplicate column" error, for example from this (try on demo):
```sql
select min(timestamp), timestamp_floor('10m', timestamp) timestamp from trades;
```

- incorrect column name propagation (model merge bug)
![image](https://github.com/questdb/questdb/assets/7276403/e7d86a56-3ac2-4c07-85f7-b4034c412ce2)

Todo:
- [x] recursive `sample by` rewrite, right now it will rewrite top level SQL only
- [x] tests to assert recursive rewrites
- [x] sort out test table model memory leak in https://github.com/questdb/questdb/pull/4259/commits/d42789dc87a30627665d04f2d8a95fa05653594b
- [x] deal with scenarios, when timestamp is selected multiple times using different aliases, e.g. 
```sql
select pickup_datetime a, pickup_datetime b, avg(trip_distance) from trips where pickup_datetime in '2010' sample by 5m ALIGN to CALENDAR;
```
- [x] collapse redundant `CHOOSE` models, which leads to simpler and slightly quicker SQL execution
- [x] test that `with` clauses are also rewritten
- [x] transfer "order by" clause when collapsing "choose" models, right now these models are unnecesserily avoided
- [x] add doc to describe collapsing behaviour and the motivation
- [x] modified `order by` generator to set designated timestamp provided it is the first field in the `order by` list

Changes in test framework necessitate Enterprise PR: https://github.com/questdb/questdb-enterprise/pull/386