### PR TITLE
chore(ilp): configuration string schema is case sensitive

### DIFF
--- a/core/src/main/java/io/questdb/client/impl/ConfStringParser.java
+++ b/core/src/main/java/io/questdb/client/impl/ConfStringParser.java
@@ -1,6 +1,5 @@
 package io.questdb.client.impl;
 
-import io.questdb.std.Chars;
 import io.questdb.std.str.StringSink;
 
 /**
@@ -108,7 +107,7 @@ public final class ConfStringParser {
                         output.put("empty schema at position 0");
                         return -1;
                     }
-                    Chars.toLowerCase(input, 0, i - 1, output);
+                    output.put(input, 0, i - 1);
                     return i + 1;
                 } else {
                     output.put("bad separator, expected '::' got ':").put(c).put("' at position ").put(i - 1);

--- a/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
+++ b/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
@@ -274,6 +274,10 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrError("http::addr=localhost:8080;auto_flush=invalid;", "invalid auto_flush [value=invalid, allowed-values=[on, off]]");
             assertConfStrError("http::addr=localhost:8080;auto_flush=off;auto_flush_rows=100;", "cannot set auto flush rows when auto-flush is disabled");
             assertConfStrError("http::addr=localhost:8080;auto_flush_rows=100;auto_flush=off;", "auto flush rows was already configured [autoFlushRows=100]");
+            assertConfStrError("HTTP::addr=localhost;", "invalid schema [schema=HTTP, supported-schemas=[http, https, tcp, tcps]]");
+            assertConfStrError("HTTPS::addr=localhost;", "invalid schema [schema=HTTPS, supported-schemas=[http, https, tcp, tcps]]");
+            assertConfStrError("TCP::addr=localhost;", "invalid schema [schema=TCP, supported-schemas=[http, https, tcp, tcps]]");
+            assertConfStrError("TCPS::addr=localhost;", "invalid schema [schema=TCPS, supported-schemas=[http, https, tcp, tcps]]");
 
             assertConfStrOk("addr=localhost:8080", "auto_flush_rows=100");
             assertConfStrOk("addr=localhost:8080", "auto_flush=on", "auto_flush_rows=100");

--- a/core/src/test/java/io/questdb/test/client/impl/ConfStringParserTest.java
+++ b/core/src/test/java/io/questdb/test/client/impl/ConfStringParserTest.java
@@ -153,10 +153,10 @@ public final class ConfStringParserTest {
     }
 
     @Test
-    public void testSchemaCaseInsensitive() {
+    public void testSchemaCaseSensitive() {
         assertSchemaOk("http::addr=localhost;USER=joe;pAsS=bloggs;", "http");
-        assertSchemaOk("HTTP::addr=localhost;USER=joe;pAsS=bloggs;", "http");
-        assertSchemaOk("HtTp::addr=localhost;USER=joe;pAsS=bloggs;", "http");
+        assertSchemaOk("HTTP::addr=localhost;USER=joe;pAsS=bloggs;", "HTTP");
+        assertSchemaOk("HtTp::addr=localhost;USER=joe;pAsS=bloggs;", "HtTp");
     }
 
     @Test
@@ -171,9 +171,9 @@ public final class ConfStringParserTest {
         assertSchemaError("x:;host=localhost;", "bad separator, expected '::' got ':;' at position 1");
         assertSchemaError("http://localhost:9000;host=localhost;", "bad separator, expected '::' got ':/' at position 4");
         assertSchemaOk("http::;", "http");
-        assertSchemaOk("HTTP::;", "http");
+        assertSchemaOk("HTTP::;", "HTTP");
         assertSchemaOk("http::addr=localhost;user=joe;pass=bloggs;auto_flush_rows=1000;", "http");
-        assertSchemaOk("TCP::addr=localhost;user=joe;pass=bloggs;auto_flush_rows=1000;", "tcp");
+        assertSchemaOk("TCP::addr=localhost;user=joe;pass=bloggs;auto_flush_rows=1000;", "TCP");
     }
 
     @Test


### PR DESCRIPTION
this makes it consistent with other clients