### PR TITLE
fix(sql): fix incorrect results returned when executing lower/upper/substring functions in parallel

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bin/Base64FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bin/Base64FunctionFactory.java
@@ -37,8 +37,8 @@ import io.questdb.std.BinarySequence;
 import io.questdb.std.Chars;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
-import io.questdb.std.str.Utf16Sink;
 import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf16Sink;
 
 public class Base64FunctionFactory implements FunctionFactory {
     @Override
@@ -81,6 +81,12 @@ public class Base64FunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public void getStr(Record rec, Utf16Sink utf16Sink) {
+            final BinarySequence sequence = getArg().getBin(rec);
+            Chars.base64Encode(sequence, this.maxLength, utf16Sink);
+        }
+
+        @Override
         public CharSequence getStrA(final Record rec) {
             final BinarySequence sequence = getArg().getBin(rec);
             sinkA.clear();
@@ -89,17 +95,16 @@ public class Base64FunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public void getStr(Record rec, Utf16Sink utf16Sink) {
-            final BinarySequence sequence = getArg().getBin(rec);
-            Chars.base64Encode(sequence, this.maxLength, utf16Sink);
-        }
-
-        @Override
         public CharSequence getStrB(final Record rec) {
             final BinarySequence sequence = getArg().getBin(rec);
             sinkB.clear();
             Chars.base64Encode(sequence, this.maxLength, sinkB);
             return sinkB;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
@@ -185,6 +185,11 @@ public class ConcatFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
+        @Override
         public void toPlan(PlanSink sink) {
             sink.val("concat(").val(functions).val(')');
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LowerVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LowerVarcharFunctionFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * Postgres-compatibility lower() alias for the to_lowercase() function.
+ */
+public class LowerVarcharFunctionFactory extends ToLowercaseFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "lower(Ø)";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/QuoteIdentFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/QuoteIdentFunctionFactory.java
@@ -51,7 +51,13 @@ public class QuoteIdentFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         Function arg = args.getQuick(0);
         if (arg.isConstant()) {
             CharSequence val = arg.getStrA(null);
@@ -62,14 +68,11 @@ public class QuoteIdentFunctionFactory implements FunctionFactory {
                 return new StrConstant(quotedVal.toString());
             }
         }
-
         return new QuoteIdentFunction(arg);
     }
 
     static class QuoteIdentFunction extends StrFunction implements UnaryFunction {
-
         private final Function arg;
-
         private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
 
@@ -95,6 +98,11 @@ public class QuoteIdentFunctionFactory implements FunctionFactory {
         @Override
         public CharSequence getStrB(Record rec) {
             return quote(sinkB, arg.getStrA(rec));
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         private static StringSink quote(StringSink sink, CharSequence str) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SizePrettyFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SizePrettyFunctionFactory.java
@@ -67,7 +67,13 @@ public class SizePrettyFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPos, CairoConfiguration config, SqlExecutionContext context) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPos,
+            CairoConfiguration config,
+            SqlExecutionContext context
+    ) {
         return new SizePretty(args.getQuick(0));
     }
 
@@ -100,11 +106,16 @@ public class SizePrettyFunctionFactory implements FunctionFactory {
             return getStr0(size.getLong(rec), sinkB);
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         @Nullable
-        private StringSink getStr0(long s, StringSink sinkA) {
+        private StringSink getStr0(long s, StringSink sink) {
             if (s != Numbers.LONG_NaN) {
-                toSizePretty(sinkA, s);
-                return sinkA;
+                toSizePretty(sink, s);
+                return sink;
             }
             return null;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringFunctionFactory.java
@@ -48,7 +48,13 @@ public class SubStringFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(final int position, final ObjList<Function> args, IntList argPositions, final CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         final Function strFunc = args.getQuick(0);
         final Function startFunc = args.getQuick(1);
         final Function lenFunc = args.getQuick(2);
@@ -69,7 +75,6 @@ public class SubStringFunctionFactory implements FunctionFactory {
     }
 
     private static class SubStringFunc extends StrFunction implements TernaryFunction {
-
         private final boolean isSimplifiable;
         private final Function lenFunc;
         private final StringSink sinkA = new StringSink();
@@ -135,6 +140,11 @@ public class SubStringFunctionFactory implements FunctionFactory {
             }
             int end = Math.min(strLen, rawStart + len - 1);
             return Math.max(0, end - start);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringVarcharFunctionFactory.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+public class SubStringVarcharFunctionFactory extends SubStringFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "substring(ØII)";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ToLowercaseFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ToLowercaseFunctionFactory.java
@@ -43,15 +43,19 @@ public class ToLowercaseFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(final int position, final ObjList<Function> args, IntList argPositions, final CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         return new ToLowercaseFunc(args.get(0));
     }
 
     private static class ToLowercaseFunc extends StrFunction implements UnaryFunction {
         private final Function arg;
-
         private final StringSink sinkA = new StringSink();
-
         private final StringSink sinkB = new StringSink();
 
         public ToLowercaseFunc(final Function arg) {
@@ -74,7 +78,6 @@ public class ToLowercaseFunctionFactory implements FunctionFactory {
             if (str == null) {
                 return null;
             }
-
             sinkA.clear();
             Chars.toLowerCase(str, sinkA);
             return sinkA;
@@ -86,7 +89,6 @@ public class ToLowercaseFunctionFactory implements FunctionFactory {
             if (str == null) {
                 return null;
             }
-
             sinkB.clear();
             Chars.toLowerCase(str, sinkB);
             return sinkB;
@@ -95,6 +97,11 @@ public class ToLowercaseFunctionFactory implements FunctionFactory {
         @Override
         public int getStrLen(final Record rec) {
             return arg.getStrLen(rec);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ToLowercaseVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ToLowercaseVarcharFunctionFactory.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+public class ToLowercaseVarcharFunctionFactory extends ToLowercaseFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_lowercase(Ø)";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ToUppercaseFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ToUppercaseFunctionFactory.java
@@ -43,15 +43,19 @@ public class ToUppercaseFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(final int position, final ObjList<Function> args, IntList argPositions, final CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         return new ToUppercaseFunc(args.get(0));
     }
 
     private static class ToUppercaseFunc extends StrFunction implements UnaryFunction {
         private final Function arg;
-
         private final StringSink sinkA = new StringSink();
-
         private final StringSink sinkB = new StringSink();
 
         public ToUppercaseFunc(final Function arg) {
@@ -74,7 +78,6 @@ public class ToUppercaseFunctionFactory implements FunctionFactory {
             if (str == null) {
                 return null;
             }
-
             sinkA.clear();
             Chars.toUpperCase(str, sinkA);
             return sinkA;
@@ -86,7 +89,6 @@ public class ToUppercaseFunctionFactory implements FunctionFactory {
             if (str == null) {
                 return null;
             }
-
             sinkB.clear();
             Chars.toUpperCase(str, sinkB);
             return sinkB;
@@ -95,6 +97,11 @@ public class ToUppercaseFunctionFactory implements FunctionFactory {
         @Override
         public int getStrLen(final Record rec) {
             return arg.getStrLen(rec);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ToUppercaseVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ToUppercaseVarcharFunctionFactory.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+public class ToUppercaseVarcharFunctionFactory extends ToUppercaseFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_uppercase(Ø)";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/UpperVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/UpperVarcharFunctionFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * Postgres-compatibility upper() alias for the to_uppercase() function.
+ */
+public class UpperVarcharFunctionFactory extends ToUppercaseFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "upper(Ø)";
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -874,9 +874,13 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.PositionFunctionFactory,
             // Change string case
             io.questdb.griffin.engine.functions.str.ToUppercaseFunctionFactory,
+            io.questdb.griffin.engine.functions.str.ToUppercaseVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.ToLowercaseFunctionFactory,
+            io.questdb.griffin.engine.functions.str.ToLowercaseVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.LowerFunctionFactory,
+            io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.UpperFunctionFactory,
+            io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory,
             // left/right
             io.questdb.griffin.engine.functions.str.LeftStrFunctionFactory,
             io.questdb.griffin.engine.functions.str.LeftVarcharFunctionFactory,
@@ -895,6 +899,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory,
             // substring
             io.questdb.griffin.engine.functions.str.SubStringFunctionFactory,
+            io.questdb.griffin.engine.functions.str.SubStringVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory,
 
             // trim

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -800,6 +800,7 @@ io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory
 
 # substring()
 io.questdb.griffin.engine.functions.str.SubStringFunctionFactory
+io.questdb.griffin.engine.functions.str.SubStringVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory
 
 #starts_with()
@@ -875,9 +876,13 @@ io.questdb.griffin.engine.functions.groupby.ApproxPercentileLongGroupByDefaultFu
 
 # Change string case
 io.questdb.griffin.engine.functions.str.ToUppercaseFunctionFactory
+io.questdb.griffin.engine.functions.str.ToUppercaseVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.ToLowercaseFunctionFactory
+io.questdb.griffin.engine.functions.str.ToLowercaseVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.LowerFunctionFactory
+io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperFunctionFactory
+io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory
 
 # Pad string
 io.questdb.griffin.engine.functions.str.LPadFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -1875,6 +1875,24 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelStringKeyGroupByWithFilter2() throws Exception {
+        testParallelStringAndVarcharKeyGroupBy(
+                "SELECT key, avg(value), sum(colTop), count() FROM tab WHERE upper(key) = 'K3' ORDER BY key",
+                "key\tavg\tsum\tcount\n" +
+                        "k3\t2025.5\t1640400.0\t1600\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyGroupByWithFilter3() throws Exception {
+        testParallelStringAndVarcharKeyGroupBy(
+                "SELECT key, avg(value), sum(colTop), count() FROM tab WHERE substring(key,2,1) = '3' ORDER BY key",
+                "key\tavg\tsum\tcount\n" +
+                        "k3\t2025.5\t1640400.0\t1600\n"
+        );
+    }
+
+    @Test
     public void testParallelStringKeyGroupByWithLimit() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
@@ -2671,7 +2689,6 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                 sqlExecutionContext
                         );
                         assertQueries(engine, sqlExecutionContext, queriesAndExpectedResults);
-
 
                         // now drop the String table and recreate it with a Varchar key
                         engine.drop("DROP TABLE tab", sqlExecutionContext);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/LowerVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/LowerVarcharFunctionFactoryTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory;
+import io.questdb.std.str.Utf8String;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class LowerVarcharFunctionFactoryTest extends AbstractFunctionFactoryTest {
+    @Test
+    public void testSimple() throws SqlException {
+        call(new Utf8String("AbC")).andAssert("abc");
+    }
+
+    @Test
+    public void testWithAllLowercase() throws SqlException {
+        call(new Utf8String("abcdefghijklmnopqrstuvxz")).andAssert("abcdefghijklmnopqrstuvxz");
+    }
+
+    @Test
+    public void testWithAllUppercase() throws SqlException {
+        call(new Utf8String("ABCDEFGHIJKLMNOPQRSTUVXZ")).andAssert("abcdefghijklmnopqrstuvxz");
+    }
+
+    @Test
+    public void testWithMixedCases() throws SqlException {
+        call(new Utf8String("ABCdefGHIjklMNOpqrSTUvxz")).andAssert("abcdefghijklmnopqrstuvxz");
+    }
+
+    @Test
+    public void testWithNonAsciiCharacters() throws SqlException {
+        call(new Utf8String("abcDEFghiJKLm...() { _; } >_[$($())] { <<< (=) \noPQRstuVXZ"))
+                .andAssert("abcdefghijklm...() { _; } >_[$($())] { <<< (=) \nopqrstuvxz");
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new LowerVarcharFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SubStringVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SubStringVarcharFunctionFactoryTest.java
@@ -27,47 +27,48 @@ package io.questdb.test.griffin.engine.functions.str;
 import io.questdb.cairo.CairoException;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
-import io.questdb.griffin.engine.functions.str.SubStringFunctionFactory;
+import io.questdb.griffin.engine.functions.str.SubStringVarcharFunctionFactory;
 import io.questdb.std.Numbers;
+import io.questdb.std.str.Utf8String;
 import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
 import org.junit.Test;
 
-public class SubStringFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class SubStringVarcharFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Test
     public void testNonPositiveStart() throws Exception {
-        call("foo", -3, 4).andAssert("");
-        call("foo", -3, 5).andAssert("f");
+        call(new Utf8String("foo"), -3, 4).andAssert("");
+        call(new Utf8String("foo"), -3, 5).andAssert("f");
         call(null, -3, 0).andAssert(null);
     }
 
     @Test
     public void testNullOrEmptyStr() throws Exception {
         call(null, 2, 4).andAssert(null);
-        call("", 2, 4).andAssert("");
+        call(Utf8String.EMPTY, 2, 4).andAssert("");
     }
 
     @Test
     public void testSimple() throws Exception {
         assertQuery(
                 "k\tsubstring\tlength\n" +
-                        "JWCPSWHYRXPEHNRXGZSXUXIB\tNRXGZS\t6\n" +
-                        "GPGWFFYUDE\t\t0\n" +
-                        "QEHBHFOWLPDXYSBEOUOJSH\tSBEOUO\t6\n" +
-                        "EDRQQULOFJGETJRSZSRY\tJRSZSR\t6\n" +
-                        "BVTMHGOOZZVDZJMYICCXZ\tJMYICC\t6\n" +
-                        "ICWEKGHVUVSDOTSEDYYCTGQ\tTSEDYY\t6\n" +
-                        "YXWCKYLSUWDSWUGSH\tUGSH\t4\n" +
-                        "NVTIQBZXIOVIKJSMSSUQSR\tJSMSSU\t6\n" +
-                        "\t\t-1\n" +  // null
-                        "VVSJOJIPHZEPIHVLTO\tHVLTO\t5\n" +
-                        "JUMLGLHMLLEOY\t\t0\n" +
-                        "\t\t-1\n" +  // null
-                        "IPZIMNZZRMFMBEZG\tEZG\t3\n" +
-                        "VDKFLOPJOXPKRGIIHY\tGIIHY\t5\n" +
-                        "OQMYSSMPGLUOHNZHZS\tNZHZS\t5\n",
-                "select k, substring(k,14,6), length(substring(k,14,6)) from x",
-                "create table x as (select rnd_str(10,25,1) k from long_sequence(15))",
+                        "раз два\tаз д\t4\n" +
+                        "раз два\tаз д\t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "пять шесть\tять \t4\n" +
+                        "пять шесть\tять \t4\n" +
+                        "пять шесть\tять \t4\n" +
+                        "пять шесть\tять \t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "раз два\tаз д\t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "пять шесть\tять \t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "три четыре\tри ч\t4\n" +
+                        "три четыре\tри ч\t4\n",
+                "select k, substring(k,2,4), length(substring(k,2,4)) from x",
+                "create table x as (select rnd_varchar('раз два','три четыре','пять шесть') k from long_sequence(15))",
                 null,
                 true,
                 true
@@ -76,20 +77,20 @@ public class SubStringFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Test
     public void testStartOrLenOutOfRange() throws Exception {
-        call("foo", 10, 1).andAssert("");
-        call("foo", 10, 10).andAssert("");
-        call("foo", 1, 10).andAssert("foo");
+        call(new Utf8String("foo"), 10, 1).andAssert("");
+        call(new Utf8String("foo"), 10, 10).andAssert("");
+        call(new Utf8String("foo"), 1, 10).andAssert("foo");
         call(null, 2, 4).andAssert(null);
     }
 
     @Test
     public void testZeroOrInvalidLength() throws Exception {
-        call("foo", 3, 0).andAssert("");
+        call(new Utf8String("foo"), 3, 0).andAssert("");
         call(null, 3, 0).andAssert(null);
-        call("foo", 3, Numbers.INT_NaN).andAssert(null);
+        call(new Utf8String("foo"), 3, Numbers.INT_NaN).andAssert(null);
 
         try {
-            call("foo", 3, -1).andAssert(null);
+            call(new Utf8String("foo"), 3, -1).andAssert(null);
             assertException("non-const negative len is not allowed");
         } catch (CairoException e) {
             // negative substring length is not allowed
@@ -110,6 +111,6 @@ public class SubStringFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Override
     protected FunctionFactory getFunctionFactory() {
-        return new SubStringFunctionFactory();
+        return new SubStringVarcharFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/UpperVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/UpperVarcharFunctionFactoryTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory;
+import io.questdb.std.str.Utf8String;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class UpperVarcharFunctionFactoryTest extends AbstractFunctionFactoryTest {
+    @Test
+    public void testSimple() throws SqlException {
+        call(new Utf8String("AbC")).andAssert("ABC");
+    }
+
+    @Test
+    public void testWithAllLowercase() throws SqlException {
+        call(new Utf8String("abcdefghijklmnopqrstuvxz")).andAssert("ABCDEFGHIJKLMNOPQRSTUVXZ");
+    }
+
+    @Test
+    public void testWithAllUppercase() throws SqlException {
+        call(new Utf8String("ABCDEFGHIJKLMNOPQRSTUVXZ")).andAssert("ABCDEFGHIJKLMNOPQRSTUVXZ");
+    }
+
+    @Test
+    public void testWithMixedCases() throws SqlException {
+        call(new Utf8String("ABCdefGHIjklMNOpqrSTUvxz")).andAssert("ABCDEFGHIJKLMNOPQRSTUVXZ");
+    }
+
+    @Test
+    public void testWithNonAsciiCharacters() throws SqlException {
+        call(new Utf8String("abcDEFghiJKLm...() { _; } >_[$($())] { <<< (=) \noPQRstuVXZ"))
+                .andAssert("ABCDEFGHIJKLM...() { _; } >_[$($())] { <<< (=) \nOPQRSTUVXZ");
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new UpperVarcharFunctionFactory();
+    }
+}


### PR DESCRIPTION
Queries with filters like `UPPER(str_col) LIKE '%FOOBAR%'` returned incorrect results when present in parallel filter or GROUP BY.

The list of affected SQL functions:
* upper/to_uppercase
* lower/to_lowercase
* substring
* base64
* quote_ident
* size_pretty
* concat