### PR TITLE
fix(sql): fix ILIKE for upper case non-ASCII patterns

### DIFF
--- a/core/src/main/java/io/questdb/cairo/RecordSinkFactory.java
+++ b/core/src/main/java/io/questdb/cairo/RecordSinkFactory.java
@@ -140,7 +140,7 @@ public class RecordSinkFactory {
         final int fGetFloat = asm.poolInterfaceMethod(Function.class, "getFloat", "(Lio/questdb/cairo/sql/Record;)F");
         final int fGetDouble = asm.poolInterfaceMethod(Function.class, "getDouble", "(Lio/questdb/cairo/sql/Record;)D");
         final int fGetStr = asm.poolInterfaceMethod(Function.class, "getStrA", "(Lio/questdb/cairo/sql/Record;)Ljava/lang/CharSequence;");
-        final int fGetVarchar = asm.poolInterfaceMethod(Function.class, "getVarchar", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/std/str/Utf8Sequence;");
+        final int fGetVarchar = asm.poolInterfaceMethod(Function.class, "getVarcharA", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/std/str/Utf8Sequence;");
         final int fGetSym = asm.poolInterfaceMethod(Function.class, "getSymbol", "(Lio/questdb/cairo/sql/Record;)Ljava/lang/CharSequence;");
         final int fGetBin = asm.poolInterfaceMethod(Function.class, "getBin", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/std/BinarySequence;");
         final int fGetRecord = asm.poolInterfaceMethod(Function.class, "getRecord", "(Lio/questdb/cairo/sql/Record;)Lio/questdb/cairo/sql/Record;");

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeStrFunctionFactory.java
@@ -146,6 +146,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
                 int flags = Pattern.DOTALL;
                 if (isCaseInsensitive()) {
                     flags |= Pattern.CASE_INSENSITIVE;
+                    p = p.toLowerCase();
                 }
                 return new ConstLikeStrFunction(
                         value,
@@ -163,7 +164,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         throw SqlException.$(argPositions.getQuick(1), "use constant or bind variable");
     }
 
-    private static int countChar(@NotNull CharSequence seq, char c) {
+    static int countChar(@NotNull CharSequence seq, char c) {
         int count = 0;
         for (int i = 0, n = seq.length(); i < n; i++) {
             if (seq.charAt(i) == c) {
@@ -175,7 +176,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
     protected abstract boolean isCaseInsensitive();
 
-    private static class BindLikeStrFunction extends BooleanFunction implements UnaryFunction {
+    static class BindLikeStrFunction extends BooleanFunction implements UnaryFunction {
         private final boolean caseInsensitive;
         private final Function pattern;
         private final Function value;
@@ -196,7 +197,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         @Override
         public boolean getBool(Record rec) {
             if (matcher != null) {
-                CharSequence cs = getArg().getStrA(rec);
+                CharSequence cs = value.getStrA(rec);
                 return cs != null && matcher.reset(cs).matches();
             }
             return false;
@@ -209,11 +210,12 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
             // this is bind variable, we can use it as constant
             final CharSequence patternValue = pattern.getStrA(null);
             if (patternValue != null && patternValue.length() > 0) {
-                final String p = escapeSpecialChars(patternValue, lastPattern);
+                String p = escapeSpecialChars(patternValue, lastPattern);
                 if (p != null) {
                     int flags = Pattern.DOTALL;
                     if (caseInsensitive) {
                         flags |= Pattern.CASE_INSENSITIVE;
+                        p = p.toLowerCase();
                     }
                     this.matcher = Pattern.compile(p, flags).matcher("");
                     this.lastPattern = p;
@@ -257,7 +259,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             if (cs == null) {
                 return false;
             }
@@ -295,7 +297,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             return Chars.endsWith(cs, pattern);
         }
 
@@ -313,7 +315,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
     }
 
-    private static class ConstIContainsStrFunction extends BooleanFunction implements UnaryFunction {
+    static class ConstIContainsStrFunction extends BooleanFunction implements UnaryFunction {
         private final String pattern;
         private final Function value;
 
@@ -329,7 +331,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             if (cs == null) {
                 return false;
             }
@@ -351,7 +353,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
     }
 
-    private static class ConstIEndsWithStrFunction extends BooleanFunction implements UnaryFunction {
+    static class ConstIEndsWithStrFunction extends BooleanFunction implements UnaryFunction {
         private final String pattern;
         private final Function value;
 
@@ -367,7 +369,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             return Chars.endsWithLowerCase(cs, pattern);
         }
 
@@ -385,7 +387,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
     }
 
-    private static class ConstIStartsWithStrFunction extends BooleanFunction implements UnaryFunction {
+    static class ConstIStartsWithStrFunction extends BooleanFunction implements UnaryFunction {
         private final String pattern;
         private final Function value;
 
@@ -401,7 +403,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             return Chars.startsWithLowerCase(cs, pattern);
         }
 
@@ -419,7 +421,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
     }
 
-    private static class ConstLikeStrFunction extends BooleanFunction implements UnaryFunction {
+    static class ConstLikeStrFunction extends BooleanFunction implements UnaryFunction {
         private final Matcher matcher;
         private final Function value;
 
@@ -435,7 +437,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             return cs != null && matcher.reset(cs).matches();
         }
 
@@ -472,7 +474,7 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
 
         @Override
         public boolean getBool(Record rec) {
-            CharSequence cs = getArg().getStrA(rec);
+            CharSequence cs = value.getStrA(rec);
             return Chars.startsWith(cs, pattern);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeVarcharFunctionFactory.java
@@ -1,0 +1,352 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.regex;
+
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8String;
+import io.questdb.std.str.Utf8s;
+
+import java.util.regex.Pattern;
+
+import static io.questdb.griffin.engine.functions.regex.AbstractLikeStrFunctionFactory.countChar;
+import static io.questdb.griffin.engine.functions.regex.AbstractLikeStrFunctionFactory.escapeSpecialChars;
+
+public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFactory {
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        final Function value = args.getQuick(0);
+        final Function pattern = args.getQuick(1);
+
+        if (pattern.isConstant()) {
+            final CharSequence likeSeq = pattern.getStrA(null);
+            int len;
+            if (likeSeq != null && (len = likeSeq.length()) > 0) {
+                int oneCount = countChar(likeSeq, '_');
+                if (oneCount == 0) {
+                    if (likeSeq.charAt(len - 1) == '\\') {
+                        throw SqlException.parserErr(len - 1, likeSeq, "LIKE pattern must not end with escape character");
+                    }
+
+                    int anyCount = countChar(likeSeq, '%');
+                    if (anyCount == 1) {
+                        if (len == 1) {
+                            return BooleanConstant.TRUE; // LIKE '%' case
+                        } else if (likeSeq.charAt(0) == '%') {
+                            // LIKE/ILIKE '%abc' case
+                            final CharSequence subPattern = likeSeq.subSequence(1, len);
+                            if (isCaseInsensitive()) {
+                                if (Chars.isAscii(subPattern)) {
+                                    return new ConstIEndsWithAsciiFunction(value, subPattern);
+                                } else {
+                                    return new AbstractLikeStrFunctionFactory.ConstIEndsWithStrFunction(value, subPattern.toString());
+                                }
+                            } else {
+                                return new ConstEndsWithVarcharFunction(value, subPattern);
+                            }
+                        } else if (likeSeq.charAt(len - 1) == '%') {
+                            // LIKE/ILIKE 'abc%' case
+                            final CharSequence subPattern = likeSeq.subSequence(0, len - 1);
+                            if (isCaseInsensitive()) {
+                                if (Chars.isAscii(subPattern)) {
+                                    return new ConstIStartsWithAsciiFunction(value, subPattern);
+                                } else {
+                                    return new AbstractLikeStrFunctionFactory.ConstIStartsWithStrFunction(value, subPattern.toString());
+                                }
+                            } else {
+                                return new ConstStartsWithVarcharFunction(value, subPattern);
+                            }
+                        }
+                    } else if (anyCount == 2) {
+                        if (len == 2) {
+                            return BooleanConstant.TRUE; // LIKE '%%' case
+                        } else if (likeSeq.charAt(0) == '%' && likeSeq.charAt(len - 1) == '%') {
+                            // LIKE/ILIKE '%abc%' case
+                            final CharSequence subPattern = likeSeq.subSequence(1, len - 1);
+                            if (isCaseInsensitive()) {
+                                if (Chars.isAscii(subPattern)) {
+                                    return new ConstIContainsAsciiFunction(value, subPattern);
+                                } else {
+                                    return new AbstractLikeStrFunctionFactory.ConstIContainsStrFunction(value, subPattern.toString());
+                                }
+                            } else {
+                                return new ConstContainsVarcharFunction(value, subPattern);
+                            }
+                        }
+                    }
+                }
+
+                String p = escapeSpecialChars(likeSeq, null);
+                assert p != null;
+                int flags = Pattern.DOTALL;
+                if (isCaseInsensitive()) {
+                    flags |= Pattern.CASE_INSENSITIVE;
+                    p = p.toLowerCase();
+                }
+                return new AbstractLikeStrFunctionFactory.ConstLikeStrFunction(
+                        value,
+                        Pattern.compile(p, flags).matcher("")
+                );
+            }
+            return BooleanConstant.FALSE;
+        }
+
+        if (pattern.isRuntimeConstant()) {
+            // bind variable
+            return new AbstractLikeStrFunctionFactory.BindLikeStrFunction(value, pattern, isCaseInsensitive());
+        }
+
+        throw SqlException.$(argPositions.getQuick(1), "use constant or bind variable");
+    }
+
+    protected abstract boolean isCaseInsensitive();
+
+    private static class ConstContainsVarcharFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstContainsVarcharFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern);
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.contains(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" like ");
+            sink.val('%');
+            sink.val(pattern);
+            sink.val('%');
+        }
+    }
+
+    private static class ConstEndsWithVarcharFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstEndsWithVarcharFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern);
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.endsWith(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" like ");
+            sink.val('%');
+            sink.val(pattern);
+        }
+    }
+
+    private static class ConstIContainsAsciiFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstIContainsAsciiFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern.toString().toLowerCase());
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.containsLowerCaseAscii(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" ilike ");
+            sink.val('%');
+            sink.val(pattern);
+            sink.val('%');
+        }
+    }
+
+    private static class ConstIEndsWithAsciiFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstIEndsWithAsciiFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern.toString().toLowerCase());
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.endsWithLowerCaseAscii(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" ilike ");
+            sink.val('%');
+            sink.val(pattern);
+        }
+    }
+
+    private static class ConstIStartsWithAsciiFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstIStartsWithAsciiFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern.toString().toLowerCase());
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.startsWithLowerCaseAscii(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" ilike ");
+            sink.val(pattern);
+            sink.val('%');
+        }
+    }
+
+    private static class ConstStartsWithVarcharFunction extends BooleanFunction implements UnaryFunction {
+        private final Utf8String pattern;
+        private final Function value;
+
+        public ConstStartsWithVarcharFunction(Function value, @Transient CharSequence pattern) {
+            this.value = value;
+            this.pattern = new Utf8String(pattern);
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && Utf8s.startsWith(us, pattern);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value);
+            sink.val(" like ");
+            sink.val(pattern);
+            sink.val('%');
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeVarcharFunctionFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.regex;
+
+public class ILikeVarcharFunctionFactory extends AbstractLikeVarcharFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "ilike(ØS)";
+    }
+
+    @Override
+    protected boolean isCaseInsensitive() {
+        return true;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeVarcharFunctionFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.regex;
+
+public class LikeVarcharFunctionFactory extends AbstractLikeVarcharFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "like(ØS)";
+    }
+
+    @Override
+    protected boolean isCaseInsensitive() {
+        return false;
+    }
+}

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -58,9 +58,9 @@ public final class Chars {
      * @param ascii ascii string to convert to byte array
      * @return byte array representation of the input string
      */
-    public static byte[] asciiToByteArray(CharSequence ascii) {
+    public static byte[] asciiToByteArray(@NotNull CharSequence ascii) {
         byte[] dst = new byte[ascii.length()];
-        for (int i = 0; i < ascii.length(); i++) {
+        for (int i = 0, n = ascii.length(); i < n; i++) {
             assert ascii.charAt(i) < 128;
             dst[i] = (byte) ascii.charAt(i);
         }
@@ -228,8 +228,8 @@ public final class Chars {
             return true;
         }
 
-        int ll;
-        if ((ll = l.length()) != rHi - rLo) {
+        int ll = l.length();
+        if (ll != rHi - rLo) {
             return false;
         }
 
@@ -275,8 +275,8 @@ public final class Chars {
             return true;
         }
 
-        int ll;
-        if ((ll = l.length()) != r.length()) {
+        int ll = l.length();
+        if (ll != r.length()) {
             return false;
         }
 
@@ -286,8 +286,8 @@ public final class Chars {
     /**
      * Case-insensitive comparison of two char sequences, with subsequence over second.
      *
-     * @param l left sequence
-     * @param r right sequence
+     * @param l   left sequence
+     * @param r   right sequence
      * @param rLo right sequence lower bound
      * @param rHi right sequence upper bound
      * @return true if sequences match exactly (ignoring char case)
@@ -297,8 +297,8 @@ public final class Chars {
             return true;
         }
 
-        int ll;
-        if ((ll = l.length()) != rHi - rLo) {
+        int ll = l.length();
+        if (ll != rHi - rLo) {
             return false;
         }
 
@@ -315,8 +315,8 @@ public final class Chars {
             return true;
         }
 
-        int ll;
-        if ((ll = lLC.length()) != rHi - rLo) {
+        int ll = lLC.length();
+        if (ll != rHi - rLo) {
             return false;
         }
 
@@ -365,8 +365,8 @@ public final class Chars {
     }
 
     public static boolean equalsLowerCaseAscii(@NotNull CharSequence l, @NotNull CharSequence r) {
-        int ll;
-        if ((ll = l.length()) != r.length()) {
+        int ll = l.length();
+        if (ll != r.length()) {
             return false;
         }
 
@@ -615,6 +615,15 @@ public final class Chars {
         return -1;
     }
 
+    public static boolean isAscii(@NotNull CharSequence cs) {
+        for (int i = 0, n = cs.length(); i < n; i++) {
+            if (cs.charAt(i) > 127) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static boolean isBlank(CharSequence s) {
         if (s == null) {
             return true;
@@ -853,7 +862,6 @@ public final class Chars {
             sink.put(Character.toLowerCase(str.charAt(i)));
         }
     }
-
 
     public static String toLowerCaseAscii(@Nullable CharSequence value) {
         if (value == null) {
@@ -1153,7 +1161,7 @@ public final class Chars {
     }
 
     private static boolean equalsCharsIgnoreCase(@NotNull CharSequence l, @NotNull CharSequence r, int len, int rLo, int rHi) {
-        assert len == (rHi-rLo);
+        assert len == (rHi - rLo);
         for (int i = 0; i < len; i++) {
             if (Character.toLowerCase(l.charAt(i)) != Character.toLowerCase(r.charAt(i + rLo))) {
                 return false;

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -56,8 +56,17 @@ public final class Utf8s {
         return Integer.compare(ll, rl);
     }
 
-    public static boolean containsAscii(Utf8Sequence sequence, CharSequence term) {
-        return indexOfAscii(sequence, 0, sequence.size(), term) != -1;
+    public static boolean contains(@NotNull Utf8Sequence sequence, @NotNull Utf8Sequence term) {
+        return indexOf(sequence, 0, sequence.size(), term) != -1;
+    }
+
+    public static boolean containsAscii(@NotNull Utf8Sequence sequence, @NotNull CharSequence asciiTerm) {
+        return indexOfAscii(sequence, 0, sequence.size(), asciiTerm) != -1;
+    }
+
+    // Pattern has to be lower-case.
+    public static boolean containsLowerCaseAscii(@NotNull Utf8Sequence sequence, @NotNull Utf8Sequence asciiTerm) {
+        return indexOfLowerCaseAscii(sequence, 0, sequence.size(), asciiTerm) != -1;
     }
 
     public static int encodeUtf16Char(@NotNull Utf8Sink sink, @NotNull CharSequence cs, int hi, int i, char c) {
@@ -74,6 +83,16 @@ public final class Utf8s {
         return i;
     }
 
+    public static boolean endsWith(@NotNull Utf8Sequence seq, @NotNull Utf8Sequence ends) {
+        int size = ends.size();
+        if (size == 0) {
+            return true;
+        }
+
+        int seqSize = seq.size();
+        return !(seqSize == 0 || seqSize < size) && equalsBytes(ends, seq, seqSize - size, seqSize);
+    }
+
     public static boolean endsWithAscii(@NotNull Utf8Sequence seq, @NotNull CharSequence endsAscii) {
         int l = endsAscii.length();
         if (l == 0) {
@@ -87,6 +106,16 @@ public final class Utf8s {
     public static boolean endsWithAscii(@NotNull Utf8Sequence us, char asciiChar) {
         final int size = us.size();
         return size != 0 && asciiChar == us.byteAt(size - 1);
+    }
+
+    // Pattern has to be lower-case.
+    public static boolean endsWithLowerCaseAscii(@NotNull Utf8Sequence seq, @NotNull Utf8Sequence asciiEnds) {
+        final int size = asciiEnds.size();
+        if (size == 0) {
+            return true;
+        }
+        final int seqSize = seq.size();
+        return !(seqSize == 0 || seqSize < size) && equalsAsciiLowerCase(asciiEnds, seq, seqSize - size, seqSize);
     }
 
     public static boolean equals(@NotNull DirectUtf8String l, @NotNull Utf8String r) {
@@ -213,8 +242,8 @@ public final class Utf8s {
     }
 
     public static boolean equalsIgnoreCaseAscii(@NotNull Utf8Sequence lSeq, @NotNull Utf8Sequence rSeq) {
-        int size;
-        if ((size = lSeq.size()) != rSeq.size()) {
+        int size = lSeq.size();
+        if (size != rSeq.size()) {
             return false;
         }
         for (int index = 0; index < size; index++) {
@@ -242,8 +271,8 @@ public final class Utf8s {
     }
 
     public static boolean equalsIgnoreCaseAscii(@NotNull CharSequence asciiSeq, @NotNull Utf8Sequence seq) {
-        int len;
-        if ((len = asciiSeq.length()) != seq.size()) {
+        int len = asciiSeq.length();
+        if (len != seq.size()) {
             return false;
         }
         for (int index = 0; index < len; index++) {
@@ -330,6 +359,37 @@ public final class Utf8s {
             h = 31 * h + value.byteAt(p);
         }
         return h;
+    }
+
+    public static int indexOf(@NotNull Utf8Sequence seq, int seqLo, int seqHi, @NotNull Utf8Sequence term) {
+        int termSize = term.size();
+        if (termSize == 0) {
+            return 0;
+        }
+
+        byte first = term.byteAt(0);
+        int max = seqHi - termSize;
+
+        for (int i = seqLo; i <= max; ++i) {
+            if (seq.byteAt(i) != first) {
+                do {
+                    ++i;
+                } while (i <= max && seq.byteAt(i) != first);
+            }
+
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + termSize - 1;
+                for (int k = 1; j < end && seq.byteAt(j) == term.byteAt(k); ++k) {
+                    ++j;
+                }
+                if (j == end) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
     }
 
     public static int indexOfAscii(@NotNull Utf8Sequence seq, char asciiChar) {
@@ -475,6 +535,38 @@ public final class Utf8s {
         return -1;
     }
 
+    // Term has to be lower-case.
+    public static int indexOfLowerCaseAscii(@NotNull Utf8Sequence seq, int seqLo, int seqHi, @NotNull Utf8Sequence termLC) {
+        int termSize = termLC.size();
+        if (termSize == 0) {
+            return 0;
+        }
+
+        byte first = termLC.byteAt(0);
+        int max = seqHi - termSize;
+
+        for (int i = seqLo; i <= max; ++i) {
+            if (toLowerCaseAscii(seq.byteAt(i)) != first) {
+                do {
+                    ++i;
+                } while (i <= max && toLowerCaseAscii(seq.byteAt(i)) != first);
+            }
+
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + termSize - 1;
+                for (int k = 1; j < end && toLowerCaseAscii(seq.byteAt(j)) == termLC.byteAt(k); ++k) {
+                    ++j;
+                }
+                if (j == end) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
     public static int lastIndexOfAscii(@NotNull Utf8Sequence seq, char asciiTerm) {
         for (int i = seq.size() - 1; i > -1; i--) {
             if (seq.byteAt(i) == asciiTerm) {
@@ -507,14 +599,23 @@ public final class Utf8s {
         return h;
     }
 
-    public static boolean startsWith(@NotNull Utf8Sequence seq, @NotNull Utf8Sequence term) {
-        final int size = term.size();
-        return seq.size() >= size && equalsBytes(seq, term, size);
+    public static boolean startsWith(@NotNull Utf8Sequence seq, @NotNull Utf8Sequence starts) {
+        final int size = starts.size();
+        return seq.size() >= size && equalsBytes(seq, starts, size);
     }
 
-    public static boolean startsWithAscii(@NotNull Utf8Sequence seq, @NotNull CharSequence asciiTerm) {
-        final int len = asciiTerm.length();
-        return seq.size() >= len && equalsAscii(asciiTerm, seq, 0, len);
+    public static boolean startsWithAscii(@NotNull Utf8Sequence seq, @NotNull CharSequence asciiStarts) {
+        final int len = asciiStarts.length();
+        return seq.size() >= len && equalsAscii(asciiStarts, seq, 0, len);
+    }
+
+    // Pattern has to be lower-case.
+    public static boolean startsWithLowerCaseAscii(@NotNull Utf8Sequence seq, @NotNull Utf8Sequence asciiStarts) {
+        final int size = asciiStarts.size();
+        if (size == 0) {
+            return true;
+        }
+        return seq.size() >= size && equalsAsciiLowerCase(asciiStarts, seq, size);
     }
 
     public static void strCpy(@NotNull Utf8Sequence src, int destLen, long destAddr) {
@@ -979,9 +1080,48 @@ public final class Utf8s {
         return pos;
     }
 
+    // Left hand has to be lower-case.
+    private static boolean equalsAsciiLowerCase(@NotNull Utf8Sequence lLC, @NotNull Utf8Sequence r, int size) {
+        for (int i = 0; i < size; i++) {
+            if (lLC.byteAt(i) != toLowerCaseAscii(r.byteAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Left hand has to be lower-case.
+    private static boolean equalsAsciiLowerCase(@NotNull Utf8Sequence lLC, @NotNull Utf8Sequence r, int rLo, int rHi) {
+        int ls = lLC.size();
+        if (ls != rHi - rLo) {
+            return false;
+        }
+
+        for (int i = 0; i < ls; i++) {
+            if (lLC.byteAt(i) != toLowerCaseAscii(r.byteAt(i + rLo))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static boolean equalsBytes(@NotNull Utf8Sequence l, @NotNull Utf8Sequence r, int size) {
         for (int i = 0; i < size; i++) {
             if (l.byteAt(i) != r.byteAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean equalsBytes(@NotNull Utf8Sequence l, @NotNull Utf8Sequence r, int rLo, int rHi) {
+        int lsize = l.size();
+        if (lsize != rHi - rLo) {
+            return false;
+        }
+
+        for (int i = 0; i < lsize; i++) {
+            if (l.byteAt(i) != r.byteAt(i + rLo)) {
                 return false;
             }
         }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -255,7 +255,9 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.regex.MatchCharFunctionFactory,
 //                    like
             io.questdb.griffin.engine.functions.regex.LikeStrFunctionFactory,
+            io.questdb.griffin.engine.functions.regex.LikeVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.regex.ILikeStrFunctionFactory,
+            io.questdb.griffin.engine.functions.regex.ILikeVarcharFunctionFactory,
 //                     '!~',
             io.questdb.griffin.engine.functions.regex.NotMatchStrFunctionFactory,
             io.questdb.griffin.engine.functions.regex.NotMatchCharFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -177,7 +177,9 @@ io.questdb.griffin.engine.functions.regex.NotMatchCharFunctionFactory
 
 #  like
 io.questdb.griffin.engine.functions.regex.LikeStrFunctionFactory
+io.questdb.griffin.engine.functions.regex.LikeVarcharFunctionFactory
 io.questdb.griffin.engine.functions.regex.ILikeStrFunctionFactory
+io.questdb.griffin.engine.functions.regex.ILikeVarcharFunctionFactory
 
 # 'to_char'
 io.questdb.griffin.engine.functions.date.ToStrDateFunctionFactory

--- a/core/src/test/java/io/questdb/test/cairo/RecordSinkFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RecordSinkFactoryTest.java
@@ -153,6 +153,7 @@ public class RecordSinkFactoryTest extends AbstractCairoTest {
         keyFunctions.add(new TestFunction(ColumnType.FLOAT));
         keyFunctions.add(new TestFunction(ColumnType.DOUBLE));
         keyFunctions.add(new TestFunction(ColumnType.STRING));
+        keyFunctions.add(new TestFunction(ColumnType.VARCHAR));
         keyFunctions.add(new TestFunction(ColumnType.BINARY));
         keyFunctions.add(new TestFunction(ColumnType.LONG256));
         keyFunctions.add(new TestFunction(ColumnType.GEOBYTE));
@@ -444,6 +445,17 @@ public class RecordSinkFactoryTest extends AbstractCairoTest {
         }
 
         @Override
+        public void getStr(Record rec, Utf16Sink utf16Sink) {
+            Assert.assertEquals(ColumnType.STRING, type);
+            callCount++;
+        }
+
+        @Override
+        public void getStr(Record rec, Utf16Sink sink, int arrayIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public CharSequence getStrA(Record rec) {
             Assert.assertEquals(ColumnType.STRING, type);
             callCount++;
@@ -452,17 +464,6 @@ public class RecordSinkFactoryTest extends AbstractCairoTest {
 
         @Override
         public CharSequence getStrA(Record rec, int arrayIndex) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void getStr(Record rec, Utf16Sink utf16Sink) {
-            Assert.assertEquals(ColumnType.STRING, type);
-            callCount++;
-        }
-
-        @Override
-        public void getStr(Record rec, Utf16Sink sink, int arrayIndex) {
             throw new UnsupportedOperationException();
         }
 

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -257,6 +257,21 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelCaseExpressionKeyGroupBy3() throws Exception {
+        testParallelStringAndVarcharKeyGroupBy(
+                "SELECT CASE WHEN (value > 2023.5) THEN key ELSE '' END AS key, avg(value) " +
+                        "FROM tab GROUP BY key ORDER BY key",
+                "key\tavg\n" +
+                        "\t1024.3435935935936\n" +
+                        "k0\t3025.155860349127\n" +
+                        "k1\t3023.65625\n" +
+                        "k2\t3024.65625\n" +
+                        "k3\t3025.65625\n" +
+                        "k4\t3024.155860349127\n"
+        );
+    }
+
+    @Test
     public void testParallelCountOverMultiKeyGroupBy() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -329,6 +329,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testByteToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t3\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t3\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 3::byte" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testCaseErrors() throws Exception {
         assertException("select case from long_sequence(1)", 7, "unbalanced 'case'");
         assertException("select case end from long_sequence(1)", 12, "'when' expected");
@@ -478,6 +508,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         " rnd_char() b," +
                         " rnd_char() c" +
                         " from long_sequence(20)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testCharToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\tf\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\tf\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 'f'::char" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
                         ")",
                 null,
                 true,
@@ -664,6 +724,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDoubleToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t3.5\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t3.5\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 3.5::double" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testFloat() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -745,6 +835,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         " rnd_float() b," +
                         " rnd_float() c" +
                         " from long_sequence(20)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testFloatToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t3.5\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t3.5\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 3.5::float" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
                         ")",
                 null,
                 true,
@@ -910,321 +1030,6 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testLongToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t3\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t3\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 3::long" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testIntToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t3\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t3\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 3" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testFloatToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t3.5\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t3.5\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 3.5::float" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testDoubleToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t3.5\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t3.5\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 3.5::double" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testByteToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t3\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t3\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 3::byte" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testIpv4ToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t127.0.0.1\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t127.0.0.1\n" +
-                        "927\t127.0.0.1\n" +
-                        "-537\tꋯɟ\uF6BE腠\n" +
-                        "71\t127.0.0.1\n" +
-                        "121\t雑\uDB9C\uDCE1\uD9F6\uDF3D횝\uDB9A\uDF230pጙ锿\n" +
-                        "195\t\uE76C\uDBE3\uDCF2\uD981\uDF09۾芊,\uD931\uDF48ҽ\uDA01\uDE60E\n" +
-                        "432\t127.0.0.1\n" +
-                        "674\t127.0.0.1\n" +
-                        "211\t127.0.0.1\n" +
-                        "478\t127.0.0.1\n" +
-                        "-294\tEǄZ҄+W!\uD9FE\uDC46Jz\n" +
-                        "-544\t\uDBD6\uDC55ﭙ@\n" +
-                        "-426\tm[<\n" +
-                        "935\t127.0.0.1\n" +
-                        "-676\t➘`ؾ\uD9F5\uDF1D楣DB\uDAAD\uDE0A\uE916G\n" +
-                        "766\t127.0.0.1\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else '127.0.0.1'::ipv4" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(20)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testStringToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\tfoo\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\tfoo\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 'foo'::string" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testCharToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\tf\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\tf\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 'f'::char" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testShortToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\t42\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\t42\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else '42'::short" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testUuidToVarcharCast() throws Exception {
-        assertQuery(
-                "x\tcase\n" +
-                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
-                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
-                        "468\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n" +
-                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
-                        "770\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n",
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid" +
-                        "    end \n" +
-                        "from tanc",
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
     public void testIntToStringCast() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1262,36 +1067,6 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         " rnd_str() b," +
                         " rnd_str() c" +
                         " from long_sequence(20)" +
-                        ")",
-                null,
-                true,
-                true
-        );
-    }
-
-    @Test
-    public void testSingleCharSymbol() throws Exception {
-        assertQuery(
-                "category\tres\n" +
-                        "V\tfalse\n" +
-                        "T\tfalse\n" +
-                        "J\tfalse\n" +
-                        "W\ttrue\n" +
-                        "C\tfalse\n" +
-                        "P\tfalse\n" +
-                        "S\tfalse\n" +
-                        "W\ttrue\n" +
-                        "H\tfalse\n" +
-                        "Y\tfalse\n",
-                "SELECT category, \n" +
-                        "  CASE\n" +
-                        "    WHEN category = 'W' THEN true\n" +
-                        "    ELSE false\n" +
-                        "  END AS res\n" +
-                        "FROM tab",
-                "create table tab as (" +
-                        "select rnd_char()::symbol as category" +
-                        " from long_sequence(10)" +
                         ")",
                 null,
                 true,
@@ -1344,6 +1119,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testIntToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t3\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t3\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 3" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testIntToVarcharCastOnBranch() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1372,6 +1177,51 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         "    case\n" +
                         "        when x < 0 then a\n" +
                         "        when x > 100 and x < 500 then 10\n" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(20)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testIpv4ToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t127.0.0.1\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t127.0.0.1\n" +
+                        "927\t127.0.0.1\n" +
+                        "-537\tꋯɟ\uF6BE腠\n" +
+                        "71\t127.0.0.1\n" +
+                        "121\t雑\uDB9C\uDCE1\uD9F6\uDF3D횝\uDB9A\uDF230pጙ锿\n" +
+                        "195\t\uE76C\uDBE3\uDCF2\uD981\uDF09۾芊,\uD931\uDF48ҽ\uDA01\uDE60E\n" +
+                        "432\t127.0.0.1\n" +
+                        "674\t127.0.0.1\n" +
+                        "211\t127.0.0.1\n" +
+                        "478\t127.0.0.1\n" +
+                        "-294\tEǄZ҄+W!\uD9FE\uDC46Jz\n" +
+                        "-544\t\uDBD6\uDC55ﭙ@\n" +
+                        "-426\tm[<\n" +
+                        "935\t127.0.0.1\n" +
+                        "-676\t➘`ؾ\uD9F5\uDF1D楣DB\uDAAD\uDE0A\uE916G\n" +
+                        "766\t127.0.0.1\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else '127.0.0.1'::ipv4" +
                         "    end \n" +
                         "from tanc",
                 "create table tanc as (" +
@@ -1586,6 +1436,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLongToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t3\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t3\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 3::long" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testNonBooleanWhen() throws Exception {
         assertException(
                 "select \n" +
@@ -1697,6 +1577,66 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testShortToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\t42\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\t42\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else '42'::short" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testSingleCharSymbol() throws Exception {
+        assertQuery(
+                "category\tres\n" +
+                        "V\tfalse\n" +
+                        "T\tfalse\n" +
+                        "J\tfalse\n" +
+                        "W\ttrue\n" +
+                        "C\tfalse\n" +
+                        "P\tfalse\n" +
+                        "S\tfalse\n" +
+                        "W\ttrue\n" +
+                        "H\tfalse\n" +
+                        "Y\tfalse\n",
+                "SELECT category, \n" +
+                        "  CASE\n" +
+                        "    WHEN category = 'W' THEN true\n" +
+                        "    ELSE false\n" +
+                        "  END AS res\n" +
+                        "FROM tab",
+                "create table tab as (" +
+                        "select rnd_char()::symbol as category" +
+                        " from long_sequence(10)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testStr() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1786,6 +1726,36 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testStringToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\tfoo\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\tfoo\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 'foo'::string" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testTimestamp() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1867,6 +1837,63 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         " timestamp_sequence(3, 100) b," +
                         " timestamp_sequence(6, 100) c" +
                         " from long_sequence(20)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testUuidToVarcharCast() throws Exception {
+        assertQuery(
+                "x\tcase\n" +
+                        "-920\t&\uDA1F\uDE98|\uD924\uDE04\n" +
+                        "138\t톬F\uD9E6\uDECD1Ѓَᯤ\\篸\n" +
+                        "468\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n" +
+                        "-352\t-\uDBED\uDC98\uDA30\uDEE01W씌\n" +
+                        "770\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x < 0 then a\n" +
+                        "        when x > 100 and x < 200 then b\n" +
+                        "        else 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid" +
+                        "    end \n" +
+                        "from tanc",
+                "create table tanc as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a," +
+                        " rnd_varchar() b," +
+                        " rnd_varchar() c" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testVarcharCast() throws Exception {
+        assertQuery(
+                "x\tswitch\n" +
+                        "-920\t\n" +
+                        "97\tӄǈ2Lg\n" +
+                        "-104\t\n" +
+                        "-194\t\n" +
+                        "416\t\n",
+                "select \n" +
+                        "    x,\n" +
+                        "    case\n" +
+                        "        when x = 97 then a\n" +
+                        "        else ''" +
+                        "    end \n" +
+                        "from x",
+                "create table x as (" +
+                        "select rnd_int() % 1000 x," +
+                        " rnd_varchar() a" +
+                        " from long_sequence(5)" +
                         ")",
                 null,
                 true,

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/ILikeFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/ILikeFunctionFactoryTest.java
@@ -50,6 +50,21 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testBindVariableConcatIndexedVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar() name from long_sequence(2000))");
+
+            bindVariableService.setStr(0, "H");
+            try (RecordCursorFactory factory = select("select * from x where name ilike '%' || $1 || '%'")) {
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    println(factory, cursor);
+                    Assert.assertNotEquals(sink.toString().indexOf('H'), -1);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testBindVariableConcatNamed() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (select rnd_str() name from long_sequence(2000))");
@@ -65,18 +80,55 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testBindVariableConcatNamedVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar() name from long_sequence(2000))");
+
+            bindVariableService.setStr("str", "H");
+            try (RecordCursorFactory factory = select("select * from x where name ilike '%' || :str || '%'")) {
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    println(factory, cursor);
+                    Assert.assertNotEquals(sink.toString().indexOf('H'), -1);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testEmptyLikeString() throws Exception {
         assertMemoryLeak(() -> {
-            String sql = "create table x as (\n" +
-                    "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
-                    ")";
-            ddl(sql);
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
+                            ")"
+            );
+            assertSql(
+                    "name\n",
+                    "select * from x where name ilike ''"
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyLikeVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as varchar) as name from long_sequence(1)\n" +
+                            ")"
+            );
             assertSql(
                     "name\n",
                     "select * from x where name ilike ''"
@@ -87,16 +139,38 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testInvalidRegex() throws Exception {
         assertMemoryLeak(() -> {
-            String sql = "create table x as (\n" +
-                    "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
-                    ")";
-            ddl(sql);
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
+                            ")"
+            );
+            assertSql(
+                    "name\n",
+                    "select * from x where name ilike '[][n'"
+            );
+        });
+    }
+
+    @Test
+    public void testInvalidRegexVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as varchar) as name from long_sequence(1)\n" +
+                            ")"
+            );
             assertSql(
                     "name\n",
                     "select * from x where name ilike '[][n'"
@@ -108,7 +182,20 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     public void testLikeCharacterNoMatch() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (select rnd_str() name from long_sequence(2000))");
-            try (RecordCursorFactory factory = select("select * from x where  name ilike 'H'")) {
+            try (RecordCursorFactory factory = select("select * from x where name ilike 'H'")) {
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    println(factory, cursor);
+                    Assert.assertEquals(Chars.indexOf(sink, 'H'), -1);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testLikeCharacterNoMatchVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar() name from long_sequence(2000))");
+            try (RecordCursorFactory factory = select("select * from x where name ilike 'H'")) {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     println(factory, cursor);
                     Assert.assertEquals(Chars.indexOf(sink, 'H'), -1);
@@ -120,16 +207,17 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testLikeStringCaseInsensitive() throws Exception {
         assertMemoryLeak(() -> {
-            String sql = "create table x as (\n" +
-                    "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
-                    "union\n" +
-                    "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
-                    ")";
-            ddl(sql);
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as string) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as string) as name from long_sequence(1)\n" +
+                            ")"
+            );
             assertSql(
                     "name\n" +
                             "ABCGE\n",
@@ -259,6 +347,48 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLikeVarcharCaseInsensitive() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('ABCGE' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('SBDHDJ' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('BDGDGGG' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('AAAAVVV' as varchar) as name from long_sequence(1)\n" +
+                            ")"
+            );
+            assertSql(
+                    "name\n" +
+                            "ABCGE\n",
+                    "select * from x where name ilike 'aBcGe'"
+            );
+        });
+    }
+
+    @Test
+    public void testLikeVarcharCaseInsensitiveNonAscii() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table x as (\n" +
+                            "select cast('фу' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('бар' as varchar) as name from long_sequence(1)\n" +
+                            "union\n" +
+                            "select cast('баз' as varchar) as name from long_sequence(1)\n" +
+                            ")"
+            );
+            assertSql(
+                    "name\n" +
+                            "бар\n",
+                    "select * from x where name ilike 'БаР'"
+            );
+        });
+    }
+
+    @Test
     public void testNonConstantExpression() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (select rnd_str() name from long_sequence(2000))");
@@ -267,9 +397,40 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testNonConstantExpressionVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar() name from long_sequence(2000))");
+            assertException("select * from x where name ilike rnd_str('foo','bar')", 33, "use constant or bind variable");
+        });
+    }
+
+    @Test
     public void testNotLikeCharacterMatch() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x as (select rnd_str('a', 'BC', 'h', 'H', 'k') name from long_sequence(20))");
+            assertSql(
+                    "name\n" +
+                            "a\n" +
+                            "BC\n" +
+                            "BC\n" +
+                            "k\n" +
+                            "BC\n" +
+                            "BC\n" +
+                            "BC\n" +
+                            "k\n" +
+                            "BC\n" +
+                            "BC\n" +
+                            "a\n" +
+                            "k\n",
+                    "select * from x where not name ilike 'H'"
+            );
+        });
+    }
+
+    @Test
+    public void testNotLikeCharacterMatchVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar('a', 'BC', 'h', 'H', 'k') name from long_sequence(20))");
             assertSql(
                     "name\n" +
                             "a\n" +
@@ -307,6 +468,23 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testNotLikeStringMatchVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select rnd_varchar('kk', 'xJ', 'Xj', 'GU', 'XJ') name from long_sequence(20))");
+            assertSql(
+                    "name\n" +
+                            "kk\n" +
+                            "GU\n" +
+                            "GU\n" +
+                            "GU\n" +
+                            "GU\n" +
+                            "kk\n",
+                    "select * from x where not name ilike 'XJ'"
+            );
+        });
+    }
+
+    @Test
     public void testSimplePatternLikeString() throws Exception {
         assertMemoryLeak(() -> {
             compile("create table x ( s string ) ");
@@ -320,6 +498,59 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
             assertLike("s\nfoo\nfoobar\n", "select * from x where s ilike 'fOO%'", false);
             assertLike("s\nfoobar\n", "select * from x where s ilike '%baR'", false);
             assertLike("s\nfoo\nfoobar\n", "select * from x where s ilike '%OO%'", false);
+        });
+    }
+
+    @Test
+    public void testSimplePatternLikeStringNonAscii() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table x ( s string ) ");
+            compile("insert into x values ( 'фу' ), ( 'фубар' ), ( null ) ");
+
+            assertLike("s\n", "select * from x where s ilike 'ф'", false);
+            assertLike("s\n", "select * from x where s ilike '_'", false);
+            assertLike("s\nфу\nфубар\n\n", "select * from x where s ilike '%'", true);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike 'ф%'", false);
+            assertLike("s\nфубар\n", "select * from x where s ilike '%р'", false);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike 'фУ%'", false);
+            assertLike("s\nфу\n", "select * from x where s ilike 'фУ'", false);
+            assertLike("s\nфубар\n", "select * from x where s ilike '%баР'", false);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike '%У%'", false);
+        });
+    }
+
+    @Test
+    public void testSimplePatternLikeVarchar() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table x ( s varchar ) ");
+            compile("insert into x values ( 'foo' ), ( 'foobar' ), ( null ) ");
+
+            assertLike("s\n", "select * from x where s ilike 'f'", false);
+            assertLike("s\n", "select * from x where s ilike '_'", false);
+            assertLike("s\nfoo\nfoobar\n\n", "select * from x where s ilike '%'", true);
+            assertLike("s\nfoo\nfoobar\n", "select * from x where s ilike 'f%'", false);
+            assertLike("s\nfoobar\n", "select * from x where s ilike '%r'", false);
+            assertLike("s\nfoo\nfoobar\n", "select * from x where s ilike 'fOO%'", false);
+            assertLike("s\nfoobar\n", "select * from x where s ilike '%baR'", false);
+            assertLike("s\nfoo\nfoobar\n", "select * from x where s ilike '%OO%'", false);
+        });
+    }
+
+    @Test
+    public void testSimplePatternLikeVarcharNonAscii() throws Exception {
+        assertMemoryLeak(() -> {
+            compile("create table x ( s varchar ) ");
+            compile("insert into x values ( 'фу' ), ( 'фубар' ), ( null ) ");
+
+            assertLike("s\n", "select * from x where s ilike 'ф'", false);
+            assertLike("s\n", "select * from x where s ilike '_'", false);
+            assertLike("s\nфу\nфубар\n\n", "select * from x where s ilike '%'", true);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike 'ф%'", false);
+            assertLike("s\nфубар\n", "select * from x where s ilike '%р'", false);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike 'фУ%'", false);
+            assertLike("s\nфу\n", "select * from x where s ilike 'фУ'", false);
+            assertLike("s\nфубар\n", "select * from x where s ilike '%баР'", false);
+            assertLike("s\nфу\nфубар\n", "select * from x where s ilike '%У%'", false);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/std/str/CharsTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/CharsTest.java
@@ -321,6 +321,13 @@ public class CharsTest {
     }
 
     @Test
+    public void testIsAscii() {
+        Assert.assertTrue(Chars.isAscii(""));
+        Assert.assertTrue(Chars.isAscii("foo bar baz"));
+        Assert.assertFalse(Chars.isAscii("фу бар баз"));
+    }
+
+    @Test
     public void testIsBlank() {
         Assert.assertTrue(Chars.isBlank(null));
         Assert.assertTrue(Chars.isBlank(""));

--- a/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
@@ -48,11 +48,29 @@ public class Utf8sTest {
     }
 
     @Test
+    public void testContains() {
+        Assert.assertTrue(Utf8s.contains(new Utf8String("аз съм грут"), new Utf8String("грут")));
+        Assert.assertTrue(Utf8s.contains(new Utf8String("foo bar baz"), new Utf8String("bar")));
+        Assert.assertFalse(Utf8s.contains(new Utf8String("foo bar baz"), new Utf8String("buz")));
+        Assert.assertTrue(Utf8s.contains(new Utf8String("foo bar baz"), Utf8String.EMPTY));
+        Assert.assertFalse(Utf8s.contains(Utf8String.EMPTY, new Utf8String("foobar")));
+    }
+
+    @Test
     public void testContainsAscii() {
         Assert.assertTrue(Utf8s.containsAscii(new Utf8String("foo bar baz"), "bar"));
         Assert.assertFalse(Utf8s.containsAscii(new Utf8String("foo bar baz"), "buz"));
         Assert.assertTrue(Utf8s.containsAscii(new Utf8String("foo bar baz"), ""));
         Assert.assertFalse(Utf8s.containsAscii(Utf8String.EMPTY, "foobar"));
+    }
+
+    @Test
+    public void testContainsLowerCaseAscii() {
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("аз съм грут foo bar baz"), new Utf8String("bar")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("foo")));
+        Assert.assertFalse(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("buz")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), Utf8String.EMPTY));
+        Assert.assertFalse(Utf8s.containsLowerCaseAscii(Utf8String.EMPTY, new Utf8String("foobar")));
     }
 
     @Test
@@ -76,6 +94,15 @@ public class Utf8sTest {
     }
 
     @Test
+    public void testEndsWith() {
+        Assert.assertTrue(Utf8s.endsWith(new Utf8String("фу бар баз"), new Utf8String("баз")));
+        Assert.assertTrue(Utf8s.endsWith(new Utf8String("foo bar baz"), new Utf8String("baz")));
+        Assert.assertFalse(Utf8s.endsWith(new Utf8String("foo bar baz"), new Utf8String("bar")));
+        Assert.assertTrue(Utf8s.endsWith(new Utf8String("foo bar baz"), Utf8String.EMPTY));
+        Assert.assertFalse(Utf8s.endsWith(Utf8String.EMPTY, new Utf8String("foo")));
+    }
+
+    @Test
     public void testEndsWithAscii() {
         Assert.assertTrue(Utf8s.endsWithAscii(new Utf8String("foo bar baz"), "baz"));
         Assert.assertFalse(Utf8s.endsWithAscii(new Utf8String("foo bar baz"), "bar"));
@@ -89,6 +116,15 @@ public class Utf8sTest {
         Assert.assertFalse(Utf8s.endsWithAscii(new Utf8String("foo bar baz"), 'f'));
         Assert.assertFalse(Utf8s.endsWithAscii(new Utf8String("foo bar baz"), (char) 0));
         Assert.assertFalse(Utf8s.endsWithAscii(Utf8String.EMPTY, ' '));
+    }
+
+    @Test
+    public void testEndsWithLowerCaseAscii() {
+        Assert.assertTrue(Utf8s.endsWithLowerCaseAscii(new Utf8String("FOO BAR BAZ"), new Utf8String("baz")));
+        Assert.assertTrue(Utf8s.endsWithLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("baz")));
+        Assert.assertFalse(Utf8s.endsWithLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("bar")));
+        Assert.assertTrue(Utf8s.endsWithLowerCaseAscii(new Utf8String("foo bar baz"), Utf8String.EMPTY));
+        Assert.assertFalse(Utf8s.endsWithLowerCaseAscii(Utf8String.EMPTY, new Utf8String("foo")));
     }
 
     @Test
@@ -195,6 +231,13 @@ public class Utf8sTest {
     }
 
     @Test
+    public void testIndexOf() {
+        Assert.assertEquals(1, Utf8s.indexOf(new Utf8String("foo bar baz"), 0, 7, new Utf8String("oo")));
+        Assert.assertEquals(-1, Utf8s.indexOf(new Utf8String("foo bar baz"), 2, 4, new Utf8String("y")));
+        Assert.assertEquals(-1, Utf8s.indexOf(Utf8String.EMPTY, 0, 0, new Utf8String("byz")));
+    }
+
+    @Test
     public void testIndexOfAscii() {
         Assert.assertEquals(1, Utf8s.indexOfAscii(new Utf8String("foo bar baz"), 0, 7, "oo"));
         Assert.assertEquals(1, Utf8s.indexOfAscii(new Utf8String("foo bar baz"), 0, 7, "oo", -1));
@@ -216,6 +259,15 @@ public class Utf8sTest {
         Assert.assertEquals(2, Utf8s.indexOfAscii(new Utf8String("foo bar baz"), 0, 4, 'o', -1));
         Assert.assertEquals(-1, Utf8s.indexOfAscii(new Utf8String("foo bar baz"), 2, 4, 'y'));
         Assert.assertEquals(-1, Utf8s.indexOfAscii(Utf8String.EMPTY, 0, 0, 'y'));
+    }
+
+    @Test
+    public void testIndexOfLowerCaseAscii() {
+        Assert.assertEquals(20, Utf8s.indexOfLowerCaseAscii(new Utf8String("фу бар баз FOO BAR BAZ"), 0, 30, new Utf8String("oo")));
+        Assert.assertEquals(1, Utf8s.indexOfLowerCaseAscii(new Utf8String("FOO BAR BAZ"), 0, 7, new Utf8String("oo")));
+        Assert.assertEquals(1, Utf8s.indexOfLowerCaseAscii(new Utf8String("foo bar baz"), 0, 7, new Utf8String("oo")));
+        Assert.assertEquals(-1, Utf8s.indexOfLowerCaseAscii(new Utf8String("foo bar baz"), 2, 4, new Utf8String("y")));
+        Assert.assertEquals(-1, Utf8s.indexOfLowerCaseAscii(Utf8String.EMPTY, 0, 0, new Utf8String("byz")));
     }
 
     @Test
@@ -409,6 +461,15 @@ public class Utf8sTest {
         Assert.assertFalse(Utf8s.startsWithAscii(new Utf8String("foo bar baz"), "bar"));
         Assert.assertTrue(Utf8s.startsWithAscii(new Utf8String("foo bar baz"), ""));
         Assert.assertFalse(Utf8s.startsWithAscii(Utf8String.EMPTY, "foo"));
+    }
+
+    @Test
+    public void testStartsWithLowerCaseAscii() {
+        Assert.assertTrue(Utf8s.startsWithLowerCaseAscii(new Utf8String("FOO BAR BAZ"), new Utf8String("foo")));
+        Assert.assertTrue(Utf8s.startsWithLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("foo")));
+        Assert.assertFalse(Utf8s.startsWithLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("bar")));
+        Assert.assertTrue(Utf8s.startsWithLowerCaseAscii(new Utf8String("foo bar baz"), Utf8String.EMPTY));
+        Assert.assertFalse(Utf8s.startsWithLowerCaseAscii(Utf8String.EMPTY, new Utf8String("foo")));
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
@@ -67,7 +67,11 @@ public class Utf8sTest {
     @Test
     public void testContainsLowerCaseAscii() {
         Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("аз съм грут foo bar baz"), new Utf8String("bar")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("аз съм грут FoO BaR BaZ"), new Utf8String("bar")));
         Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("foo")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("FOO bar baz"), new Utf8String("foo")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("baz")));
+        Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("FOO BAR BAZ"), new Utf8String("baz")));
         Assert.assertFalse(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), new Utf8String("buz")));
         Assert.assertTrue(Utf8s.containsLowerCaseAscii(new Utf8String("foo bar baz"), Utf8String.EMPTY));
         Assert.assertFalse(Utf8s.containsLowerCaseAscii(Utf8String.EMPTY, new Utf8String("foobar")));


### PR DESCRIPTION
Also, includes the following:
* Fix varchar calls generated by RecordSinkFactory
* Add LIKE/ILIKE support for varchar

Local clickbench runs:
```sql
-- varchar column
-- 2.11s
SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%';
-- string column
-- 5.36s
SELECT COUNT(*) FROM hits WHERE URL2 LIKE '%google%';
```