### PR TITLE
fix(core): fix two bugs related to out-of-order transaction commit/rollback

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -413,10 +413,10 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             // should go into the merge section.
                             mergeDataHi = Vect.boundedBinarySearch64Bit(
                                     srcTimestampAddr,
-                                    o3TimestampMax + 1,
+                                    o3TimestampHi,
                                     0,
                                     srcDataMax - 1,
-                                    BinarySearch.SCAN_UP
+                                    BinarySearch.SCAN_DOWN
                             );
 
                             suffixLo = mergeDataHi + 1;

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -350,6 +350,8 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             suffixType = O3_BLOCK_O3;
                             suffixLo = mergeO3Hi + 1;
                             suffixHi = srcOooHi;
+                            assert suffixLo <= suffixHi : String.format("Branch %,d suffixLo %,d > suffixHi %,d",
+                                    branch, suffixLo, suffixHi);
                         } else {
 
                             //
@@ -422,6 +424,8 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             suffixHi = srcDataMax - 1;
 
                         } else if (o3TimestampMax > dataTimestampHi) {
+                            assert suffixLo <= suffixHi : String.format("Branch %,d suffixLo %,d > suffixHi %,d",
+                                    branch, suffixLo, suffixHi);
 
                             // |      | |     |
                             // |      | | OOO |

--- a/core/src/test/java/io/questdb/test/griffin/O3MaxLagFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3MaxLagFuzzTest.java
@@ -57,6 +57,16 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
         executeWithPool(2, this::testRollbackFuzz);
     }
 
+    @Test
+    public void testRollbackRegression1() throws Exception {
+        executeWithPool(0, this::testRollbackRegression1);
+    }
+
+    @Test
+    public void testRollbackRegression2() throws Exception {
+        executeWithPool(0, this::testRollbackRegression2);
+    }
+
     private static void replayTransactions(Rnd rnd, CairoEngine engine, TableWriter w, ObjList<FuzzTransaction> transactions, int virtualTimestampIndex) {
         for (int i = 0, n = transactions.size(); i < n; i++) {
             FuzzTransaction tx = transactions.getQuick(i);
@@ -235,6 +245,68 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
             insertUncommitted(compiler, sqlExecutionContext, "(z limit " + lim + ") order by ts limit -" + o3Uncommitted, w);
             w.ic();
 
+            w.commit();
+        }
+        assertXY(compiler, sqlExecutionContext);
+    }
+
+    private void testRollbackRegression1(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        // We used this commented-out code to find values that make this and the other regression test fail:
+//        final Rnd rnd = TestUtils.generateRandom(LOG);
+//        final int nTotalRows = rnd.nextInt(79000);
+//        final long microsBetweenRows = rnd.nextLong(3090985);
+//        final double fraction = rnd.nextDouble();
+//        System.out.printf("*+*+*+*+ nTotalRows %,d microsBetweenRows %,d fraction %.2f\n", nTotalRows, microsBetweenRows, fraction);
+
+        final int nTotalRows = 51_555;
+        final long microsBetweenRows = 2_267_870;
+        final double fraction = 0.8;
+        runRollbackRegression(engine, compiler, sqlExecutionContext, nTotalRows, microsBetweenRows, fraction);
+    }
+
+    private void testRollbackRegression2(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        final int nTotalRows = 10_795;
+        final long microsBetweenRows = 1_970_536;
+        final double fraction = 0.09;
+        runRollbackRegression(engine, compiler, sqlExecutionContext, nTotalRows, microsBetweenRows, fraction);
+    }
+
+    private void runRollbackRegression(
+            CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext,
+            int nTotalRows, long microsBetweenRows, double fraction
+    ) throws SqlException {
+
+        // table "x" is in order
+        String sql = "create table x as (" +
+                "select" +
+                " rnd_short(10,1024) f," +
+                " timestamp_sequence(0L," + microsBetweenRows + "L) ts," +
+                " from long_sequence(" + nTotalRows + ")" +
+                ") timestamp (ts) partition by DAY";
+        compiler.compile(sql, sqlExecutionContext);
+        // table "z" is out of order - reshuffled "x"
+        compiler.compile("create table z as (select * from x order by f)", sqlExecutionContext);
+        // table "y" is our target table, where we exercise O3 and rollbacks
+        compiler.compile("create table y as (select * from x where 1 <> 1) timestamp(ts) partition by day", sqlExecutionContext);
+        try (TableWriter w = TestUtils.getWriter(engine, "y")) {
+            insertUncommitted(compiler, sqlExecutionContext, "z limit " + (int) (nTotalRows * fraction), w);
+            w.ic();
+            final long o3Uncommitted = w.getO3RowCount();
+            long expectedRowCount = w.size() - o3Uncommitted;
+            w.rollback();
+            Assert.assertEquals(expectedRowCount, w.size());
+            TestUtils.assertEquals(
+                    compiler,
+                    sqlExecutionContext,
+                    "(z limit " + (int) (nTotalRows * fraction) + ") order by ts limit " + expectedRowCount,
+                    "y"
+            );
+            // insert remaining data (that we did not try to insert yet)
+            insertUncommitted(compiler, sqlExecutionContext, "z limit " + (int) (nTotalRows * fraction) + ", " + nTotalRows, w);
+            w.ic();
+            // insert data that we rolled back
+            insertUncommitted(compiler, sqlExecutionContext, "(z limit " + (int) (nTotalRows * fraction) + ") order by ts limit -" + o3Uncommitted, w);
+            w.ic();
             w.commit();
         }
         assertXY(compiler, sqlExecutionContext);


### PR DESCRIPTION
This PR adds two `assert`s to production code that checks a condition that has so far been assumed to be true, but actually wasn't. By chance, the failed assumption did not cause incorrect behavior because the task that was constructed as a result amounted to a no-op. However, the new varchar type (not yet on master) does not ignore this and that's how it got detected.

We isolated the failures in two regression tests, then applied bug fixes that make the regression tests pass.