### PR TITLE
chore(build): add Xcheck:jni flag

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,7 @@
         <outputPath>target</outputPath>
         <runtime.assembly>none</runtime.assembly>
         <javac.target>11</javac.target>
-        <argLine>-ea -Dfile.encoding=UTF-8</argLine>
+        <argLine>-ea -Dfile.encoding=UTF-8 -Xcheck:jni</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
         <web.console.version>0.3.3</web.console.version>


### PR DESCRIPTION
# Motivation

Run testsuite with '-Xcheck:jni' to ensure we catch bugs in JNI code which could later cause issues like crashes

# Modifications

Add -Xcheck:jni

# Result

Testsuite will be able to catch more JNI bugs

# Related work

This PR was inspired by a Netty PR:
https://github.com/netty/netty/pull/13642

# JDK documentation 

https://docs.oracle.com/en/java/javase/11/tools/java.html

<img width="587" alt="image" src="https://github.com/questdb/questdb/assets/30938/5de39a9f-fdb3-464f-bd8a-0781fde9bf4c">

