### PR TITLE
perf(sql): parallel GROUP BY support for first/last functions

### DIFF
--- a/benchmarks/src/main/java/org/questdb/CairoKeywordBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CairoKeywordBenchmark.java
@@ -44,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class CairoKeywordBenchmark {
 
-
     private final long memSize = "abcde.detached".length() + 1;
     private final StringSink sink = new StringSink();
     private final StringSink sink2 = new StringSink();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
@@ -37,9 +37,29 @@ public interface GroupByFunction extends Function, Mutable {
     default void clear() {
     }
 
-    void computeFirst(MapValue mapValue, Record record);
+    /**
+     * Performs the first aggregation within a group.
+     * <p>
+     * Row id is provided for aggregation functions that consider row order, such as first/last.
+     * {@link Record#getRowId()} shouldn't be used for this purpose since not all records implement it.
+     *
+     * @param mapValue map value holding the group
+     * @param record   record holding the aggregated row
+     * @param rowId    row id, guaranteed to be monotonically growing; the value may be different from record.getRowId()
+     */
+    void computeFirst(MapValue mapValue, Record record, long rowId);
 
-    void computeNext(MapValue mapValue, Record record);
+    /**
+     * Performs a subsequent aggregation within a group.
+     * <p>
+     * Row id is provided for aggregation functions that consider row order, such as first/last.
+     * {@link Record#getRowId()} shouldn't be used for this purpose since not all records implement it.
+     *
+     * @param mapValue map value holding the group
+     * @param record   record holding the aggregated row
+     * @param rowId    row id, guaranteed to be monotonically growing; the value may be different from record.getRowId()
+     */
+    void computeNext(MapValue mapValue, Record record, long rowId);
 
     // only makes sense for non-keyed group by
     default boolean earlyExit(MapValue mapValue) {
@@ -97,10 +117,12 @@ public interface GroupByFunction extends Function, Mutable {
     default void setAllocator(GroupByAllocator allocator) {
     }
 
+    // used when doing interpolation
     default void setByte(MapValue mapValue, byte value) {
         throw new UnsupportedOperationException();
     }
 
+    // used when doing interpolation
     default void setDouble(MapValue mapValue, double value) {
         throw new UnsupportedOperationException();
     }
@@ -109,20 +131,24 @@ public interface GroupByFunction extends Function, Mutable {
         setNull(value);
     }
 
+    // used when doing interpolation
     default void setFloat(MapValue mapValue, float value) {
         throw new UnsupportedOperationException();
     }
 
+    // used when doing interpolation
     default void setInt(MapValue mapValue, int value) {
         throw new UnsupportedOperationException();
     }
 
+    // used when doing interpolation
     default void setLong(MapValue mapValue, long value) {
         throw new UnsupportedOperationException();
     }
 
     void setNull(MapValue mapValue);
 
+    // used when doing interpolation
     default void setShort(MapValue mapValue, short value) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
@@ -41,11 +41,14 @@ public interface GroupByFunction extends Function, Mutable {
      * Performs the first aggregation within a group.
      * <p>
      * Row id is provided for aggregation functions that consider row order, such as first/last.
-     * {@link Record#getRowId()} shouldn't be used for this purpose since not all records implement it.
+     * The value is guaranteed to be growing between subsequent calls. In case of parallel GROUP BY,
+     * this means that all row ids of a later page frame are guaranteed to be greater than row ids
+     * of all previous page frames. {@link Record#getRowId()} shouldn't be used for this purpose
+     * since not all records implement it, and it's not guaranteed to be growing.
      *
      * @param mapValue map value holding the group
      * @param record   record holding the aggregated row
-     * @param rowId    row id, guaranteed to be growing; the value may be different from record.getRowId()
+     * @param rowId    row id; the value may be different from record.getRowId()
      */
     void computeFirst(MapValue mapValue, Record record, long rowId);
 
@@ -53,11 +56,14 @@ public interface GroupByFunction extends Function, Mutable {
      * Performs a subsequent aggregation within a group.
      * <p>
      * Row id is provided for aggregation functions that consider row order, such as first/last.
-     * {@link Record#getRowId()} shouldn't be used for this purpose since not all records implement it.
+     * The value is guaranteed to be growing between subsequent calls. In case of parallel GROUP BY,
+     * this means that all row ids of a later page frame are guaranteed to be greater than row ids
+     * of all previous page frames. {@link Record#getRowId()} shouldn't be used for this purpose
+     * since not all records implement it, and it's not guaranteed to be growing.
      *
      * @param mapValue map value holding the group
      * @param record   record holding the aggregated row
-     * @param rowId    row id, guaranteed to be growing; the value may be different from record.getRowId()
+     * @param rowId    row id; the value may be different from record.getRowId()
      */
     void computeNext(MapValue mapValue, Record record, long rowId);
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/GroupByFunction.java
@@ -45,7 +45,7 @@ public interface GroupByFunction extends Function, Mutable {
      *
      * @param mapValue map value holding the group
      * @param record   record holding the aggregated row
-     * @param rowId    row id, guaranteed to be monotonically growing; the value may be different from record.getRowId()
+     * @param rowId    row id, guaranteed to be growing; the value may be different from record.getRowId()
      */
     void computeFirst(MapValue mapValue, Record record, long rowId);
 
@@ -57,7 +57,7 @@ public interface GroupByFunction extends Function, Mutable {
      *
      * @param mapValue map value holding the group
      * @param record   record holding the aggregated row
-     * @param rowId    row id, guaranteed to be monotonically growing; the value may be different from record.getRowId()
+     * @param rowId    row id, guaranteed to be growing; the value may be different from record.getRowId()
      */
     void computeNext(MapValue mapValue, Record record, long rowId);
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCovarGroupByFunction.java
@@ -54,7 +54,7 @@ public abstract class AbstractCovarGroupByFunction extends DoubleFunction implem
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double x = xFunction.getDouble(record);
         final double y = yFunction.getDouble(record);
         mapValue.putDouble(valueIndex, 0);
@@ -68,7 +68,7 @@ public abstract class AbstractCovarGroupByFunction extends DoubleFunction implem
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double x = xFunction.getDouble(record);
         final double y = yFunction.getDouble(record);
         if (Numbers.isFinite(x) && Numbers.isFinite(y)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
@@ -51,7 +51,7 @@ public abstract class AbstractStdDevGroupByFunction extends DoubleFunction imple
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double d = arg.getDouble(record);
         mapValue.putDouble(valueIndex, 0);
         mapValue.putDouble(valueIndex + 1, 0);
@@ -62,7 +62,7 @@ public abstract class AbstractStdDevGroupByFunction extends DoubleFunction imple
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double d = arg.getDouble(record);
         if (Numbers.isFinite(d)) {
             aggregate(mapValue, d);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -64,7 +64,7 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getIPv4(record);
         if (val != Numbers.IPv4_NULL) {
             final long hash = Hash.murmur3ToLong(val);
@@ -79,7 +79,7 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getIPv4(record);
         if (val != Numbers.IPv4_NULL) {
             final long hash = Hash.murmur3ToLong(val);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -64,7 +64,7 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getInt(record);
         if (val != Numbers.INT_NaN) {
             final long hash = Hash.murmur3ToLong(val);
@@ -79,7 +79,7 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getInt(record);
         if (val != Numbers.INT_NaN) {
             final long hash = Hash.murmur3ToLong(val);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -64,7 +64,7 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final long val = arg.getLong(record);
         if (val != Numbers.LONG_NaN) {
             final long hash = Hash.murmur3ToLong(val);
@@ -79,7 +79,7 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final long val = arg.getLong(record);
         if (val != Numbers.LONG_NaN) {
             final long hash = Hash.murmur3ToLong(val);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileDoubleGroupByFunction.java
@@ -63,7 +63,7 @@ public class ApproxPercentileDoubleGroupByFunction extends DoubleFunction implem
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final DoubleHistogram histogram;
         if (histograms.size() <= histogramIndex) {
             // We pre-size the histogram for 1000x ratio to avoid resizes in some basic use cases
@@ -83,7 +83,7 @@ public class ApproxPercentileDoubleGroupByFunction extends DoubleFunction implem
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final DoubleHistogram histogram = histograms.getQuick(mapValue.getInt(valueIndex));
         final double val = exprFunc.getDouble(record);
         if (Numbers.isFinite(val)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileDoublePackedGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileDoublePackedGroupByFunction.java
@@ -63,7 +63,7 @@ public class ApproxPercentileDoublePackedGroupByFunction extends DoubleFunction 
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final PackedDoubleHistogram histogram;
         if (histograms.size() <= histogramIndex) {
             // We pre-size the histogram for 1000x ratio to avoid resizes in some basic use cases
@@ -83,7 +83,7 @@ public class ApproxPercentileDoublePackedGroupByFunction extends DoubleFunction 
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final PackedDoubleHistogram histogram = histograms.getQuick(mapValue.getInt(valueIndex));
         final double val = exprFunc.getDouble(record);
         if (Numbers.isFinite(val)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileLongGroupByFunction.java
@@ -63,7 +63,7 @@ public class ApproxPercentileLongGroupByFunction extends DoubleFunction implemen
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final Histogram histogram;
         if (histograms.size() <= histogramIndex) {
             // We pre-size the histogram for [1, 1000] range to avoid resizes in some basic use cases
@@ -83,7 +83,7 @@ public class ApproxPercentileLongGroupByFunction extends DoubleFunction implemen
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final Histogram histogram = histograms.getQuick(mapValue.getInt(valueIndex));
         final long val = exprFunc.getLong(record);
         if (val != Numbers.LONG_NaN) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileLongPackedGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxPercentileLongPackedGroupByFunction.java
@@ -63,7 +63,7 @@ public class ApproxPercentileLongPackedGroupByFunction extends DoubleFunction im
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final PackedHistogram histogram;
         if (histograms.size() <= histogramIndex) {
             // We pre-size the histogram for [1, 1000] range to avoid resizes in some basic use cases
@@ -83,7 +83,7 @@ public class ApproxPercentileLongPackedGroupByFunction extends DoubleFunction im
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final PackedHistogram histogram = histograms.getQuick(mapValue.getInt(valueIndex));
         final long val = exprFunc.getLong(record);
         if (val != Numbers.LONG_NaN) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AvgDoubleGroupByFunction.java
@@ -44,7 +44,7 @@ public class AvgDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double d = arg.getDouble(record);
         if (Numbers.isFinite(d)) {
             mapValue.putDouble(valueIndex, d);
@@ -56,7 +56,7 @@ public class AvgDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double d = arg.getDouble(record);
         if (Numbers.isFinite(d)) {
             mapValue.addDouble(valueIndex, d);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunction.java
@@ -53,7 +53,7 @@ public class CorrGroupByFunction extends DoubleFunction implements GroupByFuncti
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double x = xFunction.getDouble(record);
         final double y = yFunction.getDouble(record);
         mapValue.putDouble(valueIndex, 0);
@@ -69,7 +69,7 @@ public class CorrGroupByFunction extends DoubleFunction implements GroupByFuncti
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double x = xFunction.getDouble(record);
         final double y = yFunction.getDouble(record);
         if (Numbers.isFinite(x) && Numbers.isFinite(y)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getIPv4(record);
         if (val != Numbers.IPv4_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -69,7 +69,7 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int val = arg.getIPv4(record);
         if (val != Numbers.IPv4_NULL) {
             long ptr = mapValue.getLong(valueIndex + 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         int val = arg.getInt(record);
         if (val != Numbers.INT_NaN) {
             mapValue.putLong(valueIndex, 1);
@@ -71,7 +71,7 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         int val = arg.getInt(record);
         if (val != Numbers.INT_NaN) {
             long ptr = mapValue.getLong(valueIndex + 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -34,7 +34,9 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByLong256HashSet;
-import io.questdb.std.*;
+import io.questdb.std.Long256;
+import io.questdb.std.Long256Impl;
+import io.questdb.std.Numbers;
 
 public class CountDistinctLong256GroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
@@ -56,7 +58,7 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final Long256 l256 = arg.getLong256A(record);
 
         if (isNotNull(l256)) {
@@ -76,12 +78,13 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
             mapValue.putLong(valueIndex + 1, setA.ptr());
         } else {
             mapValue.putLong(valueIndex, 0);
-            mapValue.putLong(valueIndex + 1, 0);;
+            mapValue.putLong(valueIndex + 1, 0);
+            ;
         }
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final Long256 l256 = arg.getLong256A(record);
 
         if (isNotNull(l256)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -56,7 +56,7 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         long val = arg.getLong(record);
         if (val != Numbers.LONG_NaN) {
             mapValue.putLong(valueIndex, 1);
@@ -71,7 +71,7 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         long val = arg.getLong(record);
         if (val != Numbers.LONG_NaN) {
             long ptr = mapValue.getLong(valueIndex + 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctStringGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctStringGroupByFunction.java
@@ -58,7 +58,7 @@ public class CountDistinctStringGroupByFunction extends LongFunction implements 
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final CompactCharSequenceHashSet set;
         if (sets.size() <= setIndex) {
             sets.extendAndSet(setIndex, set = new CompactCharSequenceHashSet(setInitialCapacity, setLoadFactor));
@@ -78,7 +78,7 @@ public class CountDistinctStringGroupByFunction extends LongFunction implements 
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final CompactCharSequenceHashSet set = sets.getQuick(mapValue.getInt(valueIndex + 1));
         final CharSequence val = arg.getStr(record);
         if (val != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -64,7 +64,7 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final BitSet set;
         if (sets.size() <= setIndex) {
             sets.extendAndSet(setIndex, set = new BitSet(setInitialCapacity));
@@ -84,7 +84,7 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final BitSet set = sets.getQuick(mapValue.getInt(valueIndex + 1));
         final int val = arg.getInt(record);
         if (val != VALUE_IS_NULL) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -34,10 +34,7 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByLong128HashSet;
-import io.questdb.griffin.engine.groupby.GroupByLongHashSet;
-import io.questdb.std.LongLongHashSet;
 import io.questdb.std.Numbers;
-import io.questdb.std.ObjList;
 import io.questdb.std.Uuid;
 
 public final class CountDistinctUuidGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
@@ -60,7 +57,7 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         long lo = arg.getLong128Lo(record);
         long hi = arg.getLong128Hi(record);
         if (!Uuid.isNull(lo, hi)) {
@@ -74,12 +71,13 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
             mapValue.putLong(valueIndex + 1, setA.ptr());
         } else {
             mapValue.putLong(valueIndex, 0);
-            mapValue.putLong(valueIndex + 1, 0);;
+            mapValue.putLong(valueIndex + 1, 0);
+            ;
         }
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         long lo = arg.getLong128Lo(record);
         long hi = arg.getLong128Hi(record);
         if (!Uuid.isNull(lo, hi)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -72,7 +72,6 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
         } else {
             mapValue.putLong(valueIndex, 0);
             mapValue.putLong(valueIndex + 1, 0);
-            ;
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDoubleGroupByFunction.java
@@ -36,7 +36,7 @@ public class CountDoubleGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (!Double.isNaN(value)) {
             mapValue.putLong(valueIndex, 1);
@@ -46,7 +46,7 @@ public class CountDoubleGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (!Double.isNaN(value)) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountFloatGroupByFunction.java
@@ -35,7 +35,7 @@ public class CountFloatGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final float value = arg.getFloat(record);
         if (!Float.isNaN(value)) {
             mapValue.putLong(valueIndex, 1);
@@ -45,7 +45,7 @@ public class CountFloatGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final float value = arg.getFloat(record);
         if (!Float.isNaN(value)) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionByte.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionByte.java
@@ -36,7 +36,7 @@ public class CountGeoHashGroupByFunctionByte extends AbstractCountGroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final byte value = arg.getGeoByte(record);
         if (value != GeoHashes.BYTE_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -46,7 +46,7 @@ public class CountGeoHashGroupByFunctionByte extends AbstractCountGroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final byte value = arg.getGeoByte(record);
         if (value != GeoHashes.BYTE_NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionInt.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionInt.java
@@ -37,7 +37,7 @@ public class CountGeoHashGroupByFunctionInt extends AbstractCountGroupByFunction
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getGeoInt(record);
         if (value != GeoHashes.INT_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountGeoHashGroupByFunctionInt extends AbstractCountGroupByFunction
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getGeoInt(record);
         if (value != GeoHashes.INT_NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionLong.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionLong.java
@@ -37,7 +37,7 @@ public class CountGeoHashGroupByFunctionLong extends AbstractCountGroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getGeoLong(record);
         if (value != GeoHashes.NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountGeoHashGroupByFunctionLong extends AbstractCountGroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getGeoLong(record);
         if (value != GeoHashes.NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionShort.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountGeoHashGroupByFunctionShort.java
@@ -37,7 +37,7 @@ public class CountGeoHashGroupByFunctionShort extends AbstractCountGroupByFuncti
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final short value = arg.getGeoShort(record);
         if (value != GeoHashes.SHORT_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountGeoHashGroupByFunctionShort extends AbstractCountGroupByFuncti
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final short value = arg.getGeoShort(record);
         if (value != GeoHashes.SHORT_NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountIPv4GroupByFunction.java
@@ -37,7 +37,7 @@ public class CountIPv4GroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getIPv4(record);
         if (value != Numbers.IPv4_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountIPv4GroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getIPv4(record);
         if (value != Numbers.IPv4_NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountIntGroupByFunction.java
@@ -37,7 +37,7 @@ public class CountIntGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getInt(record);
         if (value != Numbers.INT_NaN) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountIntGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getInt(record);
         if (value != Numbers.INT_NaN) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLong256GroupByFunction.java
@@ -38,7 +38,7 @@ public class CountLong256GroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final Long256 value = arg.getLong256A(record);
         if (!Long256Impl.isNull(value)) {
             mapValue.putLong(valueIndex, 1);
@@ -48,7 +48,7 @@ public class CountLong256GroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final Long256 value = arg.getLong256A(record);
         if (!Long256Impl.isNull(value)) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLongConstGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLongConstGroupByFunction.java
@@ -37,12 +37,12 @@ public class CountLongConstGroupByFunction extends LongFunction implements Group
     private int valueIndex;
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, 1);
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.addLong(valueIndex, 1);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLongGroupByFunction.java
@@ -37,7 +37,7 @@ public class CountLongGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getLong(record);
         if (value != Numbers.LONG_NaN) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountLongGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getLong(record);
         if (value != Numbers.LONG_NaN) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountStrGroupByFunction.java
@@ -37,7 +37,7 @@ public class CountStrGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         int value = arg.getStrLen(record);
         if (value != TableUtils.NULL_LEN) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountStrGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         int value = arg.getStrLen(record);
         if (value != TableUtils.NULL_LEN) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountSymbolGroupByFunction.java
@@ -37,7 +37,7 @@ public class CountSymbolGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         int value = arg.getInt(record);
         if (value != SymbolTable.VALUE_IS_NULL) {
             mapValue.putLong(valueIndex, 1);
@@ -47,7 +47,7 @@ public class CountSymbolGroupByFunction extends AbstractCountGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         int value = arg.getInt(record);
         if (value != SymbolTable.VALUE_IS_NULL) {
             mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstBooleanGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstBooleanGroupByFunction.java
@@ -32,10 +32,11 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstBooleanGroupByFunction extends BooleanFunction implements GroupByFunction, UnaryFunction {
-    private final Function arg;
+    protected final Function arg;
     protected int valueIndex;
 
     public FirstBooleanGroupByFunction(@NotNull Function arg) {
@@ -43,12 +44,13 @@ public class FirstBooleanGroupByFunction extends BooleanFunction implements Grou
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putBool(valueIndex, arg.getBool(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putBool(valueIndex + 1, arg.getBool(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,7 +61,7 @@ public class FirstBooleanGroupByFunction extends BooleanFunction implements Grou
 
     @Override
     public boolean getBool(Record rec) {
-        return rec.getBool(valueIndex);
+        return rec.getBool(valueIndex + 1);
     }
 
     @Override
@@ -74,22 +76,35 @@ public class FirstBooleanGroupByFunction extends BooleanFunction implements Grou
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putBool(valueIndex + 1, srcValue.getBool(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.BOOLEAN);
-    }
-
-    public void setBool(MapValue mapValue, boolean value) {
-        mapValue.putBool(valueIndex, value);
+        columnTypes.add(ColumnType.LONG);    // row id
+        columnTypes.add(ColumnType.BOOLEAN); // value
     }
 
     @Override
     public void setNull(MapValue mapValue) {
-        setBool(mapValue, false);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putBool(valueIndex + 1, false);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstByteGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstByteGroupByFunction.java
@@ -32,10 +32,11 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.ByteFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstByteGroupByFunction extends ByteFunction implements GroupByFunction, UnaryFunction {
-    private final Function arg;
+    protected final Function arg;
     protected int valueIndex;
 
     public FirstByteGroupByFunction(@NotNull Function arg) {
@@ -43,12 +44,13 @@ public class FirstByteGroupByFunction extends ByteFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putByte(valueIndex, arg.getByte(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putByte(valueIndex + 1, arg.getByte(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,7 +61,7 @@ public class FirstByteGroupByFunction extends ByteFunction implements GroupByFun
 
     @Override
     public byte getByte(Record rec) {
-        return rec.getByte(valueIndex);
+        return rec.getByte(valueIndex + 1);
     }
 
     @Override
@@ -74,17 +76,35 @@ public class FirstByteGroupByFunction extends ByteFunction implements GroupByFun
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putByte(valueIndex + 1, srcValue.getByte(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.BYTE);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.BYTE); // value
     }
 
+    @Override
     public void setByte(MapValue mapValue, byte value) {
-        mapValue.putByte(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putByte(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstByteGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstByteGroupByFunction.java
@@ -103,6 +103,8 @@ public class FirstByteGroupByFunction extends ByteFunction implements GroupByFun
 
     @Override
     public void setByte(MapValue mapValue, byte value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putByte(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstCharGroupByFunction.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.CharFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstCharGroupByFunction extends CharFunction implements GroupByFunction, UnaryFunction {
@@ -43,12 +44,13 @@ public class FirstCharGroupByFunction extends CharFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putChar(valueIndex, arg.getChar(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putChar(valueIndex + 1, arg.getChar(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,7 +61,7 @@ public class FirstCharGroupByFunction extends CharFunction implements GroupByFun
 
     @Override
     public char getChar(Record rec) {
-        return rec.getChar(valueIndex);
+        return rec.getChar(valueIndex + 1);
     }
 
     @Override
@@ -74,22 +76,35 @@ public class FirstCharGroupByFunction extends CharFunction implements GroupByFun
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putChar(valueIndex + 1, srcValue.getChar(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.SHORT);
-    }
-
-    public void setChar(MapValue mapValue, char value) {
-        mapValue.putChar(valueIndex, value);
+        columnTypes.add(ColumnType.LONG);  // row id
+        columnTypes.add(ColumnType.SHORT); // value
     }
 
     @Override
     public void setNull(MapValue mapValue) {
-        setChar(mapValue, (char) 0);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putChar(valueIndex + 1, (char) 0);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
@@ -46,7 +46,7 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
     @Override
     public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, rowId);
-        mapValue.putLong(valueIndex + 1, arg.getDate(record));
+        mapValue.putDate(valueIndex + 1, arg.getDate(record));
     }
 
     @Override
@@ -104,7 +104,7 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
     @Override
     public void setNull(MapValue mapValue) {
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
-        mapValue.putTimestamp(valueIndex + 1, Numbers.LONG_NaN);
+        mapValue.putDate(valueIndex + 1, Numbers.LONG_NaN);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
@@ -44,12 +44,13 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putLong(valueIndex, arg.getDate(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putLong(valueIndex + 1, arg.getDate(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -60,7 +61,7 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
 
     @Override
     public long getDate(Record rec) {
-        return rec.getDate(valueIndex);
+        return rec.getDate(valueIndex + 1);
     }
 
     @Override
@@ -75,18 +76,35 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDate(valueIndex + 1, srcValue.getDate(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.DATE);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.DATE); // value
     }
 
     @Override
     public void setNull(MapValue mapValue) {
-        mapValue.putTimestamp(valueIndex, Numbers.LONG_NaN);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putTimestamp(valueIndex + 1, Numbers.LONG_NaN);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDoubleGroupByFunction.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.DoubleFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstDoubleGroupByFunction extends DoubleFunction implements GroupByFunction, UnaryFunction {
@@ -43,12 +44,13 @@ public class FirstDoubleGroupByFunction extends DoubleFunction implements GroupB
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putDouble(valueIndex, arg.getDouble(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putDouble(valueIndex + 1, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,7 +61,7 @@ public class FirstDoubleGroupByFunction extends DoubleFunction implements GroupB
 
     @Override
     public double getDouble(Record rec) {
-        return rec.getDouble(valueIndex);
+        return rec.getDouble(valueIndex + 1);
     }
 
     @Override
@@ -74,18 +76,35 @@ public class FirstDoubleGroupByFunction extends DoubleFunction implements GroupB
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.DOUBLE);
+        columnTypes.add(ColumnType.LONG);   // row id
+        columnTypes.add(ColumnType.DOUBLE); // value
     }
 
     @Override
     public void setDouble(MapValue mapValue, double value) {
-        mapValue.putDouble(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putDouble(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDoubleGroupByFunction.java
@@ -103,6 +103,8 @@ public class FirstDoubleGroupByFunction extends DoubleFunction implements GroupB
 
     @Override
     public void setDouble(MapValue mapValue, double value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putDouble(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstFloatGroupByFunction.java
@@ -103,6 +103,8 @@ public class FirstFloatGroupByFunction extends FloatFunction implements GroupByF
 
     @Override
     public void setFloat(MapValue mapValue, float value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putFloat(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstFloatGroupByFunction.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.FloatFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstFloatGroupByFunction extends FloatFunction implements GroupByFunction, UnaryFunction {
@@ -43,12 +44,13 @@ public class FirstFloatGroupByFunction extends FloatFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putFloat(valueIndex, arg.getFloat(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putFloat(valueIndex + 1, arg.getFloat(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,7 +61,7 @@ public class FirstFloatGroupByFunction extends FloatFunction implements GroupByF
 
     @Override
     public float getFloat(Record rec) {
-        return rec.getFloat(valueIndex);
+        return rec.getFloat(valueIndex + 1);
     }
 
     @Override
@@ -74,18 +76,35 @@ public class FirstFloatGroupByFunction extends FloatFunction implements GroupByF
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putFloat(valueIndex + 1, srcValue.getFloat(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.FLOAT);
+        columnTypes.add(ColumnType.LONG);  // row id
+        columnTypes.add(ColumnType.FLOAT); // value
     }
 
     @Override
     public void setFloat(MapValue mapValue, float value) {
-        mapValue.putFloat(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putFloat(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionByte.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionByte.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.GeoByteFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 
 public class FirstGeoHashGroupByFunctionByte extends GeoByteFunction implements GroupByFunction, UnaryFunction {
     protected final Function arg;
@@ -44,12 +45,13 @@ public class FirstGeoHashGroupByFunctionByte extends GeoByteFunction implements 
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putByte(valueIndex, arg.getGeoByte(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putByte(valueIndex + 1, arg.getGeoByte(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -60,7 +62,7 @@ public class FirstGeoHashGroupByFunctionByte extends GeoByteFunction implements 
 
     @Override
     public byte getGeoByte(Record rec) {
-        return rec.getGeoByte(valueIndex);
+        return rec.getGeoByte(valueIndex + 1);
     }
 
     @Override
@@ -75,18 +77,35 @@ public class FirstGeoHashGroupByFunctionByte extends GeoByteFunction implements 
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putByte(valueIndex + 1, srcValue.getGeoByte(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.BYTE);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.BYTE); // value
     }
 
     @Override
     public void setByte(MapValue mapValue, byte value) {
-        mapValue.putByte(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putByte(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionByte.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionByte.java
@@ -104,6 +104,8 @@ public class FirstGeoHashGroupByFunctionByte extends GeoByteFunction implements 
 
     @Override
     public void setByte(MapValue mapValue, byte value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putByte(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionInt.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionInt.java
@@ -104,6 +104,8 @@ class FirstGeoHashGroupByFunctionInt extends GeoIntFunction implements GroupByFu
 
     @Override
     public void setInt(MapValue mapValue, int value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putInt(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionLong.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionLong.java
@@ -30,11 +30,12 @@ import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.griffin.engine.functions.GeoByteFunction;
+import io.questdb.griffin.engine.functions.GeoLongFunction;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 
-class FirstGeoHashGroupByFunctionLong extends GeoByteFunction implements GroupByFunction, UnaryFunction {
+class FirstGeoHashGroupByFunctionLong extends GeoLongFunction implements GroupByFunction, UnaryFunction {
     protected final Function arg;
     protected int valueIndex;
 
@@ -44,12 +45,13 @@ class FirstGeoHashGroupByFunctionLong extends GeoByteFunction implements GroupBy
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putLong(valueIndex, arg.getGeoLong(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putLong(valueIndex + 1, arg.getGeoLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -59,13 +61,8 @@ class FirstGeoHashGroupByFunctionLong extends GeoByteFunction implements GroupBy
     }
 
     @Override
-    public byte getGeoByte(Record rec) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public long getGeoLong(Record rec) {
-        return rec.getGeoLong(valueIndex);
+        return rec.getGeoLong(valueIndex + 1);
     }
 
     @Override
@@ -80,18 +77,35 @@ class FirstGeoHashGroupByFunctionLong extends GeoByteFunction implements GroupBy
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcValue.getGeoLong(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.LONG);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.LONG); // value
     }
 
     @Override
     public void setLong(MapValue mapValue, long value) {
-        mapValue.putLong(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putLong(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionLong.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionLong.java
@@ -104,6 +104,8 @@ class FirstGeoHashGroupByFunctionLong extends GeoLongFunction implements GroupBy
 
     @Override
     public void setLong(MapValue mapValue, long value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putLong(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
@@ -114,6 +114,8 @@ public class FirstGeoHashGroupByFunctionShort extends GeoByteFunction implements
 
     @Override
     public void setShort(MapValue mapValue, short value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putShort(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIPv4GroupByFunction.java
@@ -108,6 +108,8 @@ public class FirstIPv4GroupByFunction extends IPv4Function implements GroupByFun
 
     @Override
     public void setInt(MapValue mapValue, int value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putInt(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIPv4GroupByFunction.java
@@ -44,12 +44,14 @@ public class FirstIPv4GroupByFunction extends IPv4Function implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putInt(valueIndex, arg.getIPv4(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putInt(valueIndex + 1, arg.getIPv4(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // empty
     }
 
     @Override
@@ -59,7 +61,7 @@ public class FirstIPv4GroupByFunction extends IPv4Function implements GroupByFun
 
     @Override
     public int getIPv4(Record rec) {
-        return rec.getIPv4(valueIndex);
+        return rec.getIPv4(valueIndex + 1);
     }
 
     @Override
@@ -79,18 +81,35 @@ public class FirstIPv4GroupByFunction extends IPv4Function implements GroupByFun
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getIPv4(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.IPv4);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.IPv4); // value
     }
 
     @Override
     public void setInt(MapValue mapValue, int value) {
-        mapValue.putInt(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putInt(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIntGroupByFunction.java
@@ -109,6 +109,8 @@ public class FirstIntGroupByFunction extends IntFunction implements GroupByFunct
 
     @Override
     public void setInt(MapValue mapValue, int value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putInt(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstIntGroupByFunction.java
@@ -45,12 +45,14 @@ public class FirstIntGroupByFunction extends IntFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putInt(valueIndex, arg.getInt(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putInt(valueIndex + 1, arg.getInt(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // empty
     }
 
     @Override
@@ -60,7 +62,7 @@ public class FirstIntGroupByFunction extends IntFunction implements GroupByFunct
 
     @Override
     public int getInt(Record rec) {
-        return rec.getInt(valueIndex);
+        return rec.getInt(valueIndex + 1);
     }
 
     @Override
@@ -80,18 +82,35 @@ public class FirstIntGroupByFunction extends IntFunction implements GroupByFunct
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.INT);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.INT);  // value
     }
 
     @Override
     public void setInt(MapValue mapValue, int value) {
-        mapValue.putInt(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putInt(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstLongGroupByFunction.java
@@ -103,6 +103,8 @@ public class FirstLongGroupByFunction extends LongFunction implements GroupByFun
 
     @Override
     public void setLong(MapValue mapValue, long value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putLong(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullCharGroupByFunction.java
@@ -37,9 +37,9 @@ public class FirstNotNullCharGroupByFunction extends FirstCharGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getChar(valueIndex) == CharConstant.ZERO.getChar(null)) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDateGroupByFunction.java
@@ -37,9 +37,9 @@ public class FirstNotNullDateGroupByFunction extends FirstDateGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getDate(valueIndex) == Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDateGroupByFunction.java
@@ -38,7 +38,7 @@ public class FirstNotNullDateGroupByFunction extends FirstDateGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (mapValue.getDate(valueIndex) == Numbers.LONG_NaN) {
+        if (mapValue.getDate(valueIndex + 1) == Numbers.LONG_NaN) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -46,5 +46,20 @@ public class FirstNotNullDateGroupByFunction extends FirstDateGroupByFunction {
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getDate(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDate(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDoubleGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstNotNullDoubleGroupByFunction extends FirstDoubleGroupByFunction {
@@ -45,5 +46,20 @@ public class FirstNotNullDoubleGroupByFunction extends FirstDoubleGroupByFunctio
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        double srcVal = srcValue.getDouble(valueIndex + 1);
+        if (Double.isNaN(srcVal)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDouble(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullDoubleGroupByFunction.java
@@ -36,9 +36,9 @@ public class FirstNotNullDoubleGroupByFunction extends FirstDoubleGroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        if (Double.isNaN(mapValue.getDouble(valueIndex))) {
-            computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        if (Double.isNaN(mapValue.getDouble(valueIndex + 1))) {
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullFloatGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstNotNullFloatGroupByFunction extends FirstFloatGroupByFunction {
@@ -37,7 +38,7 @@ public class FirstNotNullFloatGroupByFunction extends FirstFloatGroupByFunction 
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (Float.isNaN(mapValue.getFloat(valueIndex))) {
+        if (Float.isNaN(mapValue.getFloat(valueIndex + 1))) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -45,5 +46,20 @@ public class FirstNotNullFloatGroupByFunction extends FirstFloatGroupByFunction 
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        float srcVal = srcValue.getFloat(valueIndex + 1);
+        if (Float.isNaN(srcVal)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putFloat(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullFloatGroupByFunction.java
@@ -36,9 +36,9 @@ public class FirstNotNullFloatGroupByFunction extends FirstFloatGroupByFunction 
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (Float.isNaN(mapValue.getFloat(valueIndex))) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullGeoHashGroupByFunctionFactory.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactory {
@@ -73,7 +74,7 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
 
         @Override
         public void computeNext(MapValue mapValue, Record record, long rowId) {
-            if (mapValue.getGeoByte(valueIndex) == GeoHashes.BYTE_NULL) {
+            if (mapValue.getGeoByte(valueIndex + 1) == GeoHashes.BYTE_NULL) {
                 computeFirst(mapValue, record, rowId);
             }
         }
@@ -81,6 +82,21 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            byte srcVal = srcValue.getGeoByte(valueIndex + 1);
+            if (srcVal == GeoHashes.BYTE_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            // srcRowId is non-null at this point since we know that the value is non-null
+            if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putByte(valueIndex + 1, srcVal);
+            }
         }
     }
 
@@ -91,7 +107,7 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
 
         @Override
         public void computeNext(MapValue mapValue, Record record, long rowId) {
-            if (mapValue.getGeoInt(valueIndex) == GeoHashes.INT_NULL) {
+            if (mapValue.getGeoInt(valueIndex + 1) == GeoHashes.INT_NULL) {
                 computeFirst(mapValue, record, rowId);
             }
         }
@@ -99,6 +115,21 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            int srcVal = srcValue.getGeoInt(valueIndex + 1);
+            if (srcVal == GeoHashes.INT_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            // srcRowId is non-null at this point since we know that the value is non-null
+            if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putInt(valueIndex + 1, srcVal);
+            }
         }
     }
 
@@ -109,7 +140,7 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
 
         @Override
         public void computeNext(MapValue mapValue, Record record, long rowId) {
-            if (mapValue.getGeoLong(valueIndex) == GeoHashes.NULL) {
+            if (mapValue.getGeoLong(valueIndex + 1) == GeoHashes.NULL) {
                 computeFirst(mapValue, record, rowId);
             }
         }
@@ -117,6 +148,21 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            long srcVal = srcValue.getGeoLong(valueIndex + 1);
+            if (srcVal == GeoHashes.NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            // srcRowId is non-null at this point since we know that the value is non-null
+            if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putLong(valueIndex + 1, srcVal);
+            }
         }
     }
 
@@ -127,7 +173,7 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
 
         @Override
         public void computeNext(MapValue mapValue, Record record, long rowId) {
-            if (mapValue.getGeoShort(valueIndex) == GeoHashes.SHORT_NULL) {
+            if (mapValue.getGeoShort(valueIndex + 1) == GeoHashes.SHORT_NULL) {
                 computeFirst(mapValue, record, rowId);
             }
         }
@@ -135,6 +181,21 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            short srcVal = srcValue.getGeoShort(valueIndex + 1);
+            if (srcVal == GeoHashes.SHORT_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            // srcRowId is non-null at this point since we know that the value is non-null
+            if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putShort(valueIndex + 1, srcVal);
+            }
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullGeoHashGroupByFunctionFactory.java
@@ -72,9 +72,9 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (mapValue.getGeoByte(valueIndex) == GeoHashes.BYTE_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -90,9 +90,9 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (mapValue.getGeoInt(valueIndex) == GeoHashes.INT_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -108,9 +108,9 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (mapValue.getGeoLong(valueIndex) == GeoHashes.NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -126,9 +126,9 @@ public class FirstNotNullGeoHashGroupByFunctionFactory implements FunctionFactor
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (mapValue.getGeoShort(valueIndex) == GeoHashes.SHORT_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIPv4GroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIPv4GroupByFunctionFactory.java
@@ -64,9 +64,9 @@ public class FirstNotNullIPv4GroupByFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (mapValue.getIPv4(valueIndex) == Numbers.IPv4_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIPv4GroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIPv4GroupByFunctionFactory.java
@@ -65,7 +65,7 @@ public class FirstNotNullIPv4GroupByFunctionFactory implements FunctionFactory {
 
         @Override
         public void computeNext(MapValue mapValue, Record record, long rowId) {
-            if (mapValue.getIPv4(valueIndex) == Numbers.IPv4_NULL) {
+            if (mapValue.getIPv4(valueIndex + 1) == Numbers.IPv4_NULL) {
                 computeFirst(mapValue, record, rowId);
             }
         }
@@ -73,6 +73,21 @@ public class FirstNotNullIPv4GroupByFunctionFactory implements FunctionFactory {
         @Override
         public String getName() {
             return "first_not_null";
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            int srcVal = srcValue.getIPv4(valueIndex + 1);
+            if (srcVal == Numbers.IPv4_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            // srcRowId is non-null at this point since we know that the value is non-null
+            if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putInt(valueIndex + 1, srcVal);
+            }
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIntGroupByFunction.java
@@ -36,9 +36,9 @@ public class FirstNotNullIntGroupByFunction extends FirstIntGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getInt(valueIndex) == Numbers.INT_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullIntGroupByFunction.java
@@ -37,7 +37,7 @@ public class FirstNotNullIntGroupByFunction extends FirstIntGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (mapValue.getInt(valueIndex) == Numbers.INT_NaN) {
+        if (mapValue.getInt(valueIndex + 1) == Numbers.INT_NaN) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -45,5 +45,20 @@ public class FirstNotNullIntGroupByFunction extends FirstIntGroupByFunction {
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        int srcVal = srcValue.getInt(valueIndex + 1);
+        if (srcVal == Numbers.INT_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullLongGroupByFunction.java
@@ -37,9 +37,9 @@ public class FirstNotNullLongGroupByFunction extends FirstLongGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getLong(valueIndex) == Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullLongGroupByFunction.java
@@ -38,7 +38,7 @@ public class FirstNotNullLongGroupByFunction extends FirstLongGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (mapValue.getLong(valueIndex) == Numbers.LONG_NaN) {
+        if (mapValue.getLong(valueIndex + 1) == Numbers.LONG_NaN) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -46,5 +46,20 @@ public class FirstNotNullLongGroupByFunction extends FirstLongGroupByFunction {
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getLong(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullStrGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.str.DirectUtf16Sink;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstNotNullStrGroupByFunction extends FirstStrGroupByFunction {
@@ -37,13 +36,15 @@ public class FirstNotNullStrGroupByFunction extends FirstStrGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        if (mapValue.getBool(valueIndex + 1)) {
-            final CharSequence str = arg.getStr(record);
-            if (str != null) {
-                final DirectUtf16Sink sink = sinks.getQuick(mapValue.getInt(valueIndex));
-                sink.put(str);
-                mapValue.putBool(valueIndex + 1, false);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        if (mapValue.getBool(valueIndex + 2)) {
+            final CharSequence val = arg.getStr(record);
+            if (val != null) {
+                long ptr = mapValue.getLong(valueIndex + 1);
+                sink.of(ptr).clear();
+                sink.put(val);
+                mapValue.putLong(valueIndex + 1, sink.ptr());
+                mapValue.putBool(valueIndex + 2, false);
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullStrGroupByFunction.java
@@ -41,6 +41,7 @@ public class FirstNotNullStrGroupByFunction extends FirstStrGroupByFunction {
         if (mapValue.getBool(valueIndex + 2)) {
             final CharSequence val = arg.getStr(record);
             if (val != null) {
+                mapValue.putLong(valueIndex, rowId);
                 long ptr = mapValue.getLong(valueIndex + 1);
                 sink.of(ptr).clear();
                 sink.put(val);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullSymbolGroupByFunction.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunction {
@@ -38,7 +39,7 @@ public class FirstNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunctio
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (mapValue.getInt(valueIndex) == SymbolTable.VALUE_IS_NULL) {
+        if (mapValue.getInt(valueIndex + 1) == SymbolTable.VALUE_IS_NULL) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -46,5 +47,20 @@ public class FirstNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunctio
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        int srcVal = srcValue.getInt(valueIndex + 1);
+        if (srcVal == SymbolTable.VALUE_IS_NULL) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullSymbolGroupByFunction.java
@@ -37,9 +37,9 @@ public class FirstNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getInt(valueIndex) == SymbolTable.VALUE_IS_NULL) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullTimestampGroupByFunction.java
@@ -36,9 +36,9 @@ public class FirstNotNullTimestampGroupByFunction extends FirstTimestampGroupByF
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getTimestamp(valueIndex) == Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullTimestampGroupByFunction.java
@@ -37,7 +37,7 @@ public class FirstNotNullTimestampGroupByFunction extends FirstTimestampGroupByF
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        if (mapValue.getTimestamp(valueIndex) == Numbers.LONG_NaN) {
+        if (mapValue.getTimestamp(valueIndex + 1) == Numbers.LONG_NaN) {
             computeFirst(mapValue, record, rowId);
         }
     }
@@ -45,5 +45,20 @@ public class FirstNotNullTimestampGroupByFunction extends FirstTimestampGroupByF
     @Override
     public String getName() {
         return "first_not_null";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getTimestamp(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        // srcRowId is non-null at this point since we know that the value is non-null
+        if (srcRowId < destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcVal);
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstNotNullUuidGroupByFunction.java
@@ -36,9 +36,9 @@ public class FirstNotNullUuidGroupByFunction extends FirstUuidGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (Uuid.isNull(mapValue.getLong128Lo(valueIndex), mapValue.getLong128Hi(valueIndex))) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstShortGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstShortGroupByFunction.java
@@ -107,6 +107,8 @@ public class FirstShortGroupByFunction extends ShortFunction implements GroupByF
     }
 
     public void setShort(MapValue mapValue, short value) {
+        // This method is used to define interpolated points and to init
+        // an empty value, so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NaN);
         mapValue.putShort(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstShortGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstShortGroupByFunction.java
@@ -32,10 +32,11 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.ShortFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstShortGroupByFunction extends ShortFunction implements GroupByFunction, UnaryFunction {
-    private final Function arg;
+    protected final Function arg;
     protected int valueIndex;
 
     public FirstShortGroupByFunction(@NotNull Function arg) {
@@ -43,12 +44,13 @@ public class FirstShortGroupByFunction extends ShortFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putShort(valueIndex, arg.getShort(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putShort(valueIndex + 1, arg.getShort(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -64,7 +66,7 @@ public class FirstShortGroupByFunction extends ShortFunction implements GroupByF
 
     @Override
     public short getShort(Record rec) {
-        return rec.getShort(valueIndex);
+        return rec.getShort(valueIndex + 1);
     }
 
     @Override
@@ -74,13 +76,29 @@ public class FirstShortGroupByFunction extends ShortFunction implements GroupByF
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putShort(valueIndex + 1, srcValue.getShort(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.SHORT);
+        columnTypes.add(ColumnType.LONG);  // row id
+        columnTypes.add(ColumnType.SHORT); // value
     }
 
     @Override
@@ -89,7 +107,8 @@ public class FirstShortGroupByFunction extends ShortFunction implements GroupByF
     }
 
     public void setShort(MapValue mapValue, short value) {
-        mapValue.putShort(valueIndex, value);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putShort(valueIndex + 1, value);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstStrGroupByFunction.java
@@ -32,19 +32,15 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.StrFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
-import io.questdb.std.Misc;
-import io.questdb.std.ObjList;
-import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.griffin.engine.groupby.GroupByCharSink;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class FirstStrGroupByFunction extends StrFunction implements GroupByFunction, UnaryFunction {
-    private static final int INITIAL_SINK_CAPACITY = 16;
-    private static final int LIST_CLEAR_THRESHOLD = 64;
-
     protected final Function arg;
-    protected final ObjList<DirectUtf16Sink> sinks = new ObjList<>();
+    protected final GroupByCharSink sink = new GroupByCharSink();
     protected int valueIndex;
-    private int sinkIndex = 0;
 
     public FirstStrGroupByFunction(@NotNull Function arg) {
         this.arg = arg;
@@ -52,52 +48,25 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
 
     @Override
     public void clear() {
-        // Free extra sinks.
-        if (sinks.size() > LIST_CLEAR_THRESHOLD) {
-            for (int i = LIST_CLEAR_THRESHOLD, n = sinks.size(); i < n; i++) {
-                sinks.getAndSetQuick(i, null).close();
-            }
-            sinks.setPos(LIST_CLEAR_THRESHOLD);
-        }
-        // Reset capacity on the remaining ones.
-        for (int i = 0, n = sinks.size(); i < n; i++) {
-            DirectUtf16Sink sink = sinks.getQuick(i);
-            if (sink != null) {
-                sink.resetCapacity();
-            }
-        }
-        sinkIndex = 0;
+        sink.of(0);
     }
 
     @Override
-    public void close() {
-        Misc.freeObjListAndClear(sinks);
-    }
-
-    @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        final DirectUtf16Sink sink;
-        final CharSequence str = arg.getStr(record);
-        final int strLen = str != null ? str.length() : 0;
-
-        if (sinks.size() <= sinkIndex) {
-            sinks.extendAndSet(sinkIndex, sink = new DirectUtf16Sink(Math.max(INITIAL_SINK_CAPACITY, strLen)));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        final CharSequence val = arg.getStr(record);
+        if (val == null) {
+            mapValue.putLong(valueIndex + 1, 0);
+            mapValue.putBool(valueIndex + 2, true);
         } else {
-            sink = sinks.getQuick(sinkIndex);
-            sink.clear();
+            sink.of(0).put(val);
+            mapValue.putLong(valueIndex + 1, sink.ptr());
+            mapValue.putBool(valueIndex + 2, false);
         }
-
-        if (str != null) {
-            sink.put(str);
-            mapValue.putBool(valueIndex + 1, false);
-        } else {
-            mapValue.putBool(valueIndex + 1, true);
-        }
-        mapValue.putInt(valueIndex, sinkIndex++);
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -113,11 +82,12 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
 
     @Override
     public CharSequence getStr(Record rec) {
-        final boolean nullValue = rec.getBool(valueIndex + 1);
+        final boolean nullValue = rec.getBool(valueIndex + 2);
         if (nullValue) {
             return null;
         }
-        return sinks.getQuick(rec.getInt(valueIndex));
+        final long ptr = rec.getLong(valueIndex + 1);
+        return ptr == 0 ? null : sink.of(ptr);
     }
 
     @Override
@@ -137,6 +107,11 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
 
     @Override
     public boolean isParallelismSupported() {
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
         return false;
     }
 
@@ -146,15 +121,34 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
     }
 
     @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
+            destValue.putBool(valueIndex + 2, srcValue.getBool(valueIndex + 2));
+        }
+    }
+
+    @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.INT); // sink index
+        columnTypes.add(ColumnType.LONG);    // row id
+        columnTypes.add(ColumnType.LONG);    // sink pointer
         columnTypes.add(ColumnType.BOOLEAN); // null flag
     }
 
     @Override
+    public void setAllocator(GroupByAllocator allocator) {
+        sink.setAllocator(allocator);
+    }
+
+    @Override
     public void setNull(MapValue mapValue) {
-        mapValue.putBool(valueIndex + 1, true);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putLong(valueIndex + 1, 0);
+        mapValue.putBool(valueIndex + 2, true);
     }
 
     @Override
@@ -165,6 +159,5 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
     @Override
     public void toTop() {
         UnaryFunction.super.toTop();
-        sinkIndex = 0;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstSymbolGroupByFunction.java
@@ -34,6 +34,7 @@ import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,12 +47,14 @@ public class FirstSymbolGroupByFunction extends SymbolFunction implements GroupB
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putInt(valueIndex, arg.getInt(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putInt(valueIndex + 1, arg.getInt(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // empty
     }
 
     @Override
@@ -61,7 +64,7 @@ public class FirstSymbolGroupByFunction extends SymbolFunction implements GroupB
 
     @Override
     public int getInt(Record rec) {
-        return rec.getInt(valueIndex);
+        return rec.getInt(valueIndex + 1);
     }
 
     @Override
@@ -90,8 +93,28 @@ public class FirstSymbolGroupByFunction extends SymbolFunction implements GroupB
     }
 
     @Override
+    public boolean isParallelismSupported() {
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
     public boolean isSymbolTableStatic() {
         return arg.isSymbolTableStatic();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
+        }
     }
 
     @Override
@@ -104,12 +127,14 @@ public class FirstSymbolGroupByFunction extends SymbolFunction implements GroupB
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.INT);
+        columnTypes.add(ColumnType.LONG); // row id
+        columnTypes.add(ColumnType.INT);  // value
     }
 
     @Override
     public void setNull(MapValue mapValue) {
-        mapValue.putInt(valueIndex, SymbolTable.VALUE_IS_NULL);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putInt(valueIndex + 1, SymbolTable.VALUE_IS_NULL);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstTimestampGroupByFunction.java
@@ -44,12 +44,13 @@ public class FirstTimestampGroupByFunction extends TimestampFunction implements 
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        mapValue.putLong(valueIndex, arg.getTimestamp(record));
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        mapValue.putLong(valueIndex + 1, arg.getTimestamp(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         // empty
     }
 
@@ -65,7 +66,7 @@ public class FirstTimestampGroupByFunction extends TimestampFunction implements 
 
     @Override
     public long getTimestamp(Record rec) {
-        return rec.getTimestamp(valueIndex);
+        return rec.getTimestamp(valueIndex + 1);
     }
 
     @Override
@@ -75,18 +76,35 @@ public class FirstTimestampGroupByFunction extends TimestampFunction implements 
 
     @Override
     public boolean isParallelismSupported() {
-        return false;
+        return UnaryFunction.super.isParallelismSupported();
+    }
+
+    @Override
+    public boolean isReadThreadSafe() {
+        return UnaryFunction.super.isReadThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId != Numbers.LONG_NaN && (srcRowId < destRowId || destRowId == Numbers.LONG_NaN)) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putTimestamp(valueIndex + 1, srcValue.getTimestamp(valueIndex + 1));
+        }
     }
 
     @Override
     public void pushValueTypes(ArrayColumnTypes columnTypes) {
         this.valueIndex = columnTypes.getColumnCount();
-        columnTypes.add(ColumnType.TIMESTAMP);
+        columnTypes.add(ColumnType.LONG);      // row id
+        columnTypes.add(ColumnType.TIMESTAMP); // value
     }
 
     @Override
     public void setNull(MapValue mapValue) {
-        mapValue.putTimestamp(valueIndex, Numbers.LONG_NaN);
+        mapValue.putLong(valueIndex, Numbers.LONG_NaN);
+        mapValue.putTimestamp(valueIndex + 1, Numbers.LONG_NaN);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/HaversineDistDegreeGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/HaversineDistDegreeGroupByFunction.java
@@ -51,7 +51,7 @@ public class HaversineDistDegreeGroupByFunction extends DoubleFunction implement
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         // first item
         saveFirstItem(mapValue, latDegree.getDouble(record), lonDegree.getDouble(record), timestamp.getTimestamp(record));
         // last item
@@ -61,7 +61,7 @@ public class HaversineDistDegreeGroupByFunction extends DoubleFunction implement
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         double lat1Degrees = getLastLatitude(mapValue);
         double lon1Degrees = getLastLongitude(mapValue);
         long timestamp1 = getLastTimestamp(mapValue);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/InterpolationGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/InterpolationGroupByFunction.java
@@ -33,8 +33,8 @@ import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.groupby.InterpolationUtil;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Long256;
-import io.questdb.std.str.Utf16Sink;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.Utf16Sink;
 
 public class InterpolationGroupByFunction implements GroupByFunction {
     private final GroupByFunction wrappedFunction;
@@ -54,13 +54,13 @@ public class InterpolationGroupByFunction implements GroupByFunction {
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
-        wrappedFunction.computeFirst(mapValue, record);
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        wrappedFunction.computeFirst(mapValue, record, rowId);
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        wrappedFunction.computeNext(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        wrappedFunction.computeNext(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/IsIPv4OrderedGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/IsIPv4OrderedGroupByFunction.java
@@ -44,13 +44,13 @@ public class IsIPv4OrderedGroupByFunction extends BooleanFunction implements Gro
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putBool(valueIndex, true);
         mapValue.putLong(valueIndex + 1, Numbers.ipv4ToLong(arg.getIPv4(record)));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getBool(valueIndex)) {
             long prev = Numbers.ipv4ToLong(mapValue.getIPv4(valueIndex + 1));
             long curr = Numbers.ipv4ToLong(arg.getIPv4(record));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/IsLongOrderedGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/IsLongOrderedGroupByFunction.java
@@ -43,13 +43,13 @@ public class IsLongOrderedGroupByFunction extends BooleanFunction implements Gro
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putBool(valueIndex, true);
         mapValue.putLong(valueIndex + 1, arg.getLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (mapValue.getBool(valueIndex)) {
             long prev = mapValue.getLong(valueIndex + 1);
             long curr = arg.getLong(record);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KSumDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KSumDoubleGroupByFunction.java
@@ -44,7 +44,7 @@ public class KSumDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             mapValue.putDouble(valueIndex, value);
@@ -57,7 +57,7 @@ public class KSumDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             double sum = mapValue.getDouble(valueIndex);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastBooleanGroupByFunction extends FirstBooleanGroupByFunction {
@@ -50,7 +49,7 @@ public class LastBooleanGroupByFunction extends FirstBooleanGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putBool(valueIndex + 1, srcValue.getBool(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastBooleanGroupByFunction extends FirstBooleanGroupByFunction {
@@ -36,12 +37,22 @@ public class LastBooleanGroupByFunction extends FirstBooleanGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putBool(valueIndex + 1, srcValue.getBool(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastBooleanGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastBooleanGroupByFunction extends FirstBooleanGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastByteGroupByFunction extends FirstByteGroupByFunction {
@@ -50,7 +49,7 @@ public class LastByteGroupByFunction extends FirstByteGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putByte(valueIndex + 1, srcValue.getByte(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastByteGroupByFunction extends FirstByteGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastByteGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastByteGroupByFunction extends FirstByteGroupByFunction {
@@ -36,12 +37,22 @@ public class LastByteGroupByFunction extends FirstByteGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putByte(valueIndex + 1, srcValue.getByte(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastCharGroupByFunction extends FirstCharGroupByFunction {
@@ -36,12 +37,22 @@ public class LastCharGroupByFunction extends FirstCharGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putChar(valueIndex + 1, srcValue.getChar(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastCharGroupByFunction extends FirstCharGroupByFunction {
@@ -50,7 +49,7 @@ public class LastCharGroupByFunction extends FirstCharGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putChar(valueIndex + 1, srcValue.getChar(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastCharGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastCharGroupByFunction extends FirstCharGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastDateGroupByFunction extends FirstDateGroupByFunction {
@@ -50,7 +49,7 @@ public class LastDateGroupByFunction extends FirstDateGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putDate(valueIndex + 1, srcValue.getDate(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastDateGroupByFunction extends FirstDateGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDateGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastDateGroupByFunction extends FirstDateGroupByFunction {
@@ -36,12 +37,22 @@ public class LastDateGroupByFunction extends FirstDateGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDate(valueIndex + 1, srcValue.getDate(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastDoubleGroupByFunction extends FirstDoubleGroupByFunction {
@@ -36,12 +37,22 @@ public class LastDoubleGroupByFunction extends FirstDoubleGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastDoubleGroupByFunction extends FirstDoubleGroupByFunction {
@@ -50,7 +49,7 @@ public class LastDoubleGroupByFunction extends FirstDoubleGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastDoubleGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastDoubleGroupByFunction extends FirstDoubleGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastFloatGroupByFunction extends FirstFloatGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastFloatGroupByFunction extends FirstFloatGroupByFunction {
@@ -50,7 +49,7 @@ public class LastFloatGroupByFunction extends FirstFloatGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putFloat(valueIndex + 1, srcValue.getFloat(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastFloatGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastFloatGroupByFunction extends FirstFloatGroupByFunction {
@@ -36,12 +37,22 @@ public class LastFloatGroupByFunction extends FirstFloatGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putFloat(valueIndex + 1, srcValue.getFloat(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastGeoHashGroupByFunctionFactory.java
@@ -62,7 +62,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                 return new FirstGeoHashGroupByFunctionByte(type, function) {
                     @Override
                     public void computeNext(MapValue mapValue, Record record, long rowId) {
-                        mapValue.putByte(this.valueIndex, this.arg.getGeoByte(record));
+                        computeFirst(mapValue, record, rowId);
                     }
 
                     @Override
@@ -84,7 +84,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                 return new FirstGeoHashGroupByFunctionShort(type, function) {
                     @Override
                     public void computeNext(MapValue mapValue, Record record, long rowId) {
-                        mapValue.putShort(this.valueIndex, this.arg.getGeoShort(record));
+                        computeFirst(mapValue, record, rowId);
                     }
 
                     @Override
@@ -106,7 +106,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                 return new FirstGeoHashGroupByFunctionInt(type, function) {
                     @Override
                     public void computeNext(MapValue mapValue, Record record, long rowId) {
-                        mapValue.putInt(this.valueIndex, this.arg.getGeoInt(record));
+                        computeFirst(mapValue, record, rowId);
                     }
 
                     @Override
@@ -128,7 +128,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                 return new FirstGeoHashGroupByFunctionLong(type, function) {
                     @Override
                     public void computeNext(MapValue mapValue, Record record, long rowId) {
-                        mapValue.putLong(this.valueIndex, this.arg.getGeoLong(record));
+                        computeFirst(mapValue, record, rowId);
                     }
 
                     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastGeoHashGroupByFunctionFactory.java
@@ -32,7 +32,6 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
-import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
@@ -75,7 +74,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                     public void merge(MapValue destValue, MapValue srcValue) {
                         long srcRowId = srcValue.getLong(valueIndex);
                         long destRowId = destValue.getLong(valueIndex);
-                        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+                        if (srcRowId > destRowId) {
                             destValue.putLong(valueIndex, srcRowId);
                             destValue.putByte(valueIndex + 1, srcValue.getGeoByte(valueIndex + 1));
                         }
@@ -97,7 +96,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                     public void merge(MapValue destValue, MapValue srcValue) {
                         long srcRowId = srcValue.getLong(valueIndex);
                         long destRowId = destValue.getLong(valueIndex);
-                        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+                        if (srcRowId > destRowId) {
                             destValue.putLong(valueIndex, srcRowId);
                             destValue.putShort(valueIndex + 1, srcValue.getGeoShort(valueIndex + 1));
                         }
@@ -119,7 +118,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                     public void merge(MapValue destValue, MapValue srcValue) {
                         long srcRowId = srcValue.getLong(valueIndex);
                         long destRowId = destValue.getLong(valueIndex);
-                        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+                        if (srcRowId > destRowId) {
                             destValue.putLong(valueIndex, srcRowId);
                             destValue.putInt(valueIndex + 1, srcValue.getGeoInt(valueIndex + 1));
                         }
@@ -141,7 +140,7 @@ public class LastGeoHashGroupByFunctionFactory implements FunctionFactory {
                     public void merge(MapValue destValue, MapValue srcValue) {
                         long srcRowId = srcValue.getLong(valueIndex);
                         long destRowId = destValue.getLong(valueIndex);
-                        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+                        if (srcRowId > destRowId) {
                             destValue.putLong(valueIndex, srcRowId);
                             destValue.putLong(valueIndex + 1, srcValue.getGeoLong(valueIndex + 1));
                         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastIPv4GroupByFunction extends FirstIPv4GroupByFunction {
@@ -35,12 +36,22 @@ public class LastIPv4GroupByFunction extends FirstIPv4GroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getIPv4(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastIPv4GroupByFunction extends FirstIPv4GroupByFunction {
@@ -49,7 +48,7 @@ public class LastIPv4GroupByFunction extends FirstIPv4GroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putInt(valueIndex + 1, srcValue.getIPv4(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIPv4GroupByFunction.java
@@ -36,7 +36,7 @@ public class LastIPv4GroupByFunction extends FirstIPv4GroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastIntGroupByFunction extends FirstIntGroupByFunction {
@@ -50,7 +49,7 @@ public class LastIntGroupByFunction extends FirstIntGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastIntGroupByFunction extends FirstIntGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastIntGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastIntGroupByFunction extends FirstIntGroupByFunction {
@@ -36,12 +37,22 @@ public class LastIntGroupByFunction extends FirstIntGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastLongGroupByFunction extends FirstLongGroupByFunction {
@@ -36,12 +37,22 @@ public class LastLongGroupByFunction extends FirstLongGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastLongGroupByFunction extends FirstLongGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastLongGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastLongGroupByFunction extends FirstLongGroupByFunction {
@@ -50,7 +49,7 @@ public class LastLongGroupByFunction extends FirstLongGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullCharGroupByFunction.java
@@ -37,9 +37,9 @@ public class LastNotNullCharGroupByFunction extends FirstCharGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getChar(record) != CharConstant.ZERO.getChar(null)) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullCharGroupByFunction.java
@@ -47,4 +47,18 @@ public class LastNotNullCharGroupByFunction extends FirstCharGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        char srcVal = srcValue.getChar(valueIndex + 1);
+        if (srcVal == CharConstant.ZERO.getChar(null)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putChar(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDateGroupByFunction.java
@@ -37,9 +37,9 @@ public class LastNotNullDateGroupByFunction extends FirstDateGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getDate(record) != Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDateGroupByFunction.java
@@ -47,4 +47,18 @@ public class LastNotNullDateGroupByFunction extends FirstDateGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getDate(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDate(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDoubleGroupByFunction.java
@@ -46,4 +46,18 @@ public class LastNotNullDoubleGroupByFunction extends FirstDoubleGroupByFunction
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        double srcVal = srcValue.getDouble(valueIndex + 1);
+        if (Double.isNaN(srcVal)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putDouble(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullDoubleGroupByFunction.java
@@ -36,9 +36,9 @@ public class LastNotNullDoubleGroupByFunction extends FirstDoubleGroupByFunction
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (!Double.isNaN(arg.getDouble(record))) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullFloatGroupByFunction.java
@@ -46,4 +46,18 @@ public class LastNotNullFloatGroupByFunction extends FirstFloatGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        float srcVal = srcValue.getFloat(valueIndex + 1);
+        if (Float.isNaN(srcVal)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putFloat(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullFloatGroupByFunction.java
@@ -36,9 +36,9 @@ public class LastNotNullFloatGroupByFunction extends FirstFloatGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (!Float.isNaN(arg.getFloat(record))) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullGeoHashGroupByFunctionFactory.java
@@ -72,9 +72,9 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (arg.getGeoByte(record) != GeoHashes.BYTE_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -90,9 +90,9 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (arg.getGeoInt(record) != GeoHashes.INT_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -108,9 +108,9 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (arg.getGeoLong(record) != GeoHashes.NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 
@@ -126,9 +126,9 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (arg.getGeoShort(record) != GeoHashes.SHORT_NULL) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullGeoHashGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullGeoHashGroupByFunctionFactory.java
@@ -82,6 +82,20 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         public String getName() {
             return NAME;
         }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            byte srcVal = srcValue.getGeoByte(valueIndex + 1);
+            if (srcVal == GeoHashes.BYTE_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            if (srcRowId > destRowId) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putByte(valueIndex + 1, srcVal);
+            }
+        }
     }
 
     private static class LastNotNullGeoHashGroupByFunctionInt extends FirstGeoHashGroupByFunctionInt {
@@ -99,6 +113,20 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            int srcVal = srcValue.getGeoInt(valueIndex + 1);
+            if (srcVal == GeoHashes.INT_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            if (srcRowId > destRowId) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putInt(valueIndex + 1, srcVal);
+            }
         }
     }
 
@@ -118,6 +146,20 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         public String getName() {
             return NAME;
         }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            long srcVal = srcValue.getGeoLong(valueIndex + 1);
+            if (srcVal == GeoHashes.NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            if (srcRowId > destRowId) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putLong(valueIndex + 1, srcVal);
+            }
+        }
     }
 
     private static class LastNotNullGeoHashGroupByFunctionShort extends FirstGeoHashGroupByFunctionShort {
@@ -135,6 +177,20 @@ public class LastNotNullGeoHashGroupByFunctionFactory implements FunctionFactory
         @Override
         public String getName() {
             return NAME;
+        }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            short srcVal = srcValue.getGeoShort(valueIndex + 1);
+            if (srcVal == GeoHashes.SHORT_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            if (srcRowId > destRowId) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putShort(valueIndex + 1, srcVal);
+            }
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIPv4GroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIPv4GroupByFunctionFactory.java
@@ -57,9 +57,9 @@ public class LastNotNullIPv4GroupByFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             if (Numbers.IPv4_NULL != arg.getIPv4(record)) {
-                computeFirst(mapValue, record);
+                computeFirst(mapValue, record, rowId);
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIPv4GroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIPv4GroupByFunctionFactory.java
@@ -67,6 +67,20 @@ public class LastNotNullIPv4GroupByFunctionFactory implements FunctionFactory {
         public String getName() {
             return "last_not_null";
         }
+
+        @Override
+        public void merge(MapValue destValue, MapValue srcValue) {
+            int srcVal = srcValue.getIPv4(valueIndex + 1);
+            if (srcVal == Numbers.IPv4_NULL) {
+                return;
+            }
+            long srcRowId = srcValue.getLong(valueIndex);
+            long destRowId = destValue.getLong(valueIndex);
+            if (srcRowId > destRowId) {
+                destValue.putLong(valueIndex, srcRowId);
+                destValue.putInt(valueIndex + 1, srcVal);
+            }
+        }
     }
 }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIntGroupByFunction.java
@@ -46,4 +46,18 @@ public class LastNotNullIntGroupByFunction extends FirstIntGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        int srcVal = srcValue.getInt(valueIndex + 1);
+        if (srcVal == Numbers.INT_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullIntGroupByFunction.java
@@ -36,9 +36,9 @@ public class LastNotNullIntGroupByFunction extends FirstIntGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getInt(record) != Numbers.INT_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullLongGroupByFunction.java
@@ -37,9 +37,9 @@ public class LastNotNullLongGroupByFunction extends FirstLongGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getLong(record) != Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullLongGroupByFunction.java
@@ -47,4 +47,18 @@ public class LastNotNullLongGroupByFunction extends FirstLongGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getLong(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.str.DirectUtf16Sink;
 import org.jetbrains.annotations.NotNull;
 
 public class LastNotNullStrGroupByFunction extends FirstStrGroupByFunction {
@@ -37,13 +36,14 @@ public class LastNotNullStrGroupByFunction extends FirstStrGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        final CharSequence str = arg.getStr(record);
-        if (str != null) {
-            final DirectUtf16Sink sink = sinks.getQuick(mapValue.getInt(valueIndex));
-            sink.clear();
-            sink.put(str);
-            mapValue.putBool(valueIndex + 1, false);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        final CharSequence val = arg.getStr(record);
+        if (val != null) {
+            long ptr = mapValue.getLong(valueIndex + 1);
+            sink.of(ptr).clear();
+            sink.put(val);
+            mapValue.putLong(valueIndex + 1, sink.ptr());
+            mapValue.putBool(valueIndex + 2, false);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
@@ -39,6 +39,7 @@ public class LastNotNullStrGroupByFunction extends FirstStrGroupByFunction {
     public void computeNext(MapValue mapValue, Record record, long rowId) {
         final CharSequence val = arg.getStr(record);
         if (val != null) {
+            mapValue.putLong(valueIndex, rowId);
             long ptr = mapValue.getLong(valueIndex + 1);
             sink.of(ptr).clear();
             sink.put(val);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullStrGroupByFunction.java
@@ -51,4 +51,18 @@ public class LastNotNullStrGroupByFunction extends FirstStrGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        if (srcValue.getBool(valueIndex + 2)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
+            destValue.putBool(valueIndex + 2, false);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullSymbolGroupByFunction.java
@@ -47,4 +47,18 @@ public class LastNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunction
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        int srcVal = srcValue.getInt(valueIndex + 1);
+        if (srcVal == SymbolTable.VALUE_IS_NULL) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullSymbolGroupByFunction.java
@@ -37,9 +37,9 @@ public class LastNotNullSymbolGroupByFunction extends FirstSymbolGroupByFunction
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getInt(record) != SymbolTable.VALUE_IS_NULL) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullTimestampGroupByFunction.java
@@ -36,9 +36,9 @@ public class LastNotNullTimestampGroupByFunction extends FirstTimestampGroupByFu
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (arg.getTimestamp(record) != Numbers.LONG_NaN) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullTimestampGroupByFunction.java
@@ -46,4 +46,18 @@ public class LastNotNullTimestampGroupByFunction extends FirstTimestampGroupByFu
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcVal = srcValue.getTimestamp(valueIndex + 1);
+        if (srcVal == Numbers.LONG_NaN) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcVal);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullUuidGroupByFunction.java
@@ -36,9 +36,9 @@ public class LastNotNullUuidGroupByFunction extends FirstUuidGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         if (!Uuid.isNull(arg.getLong128Lo(record), arg.getLong128Hi(record))) {
-            computeFirst(mapValue, record);
+            computeFirst(mapValue, record, rowId);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastNotNullUuidGroupByFunction.java
@@ -46,4 +46,19 @@ public class LastNotNullUuidGroupByFunction extends FirstUuidGroupByFunction {
     public String getName() {
         return "last_not_null";
     }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcValLo = srcValue.getLong128Lo(valueIndex + 1);
+        long srcValHi = srcValue.getLong128Hi(valueIndex + 1);
+        if (Uuid.isNull(srcValLo, srcValHi)) {
+            return;
+        }
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong128(valueIndex + 1, srcValLo, srcValHi);
+        }
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastShortGroupByFunction extends FirstShortGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastShortGroupByFunction extends FirstShortGroupByFunction {
@@ -36,12 +37,22 @@ public class LastShortGroupByFunction extends FirstShortGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putShort(valueIndex + 1, srcValue.getShort(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastShortGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastShortGroupByFunction extends FirstShortGroupByFunction {
@@ -50,7 +49,7 @@ public class LastShortGroupByFunction extends FirstShortGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putShort(valueIndex + 1, srcValue.getShort(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastStrGroupByFunction.java
@@ -27,7 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastStrGroupByFunction extends FirstStrGroupByFunction {
@@ -37,20 +37,34 @@ public class LastStrGroupByFunction extends FirstStrGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        final CharSequence str = arg.getStr(record);
-        if (str != null) {
-            final DirectUtf16Sink sink = sinks.getQuick(mapValue.getInt(valueIndex));
-            sink.clear();
-            sink.put(str);
-            mapValue.putBool(valueIndex + 1, false);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        mapValue.putLong(valueIndex, rowId);
+        final CharSequence val = arg.getStr(record);
+        if (val == null) {
+            mapValue.putLong(valueIndex + 1, 0);
+            mapValue.putBool(valueIndex + 2, true);
         } else {
-            mapValue.putBool(valueIndex + 1, true);
+            long ptr = mapValue.getLong(valueIndex + 1);
+            sink.of(ptr).clear();
+            sink.put(val);
+            mapValue.putLong(valueIndex + 1, sink.ptr());
+            mapValue.putBool(valueIndex + 2, false);
         }
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
+            destValue.putBool(valueIndex + 2, srcValue.getBool(valueIndex + 2));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastStrGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastStrGroupByFunction extends FirstStrGroupByFunction {
@@ -61,7 +60,7 @@ public class LastStrGroupByFunction extends FirstStrGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putLong(valueIndex + 1, srcValue.getLong(valueIndex + 1));
             destValue.putBool(valueIndex + 2, srcValue.getBool(valueIndex + 2));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastSymbolGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.SymbolFunction;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastSymbolGroupByFunction extends FirstSymbolGroupByFunction {
@@ -49,7 +48,7 @@ public class LastSymbolGroupByFunction extends FirstSymbolGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastSymbolGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastSymbolGroupByFunction extends FirstSymbolGroupByFunction {
@@ -35,12 +36,22 @@ public class LastSymbolGroupByFunction extends FirstSymbolGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putInt(valueIndex + 1, srcValue.getInt(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastTimestampGroupByFunction extends FirstTimestampGroupByFunction {
@@ -50,7 +49,7 @@ public class LastTimestampGroupByFunction extends FirstTimestampGroupByFunction 
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putTimestamp(valueIndex + 1, srcValue.getTimestamp(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
@@ -37,7 +37,7 @@ public class LastTimestampGroupByFunction extends FirstTimestampGroupByFunction 
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastTimestampGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public class LastTimestampGroupByFunction extends FirstTimestampGroupByFunction {
@@ -36,12 +37,22 @@ public class LastTimestampGroupByFunction extends FirstTimestampGroupByFunction 
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putTimestamp(valueIndex + 1, srcValue.getTimestamp(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
@@ -37,7 +37,7 @@ public final class LastUuidGroupByFunction extends FirstUuidGroupByFunction {
 
     @Override
     public void computeNext(MapValue mapValue, Record record, long rowId) {
-        super.computeFirst(mapValue, record, rowId);
+        computeFirst(mapValue, record, rowId);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public final class LastUuidGroupByFunction extends FirstUuidGroupByFunction {
@@ -36,12 +37,22 @@ public final class LastUuidGroupByFunction extends FirstUuidGroupByFunction {
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
-        super.computeFirst(mapValue, record);
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        super.computeFirst(mapValue, record, rowId);
     }
 
     @Override
     public String getName() {
         return "last";
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcRowId = srcValue.getLong(valueIndex);
+        long destRowId = destValue.getLong(valueIndex);
+        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+            destValue.putLong(valueIndex, srcRowId);
+            destValue.putLong128(valueIndex + 1, srcValue.getLong128Lo(valueIndex + 1), srcValue.getLong128Hi(valueIndex + 1));
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/LastUuidGroupByFunction.java
@@ -27,7 +27,6 @@ package io.questdb.griffin.engine.functions.groupby;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.Numbers;
 import org.jetbrains.annotations.NotNull;
 
 public final class LastUuidGroupByFunction extends FirstUuidGroupByFunction {
@@ -50,7 +49,7 @@ public final class LastUuidGroupByFunction extends FirstUuidGroupByFunction {
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcRowId = srcValue.getLong(valueIndex);
         long destRowId = destValue.getLong(valueIndex);
-        if (srcRowId > destRowId || destRowId == Numbers.LONG_NaN) {
+        if (srcRowId > destRowId) {
             destValue.putLong(valueIndex, srcRowId);
             destValue.putLong128(valueIndex + 1, srcValue.getLong128Lo(valueIndex + 1), srcValue.getLong128Hi(valueIndex + 1));
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxCharGroupByFunction.java
@@ -43,12 +43,12 @@ public class MaxCharGroupByFunction extends CharFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putChar(valueIndex, arg.getChar(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         char max = mapValue.getChar(valueIndex);
         char next = arg.getChar(record);
         if (next > max) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
@@ -92,7 +92,7 @@ public class MaxDateGroupByFunction extends DateFunction implements GroupByFunct
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcMax = srcValue.getDate(valueIndex);
         long destMax = destValue.getDate(valueIndex);
-        if (srcMax > destMax || destMax == Numbers.LONG_NaN) {
+        if (srcMax > destMax) {
             destValue.putDate(valueIndex, srcMax);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
@@ -44,12 +44,12 @@ public class MaxDateGroupByFunction extends DateFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, arg.getLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.maxLong(valueIndex, arg.getDate(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDoubleGroupByFunction.java
@@ -43,12 +43,12 @@ public class MaxDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         double max = mapValue.getDouble(valueIndex);
         double next = arg.getDouble(record);
         if (next > max || Double.isNaN(max)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxFloatGroupByFunction.java
@@ -43,12 +43,12 @@ public class MaxFloatGroupByFunction extends FloatFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putFloat(valueIndex, arg.getFloat(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         float max = mapValue.getFloat(valueIndex);
         float next = arg.getFloat(record);
         if (next > max || Float.isNaN(max)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIPv4GroupByFunction.java
@@ -45,12 +45,12 @@ public class MaxIPv4GroupByFunction extends IPv4Function implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putInt(valueIndex, arg.getIPv4(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         long max = Numbers.ipv4ToLong(mapValue.getIPv4(valueIndex));
         long next = Numbers.ipv4ToLong(arg.getIPv4(record));
         if (next > max) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIntGroupByFunction.java
@@ -44,12 +44,12 @@ public class MaxIntGroupByFunction extends IntFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putInt(valueIndex, arg.getInt(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.maxInt(valueIndex, arg.getInt(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxIntGroupByFunction.java
@@ -92,7 +92,7 @@ public class MaxIntGroupByFunction extends IntFunction implements GroupByFunctio
     public void merge(MapValue destValue, MapValue srcValue) {
         int srcMax = srcValue.getInt(valueIndex);
         int destMax = destValue.getInt(valueIndex);
-        if (srcMax > destMax || destMax == Numbers.INT_NaN) {
+        if (srcMax > destMax) {
             destValue.putInt(valueIndex, srcMax);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxLongGroupByFunction.java
@@ -92,7 +92,7 @@ public class MaxLongGroupByFunction extends LongFunction implements GroupByFunct
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcMax = srcValue.getLong(valueIndex);
         long destMax = destValue.getLong(valueIndex);
-        if (srcMax > destMax || destMax == Numbers.LONG_NaN) {
+        if (srcMax > destMax) {
             destValue.putLong(valueIndex, srcMax);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxLongGroupByFunction.java
@@ -44,12 +44,12 @@ public class MaxLongGroupByFunction extends LongFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, arg.getLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.maxLong(valueIndex, arg.getLong(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxStrGroupByFunction.java
@@ -55,7 +55,7 @@ public class MaxStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final CharSequence val = arg.getStr(record);
         if (val == null) {
             mapValue.putLong(valueIndex, 0);
@@ -66,7 +66,7 @@ public class MaxStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final CharSequence val = arg.getStr(record);
         if (val != null) {
             final long ptr = mapValue.getLong(valueIndex);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxTimestampGroupByFunction.java
@@ -92,7 +92,7 @@ public class MaxTimestampGroupByFunction extends TimestampFunction implements Gr
     public void merge(MapValue destValue, MapValue srcValue) {
         long srcMax = srcValue.getLong(valueIndex);
         long destMax = destValue.getLong(valueIndex);
-        if (srcMax > destMax || destMax == Numbers.LONG_NaN) {
+        if (srcMax > destMax) {
             destValue.putLong(valueIndex, srcMax);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxTimestampGroupByFunction.java
@@ -44,12 +44,12 @@ public class MaxTimestampGroupByFunction extends TimestampFunction implements Gr
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putTimestamp(valueIndex, arg.getTimestamp(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.maxLong(valueIndex, arg.getTimestamp(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinCharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinCharGroupByFunction.java
@@ -43,12 +43,12 @@ public class MinCharGroupByFunction extends CharFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putChar(valueIndex, arg.getChar(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         char min = mapValue.getChar(valueIndex);
         char next = arg.getChar(record);
         if (next > 0 && next < min) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinDateGroupByFunction.java
@@ -44,12 +44,12 @@ public class MinDateGroupByFunction extends DateFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDate(valueIndex, arg.getDate(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.minLong(valueIndex, arg.getDate(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinDoubleGroupByFunction.java
@@ -43,12 +43,12 @@ public class MinDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         double min = mapValue.getDouble(valueIndex);
         double next = arg.getDouble(record);
         if (next < min || Double.isNaN(min)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinFloatGroupByFunction.java
@@ -43,12 +43,12 @@ public class MinFloatGroupByFunction extends FloatFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putFloat(valueIndex, arg.getFloat(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         float min = mapValue.getFloat(valueIndex);
         float next = arg.getFloat(record);
         if (next < min || Float.isNaN(min)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinIPv4GroupByFunction.java
@@ -44,12 +44,12 @@ public class MinIPv4GroupByFunction extends IPv4Function implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putInt(valueIndex, arg.getIPv4(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         long min = Numbers.ipv4ToLong(mapValue.getIPv4(valueIndex));
         long next = Numbers.ipv4ToLong(arg.getIPv4(record));
         if (next != Numbers.IPv4_NULL && (next < min || min == Numbers.IPv4_NULL)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinIntGroupByFunction.java
@@ -44,12 +44,12 @@ public class MinIntGroupByFunction extends IntFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putInt(valueIndex, arg.getInt(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.minInt(valueIndex, arg.getInt(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinLongGroupByFunction.java
@@ -44,12 +44,12 @@ public class MinLongGroupByFunction extends LongFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, arg.getLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.minLong(valueIndex, arg.getLong(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinStrGroupByFunction.java
@@ -55,7 +55,7 @@ public class MinStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final CharSequence val = arg.getStr(record);
         if (val == null) {
             mapValue.putLong(valueIndex, 0);
@@ -66,7 +66,7 @@ public class MinStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final CharSequence val = arg.getStr(record);
         if (val != null) {
             final long ptr = mapValue.getLong(valueIndex);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinTimestampGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinTimestampGroupByFunction.java
@@ -44,12 +44,12 @@ public class MinTimestampGroupByFunction extends TimestampFunction implements Gr
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putLong(valueIndex, arg.getLong(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.minLong(valueIndex, arg.getTimestamp(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/NSumDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/NSumDoubleGroupByFunction.java
@@ -45,7 +45,7 @@ public class NSumDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             sum(mapValue, value, 0, 0);
@@ -58,7 +58,7 @@ public class NSumDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             sum(mapValue, value, mapValue.getDouble(valueIndex), mapValue.getDouble(valueIndex + 1));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunction.java
@@ -77,7 +77,7 @@ class StringAggGroupByFunction extends StrFunction implements UnaryFunction, Gro
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final DirectUtf16Sink sink;
         if (sinks.size() <= sinkIndex) {
             sinks.extendAndSet(sinkIndex, sink = new DirectUtf16Sink(INITIAL_SINK_CAPACITY));
@@ -97,7 +97,7 @@ class StringAggGroupByFunction extends StrFunction implements UnaryFunction, Gro
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final DirectUtf16Sink sink = sinks.getQuick(mapValue.getInt(valueIndex));
         final CharSequence str = arg.getStr(record);
         if (str != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumDoubleGroupByFunction.java
@@ -44,7 +44,7 @@ public class SumDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             mapValue.putDouble(valueIndex, value);
@@ -56,7 +56,7 @@ public class SumDoubleGroupByFunction extends DoubleFunction implements GroupByF
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double value = arg.getDouble(record);
         if (Numbers.isFinite(value)) {
             mapValue.addDouble(valueIndex, value);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumFloatGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumFloatGroupByFunction.java
@@ -43,7 +43,7 @@ public class SumFloatGroupByFunction extends FloatFunction implements GroupByFun
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final float value = arg.getFloat(record);
         if (Float.isFinite(value)) {
             mapValue.putFloat(valueIndex, value);
@@ -55,7 +55,7 @@ public class SumFloatGroupByFunction extends FloatFunction implements GroupByFun
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final float value = arg.getFloat(record);
         if (Float.isFinite(value)) {
             mapValue.addFloat(valueIndex, value);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumIntGroupByFunction.java
@@ -44,7 +44,7 @@ public class SumIntGroupByFunction extends LongFunction implements GroupByFuncti
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getInt(record);
         if (value != Numbers.INT_NaN) {
             mapValue.putLong(valueIndex, value);
@@ -56,7 +56,7 @@ public class SumIntGroupByFunction extends LongFunction implements GroupByFuncti
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final int value = arg.getInt(record);
         if (value != Numbers.INT_NaN) {
             mapValue.addLong(valueIndex, arg.getInt(record));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumLong256GroupByFunction.java
@@ -48,7 +48,7 @@ public class SumLong256GroupByFunction extends Long256Function implements GroupB
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final Long256 value = arg.getLong256A(record);
         if (!value.equals(Long256Impl.NULL_LONG256)) {
             mapValue.putLong256(valueIndex, value);
@@ -60,7 +60,7 @@ public class SumLong256GroupByFunction extends Long256Function implements GroupB
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final Long256 value = arg.getLong256A(record);
         if (!value.equals(Long256Impl.NULL_LONG256)) {
             mapValue.addLong256(valueIndex, value);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SumLongGroupByFunction.java
@@ -44,7 +44,7 @@ public class SumLongGroupByFunction extends LongFunction implements GroupByFunct
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getLong(record);
         if (value != Numbers.LONG_NaN) {
             mapValue.putLong(valueIndex, value);
@@ -56,7 +56,7 @@ public class SumLongGroupByFunction extends LongFunction implements GroupByFunct
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final long value = arg.getLong(record);
         if (value != Numbers.LONG_NaN) {
             mapValue.addLong(valueIndex, value);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/VwapDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/VwapDoubleGroupByFunction.java
@@ -46,7 +46,7 @@ public class VwapDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         final double price = priceFunction.getDouble(record);
         final double volume = volumeFunction.getDouble(record);
         if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0d) {
@@ -63,7 +63,7 @@ public class VwapDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         final double price = priceFunction.getDouble(record);
         final double volume = volumeFunction.getDouble(record);
         if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0d) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumDoubleGroupByFunction.java
@@ -48,12 +48,12 @@ public class TestSumDoubleGroupByFunction extends DoubleFunction implements Grou
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, mapValue.getDouble(valueIndex) + arg.getDouble(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumStringGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumStringGroupByFunction.java
@@ -56,12 +56,12 @@ public class TestSumStringGroupByFunction extends StrFunction implements GroupBy
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, mapValue.getDouble(valueIndex) + arg.getDouble(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumTDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestSumTDoubleGroupByFunction.java
@@ -52,12 +52,12 @@ public class TestSumTDoubleGroupByFunction extends DoubleFunction implements Gro
     }
 
     @Override
-    public void computeFirst(MapValue mapValue, Record record) {
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, arg.getDouble(record));
     }
 
     @Override
-    public void computeNext(MapValue mapValue, Record record) {
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
         mapValue.putDouble(valueIndex, mapValue.getDouble(valueIndex) + arg.getDouble(record));
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByFunctionsUpdater.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByFunctionsUpdater.java
@@ -36,7 +36,7 @@ public interface GroupByFunctionsUpdater extends MapValueMergeFunction {
 
     void updateEmpty(MapValue value);
 
-    void updateExisting(MapValue value, Record record);
+    void updateExisting(MapValue value, Record record, long rowId);
 
-    void updateNew(MapValue value, Record record);
+    void updateNew(MapValue value, Record record, long rowId);
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByFunctionsUpdaterFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByFunctionsUpdaterFactory.java
@@ -42,8 +42,8 @@ public class GroupByFunctionsUpdaterFactory {
      * <p>
      * The generated class will have the following methods:
      * <ul>
-     * <li>updateNew(MapValue value, Record record) - calls f0, f1, f2 ... fn.computeFirst(value, record) for each group by function</li>
-     * <li>updateExisting(MapValue value, Record record) - calls f0, f1, f2 ... fn.computeNext(value, record) for each group by function</li>
+     * <li>updateNew(MapValue value, Record record, long rowId) - calls f0, f1, f2 ... fn.computeFirst(value, record, rowId) for each group by function</li>
+     * <li>updateExisting(MapValue value, Record record, long rowId) - calls f0, f1, f2 ... fn.computeNext(value, record, rowId) for each group by function</li>
      * <li>updateEmpty(MapValue value) - calls f0, f1, f2 ... fn.setEmpty(value) for each group by function</li>
      * <li>merge(MapValue destValue, MapValue srcValue) - calls fn.merge(destValue, srcValue) for each group by function</li>
      * <li>setFunctions(ObjList&lt;GroupByFunction&gt; groupByFunctions) - sets the group by functions to the fields. This method is called by the factory and should not be called by the caller.</li>
@@ -81,15 +81,15 @@ public class GroupByFunctionsUpdaterFactory {
             }
         }
 
-        final int computeFirstIndex = asm.poolInterfaceMethod(GroupByFunction.class, "computeFirst", "(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;)V");
-        final int computeNextIndex = asm.poolInterfaceMethod(GroupByFunction.class, "computeNext", "(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;)V");
+        final int computeFirstIndex = asm.poolInterfaceMethod(GroupByFunction.class, "computeFirst", "(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;J)V");
+        final int computeNextIndex = asm.poolInterfaceMethod(GroupByFunction.class, "computeNext", "(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;J)V");
         final int setEmptyIndex = asm.poolInterfaceMethod(GroupByFunction.class, "setEmpty", "(Lio/questdb/cairo/map/MapValue;)V");
         final int mergeFunctionIndex = asm.poolInterfaceMethod(GroupByFunction.class, "merge", "(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/map/MapValue;)V");
 
         final int updateNewIndex = asm.poolUtf8("updateNew");
-        final int updateNewSigIndex = asm.poolUtf8("(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;)V");
+        final int updateNewSigIndex = asm.poolUtf8("(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;J)V");
         final int updateExistingIndex = asm.poolUtf8("updateExisting");
-        final int updateExistingSigIndex = asm.poolUtf8("(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;)V");
+        final int updateExistingSigIndex = asm.poolUtf8("(Lio/questdb/cairo/map/MapValue;Lio/questdb/cairo/sql/Record;J)V");
         final int updateEmptyIndex = asm.poolUtf8("updateEmpty");
         final int updateEmptySigIndex = asm.poolUtf8("(Lio/questdb/cairo/map/MapValue;)V");
         final int setFunctionsIndex = asm.poolUtf8("setFunctions");
@@ -201,13 +201,14 @@ public class GroupByFunctionsUpdaterFactory {
             int updateNameIndex,
             int updateSigIndex
     ) {
-        asm.startMethod(updateNameIndex, updateSigIndex, 3, 3);
+        asm.startMethod(updateNameIndex, updateSigIndex, 5, 5);
         for (int i = 0; i < fieldCount; i++) {
             asm.aload(0);
             asm.getfield(firstFieldIndex + (i * FIELD_POOL_OFFSET));
             asm.aload(1); // map value
             asm.aload(2); // record
-            asm.invokeInterface(computeNextIndex, 2);
+            asm.lload(3); // row id
+            asm.invokeInterface(computeNextIndex, 4);
         }
         asm.return_();
         asm.endMethodCode();
@@ -238,13 +239,14 @@ public class GroupByFunctionsUpdaterFactory {
             int updateNameIndex,
             int updateSigIndex
     ) {
-        asm.startMethod(updateNameIndex, updateSigIndex, 3, 3);
+        asm.startMethod(updateNameIndex, updateSigIndex, 5, 5);
         for (int i = 0; i < fieldCount; i++) {
             asm.aload(0);
             asm.getfield(firstFieldIndex + (i * FIELD_POOL_OFFSET));
             asm.aload(1); // map value
             asm.aload(2); // record
-            asm.invokeInterface(computeFirstIndex, 2);
+            asm.lload(3); // row id
+            asm.invokeInterface(computeFirstIndex, 4);
         }
         asm.return_();
         asm.endMethodCode();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
@@ -158,6 +158,7 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
         private SqlExecutionCircuitBreaker circuitBreaker;
         private int initState;
         private int recordsRemaining = 1;
+        private long rowId;
 
         public GroupByNotKeyedRecordCursor(
                 CairoConfiguration configuration,
@@ -204,7 +205,7 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
                 final Record baseRecord = baseCursor.getRecord();
                 if (initState != INIT_FIRST_RECORD_DONE) {
                     if (baseCursor.hasNext()) {
-                        groupByFunctionsUpdater.updateNew(simpleMapValue, baseRecord);
+                        groupByFunctionsUpdater.updateNew(simpleMapValue, baseRecord, rowId++);
                     } else {
                         groupByFunctionsUpdater.updateEmpty(simpleMapValue);
                     }
@@ -212,7 +213,7 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
                 }
                 while (baseCursor.hasNext()) {
                     circuitBreaker.statefulThrowExceptionIfTripped();
-                    groupByFunctionsUpdater.updateExisting(simpleMapValue, baseRecord);
+                    groupByFunctionsUpdater.updateExisting(simpleMapValue, baseRecord, rowId++);
                     if (earlyExit()) {
                         break;
                     }
@@ -244,6 +245,7 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
 
         @Override
         public void toTop() {
+            rowId = 0;
             recordsRemaining = 1;
             GroupByUtils.toTop(groupByFunctions);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -150,6 +150,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         private SqlExecutionCircuitBreaker circuitBreaker;
         private boolean isDataMapBuilt;
         private boolean isOpen;
+        private long rowId;
 
         public GroupByRecordCursor(
                 CairoConfiguration configuration,
@@ -203,6 +204,14 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
             this.managedCursor = managedCursor;
             Function.init(keyFunctions, managedCursor, executionContext);
             isDataMapBuilt = false;
+            rowId = 0;
+        }
+
+        @Override
+        public void toTop() {
+            super.toTop();
+            isDataMapBuilt = false;
+            rowId = 0;
         }
 
         private void buildDataMap() {
@@ -213,9 +222,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                 mapSink.copy(baseRecord, key);
                 MapValue value = key.createValue();
                 if (value.isNew()) {
-                    groupByFunctionsUpdater.updateNew(value, baseRecord);
+                    groupByFunctionsUpdater.updateNew(value, baseRecord, rowId++);
                 } else {
-                    groupByFunctionsUpdater.updateExisting(value, baseRecord);
+                    groupByFunctionsUpdater.updateExisting(value, baseRecord, rowId++);
                 }
             }
             super.of(dataMap.getCursor());

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillNoneRecordCursor.java
@@ -43,6 +43,7 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
     private boolean isHasNextPending;
     private boolean isMapBuildPending;
     private boolean isOpen;
+    private long rowId;
 
     public SampleByFillNoneRecordCursor(
             CairoConfiguration configuration,
@@ -110,6 +111,7 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
             map.reopen();
             isOpen = true;
         }
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
     }
@@ -117,6 +119,7 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
     @Override
     public void toTop() {
         super.toTop();
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
     }
@@ -141,9 +144,9 @@ class SampleByFillNoneRecordCursor extends AbstractVirtualRecordSampleByCursor {
                     keyMapSink.copy(baseRecord, key);
                     MapValue value = key.createValue();
                     if (value.isNew()) {
-                        groupByFunctionsUpdater.updateNew(value, baseRecord);
+                        groupByFunctionsUpdater.updateNew(value, baseRecord, rowId++);
                     } else {
-                        groupByFunctionsUpdater.updateExisting(value, baseRecord);
+                        groupByFunctionsUpdater.updateExisting(value, baseRecord, rowId++);
                     }
                 } else {
                     // map value is conditional and only required when clock goes back

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillPrevRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillPrevRecordCursor.java
@@ -46,6 +46,7 @@ class SampleByFillPrevRecordCursor extends AbstractVirtualRecordSampleByCursor i
     private boolean isMapBuildPending;
     private boolean isMapInitialized;
     private boolean isOpen;
+    private long rowId;
 
     public SampleByFillPrevRecordCursor(
             CairoConfiguration configuration,
@@ -112,6 +113,7 @@ class SampleByFillPrevRecordCursor extends AbstractVirtualRecordSampleByCursor i
     @Override
     public void of(RecordCursor baseCursor, SqlExecutionContext executionContext) throws SqlException {
         super.of(baseCursor, executionContext);
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
         isMapInitialized = false;
@@ -129,6 +131,7 @@ class SampleByFillPrevRecordCursor extends AbstractVirtualRecordSampleByCursor i
     public void toTop() {
         super.toTop();
         map.clear();
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
         isMapInitialized = false;
@@ -169,9 +172,9 @@ class SampleByFillPrevRecordCursor extends AbstractVirtualRecordSampleByCursor i
 
                     if (value.getLong(0) != localEpoch) {
                         value.putLong(0, localEpoch);
-                        groupByFunctionsUpdater.updateNew(value, baseRecord);
+                        groupByFunctionsUpdater.updateNew(value, baseRecord, rowId++);
                     } else {
-                        groupByFunctionsUpdater.updateExisting(value, baseRecord);
+                        groupByFunctionsUpdater.updateExisting(value, baseRecord, rowId++);
                     }
                 }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursor.java
@@ -48,6 +48,7 @@ class SampleByFillValueRecordCursor extends AbstractSplitVirtualRecordSampleByCu
     private boolean isMapBuildPending;
     private boolean isMapInitialized;
     private boolean isOpen;
+    private long rowId;
 
     public SampleByFillValueRecordCursor(
             CairoConfiguration configuration,
@@ -117,6 +118,7 @@ class SampleByFillValueRecordCursor extends AbstractSplitVirtualRecordSampleByCu
     @Override
     public void of(RecordCursor baseCursor, SqlExecutionContext executionContext) throws SqlException {
         super.of(baseCursor, executionContext);
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
         isMapInitialized = false;
@@ -134,6 +136,7 @@ class SampleByFillValueRecordCursor extends AbstractSplitVirtualRecordSampleByCu
     public void toTop() {
         super.toTop();
         map.clear();
+        rowId = 0;
         isHasNextPending = false;
         isMapBuildPending = true;
         isMapInitialized = false;
@@ -176,9 +179,9 @@ class SampleByFillValueRecordCursor extends AbstractSplitVirtualRecordSampleByCu
 
                     if (value.getLong(0) != localEpoch) {
                         value.putLong(0, localEpoch);
-                        groupByFunctionsUpdater.updateNew(value, baseRecord);
+                        groupByFunctionsUpdater.updateNew(value, baseRecord, rowId++);
                     } else {
-                        groupByFunctionsUpdater.updateExisting(value, baseRecord);
+                        groupByFunctionsUpdater.updateExisting(value, baseRecord, rowId++);
                     }
                 }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
@@ -230,6 +230,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
         private long loSample = -1;
         private Record managedRecord;
         private long prevSample = -1;
+        private long rowId;
 
         public SampleByInterpolateRecordCursor(
                 CairoConfiguration configuration,
@@ -282,6 +283,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
             loSample = -1;
             hiSample = -1;
             prevSample = -1;
+            rowId = 0;
             isHasNextPending = false;
             isMapInitialized = false;
             isMapFilled = false;
@@ -303,6 +305,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
                 loSample = -1;
                 hiSample = -1;
                 prevSample = -1;
+                rowId = 0;
                 isHasNextPending = false;
                 isMapInitialized = false;
                 isMapFilled = false;
@@ -520,11 +523,11 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
                     if (value.isNew()) {
                         value.putByte(0, (byte) 0); // not a gap
                         for (int i = 0; i < groupByFunctionCount; i++) {
-                            groupByFunctions.getQuick(i).computeFirst(value, managedRecord);
+                            groupByFunctions.getQuick(i).computeFirst(value, managedRecord, rowId++);
                         }
                     } else {
                         for (int i = 0; i < groupByFunctionCount; i++) {
-                            groupByFunctions.getQuick(i).computeNext(value, managedRecord);
+                            groupByFunctions.getQuick(i).computeNext(value, managedRecord, rowId++);
                         }
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -181,6 +181,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             @Nullable PageFrameSequence<?> stealingFrameSequence
     ) {
         final long frameRowCount = task.getFrameRowCount();
+        assert frameRowCount > 0;
         final AsyncGroupByAtom atom = task.getFrameSequence(AsyncGroupByAtom.class).getAtom();
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
@@ -189,10 +190,13 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         final AsyncGroupByAtom.Particle particle = atom.getParticle(slotId);
         final RecordSink mapSink = atom.getMapSink(slotId);
         try {
+            record.setRowIndex(0);
+            long baseRowId = record.getRowId();
+
             if (!particle.isSharded()) {
-                aggregateNonSharded(record, frameRowCount, functionUpdater, particle, mapSink);
+                aggregateNonSharded(record, frameRowCount, baseRowId, functionUpdater, particle, mapSink);
             } else {
-                aggregateSharded(record, frameRowCount, functionUpdater, particle, mapSink);
+                aggregateSharded(record, frameRowCount, baseRowId, functionUpdater, particle, mapSink);
             }
             atom.tryShard(particle);
         } finally {
@@ -203,21 +207,23 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
     private static void aggregateFilteredNonSharded(
             PageAddressCacheRecord record,
             DirectLongList rows,
+            long baseRowId,
             GroupByFunctionsUpdater functionUpdater,
             AsyncGroupByAtom.Particle particle,
             RecordSink mapSink
     ) {
         final Map map = particle.getMap();
         for (long p = 0, n = rows.size(); p < n; p++) {
-            record.setRowIndex(rows.get(p));
+            long r = rows.get(p);
+            record.setRowIndex(r);
 
             final MapKey key = map.withKey();
             mapSink.copy(record, key);
             MapValue value = key.createValue();
             if (value.isNew()) {
-                functionUpdater.updateNew(value, record);
+                functionUpdater.updateNew(value, record, baseRowId + r);
             } else {
-                functionUpdater.updateExisting(value, record);
+                functionUpdater.updateExisting(value, record, baseRowId + r);
             }
         }
     }
@@ -225,6 +231,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
     private static void aggregateFilteredSharded(
             PageAddressCacheRecord record,
             DirectLongList rows,
+            long baseRowId,
             GroupByFunctionsUpdater functionUpdater,
             AsyncGroupByAtom.Particle particle,
             RecordSink mapSink
@@ -232,7 +239,8 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         // The first map is used to write keys.
         final Map lookupShard = particle.getShardMaps().getQuick(0);
         for (long p = 0, n = rows.size(); p < n; p++) {
-            record.setRowIndex(rows.get(p));
+            long r = rows.get(p);
+            record.setRowIndex(r);
 
             final MapKey lookupKey = lookupShard.withKey();
             mapSink.copy(record, lookupKey);
@@ -250,9 +258,9 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
 
             MapValue shardValue = shardKey.createValue(hashCode);
             if (shardValue.isNew()) {
-                functionUpdater.updateNew(shardValue, record);
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
             } else {
-                functionUpdater.updateExisting(shardValue, record);
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
             }
         }
     }
@@ -260,6 +268,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
     private static void aggregateNonSharded(
             PageAddressCacheRecord record,
             long frameRowCount,
+            long baseRowId,
             GroupByFunctionsUpdater functionUpdater,
             AsyncGroupByAtom.Particle particle,
             RecordSink mapSink
@@ -272,9 +281,9 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             mapSink.copy(record, key);
             MapValue value = key.createValue();
             if (value.isNew()) {
-                functionUpdater.updateNew(value, record);
+                functionUpdater.updateNew(value, record, baseRowId + r);
             } else {
-                functionUpdater.updateExisting(value, record);
+                functionUpdater.updateExisting(value, record, baseRowId + r);
             }
         }
     }
@@ -282,6 +291,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
     private static void aggregateSharded(
             PageAddressCacheRecord record,
             long frameRowCount,
+            long baseRowId,
             GroupByFunctionsUpdater functionUpdater,
             AsyncGroupByAtom.Particle particle,
             RecordSink mapSink
@@ -307,9 +317,9 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
 
             MapValue shardValue = shardKey.createValue(hashCode);
             if (shardValue.isNew()) {
-                functionUpdater.updateNew(shardValue, record);
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
             } else {
-                functionUpdater.updateExisting(shardValue, record);
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
             }
         }
     }
@@ -326,6 +336,8 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
 
         rows.clear();
 
+        final long frameRowCount = task.getFrameRowCount();
+        assert frameRowCount > 0;
         final AsyncGroupByAtom atom = task.getFrameSequence(AsyncGroupByAtom.class).getAtom();
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
@@ -338,15 +350,18 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         try {
             if (compiledFilter == null || pageAddressCache.hasColumnTops(task.getFrameIndex())) {
                 // Use Java-based filter when there is no compiled filter or in case of a page frame with column tops.
-                applyFilter(filter, rows, record, task.getFrameRowCount());
+                applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
             }
 
+            record.setRowIndex(0);
+            long baseRowId = record.getRowId();
+
             if (!particle.isSharded()) {
-                aggregateFilteredNonSharded(record, rows, functionUpdater, particle, mapSink);
+                aggregateFilteredNonSharded(record, rows, baseRowId, functionUpdater, particle, mapSink);
             } else {
-                aggregateFilteredSharded(record, rows, functionUpdater, particle, mapSink);
+                aggregateFilteredSharded(record, rows, baseRowId, functionUpdater, particle, mapSink);
             }
             atom.tryShard(particle);
         } finally {

--- a/core/src/test/java/io/questdb/test/StaticOverrides.java
+++ b/core/src/test/java/io/questdb/test/StaticOverrides.java
@@ -25,10 +25,8 @@
 package io.questdb.test;
 
 import io.questdb.FactoryProvider;
-import io.questdb.PropertyKey;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.std.FilesFacade;
-import io.questdb.std.datetime.DateFormat;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.test.cairo.Overrides;
 
@@ -95,5 +93,4 @@ public class StaticOverrides extends Overrides {
     public void setTestMicrosClock(MicrosecondClock testMicrosClock) {
         AbstractCairoTest.testMicrosClock = testMicrosClock;
     }
-
 }

--- a/core/src/test/java/io/questdb/test/cairo/Overrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/Overrides.java
@@ -132,10 +132,6 @@ public class Overrides {
         changed = true;
     }
 
-    public void resetStatic() {
-        reset();
-    }
-
     public void setCurrentMicros(long currentMicros) {
         this.currentMicros = currentMicros;
     }

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -1714,14 +1714,13 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         "and timestamp > dateadd('m', -30, now())) " +
                         "timestamp(x))",
                 "SelectedRecord\n" +
-                        "    GroupBy vectorized: false\n" +
+                        "    Async JIT Group By workers: 1\n" +
                         "      values: [last(timestamp),last(price)]\n" +
-                        "        Async JIT Filter workers: 1\n" +
-                        "          filter: symbol='BTC-USD'\n" +
-                        "            DataFrame\n" +
-                        "                Row forward scan\n" +
-                        "                Interval forward scan on: trades\n" +
-                        "                  intervals: [(\"1969-12-31T23:30:00.000001Z\",\"MAX\")]\n"
+                        "      filter: symbol='BTC-USD'\n" +
+                        "        DataFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Interval forward scan on: trades\n" +
+                        "              intervals: [(\"1969-12-31T23:30:00.000001Z\",\"MAX\")]\n"
         );
     }
 
@@ -2798,8 +2797,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table a ( gb geohash(4b), gs geohash(12b), gi geohash(24b), gl geohash(40b))",
                 "select first(gb), last(gb), first(gs), last(gs), first(gi), last(gi), first(gl), last(gl) from a",
-                "GroupBy vectorized: false\n" +
+                "Async Group By workers: 1\n" +
                         "  values: [first(gb),last(gb),first(gs),last(gs),first(gi),last(gi),first(gl),last(gl)]\n" +
+                        "  filter: null\n" +
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: a\n"
@@ -2811,13 +2811,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table a ( gb geohash(4b), gs geohash(12b), gi geohash(24b), gl geohash(40b), i int)",
                 "select first(gb), last(gb), first(gs), last(gs), first(gi), last(gi), first(gl), last(gl) from a where i > 42",
-                "GroupBy vectorized: false\n" +
+                "Async JIT Group By workers: 1\n" +
                         "  values: [first(gb),last(gb),first(gs),last(gs),first(gi),last(gi),first(gl),last(gl)]\n" +
-                        "    Async JIT Filter workers: 1\n" +
-                        "      filter: 42<i\n" +
-                        "        DataFrame\n" +
-                        "            Row forward scan\n" +
-                        "            Frame forward scan on: a\n"
+                        "  filter: 42<i\n" +
+                        "    DataFrame\n" +
+                        "        Row forward scan\n" +
+                        "        Frame forward scan on: a\n"
         );
     }
 
@@ -2862,13 +2861,14 @@ public class ExplainPlanTest extends AbstractCairoTest {
         );
     }
 
-    @Test // constant values used in aggregates disable vectorization
+    @Test
     public void testGroupByNotKeyed5() throws Exception {
         assertPlan(
                 "create table a ( i int, d double)",
                 "select first(10), last(d), avg(10), min(10), max(10) from a",
-                "GroupBy vectorized: false\n" +
+                "Async Group By workers: 1\n" +
                         "  values: [first(10),last(d),avg(10),min(10),max(10)]\n" +
+                        "  filter: null\n" +
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: a\n"

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -2353,7 +2353,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                         " rnd_str(5,16,3) astring," +
                                         " rnd_uuid4() auuid," +
                                         " timestamp_sequence(400000000000, 500000000) ts" +
-                                        " from long_sequence(" + ROW_COUNT + ")) timestamp(ts) partition by day",
+                                        " from long_sequence(10000)) timestamp(ts) partition by day",
                                 sqlExecutionContext
                         );
 

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -1104,7 +1104,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         " and ageolong != :ageolong" +
                         " and ts != :atimestamp",
                 "max\tmin\n" +
-                        "9205610066984479988\t-9211162377139482426\n"
+                        "9222440717001210457\t-9216152523287705363\n"
         );
     }
 
@@ -1144,7 +1144,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 },
                 "SELECT min(anint), max(anint) FROM tab WHERE asymbol = $1",
                 "min\tmax\n" +
-                        "-2141059164\t2147164481\n"
+                        "-2138876769\t2140835033\n"
         );
     }
 
@@ -1186,7 +1186,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelGroupByAllTypes(
                 "SELECT count_distinct(adate) FROM tab",
                 "count_distinct\n" +
-                        "3304\n"
+                        "3360\n"
         );
     }
 
@@ -1250,7 +1250,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelGroupByAllTypes(
                 "SELECT count_distinct(ashort), count_distinct(anint), count_distinct(along) FROM tab",
                 "count_distinct\tcount_distinct1\tcount_distinct2\n" +
-                        "997\t4000\t4000\n"
+                        "993\t4000\t4000\n"
         );
     }
 
@@ -1289,7 +1289,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelGroupByAllTypes(
                 "SELECT count_distinct(adate) FROM tab WHERE ts in '1970-01-13' and anint > 0",
                 "count_distinct\n" +
-                        "69\n"
+                        "71\n"
         );
     }
 
@@ -1343,6 +1343,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelNonKeyedGroupByWithTwoApproxCountDistinctIPv4Functions() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
         testParallelGroupByAllTypes(
                 "SELECT " +
                         "count_distinct(anint::ipv4), " +
@@ -1357,6 +1359,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelNonKeyedGroupByWithTwoApproxCountDistinctIntFunctions() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
         testParallelGroupByAllTypes(
                 "SELECT " +
                         "count_distinct(anint), " +
@@ -1371,6 +1375,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelNonKeyedGroupByWithTwoApproxCountDistinctLongFunctions() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
         testParallelGroupByAllTypes(
                 "SELECT " +
                         "count_distinct(along), " +
@@ -1397,12 +1403,12 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     @Test
     public void testParallelNonKeyedGroupByWithUnionAll() throws Exception {
         testParallelGroupByAllTypes(
-                "SELECT min(achar), max(achar) FROM tab WHERE astring = 'BBQRHKLSSCIQ' " +
+                "SELECT min(achar), max(achar) FROM tab WHERE astring = 'ZYJDGSUYYESCKPGP' " +
                         "UNION ALL " +
-                        "SELECT min(achar), max(achar) FROM tab WHERE astring = 'ZXJBJEX';",
+                        "SELECT min(achar), max(achar) FROM tab WHERE astring = 'BBOYHGPKTIIFPB';",
                 "min\tmax\n" +
-                        "W\tW\n" +
-                        "G\tG\n"
+                        "S\tS\n" +
+                        "Y\tY\n"
         );
     }
 
@@ -1420,19 +1426,41 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelShortKeyGroupBy() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
         testParallelGroupByAllTypes(
                 "SELECT ashort, min(along), max(along), min(anint), max(anint) FROM tab ORDER BY ashort LIMIT 10",
                 "ashort\tmin\tmax\tmin1\tmax1\n" +
-                        "10\t-9034587980761366171\t8241274134787696389\t-1493851145\t2030940694\n" +
-                        "11\t-8883842583685157250\t6964067227983995217\t-935653897\t1333246810\n" +
-                        "12\t-3197702176158331996\t4290056275098552124\t-1630398971\t1963882355\n" +
-                        "13\t-8278430792102412405\t4014190873568803122\t-2098187259\t1970675681\n" +
-                        "14\t2421752788016054233\t6338178220630434184\t-1631999006\t-722698516\n" +
-                        "15\t-8125853980339274130\t9051606766571205010\t-1858977498\t1150611667\n" +
-                        "16\t-9013114500574911839\t5870730758990824819\t-540262757\t1849540102\n" +
-                        "17\t-6999485272489290469\t7050703886046737412\t-940880966\t1965693358\n" +
-                        "18\t-3572916331642699731\t8246112648868146347\t-583762669\t1962662189\n" +
-                        "19\t-8236862851826364610\t7519544311952262364\t-1167241739\t-501299886\n"
+                        "10\t-7014037229734002476\t7183543099461850887\t-1923591798\t1614272726\n" +
+                        "11\t-8094563283586603797\t8266945525792915855\t-2019994796\t210531539\n" +
+                        "12\t5618009227733669273\t8843912384659881242\t-652636844\t1190519150\n" +
+                        "13\t-7540841016814556599\t6605106079379923850\t-1732278194\t732327460\n" +
+                        "14\t-5460379094988165507\t8508185526576303912\t-1006265366\t1983534078\n" +
+                        "15\t-8981189571240767552\t8925512637731362403\t-1578813385\t2074645817\n" +
+                        "16\t-4066776978860718462\t6817629763366381128\t-1183238579\t706490660\n" +
+                        "17\t-7818508517164276162\t8840276378973040058\t-1908962198\t1965693358\n" +
+                        "19\t-9081142346003583492\t5148856316963763479\t-1242130097\t810630533\n" +
+                        "20\t-8639548466303198922\t4998555152747068047\t-1594623294\t2041653124\n"
+        );
+    }
+
+    @Test
+    public void testParallelShortKeyGroupBy2() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelGroupByAllTypes(
+                "SELECT ashort, max(along) - min(along) delta FROM tab ORDER BY ashort LIMIT 10",
+                "ashort\tdelta\n" +
+                        "10\t-4249163744513698253\n" +
+                        "11\t-2085235264330031964\n" +
+                        "12\t3225903156926211969\n" +
+                        "13\t-4300796977515071167\n" +
+                        "14\t-4478179452145082197\n" +
+                        "15\t-540041864737421661\n" +
+                        "16\t-7562337331482452026\n" +
+                        "17\t-1787959177572235396\n" +
+                        "19\t-4216745410742204645\n" +
+                        "20\t-4808640454659284647\n"
         );
     }
 
@@ -1442,25 +1470,24 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT ashort, count_distinct(along) FROM tab " +
                         "WHERE ts in '1970-01-13' and ashort < 100 ORDER BY ashort DESC",
                 "ashort\tcount_distinct\n" +
-                        "97\t1\n" +
+                        "96\t1\n" +
                         "94\t1\n" +
-                        "87\t1\n" +
-                        "86\t1\n" +
-                        "81\t1\n" +
-                        "74\t1\n" +
+                        "89\t1\n" +
+                        "88\t1\n" +
+                        "82\t1\n" +
+                        "72\t2\n" +
                         "70\t1\n" +
-                        "64\t1\n" +
-                        "63\t1\n" +
-                        "60\t1\n" +
-                        "59\t1\n" +
-                        "56\t1\n" +
+                        "65\t1\n" +
                         "55\t1\n" +
-                        "50\t1\n" +
+                        "52\t1\n" +
+                        "49\t1\n" +
+                        "48\t1\n" +
+                        "45\t1\n" +
                         "44\t1\n" +
+                        "43\t1\n" +
                         "42\t1\n" +
-                        "34\t1\n" +
-                        "24\t1\n" +
-                        "22\t1\n" +
+                        "40\t2\n" +
+                        "33\t1\n" +
                         "19\t1\n"
         );
     }
@@ -1471,14 +1498,13 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT ashort, count_distinct(anint) FROM tab " +
                         "WHERE ts in '1970-01-13' and ashort < 100 and key in ('k1', 'k2') ORDER BY ashort DESC",
                 "ashort\tcount_distinct\n" +
-                        "97\t1\n" +
-                        "94\t1\n" +
-                        "86\t1\n" +
-                        "81\t1\n" +
-                        "59\t1\n" +
-                        "56\t1\n" +
-                        "42\t1\n" +
-                        "22\t1\n"
+                        "89\t1\n" +
+                        "88\t1\n" +
+                        "70\t1\n" +
+                        "49\t1\n" +
+                        "43\t1\n" +
+                        "40\t1\n" +
+                        "33\t1\n"
         );
     }
 
@@ -1717,19 +1743,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                     BindVariableService bindVariableService = sqlExecutionContext.getBindVariableService();
                     bindVariableService.clear();
                     bindVariableService.setBoolean("aboolean", true);
-                    bindVariableService.setByte("abyte", (byte) 27);
-                    bindVariableService.setGeoHash("ageobyte", 0b1110, ColumnType.getGeoHashTypeWithBits(4));
-                    bindVariableService.setShort("ashort", (short) 967);
-                    bindVariableService.setGeoHash("ageoshort", 0b110101110001, ColumnType.getGeoHashTypeWithBits(12));
-                    bindVariableService.setChar("achar", 'T');
-                    bindVariableService.setInt("anint", -382110917);
-                    bindVariableService.setGeoHash("ageoint", 0b0011000110101001L, ColumnType.getGeoHashTypeWithBits(16));
-                    bindVariableService.setStr("asymbol", null);
-                    bindVariableService.setLong("along", 4625553163167802495L);
-                    bindVariableService.setDate("adate", 1432692897394L);
-                    bindVariableService.setGeoHash("ageolong", 0b01001001000101100011111011100111L, ColumnType.getGeoHashTypeWithBits(32));
-                    bindVariableService.setStr("astring", "FMIFFNCGOR");
-                    bindVariableService.setTimestamp("atimestamp", 2399500000000L);
+                    bindVariableService.setByte("abyte", (byte) 25);
+                    bindVariableService.setGeoHash("ageobyte", 0b1100, ColumnType.getGeoHashTypeWithBits(4));
+                    bindVariableService.setShort("ashort", (short) 1013);
+                    bindVariableService.setGeoHash("ageoshort", 0b001111001001, ColumnType.getGeoHashTypeWithBits(12));
+                    bindVariableService.setChar("achar", 'C');
+                    bindVariableService.setInt("anint", -1269042121);
+                    bindVariableService.setGeoHash("ageoint", 0b0101011010000100, ColumnType.getGeoHashTypeWithBits(16));
+                    bindVariableService.setStr("asymbol", "PEHN");
+                    bindVariableService.setLong("along", -3214230645884399728L);
+                    bindVariableService.setDate("adate", 1447246617854L);
+                    bindVariableService.setGeoHash("ageolong", 0b11111100110100011011101011101011L, ColumnType.getGeoHashTypeWithBits(32));
+                    bindVariableService.setStr("astring", "LYXWCKYLSU");
+                    bindVariableService.setTimestamp("atimestamp", 401000000000L);
+                    bindVariableService.setStr("auuid", "78c594c4-9699-4885-aa18-96d0ad3419d2");
                 },
                 "SELECT key, count(anint), count(along) FROM tab " +
                         "WHERE aboolean = :aboolean" +
@@ -1745,10 +1772,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         " and adate = :adate" +
                         " and ageolong = :ageolong" +
                         " and astring = :astring" +
+                        " and auuid = :auuid" +
                         " and ts = :atimestamp " +
                         "ORDER BY key",
                 "key\tcount\tcount1\n" +
-                        "k0\t1\t1\n"
+                        "k3\t1\t1\n"
         );
     }
 
@@ -1762,11 +1790,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 },
                 "SELECT key, min(along), max(along) FROM tab WHERE anint > $1 and along < $2 ORDER BY key",
                 "key\tmin\tmax\n" +
-                        "k0\t-9163665195049517449\t-821679930140433295\n" +
-                        "k1\t-9211162377139482426\t-315372252554695059\n" +
-                        "k2\t-9210040949198821598\t-392919441181422827\n" +
-                        "k3\t-9206124989211917513\t-169245080956466231\n" +
-                        "k4\t-9201446338235814877\t-523002682211837829\n"
+                        "k0\t-9219668933902983867\t-608075365086093881\n" +
+                        "k1\t-9183391647798320265\t-537033525381181954\n" +
+                        "k2\t-9185973508459496019\t-742318963566750163\n" +
+                        "k3\t-9188002349803268631\t-218100546579477944\n" +
+                        "k4\t-9211367153776244683\t-618781741402001353\n"
         );
     }
 
@@ -1838,11 +1866,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelGroupByAllTypes(
                 "SELECT key, min(astring), max(astring) FROM tab ORDER BY key",
                 "key\tmin\tmax\n" +
-                        "k0\tBBQRHKLSSCIQ\tZZRMFMBEZGHWVD\n" +
-                        "k1\tBBHLHQWQCSE\tZZQVVCJZSDLNDV\n" +
-                        "k2\tBBHLPGXIIDYSTGX\tZXJBJEX\n" +
-                        "k3\tBDBJTHFBKJJLT\tZZSRLZQQNGCQTSFD\n" +
-                        "k4\tBBKYQSWZHTVJQD\tZZYFVYUXFENY\n"
+                        "k0\tBBCNG\tZVBNJWFNBZC\n" +
+                        "k1\tBBSHZZIC\tZZUMQFJLG\n" +
+                        "k2\tBDHTRTU\tZYJDGSUYYESCKPGP\n" +
+                        "k3\tBBIMTJZLB\tZZCLVWGJMOXN\n" +
+                        "k4\tBBOYHGPKTIIFPB\tZYQPYIWSMSTJ\n"
         );
     }
 
@@ -1881,8 +1909,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT key, count_distinct(anint) FROM tab " +
                         "WHERE ts in '1970-01-13' and adouble < 1000 ORDER BY key DESC",
                 "key\tcount_distinct\n" +
-                        "k4\t30\n" +
-                        "k3\t26\n" +
+                        "k4\t29\n" +
+                        "k3\t27\n" +
                         "k2\t31\n" +
                         "k1\t29\n" +
                         "k0\t28\n"
@@ -1924,18 +1952,106 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelStringKeyedFirstFunction() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelGroupByAllTypes(
+                "SELECT key, " +
+                        " first(aboolean) aboolean, first(abyte) abyte, first(ageobyte) ageobyte, " +
+                        " first(ashort) ashort, first(ageoshort) ageoshort, first(achar) achar, " +
+                        " first(anint) anint, first(anipv4) anipv4, first(ageoint) ageoint, first(afloat) afloat, " +
+                        " first(along) along, first(adouble) adouble, first(adate) adate, first(ts) ts, first(ageolong) ageolong, " +
+                        " first(asymbol) asymbol, first(astring) astring, " +
+                        " first(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC",
+                "key\taboolean\tabyte\tageobyte\tashort\tageoshort\tachar\tanint\tanipv4\tageoint\tafloat\talong\tadouble\tadate\tts\tageolong\tasymbol\tastring\tauuid\n" +
+                        "k4\tfalse\t29\t1100\t664\t000101011000\tI\t1506802640\t66.9.11.179\t1011000011101011\t0.6260\t-5024542231726589509\tNaN\t2015-08-03T15:58:03.335Z\t1970-01-05T15:31:40.000000Z\t01011101101001101000100100101110\t\tTKVVSJ\t8e4a7f66-1df6-432b-af17-1b3f06f6387d\n" +
+                        "k3\ttrue\t25\t1100\t1013\t001111001001\tC\t-1269042121\t184.92.27.200\t0101011010000100\t0.9566\t-3214230645884399728\t0.5406709846540508\t2015-11-11T12:56:57.854Z\t1970-01-05T15:23:20.000000Z\t11111100110100011011101011101011\tPEHN\tLYXWCKYLSU\t78c594c4-9699-4885-aa18-96d0ad3419d2\n" +
+                        "k2\tfalse\t9\t0101\t279\t011101100011\tL\t1978144263\t171.117.213.66\t0111100011010111\tNaN\t-7439145921574737517\t0.7763904674818695\t2015-09-18T13:48:49.642Z\t1970-01-05T15:15:00.000000Z\t01010100000001000011010111010101\tCPSW\tOOZZV\t9b27eba5-e9cf-41e2-9660-300cea7db540\n" +
+                        "k1\ttrue\t5\t1100\t788\t001111011001\tT\t-85170055\t149.34.19.60\t0010110111110001\t0.8757\t8416773233910814357\t0.8799634725391621\t2015-08-17T21:12:06.116Z\t1970-01-05T15:06:40.000000Z\t10110001001100000010111011111011\tCPSW\tDXYSBEO\t4c009450-0fbf-4dfe-b6fb-2001fe5dfb09\n" +
+                        "k0\tfalse\t13\t0000\t165\t000000110100\tO\t-640305320\t22.51.83.99\t1011000000001111\t0.9918\t-5315599072928175674\t0.32424562653969957\t2015-02-10T08:56:03.707Z\t1970-01-05T15:40:00.000000Z\t11011011111111001010110010100110\tCPSW\t\ta1d06d6e-b3a5-4079-8972-5663d8da9768\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyedFirstNotNullFunction() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelGroupByAllTypes(
+                "SELECT key, " +
+                        " first_not_null(ageobyte) ageobyte, " +
+                        " first_not_null(ageoshort) ageoshort, first_not_null(achar) achar, " +
+                        " first_not_null(anint) anint, first_not_null(anipv4) anipv4, first_not_null(ageoint) ageoint, first_not_null(afloat) afloat, " +
+                        " first_not_null(along) along, first_not_null(adouble) adouble, first_not_null(adate) adate, first_not_null(ts) ts, first_not_null(ageolong) ageolong, " +
+                        " first_not_null(asymbol) asymbol, first_not_null(astring) astring, " +
+                        " first_not_null(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC",
+                "key\tageobyte\tageoshort\tachar\tanint\tanipv4\tageoint\tafloat\talong\tadouble\tadate\tts\tageolong\tasymbol\tastring\tauuid\n" +
+                        "k4\t1100\t000101011000\tI\t1506802640\t66.9.11.179\t1011000011101011\t0.6260\t-5024542231726589509\t0.6213434403332111\t2015-08-03T15:58:03.335Z\t1970-01-05T15:31:40.000000Z\t01011101101001101000100100101110\tPEHN\tTKVVSJ\t8e4a7f66-1df6-432b-af17-1b3f06f6387d\n" +
+                        "k3\t1100\t001111001001\tC\t-1269042121\t184.92.27.200\t0101011010000100\t0.9566\t-3214230645884399728\t0.5406709846540508\t2015-11-11T12:56:57.854Z\t1970-01-05T15:23:20.000000Z\t11111100110100011011101011101011\tPEHN\tLYXWCKYLSU\t78c594c4-9699-4885-aa18-96d0ad3419d2\n" +
+                        "k2\t0101\t011101100011\tL\t1978144263\t171.117.213.66\t0111100011010111\t0.5709\t-7439145921574737517\t0.7763904674818695\t2015-09-18T13:48:49.642Z\t1970-01-05T15:15:00.000000Z\t01010100000001000011010111010101\tCPSW\tOOZZV\t9b27eba5-e9cf-41e2-9660-300cea7db540\n" +
+                        "k1\t1100\t001111011001\tT\t-85170055\t149.34.19.60\t0010110111110001\t0.8757\t8416773233910814357\t0.8799634725391621\t2015-08-17T21:12:06.116Z\t1970-01-05T15:06:40.000000Z\t10110001001100000010111011111011\tCPSW\tDXYSBEO\t4c009450-0fbf-4dfe-b6fb-2001fe5dfb09\n" +
+                        "k0\t0000\t000000110100\tO\t-640305320\t22.51.83.99\t1011000000001111\t0.9918\t-5315599072928175674\t0.32424562653969957\t2015-02-10T08:56:03.707Z\t1970-01-05T15:40:00.000000Z\t11011011111111001010110010100110\tCPSW\tQZSLQVFGPPRGSXB\ta1d06d6e-b3a5-4079-8972-5663d8da9768\n"
+        );
+    }
+
+    @Test
     public void testParallelStringKeyedGroupByWithUnionAll() throws Exception {
         testParallelGroupByAllTypes(
                 "SELECT * " +
                         "FROM ( " +
-                        "  SELECT key, min(achar), max(achar) FROM tab WHERE astring = 'BBQRHKLSSCIQ' " +
+                        "  SELECT key, min(achar), max(achar) FROM tab WHERE astring = 'ZZCLVWGJMOXN' " +
                         "  UNION ALL " +
-                        "  SELECT key, min(achar), max(achar) FROM tab WHERE astring = 'ZXJBJEX'" +
+                        "  SELECT key, min(achar), max(achar) FROM tab WHERE astring = 'BBCNG'" +
                         ") " +
                         "ORDER BY key DESC;",
                 "key\tmin\tmax\n" +
-                        "k2\tG\tG\n" +
-                        "k0\tW\tW\n"
+                        "k3\tB\tB\n" +
+                        "k0\tD\tD\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyedLastFunction() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelGroupByAllTypes(
+                "SELECT key, " +
+                        " last(aboolean) aboolean, last(abyte) abyte, last(ageobyte) ageobyte, " +
+                        " last(ashort) ashort, last(ageoshort) ageoshort, last(achar) achar, " +
+                        " last(anint) anint, last(anipv4) anipv4, last(ageoint) ageoint, last(afloat) afloat, " +
+                        " last(along) along, last(adouble) adouble, last(adate) adate, last(ts) ts, last(ageolong) ageolong, " +
+                        " last(asymbol) asymbol, last(astring) astring, " +
+                        " last(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC",
+                "key\taboolean\tabyte\tageobyte\tashort\tageoshort\tachar\tanint\tanipv4\tageoint\tafloat\talong\tadouble\tadate\tts\tageolong\tasymbol\tastring\tauuid\n" +
+                        "k4\tfalse\t31\t0101\t330\t110110100011\tF\t-848336394\t235.231.19.15\t0110111101100110\t0.2565\t-9157587264521797613\t0.21377964990604514\t2015-02-01T20:25:30.629Z\t1970-01-28T18:23:20.000000Z\t01011011001110110000010000101101\tCPSW\tMPVGXH\t18362dcf-ef83-4aab-ac47-04e5093bf747\n" +
+                        "k3\tfalse\t38\t1010\t87\t110111011001\tJ\t1901541154\t37.251.146.2\t1001000010010001\tNaN\t-5509931004723445033\t0.023379956696789717\t2015-02-12T10:52:41.010Z\t1970-01-28T18:15:00.000000Z\t11010110001110011010110000001111\tPEHN\tCSXKOBEGGNBZMI\t6e80006a-871f-417a-b33a-82ae2a7b83e8\n" +
+                        "k2\ttrue\t8\t0110\t556\t101001101101\tS\t1284672871\t123.157.83.21\t0000001101111100\t0.0007\t9154573717374787696\t0.151734552716993\t2015-02-06T11:08:08.607Z\t1970-01-28T18:06:40.000000Z\t00011101011001001010001110011010\t\tPWKZMYWJ\tcd1c6b4b-1b2d-4324-9477-dc8aeb3e13f3\n" +
+                        "k1\ttrue\t17\t1100\t147\t011101001110\tI\t1516951853\t88.98.63.55\t1010001110110001\t0.5834\t-6618178923628468143\t0.1996073004071821\t2015-05-23T20:25:36.412Z\t1970-01-28T17:58:20.000000Z\t11001011111011110001101111100000\tPEHN\tFBGWS\t232fceaa-4da1-4f63-8f6d-0b7977b184bf\n" +
+                        "k0\tfalse\t28\t0100\t859\t111101110010\tY\t1033747429\t210.8.117.61\t0100111000110011\t0.0301\t6812734169481155056\t0.15322992873721464\t2015-06-04T13:11:05.363Z\t1970-01-28T18:31:40.000000Z\t01001000100000110011110011111100\tHYRX\t\t8055fd98-3b39-4806-9dbf-5a050468a62a\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyedLastNotNullFunction() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testParallelGroupByAllTypes(
+                "SELECT key, " +
+                        " last_not_null(ageobyte) ageobyte, " +
+                        " last_not_null(ageoshort) ageoshort, last_not_null(achar) achar, " +
+                        " last_not_null(anint) anint, last_not_null(anipv4) anipv4, last_not_null(ageoint) ageoint, last_not_null(afloat) afloat, " +
+                        " last_not_null(along) along, last_not_null(adouble) adouble, last_not_null(adate) adate, last_not_null(ts) ts, last_not_null(ageolong) ageolong, " +
+                        " last_not_null(asymbol) asymbol, last_not_null(astring) astring, " +
+                        " last_not_null(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC",
+                "key\tageobyte\tageoshort\tachar\tanint\tanipv4\tageoint\tafloat\talong\tadouble\tadate\tts\tageolong\tasymbol\tastring\tauuid\n" +
+                        "k4\t0101\t110110100011\tF\t-848336394\t235.231.19.15\t0110111101100110\t0.2565\t-9157587264521797613\t0.21377964990604514\t2015-02-01T20:25:30.629Z\t1970-01-28T18:23:20.000000Z\t01011011001110110000010000101101\tCPSW\tMPVGXH\t18362dcf-ef83-4aab-ac47-04e5093bf747\n" +
+                        "k3\t1010\t110111011001\tJ\t1901541154\t37.251.146.2\t1001000010010001\t0.1488\t-5509931004723445033\t0.023379956696789717\t2015-02-12T10:52:41.010Z\t1970-01-28T18:15:00.000000Z\t11010110001110011010110000001111\tPEHN\tCSXKOBEGGNBZMI\t6e80006a-871f-417a-b33a-82ae2a7b83e8\n" +
+                        "k2\t0110\t101001101101\tS\t1284672871\t123.157.83.21\t0000001101111100\t0.0007\t9154573717374787696\t0.151734552716993\t2015-02-06T11:08:08.607Z\t1970-01-28T18:06:40.000000Z\t00011101011001001010001110011010\tCPSW\tPWKZMYWJ\tcd1c6b4b-1b2d-4324-9477-dc8aeb3e13f3\n" +
+                        "k1\t1100\t011101001110\tI\t1516951853\t88.98.63.55\t1010001110110001\t0.5834\t-6618178923628468143\t0.1996073004071821\t2015-05-23T20:25:36.412Z\t1970-01-28T17:58:20.000000Z\t11001011111011110001101111100000\tPEHN\tFBGWS\t232fceaa-4da1-4f63-8f6d-0b7977b184bf\n" +
+                        "k0\t0100\t111101110010\tY\t1033747429\t210.8.117.61\t0100111000110011\t0.0301\t6812734169481155056\t0.15322992873721464\t2015-06-04T13:11:05.363Z\t1970-01-28T18:31:40.000000Z\t01001000100000110011110011111100\tHYRX\tFYJXOSBUGGYTSKTY\t8055fd98-3b39-4806-9dbf-5a050468a62a\n"
         );
     }
 
@@ -2161,6 +2277,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                         " rnd_geohash(12) ageoshort," +
                                         " rnd_char() achar," +
                                         " rnd_int() anint," +
+                                        " rnd_ipv4() anipv4," +
                                         " rnd_geohash(16) ageoint," +
                                         " rnd_symbol(4,4,4,2) asymbol," +
                                         " rnd_float(2) afloat," +
@@ -2169,6 +2286,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                         " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 2) adate," +
                                         " rnd_geohash(32) ageolong," +
                                         " rnd_str(5,16,2) astring," +
+                                        " rnd_uuid4() auuid," +
                                         " timestamp_sequence(400000000000, 500000000) ts" +
                                         " from long_sequence(" + ROW_COUNT + ")) timestamp(ts) partition by day",
                                 sqlExecutionContext

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -42,6 +42,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
+import io.questdb.std.Rnd;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
@@ -1974,6 +1975,22 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelStringKeyedFirstFunctionFuzz() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testFirstLastFunctionFuzz(
+                "SELECT key, " +
+                        " first(aboolean) aboolean, first(abyte) abyte, first(ageobyte) ageobyte, " +
+                        " first(ashort) ashort, first(ageoshort) ageoshort, first(achar) achar, " +
+                        " first(anint) anint, first(anipv4) anipv4, first(ageoint) ageoint, first(afloat) afloat, " +
+                        " first(along) along, first(adouble) adouble, first(adate) adate, first(ts) ts, first(ageolong) ageolong, " +
+                        " first(asymbol) asymbol, first(astring) astring, " +
+                        " first(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC"
+        );
+    }
+
+    @Test
     public void testParallelStringKeyedFirstNotNullFunction() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
@@ -1992,6 +2009,22 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         "k2\t0101\t011101100011\tL\t1978144263\t171.117.213.66\t0111100011010111\t0.5709\t-7439145921574737517\t0.7763904674818695\t2015-09-18T13:48:49.642Z\t1970-01-05T15:15:00.000000Z\t01010100000001000011010111010101\tCPSW\tOOZZV\t9b27eba5-e9cf-41e2-9660-300cea7db540\n" +
                         "k1\t1100\t001111011001\tT\t-85170055\t149.34.19.60\t0010110111110001\t0.8757\t8416773233910814357\t0.8799634725391621\t2015-08-17T21:12:06.116Z\t1970-01-05T15:06:40.000000Z\t10110001001100000010111011111011\tCPSW\tDXYSBEO\t4c009450-0fbf-4dfe-b6fb-2001fe5dfb09\n" +
                         "k0\t0000\t000000110100\tO\t-640305320\t22.51.83.99\t1011000000001111\t0.9918\t-5315599072928175674\t0.32424562653969957\t2015-02-10T08:56:03.707Z\t1970-01-05T15:40:00.000000Z\t11011011111111001010110010100110\tCPSW\tQZSLQVFGPPRGSXB\ta1d06d6e-b3a5-4079-8972-5663d8da9768\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyedFirstNotNullFunctionFuzz() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testFirstLastFunctionFuzz(
+                "SELECT key, " +
+                        " first_not_null(ageobyte) ageobyte, " +
+                        " first_not_null(ageoshort) ageoshort, first_not_null(achar) achar, " +
+                        " first_not_null(anint) anint, first_not_null(anipv4) anipv4, first_not_null(ageoint) ageoint, first_not_null(afloat) afloat, " +
+                        " first_not_null(along) along, first_not_null(adouble) adouble, first_not_null(adate) adate, first_not_null(ts) ts, first_not_null(ageolong) ageolong, " +
+                        " first_not_null(asymbol) asymbol, first_not_null(astring) astring, " +
+                        " first_not_null(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC"
         );
     }
 
@@ -2034,6 +2067,22 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelStringKeyedLastFunctionFuzz() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testFirstLastFunctionFuzz(
+                "SELECT key, " +
+                        " last(aboolean) aboolean, last(abyte) abyte, last(ageobyte) ageobyte, " +
+                        " last(ashort) ashort, last(ageoshort) ageoshort, last(achar) achar, " +
+                        " last(anint) anint, last(anipv4) anipv4, last(ageoint) ageoint, last(afloat) afloat, " +
+                        " last(along) along, last(adouble) adouble, last(adate) adate, last(ts) ts, last(ageolong) ageolong, " +
+                        " last(asymbol) asymbol, last(astring) astring, " +
+                        " last(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC"
+        );
+    }
+
+    @Test
     public void testParallelStringKeyedLastNotNullFunction() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
@@ -2052,6 +2101,22 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         "k2\t0110\t101001101101\tS\t1284672871\t123.157.83.21\t0000001101111100\t0.0007\t9154573717374787696\t0.151734552716993\t2015-02-06T11:08:08.607Z\t1970-01-28T18:06:40.000000Z\t00011101011001001010001110011010\tCPSW\tPWKZMYWJ\tcd1c6b4b-1b2d-4324-9477-dc8aeb3e13f3\n" +
                         "k1\t1100\t011101001110\tI\t1516951853\t88.98.63.55\t1010001110110001\t0.5834\t-6618178923628468143\t0.1996073004071821\t2015-05-23T20:25:36.412Z\t1970-01-28T17:58:20.000000Z\t11001011111011110001101111100000\tPEHN\tFBGWS\t232fceaa-4da1-4f63-8f6d-0b7977b184bf\n" +
                         "k0\t0100\t111101110010\tY\t1033747429\t210.8.117.61\t0100111000110011\t0.0301\t6812734169481155056\t0.15322992873721464\t2015-06-04T13:11:05.363Z\t1970-01-28T18:31:40.000000Z\t01001000100000110011110011111100\tHYRX\tFYJXOSBUGGYTSKTY\t8055fd98-3b39-4806-9dbf-5a050468a62a\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyedLastNotNullFunctionFuzz() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
+        testFirstLastFunctionFuzz(
+                "SELECT key, " +
+                        " last_not_null(ageobyte) ageobyte, " +
+                        " last_not_null(ageoshort) ageoshort, last_not_null(achar) achar, " +
+                        " last_not_null(anint) anint, last_not_null(anipv4) anipv4, last_not_null(ageoint) ageoint, last_not_null(afloat) afloat, " +
+                        " last_not_null(along) along, last_not_null(adouble) adouble, last_not_null(adate) adate, last_not_null(ts) ts, last_not_null(ageolong) ageolong, " +
+                        " last_not_null(asymbol) asymbol, last_not_null(astring) astring, " +
+                        " last_not_null(auuid) auuid " +
+                        "FROM tab ORDER BY key DESC"
         );
     }
 
@@ -2251,8 +2316,73 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         }
     }
 
-    private void testParallelGroupByAllTypes(String... queriesAndExpectedResults) throws Exception {
-        testParallelGroupByAllTypes(null, queriesAndExpectedResults);
+    private void testFirstLastFunctionFuzz(String query) throws Exception {
+        // With this test, we aim to verify correctness of merge() method
+        // implementation in first/last functions.
+
+        // This test controls sets enable parallel GROUP BY flag on its own.
+        Assume.assumeTrue(enableParallelGroupBy);
+        assertMemoryLeak(() -> {
+            final Rnd rnd = TestUtils.generateRandom(LOG);
+            final WorkerPool pool = new WorkerPool((() -> 4));
+            TestUtils.execute(
+                    pool,
+                    (engine, compiler, sqlExecutionContext) -> {
+                        sqlExecutionContext.setJitMode(enableJitCompiler ? SqlJitMode.JIT_MODE_ENABLED : SqlJitMode.JIT_MODE_DISABLED);
+                        sqlExecutionContext.setRandom(rnd);
+
+                        ddl(
+                                compiler,
+                                "create table tab as (select" +
+                                        " 'k' || ((50 + x) % 5) key," +
+                                        " rnd_boolean() aboolean," +
+                                        " rnd_byte(2,50) abyte," +
+                                        " rnd_geohash(4) ageobyte," +
+                                        " rnd_short(10,1024) ashort," +
+                                        " rnd_geohash(12) ageoshort," +
+                                        " rnd_char() achar," +
+                                        " rnd_int(0,1000,3) anint," +
+                                        " rnd_ipv4() anipv4," +
+                                        " rnd_geohash(16) ageoint," +
+                                        " rnd_symbol(4,4,4,2) asymbol," +
+                                        " rnd_float(3) afloat," +
+                                        " rnd_long(0,1000,3) along," +
+                                        " rnd_double(3) adouble," +
+                                        " rnd_date(to_date('2015', 'yyyy'), to_date('2016', 'yyyy'), 3) adate," +
+                                        " rnd_geohash(32) ageolong," +
+                                        " rnd_str(5,16,3) astring," +
+                                        " rnd_uuid4() auuid," +
+                                        " timestamp_sequence(400000000000, 500000000) ts" +
+                                        " from long_sequence(" + ROW_COUNT + ")) timestamp(ts) partition by day",
+                                sqlExecutionContext
+                        );
+
+                        // Run with single-threaded GROUP BY.
+                        node1.setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUP_BY_ENABLED, "false");
+                        TestUtils.printSql(
+                                engine,
+                                sqlExecutionContext,
+                                query,
+                                sink
+                        );
+
+                        // Run with parallel GROUP BY.
+                        node1.setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUP_BY_ENABLED, "true");
+                        final StringSink sinkB = new StringSink();
+                        TestUtils.printSql(
+                                engine,
+                                sqlExecutionContext,
+                                query,
+                                sinkB
+                        );
+
+                        // Compare the results.
+                        TestUtils.assertEquals(sink, sinkB);
+                    },
+                    configuration,
+                    LOG
+            );
+        });
     }
 
     private void testParallelGroupByAllTypes(BindVariablesInitializer initializer, String... queriesAndExpectedResults) throws Exception {
@@ -2297,6 +2427,10 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                     LOG
             );
         });
+    }
+
+    private void testParallelGroupByAllTypes(String... queriesAndExpectedResults) throws Exception {
+        testParallelGroupByAllTypes(null, queriesAndExpectedResults);
     }
 
     private void testParallelGroupByFaultTolerance(String query) throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/GroupByFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/GroupByFunctionTest.java
@@ -31,18 +31,18 @@ import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Long256;
-import io.questdb.std.str.Utf16Sink;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.Utf16Sink;
 import org.junit.Test;
 
 public class GroupByFunctionTest {
     private static final GroupByFunction function = new GroupByFunction() {
         @Override
-        public void computeFirst(MapValue mapValue, Record record) {
+        public void computeFirst(MapValue mapValue, Record record, long rowId) {
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstBooleanGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstBooleanGroupByFunctionFactoryTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class FirstBooleanGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
-    public void testAllNull() throws SqlException {
+    public void testAllFalse() throws SqlException {
         ddl("create table tab (f boolean)");
 
         try (TableWriter w = getWriter("tab")) {
@@ -71,7 +71,7 @@ public class FirstBooleanGroupByFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testLastBoolean2() throws Exception {
+    public void testFirstBoolean2() throws Exception {
         assertQuery(
                 "a\n" +
                         "true\n",

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstByteGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstByteGroupByFunctionFactoryTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class FirstByteGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testFirstByte() throws Exception {
+        assertQuery(
+                "a\n" +
+                        "1\n",
+                "select first(a) a from tab",
+                "create table tab as (select 1::byte a union select 2::byte a union select 3::byte a)",
+                null,
+                false,
+                true
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstCharGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstCharGroupByFunctionFactoryTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FirstCharGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f char)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 10; i > 0; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals((char) 0, record.getChar(0));
+            }
+        }
+    }
+
+    @Test
+    public void testFirstChar() throws Exception {
+        assertQuery(
+                "a\n" +
+                        "1\n",
+                "select first(a) a from tab",
+                "create table tab as (select '1' a union select '2' a union select '3' a)",
+                null,
+                false,
+                true
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstFloatGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstFloatGroupByFunctionFactoryTest.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FirstFloatGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f float)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertTrue(Float.isNaN(record.getFloat(0)));
+            }
+        }
+    }
+
+    @Test
+    public void testFirstNull() throws SqlException {
+        ddl("create table tab (f float)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            TableWriter.Row r = w.newRow();
+            r.append();
+            for (int i = 100; i > 10; i--) {
+                r = w.newRow();
+                r.putFloat(0, rnd.nextFloat());
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Float.NaN, record.getFloat(0), 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f float)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putFloat(0, rnd.nextFloat());
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(0.6607777894187332, record.getFloat(0), 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testSampleFill() throws Exception {
+        assertQuery(
+                "b\tfirst\tk\n" +
+                        "HYRX\t0.1143\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t0.4218\t1970-01-03T00:00:00.000000Z\n" +
+                        "\t0.7261\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.3854\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t0.3361\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t0.9687\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.8685\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t0.4372\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t0.6359\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t0.6807\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t0.8231\t1970-01-03T03:00:00.000000Z\n" +
+                        "RXGZ\t0.8314\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t0.2263\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t0.2712\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t0.7365\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t0.9419\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t0.2464\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.6941\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.4440\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t0.0962\t1970-01-03T09:00:00.000000Z\n" +
+                        "CPSW\t0.7292\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t0.2535\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t0.0400\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t-0.4159\t1970-01-03T09:00:00.000000Z\n",
+                "select b, first(a), k from x sample by 3h fill(linear)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_float(0) a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(172800000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(100)" +
+                        ") timestamp(k) partition by NONE",
+                "k",
+                "insert into x select * from (" +
+                        "select" +
+                        " rnd_float(0) a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(277200000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(35)" +
+                        ") timestamp(k)",
+                "b\tfirst\tk\n" +
+                        "HYRX\t0.1143\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t0.4218\t1970-01-03T00:00:00.000000Z\n" +
+                        "\t0.7261\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.3854\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t0.3361\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t0.9687\t1970-01-03T00:00:00.000000Z\n" +
+                        "UQDY\t1.9459\t1970-01-03T00:00:00.000000Z\n" +
+                        "UKLG\t4.2643\t1970-01-03T00:00:00.000000Z\n" +
+                        "IMYF\t0.7330\t1970-01-03T00:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T00:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.8685\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t0.4372\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t0.6359\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t0.6807\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t0.8231\t1970-01-03T03:00:00.000000Z\n" +
+                        "RXGZ\t0.8314\t1970-01-03T03:00:00.000000Z\n" +
+                        "UQDY\t1.8404\t1970-01-03T03:00:00.000000Z\n" +
+                        "UKLG\t3.8671\t1970-01-03T03:00:00.000000Z\n" +
+                        "IMYF\t0.7160\t1970-01-03T03:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T03:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t0.2263\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t0.2712\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t0.7365\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t0.9419\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t0.2464\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.6941\t1970-01-03T06:00:00.000000Z\n" +
+                        "UQDY\t1.7350\t1970-01-03T06:00:00.000000Z\n" +
+                        "UKLG\t3.4698\t1970-01-03T06:00:00.000000Z\n" +
+                        "IMYF\t0.6989\t1970-01-03T06:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T06:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.4440\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t0.0962\t1970-01-03T09:00:00.000000Z\n" +
+                        "CPSW\t0.7292\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t0.2535\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t0.0400\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t-0.4159\t1970-01-03T09:00:00.000000Z\n" +
+                        "UQDY\t1.6295\t1970-01-03T09:00:00.000000Z\n" +
+                        "UKLG\t3.0725\t1970-01-03T09:00:00.000000Z\n" +
+                        "IMYF\t0.6819\t1970-01-03T09:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T09:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t-0.1664\t1970-01-03T12:00:00.000000Z\n" +
+                        "PEHN\t-0.4348\t1970-01-03T12:00:00.000000Z\n" +
+                        "\t0.1302\t1970-01-03T12:00:00.000000Z\n" +
+                        "VTJW\t-1.0581\t1970-01-03T12:00:00.000000Z\n" +
+                        "CPSW\t0.7220\t1970-01-03T12:00:00.000000Z\n" +
+                        "RXGZ\t0.1940\t1970-01-03T12:00:00.000000Z\n" +
+                        "UQDY\t1.5240\t1970-01-03T12:00:00.000000Z\n" +
+                        "UKLG\t2.6752\t1970-01-03T12:00:00.000000Z\n" +
+                        "IMYF\t0.6648\t1970-01-03T12:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T12:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T12:00:00.000000Z\n" +
+                        "HYRX\t-0.3728\t1970-01-03T15:00:00.000000Z\n" +
+                        "PEHN\t-1.1231\t1970-01-03T15:00:00.000000Z\n" +
+                        "\t0.1642\t1970-01-03T15:00:00.000000Z\n" +
+                        "VTJW\t-1.7003\t1970-01-03T15:00:00.000000Z\n" +
+                        "CPSW\t0.7147\t1970-01-03T15:00:00.000000Z\n" +
+                        "RXGZ\t-0.0561\t1970-01-03T15:00:00.000000Z\n" +
+                        "UQDY\t1.4185\t1970-01-03T15:00:00.000000Z\n" +
+                        "UKLG\t2.2779\t1970-01-03T15:00:00.000000Z\n" +
+                        "IMYF\t0.6478\t1970-01-03T15:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T15:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T15:00:00.000000Z\n" +
+                        "HYRX\t-0.5792\t1970-01-03T18:00:00.000000Z\n" +
+                        "PEHN\t-1.8115\t1970-01-03T18:00:00.000000Z\n" +
+                        "\t0.1982\t1970-01-03T18:00:00.000000Z\n" +
+                        "VTJW\t-2.3425\t1970-01-03T18:00:00.000000Z\n" +
+                        "CPSW\t0.7075\t1970-01-03T18:00:00.000000Z\n" +
+                        "RXGZ\t-0.3062\t1970-01-03T18:00:00.000000Z\n" +
+                        "UQDY\t1.3131\t1970-01-03T18:00:00.000000Z\n" +
+                        "UKLG\t1.8806\t1970-01-03T18:00:00.000000Z\n" +
+                        "IMYF\t0.6308\t1970-01-03T18:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T18:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T18:00:00.000000Z\n" +
+                        "HYRX\t-0.7856\t1970-01-03T21:00:00.000000Z\n" +
+                        "PEHN\t-2.4998\t1970-01-03T21:00:00.000000Z\n" +
+                        "\t0.2323\t1970-01-03T21:00:00.000000Z\n" +
+                        "VTJW\t-2.9847\t1970-01-03T21:00:00.000000Z\n" +
+                        "CPSW\t0.7002\t1970-01-03T21:00:00.000000Z\n" +
+                        "RXGZ\t-0.5562\t1970-01-03T21:00:00.000000Z\n" +
+                        "UQDY\t1.2076\t1970-01-03T21:00:00.000000Z\n" +
+                        "UKLG\t1.4834\t1970-01-03T21:00:00.000000Z\n" +
+                        "IMYF\t0.6137\t1970-01-03T21:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T21:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T21:00:00.000000Z\n" +
+                        "HYRX\t-0.9920\t1970-01-04T00:00:00.000000Z\n" +
+                        "PEHN\t-3.1882\t1970-01-04T00:00:00.000000Z\n" +
+                        "\t0.2663\t1970-01-04T00:00:00.000000Z\n" +
+                        "VTJW\t-3.6269\t1970-01-04T00:00:00.000000Z\n" +
+                        "CPSW\t0.6929\t1970-01-04T00:00:00.000000Z\n" +
+                        "RXGZ\t-0.8063\t1970-01-04T00:00:00.000000Z\n" +
+                        "UQDY\t1.1021\t1970-01-04T00:00:00.000000Z\n" +
+                        "UKLG\t1.0861\t1970-01-04T00:00:00.000000Z\n" +
+                        "IMYF\t0.5967\t1970-01-04T00:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-04T00:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-04T00:00:00.000000Z\n" +
+                        "UQDY\t0.9966\t1970-01-04T03:00:00.000000Z\n" +
+                        "\t0.3003\t1970-01-04T03:00:00.000000Z\n" +
+                        "UKLG\t0.6888\t1970-01-04T03:00:00.000000Z\n" +
+                        "IMYF\t0.5797\t1970-01-04T03:00:00.000000Z\n" +
+                        "HYRX\t-1.1984\t1970-01-04T03:00:00.000000Z\n" +
+                        "PEHN\t-3.8765\t1970-01-04T03:00:00.000000Z\n" +
+                        "VTJW\t-4.2691\t1970-01-04T03:00:00.000000Z\n" +
+                        "CPSW\t0.6857\t1970-01-04T03:00:00.000000Z\n" +
+                        "RXGZ\t-1.0564\t1970-01-04T03:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-04T03:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-04T03:00:00.000000Z\n" +
+                        "\t0.8380\t1970-01-04T06:00:00.000000Z\n" +
+                        "IMYF\t0.5626\t1970-01-04T06:00:00.000000Z\n" +
+                        "OPHN\t0.4920\t1970-01-04T06:00:00.000000Z\n" +
+                        "UKLG\t0.2915\t1970-01-04T06:00:00.000000Z\n" +
+                        "MXSL\t0.7408\t1970-01-04T06:00:00.000000Z\n" +
+                        "UQDY\t0.8912\t1970-01-04T06:00:00.000000Z\n" +
+                        "HYRX\t-1.4048\t1970-01-04T06:00:00.000000Z\n" +
+                        "PEHN\t-4.5648\t1970-01-04T06:00:00.000000Z\n" +
+                        "VTJW\t-4.9113\t1970-01-04T06:00:00.000000Z\n" +
+                        "CPSW\t0.6784\t1970-01-04T06:00:00.000000Z\n" +
+                        "RXGZ\t-1.3064\t1970-01-04T06:00:00.000000Z\n",
+                true,
+                true,
+                false
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstIPv4GroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstIPv4GroupByFunctionFactoryTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Numbers;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FirstIPv4GroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.IPv4_NULL, record.getIPv4(0));
+            }
+        }
+    }
+
+    @Test
+    public void testFirstNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            TableWriter.Row r = w.newRow();
+            r.append();
+            for (int i = 100; i > 10; i--) {
+                r = w.newRow();
+                r.putInt(0, i);
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.IPv4_NULL, record.getIPv4(0));
+            }
+        }
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putInt(0, i);
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(100, record.getIPv4(0));
+            }
+        }
+    }
+
+    @Test
+    public void testSomeNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                if (i % 4 == 0) {
+                    r.putInt(0, i);
+                }
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(100, record.getIPv4(0));
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstNotNullGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstNotNullGroupByFunctionFactoryTest.java
@@ -33,7 +33,8 @@ public class FirstNotNullGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testAllNull() throws Exception {
-        assertQuery("a0\ta1\ta2\ta3\ta4\ta5\ta6\ta7\ta8\ta9\ta10\ta11\ta12\ta13\ta14\n" +
+        assertQuery(
+                "a0\ta1\ta2\ta3\ta4\ta5\ta6\ta7\ta8\ta9\ta10\ta11\ta12\ta13\ta14\n" +
                         "\t\tNaN\tNaN\tNaN\tNaN\t\t\t\t\t\t\t\t\t\n",
                 "select first_not_null(a0) a0," +
                         "     first_not_null(a1) a1," +
@@ -133,7 +134,8 @@ public class FirstNotNullGroupByFunctionFactoryTest extends AbstractCairoTest {
                 " '2.0.0.0'" +
                 ")");
 
-        assertSql("a0\ta1\ta2\ta3\ta4\ta5\ta6\ta7\ta8\ta9\ta10\ta11\ta12\ta13\ta14\n" +
+        assertSql(
+                "a0\ta1\ta2\ta3\ta4\ta5\ta6\ta7\ta8\ta9\ta10\ta11\ta12\ta13\ta14\n" +
                         "a\t2023-10-23T00:00:00.000Z\t2.2\t3.3000\t4\t5\ta_symbol\t2023-10-23T12:34:59.000000Z\t" + firstUuid + "\ta_string\tu\tuu\tuuuuu\tuuuuuuu\t1.0.0.0\n",
                 "select first_not_null(a0) a0," +
                         "     first_not_null(a1) a1," +
@@ -150,6 +152,7 @@ public class FirstNotNullGroupByFunctionFactoryTest extends AbstractCairoTest {
                         "     first_not_null(a12) a12, " +
                         "     first_not_null(a13) a13, " +
                         "     first_not_null(a14) a14 " +
-                        "from tab");
+                        "from tab"
+        );
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstShortGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstShortGroupByFunctionFactoryTest.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FirstShortGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testFirstShort() throws SqlException {
+        ddl("create table tab (f short)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putShort(0, (short) i);
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(100, record.getShort(0));
+            }
+        }
+    }
+
+    @Test
+    public void testFirstZero() throws SqlException {
+        ddl("create table tab (f short)");
+
+        try (TableWriter w = getWriter("tab")) {
+            TableWriter.Row r = w.newRow();
+            r.append();
+            for (int i = 100; i > 10; i--) {
+                r = w.newRow();
+                r.putInt(0, i);
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(0, record.getShort(0));
+            }
+        }
+    }
+
+    @Test
+    public void testSampleFill() throws Exception {
+        assertQuery(
+                "b\tfirst\tk\n" +
+                        "\t-24357\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t-1593\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t21781\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t18457\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t-19127\t1970-01-03T00:00:00.000000Z\n" +
+                        "HYRX\t26142\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t29978\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t-18357\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t-2018\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t-15331\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t-10913\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t3172\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t-1605\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t2733\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t24092\t1970-01-03T06:00:00.000000Z\n" +
+                        "VTJW\t-5716\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t-31322\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t-30103\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t-26777\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t24682\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t-26828\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t6667\t1970-01-03T09:00:00.000000Z\n" +
+                        "RXGZ\t-24648\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t-6439\t1970-01-03T09:00:00.000000Z\n",
+                "select b, first(a), k from x sample by 3h fill(linear)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_short() a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(172800000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(100)" +
+                        ") timestamp(k) partition by NONE",
+                "k",
+                "insert into x select * from (" +
+                        "select" +
+                        " rnd_short() a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(277200000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(35)" +
+                        ") timestamp(k)",
+                "b\tfirst\tk\n" +
+                        "\t-24357\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t-1593\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t21781\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t18457\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t-19127\t1970-01-03T00:00:00.000000Z\n" +
+                        "HYRX\t26142\t1970-01-03T00:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T00:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T00:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T00:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T00:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t29978\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t-18357\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t-2018\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t-15331\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t-10913\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t3172\t1970-01-03T03:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T03:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T03:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T03:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T03:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t-1605\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t2733\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t24092\t1970-01-03T06:00:00.000000Z\n" +
+                        "VTJW\t-5716\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t-31322\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t-30103\t1970-01-03T06:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T06:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T06:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T06:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T06:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t-26777\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t24682\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t-26828\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t6667\t1970-01-03T09:00:00.000000Z\n" +
+                        "RXGZ\t-24648\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t-6439\t1970-01-03T09:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T09:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T09:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T09:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T09:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t17459\t1970-01-03T12:00:00.000000Z\n" +
+                        "VTJW\t19050\t1970-01-03T12:00:00.000000Z\n" +
+                        "RXGZ\t-19193\t1970-01-03T12:00:00.000000Z\n" +
+                        "PEHN\t-22334\t1970-01-03T12:00:00.000000Z\n" +
+                        "CPSW\t13587\t1970-01-03T12:00:00.000000Z\n" +
+                        "HYRX\t28566\t1970-01-03T12:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T12:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T12:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T12:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T12:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T12:00:00.000000Z\n" +
+                        "\t10237\t1970-01-03T15:00:00.000000Z\n" +
+                        "VTJW\t31433\t1970-01-03T15:00:00.000000Z\n" +
+                        "RXGZ\t-13738\t1970-01-03T15:00:00.000000Z\n" +
+                        "PEHN\t-17840\t1970-01-03T15:00:00.000000Z\n" +
+                        "CPSW\t-11585\t1970-01-03T15:00:00.000000Z\n" +
+                        "HYRX\t-1965\t1970-01-03T15:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T15:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T15:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T15:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T15:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T15:00:00.000000Z\n" +
+                        "\t3014\t1970-01-03T18:00:00.000000Z\n" +
+                        "VTJW\t-21720\t1970-01-03T18:00:00.000000Z\n" +
+                        "RXGZ\t-8283\t1970-01-03T18:00:00.000000Z\n" +
+                        "PEHN\t-13346\t1970-01-03T18:00:00.000000Z\n" +
+                        "CPSW\t28779\t1970-01-03T18:00:00.000000Z\n" +
+                        "HYRX\t-32496\t1970-01-03T18:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T18:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T18:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T18:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T18:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T18:00:00.000000Z\n" +
+                        "\t-4208\t1970-01-03T21:00:00.000000Z\n" +
+                        "VTJW\t-9337\t1970-01-03T21:00:00.000000Z\n" +
+                        "RXGZ\t-2828\t1970-01-03T21:00:00.000000Z\n" +
+                        "PEHN\t-8852\t1970-01-03T21:00:00.000000Z\n" +
+                        "CPSW\t3607\t1970-01-03T21:00:00.000000Z\n" +
+                        "HYRX\t2509\t1970-01-03T21:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-03T21:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-03T21:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-03T21:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-03T21:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-03T21:00:00.000000Z\n" +
+                        "\t-11430\t1970-01-04T00:00:00.000000Z\n" +
+                        "VTJW\t3046\t1970-01-04T00:00:00.000000Z\n" +
+                        "RXGZ\t2627\t1970-01-04T00:00:00.000000Z\n" +
+                        "PEHN\t-4358\t1970-01-04T00:00:00.000000Z\n" +
+                        "CPSW\t-21565\t1970-01-04T00:00:00.000000Z\n" +
+                        "HYRX\t-28022\t1970-01-04T00:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-04T00:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-04T00:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-04T00:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-04T00:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-04T00:00:00.000000Z\n" +
+                        "\t-18653\t1970-01-04T03:00:00.000000Z\n" +
+                        "ZMZV\t31406\t1970-01-04T03:00:00.000000Z\n" +
+                        "VTJW\t15429\t1970-01-04T03:00:00.000000Z\n" +
+                        "RXGZ\t8082\t1970-01-04T03:00:00.000000Z\n" +
+                        "PEHN\t136\t1970-01-04T03:00:00.000000Z\n" +
+                        "CPSW\t18799\t1970-01-04T03:00:00.000000Z\n" +
+                        "HYRX\t6983\t1970-01-04T03:00:00.000000Z\n" +
+                        "QLDG\t0\t1970-01-04T03:00:00.000000Z\n" +
+                        "LOGI\t0\t1970-01-04T03:00:00.000000Z\n" +
+                        "QEBN\t0\t1970-01-04T03:00:00.000000Z\n" +
+                        "FOUS\t0\t1970-01-04T03:00:00.000000Z\n" +
+                        "QLDG\t28775\t1970-01-04T06:00:00.000000Z\n" +
+                        "LOGI\t25721\t1970-01-04T06:00:00.000000Z\n" +
+                        "QEBN\t-9244\t1970-01-04T06:00:00.000000Z\n" +
+                        "\t11356\t1970-01-04T06:00:00.000000Z\n" +
+                        "FOUS\t2503\t1970-01-04T06:00:00.000000Z\n" +
+                        "VTJW\t27812\t1970-01-04T06:00:00.000000Z\n" +
+                        "RXGZ\t13537\t1970-01-04T06:00:00.000000Z\n" +
+                        "PEHN\t4630\t1970-01-04T06:00:00.000000Z\n" +
+                        "CPSW\t-6373\t1970-01-04T06:00:00.000000Z\n" +
+                        "HYRX\t-23548\t1970-01-04T06:00:00.000000Z\n" +
+                        "ZMZV\t0\t1970-01-04T06:00:00.000000Z\n",
+                true,
+                true,
+                false
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstUuidGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstUuidGroupByFunctionFactoryTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Numbers;
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FirstUuidGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Lo(0));
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Hi(0));
+            }
+        }
+    }
+
+    @Test
+    public void testFirstNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            TableWriter.Row r = w.newRow();
+            r.append();
+            for (int i = 100; i > 10; i--) {
+                r = w.newRow();
+                r.putLong128(0, rnd.nextLong(), rnd.nextLong());
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Lo(0));
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Hi(0));
+            }
+        }
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putLong128(0, rnd.nextLong(), rnd.nextLong());
+                r.append();
+            }
+            w.commit();
+        }
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(4689592037643856L, record.getLong128Lo(0));
+                Assert.assertEquals(4729996258992366L, record.getLong128Hi(0));
+            }
+        }
+    }
+
+    @Test
+    public void testSomeNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                if (i % 4 == 0) {
+                    r.putLong128(0, i, i);
+                }
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select first(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(100, record.getLong128Lo(0));
+                Assert.assertEquals(100, record.getLong128Hi(0));
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastBooleanGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastBooleanGroupByFunctionFactoryTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class LastBooleanGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
-    public void testAllNull() throws SqlException {
+    public void testAllFalse() throws SqlException {
         ddl("create table tab (f boolean)");
 
         try (TableWriter w = getWriter("tab")) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastByteGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastByteGroupByFunctionFactoryTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class LastByteGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testLastByte() throws Exception {
+        assertQuery(
+                "a\n" +
+                        "3\n",
+                "select last(a) a from tab",
+                "create table tab as (select 1::byte a union select 2::byte a union select 3::byte a)",
+                null,
+                false,
+                true
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastCharGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastCharGroupByFunctionFactoryTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LastCharGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f char)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 10; i > 0; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals((char) 0, record.getChar(0));
+            }
+        }
+    }
+
+    @Test
+    public void testLastChar() throws Exception {
+        assertQuery(
+                "a\n" +
+                        "3\n",
+                "select last(a) a from tab",
+                "create table tab as (select '1' a union select '2' a union select '3' a)",
+                null,
+                false,
+                true
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastFloatGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastFloatGroupByFunctionFactoryTest.java
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LastFloatGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f float)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertTrue(Float.isNaN(record.getFloat(0)));
+            }
+        }
+    }
+
+    @Test
+    public void testLastFloat() throws Exception {
+        assertQuery(
+                "x\n" +
+                        "10.0000\n",
+                "select last(x) x from tab",
+                "create table tab as (select cast(x as float) x from long_sequence(10))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testLastFloatNull() throws Exception {
+        assertQuery(
+                "y\n" +
+                        "NaN\n",
+                "select last(y) y from tab",
+                "create table tab as (select cast(x as float) x, cast(null as float) y from long_sequence(100))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f float)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putFloat(0, rnd.nextFloat());
+                r.append();
+            }
+            w.commit();
+        }
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(0.4900510311126709, record.getFloat(0), 0.0001);
+            }
+        }
+    }
+
+    @Test
+    public void testSampleFill() throws Exception {
+        assertQuery(
+                "b\tlast\tk\n" +
+                        "HYRX\t0.9644\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t0.1250\t1970-01-03T00:00:00.000000Z\n" +
+                        "\t0.9703\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.2692\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t0.4150\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t0.8664\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.9918\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t0.8222\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t0.1053\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t0.8677\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t0.8231\t1970-01-03T03:00:00.000000Z\n" +
+                        "RXGZ\t0.7864\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t0.8721\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t0.7216\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t0.7365\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t0.8144\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t0.5691\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.7065\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.4835\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t0.7873\t1970-01-03T09:00:00.000000Z\n" +
+                        "CPSW\t0.1195\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t0.2535\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t0.0400\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t0.7524\t1970-01-03T09:00:00.000000Z\n",
+                "select b, last(a), k from x sample by 3h fill(linear)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_float(0) a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(172800000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(100)" +
+                        ") timestamp(k) partition by NONE",
+                "k",
+                "insert into x select * from (" +
+                        "select" +
+                        " rnd_float(0) a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " timestamp_sequence(277200000000, 360000000) k" +
+                        " from" +
+                        " long_sequence(35)" +
+                        ") timestamp(k)",
+                "b\tlast\tk\n" +
+                        "HYRX\t0.9644\t1970-01-03T00:00:00.000000Z\n" +
+                        "PEHN\t0.1250\t1970-01-03T00:00:00.000000Z\n" +
+                        "\t0.9703\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.2692\t1970-01-03T00:00:00.000000Z\n" +
+                        "CPSW\t0.4150\t1970-01-03T00:00:00.000000Z\n" +
+                        "RXGZ\t0.8664\t1970-01-03T00:00:00.000000Z\n" +
+                        "UQDY\t1.9459\t1970-01-03T00:00:00.000000Z\n" +
+                        "UKLG\t3.9211\t1970-01-03T00:00:00.000000Z\n" +
+                        "IMYF\t1.5957\t1970-01-03T00:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T00:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T00:00:00.000000Z\n" +
+                        "VTJW\t0.9918\t1970-01-03T03:00:00.000000Z\n" +
+                        "\t0.8222\t1970-01-03T03:00:00.000000Z\n" +
+                        "CPSW\t0.1053\t1970-01-03T03:00:00.000000Z\n" +
+                        "HYRX\t0.8677\t1970-01-03T03:00:00.000000Z\n" +
+                        "PEHN\t0.8231\t1970-01-03T03:00:00.000000Z\n" +
+                        "RXGZ\t0.7864\t1970-01-03T03:00:00.000000Z\n" +
+                        "UQDY\t1.8404\t1970-01-03T03:00:00.000000Z\n" +
+                        "UKLG\t3.5400\t1970-01-03T03:00:00.000000Z\n" +
+                        "IMYF\t1.4828\t1970-01-03T03:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T03:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T03:00:00.000000Z\n" +
+                        "VTJW\t0.8721\t1970-01-03T06:00:00.000000Z\n" +
+                        "\t0.7216\t1970-01-03T06:00:00.000000Z\n" +
+                        "CPSW\t0.7365\t1970-01-03T06:00:00.000000Z\n" +
+                        "PEHN\t0.8144\t1970-01-03T06:00:00.000000Z\n" +
+                        "HYRX\t0.5691\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.7065\t1970-01-03T06:00:00.000000Z\n" +
+                        "UQDY\t1.7350\t1970-01-03T06:00:00.000000Z\n" +
+                        "UKLG\t3.1589\t1970-01-03T06:00:00.000000Z\n" +
+                        "IMYF\t1.3699\t1970-01-03T06:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T06:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T06:00:00.000000Z\n" +
+                        "RXGZ\t0.4835\t1970-01-03T09:00:00.000000Z\n" +
+                        "\t0.7873\t1970-01-03T09:00:00.000000Z\n" +
+                        "CPSW\t0.1195\t1970-01-03T09:00:00.000000Z\n" +
+                        "PEHN\t0.2535\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t0.0400\t1970-01-03T09:00:00.000000Z\n" +
+                        "VTJW\t0.7524\t1970-01-03T09:00:00.000000Z\n" +
+                        "UQDY\t1.6295\t1970-01-03T09:00:00.000000Z\n" +
+                        "UKLG\t2.7779\t1970-01-03T09:00:00.000000Z\n" +
+                        "IMYF\t1.2570\t1970-01-03T09:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T09:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T09:00:00.000000Z\n" +
+                        "HYRX\t-0.4891\t1970-01-03T12:00:00.000000Z\n" +
+                        "PEHN\t-0.3074\t1970-01-03T12:00:00.000000Z\n" +
+                        "\t0.7816\t1970-01-03T12:00:00.000000Z\n" +
+                        "VTJW\t0.6327\t1970-01-03T12:00:00.000000Z\n" +
+                        "CPSW\t-0.4975\t1970-01-03T12:00:00.000000Z\n" +
+                        "RXGZ\t0.2606\t1970-01-03T12:00:00.000000Z\n" +
+                        "UQDY\t1.5240\t1970-01-03T12:00:00.000000Z\n" +
+                        "UKLG\t2.3968\t1970-01-03T12:00:00.000000Z\n" +
+                        "IMYF\t1.1441\t1970-01-03T12:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T12:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T12:00:00.000000Z\n" +
+                        "HYRX\t-1.0182\t1970-01-03T15:00:00.000000Z\n" +
+                        "PEHN\t-0.8682\t1970-01-03T15:00:00.000000Z\n" +
+                        "\t0.7759\t1970-01-03T15:00:00.000000Z\n" +
+                        "VTJW\t0.5130\t1970-01-03T15:00:00.000000Z\n" +
+                        "CPSW\t-1.1145\t1970-01-03T15:00:00.000000Z\n" +
+                        "RXGZ\t0.0376\t1970-01-03T15:00:00.000000Z\n" +
+                        "UQDY\t1.4185\t1970-01-03T15:00:00.000000Z\n" +
+                        "UKLG\t2.0158\t1970-01-03T15:00:00.000000Z\n" +
+                        "IMYF\t1.0312\t1970-01-03T15:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T15:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T15:00:00.000000Z\n" +
+                        "HYRX\t-1.5472\t1970-01-03T18:00:00.000000Z\n" +
+                        "PEHN\t-1.4291\t1970-01-03T18:00:00.000000Z\n" +
+                        "\t0.7702\t1970-01-03T18:00:00.000000Z\n" +
+                        "VTJW\t0.3933\t1970-01-03T18:00:00.000000Z\n" +
+                        "CPSW\t-1.7315\t1970-01-03T18:00:00.000000Z\n" +
+                        "RXGZ\t-0.1853\t1970-01-03T18:00:00.000000Z\n" +
+                        "UQDY\t1.3131\t1970-01-03T18:00:00.000000Z\n" +
+                        "UKLG\t1.6347\t1970-01-03T18:00:00.000000Z\n" +
+                        "IMYF\t0.9184\t1970-01-03T18:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T18:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T18:00:00.000000Z\n" +
+                        "HYRX\t-2.0763\t1970-01-03T21:00:00.000000Z\n" +
+                        "PEHN\t-1.9900\t1970-01-03T21:00:00.000000Z\n" +
+                        "\t0.7645\t1970-01-03T21:00:00.000000Z\n" +
+                        "VTJW\t0.2736\t1970-01-03T21:00:00.000000Z\n" +
+                        "CPSW\t-2.3485\t1970-01-03T21:00:00.000000Z\n" +
+                        "RXGZ\t-0.4083\t1970-01-03T21:00:00.000000Z\n" +
+                        "UQDY\t1.2076\t1970-01-03T21:00:00.000000Z\n" +
+                        "UKLG\t1.2537\t1970-01-03T21:00:00.000000Z\n" +
+                        "IMYF\t0.8055\t1970-01-03T21:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-03T21:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-03T21:00:00.000000Z\n" +
+                        "HYRX\t-2.6054\t1970-01-04T00:00:00.000000Z\n" +
+                        "PEHN\t-2.5509\t1970-01-04T00:00:00.000000Z\n" +
+                        "\t0.7588\t1970-01-04T00:00:00.000000Z\n" +
+                        "VTJW\t0.1538\t1970-01-04T00:00:00.000000Z\n" +
+                        "CPSW\t-2.9655\t1970-01-04T00:00:00.000000Z\n" +
+                        "RXGZ\t-0.6312\t1970-01-04T00:00:00.000000Z\n" +
+                        "UQDY\t1.1021\t1970-01-04T00:00:00.000000Z\n" +
+                        "UKLG\t0.8726\t1970-01-04T00:00:00.000000Z\n" +
+                        "IMYF\t0.6926\t1970-01-04T00:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-04T00:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-04T00:00:00.000000Z\n" +
+                        "UQDY\t0.9966\t1970-01-04T03:00:00.000000Z\n" +
+                        "\t0.7530\t1970-01-04T03:00:00.000000Z\n" +
+                        "UKLG\t0.4915\t1970-01-04T03:00:00.000000Z\n" +
+                        "IMYF\t0.5797\t1970-01-04T03:00:00.000000Z\n" +
+                        "HYRX\t-3.1345\t1970-01-04T03:00:00.000000Z\n" +
+                        "PEHN\t-3.1118\t1970-01-04T03:00:00.000000Z\n" +
+                        "VTJW\t0.0341\t1970-01-04T03:00:00.000000Z\n" +
+                        "CPSW\t-3.5825\t1970-01-04T03:00:00.000000Z\n" +
+                        "RXGZ\t-0.8542\t1970-01-04T03:00:00.000000Z\n" +
+                        "OPHN\tNaN\t1970-01-04T03:00:00.000000Z\n" +
+                        "MXSL\tNaN\t1970-01-04T03:00:00.000000Z\n" +
+                        "\t0.0140\t1970-01-04T06:00:00.000000Z\n" +
+                        "IMYF\t0.4668\t1970-01-04T06:00:00.000000Z\n" +
+                        "OPHN\t0.7203\t1970-01-04T06:00:00.000000Z\n" +
+                        "UKLG\t0.1105\t1970-01-04T06:00:00.000000Z\n" +
+                        "MXSL\t0.7943\t1970-01-04T06:00:00.000000Z\n" +
+                        "UQDY\t0.8912\t1970-01-04T06:00:00.000000Z\n" +
+                        "HYRX\t-3.6636\t1970-01-04T06:00:00.000000Z\n" +
+                        "PEHN\t-3.6727\t1970-01-04T06:00:00.000000Z\n" +
+                        "VTJW\t-0.0856\t1970-01-04T06:00:00.000000Z\n" +
+                        "CPSW\t-4.1995\t1970-01-04T06:00:00.000000Z\n" +
+                        "RXGZ\t-1.0771\t1970-01-04T06:00:00.000000Z\n",
+                true,
+                true,
+                false
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastIPv4GroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastIPv4GroupByFunctionFactoryTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Numbers;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LastIPv4GroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.IPv4_NULL, record.getIPv4(0));
+            }
+        }
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putInt(0, i);
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(11, record.getIPv4(0));
+            }
+        }
+    }
+
+    @Test
+    public void testSomeNull() throws SqlException {
+        ddl("create table tab (f ipv4)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                if (i % 4 == 0) {
+                    r.putInt(0, i);
+                }
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.IPv4_NULL, record.getIPv4(0));
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastUuidGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/LastUuidGroupByFunctionFactoryTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.std.Numbers;
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LastUuidGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Lo(0));
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Hi(0));
+            }
+        }
+    }
+
+    @Test
+    public void testNonNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        final Rnd rnd = new Rnd();
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                r.putLong128(0, rnd.nextLong(), rnd.nextLong());
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(7505077128008208443L, record.getLong128Lo(0));
+                Assert.assertEquals(6624299878707135910L, record.getLong128Hi(0));
+            }
+        }
+    }
+
+    @Test
+    public void testSomeNull() throws SqlException {
+        ddl("create table tab (f uuid)");
+
+        try (TableWriter w = getWriter("tab")) {
+            for (int i = 100; i > 10; i--) {
+                TableWriter.Row r = w.newRow();
+                if (i % 4 == 0) {
+                    r.putLong128(0, i, i);
+                }
+                r.append();
+            }
+            w.commit();
+        }
+
+        try (RecordCursorFactory factory = select("select last(f) from tab")) {
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Record record = cursor.getRecord();
+                Assert.assertEquals(1, cursor.size());
+                Assert.assertTrue(cursor.hasNext());
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Lo(0));
+                Assert.assertEquals(Numbers.LONG_NaN, record.getLong128Hi(0));
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionsUpdaterFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByFunctionsUpdaterFactoryTest.java
@@ -50,36 +50,45 @@ public class GroupByFunctionsUpdaterFactoryTest {
         functions.add(new TestGroupByFunction());
         GroupByFunctionsUpdater updater = GroupByFunctionsUpdaterFactory.getInstance(new BytecodeAssembler(), functions);
 
-        MapValue value = new SimpleMapValue(1);
+        MapValue value = new SimpleMapValue(2);
         Record record = new TestRecord();
 
-        updater.updateNew(value, record);
+        updater.updateNew(value, record, 42);
         Assert.assertEquals(1, value.getLong(0));
+        Assert.assertEquals(42, value.getLong(1));
 
-        updater.updateExisting(value, record);
+        updater.updateExisting(value, record, 43);
         Assert.assertEquals(1 + functions.size(), value.getLong(0));
+        Assert.assertEquals(43, value.getLong(1));
 
         updater.updateEmpty(value);
         Assert.assertEquals(-1, value.getLong(0));
+        Assert.assertEquals(-1, value.getLong(1));
 
-        MapValue destValue = new SimpleMapValue(1);
-        MapValue srcValue = new SimpleMapValue(1);
+        MapValue destValue = new SimpleMapValue(2);
+        destValue.putLong(0, 0);
+        destValue.putLong(1, 0);
+        MapValue srcValue = new SimpleMapValue(2);
         srcValue.putLong(0, 42);
+        srcValue.putLong(1, 1);
         updater.merge(destValue, srcValue);
         Assert.assertEquals(42, destValue.getLong(0));
+        Assert.assertEquals(0, destValue.getLong(1));
     }
 
     private static class TestGroupByFunction extends LongFunction implements GroupByFunction, UnaryFunction {
 
         @Override
-        public void computeFirst(MapValue mapValue, Record record) {
+        public void computeFirst(MapValue mapValue, Record record, long rowId) {
             mapValue.putLong(0, 1);
+            mapValue.putLong(1, rowId);
         }
 
         @Override
-        public void computeNext(MapValue mapValue, Record record) {
+        public void computeNext(MapValue mapValue, Record record, long rowId) {
             long value = mapValue.getLong(0);
             mapValue.putLong(0, value + 1);
+            mapValue.putLong(1, rowId);
         }
 
         @Override
@@ -106,6 +115,7 @@ public class GroupByFunctionsUpdaterFactoryTest {
         public void merge(MapValue destValue, MapValue srcValue) {
             long value = srcValue.getLong(0);
             destValue.putLong(0, value);
+            destValue.putLong(1, Math.min(srcValue.getLong(1), destValue.getLong(1)));
         }
 
         @Override
@@ -115,6 +125,7 @@ public class GroupByFunctionsUpdaterFactoryTest {
         @Override
         public void setNull(MapValue mapValue) {
             mapValue.putLong(0, -1);
+            mapValue.putLong(1, -1);
         }
 
         @Override


### PR DESCRIPTION
Ports all `first`/`last`/`first_not_null`/`last_not_null` SQL functions to parallel GROUP BY.

To achieve that, this patch adds `rowId` argument to `computeFirst()`/`computeNext()` methods of the `GroupByFunction` class. This argument contains growing non-negative numbers, so it's first/last parallel SQL functions. The `rowId` values are also different from `record.getRowId()` - that's because not all record classes implement that method and, for those that do, there is no growth guarantee.