### PR TITLE
test(core): fix SIGABRT in mac CI runs

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV2.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV2.java
@@ -89,6 +89,7 @@ public class TableTransactionLogV2 implements TableTransactionLogFile {
         TransactionLogCursorImpl cursor = tlTransactionLogCursor.get();
         if (cursor != null) {
             cursor.closePath();
+            tlTransactionLogCursor.remove();
         }
     }
 

--- a/core/src/main/java/io/questdb/std/str/Path.java
+++ b/core/src/main/java/io/questdb/std/str/Path.java
@@ -75,7 +75,6 @@ public class Path implements Utf8Sink, LPSZ, Closeable {
         PATH2.close();
     }
 
-
     public static Path getThreadLocal(CharSequence root) {
         return PATH.get().of(root);
     }

--- a/core/src/main/java/io/questdb/std/str/Path.java
+++ b/core/src/main/java/io/questdb/std/str/Path.java
@@ -71,9 +71,10 @@ public class Path implements Utf8Sink, LPSZ, Closeable {
     }
 
     public static void clearThreadLocals() {
-        PATH.get().close();
-        PATH2.get().close();
+        PATH.close();
+        PATH2.close();
     }
+
 
     public static Path getThreadLocal(CharSequence root) {
         return PATH.get().of(root);

--- a/core/src/main/java/io/questdb/std/str/Path.java
+++ b/core/src/main/java/io/questdb/std/str/Path.java
@@ -71,6 +71,10 @@ public class Path implements Utf8Sink, LPSZ, Closeable {
     }
 
     public static void clearThreadLocals() {
+        // It could be PATH.get.close(); but this would generated JDK failures on MacOS (SIGABRT)
+        // when running tests. Despite all the effort to find the exact cause, it was not possible
+        // and this is the best solution so far. This approach will remove the thread local
+        // on close and the next time a new object is created.
         PATH.close();
         PATH2.close();
     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -7858,7 +7858,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             } finally {
                                 // release native path memory used by the job
-                                Path.PATH.get().close();
+                                Path.clearThreadLocals();
                                 stopped.countDown();
                             }
                         }, "wal_job");
@@ -8025,7 +8025,7 @@ public class IODispatcherTest extends AbstractTest {
                             }
                         } finally {
                             // release native path memory used by the job
-                            Path.PATH.get().close();
+                            Path.clearThreadLocals();
                             stopped.countDown();
                         }
                     }, "wal_job");

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3090,7 +3090,7 @@ if __name__ == "__main__":
                                         }
                                     } finally {
                                         // release native path memory used by the job
-                                        Path.PATH.get().close();
+                                        Path.clearThreadLocals();
                                         stopped.countDown();
                                     }
                                 }, "wal_job");


### PR DESCRIPTION
fixes #4283

Problem is reproducible by running `testDetachPartitionsColumnTops` in a loop on MacOS