### PR TITLE
perf(sql): avoid redundant parsing of UUID bind variables

### DIFF
--- a/core/src/main/java/io/questdb/cairo/RecordChain.java
+++ b/core/src/main/java/io/questdb/cairo/RecordChain.java
@@ -211,6 +211,11 @@ public class RecordChain implements Closeable, RecordCursor, Mutable, RecordSink
     }
 
     @Override
+    public void putIPv4(int value) {
+        putInt(value);
+    }
+
+    @Override
     public void putInt(int value) {
         mem.putInt(value);
     }
@@ -232,12 +237,12 @@ public class RecordChain implements Closeable, RecordCursor, Mutable, RecordSink
 
     @Override
     public void putLong256(long l0, long l1, long l2, long l3) {
-       mem.putLong256(l0, l1, l2, l3);
+        mem.putLong256(l0, l1, l2, l3);
     }
 
     @Override
     public void putRecord(Record value) {
-        // noop
+        // no-op
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/RecordSinkFactory.java
+++ b/core/src/main/java/io/questdb/cairo/RecordSinkFactory.java
@@ -124,8 +124,9 @@ public class RecordSinkFactory {
         final int fGetBin = asm.poolInterfaceMethod(Function.class, "getBin", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/std/BinarySequence;");
         final int fGetRecord = asm.poolInterfaceMethod(Function.class, "getRecord", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/cairo/sql/Record;");
 
-        final int wPutInt = asm.poolInterfaceMethod(RecordSinkSPI.class, "putInt", "(I)V");
         final int wSkip = asm.poolInterfaceMethod(RecordSinkSPI.class, "skip", "(I)V");
+        final int wPutInt = asm.poolInterfaceMethod(RecordSinkSPI.class, "putInt", "(I)V");
+        final int wPutIPv4 = asm.poolInterfaceMethod(RecordSinkSPI.class, "putIPv4", "(I)V");
         final int wPutLong = asm.poolInterfaceMethod(RecordSinkSPI.class, "putLong", "(J)V");
         final int wPutLong256 = asm.poolInterfaceMethod(RecordSinkSPI.class, "putLong256", "(Lio/questdb/std/Long256;)V");
         final int wPutLong128 = asm.poolInterfaceMethod(RecordSinkSPI.class, "putLong128", "(JJ)V");
@@ -208,7 +209,7 @@ public class RecordSinkFactory {
                     asm.aload(1);
                     asm.iconst(getSkewedIndex(index, skewIndex));
                     asm.invokeInterface(rGetIPv4, 1);
-                    asm.invokeInterface(wPutInt, 1);
+                    asm.invokeInterface(wPutIPv4, 1);
                     break;
                 case ColumnType.SYMBOL:
                     asm.aload(2);
@@ -392,7 +393,7 @@ public class RecordSinkFactory {
                     asm.getfield(firstFieldIndex + (i * FIELD_POOL_OFFSET));
                     asm.aload(1);
                     asm.invokeInterface(fGetIPv4, 1);
-                    asm.invokeInterface(wPutInt, 1);
+                    asm.invokeInterface(wPutIPv4, 1);
                     break;
                 case ColumnType.SYMBOL:
                     asm.aload(2);

--- a/core/src/main/java/io/questdb/cairo/RecordSinkSPI.java
+++ b/core/src/main/java/io/questdb/cairo/RecordSinkSPI.java
@@ -29,6 +29,7 @@ import io.questdb.std.BinarySequence;
 import io.questdb.std.Long256;
 
 public interface RecordSinkSPI {
+
     void putBin(BinarySequence value);
 
     void putBool(boolean value);
@@ -42,6 +43,8 @@ public interface RecordSinkSPI {
     void putDouble(double value);
 
     void putFloat(float value);
+
+    void putIPv4(int value);
 
     void putInt(int value);
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -8017,6 +8017,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         void putGeoStr(int columnIndex, CharSequence value);
 
+        void putIPv4(int columnIndex, int value);
+
         void putInt(int columnIndex, int value);
 
         void putLong(int columnIndex, long value);
@@ -8134,6 +8136,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         @Override
         public void putGeoStr(int columnIndex, CharSequence value) {
+            // no-op
+        }
+
+        @Override
+        public void putIPv4(int columnIndex, int value) {
             // no-op
         }
 
@@ -8312,6 +8319,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         public void putGeoStr(int columnIndex, CharSequence hash) {
             final int type = metadata.getColumnType(columnIndex);
             WriterRowUtils.putGeoStr(columnIndex, hash, type, this);
+        }
+
+        @Override
+        public void putIPv4(int columnIndex, int value) {
+            putInt(columnIndex, value);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
@@ -653,6 +653,11 @@ public class OrderedMap implements Map, Reopenable {
         }
 
         @Override
+        public void putIPv4(int value) {
+            putInt(value);
+        }
+
+        @Override
         public void putInt(int value) {
             Unsafe.getUnsafe().putInt(appendAddress, value);
             appendAddress += 4L;
@@ -905,6 +910,11 @@ public class OrderedMap implements Map, Reopenable {
             checkCapacity(4L);
             Unsafe.getUnsafe().putFloat(appendAddress, value);
             appendAddress += 4L;
+        }
+
+        @Override
+        public void putIPv4(int value) {
+            putInt(value);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
@@ -577,6 +577,11 @@ public class Unordered16Map implements Map, Reopenable {
         }
 
         @Override
+        public void putIPv4(int value) {
+            putInt(value);
+        }
+
+        @Override
         public void putInt(int value) {
             Unsafe.getUnsafe().putInt(appendAddress, value);
             appendAddress += 4L;

--- a/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
@@ -384,6 +384,11 @@ public class Unordered2Map implements Map, Reopenable {
         }
 
         @Override
+        public void putIPv4(int value) {
+            putInt(value);
+        }
+
+        @Override
         public void putInt(int value) {
             throw new UnsupportedOperationException();
         }

--- a/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
@@ -561,6 +561,11 @@ public class Unordered4Map implements Map, Reopenable {
         }
 
         @Override
+        public void putIPv4(int value) {
+            putInt(value);
+        }
+
+        @Override
         public void putInt(int value) {
             Unsafe.getUnsafe().putInt(appendAddress, value);
             appendAddress += 4L;

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -562,6 +562,11 @@ public class Unordered8Map implements Map, Reopenable {
         }
 
         @Override
+        public void putIPv4(int value) {
+            putInt(value);
+        }
+
+        @Override
         public void putInt(int value) {
             Unsafe.getUnsafe().putInt(appendAddress, value);
             appendAddress += 4L;

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1093,6 +1093,10 @@ public class WalWriter implements TableWriterAPI {
         return metadata.getMetadataVersion();
     }
 
+    private long getDataAppendPageSize() {
+        return tableToken.isSystem() ? configuration.getSystemWalDataAppendPageSize() : configuration.getWalDataAppendPageSize();
+    }
+
     private MemoryMA getPrimaryColumn(int column) {
         assert column < columnCount : "Column index is out of bounds: " + column + " >= " + columnCount;
         return columns.getQuick(getPrimaryColumnIndex(column));
@@ -1164,10 +1168,6 @@ public class WalWriter implements TableWriterAPI {
             throw CairoException.critical(ff.errno()).put("Cannot create WAL directory: ").put(path);
         }
         path.trimTo(walDirLength);
-    }
-
-    private long getDataAppendPageSize() {
-        return tableToken.isSystem() ? configuration.getSystemWalDataAppendPageSize() : configuration.getWalDataAppendPageSize();
     }
 
     private void openColumnFiles(CharSequence name, int columnIndex, int pathTrimToLen) {
@@ -1940,6 +1940,11 @@ public class WalWriter implements TableWriterAPI {
         public void putGeoStr(int columnIndex, CharSequence hash) {
             final int type = metadata.getColumnType(columnIndex);
             WriterRowUtils.putGeoStr(columnIndex, hash, type, this);
+        }
+
+        @Override
+        public void putIPv4(int columnIndex, int value) {
+            putInt(columnIndex, value);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserSupport.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserSupport.java
@@ -141,7 +141,7 @@ public class LineUdpParserSupport {
                         row.putInt(columnIndex, Numbers.parseInt(value, 0, value.length() - 1));
                         break;
                     case ColumnType.IPv4:
-                        row.putInt(columnIndex, Numbers.parseIPv4UDP(value));
+                        row.putIPv4(columnIndex, Numbers.parseIPv4UDP(value));
                         break;
                     case ColumnType.SHORT:
                         row.putShort(columnIndex, Numbers.parseShort(value, 0, value.length() - 1));
@@ -264,7 +264,7 @@ public class LineUdpParserSupport {
                 row.putInt(columnIndex, Numbers.INT_NaN);
                 break;
             case ColumnType.IPv4:
-                row.putInt(columnIndex, Numbers.IPv4_NULL);
+                row.putIPv4(columnIndex, Numbers.IPv4_NULL);
             case ColumnType.SHORT:
                 row.putShort(columnIndex, (short) 0);
                 break;

--- a/core/src/main/java/io/questdb/cutlass/text/types/IPv4Adapter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/types/IPv4Adapter.java
@@ -63,7 +63,7 @@ public final class IPv4Adapter extends AbstractTypeAdapter {
 
     @Override
     public void write(TableWriter.Row row, int column, DirectUtf8Sequence value) throws Exception {
-        row.putInt(column, SqlKeywords.isNullKeyword(value) ? Numbers.IPv4_NULL : parseIPv4(value));
+        row.putIPv4(column, SqlKeywords.isNullKeyword(value) ? Numbers.IPv4_NULL : parseIPv4(value));
     }
 
     private int parseIPv4(DirectUtf8Sequence value) throws NumericException {

--- a/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/JsonPlanSink.java
@@ -252,6 +252,18 @@ public class JsonPlanSink extends BasePlanSink {
     }
 
     @Override
+    public PlanSink valIPv4(int ip) {
+        quoteValue = true;
+        checkType(NODE_VALUE);
+        if (ip == Numbers.IPv4_NULL) {
+            sink.put("null");
+        } else {
+            Numbers.intToIPv4Sink(sink, ip);
+        }
+        return this;
+    }
+
+    @Override
     public PlanSink valUuid(long lo, long hi) {
         quoteValue = true;
         checkType(NODE_VALUE);

--- a/core/src/main/java/io/questdb/griffin/PlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/PlanSink.java
@@ -114,6 +114,8 @@ public interface PlanSink {
 
     PlanSink val(long hash, int geoHashBits);
 
+    PlanSink valIPv4(int ip);
+
     PlanSink valISODate(long l);
 
     PlanSink valUuid(long lo, long hi);

--- a/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
+++ b/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
@@ -57,8 +57,8 @@ public class RecordToRowCopierUtils {
         // C                char        Unicode character code point in the Basic Multilingual Plane, encoded with UTF-16
         // D                double      double-precision floating-point value
         // F                float       single-precision floating-point value
-        // I                int         integer
-        // J                long        long integer
+        // I                int         32-bit integer
+        // J                long        64-bit integer
         // L ClassName ;    reference   an instance of class ClassName
         // S                short       signed short
         // Z                boolean     true or false
@@ -89,6 +89,7 @@ public class RecordToRowCopierUtils {
         int rGetBin = asm.poolInterfaceMethod(Record.class, "getBin", "(I)Lio/questdb/std/BinarySequence;");
         //
         int wPutInt = asm.poolInterfaceMethod(TableWriter.Row.class, "putInt", "(II)V");
+        int wPutIPv4 = asm.poolInterfaceMethod(TableWriter.Row.class, "putIPv4", "(II)V");
         int wPutLong = asm.poolInterfaceMethod(TableWriter.Row.class, "putLong", "(IJ)V");
         int wPutLong256 = asm.poolInterfaceMethod(TableWriter.Row.class, "putLong256", "(ILio/questdb/std/Long256;)V");
         int wPutLong128 = asm.poolInterfaceMethod(TableWriter.Row.class, "putLong128", "(IJJ)V");
@@ -237,7 +238,7 @@ public class RecordToRowCopierUtils {
                 case ColumnType.IPv4:
                     assert toColumnTypeTag == ColumnType.IPv4;
                     asm.invokeInterface(rGetIPv4);
-                    asm.invokeInterface(wPutInt, 2);
+                    asm.invokeInterface(wPutIPv4, 2);
                     break;
                 case ColumnType.LONG:
                     asm.invokeInterface(rGetLong);
@@ -617,7 +618,7 @@ public class RecordToRowCopierUtils {
                             break;
                         case ColumnType.IPv4:
                             asm.invokeStatic(implicitCastStrAsIPv4);
-                            asm.invokeInterface(wPutInt, 2);
+                            asm.invokeInterface(wPutIPv4, 2);
                             break;
                         case ColumnType.LONG:
                             asm.invokeStatic(implicitCastStrAsLong);

--- a/core/src/main/java/io/questdb/griffin/TextPlanSink.java
+++ b/core/src/main/java/io/questdb/griffin/TextPlanSink.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.std.IntList;
 import io.questdb.std.Numbers;
+import io.questdb.std.Uuid;
 import io.questdb.std.str.Sinkable;
 
 /**
@@ -113,7 +114,7 @@ public class TextPlanSink extends BasePlanSink {
             this.childIndent = "&nbsp;&nbsp;&nbsp;&nbsp;";
             this.attrIndent = "&nbsp;&nbsp;";
             this.sink = htmlSink;
-        } else {//pg wire
+        } else { // pg wire
             this.childIndent = "    ";
             this.attrIndent = "  ";
             this.sink = textSink;
@@ -192,8 +193,22 @@ public class TextPlanSink extends BasePlanSink {
         return this;
     }
 
+    @Override
+    public PlanSink valIPv4(int ip) {
+        if (ip == Numbers.IPv4_NULL) {
+            sink.put("null");
+        } else {
+            Numbers.intToIPv4Sink(sink, ip);
+        }
+        return this;
+    }
+
     public PlanSink valUuid(long lo, long hi) {
-        Numbers.appendUuid(lo, hi, sink);
+        if (Uuid.isNull(lo, hi)) {
+            sink.put("null");
+        } else {
+            Numbers.appendUuid(lo, hi, sink);
+        }
         return this;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/NegatingFunctionFactory.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.engine.functions.constants.BooleanConstant;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.griffin.FunctionFactoryDescriptor.replaceSignatureName;
 
@@ -43,6 +44,11 @@ public class NegatingFunctionFactory implements FunctionFactory {
     public NegatingFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
         this.signature = replaceSignatureName(name, delegate.getSignature());
         this.delegate = delegate;
+    }
+
+    @TestOnly
+    public FunctionFactory getDelegate() {
+        return delegate;
     }
 
     @Override
@@ -60,9 +66,9 @@ public class NegatingFunctionFactory implements FunctionFactory {
     ) throws SqlException {
         Function function = delegate.newInstance(position, args, argPositions, configuration, sqlExecutionContext);
         if (function instanceof NegatableBooleanFunction) {
-            NegatableBooleanFunction negateableFunction = (NegatableBooleanFunction) function;
-            negateableFunction.setNegated();
-            return negateableFunction;
+            NegatableBooleanFunction negatableFunction = (NegatableBooleanFunction) function;
+            negatableFunction.setNegated();
+            return negatableFunction;
         }
         if (function instanceof BooleanConstant) {
             return BooleanConstant.of(!function.getBool(null));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/SwappingArgsFunctionFactory.java
@@ -32,6 +32,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.griffin.FunctionFactoryDescriptor.replaceSignatureNameAndSwapArgs;
 
@@ -42,6 +43,11 @@ public class SwappingArgsFunctionFactory implements FunctionFactory {
     public SwappingArgsFunctionFactory(String name, FunctionFactory delegate) throws SqlException {
         this.signature = replaceSignatureNameAndSwapArgs(name, delegate.getSignature());
         this.delegate = delegate;
+    }
+
+    @TestOnly
+    public FunctionFactory getDelegate() {
+        return delegate;
     }
 
     @Override
@@ -57,9 +63,12 @@ public class SwappingArgsFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-        Function tmp = args.getQuick(0);
+        Function tmpArg = args.getQuick(0);
         args.setQuick(0, args.getQuick(1));
-        args.setQuick(1, tmp);
+        args.setQuick(1, tmpArg);
+        int tmpPosition = argPositions.getQuick(0);
+        argPositions.setQuick(0, argPositions.getQuick(1));
+        argPositions.setQuick(1, tmpPosition);
         return delegate.newInstance(position, args, argPositions, configuration, sqlExecutionContext);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/NamedParameterLinkFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/NamedParameterLinkFunction.java
@@ -114,7 +114,7 @@ public class NamedParameterLinkFunction implements ScalarFunction {
 
     @Override
     public final int getIPv4(Record rec) {
-        throw new UnsupportedOperationException();
+        return getBase().getIPv4(rec);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InStrFunctionFactory.java
@@ -68,7 +68,7 @@ public class InStrFunctionFactory implements FunctionFactory {
                 case ColumnType.NULL:
                 case ColumnType.STRING:
                 case ColumnType.SYMBOL:
-                    if (func.isRuntimeConstant()) {//bind variables
+                    if (func.isRuntimeConstant()) { // bind variables
                         if (deferredValues == null) {
                             deferredValues = new ObjList<>();
                         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIPv4FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIPv4FunctionFactory.java
@@ -58,28 +58,22 @@ public class EqIPv4FunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-
         final Function a = args.getQuick(0);
         final Function b = args.getQuick(1);
-
-
         if (!a.isConstant() && b.isConstant()) {
             return createHalfConstantFunc(b, a);
         } else if (a.isConstant() && !b.isConstant()) {
             return createHalfConstantFunc(a, b);
         }
-
-        return new EqIPv4FunctionFactory.Func(a, b);
+        return new Func(a, b);
     }
 
-    static Function createHalfConstantFunc(Function constFunc, Function varFunc) {
+    private static Function createHalfConstantFunc(Function constFunc, Function varFunc) {
         int constValue = constFunc.getIPv4(null);
-
         if (constValue == IPv4_NULL) {
-            return new EqIPv4FunctionFactory.NullCheckFunc(varFunc);
+            return new NullCheckFunc(varFunc);
         }
-
-        return new EqIPv4FunctionFactory.ConstCheckFunc(varFunc, constValue);
+        return new ConstCheckFunc(varFunc, constValue);
     }
 
     private static class ConstCheckFunc extends NegatableBooleanFunction implements UnaryFunction {
@@ -111,7 +105,7 @@ public class EqIPv4FunctionFactory implements FunctionFactory {
         }
     }
 
-    static class Func extends AbstractEqBinaryFunction {
+    private static class Func extends AbstractEqBinaryFunction {
         public Func(Function left, Function right) {
             super(left, right);
         }
@@ -131,7 +125,7 @@ public class EqIPv4FunctionFactory implements FunctionFactory {
         }
     }
 
-    public static class NullCheckFunc extends NegatableBooleanFunction implements UnaryFunction {
+    private static class NullCheckFunc extends NegatableBooleanFunction implements UnaryFunction {
         private final Function arg;
 
         public NullCheckFunc(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIPv4StrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqIPv4StrFunctionFactory.java
@@ -35,7 +35,7 @@ import io.questdb.std.ObjList;
 public class EqIPv4StrFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "=(Xs)";
+        return "=(XS)";
     }
 
     @Override
@@ -51,9 +51,9 @@ public class EqIPv4StrFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-        final Function a = args.getQuick(0);
-        final Function b = args.getQuick(1);
-
-        return EqIPv4FunctionFactory.createHalfConstantFunc(b, a);
+        Function ipv4Func = args.getQuick(0);
+        int strFuncPosition = argPositions.getQuick(1);
+        Function strFunc = args.getQuick(1);
+        return IPv4EqUtils.eqStrIPv4(strFuncPosition, strFunc, ipv4Func);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrIPv4FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrIPv4FunctionFactory.java
@@ -32,10 +32,10 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
-public final class EqUuidStrFunctionFactory implements FunctionFactory {
+public class EqStrIPv4FunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "=(ZS)";
+        return "=(SX)";
     }
 
     @Override
@@ -51,8 +51,9 @@ public final class EqUuidStrFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-        Function uuidFunc = args.getQuick(0);
-        Function strFunc = args.getQuick(1);
-        return UuidEqUtils.eqStrUuid(strFunc, uuidFunc);
+        int strFuncPosition = argPositions.getQuick(0);
+        Function strFunc = args.getQuick(0);
+        Function ipv4Func = args.getQuick(1);
+        return IPv4EqUtils.eqStrIPv4(strFuncPosition, strFunc, ipv4Func);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrUuidFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqStrUuidFunctionFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions.eq;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
@@ -43,9 +44,15 @@ public final class EqStrUuidFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
-        Function strFun = args.getQuick(0);
-        Function uuidFun = args.getQuick(1);
-        return UuidEqUtils.eqStrUuid(strFun, uuidFun);
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        Function strFunc = args.getQuick(0);
+        Function uuidFunc = args.getQuick(1);
+        return UuidEqUtils.eqStrUuid(strFunc, uuidFunc);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/UuidEqUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/UuidEqUtils.java
@@ -26,7 +26,10 @@ package io.questdb.griffin.engine.functions.eq;
 
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
@@ -35,7 +38,7 @@ import io.questdb.griffin.engine.functions.constants.BooleanConstant;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
 import io.questdb.std.Uuid;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Specialized functions for comparing UUIDs with Strings.
@@ -52,10 +55,9 @@ final class UuidEqUtils {
     private UuidEqUtils() {
     }
 
-    @Nullable
-    static BooleanFunction eqStrUuid(Function strFun, Function uuidFun) {
-        if (strFun.isConstant()) {
-            CharSequence uuidStr = strFun.getStr(null);
+    static @NotNull BooleanFunction eqStrUuid(Function strFunc, Function uuidFunc) {
+        if (strFunc.isConstant()) {
+            CharSequence uuidStr = strFunc.getStr(null);
             long lo;
             long hi;
             if (uuidStr == null) {
@@ -71,53 +73,47 @@ final class UuidEqUtils {
                     return BooleanConstant.FALSE;
                 }
             }
-            if (uuidFun.isConstant()) {
-                return BooleanConstant.of(hi == uuidFun.getLong128Hi(null) && lo == uuidFun.getLong128Hi(null));
-            } else {
-                return new ConstStrFun(lo, hi, uuidFun);
+            return new ConstStrFunc(lo, hi, uuidFunc);
+        } else if (strFunc.isRuntimeConstant()) {
+            return new RuntimeConstStrFunc(strFunc, uuidFunc);
+        } else if (uuidFunc.isConstant()) {
+            long lo = uuidFunc.getLong128Lo(null);
+            long hi = uuidFunc.getLong128Hi(null);
+            if (Uuid.isNull(lo, hi)) {
+                return new EqStrFunctionFactory.NullCheckFunc(strFunc);
             }
-        } else {
-            if (uuidFun.isConstant()) {
-                long lo = uuidFun.getLong128Lo(null);
-                long hi = uuidFun.getLong128Hi(null);
-                if (Uuid.isNull(lo, hi)) {
-                    return new EqStrFunctionFactory.NullCheckFunc(strFun);
-                } else {
-                    return new ConstUuidFun(lo, hi, strFun);
-                }
-            } else {
-                return new Fun(strFun, uuidFun);
-            }
+            return new ConstUuidFunc(lo, hi, strFunc);
         }
+        return new Func(strFunc, uuidFunc);
     }
 
     /**
      * The string function is constant and the UUID function is not constant.
      */
-    private static class ConstStrFun extends NegatableBooleanFunction implements UnaryFunction {
+    private static class ConstStrFunc extends NegatableBooleanFunction implements UnaryFunction {
         private final long constStrHi;
         private final long constStrLo;
-        private final Function fun;
+        private final Function uuidFunc;
 
-        private ConstStrFun(long constStrLo, long constStrHi, Function fun) {
+        private ConstStrFunc(long constStrLo, long constStrHi, Function uuidFunc) {
             this.constStrLo = constStrLo;
             this.constStrHi = constStrHi;
-            this.fun = fun;
+            this.uuidFunc = uuidFunc;
         }
 
         @Override
         public Function getArg() {
-            return fun;
+            return uuidFunc;
         }
 
         @Override
         public boolean getBool(Record rec) {
-            return negated != (constStrHi == fun.getLong128Hi(rec) && constStrLo == fun.getLong128Lo(rec));
+            return negated != (constStrHi == uuidFunc.getLong128Hi(rec) && constStrLo == uuidFunc.getLong128Lo(rec));
         }
 
         @Override
         public void toPlan(PlanSink sink) {
-            sink.val(fun);
+            sink.val(uuidFunc);
             if (negated) {
                 sink.val('!');
             }
@@ -128,12 +124,12 @@ final class UuidEqUtils {
     /**
      * The UUID function is constant and the string function is not constant.
      */
-    private static class ConstUuidFun extends NegatableBooleanFunction implements UnaryFunction {
+    private static class ConstUuidFunc extends NegatableBooleanFunction implements UnaryFunction {
         private final long constUuidHi;
         private final long constUuidLo;
         private final Function fun;
 
-        private ConstUuidFun(long constUuidLo, long constUuidHi, Function fun) {
+        private ConstUuidFunc(long constUuidLo, long constUuidHi, Function fun) {
             this.constUuidLo = constUuidLo;
             this.constUuidHi = constUuidHi;
             this.fun = fun;
@@ -171,9 +167,10 @@ final class UuidEqUtils {
     /**
      * The string function is not constant and the UUID function is not constant either.
      */
-    private static class Fun extends AbstractEqBinaryFunction implements BinaryFunction {
-        private Fun(Function strFunction, Function uuidFunction) {
-            super(strFunction, uuidFunction);
+    private static class Func extends AbstractEqBinaryFunction implements BinaryFunction {
+
+        private Func(Function strFunc, Function uuidFunc) {
+            super(strFunc, uuidFunc);
         }
 
         @Override
@@ -190,6 +187,70 @@ final class UuidEqUtils {
             } catch (NumericException e) {
                 return negated;
             }
+        }
+    }
+
+    /**
+     * The string function is runtime constant and the UUID function is not constant.
+     */
+    private static class RuntimeConstStrFunc extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function strFunc;
+        private final Function uuidFunc;
+        private long constStrHi;
+        private long constStrLo;
+        private boolean validUuidStr;
+
+        private RuntimeConstStrFunc(Function strFunc, Function uuidFunc) {
+            this.strFunc = strFunc;
+            this.uuidFunc = uuidFunc;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            if (!validUuidStr) {
+                // ok, so the constant string is not a UUID format -> it cannot be equal to any UUID
+                return negated;
+            }
+            return negated != (constStrHi == uuidFunc.getLong128Hi(rec) && constStrLo == uuidFunc.getLong128Lo(rec));
+        }
+
+        @Override
+        public Function getLeft() {
+            return uuidFunc;
+        }
+
+        @Override
+        public Function getRight() {
+            return strFunc;
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            BinaryFunction.super.init(symbolTableSource, executionContext);
+
+            validUuidStr = true;
+            CharSequence uuidStr = strFunc.getStr(null);
+            if (uuidStr == null) {
+                constStrLo = Numbers.LONG_NaN;
+                constStrHi = Numbers.LONG_NaN;
+            } else {
+                try {
+                    Uuid.checkDashesAndLength(uuidStr);
+                    constStrLo = Uuid.parseLo(uuidStr);
+                    constStrHi = Uuid.parseHi(uuidStr);
+                } catch (NumericException e) {
+                    validUuidStr = false;
+                }
+            }
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(uuidFunc);
+            if (negated) {
+                sink.val('!');
+            }
+            sink.val("='").val(strFunc).val('\'');
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4FunctionFactory.java
@@ -55,23 +55,23 @@ public class LtIPv4FunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new LtIPv4FunctionFactory.LtIPv4Function(args.getQuick(0), args.getQuick(1));
+        return new Func(args.getQuick(0), args.getQuick(1));
     }
 
-    static class LtIPv4Function extends NegatableBooleanFunction implements BinaryFunction {
-        private final Function left;
-        private final Function right;
+    private static class Func extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function leftFunc;
+        private final Function rightFunc;
 
-        public LtIPv4Function(Function left, Function right) {
-            this.left = left;
-            this.right = right;
+        public Func(Function leftFunc, Function rightFunc) {
+            this.leftFunc = leftFunc;
+            this.rightFunc = rightFunc;
         }
 
         @Override
         public boolean getBool(Record rec) {
-            long left = Numbers.ipv4ToLong(this.left.getIPv4(rec));
+            long left = Numbers.ipv4ToLong(leftFunc.getIPv4(rec));
             if (left != Numbers.IPv4_NULL) {
-                long right = Numbers.ipv4ToLong(this.right.getIPv4(rec));
+                long right = Numbers.ipv4ToLong(rightFunc.getIPv4(rec));
                 if (right != Numbers.IPv4_NULL) {
                     return negated == (left >= right);
                 }
@@ -81,23 +81,23 @@ public class LtIPv4FunctionFactory implements FunctionFactory {
 
         @Override
         public Function getLeft() {
-            return left;
+            return leftFunc;
         }
 
         @Override
         public Function getRight() {
-            return right;
+            return rightFunc;
         }
 
         @Override
         public void toPlan(PlanSink sink) {
-            sink.val(left);
+            sink.val(leftFunc);
             if (negated) {
                 sink.val(">=");
             } else {
                 sink.val('<');
             }
-            sink.val(right);
+            sink.val(rightFunc);
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4StrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/lt/LtIPv4StrFunctionFactory.java
@@ -26,16 +26,24 @@ package io.questdb.griffin.engine.functions.lt;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class LtIPv4StrFunctionFactory implements FunctionFactory {
 
     @Override
     public String getSignature() {
-        return "<(Xs)";
+        return "<(XS)";
     }
 
     @Override
@@ -50,7 +58,102 @@ public class LtIPv4StrFunctionFactory implements FunctionFactory {
             IntList argPositions,
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
-    ) {
-        return new LtIPv4FunctionFactory.LtIPv4Function(args.getQuick(0), args.getQuick(1));
+    ) throws SqlException {
+        final Function ipv4Func = args.getQuick(0);
+        final int strFuncPosition = argPositions.getQuick(1);
+        final Function strFunc = args.getQuick(1);
+        if (strFunc.isConstant()) {
+            int ipv4 = strFunc.getIPv4(null);
+            return new ConstStrFunc(ipv4Func, ipv4);
+        } else if (strFunc.isRuntimeConstant()) {
+            return new RuntimeConstStrFunc(ipv4Func, strFunc);
+        }
+        throw SqlException.$(strFuncPosition, "STRING constant expected");
+    }
+
+    private static class ConstStrFunc extends NegatableBooleanFunction implements UnaryFunction {
+        private final Function arg;
+        private final int constIPv4;
+
+        public ConstStrFunc(Function arg, int constIPv4) {
+            this.arg = arg;
+            this.constIPv4 = constIPv4;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            if (constIPv4 != Numbers.IPv4_NULL) {
+                int ipv4 = arg.getIPv4(rec);
+                if (ipv4 != Numbers.IPv4_NULL) {
+                    return negated == (Numbers.ipv4ToLong(ipv4) >= Numbers.ipv4ToLong(constIPv4));
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(arg);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val('<');
+            }
+            sink.valIPv4(constIPv4);
+        }
+    }
+
+    private static class RuntimeConstStrFunc extends NegatableBooleanFunction implements BinaryFunction {
+        private final Function ipv4Func;
+        private final Function strFunc;
+        private int constIPv4;
+
+        public RuntimeConstStrFunc(Function ipv4Func, Function strFunc) {
+            this.ipv4Func = ipv4Func;
+            this.strFunc = strFunc;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            if (constIPv4 != Numbers.IPv4_NULL) {
+                int ipv4 = ipv4Func.getIPv4(rec);
+                if (ipv4 != Numbers.IPv4_NULL) {
+                    return negated == (Numbers.ipv4ToLong(ipv4) >= Numbers.ipv4ToLong(constIPv4));
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Function getLeft() {
+            return ipv4Func;
+        }
+
+        @Override
+        public Function getRight() {
+            return strFunc;
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            BinaryFunction.super.init(symbolTableSource, executionContext);
+            constIPv4 = strFunc.getIPv4(null);
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(ipv4Func);
+            if (negated) {
+                sink.val(">=");
+            } else {
+                sink.val('<');
+            }
+            sink.val(strFunc);
+        }
     }
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -145,6 +145,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.eq.EqIntFunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqIPv4FunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqIPv4StrFunctionFactory,
+            io.questdb.griffin.engine.functions.eq.EqStrIPv4FunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqLongFunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqLong128FunctionFactory,
             io.questdb.griffin.engine.functions.eq.EqDoubleFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -51,6 +51,7 @@ io.questdb.griffin.engine.functions.eq.EqShortFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqIntFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqIPv4FunctionFactory
 io.questdb.griffin.engine.functions.eq.EqIPv4StrFunctionFactory
+io.questdb.griffin.engine.functions.eq.EqStrIPv4FunctionFactory
 io.questdb.griffin.engine.functions.eq.EqLongFunctionFactory
 io.questdb.griffin.engine.functions.eq.EqLong128FunctionFactory
 io.questdb.griffin.engine.functions.eq.EqDoubleFunctionFactory

--- a/core/src/test/java/io/questdb/test/cairo/RecordSinkFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RecordSinkFactoryTest.java
@@ -230,6 +230,8 @@ public class RecordSinkFactoryTest extends AbstractCairoTest {
                 }
                 break;
             case ColumnType.IPv4:
+                expectedPutTypes.add(ColumnType.IPv4);
+                break;
             case ColumnType.GEOINT:
                 expectedPutTypes.add(ColumnType.INT);
                 break;
@@ -698,6 +700,11 @@ public class RecordSinkFactoryTest extends AbstractCairoTest {
         @Override
         public void putFloat(float value) {
             recordedTypes.add(ColumnType.FLOAT);
+        }
+
+        @Override
+        public void putIPv4(int value) {
+            recordedTypes.add(ColumnType.IPv4);
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -33,6 +33,8 @@ import io.questdb.griffin.*;
 import io.questdb.griffin.engine.EmptyTableRecordCursorFactory;
 import io.questdb.griffin.engine.functions.CursorFunction;
 import io.questdb.griffin.engine.functions.NegatableBooleanFunction;
+import io.questdb.griffin.engine.functions.NegatingFunctionFactory;
+import io.questdb.griffin.engine.functions.SwappingArgsFunctionFactory;
 import io.questdb.griffin.engine.functions.bool.InCharFunctionFactory;
 import io.questdb.griffin.engine.functions.bool.InDoubleFunctionFactory;
 import io.questdb.griffin.engine.functions.bool.InTimestampStrFunctionFactory;
@@ -47,6 +49,8 @@ import io.questdb.griffin.engine.functions.conditional.SwitchFunctionFactory;
 import io.questdb.griffin.engine.functions.constants.*;
 import io.questdb.griffin.engine.functions.date.*;
 import io.questdb.griffin.engine.functions.eq.*;
+import io.questdb.griffin.engine.functions.lt.LtIPv4StrFunctionFactory;
+import io.questdb.griffin.engine.functions.lt.LtStrIPv4FunctionFactory;
 import io.questdb.griffin.engine.functions.rnd.LongSequenceFunctionFactory;
 import io.questdb.griffin.engine.functions.rnd.RndIPv4CCFunctionFactory;
 import io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory;
@@ -2303,7 +2307,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                                 args.add(new CharConstant('s'));
                             } else if (factory instanceof EqIntStrCFunctionFactory && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("1"));
-                            } else if (factory instanceof EqIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
+                            } else if (isIPv4StrFactory(factory) && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("10.8.6.5"));
                             } else if (factory instanceof ContainsIPv4FunctionFactory && sigArgType == ColumnType.STRING) {
                                 args.add(new StrConstant("12.6.5.10/24"));
@@ -2334,7 +2338,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
 
                         argPositions.setAll(args.size(), 0);
 
-                        //TODO: test with partition by, order by and various frame modes
+                        // TODO: test with partition by, order by and various frame modes
                         if (factory.isWindow()) {
                             sqlExecutionContext.configureWindowContext(null, null, null, false, DataFrameRecordCursorFactory.SCAN_DIRECTION_FORWARD, -1, true, WindowColumn.FRAMING_RANGE, Long.MIN_VALUE, 10, 0, 20, WindowColumn.EXCLUDE_NO_OTHERS, 0, -1);
                         }
@@ -10060,6 +10064,20 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 sqlExecutionContext.setJitMode(jitMode);
             }
         });
+    }
+
+    private static boolean isIPv4StrFactory(FunctionFactory factory) {
+        if (factory instanceof SwappingArgsFunctionFactory) {
+            return isIPv4StrFactory(((SwappingArgsFunctionFactory) factory).getDelegate());
+        }
+        if (factory instanceof NegatingFunctionFactory) {
+            return isIPv4StrFactory(((NegatingFunctionFactory) factory).getDelegate());
+        }
+        return factory instanceof EqIPv4FunctionFactory
+                || factory instanceof EqStrIPv4FunctionFactory
+                || factory instanceof EqIPv4StrFunctionFactory
+                || factory instanceof LtIPv4StrFunctionFactory
+                || factory instanceof LtStrIPv4FunctionFactory;
     }
 
     private void assertBindVarPlan(String type) throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -34,20 +34,6 @@ import org.junit.Test;
 public class IPv4Test extends AbstractCairoTest {
 
     @Test
-    public void ipv4NullTest() throws Exception {
-        ddl("create table x (b ipv4)");
-        insert("insert into x values('128.0.0.0')");
-        insert("insert into x values('0.0.0.0')");
-
-        assertSql(
-                "b\n" +
-                        "128.0.0.0\n" +
-                        "\n",
-                "x"
-        );
-    }
-
-    @Test
     public void testAggregateByIPv4() throws Exception {
         assertQuery(
                 "ip\tsum\n" +
@@ -73,27 +59,49 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testAlterTableIPv4NullCol() throws Exception {
-        ddl("create table test (col1 ipv4)");
-        insert("insert into test values ('0.0.0.1')");
-        ddl("alter table test add col2 ipv4");
+        assertMemoryLeak(() -> {
+            ddl("create table test (col1 ipv4)");
+            insert("insert into test values ('0.0.0.1')");
+            ddl("alter table test add col2 ipv4");
 
-        assertSql(
-                "col1\tcol2\n" +
-                        "0.0.0.1\t\n",
-                "test"
-        );
+            assertSql(
+                    "col1\tcol2\n" +
+                            "0.0.0.1\t\n",
+                    "test"
+            );
+        });
+    }
+
+    @Test
+    public void testBindVariableInEqFilterInvalid() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr("ip", "foobar");
+            assertException("x where b = :ip", 0, "invalid ipv4 format: foobar");
+        });
     }
 
     @Test
     public void testBitAndStr() throws Exception {
-        assertSql("column\n" +
-                "2.0.0.0\n", "select ipv4 '2.1.1.1' & '2.2.2.2'");
+        assertSql(
+                "column\n" +
+                        "2.0.0.0\n",
+                "select ipv4 '2.1.1.1' & '2.2.2.2'"
+        );
     }
 
     @Test
     public void testBitAndStr2() throws Exception {
-        assertSql("column\n" +
-                "2.0.0.0\n", "select '2.2.2.2' & ipv4 '2.1.1.1'");
+        assertSql(
+                "column\n" +
+                        "2.0.0.0\n",
+                "select '2.2.2.2' & ipv4 '2.1.1.1'"
+        );
     }
 
     @Test
@@ -520,6 +528,21 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testConstantInEqFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+            assertSql(
+                    "b\n" +
+                            "192.168.0.1\n",
+                    "x where b = '192.168.0.1'"
+            );
+        });
+    }
+
+    @Test
     public void testContainsIPv4FunctionFactoryError() throws Exception {
         ddl("create table t (ip ipv4)");
         assertException("select * from t where ip << '1.1.1.1/35'", 28, "invalid argument: 1.1.1.1/35");
@@ -787,6 +810,12 @@ public class IPv4Test extends AbstractCairoTest {
     public void testGreaterThanEqIPv4Null2() throws Exception {
         assertSql("column\n" +
                 "false\n", "select ipv4 '34.11.45.3' >= null");
+    }
+
+    @Test
+    public void testGreaterThanEqIPv4Null3() throws Exception {
+        assertSql("column\n" +
+                "false\n", "select null >= ipv4 '34.11.45.3'");
     }
 
     @Test
@@ -4209,6 +4238,60 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testIndexedBindVariableInEqFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr(0, "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "192.168.0.1\n",
+                    "x where b = $1"
+            );
+        });
+    }
+
+    @Test
+    public void testIndexedBindVariableInLtFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr(0, "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "127.0.0.1\n",
+                    "x where b < $1"
+            );
+        });
+    }
+
+    @Test
+    public void testIndexedBindVariableInLtFilter2() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr(0, "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "255.255.255.255\n",
+                    "x where $1 < b"
+            );
+        });
+    }
+
+    @Test
     public void testInnerJoinIPv4() throws Exception {
         ddl("create table test as (select rnd_ipv4('1.1.1.1/32', 0) ip, 1 count from long_sequence(5))");
         ddl("create table test2 as (select rnd_ipv4('1.1.1.1/32', 0) ip2, 2 count2 from long_sequence(5))");
@@ -4538,6 +4621,14 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testInvalidConstantInEqFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4, a string)");
+            assertException("x where b = 'foobar'", 0, "invalid ipv4 format: foobar");
+        });
+    }
+
+    @Test
     public void testLastIPv4() throws Exception {
         ddl("create table test as (select rnd_ipv4('10.5/16', 2) ip, rnd_symbol('ab', '$a', 'ac') sym from long_sequence(20))");
         assertSql(
@@ -4743,6 +4834,60 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testNamedBindVariableInEqFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr("ip", "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "192.168.0.1\n",
+                    "x where b = :ip"
+            );
+        });
+    }
+
+    @Test
+    public void testNamedBindVariableInLtFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr("ip", "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "127.0.0.1\n",
+                    "x where b < :ip"
+            );
+        });
+    }
+
+    @Test
+    public void testNamedBindVariableInLtFilter2() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into x values('192.168.0.1')");
+            insert("insert into x values('255.255.255.255')");
+
+            sqlExecutionContext.getBindVariableService().clear();
+            sqlExecutionContext.getBindVariableService().setStr("ip", "192.168.0.1");
+            assertSql(
+                    "b\n" +
+                            "255.255.255.255\n",
+                    "x where :ip < b"
+            );
+        });
+    }
+
+    @Test
     public void testNegContainsIPv4FunctionFactoryError() throws Exception {
         ddl("create table t (ip ipv4)");
         assertException("select * from t where '1.1.1.1/35' >> ip", 22, "invalid argument: 1.1.1.1/35");
@@ -4775,6 +4920,22 @@ public class IPv4Test extends AbstractCairoTest {
         assertSql("netmask\n255.255.255.254\n", "select netmask('1.1.1.1/31');");
         assertSql("netmask\n255.255.255.255\n", "select netmask('1.1.1.1/32');");
         assertSql("netmask\n\n", "select netmask('1.1.1.1/33');");
+    }
+
+    @Test
+    public void testNull() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4)");
+            insert("insert into x values('128.0.0.0')");
+            insert("insert into x values('0.0.0.0')");
+
+            assertSql(
+                    "b\n" +
+                            "128.0.0.0\n" +
+                            "\n",
+                    "x"
+            );
+        });
     }
 
     @Test
@@ -5035,6 +5196,30 @@ public class IPv4Test extends AbstractCairoTest {
                 true,
                 false
         );
+    }
+
+    @Test
+    public void testStrColumnInEqFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4, a string)");
+            assertException("x where b = a", 12, "STRING constant expected");
+        });
+    }
+
+    @Test
+    public void testStrColumnInLtFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4, a string)");
+            assertException("x where b < a", 12, "STRING constant expected");
+        });
+    }
+
+    @Test
+    public void testStrColumnInLtFilter2() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (b ipv4, a string)");
+            assertException("x where b > a", 12, "STRING constant expected");
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JsonPlanSinkTest.java
@@ -45,6 +45,7 @@ public class JsonPlanSinkTest {
                 "        \"long256\": \"0x04000000000000000300000000000000020000000000000001\",\n" +
                 "        \"plan\": \"null\",\n" +
                 "        \"uuid\": \"00000000-0000-0002-0000-000000000001\",\n" +
+                "        \"ipv4\": \"0.0.0.1\",\n" +
                 "        \"uuid_null\": \"null\"\n" +
                 "    }\n" +
                 "  }\n" +
@@ -75,34 +76,6 @@ public class JsonPlanSinkTest {
         Assert.assertEquals(expected, sink.getSink().toString());
     }
 
-    static class TestFactory implements RecordCursorFactory {
-
-        @Override
-        public RecordMetadata getMetadata() {
-            return null;
-        }
-
-        @Override
-        public boolean recordCursorSupportsRandomAccess() {
-            return false;
-        }
-
-        @Override
-        public void toPlan(PlanSink sink) {
-            sink.type("test");
-            sink.attr("geohash");
-            sink.val(101010L, 32);
-            sink.attr("long256");
-            sink.val(1L, 2L, 3L, 4L);
-            sink.attr("plan");
-            sink.val((Plannable) null);
-            sink.attr("uuid");
-            sink.valUuid(1L, 2L);
-            sink.attr("uuid_null");
-            sink.valUuid(Numbers.LONG_NaN, Numbers.LONG_NaN);
-        }
-    }
-
     static class NumericalTestFactory implements RecordCursorFactory {
 
         @Override
@@ -128,6 +101,36 @@ public class JsonPlanSinkTest {
             sink.val(2);
             sink.attr("long");
             sink.val(100L);
+        }
+    }
+
+    static class TestFactory implements RecordCursorFactory {
+
+        @Override
+        public RecordMetadata getMetadata() {
+            return null;
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.type("test");
+            sink.attr("geohash");
+            sink.val(101010L, 32);
+            sink.attr("long256");
+            sink.val(1L, 2L, 3L, 4L);
+            sink.attr("plan");
+            sink.val((Plannable) null);
+            sink.attr("uuid");
+            sink.valUuid(1L, 2L);
+            sink.attr("ipv4");
+            sink.valIPv4(1);
+            sink.attr("uuid_null");
+            sink.valUuid(Numbers.LONG_NaN, Numbers.LONG_NaN);
         }
     }
 }


### PR DESCRIPTION
Also, adds bind variable support for IPv4. Before this patch, equals and comparison operators on IPv4 supported string constants, but not runtime constants (bind variables).