### PR TITLE
chore(core): fix WAL append crash for varchar column

### DIFF
--- a/core/src/main/java/io/questdb/cairo/BinaryTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/BinaryTypeDriver.java
@@ -61,7 +61,7 @@ public class BinaryTypeDriver extends StringTypeDriver {
 
     @Override
     public void setColumnRefs(long address, long initialOffset, long count) {
-        Vect.setVarColumnRefs64Bit(address, initialOffset, count);
+        Vect.setVarColumnRefs64Bit(address, initialOffset, count + 1);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/BinaryTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/BinaryTypeDriver.java
@@ -30,6 +30,11 @@ import io.questdb.std.Vect;
 public class BinaryTypeDriver extends StringTypeDriver {
     public static final BinaryTypeDriver INSTANCE = new BinaryTypeDriver();
 
+    @Override
+    public void appendNull(MemoryA dataMem, MemoryA auxMem) {
+        auxMem.putLong(dataMem.putNullBin());
+    }
+
     public long getDataVectorMinEntrySize() {
         return Long.BYTES;
     }
@@ -60,17 +65,17 @@ public class BinaryTypeDriver extends StringTypeDriver {
     }
 
     @Override
-    public void setColumnRefs(long address, long initialOffset, long count) {
-        Vect.setVarColumnRefs64Bit(address, initialOffset, count + 1);
-    }
-
-    @Override
     public void setDataVectorEntriesToNull(long dataMemAddr, long rowCount) {
         Vect.memset(dataMemAddr, rowCount * Long.BYTES, -1);
     }
 
     @Override
-    public void appendNull(MemoryA dataMem, MemoryA auxMem) {
-        auxMem.putLong(dataMem.putNullBin());
+    public void setFullAuxVectorNull(long auxMemAddr, long rowCount) {
+        Vect.setVarColumnRefs64Bit(auxMemAddr, 0, rowCount + 1);
+    }
+
+    @Override
+    public void setPartAuxVectorNull(long auxMemAddr, long initialOffset, long columnTop) {
+        Vect.setVarColumnRefs64Bit(auxMemAddr, initialOffset, columnTop);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/ColumnTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnTypeDriver.java
@@ -170,7 +170,25 @@ public interface ColumnTypeDriver {
 
     long setAppendPosition(long pos, MemoryMA auxMem, MemoryMA dataMem);
 
-    void setColumnRefs(long address, long initialOffset, long count);
+    /**
+     * Materializes nulls in the entire column, typically happens after
+     * new column is added to WAL file. This is because WAL does not have
+     * column tops yet.
+     *
+     * @param auxMemAddr aux vector address
+     * @param rowCount the number of rows
+     */
+    void setFullAuxVectorNull(long auxMemAddr, long rowCount);
+
+    /**
+     * Materializes column top in the aux vector. This is typically required if there
+     * is some data to be written after the nulls.
+     *
+     * @param auxMemAddr the aux memory address
+     * @param initialOffset the offset we begin writing nulls with, e.g. the offset that would begin locating our nulls
+     * @param columnTop the column top
+     */
+    void setPartAuxVectorNull(long auxMemAddr, long initialOffset, long columnTop);
 
     void setDataVectorEntriesToNull(long dataMemAddr, long rowCount);
 

--- a/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
@@ -333,7 +333,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                     // null strings we just added
                     // Call to o3setColumnRefs must be after o3shiftCopyAuxVector
                     // because data first have to be shifted before overwritten
-                    columnTypeDriver.setColumnRefs(srcAuxAddr + oldAuxSize, 0, srcDataTop);
+                    columnTypeDriver.setPartAuxVectorNull(srcAuxAddr + oldAuxSize, 0, srcDataTop);
                     srcDataTop = 0;
                     srcDataFixOffset = oldAuxSize;
                 } else {

--- a/core/src/main/java/io/questdb/cairo/StringTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/StringTypeDriver.java
@@ -289,13 +289,18 @@ public class StringTypeDriver implements ColumnTypeDriver {
     }
 
     @Override
-    public void setColumnRefs(long address, long initialOffset, long count) {
-        Vect.setVarColumnRefs32Bit(address, initialOffset, count + 1);
+    public void setDataVectorEntriesToNull(long dataMemAddr, long rowCount) {
+        Vect.memset(dataMemAddr, rowCount * Integer.BYTES, -1);
     }
 
     @Override
-    public void setDataVectorEntriesToNull(long dataMemAddr, long rowCount) {
-        Vect.memset(dataMemAddr, rowCount * Integer.BYTES, -1);
+    public void setFullAuxVectorNull(long auxMemAddr, long rowCount) {
+        Vect.setVarColumnRefs32Bit(auxMemAddr, 0, rowCount + 1);
+    }
+
+    @Override
+    public void setPartAuxVectorNull(long auxMemAddr, long initialOffset, long columnTop) {
+        Vect.setVarColumnRefs32Bit(auxMemAddr, initialOffset, columnTop);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
@@ -35,24 +35,22 @@ import static io.questdb.cairo.ColumnType.VARCHAR_AUX_SHL;
 public class VarcharTypeDriver implements ColumnTypeDriver {
     public static final VarcharTypeDriver INSTANCE = new VarcharTypeDriver();
     public static final int VARCHAR_AUX_WIDTH_BYTES = 2 * Long.BYTES;
+    // We store a prefix of this many bytes in auxiliary memory when the value is too large to inline.
+    public static final int VARCHAR_INLINED_PREFIX_BYTES = 6;
+    public static final long VARCHAR_INLINED_PREFIX_MASK = (1L << 8 * VARCHAR_INLINED_PREFIX_BYTES) - 1L;
     // Maximum byte length that we can fully inline into auxiliary memory. In this case
     // there is no need to store any part of the string in data memory.
     // When the string is longer than this, we store the first few bytes in auxiliary memory,
     // and the full value in data memory.
     public static final int VARCHAR_MAX_BYTES_FULLY_INLINED = 9;
-    // We store a prefix of this many bytes in auxiliary memory when the value is too large to inline.
-    public static final int VARCHAR_INLINED_PREFIX_BYTES = 6;
-    public static final long VARCHAR_INLINED_PREFIX_MASK = (1L << 8 * VARCHAR_INLINED_PREFIX_BYTES) - 1L;
     public static final long VARCHAR_MAX_COLUMN_SIZE = 1L << 48;
-
-    private static final int HEADER_FLAGS_WIDTH = 4;
-    private static final int HEADER_FLAGS_MASK = (1 << HEADER_FLAGS_WIDTH) - 1;
-    private static final int HEADER_FLAG_INLINED = 1;
-    private static final int HEADER_FLAG_ASCII = 2;
-    private static final int HEADER_FLAG_NULL = 4;
     private static final int FULLY_INLINED_STRING_OFFSET = 1;
-    private static final int INLINED_PREFIX_OFFSET = 4;
+    private static final int HEADER_FLAGS_WIDTH = 4;
+    private static final int HEADER_FLAG_ASCII = 2;
+    private static final int HEADER_FLAG_INLINED = 1;
+    private static final int HEADER_FLAG_NULL = 4;
     private static final int INLINED_LENGTH_MASK = (1 << 4) - 1;
+    private static final int INLINED_PREFIX_OFFSET = 4;
     // The exclusive limit on the byte length of a varchar value. The length is encoded in 28 bits.
     private static final int LENGTH_LIMIT_BYTES = 1 << 28;
     private static final int DATA_LENGTH_MASK = LENGTH_LIMIT_BYTES - 1;
@@ -214,10 +212,10 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
     /**
      * Reads a UTF-8 value from a VARCHAR column.
      *
-     * @param rowNum the row number to read
+     * @param rowNum  the row number to read
      * @param dataMem base pointer of the data vector
-     * @param auxMem base pointer of the auxiliary vector
-     * @param ab whether to return the A or B flyweight
+     * @param auxMem  base pointer of the auxiliary vector
+     * @param ab      whether to return the A or B flyweight
      * @return a <code>Utf8Seqence</code> representing the value at <code>rowNum</code>
      */
     public static Utf8Sequence getValue(long rowNum, MemoryR dataMem, MemoryR auxMem, int ab) {
@@ -253,10 +251,10 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
     /**
      * Reads a UTF-8 value from a VARCHAR column.
      *
-     * @param auxAddr base pointer of the auxiliary vector
-     * @param dataAddr base pointer of the data vector
-     * @param rowNum the row number to read
-     * @param utf8view flyweight for the inlined string
+     * @param auxAddr       base pointer of the auxiliary vector
+     * @param dataAddr      base pointer of the data vector
+     * @param rowNum        the row number to read
+     * @param utf8view      flyweight for the inlined string
      * @param utf8SplitView flyweight for the split string
      * @return utf8view or utf8SplitView loaded with the read value
      */
@@ -289,22 +287,6 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
                 (raw >> HEADER_FLAGS_WIDTH) & DATA_LENGTH_MASK,
                 ascii
         );
-    }
-
-    private static boolean hasNullFlag(int auxHeader) {
-        return (auxHeader & HEADER_FLAG_NULL) == HEADER_FLAG_NULL;
-    }
-
-    private static boolean hasInlinedFlag(int auxHeader) {
-        return (auxHeader & HEADER_FLAG_INLINED) == HEADER_FLAG_INLINED;
-    }
-
-    private static boolean hasNullOrInlinedFlag(int auxHeader) {
-        return (auxHeader & (HEADER_FLAG_NULL | HEADER_FLAG_INLINED)) != 0;
-    }
-
-    private static boolean hasAsciiFlag(int auxHeader) {
-        return (auxHeader & HEADER_FLAG_ASCII) == HEADER_FLAG_ASCII;
     }
 
     @Override
@@ -549,6 +531,7 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
 
     @Override
     public void setColumnRefs(long address, long initialOffset, long count) {
+        assert address != 0 && count > 0;
         Vect.setVarcharColumnNullRefs(address, initialOffset, count);
     }
 
@@ -585,6 +568,22 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
                 size, VARCHAR_MAX_BYTES_FULLY_INLINED, dataOffset);
 
         return dataOffset + size;
+    }
+
+    private static boolean hasAsciiFlag(int auxHeader) {
+        return (auxHeader & HEADER_FLAG_ASCII) == HEADER_FLAG_ASCII;
+    }
+
+    private static boolean hasInlinedFlag(int auxHeader) {
+        return (auxHeader & HEADER_FLAG_INLINED) == HEADER_FLAG_INLINED;
+    }
+
+    private static boolean hasNullFlag(int auxHeader) {
+        return (auxHeader & HEADER_FLAG_NULL) == HEADER_FLAG_NULL;
+    }
+
+    private static boolean hasNullOrInlinedFlag(int auxHeader) {
+        return (auxHeader & (HEADER_FLAG_NULL | HEADER_FLAG_INLINED)) != 0;
     }
 
     private static boolean isAscii(int header) {

--- a/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
@@ -530,9 +530,14 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
     }
 
     @Override
-    public void setColumnRefs(long address, long initialOffset, long count) {
-        assert address != 0 && count > 0;
-        Vect.setVarcharColumnNullRefs(address, initialOffset, count);
+    public void setFullAuxVectorNull(long auxMemAddr, long rowCount) {
+        // varchar vector does not have suffix
+        Vect.setVarcharColumnNullRefs(auxMemAddr, 0, rowCount);
+    }
+
+    @Override
+    public void setPartAuxVectorNull(long auxMemAddr, long initialOffset, long columnTop) {
+        Vect.setVarcharColumnNullRefs(auxMemAddr, initialOffset, columnTop);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileVarFrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileVarFrameColumn.java
@@ -200,7 +200,7 @@ public class ContiguousFileVarFrameColumn implements FrameColumn {
             TableUtils.allocateDiskSpaceToPage(ff, auxFd, srcAuxOffset + srcAuxSize);
             long targetAuxMemAddr = TableUtils.mapAppendColumnBuffer(ff, auxFd, srcAuxOffset, srcAuxSize, true, MEMORY_TAG);
             try {
-                columnTypeDriver.setColumnRefs(
+                columnTypeDriver.setPartAuxVectorNull(
                         targetAuxMemAddr,
                         targetDataOffset,
                         sourceColumnTop

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1448,7 +1448,7 @@ public class WalWriter implements TableWriterAPI {
         if (ColumnType.isVarSize(columnType)) {
             final ColumnTypeDriver columnTypeDriver = ColumnType.getDriver(columnType);
             setVarColumnDataFileNull(columnTypeDriver, columnIndex, rowCount, commitMode);
-            setVarColumnFixedFileNull(columnTypeDriver, columnIndex, rowCount, commitMode);
+            setVarColumnAuxFileNull(columnTypeDriver, columnIndex, rowCount, commitMode);
         } else {
             setFixColumnNulls(columnType, columnIndex, rowCount);
         }
@@ -1474,6 +1474,25 @@ public class WalWriter implements TableWriterAPI {
         rowValueIsNotNull.setQuick(columnIndex, segmentRowCount);
     }
 
+    private void setVarColumnAuxFileNull(
+            ColumnTypeDriver columnTypeDriver,
+            int columnIndex,
+            long rowCount,
+            int commitMode
+    ) {
+        MemoryMA auxMem = getAuxColumn(columnIndex);
+        final long auxMemSize = columnTypeDriver.getAuxVectorSize(rowCount);
+        auxMem.jumpTo(auxMemSize);
+        if (rowCount > 0) {
+            final long auxMemAddr = TableUtils.mapRW(ff, auxMem.getFd(), auxMemSize, MEM_TAG);
+            columnTypeDriver.setFullAuxVectorNull(auxMemAddr,  rowCount);
+            if (commitMode != CommitMode.NOSYNC) {
+                ff.msync(auxMemAddr, auxMemSize, commitMode == CommitMode.ASYNC);
+            }
+            ff.munmap(auxMemAddr, auxMemSize, MEM_TAG);
+        }
+    }
+
     private void setVarColumnDataFileNull(ColumnTypeDriver columnTypeDriver, int columnIndex, long rowCount, int commitMode) {
         MemoryMA dataMem = getDataColumn(columnIndex);
         final long varColSize = rowCount * columnTypeDriver.getDataVectorMinEntrySize();
@@ -1488,22 +1507,6 @@ public class WalWriter implements TableWriterAPI {
                 ff.msync(dataMemAddr, varColSize, commitMode == CommitMode.ASYNC);
             }
             ff.munmap(dataMemAddr, varColSize, MEM_TAG);
-        }
-    }
-
-    private void setVarColumnFixedFileNull(
-            ColumnTypeDriver columnTypeDriver, int columnIndex, long rowCount, int commitMode
-    ) {
-        MemoryMA auxMem = getAuxColumn(columnIndex);
-        final long auxMemSize = columnTypeDriver.getAuxVectorSize(rowCount);
-        auxMem.jumpTo(auxMemSize);
-        if (rowCount > 0) {
-            final long auxMemAddr = TableUtils.mapRW(ff, auxMem.getFd(), auxMemSize, MEM_TAG);
-            columnTypeDriver.setColumnRefs(auxMemAddr, 0, rowCount);
-            if (commitMode != CommitMode.NOSYNC) {
-                ff.msync(auxMemAddr, auxMemSize, commitMode == CommitMode.ASYNC);
-            }
-            ff.munmap(auxMemAddr, auxMemSize, MEM_TAG);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1499,8 +1499,7 @@ public class WalWriter implements TableWriterAPI {
         auxMem.jumpTo(auxMemSize);
         if (rowCount > 0) {
             final long auxMemAddr = TableUtils.mapRW(ff, auxMem.getFd(), auxMemSize, MEM_TAG);
-            // todo: why + 1?
-            columnTypeDriver.setColumnRefs(auxMemAddr, 0, rowCount + 1);
+            columnTypeDriver.setColumnRefs(auxMemAddr, 0, rowCount);
             if (commitMode != CommitMode.NOSYNC) {
                 ff.msync(auxMemAddr, auxMemSize, commitMode == CommitMode.ASYNC);
             }

--- a/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
@@ -88,7 +88,7 @@ public class VarcharTypeDriverTest extends AbstractTest {
                     auxMem.resize((n + auxOffset) * 2 * Long.BYTES);
                     dataMem.resize(dataOffset);
 
-                    driver.setColumnRefs(auxMem.addressOf(auxOffset * 2 * Long.BYTES), dataOffset, n);
+                    driver.setPartAuxVectorNull(auxMem.addressOf(auxOffset * 2 * Long.BYTES), dataOffset, n);
 
                     for (int i = 0; i < n; i++) {
                         Assert.assertNull(VarcharTypeDriver.getValue((i + auxOffset), dataMem, auxMem, 1));

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -153,6 +153,15 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
     }
 
     @Test
+    public void testWalMetadataChangeHeavyCrashRepro() throws Exception {
+        Rnd rnd = fuzzer.generateRandom(LOG, 605244862282L, 1711936717971L);
+        setFuzzProbabilities(0.05, 0.2, 0.1, 0.005, 0.25, 0.25, 0.25, 1.0, 0.01, 0.01, 0.0);
+        setFuzzCounts(false, 50_000, 100, 20, 1000, 1000, 100, 5);
+        setFuzzProperties(rnd);
+        runFuzz(rnd);
+    }
+
+    @Test
     public void testWalSmallWalFdReuse() throws Exception {
         Rnd rnd = generateRandom(LOG);
         fuzzer.setFuzzCounts(false, 100_000, 50, 20, 10, 20, 0, 5, 2);


### PR DESCRIPTION
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f0a2aed15ef, pid=1934, tid=3258
#
# JRE version: OpenJDK Runtime Environment Temurin-11.0.22+7 (11.0.22+7) (build 11.0.22+7)
# Java VM: OpenJDK 64-Bit Server VM Temurin-11.0.22+7 (11.0.22+7, mixed mode, tiered, compressed oops, g1 gc, linux-amd64)
# Problematic frame:
# C  [libquestdb2941880153616460049.so+0x7e5ef]  set_varchar_null_refs_AVX2(long*, long, long)+0x5f
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E" (or dumping to /home/vsts/work/1/s/core/core.1934)
#
# If you would like to submit a bug report, please visit:
#   https://github.com/adoptium/adoptium-support/issues
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  S U M M A R Y ------------

Command Line: -ea -Dfile.encoding=UTF-8 /home/vsts/work/1/s/core/target/surefire/surefirebooter6109048573964084745.jar /home/vsts/work/1/s/core/target/surefire/surefire11576409589169175072tmp /home/vsts/work/1/s/core/target/surefire/surefire_07837652167085883151tmp

Host: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz, 2 cores, 6G, Ubuntu 22.04.4 LTS
Time: Mon Apr  1 01:58:41 2024 UTC elapsed time: 374.041564 seconds (0d 0h 6m 14s)

---------------  T H R E A D  ---------------

Current thread (0x00007f09d83d2800):  JavaThread "Thread-705" daemon [_thread_in_native, id=3258, stack(0x00007f09c8bfd000,0x00007f09c8cfd000)]

Stack: [0x00007f09c8bfd000,0x00007f09c8cfd000],  sp=0x00007f09c8cfaed8,  free space=1015k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libquestdb2941880153616460049.so+0x7e5ef]  set_varchar_null_refs_AVX2(long*, long, long)+0x5f
j  io.questdb.cairo.VarcharTypeDriver.setColumnRefs(JJJ)V+4
j  io.questdb.cairo.wal.WalWriter.setVarColumnFixedFileNull(Lio/questdb/cairo/ColumnTypeDriver;IJI)V+58
J 7850 c1 io.questdb.cairo.wal.WalWriter.setColumnNull(IIJI)V (44 bytes) @ 0x00007f0a0dc65834 [0x00007f0a0dc65600+0x0000000000000234]
J 4601 c1 io.questdb.cairo.wal.WalWriter$MetadataWriterService.addColumn(Ljava/lang/CharSequence;IIZZIZLio/questdb/cairo/SecurityContext;)V (515 bytes) @ 0x00007f0a0d44c68c [0x00007f0a0d44b160+0x000000000000152c]
J 4356 c1 io.questdb.griffin.engine.ops.AlterOperation.applyAddColumn(Lio/questdb/cairo/wal/MetadataService;)V (226 bytes) @ 0x00007f0a0d3cbddc [0x00007f0a0d3cb580+0x000000000000085c]
J 4355 c1 io.questdb.griffin.engine.ops.AlterOperation.apply(Lio/questdb/cairo/wal/MetadataService;Z)J (504 bytes) @ 0x00007f0a0d3c3fd4 [0x00007f0a0d3c2a40+0x0000000000001594]
J 7934 c1 io.questdb.cairo.wal.WalWriter.applyMetadataChangeLog(J)V (147 bytes) @ 0x00007f0a0dc92594 [0x00007f0a0dc921a0+0x00000000000003f4]
J 3482 c1 io.questdb.cairo.wal.WalWriter.getSequencerTxn()J (75 bytes) @ 0x00007f0a0d14edf4 [0x00007f0a0d14ed60+0x0000000000000094]
J 3480 c1 io.questdb.cairo.wal.WalWriter.commit()J (293 bytes) @ 0x00007f0a0d14cea4 [0x00007f0a0d14cd80+0x0000000000000124]
J 10513 c2 io.questdb.test.griffin.wal.FuzzRunner.lambda$createWalWriteThread$5(Ljava/util/concurrent/atomic/AtomicInteger;Lio/questdb/std/ObjList;Ljava/util/concurrent/ConcurrentLinkedQueue;Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/concurrent/atomic/AtomicLong;Lio/questdb/std/ObjList;ILjava/lang/String;Ljava/util/concurrent/atomic/AtomicInteger;)V (450 bytes) @ 0x00007f0a14378f3c [0x00007f0a14378240+0x0000000000000cfc]
j  io.questdb.test.griffin.wal.FuzzRunner$$Lambda$526.run()V+40
J 8027 c1 java.lang.Thread.run()V java.base@11.0.22 (17 bytes) @ 0x00007f0a0cdf1474 [0x00007f0a0cdf1340+0x0000000000000134]
v  ~StubRoutines::call_stub
V  [libjvm.so+0x8dfedb]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x39b
V  [libjvm.so+0x8dde9d]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, Thread*)+0x1ed
V  [libjvm.so+0x98c6ec]  thread_entry(JavaThread*, Thread*)+0x6c
V  [libjvm.so+0xee06da]  JavaThread::thread_main_inner()+0x1ba
V  [libjvm.so+0xedd31f]  Thread::call_run()+0x14f
V  [libjvm.so+0xc7b6b6]  thread_native_entry(Thread*)+0xe6
```