### PR TITLE
chore(core): reduce thread static cleanup

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -225,7 +225,6 @@ public final class TableUtils {
 
     public static void clearThreadLocals() {
         Path.clearThreadLocals();
-        TableTransactionLogV2.clearThreadLocals();
     }
 
     public static int compressColumnCount(RecordMetadata metadata) {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV2.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV2.java
@@ -85,14 +85,6 @@ public class TableTransactionLogV2 implements TableTransactionLogFile {
         rootPath = new Path();
     }
 
-    public static void clearThreadLocals() {
-        TransactionLogCursorImpl cursor = tlTransactionLogCursor.get();
-        if (cursor != null) {
-            cursor.closePath();
-            tlTransactionLogCursor.remove();
-        }
-    }
-
     public static long readMaxStructureVersion(Path path, int logFileFd, FilesFacade ff) {
         long lastTxn = ff.readNonNegativeLong(logFileFd, TableTransactionLogFile.MAX_TXN_OFFSET_64);
         if (lastTxn < 0) {
@@ -347,13 +339,7 @@ public class TableTransactionLogV2 implements TableTransactionLogFile {
                 address = 0;
             }
             closePart();
-        }
-
-        public void closePath() {
-            if (rootPath != null) {
-                rootPath.close();
-                rootPath = null;
-            }
+            rootPath.close();
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/wal/TableTransactionLogFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/wal/TableTransactionLogFuzzTest.java
@@ -123,8 +123,6 @@ public class TableTransactionLogFuzzTest extends AbstractCairoTest {
 
                 v1.close();
                 v2.close();
-
-                TableTransactionLogV2.clearThreadLocals();
             }
         });
     }


### PR DESCRIPTION
Having a cleanup thread static code in `TableTransactionLogV2` can lead to dead lock in logging threads on a failed startup.

This PR removes thread static cleanup code.