### PR TITLE
fix(sql): fix altering table to add index can remove dedup key

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3275,13 +3275,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     denseSymbolMapWriters.add(symbolMapWriter);
                 }
                 if (metadata.isDedupKey(i)) {
-                    // Calculate non-timestamp dedup column count
                     dedupColCount++;
                 }
             }
         }
         if (isDeduplicationEnabled()) {
             dedupColumnCommitAddresses = new DedupColumnCommitAddresses();
+            // Set dedup column count, excluding designated timestamp
             dedupColumnCommitAddresses.setDedupColumnCount(dedupColCount - 1);
         }
         final int timestampIndex = metadata.getTimestampIndex();


### PR DESCRIPTION
Fixes a bug so that adding/removing an index on a symbol column removes the column from deduplication keys list.