### PR TITLE
perf(core): improve hash table lookup performance for small string keys such as column names and symbols

### DIFF
--- a/benchmarks/src/main/java/org/questdb/GroupByLong128HashSetBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/GroupByLong128HashSetBenchmark.java
@@ -79,7 +79,7 @@ public class GroupByLong128HashSetBenchmark {
     public void testGroupByLong128HashSet() {
         long lo = rnd.nextLong(size);
         long hi = rnd.nextLong(size);
-        int index = groupByLong128HashSet.of(ptr).keyIndex(lo, hi);
+        long index = groupByLong128HashSet.of(ptr).keyIndex(lo, hi);
         if (index >= 0) {
             groupByLong128HashSet.addAt(index, lo, hi);
             ptr = groupByLong128HashSet.ptr();

--- a/benchmarks/src/main/java/org/questdb/GroupByLong256HashSetBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/GroupByLong256HashSetBenchmark.java
@@ -81,7 +81,7 @@ public class GroupByLong256HashSetBenchmark {
         long l1 = rnd.nextLong(size);
         long l2 = rnd.nextLong(size);
         long l3 = rnd.nextLong(size);
-        int index = groupByLong256HashSet.of(ptr).keyIndex(l0, l1, l2, l3);
+        long index = groupByLong256HashSet.of(ptr).keyIndex(l0, l1, l2, l3);
         if (index >= 0) {
             groupByLong256HashSet.addAt(index, l0, l1, l2, l3);
             ptr = groupByLong256HashSet.ptr();

--- a/benchmarks/src/main/java/org/questdb/GroupByLongHashSetBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/GroupByLongHashSetBenchmark.java
@@ -78,7 +78,7 @@ public class GroupByLongHashSetBenchmark {
     @Benchmark
     public void testGroupByLongHashSet() {
         long value = rnd.nextLong(size);
-        int index = groupByLongHashSet.of(ptr).keyIndex(value);
+        long index = groupByLongHashSet.of(ptr).keyIndex(value);
         if (index >= 0) {
             groupByLongHashSet.addAt(index, value);
             ptr = groupByLongHashSet.ptr();

--- a/benchmarks/src/main/java/org/questdb/HyperLogLogBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/HyperLogLogBenchmark.java
@@ -80,7 +80,7 @@ public class HyperLogLogBenchmark {
     @Benchmark
     public void testGroupByLongHashSet() {
         long value = rnd.nextLong(N);
-        int index = set.of(setPtr).keyIndex(value);
+        long index = set.of(setPtr).keyIndex(value);
         if (index >= 0) {
             set.addAt(index, value);
             setPtr = set.ptr();

--- a/benchmarks/src/main/java/org/questdb/StringHashFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/StringHashFunctionBenchmark.java
@@ -26,9 +26,10 @@ package org.questdb;
 
 import io.questdb.std.Chars;
 import io.questdb.std.Hash;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.Unsafe;
+import io.questdb.std.Misc;
 import io.questdb.std.str.DirectString;
+import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.std.str.DirectUtf8String;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
@@ -43,11 +44,12 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class StringHashFunctionBenchmark {
 
-    private final DirectString charSequence = new DirectString();
-    private final DirectUtf8String utf8Sequence = new DirectUtf8String();
-    @Param({"7", "15", "31", "63"})
+    private final DirectString utf16String = new DirectString();
+    private final DirectUtf8String utf8String = new DirectUtf8String();
+    @Param({"7", "15", "31", "63", "1024"})
     private int len;
-    private long ptr;
+    private DirectUtf16Sink utf16Sink;
+    private DirectUtf8Sink utf8Sink;
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
@@ -61,26 +63,29 @@ public class StringHashFunctionBenchmark {
 
     @Setup(Level.Iteration)
     public void setUp() {
-        ptr = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);
-        charSequence.of(ptr, ptr + len);
-        utf8Sequence.of(ptr, ptr + len);
+        utf8Sink = new DirectUtf8Sink(len);
+        utf16Sink = new DirectUtf16Sink(2 * len);
         for (int i = 0; i < len; i++) {
-            Unsafe.getUnsafe().putByte(ptr + i, (byte) 'a');
+            utf8Sink.put('a');
+            utf16Sink.put('a');
         }
+        utf8String.of(utf8Sink.ptr(), utf8Sink.ptr() + utf8Sink.size());
+        utf16String.of(utf16Sink.ptr(), utf16Sink.ptr() + utf16Sink.size());
     }
 
     @TearDown(Level.Iteration)
     public void tearDown() {
-        ptr = Unsafe.free(ptr, len, MemoryTag.NATIVE_DEFAULT);
+        utf8Sink = Misc.free(utf8Sink);
+        utf16Sink = Misc.free(utf16Sink);
     }
 
     @Benchmark
-    public long testHashMemDirectByteCharSequence() {
-        return Hash.hashUtf8(utf8Sequence);
+    public long testHashUtf8() {
+        return Hash.hashUtf8(utf8String);
     }
 
     @Benchmark
-    public int testStandardDirectByteCharSequence() {
-        return Chars.hashCode(charSequence);
+    public int testStandardHashCharSequence() {
+        return Chars.hashCode(utf16String);
     }
 }

--- a/benchmarks/src/main/java/org/questdb/StringHashFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/StringHashFunctionBenchmark.java
@@ -76,7 +76,7 @@ public class StringHashFunctionBenchmark {
 
     @Benchmark
     public long testHashMemDirectByteCharSequence() {
-        return Hash.hashMem32(utf8Sequence);
+        return Hash.hashUtf8(utf8Sequence);
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
@@ -43,11 +43,9 @@ public class Utf8StringIntHashMapBenchmark {
 
     private final DirectString utf16String = new DirectString();
     private final DirectUtf8String utf8String = new DirectUtf8String();
-    //@Param({"16", "256", "1024"})
-    @Param({"1024"})
+    @Param({"16", "256", "1024"})
     private int n;
-    //@Param({"5", "7", "31", "63"})
-    @Param({"5"})
+    @Param({"5", "7", "31", "63"})
     private int prefixLength;
     private long[] utf16Addresses;
     private CharSequenceIntHashMap utf16Map = new CharSequenceIntHashMap();
@@ -98,7 +96,7 @@ public class Utf8StringIntHashMapBenchmark {
         utf16Map = new CharSequenceIntHashMap();
     }
 
-    //@Benchmark
+    @Benchmark
     public long testUtf16Map() {
         int sum = 0;
         for (int i = 0; i < n; i++) {

--- a/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
@@ -73,6 +73,7 @@ public class Utf8StringIntHashMapBenchmark {
         utf8Addresses[0] = utf8Sink.ptr();
         utf16Addresses[0] = utf16Sink.ptr();
         for (int i = 0; i < n; i++) {
+            // The keys have identical prefix, but different suffixes.
             for (int j = 0; j < prefixLength; j++) {
                 utf8Sink.put('a');
                 utf16Sink.put('a');

--- a/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/Utf8StringIntHashMapBenchmark.java
@@ -25,12 +25,9 @@
 package org.questdb;
 
 import io.questdb.std.CharSequenceIntHashMap;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.Unsafe;
+import io.questdb.std.Misc;
 import io.questdb.std.Utf8StringIntHashMap;
-import io.questdb.std.str.FlyweightDirectUtf16Sink;
-import io.questdb.std.str.DirectUtf8String;
-import io.questdb.std.str.Utf8String;
+import io.questdb.std.str.*;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -44,15 +41,20 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class Utf8StringIntHashMapBenchmark {
 
-    private final FlyweightDirectUtf16Sink dcs = new FlyweightDirectUtf16Sink();
-    private final DirectUtf8String dus = new DirectUtf8String();
-    private Utf8StringIntHashMap directMap = new Utf8StringIntHashMap();
-    @Param({"7", "15", "31", "63"})
-    private int len;
-    @Param({"16", "256"})
+    private final DirectString utf16String = new DirectString();
+    private final DirectUtf8String utf8String = new DirectUtf8String();
+    //@Param({"16", "256", "1024"})
+    @Param({"1024"})
     private int n;
-    private CharSequenceIntHashMap nonDirectMap = new CharSequenceIntHashMap();
-    private long ptr;
+    //@Param({"5", "7", "31", "63"})
+    @Param({"5"})
+    private int prefixLength;
+    private long[] utf16Addresses;
+    private CharSequenceIntHashMap utf16Map = new CharSequenceIntHashMap();
+    private DirectUtf16Sink utf16Sink;
+    private long[] utf8Addresses;
+    private Utf8StringIntHashMap utf8Map = new Utf8StringIntHashMap();
+    private DirectUtf8Sink utf8Sink;
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
@@ -66,43 +68,50 @@ public class Utf8StringIntHashMapBenchmark {
 
     @Setup(Level.Iteration)
     public void setUp() {
-        ptr = Unsafe.malloc((long) n * len, MemoryTag.NATIVE_DEFAULT);
-        dus.of(ptr, ptr + len);
+        utf8Sink = new DirectUtf8Sink(2 * n * prefixLength);
+        utf16Sink = new DirectUtf16Sink(4 * n * prefixLength);
+        utf8Addresses = new long[n + 1];
+        utf16Addresses = new long[n + 1];
+        utf8Addresses[0] = utf8Sink.ptr();
+        utf16Addresses[0] = utf16Sink.ptr();
         for (int i = 0; i < n; i++) {
-            StringBuilder sb = new StringBuilder();
-            for (int j = 0; j < len; j++) {
-                char ch = (char) ('a' + i + j);
-                Unsafe.getUnsafe().putByte(ptr + (long) i * len + j, (byte) ch);
-                sb.append(ch);
+            for (int j = 0; j < prefixLength; j++) {
+                utf8Sink.put('a');
+                utf16Sink.put('a');
             }
-            nonDirectMap.put(sb.toString(), 42);
-            directMap.put(Utf8String.newInstance(dus), 42);
+            utf8Sink.put(i);
+            utf16Sink.put(i);
+
+            utf8Map.put(Utf8String.newInstance(utf8Sink), 42);
+            utf16Map.put(utf16Sink.toString(), 42);
+
+            utf8Addresses[i + 1] = utf8Sink.ptr() + utf8Sink.size();
+            utf16Addresses[i + 1] = utf16Sink.ptr() + utf16Sink.size();
         }
     }
 
     @TearDown(Level.Iteration)
     public void tearDown() {
-        ptr = Unsafe.free(ptr, (long) n * len, MemoryTag.NATIVE_DEFAULT);
-        directMap = new Utf8StringIntHashMap();
-        nonDirectMap = new CharSequenceIntHashMap();
+        utf8Sink = Misc.free(utf8Sink);
+        utf16Sink = Misc.free(utf16Sink);
+        utf8Map = new Utf8StringIntHashMap();
+        utf16Map = new CharSequenceIntHashMap();
     }
 
-    @Benchmark
-    public int testDirectMap() {
+    //@Benchmark
+    public long testUtf16Map() {
         int sum = 0;
         for (int i = 0; i < n; i++) {
-            dus.of(ptr + (long) i * len, ptr + (long) (i + 1) * len);
-            sum += directMap.get(dus);
+            sum += utf16Map.get(utf16String.of(utf16Addresses[i], utf16Addresses[i + 1]));
         }
         return sum;
     }
 
     @Benchmark
-    public long testNonDirectMap() {
+    public int testUtf8Map() {
         int sum = 0;
         for (int i = 0; i < n; i++) {
-            dcs.of(ptr + (long) i * len, ptr + (long) (i + 1) * len);
-            sum += nonDirectMap.get(dcs);
+            sum += utf8Map.get(utf8String.of(utf8Addresses[i], utf8Addresses[i + 1]));
         }
         return sum;
     }

--- a/core/src/main/java/io/questdb/cairo/map/MapKey.java
+++ b/core/src/main/java/io/questdb/cairo/map/MapKey.java
@@ -43,7 +43,7 @@ public interface MapKey extends RecordSinkSPI {
     MapValue createValue();
 
     // Same as createValue(), but doesn't calculate hash code.
-    MapValue createValue(int hashCode);
+    MapValue createValue(long hashCode);
 
     // Commits implicitly.
     MapValue findValue();
@@ -55,7 +55,7 @@ public interface MapKey extends RecordSinkSPI {
     MapValue findValue3();
 
     // Must be called after commit.
-    int hash();
+    long hash();
 
     default boolean notFound() {
         return findValue() == null;

--- a/core/src/main/java/io/questdb/cairo/map/MapRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/MapRecord.java
@@ -36,7 +36,7 @@ public interface MapRecord extends Record {
 
     MapValue getValue();
 
-    int keyHashCode();
+    long keyHashCode();
 
     void setSymbolTableResolver(RecordCursor resolver, IntList symbolTableIndex);
 }

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
@@ -239,7 +239,7 @@ public class OrderedMap implements Map, Reopenable {
     }
 
     @Override
-    public final void close() {
+    public void close() {
         Misc.free(offsets);
         if (heapStart != 0) {
             Unsafe.free(heapStart, heapSize, heapMemoryTag);

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMapFixedSizeRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMapFixedSizeRecord.java
@@ -295,8 +295,8 @@ final class OrderedMapFixedSizeRecord implements OrderedMapRecord {
     }
 
     @Override
-    public int keyHashCode() {
-        return Hash.hashMem32(keyAddress, keySize);
+    public long keyHashCode() {
+        return Hash.hashMem64(keyAddress, keySize);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMapVarSizeRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMapVarSizeRecord.java
@@ -439,9 +439,9 @@ final class OrderedMapVarSizeRecord implements OrderedMapRecord {
     }
 
     @Override
-    public int keyHashCode() {
+    public long keyHashCode() {
         int keySize = Unsafe.getUnsafe().getInt(startAddress);
-        return Hash.hashMem32(startAddress + Integer.BYTES, keySize);
+        return Hash.hashMem64(startAddress + Integer.BYTES, keySize);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/map/ShardedMapCursor.java
+++ b/core/src/main/java/io/questdb/cairo/map/ShardedMapCursor.java
@@ -251,13 +251,13 @@ public class ShardedMapCursor implements MapRecordCursor {
         }
 
         @Override
-        public CharSequence getStrA(int columnIndex) {
-            return baseRecord.getStrA(columnIndex);
+        public void getStr(int columnIndex, Utf16Sink utf16Sink) {
+            baseRecord.getStr(columnIndex, utf16Sink);
         }
 
         @Override
-        public void getStr(int columnIndex, Utf16Sink utf16Sink) {
-            baseRecord.getStr(columnIndex, utf16Sink);
+        public CharSequence getStrA(int columnIndex) {
+            return baseRecord.getStrA(columnIndex);
         }
 
         @Override
@@ -301,7 +301,7 @@ public class ShardedMapCursor implements MapRecordCursor {
         }
 
         @Override
-        public int keyHashCode() {
+        public long keyHashCode() {
             return baseRecord.keyHashCode();
         }
 

--- a/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered16Map.java
@@ -190,7 +190,7 @@ public class Unordered16Map implements Map, Reopenable {
     }
 
     @Override
-    public final void close() {
+    public void close() {
         if (memStart != 0) {
             memLimit = memStart = Unsafe.free(memStart, memLimit - memStart, memoryTag);
             keyMemStart = Unsafe.free(keyMemStart, KEY_SIZE, memoryTag);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered16MapRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered16MapRecord.java
@@ -290,10 +290,10 @@ final class Unordered16MapRecord implements MapRecord {
     }
 
     @Override
-    public int keyHashCode() {
+    public long keyHashCode() {
         long key1 = Unsafe.getUnsafe().getLong(startAddress);
         long key2 = Unsafe.getUnsafe().getLong(startAddress + 8L);
-        return Hash.hashLong128(key1, key2);
+        return Hash.hashLong128_64(key1, key2);
     }
 
     public void of(long address) {

--- a/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
@@ -312,7 +312,7 @@ public class Unordered2Map implements Map, Reopenable {
         }
 
         @Override
-        public MapValue createValue(int hashCode) {
+        public MapValue createValue(long hashCode) {
             return createValue();
         }
 
@@ -332,7 +332,7 @@ public class Unordered2Map implements Map, Reopenable {
         }
 
         @Override
-        public int hash() {
+        public long hash() {
             return 0; // no-op
         }
 

--- a/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
@@ -140,7 +140,7 @@ public class Unordered2Map implements Map, Reopenable {
     }
 
     @Override
-    public final void close() {
+    public void close() {
         if (memStart != 0) {
             memStart = memLimit = Unsafe.free(memStart, entrySize * TABLE_SIZE, memoryTag);
             keyMemStart = Unsafe.free(keyMemStart, KEY_SIZE, memoryTag);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered2MapRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2MapRecord.java
@@ -290,7 +290,7 @@ final class Unordered2MapRecord implements MapRecord {
     }
 
     @Override
-    public int keyHashCode() {
+    public long keyHashCode() {
         return 0; // no-op
     }
 

--- a/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
@@ -188,7 +188,7 @@ public class Unordered4Map implements Map, Reopenable {
     }
 
     @Override
-    public final void close() {
+    public void close() {
         if (memStart != 0) {
             memLimit = memStart = Unsafe.free(memStart, memLimit - memStart, memoryTag);
             keyMemStart = Unsafe.free(keyMemStart, KEY_SIZE, memoryTag);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered4MapRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered4MapRecord.java
@@ -290,8 +290,8 @@ final class Unordered4MapRecord implements MapRecord {
     }
 
     @Override
-    public int keyHashCode() {
-        return Hash.hashInt(Unsafe.getUnsafe().getInt(startAddress));
+    public long keyHashCode() {
+        return Hash.hashInt64(Unsafe.getUnsafe().getInt(startAddress));
     }
 
     public void of(long address) {

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -86,7 +86,7 @@ public class Unordered8Map implements Map, Reopenable {
     private int initialKeyCapacity;
     private int keyCapacity;
     private long keyMemStart; // Key look-up memory start pointer.
-    private int mask;
+    private long mask;
     private long memLimit; // Hash table memory limit pointer.
     private long memStart; // Hash table memory start pointer.
     private int nResizes;
@@ -252,7 +252,7 @@ public class Unordered8Map implements Map, Reopenable {
                 continue;
             }
 
-            long destAddr = getStartAddress(Hash.hashLong(key) & mask);
+            long destAddr = getStartAddress(Hash.hashLong64(key) & mask);
             for (; ; ) {
                 long k = Unsafe.getUnsafe().getLong(destAddr);
                 if (k == 0) {
@@ -340,7 +340,7 @@ public class Unordered8Map implements Map, Reopenable {
         return key.init();
     }
 
-    private Unordered8MapValue asNew(long startAddress, long key, int hashCode, Unordered8MapValue value) {
+    private Unordered8MapValue asNew(long startAddress, long key, long hashCode, Unordered8MapValue value) {
         Unsafe.getUnsafe().putLong(startAddress, key);
         if (--free == 0) {
             rehash();
@@ -368,15 +368,15 @@ public class Unordered8Map implements Map, Reopenable {
         return memStart;
     }
 
-    private long getStartAddress(long memStart, int index) {
+    private long getStartAddress(long memStart, long index) {
         return memStart + entrySize * index;
     }
 
-    private long getStartAddress(int index) {
+    private long getStartAddress(long index) {
         return memStart + entrySize * index;
     }
 
-    private Unordered8MapValue probe0(long key, long startAddress, int hashCode, Unordered8MapValue value) {
+    private Unordered8MapValue probe0(long key, long startAddress, long hashCode, Unordered8MapValue value) {
         for (; ; ) {
             startAddress = getNextAddress(startAddress);
             long k = Unsafe.getUnsafe().getLong(startAddress);
@@ -427,7 +427,7 @@ public class Unordered8Map implements Map, Reopenable {
                 continue;
             }
 
-            long newAddr = getStartAddress(newMemStart, Hash.hashLong(key) & newMask);
+            long newAddr = getStartAddress(newMemStart, Hash.hashLong64(key) & newMask);
             while (Unsafe.getUnsafe().getLong(newAddr) != 0) {
                 newAddr += entrySize;
                 if (newAddr >= newMemLimit) {
@@ -480,11 +480,11 @@ public class Unordered8Map implements Map, Reopenable {
             if (key == 0) {
                 return createZeroKeyValue();
             }
-            return createNonZeroKeyValue(key, Hash.hashLong(key));
+            return createNonZeroKeyValue(key, Hash.hashLong64(key));
         }
 
         @Override
-        public MapValue createValue(int hashCode) {
+        public MapValue createValue(long hashCode) {
             long key = Unsafe.getUnsafe().getLong(keyMemStart);
             if (key == 0) {
                 return createZeroKeyValue();
@@ -508,8 +508,8 @@ public class Unordered8Map implements Map, Reopenable {
         }
 
         @Override
-        public int hash() {
-            return Hash.hashLong(Unsafe.getUnsafe().getLong(keyMemStart));
+        public long hash() {
+            return Hash.hashLong64(Unsafe.getUnsafe().getLong(keyMemStart));
         }
 
         public Key init() {
@@ -630,7 +630,7 @@ public class Unordered8Map implements Map, Reopenable {
             appendAddress += bytes;
         }
 
-        private MapValue createNonZeroKeyValue(long key, int hashCode) {
+        private MapValue createNonZeroKeyValue(long key, long hashCode) {
             long startAddress = getStartAddress(hashCode & mask);
             long k = Unsafe.getUnsafe().getLong(startAddress);
             if (k == 0) {
@@ -655,7 +655,7 @@ public class Unordered8Map implements Map, Reopenable {
                 return hasZero ? valueOf(zeroMemStart, false, value) : null;
             }
 
-            long startAddress = getStartAddress(Hash.hashLong(key) & mask);
+            long startAddress = getStartAddress(Hash.hashLong64(key) & mask);
             long k = Unsafe.getUnsafe().getLong(startAddress);
             if (k == 0) {
                 return null;

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -189,7 +189,7 @@ public class Unordered8Map implements Map, Reopenable {
     }
 
     @Override
-    public final void close() {
+    public void close() {
         if (memStart != 0) {
             memLimit = memStart = Unsafe.free(memStart, memLimit - memStart, memoryTag);
             keyMemStart = Unsafe.free(keyMemStart, KEY_SIZE, memoryTag);

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8MapRecord.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8MapRecord.java
@@ -290,8 +290,8 @@ final class Unordered8MapRecord implements MapRecord {
     }
 
     @Override
-    public int keyHashCode() {
-        return Hash.hashLong(Unsafe.getUnsafe().getLong(startAddress));
+    public long keyHashCode() {
+        return Hash.hashLong64(Unsafe.getUnsafe().getLong(startAddress));
     }
 
     public void of(long address) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/SymbolCache.java
@@ -36,12 +36,6 @@ import io.questdb.std.str.*;
 
 import java.io.Closeable;
 
-/**
- * Important note:
- * This cache is optimized for ASCII and UTF8 DirectByteCharSequence lookups. Lookups of UTF16
- * strings (j.l.String) with non-ASCII chars will not work correctly, so make sure to re-encode
- * the string in UTF8.
- */
 public class SymbolCache implements DirectUtf8SymbolLookup, Closeable {
     private final MicrosecondClock clock;
     private final SymbolMapReaderImpl symbolMapReader = new SymbolMapReaderImpl();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -73,7 +73,7 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
         final int val = arg.getIPv4(record);
         if (val != Numbers.IPv4_NULL) {
             long ptr = mapValue.getLong(valueIndex + 1);
-            final int index = setA.of(ptr).keyIndex(val);
+            final long index = setA.of(ptr).keyIndex(val);
             if (index >= 0) {
                 setA.addAt(index, val);
                 mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -77,7 +77,7 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
             long ptr = mapValue.getLong(valueIndex + 1);
             // Remap zero since it's used as the no entry key.
             val = (val == 0) ? Numbers.INT_NaN : val;
-            final int index = setA.of(ptr).keyIndex(val);
+            final long index = setA.of(ptr).keyIndex(val);
             if (index >= 0) {
                 setA.addAt(index, val);
                 mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -100,7 +100,7 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
                 l2 = Numbers.LONG_NaN;
                 l3 = Numbers.LONG_NaN;
             }
-            final int index = setA.of(ptr).keyIndex(l0, l1, l2, l3);
+            final long index = setA.of(ptr).keyIndex(l0, l1, l2, l3);
             if (index >= 0) {
                 setA.addAt(index, l0, l1, l2, l3);
                 mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -77,7 +77,7 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
             long ptr = mapValue.getLong(valueIndex + 1);
             // Remap zero since it's used as the no entry key.
             val = (val == 0) ? Numbers.LONG_NaN : val;
-            final int index = setA.of(ptr).keyIndex(val);
+            final long index = setA.of(ptr).keyIndex(val);
             if (index >= 0) {
                 setA.addAt(index, val);
                 mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -86,7 +86,7 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
                 lo = Numbers.LONG_NaN;
                 hi = Numbers.LONG_NaN;
             }
-            final int index = setA.of(ptr).keyIndex(lo, hi);
+            final long index = setA.of(ptr).keyIndex(lo, hi);
             if (index >= 0) {
                 setA.addAt(index, lo, hi);
                 mapValue.addLong(valueIndex, 1);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
@@ -52,7 +52,7 @@ public class GroupByLong128HashSet {
     private final double loadFactor;
     private final long noKeyValue;
     private GroupByAllocator allocator;
-    private int mask;
+    private long mask;
     private long ptr;
 
     public GroupByLong128HashSet(int initialCapacity, double loadFactor, long noKeyValue) {
@@ -72,7 +72,7 @@ public class GroupByLong128HashSet {
      * @return false if key is already in the set and true otherwise.
      */
     public boolean add(long lo, long hi) {
-        int index = keyIndex(lo, hi);
+        long index = keyIndex(lo, hi);
         if (index < 0) {
             return false;
         }
@@ -80,7 +80,7 @@ public class GroupByLong128HashSet {
         return true;
     }
 
-    public void addAt(int index, long lo, long hi) {
+    public void addAt(long index, long lo, long hi) {
         setKeyAt(index, lo, hi);
         int size = size();
         int sizeLimit = sizeLimit();
@@ -94,13 +94,13 @@ public class GroupByLong128HashSet {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
     }
 
-    public long keyAddrAt(int index) {
+    public long keyAddrAt(long index) {
         return ptr + HEADER_SIZE + 16L * index;
     }
 
-    public int keyIndex(long lo, long hi) {
-        int hashCode = Hash.hashLong128(lo, hi);
-        int index = hashCode & mask;
+    public long keyIndex(long lo, long hi) {
+        long hashCode = Hash.hashLong128_64(lo, hi);
+        long index = hashCode & mask;
         long keyAddr = keyAddrAt(index);
         long loKey = Unsafe.getUnsafe().getLong(keyAddr);
         long hiKey = Unsafe.getUnsafe().getLong(keyAddr + 8L);
@@ -132,7 +132,7 @@ public class GroupByLong128HashSet {
             long lo = Unsafe.getUnsafe().getLong(p);
             long hi = Unsafe.getUnsafe().getLong(p + 8L);
             if (lo != noKeyValue || hi != noKeyValue) {
-                final int index = keyIndex(lo, hi);
+                final long index = keyIndex(lo, hi);
                 if (index >= 0) {
                     addAt(index, lo, hi);
                 }
@@ -175,7 +175,7 @@ public class GroupByLong128HashSet {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
     }
 
-    private int probe(long lo, long hi, int index) {
+    private long probe(long lo, long hi, long index) {
         do {
             index = (index + 1) & mask;
             long p = keyAddrAt(index);
@@ -210,7 +210,7 @@ public class GroupByLong128HashSet {
             long lo = Unsafe.getUnsafe().getLong(p);
             long hi = Unsafe.getUnsafe().getLong(p + 8L);
             if (lo != noKeyValue || hi != noKeyValue) {
-                int index = keyIndex(lo, hi);
+                long index = keyIndex(lo, hi);
                 setKeyAt(index, lo, hi);
             }
         }
@@ -218,7 +218,7 @@ public class GroupByLong128HashSet {
         allocator.free(oldPtr, HEADER_SIZE + 16L * oldCapacity);
     }
 
-    private void setKeyAt(int index, long lo, long hi) {
+    private void setKeyAt(long index, long lo, long hi) {
         long p = keyAddrAt(index);
         Unsafe.getUnsafe().putLong(p, lo);
         Unsafe.getUnsafe().putLong(p + 8L, hi);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
@@ -52,7 +52,7 @@ public class GroupByLong256HashSet {
     private final double loadFactor;
     private final long noKeyValue;
     private GroupByAllocator allocator;
-    private int mask;
+    private long mask;
     private long ptr;
 
     public GroupByLong256HashSet(int initialCapacity, double loadFactor, long noKeyValue) {
@@ -74,7 +74,7 @@ public class GroupByLong256HashSet {
      * @return false if key is already in the set and true otherwise.
      */
     public boolean add(long k0, long k1, long k2, long k3) {
-        int index = keyIndex(k0, k1, k2, k3);
+        long index = keyIndex(k0, k1, k2, k3);
         if (index < 0) {
             return false;
         }
@@ -82,7 +82,7 @@ public class GroupByLong256HashSet {
         return true;
     }
 
-    public void addAt(int index, long k0, long k1, long k2, long k3) {
+    public void addAt(long index, long k0, long k1, long k2, long k3) {
         setKeyAt(index, k0, k1, k2, k3);
         int size = size();
         int sizeLimit = sizeLimit();
@@ -96,13 +96,13 @@ public class GroupByLong256HashSet {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
     }
 
-    public long keyAddrAt(int index) {
+    public long keyAddrAt(long index) {
         return ptr + HEADER_SIZE + 32L * index;
     }
 
-    public int keyIndex(long k0, long k1, long k2, long k3) {
-        int hashCode = Hash.hashLong256(k0, k1, k2, k3);
-        int index = hashCode & mask;
+    public long keyIndex(long k0, long k1, long k2, long k3) {
+        long hashCode = Hash.hashLong256_64(k0, k1, k2, k3);
+        long index = hashCode & mask;
         long p = keyAddrAt(index);
         long k0Key = Unsafe.getUnsafe().getLong(p);
         long k1Key = Unsafe.getUnsafe().getLong(p + 8L);
@@ -138,7 +138,7 @@ public class GroupByLong256HashSet {
             long k2 = Unsafe.getUnsafe().getLong(p + 16L);
             long k3 = Unsafe.getUnsafe().getLong(p + 24L);
             if (k0 != noKeyValue || k1 != noKeyValue || k2 != noKeyValue || k3 != noKeyValue) {
-                final int index = keyIndex(k0, k1, k2, k3);
+                final long index = keyIndex(k0, k1, k2, k3);
                 if (index >= 0) {
                     addAt(index, k0, k1, k2, k3);
                 }
@@ -181,7 +181,7 @@ public class GroupByLong256HashSet {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
     }
 
-    private int probe(long k0, long k1, long k2, long k3, int index) {
+    private long probe(long k0, long k1, long k2, long k3, long index) {
         do {
             index = (index + 1) & mask;
             long p = keyAddrAt(index);
@@ -220,7 +220,7 @@ public class GroupByLong256HashSet {
             long k2 = Unsafe.getUnsafe().getLong(p + 16L);
             long k3 = Unsafe.getUnsafe().getLong(p + 24L);
             if (k0 != noKeyValue || k1 != noKeyValue || k2 != noKeyValue || k3 != noKeyValue) {
-                int index = keyIndex(k0, k1, k2, k3);
+                long index = keyIndex(k0, k1, k2, k3);
                 setKeyAt(index, k0, k1, k2, k3);
             }
         }
@@ -228,7 +228,7 @@ public class GroupByLong256HashSet {
         allocator.free(oldPtr, HEADER_SIZE + 32L * oldCapacity);
     }
 
-    private void setKeyAt(int index, long k0, long k1, long k2, long k3) {
+    private void setKeyAt(long index, long k0, long k1, long k2, long k3) {
         long p = keyAddrAt(index);
         Unsafe.getUnsafe().putLong(p, k0);
         Unsafe.getUnsafe().putLong(p + 8L, k1);

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -48,8 +48,8 @@ import java.io.Closeable;
 import static io.questdb.griffin.engine.table.AsyncJitFilteredRecordCursorFactory.prepareBindVarMemory;
 
 public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Plannable {
-    // We use the first 8 bits of a hash code to determine the shard, hence 128 as the max number of shards.
-    private static final int MAX_SHARDS = 128;
+    // We use the first 8 bits of a hash code to determine the shard, hence 256 as the max number of shards.
+    private static final int MAX_SHARDS = 256;
     private final ObjList<Function> bindVarFunctions;
     private final MemoryCARW bindVarMemory;
     private final CompiledFilter compiledFilter;
@@ -123,7 +123,7 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
             perWorkerLocks = new PerWorkerLocks(configuration, slotCount);
 
             shardCount = Math.min(Numbers.ceilPow2(2 * workerCount), MAX_SHARDS);
-            shardCountShr = Integer.numberOfLeadingZeros(shardCount) + 1;
+            shardCountShr = Long.numberOfLeadingZeros(shardCount) + 1;
             ownerParticle = new Particle();
             perWorkerParticles = new ObjList<>(slotCount);
             for (int i = 0; i < slotCount; i++) {
@@ -422,8 +422,8 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
             return map;
         }
 
-        public Map getShardMap(int hashCode) {
-            return shards.getQuick(hashCode >>> shardCountShr);
+        public Map getShardMap(long hashCode) {
+            return shards.getQuick((int) (hashCode >>> shardCountShr));
         }
 
         public ObjList<Map> getShardMaps() {
@@ -471,7 +471,7 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
                 RecordCursor cursor = map.getCursor();
                 MapRecord record = map.getRecord();
                 while (cursor.hasNext()) {
-                    final int hashCode = record.keyHashCode();
+                    final long hashCode = record.keyHashCode();
                     final Map shard = getShardMap(hashCode);
                     MapKey shardKey = shard.withKey();
                     record.copyToKey(shardKey);

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -245,7 +245,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             final MapKey lookupKey = lookupShard.withKey();
             mapSink.copy(record, lookupKey);
             lookupKey.commit();
-            final int hashCode = lookupKey.hash();
+            final long hashCode = lookupKey.hash();
 
             final Map shard = particle.getShardMap(hashCode);
             final MapKey shardKey;
@@ -304,7 +304,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             final MapKey lookupKey = lookupShard.withKey();
             mapSink.copy(record, lookupKey);
             lookupKey.commit();
-            final int hashCode = lookupKey.hash();
+            final long hashCode = lookupKey.hash();
 
             final Map shard = particle.getShardMap(hashCode);
             final MapKey shardKey;

--- a/core/src/main/java/io/questdb/std/AbstractLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/AbstractLongHashSet.java
@@ -64,7 +64,7 @@ public abstract class AbstractLongHashSet implements Mutable {
     }
 
     public int keyIndex(long key) {
-        int hashCode = Hash.hashLong(key);
+        int hashCode = Hash.hashLong32(key);
         int index = hashCode & mask;
         if (keys[index] == noEntryKeyValue) {
             return index;
@@ -103,7 +103,7 @@ public abstract class AbstractLongHashSet implements Mutable {
                     key != noEntryKeyValue;
                     from = (from + 1) & mask, key = keys[from]
             ) {
-                int hashCode = Hash.hashLong(key);
+                int hashCode = Hash.hashLong32(key);
                 int idealHit = hashCode & mask;
                 if (idealHit != from) {
                     int to;

--- a/core/src/main/java/io/questdb/std/CharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceIntHashMap.java
@@ -38,7 +38,7 @@ public class CharSequenceIntHashMap extends AbstractCharSequenceHashSet {
     }
 
     public CharSequenceIntHashMap(int initialCapacity) {
-        this(initialCapacity, 0.5, NO_ENTRY_VALUE);
+        this(initialCapacity, 0.4, NO_ENTRY_VALUE);
     }
 
     public CharSequenceIntHashMap(int initialCapacity, double loadFactor, int noEntryValue) {

--- a/core/src/main/java/io/questdb/std/ConcurrentLongHashMap.java
+++ b/core/src/main/java/io/questdb/std/ConcurrentLongHashMap.java
@@ -1550,7 +1550,7 @@ public class ConcurrentLongHashMap<V> implements Serializable {
     /* ---------------- Table Initialization and Resizing -------------- */
 
     private static int keyHashCode(final long key) {
-        return Hash.hashLong(key);
+        return Hash.hashLong32(key);
     }
 
     private static long mix64(long z) {

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -97,9 +97,8 @@ public final class Hash {
             i += 4;
         }
         for (; i < len; i++) {
-            h = h * M2 + (Unsafe.getUnsafe().getByte(p + i) & 0xff);
+            h = h * M2 + Unsafe.getUnsafe().getByte(p + i);
         }
-        h = h * M2;
         return fmix64(h);
     }
 
@@ -127,9 +126,8 @@ public final class Hash {
             i += 4;
         }
         for (; i < len; i++) {
-            h = h * M2 + (us.byteAt(i) & 0xff);
+            h = h * M2 + us.byteAt(i);
         }
-        h *= M2;
         return (int) fmix64(h);
     }
 

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -50,35 +50,72 @@ public final class Hash {
         return seq == null ? -1 : (Chars.hashCode(seq) & 0xFFFFFFF) & max;
     }
 
-    public static int hashInt(int k) {
-        long h = Integer.toUnsignedLong(k) * M2;
-        return (int) (h ^ h >>> 32);
+    public static long hashInt64(int k) {
+        return fmix64(Integer.toUnsignedLong(k));
     }
 
-    public static int hashLong(long k) {
-        long h = k * M2;
-        return (int) (h ^ h >>> 32);
+    public static int hashLong128_32(long key1, long key2) {
+        return (int) hashLong128_64(key1, key2);
     }
 
-    public static int hashLong128(long key1, long key2) {
-        long h = key1 * M2 + key2;
-        h *= M2;
-        return (int) (h ^ h >>> 32);
+    public static long hashLong128_64(long key1, long key2) {
+        return fmix64(key1 * M2 + key2);
     }
 
-    public static int hashLong256(long key1, long key2, long key3, long key4) {
-        long h = key1 * M2 + key2;
-        h = (h * M2) + key3;
-        h = (h * M2) + key4;
-        h *= M2;
-        return (int) (h ^ h >>> 32);
+    public static long hashLong256_64(long key1, long key2, long key3, long key4) {
+        return fmix64(key1 * M2 * M2 * M2 + key2 * M2 * M2 + key3 * M2 + key4);
+    }
+
+    public static int hashLong32(long k) {
+        return (int) hashLong64(k);
+    }
+
+    public static long hashLong64(long k) {
+        return fmix64(k);
     }
 
     /**
-     * Same as {@link #hashMem32(long, long)}, but with on-heap char sequence
+     * Calculates integer hash for the given chunk of native memory using a polynomial hash function.
+     * Suitable for potentially large sequences of bytes.
+     * <p>
+     * The function is a modified version of the function from
+     * <a href="https://vanilla-java.github.io/2018/08/15/Looking-at-randomness-and-performance-for-hash-codes.html">this article</a>
+     * by Peter Lawrey.
+     *
+     * @param p   memory pointer
+     * @param len memory length in bytes
+     * @return hash code
+     */
+    public static long hashMem64(long p, long len) {
+        long h = 0;
+        long i = 0;
+        for (; i + 7 < len; i += 8) {
+            h = h * M2 + Unsafe.getUnsafe().getLong(p + i);
+        }
+        if (i + 3 < len) {
+            h = h * M2 + Unsafe.getUnsafe().getInt(p + i);
+            i += 4;
+        }
+        for (; i < len; i++) {
+            h = h * M2 + (Unsafe.getUnsafe().getByte(p + i) & 0xff);
+        }
+        h = h * M2;
+        return fmix64(h);
+    }
+
+    /**
+     * Same as {@link #hashMem64(long, long)}, but with direct UTF8 string
      * instead of direct unsafe access.
      */
-    public static int hashMem32(Utf8String us) {
+    public static int hashUtf8(DirectUtf8Sequence seq) {
+        return (int) hashMem64(seq.lo(), seq.size());
+    }
+
+    /**
+     * Same as {@link #hashMem64(long, long)}, but with on-heap char sequence
+     * instead of direct unsafe access.
+     */
+    public static int hashUtf8(Utf8String us) {
         final int len = us.size();
         long h = 0;
         int i = 0;
@@ -90,47 +127,10 @@ public final class Hash {
             i += 4;
         }
         for (; i < len; i++) {
-            h = h * M2 + us.byteAt(i);
+            h = h * M2 + (us.byteAt(i) & 0xff);
         }
         h *= M2;
-        return (int) (h ^ h >>> 32);
-    }
-
-    /**
-     * Calculates positive integer hash of memory pointer using a polynomial
-     * hash function.
-     * <p>
-     * The function is a modified version of the function from
-     * <a href="https://vanilla-java.github.io/2018/08/15/Looking-at-randomness-and-performance-for-hash-codes.html">this article</a>
-     * by Peter Lawrey.
-     *
-     * @param p   memory pointer
-     * @param len memory length in bytes
-     * @return hash code
-     */
-    public static int hashMem32(long p, long len) {
-        long h = 0;
-        long i = 0;
-        for (; i + 7 < len; i += 8) {
-            h = h * M2 + Unsafe.getUnsafe().getLong(p + i);
-        }
-        if (i + 3 < len) {
-            h = h * M2 + Unsafe.getUnsafe().getInt(p + i);
-            i += 4;
-        }
-        for (; i < len; i++) {
-            h = h * M2 + Unsafe.getUnsafe().getByte(p + i);
-        }
-        h *= M2;
-        return (int) (h ^ h >>> 32);
-    }
-
-    /**
-     * Same as {@link #hashMem32(long, long)}, but with direct UTF8 string
-     * instead of direct unsafe access.
-     */
-    public static int hashMem32(DirectUtf8Sequence seq) {
-        return hashMem32(seq.lo(), seq.size());
+        return (int) fmix64(h);
     }
 
     /**
@@ -171,13 +171,13 @@ public final class Hash {
         return (h ^ (h >>> 16)) & SPREAD_HASH_BITS;
     }
 
+    /**
+     * Murmur finalizer.
+     */
     private static long fmix64(long h) {
-        h ^= (h >>> 33);
-        h *= 0xff51afd7ed558ccdL;
-        h ^= (h >>> 33);
-        h *= 0xc4ceb9fe1a85ec53L;
-        h ^= (h >>> 33);
-        return h;
+        h = (h ^ (h >>> 33)) * 0xff51afd7ed558ccdL;
+        h = (h ^ (h >>> 33)) * 0xc4ceb9fe1a85ec53L;
+        return h ^ (h >>> 33);
     }
 
     /**

--- a/core/src/main/java/io/questdb/std/LongLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/LongLongHashSet.java
@@ -106,7 +106,7 @@ public final class LongLongHashSet implements Mutable, Sinkable {
         if (key1 == noEntryKeyValue && key2 == noEntryKeyValue) {
             throw new IllegalArgumentException("keys cannot be NO_ENTRY_KEY (" + noEntryKeyValue + ")");
         }
-        int slot = keySlot(key1, key2);
+        int slot = keyIndex(key1, key2);
         if (slot < 0) {
             return false;
         }
@@ -143,7 +143,7 @@ public final class LongLongHashSet implements Mutable, Sinkable {
      * @return true if the set contains the tuple, false otherwise
      */
     public boolean contains(long key1, long key2) {
-        return keySlot(key1, key2) < 0;
+        return keyIndex(key1, key2) < 0;
     }
 
     /**
@@ -156,10 +156,10 @@ public final class LongLongHashSet implements Mutable, Sinkable {
      * @param key2 second key
      * @return slot index
      */
-    public int keySlot(long key1, long key2) {
-        int hash = Hash.hashLong128(key1, key2);
-        int slot = (hash & mask);
-        return probe(key1, key2, slot);
+    public int keyIndex(long key1, long key2) {
+        int hash = Hash.hashLong128_32(key1, key2);
+        int index = hash & mask;
+        return probe(key1, key2, index);
     }
 
     /**
@@ -225,7 +225,7 @@ public final class LongLongHashSet implements Mutable, Sinkable {
             long key1 = firstValue(oldKeys, i);
             long key2 = secondValue(oldKeys, i);
             if (key1 != noEntryKeyValue || key2 != noEntryKeyValue) {
-                int slot = keySlot(key1, key2);
+                int slot = keyIndex(key1, key2);
                 set(slot, key1, key2);
             }
         }

--- a/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
@@ -30,17 +30,6 @@ import io.questdb.std.str.Utf8s;
 
 import java.util.Arrays;
 
-/**
- * A copy implementation of CharSequenceIntHashMap. It is there to work with concrete classes
- * and avoid incurring performance penalty of megamorphic virtual calls. These calls originate
- * from calling charAt() on CharSequence interface. C2 compiler cannot inline these calls due to
- * multiple implementations of charAt(). It resorts to a virtual method call via itable. ILP is the
- * main victim of itable, suffering from non-deterministic performance loss. With this specific
- * implementation of the map C2 compiler seems to be able to inline chatAt() calls and itables are
- * no longer present in the async profiler.
- * <p>
- * This map is optimized for ASCII and UTF-8 DirectUtf8String lookups.
- */
 public class Utf8StringIntHashMap implements Mutable {
 
     public static final int NO_ENTRY_VALUE = -1;
@@ -60,7 +49,7 @@ public class Utf8StringIntHashMap implements Mutable {
     }
 
     public Utf8StringIntHashMap(int initialCapacity) {
-        this(initialCapacity, 0.5, NO_ENTRY_VALUE);
+        this(initialCapacity, 0.4, NO_ENTRY_VALUE);
     }
 
     public Utf8StringIntHashMap(int initialCapacity, double loadFactor, int noEntryValue) {
@@ -109,8 +98,8 @@ public class Utf8StringIntHashMap implements Mutable {
     }
 
     public int keyIndex(DirectUtf8Sequence key) {
-        int hashCode = Hash.hashMem32(key);
-        int index = hashCode & mask;
+        int hashCode = Hash.hashUtf8(key);
+        int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
             return index;
         }
@@ -121,8 +110,8 @@ public class Utf8StringIntHashMap implements Mutable {
     }
 
     public int keyIndex(Utf8String key) {
-        int hashCode = Hash.hashMem32(key);
-        int index = hashCode & mask;
+        int hashCode = Hash.hashUtf8(key);
+        int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
             return index;
         }
@@ -173,8 +162,8 @@ public class Utf8StringIntHashMap implements Mutable {
                     key != null;
                     from = (from + 1) & mask, key = keys[from]
             ) {
-                int hashCode = Hash.hashMem32(key);
-                int idealHit = hashCode & mask;
+                int hashCode = Hash.hashUtf8(key);
+                int idealHit = Hash.spread(hashCode) & mask;
                 if (idealHit != from) {
                     int to;
                     if (keys[idealHit] != null) {
@@ -253,7 +242,7 @@ public class Utf8StringIntHashMap implements Mutable {
 
     private void putAt0(int index, Utf8String key, int value) {
         keys[index] = key;
-        hashCodes[index] = Hash.hashMem32(key);
+        hashCodes[index] = Hash.hashUtf8(key);
         values[index] = value;
         if (--free == 0) {
             rehash();

--- a/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
@@ -45,7 +45,7 @@ public class Utf8StringIntHashMap implements Mutable {
     private int[] values;
 
     public Utf8StringIntHashMap() {
-        this(8);
+        this(MIN_INITIAL_CAPACITY);
     }
 
     public Utf8StringIntHashMap(int initialCapacity) {

--- a/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
@@ -31,17 +31,6 @@ import io.questdb.std.str.Utf8s;
 
 import java.util.Arrays;
 
-/**
- * A copy implementation of CharSequenceObjHashMap. It is there to work with concrete classes
- * and avoid incurring performance penalty of megamorphic virtual calls. These calls originate
- * from calling charAt() on CharSequence interface. C2 compiler cannot inline these calls due to
- * multiple implementations of charAt(). It resorts to a virtual method call via itable. ILP is the
- * main victim of itable, suffering from non-deterministic performance loss. With this specific
- * implementation of the map C2 compiler seems to be able to inline chatAt() calls and itables are
- * no longer present in the async profiler.
- * <p>
- * This map is optimized for ASCII and UTF-8 DirectUtf8String lookups.
- */
 public class Utf8StringObjHashMap<V> implements Mutable {
 
     private static final int MIN_INITIAL_CAPACITY = 16;
@@ -56,7 +45,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
     private V[] values;
 
     public Utf8StringObjHashMap() {
-        this(8);
+        this(MIN_INITIAL_CAPACITY);
     }
 
     public Utf8StringObjHashMap(int initialCapacity) {

--- a/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
@@ -60,7 +60,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
     }
 
     public Utf8StringObjHashMap(int initialCapacity) {
-        this(initialCapacity, 0.5);
+        this(initialCapacity, 0.4);
     }
 
     @SuppressWarnings("unchecked")
@@ -105,7 +105,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
     }
 
     public int keyIndex(DirectUtf8Sequence key) {
-        int hashCode = Hash.hashMem32(key);
+        int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
             return index;
@@ -117,7 +117,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
     }
 
     public int keyIndex(Utf8String key) {
-        int hashCode = Hash.hashMem32(key);
+        int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
             return index;
@@ -147,7 +147,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
             return false;
         }
         keys[index] = key;
-        hashCodes[index] = Hash.hashMem32(key);
+        hashCodes[index] = Hash.hashUtf8(key);
         values[index] = value;
         if (--free == 0) {
             rehash();
@@ -164,7 +164,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         }
         Utf8String onHeapKey = Utf8String.newInstance(key);
         keys[index] = onHeapKey;
-        hashCodes[index] = Hash.hashMem32(key);
+        hashCodes[index] = Hash.hashUtf8(key);
         values[index] = value;
         if (--free == 0) {
             rehash();
@@ -209,7 +209,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
                     key != null;
                     from = (from + 1) & mask, key = keys[from]
             ) {
-                int hashCode = Hash.hashMem32(key);
+                int hashCode = Hash.hashUtf8(key);
                 int idealHit = Hash.spread(hashCode) & mask;
                 if (idealHit != from) {
                     int to;

--- a/core/src/main/java/io/questdb/std/Uuid.java
+++ b/core/src/main/java/io/questdb/std/Uuid.java
@@ -158,7 +158,7 @@ public final class Uuid implements Sinkable {
 
     @Override
     public int hashCode() {
-        return Hash.hashLong128(lo, hi);
+        return Hash.hashLong128_32(lo, hi);
     }
 
     public void of(long lo, long hi) {

--- a/core/src/main/java/io/questdb/std/str/DirectUtf8Sink.java
+++ b/core/src/main/java/io/questdb/std/str/DirectUtf8Sink.java
@@ -84,6 +84,11 @@ public class DirectUtf8Sink implements MutableUtf8Sink, BorrowableUtf8Sink, Dire
     }
 
     @Override
+    public boolean isAscii() {
+        return ascii;
+    }
+
+    @Override
     public long ptr() {
         return sink.ptr();
     }

--- a/core/src/test/java/io/questdb/test/cairo/map/MapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/MapTest.java
@@ -385,7 +385,7 @@ public class MapTest extends AbstractCairoTest {
                     MapKey key = map.withKey();
                     key.putInt(i);
                     key.commit();
-                    int hashCode = key.hash();
+                    long hashCode = key.hash();
                     keyHashCodes.add(hashCode);
 
                     MapValue value = key.createValue(hashCode);

--- a/core/src/test/java/io/questdb/test/cairo/map/MapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/MapTest.java
@@ -621,6 +621,7 @@ public class MapTest extends AbstractCairoTest {
                 Assert.assertEquals(N, map.size());
 
                 map.close();
+                map.close(); // Close must be idempotent
                 map.reopen();
 
                 Assert.assertEquals(0, map.size());

--- a/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
@@ -1171,12 +1171,12 @@ public class OrderedMapTest extends AbstractCairoTest {
 
             try (OrderedMap map = new OrderedMap(1024, keyTypes, valueTypes, 64, 0.8, 24)) {
                 final int N = 100000;
-                final IntList keyHashCodes = new IntList(N);
+                final LongList keyHashCodes = new LongList(N);
                 for (int i = 0; i < N; i++) {
                     MapKey key = map.withKey();
                     key.putInt(i);
                     key.putLong(i + 1);
-                    int hashCode = key.hash();
+                    long hashCode = key.hash();
                     keyHashCodes.add(hashCode);
 
                     MapValue value = key.createValue(hashCode);
@@ -1184,7 +1184,7 @@ public class OrderedMapTest extends AbstractCairoTest {
                     value.putLong(0, i + 2);
                 }
 
-                final IntList recordHashCodes = new IntList(N);
+                final LongList recordHashCodes = new LongList(N);
                 RecordCursor cursor = map.getCursor();
                 MapRecord record = map.getRecord();
                 while (cursor.hasNext()) {
@@ -1208,13 +1208,13 @@ public class OrderedMapTest extends AbstractCairoTest {
 
             try (OrderedMap map = new OrderedMap(1024, keyTypes, valueTypes, 64, 0.8, 24)) {
                 final int N = 100000;
-                final IntList keyHashCodes = new IntList(N);
+                final LongList keyHashCodes = new LongList(N);
                 for (int i = 0; i < N; i++) {
                     MapKey key = map.withKey();
                     key.putInt(i);
                     key.putStr(Chars.repeat("a", i % 32));
                     key.commit();
-                    int hashCode = key.hash();
+                    long hashCode = key.hash();
                     keyHashCodes.add(hashCode);
 
                     MapValue value = key.createValue(hashCode);
@@ -1222,7 +1222,7 @@ public class OrderedMapTest extends AbstractCairoTest {
                     value.putLong(0, i + 2);
                 }
 
-                final IntList recordHashCodes = new IntList(N);
+                final LongList recordHashCodes = new LongList(N);
                 RecordCursor cursor = map.getCursor();
                 MapRecord record = map.getRecord();
                 while (cursor.hasNext()) {

--- a/core/src/test/java/io/questdb/test/cairo/map/Unordered2MapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/Unordered2MapTest.java
@@ -563,6 +563,71 @@ public class Unordered2MapTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testPutBinUnsupported() throws Exception {
+        assertUnsupported(key -> key.putBin(null));
+    }
+
+    @Test
+    public void testPutDateUnsupported() throws Exception {
+        assertUnsupported(key -> key.putDate(0));
+    }
+
+    @Test
+    public void testPutDoubleUnsupported() throws Exception {
+        assertUnsupported(key -> key.putDouble(0.0));
+    }
+
+    @Test
+    public void testPutFloatUnsupported() throws Exception {
+        assertUnsupported(key -> key.putFloat(0.0f));
+    }
+
+    @Test
+    public void testPutIntUnsupported() throws Exception {
+        assertUnsupported(key -> key.putInt(0));
+    }
+
+    @Test
+    public void testPutLong128Unsupported() throws Exception {
+        assertUnsupported(key -> key.putLong128(0, 0));
+    }
+
+    @Test
+    public void testPutLong256ObjectUnsupported() throws Exception {
+        assertUnsupported(key -> key.putLong256(null));
+    }
+
+    @Test
+    public void testPutLong256ValuesUnsupported() throws Exception {
+        assertUnsupported(key -> key.putLong256(0, 0, 0, 0));
+    }
+
+    @Test
+    public void testPutLongUnsupported() throws Exception {
+        assertUnsupported(key -> key.putLong(0));
+    }
+
+    @Test
+    public void testPutStrRangeUnsupported() throws Exception {
+        assertUnsupported(key -> key.putStr(null, 0, 0));
+    }
+
+    @Test
+    public void testPutStrUnsupported() throws Exception {
+        assertUnsupported(key -> key.putStr(null));
+    }
+
+    @Test
+    public void testPutTimestampUnsupported() throws Exception {
+        assertUnsupported(key -> key.putTimestamp(0));
+    }
+
+    @Test
+    public void testPutVarcharUnsupported() throws Exception {
+        assertUnsupported(key -> key.putVarchar((Utf8Sequence) null));
+    }
+
+    @Test
     public void testReopen() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10;
@@ -588,6 +653,7 @@ public class Unordered2MapTest extends AbstractCairoTest {
                 Assert.assertEquals(N, map.size());
 
                 map.close();
+                map.close(); // Close must be idempotent
                 map.reopen();
 
                 Assert.assertEquals(0, map.size());
@@ -755,71 +821,6 @@ public class Unordered2MapTest extends AbstractCairoTest {
                 }
             });
         }
-    }
-
-    @Test
-    public void testPutBinUnsupported() throws Exception {
-        assertUnsupported(key -> key.putBin(null));
-    }
-
-    @Test
-    public void testPutDateUnsupported() throws Exception {
-        assertUnsupported(key -> key.putDate(0));
-    }
-
-    @Test
-    public void testPutDoubleUnsupported() throws Exception {
-        assertUnsupported(key -> key.putDouble(0.0));
-    }
-
-    @Test
-    public void testPutFloatUnsupported() throws Exception {
-        assertUnsupported(key -> key.putFloat(0.0f));
-    }
-
-    @Test
-    public void testPutIntUnsupported() throws Exception {
-        assertUnsupported(key -> key.putInt(0));
-    }
-
-    @Test
-    public void testPutLongUnsupported() throws Exception {
-        assertUnsupported(key -> key.putLong(0));
-    }
-
-    @Test
-    public void testPutLong128Unsupported() throws Exception {
-        assertUnsupported(key -> key.putLong128(0, 0));
-    }
-
-    @Test
-    public void testPutLong256ObjectUnsupported() throws Exception {
-        assertUnsupported(key -> key.putLong256(null));
-    }
-
-    @Test
-    public void testPutLong256ValuesUnsupported() throws Exception {
-        assertUnsupported(key -> key.putLong256(0, 0, 0, 0));
-    }
-
-    @Test
-    public void testPutStrUnsupported() throws Exception {
-        assertUnsupported(key -> key.putStr(null));
-    }
-
-    @Test
-    public void testPutStrRangeUnsupported() throws Exception {
-        assertUnsupported(key -> key.putStr(null, 0, 0));
-    }
-
-    @Test
-    public void testPutTimestampUnsupported() throws Exception {
-        assertUnsupported(key -> key.putTimestamp(0));
-    }
-
-    @Test
-    public void testPutVarcharUnsupported() throws Exception {
-        assertUnsupported(key -> key.putVarchar((Utf8Sequence) null));
     }
 
     private static void assertUnsupported(Consumer<? super MapKey> putKeyFn) throws Exception {

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
@@ -909,7 +909,7 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
         row.putGeoHash(col++, i); // geo long
         row.putStr(col++, (char) (65 + i % 26));
         row.putSym(col++, symbol);
-        row.putLong128(col++, Hash.hashLong(i), Hash.hashLong(i + 1)); // UUID
+        row.putLong128(col++, Hash.hashLong64(i), Hash.hashLong64(i + 1)); // UUID
         col++; // binary ('bin') column is not set
         row.putVarchar(col, rndVarchar);
         row.append();

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -3364,7 +3364,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table a (u uuid, ts timestamp) timestamp(ts);",
                 "select u, ts from a where u in ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333')",
                 "Async Filter workers: 1\n" +
-                        "  filter: u in ['33333333-3333-3333-3333-333333333333','22222222-2222-2222-2222-222222222222','11111111-1111-1111-1111-111111111111']\n" +
+                        "  filter: u in ['22222222-2222-2222-2222-222222222222','11111111-1111-1111-1111-111111111111','33333333-3333-3333-3333-333333333333']\n" +
                         "    DataFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: a\n"

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -1199,25 +1199,28 @@ public class GroupByTest extends AbstractCairoTest {
             String query = "select t1.x, max(t2.y), dateadd('d', t1.x, '2023-03-01T00:00:00')::long + t2.x " +
                     "from t1 " +
                     "join t2 on t1.y = t2.y  " +
-                    "group by t1.x, t2.x, dateadd('d', t1.x, '2023-03-01T00:00:00') ";
+                    "group by t1.x, t2.x, dateadd('d', t1.x, '2023-03-01T00:00:00') " +
+                    "order by 1";
 
-            assertPlan(query, "VirtualRecord\n" +
-                    "  functions: [x,max,dateadd::long+x1]\n" +
-                    "    GroupBy vectorized: false\n" +
-                    "      keys: [x,x1,dateadd]\n" +
-                    "      values: [max(y)]\n" +
-                    "        VirtualRecord\n" +
-                    "          functions: [x,y,x1,dateadd('d',1677628800000000,x)]\n" +
-                    "            SelectedRecord\n" +
-                    "                Hash Join Light\n" +
-                    "                  condition: t2.y=t1.y\n" +
-                    "                    DataFrame\n" +
-                    "                        Row forward scan\n" +
-                    "                        Frame forward scan on: t1\n" +
-                    "                    Hash\n" +
+            assertPlan(query, "Sort light\n" +
+                    "  keys: [x]\n" +
+                    "    VirtualRecord\n" +
+                    "      functions: [x,max,dateadd::long+x1]\n" +
+                    "        GroupBy vectorized: false\n" +
+                    "          keys: [x,x1,dateadd]\n" +
+                    "          values: [max(y)]\n" +
+                    "            VirtualRecord\n" +
+                    "              functions: [x,y,x1,dateadd('d',1677628800000000,x)]\n" +
+                    "                SelectedRecord\n" +
+                    "                    Hash Join Light\n" +
+                    "                      condition: t2.y=t1.y\n" +
                     "                        DataFrame\n" +
                     "                            Row forward scan\n" +
-                    "                            Frame forward scan on: t2\n");
+                    "                            Frame forward scan on: t1\n" +
+                    "                        Hash\n" +
+                    "                            DataFrame\n" +
+                    "                                Row forward scan\n" +
+                    "                                Frame forward scan on: t2\n");
 
             assertQuery(
                     "x\tmax\tcolumn\n" +

--- a/core/src/test/java/io/questdb/test/griffin/UuidTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UuidTest.java
@@ -351,7 +351,7 @@ public class UuidTest extends AbstractCairoTest {
                 "u\tsum\n" +
                         "11111111-1111-1111-1111-111111111111\t1\n" +
                         "22222222-2222-2222-2222-222222222222\t5\n",
-                "select u, sum(i) from x group by u"
+                "select u, sum(i) from x group by u order by u"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByIntHashSetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByIntHashSetTest.java
@@ -109,7 +109,7 @@ public class GroupByIntHashSetTest extends AbstractCairoTest {
 
                 for (int i = 0; i < N; i++) {
                     int val = rnd.nextPositiveInt();
-                    int index = set.keyIndex(val);
+                    long index = set.keyIndex(val);
                     Assert.assertTrue(index >= 0);
                     set.addAt(index, val);
                 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLong128HashSetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLong128HashSetTest.java
@@ -125,7 +125,7 @@ public class GroupByLong128HashSetTest extends AbstractCairoTest {
                 for (int i = 0; i < N; i++) {
                     long lo = rnd.nextPositiveLong() + 1;
                     long hi = rnd.nextPositiveLong() + 1;
-                    int index = set.keyIndex(lo, hi);
+                    long index = set.keyIndex(lo, hi);
                     Assert.assertTrue(index >= 0);
                     set.addAt(index, lo, hi);
                 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLong256HashSetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLong256HashSetTest.java
@@ -129,7 +129,7 @@ public class GroupByLong256HashSetTest extends AbstractCairoTest {
                     long l1 = rnd.nextPositiveLong() + 1;
                     long l2 = rnd.nextPositiveLong() + 1;
                     long l3 = rnd.nextPositiveLong() + 1;
-                    int index = set.keyIndex(l0, l1, l2, l3);
+                    long index = set.keyIndex(l0, l1, l2, l3);
                     Assert.assertTrue(index >= 0);
                     set.addAt(index, l0, l1, l2, l3);
                 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLongHashSetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLongHashSetTest.java
@@ -109,7 +109,7 @@ public class GroupByLongHashSetTest extends AbstractCairoTest {
 
                 for (int i = 0; i < N; i++) {
                     long val = rnd.nextPositiveLong() + 1;
-                    int index = set.keyIndex(val);
+                    long index = set.keyIndex(val);
                     Assert.assertTrue(index >= 0);
                     set.addAt(index, val);
                 }

--- a/core/src/test/java/io/questdb/test/std/HashTest.java
+++ b/core/src/test/java/io/questdb/test/std/HashTest.java
@@ -57,7 +57,8 @@ public class HashTest {
                 for (int i = 0; i < bytes.length; i++) {
                     Unsafe.getUnsafe().putByte(address + i, bytes[i]);
                 }
-                hashes.add(Hash.hashMem64(address, bytes.length));
+                // Use only 32 LSBs for the unique value check since that's where we want entropy.
+                hashes.add((int) Hash.hashMem64(address, bytes.length));
             }
             // 466189 is the number of unique values of String#hashCode() on the same corpus.
             Assert.assertTrue("hash function distribution on English words corpus dropped", hashes.size() >= 466189);
@@ -76,7 +77,8 @@ public class HashTest {
         try {
             for (int i = 0; i < 100000; i++) {
                 rnd.nextChars(address, len / 2);
-                hashes.add(Hash.hashMem64(address, len));
+                // Use only 32 LSBs for the unique value check since that's where we want entropy.
+                hashes.add((int) Hash.hashMem64(address, len));
             }
             Assert.assertTrue("Hash function distribution dropped", hashes.size() > 99990);
         } finally {

--- a/core/src/test/java/io/questdb/test/std/HashTest.java
+++ b/core/src/test/java/io/questdb/test/std/HashTest.java
@@ -57,7 +57,7 @@ public class HashTest {
                 for (int i = 0; i < bytes.length; i++) {
                     Unsafe.getUnsafe().putByte(address + i, bytes[i]);
                 }
-                hashes.add(Hash.hashMem32(address, bytes.length));
+                hashes.add(Hash.hashMem64(address, bytes.length));
             }
             // 466189 is the number of unique values of String#hashCode() on the same corpus.
             Assert.assertTrue("hash function distribution on English words corpus dropped", hashes.size() >= 466189);
@@ -76,7 +76,7 @@ public class HashTest {
         try {
             for (int i = 0; i < 100000; i++) {
                 rnd.nextChars(address, len / 2);
-                hashes.add(Hash.hashMem32(address, len));
+                hashes.add(Hash.hashMem64(address, len));
             }
             Assert.assertTrue("Hash function distribution dropped", hashes.size() > 99990);
         } finally {

--- a/core/src/test/java/io/questdb/test/std/LongLongHashSetTest.java
+++ b/core/src/test/java/io/questdb/test/std/LongLongHashSetTest.java
@@ -72,7 +72,7 @@ public class LongLongHashSetTest {
         for (int i = 0; i < 10_000; i++) {
             long key1 = rnd.nextLong();
             long key2 = rnd.nextLong();
-            final int index = longSet.keySlot(key1, key2);
+            final int index = longSet.keyIndex(key1, key2);
             if (index < 0) {
                 continue;
             }
@@ -196,7 +196,7 @@ public class LongLongHashSetTest {
         longSet.add(2, 1);
         StringSink sink = new StringSink();
         longSet.toSink(sink);
-        assertEquals("[[2,1],[1,1]]", sink.toString());
+        assertEquals("[[1,1],[2,1]]", sink.toString());
     }
 
     @Test
@@ -206,7 +206,7 @@ public class LongLongHashSetTest {
         longSet.add(2, 1);
         StringSink sink = new StringSink();
         longSet.toSink(sink);
-        String expected = "['" + new UUID(1, 2) + "','" + new UUID(1, 1) + "']";
+        String expected = "['" + new UUID(1, 1) + "','" + new UUID(1, 2) + "']";
         assertEquals(expected, sink.toString());
     }
 


### PR DESCRIPTION
Reduces the number of hash code collisions in hash tables used in table/column name caches, especially for strings with differences in a few last characters.

Includes the following changes:
* Decreases load factors in hash tables used for table/column name caches.
* Adds `Hash#spread()` finalizer to `Utf8StringIntHashMap` and `Utf8StringObjHashMap`. Perf improvement shown below comes mainly from this change.
* Adds MurmurHash finalizer to hash functions from `Hash`.
* Converts hash functions used in `Map` implementations to 64-bit. This helps with less collisions in sharded map scenarios, i.e. when there are many groups aggregated by a GROUP BY query.

### Microbenchmarks

```
Benchmark                                                 (len)  Mode  Cnt    Score    Error  Units
StringHashFunctionBenchmark.testHashUtf8                      7  avgt    3    4.914 ±  1.876  ns/op
StringHashFunctionBenchmark.testHashUtf8                     15  avgt    3    6.151 ±  2.879  ns/op
StringHashFunctionBenchmark.testHashUtf8                     31  avgt    3    8.328 ±  0.529  ns/op
StringHashFunctionBenchmark.testHashUtf8                     63  avgt    3   12.032 ±  2.327  ns/op
StringHashFunctionBenchmark.testHashUtf8                   1024  avgt    3  138.408 ±  0.742  ns/op
StringHashFunctionBenchmark.testStandardHashCharSequence      7  avgt    3    6.219 ±  1.614  ns/op
StringHashFunctionBenchmark.testStandardHashCharSequence     15  avgt    3   11.333 ±  0.684  ns/op
StringHashFunctionBenchmark.testStandardHashCharSequence     31  avgt    3   24.067 ±  0.899  ns/op
StringHashFunctionBenchmark.testStandardHashCharSequence     63  avgt    3   53.197 ±  0.736  ns/op
StringHashFunctionBenchmark.testStandardHashCharSequence   1024  avgt    3  907.643 ± 14.018  ns/op
```

`Utf8StringIntHashMapBenchmark` uses string keys with differences in a few last characters. The `prefixLength` parameter specifies the length of the identical part of the strings.
```
Benchmark                                    (n)  (prefixLength)  Mode  Cnt      Score      Error  Units
Utf8StringIntHashMapBenchmark.testUtf16Map    16               5  avgt    3    118.189 ±    6.163  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map    16               7  avgt    3    144.288 ±    6.233  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map    16              31  avgt    3    438.458 ±    9.096  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map    16              63  avgt    3    915.738 ±   27.589  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map   256               5  avgt    3   2001.784 ±   39.868  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map   256               7  avgt    3   2255.600 ±  914.338  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map   256              31  avgt    3   6850.364 ±  108.525  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map   256              63  avgt    3  14577.537 ±  135.006  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map  1024               5  avgt    3   9047.163 ±  961.982  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map  1024               7  avgt    3   9742.841 ± 5326.609  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map  1024              31  avgt    3  28918.299 ± 8820.928  ns/op
Utf8StringIntHashMapBenchmark.testUtf16Map  1024              63  avgt    3  58900.686 ± 2143.095  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map     16               5  avgt    3    104.839 ±   31.743  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map     16               7  avgt    3     79.055 ±   62.847  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map     16              31  avgt    3    136.725 ±   21.795  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map     16              63  avgt    3    198.512 ±  100.215  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map    256               5  avgt    3   1303.660 ±  432.664  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map    256               7  avgt    3   1493.835 ±  397.566  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map    256              31  avgt    3   2258.106 ±  283.167  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map    256              63  avgt    3   3465.830 ± 1492.208  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map   1024               5  avgt    3   5207.690 ± 3090.980  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map   1024               7  avgt    3   8100.634 ± 6388.336  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map   1024              31  avgt    3  10954.549 ±  149.008  ns/op
Utf8StringIntHashMapBenchmark.testUtf8Map   1024              63  avgt    3  15563.850 ± 1083.949  ns/op
```

### Benchmarks

Modified TSBS: https://github.com/questdb/tsbs/tree/1k_column_table_experiment (table with 1k columns)

Before:
```bash
$ cat /tmp/qdb-data-1k.gz | gunzip | ./tsbs_load_questdb --workers=2
time,per. metric/s,metric total,overall metric/s,per. row/s,row total,overall row/s
1711643508,5939411.24,5.940000E+07,5939411.24,5999.41,6.000000E+04,5999.41
1711643518,7920592.07,1.386000E+08,6929915.53,8000.60,1.400000E+05,6999.91
1711643528,6930020.65,2.079000E+08,6929950.57,7000.02,2.100000E+05,6999.95
1711643538,6930002.83,2.772000E+08,6929963.64,7000.00,2.800000E+05,6999.96
1711643548,5940010.18,3.366000E+08,6731974.05,6000.01,3.400000E+05,6799.97

Summary:
loaded 356400000 metrics in 51.342sec with 2 workers (mean rate 6941630.71 metrics/sec)
loaded 360000 rows in 51.342sec with 2 workers (mean rate 7011.75 rows/sec)
```

After:
```bash
$ cat /tmp/qdb-data-1k.gz | gunzip | ./tsbs_load_questdb --workers=2
time,per. metric/s,metric total,overall metric/s,per. row/s,row total,overall row/s
1711643394,13857949.49,1.386000E+08,13857949.49,13997.93,1.400000E+05,13997.93
1711643404,14850021.75,2.871000E+08,14353948.56,15000.02,2.900000E+05,14498.94

Summary:
loaded 356400000 metrics in 24.073sec with 2 workers (mean rate 14804847.93 metrics/sec)
loaded 360000 rows in 24.073sec with 2 workers (mean rate 14954.39 rows/sec)
```