### PR TITLE
chore(core): fix deadlock on shutdown

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -33,7 +33,6 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.*;
-import io.questdb.cairo.wal.seq.TableTransactionLogV2;
 import io.questdb.griffin.AnyRecordMetadata;
 import io.questdb.griffin.FunctionParser;
 import io.questdb.griffin.SqlException;
@@ -166,7 +165,6 @@ public final class TableUtils {
     public static final String UPGRADE_FILE_NAME = "_upgrade.d";
     static final int COLUMN_VERSION_FILE_HEADER_SIZE = 40;
     static final int META_FLAG_BIT_INDEXED = 1;
-    static final int META_FLAG_BIT_NOT_INDEXED = 0;
     static final int META_FLAG_BIT_SEQUENTIAL = 1 << 1;
     static final int META_FLAG_BIT_SYMBOL_CACHE = META_FLAG_BIT_SEQUENTIAL << 1;
     static final int META_FLAG_BIT_DEDUP_KEY = META_FLAG_BIT_SYMBOL_CACHE << 1;
@@ -221,10 +219,6 @@ public final class TableUtils {
             throw CairoException.critical(0).put("File is too small, size=").put(memSize).put(", required=").put(minSize);
         }
         return memSize;
-    }
-
-    public static void clearThreadLocals() {
-        Path.clearThreadLocals();
     }
 
     public static int compressColumnCount(RecordMetadata metadata) {

--- a/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/AbstractLineProtoUdpReceiver.java
@@ -25,7 +25,6 @@
 package io.questdb.cutlass.line.udp;
 
 import io.questdb.cairo.CairoEngine;
-import io.questdb.cairo.TableUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
@@ -35,6 +34,7 @@ import io.questdb.network.NetworkError;
 import io.questdb.network.NetworkFacade;
 import io.questdb.std.Misc;
 import io.questdb.std.Os;
+import io.questdb.std.str.Path;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -127,7 +127,7 @@ public abstract class AbstractLineProtoUdpReceiver extends SynchronizedJob imple
                     runSerially();
                 }
                 LOG.info().$("shutdown").$();
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 halted.countDown();
             }).start();
         }

--- a/core/src/main/java/io/questdb/std/str/Path.java
+++ b/core/src/main/java/io/questdb/std/str/Path.java
@@ -25,7 +25,6 @@
 package io.questdb.std.str;
 
 import io.questdb.cairo.TableToken;
-import io.questdb.cairo.TableUtils;
 import io.questdb.std.ThreadLocal;
 import io.questdb.std.*;
 import io.questdb.std.bytes.Bytes;
@@ -45,7 +44,7 @@ import java.io.Closeable;
 public class Path implements Utf8Sink, LPSZ, Closeable {
     public static final ThreadLocal<Path> PATH = new ThreadLocal<>(Path::new);
     public static final ThreadLocal<Path> PATH2 = new ThreadLocal<>(Path::new);
-    public static final Closeable THREAD_LOCAL_CLEANER = TableUtils::clearThreadLocals;
+    public static final Closeable THREAD_LOCAL_CLEANER = Path::clearThreadLocals;
     private static final byte NULL = (byte) 0;
     private static final int OVERHEAD = 4;
     private final static ThreadLocal<StringSink> tlSink = new ThreadLocal<>(StringSink::new);

--- a/core/src/test/java/io/questdb/test/ServerMainBackupDatabaseTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainBackupDatabaseTest.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CursorPrinter;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableToken;
-import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.RecordMetadata;
@@ -41,6 +40,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.*;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -338,7 +338,7 @@ public class ServerMainBackupDatabaseTest extends AbstractBootstrapTest {
             } catch (Throwable err) {
                 errors.get().add(err);
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 completedLatch.countDown();
             }
         }).start();

--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -591,7 +591,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
                     throw new RuntimeException(unexpected);
                 }
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 haltLatch.countDown();
             }
         }, threadName);

--- a/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
@@ -156,7 +156,7 @@ public class CairoEngineTest extends AbstractCairoTest {
                 } finally {
                     ff = null;
                 }
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             }
         });
     }
@@ -247,7 +247,7 @@ public class CairoEngineTest extends AbstractCairoTest {
                     LOG.error().$("Error in thread").$(th).$();
                     ref.set(th);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             });
             createTableThread.start();

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -32,6 +32,7 @@ import io.questdb.std.IntList;
 import io.questdb.std.ObjHashSet;
 import io.questdb.std.ObjList;
 import io.questdb.std.Os;
+import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
@@ -297,7 +298,7 @@ public class CreateTableTest extends AbstractCairoTest {
                         LOG.error().$("Error in thread").$(e).$();
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(i).start();
@@ -334,7 +335,7 @@ public class CreateTableTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(i).start();
@@ -510,7 +511,7 @@ public class CreateTableTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(i).start();
@@ -551,7 +552,7 @@ public class CreateTableTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(i).start();
@@ -616,7 +617,7 @@ public class CreateTableTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(2 * i).start();
@@ -638,7 +639,7 @@ public class CreateTableTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(2 * i + 1).start();

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -96,7 +96,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(2 * i).start();
@@ -137,7 +137,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.get(2 * i + 1).start();
@@ -167,7 +167,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                 } catch (Throwable e) {
                     ref.set(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             }));
             threads.getLast().start();
@@ -183,7 +183,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                 } catch (Throwable e) {
                     ref.set(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             }));
             threads.getLast().start();
@@ -243,7 +243,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         halted.countDown();
                     }
                 }));
@@ -305,7 +305,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                 } finally {
                     done.set(true);
                     halted.await(TimeUnit.SECONDS.toNanos(4L));
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             }
 
@@ -353,7 +353,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.getLast().start();
@@ -609,7 +609,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
                         LOG.error().$(e).I$();
                         errorCounter.incrementAndGet();
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 });
                 th.start();

--- a/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
@@ -33,6 +33,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.Os;
 import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
@@ -194,7 +195,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             // check that we can't create standalone writer either
             try {
-                newOffPoolWriter(configuration, "z", metrics);
+                newOffPoolWriter(configuration, "z", metrics).close();
                 Assert.fail();
             } catch (CairoException ignored) {
             }
@@ -500,7 +501,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                         exceptionCount.incrementAndGet();
                         e.printStackTrace();
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         stopLatch.countDown();
                     }
                 }).start();
@@ -552,7 +553,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                             e.printStackTrace();
                             errors.incrementAndGet();
                         } finally {
-                            TableUtils.clearThreadLocals();
+                            Path.clearThreadLocals();
                             halt.countDown();
                         }
                     }).start();
@@ -764,7 +765,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                             e.printStackTrace();
                             errors.incrementAndGet();
                         } finally {
-                            TableUtils.clearThreadLocals();
+                            Path.clearThreadLocals();
                             halt.countDown();
                         }
                     }).start();

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContiguousMemoryMTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContiguousMemoryMTest.java
@@ -1001,7 +1001,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
             ) {
                 code.run(rwMem, roMem);
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             }
         });
 

--- a/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/TableSequencerImplTest.java
@@ -52,12 +52,12 @@ public class TableSequencerImplTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCanReadStructureVersionV1() throws Exception {
+    public void testCanReadStructureVersionV1() {
         testTableTransactionLogCanReadStructureVersion();
     }
 
     @Test
-    public void testCanReadStructureVersionV2() throws Exception {
+    public void testCanReadStructureVersionV2() {
         Rnd rnd = TestUtils.generateRandom(LOG);
         node1.setProperty(PropertyKey.CAIRO_DEFAULT_SEQ_PART_TXN_COUNT, rnd.nextInt(20) + 10);
         testTableTransactionLogCanReadStructureVersion();
@@ -85,7 +85,7 @@ public class TableSequencerImplTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         exception.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }
         );
@@ -130,7 +130,7 @@ public class TableSequencerImplTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         exception.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }
         );
@@ -155,7 +155,7 @@ public class TableSequencerImplTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         exception.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }
         );
@@ -186,7 +186,7 @@ public class TableSequencerImplTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         exception.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }
         );

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -978,7 +978,7 @@ public class WalWriterTest extends AbstractCairoTest {
                     } catch (Throwable th) {
                         errors.put(walId, th);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         if (!countedDown) {
                             alterFinished.countDown();
                         }
@@ -1125,7 +1125,7 @@ public class WalWriterTest extends AbstractCairoTest {
                     } catch (Throwable th) {
                         errors.put(walId, th);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         writeFinished.countDown();
                     }
                 }).start();

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderFailureTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderFailureTest.java
@@ -24,10 +24,10 @@
 
 package io.questdb.test.cutlass.http.line;
 
-import io.questdb.cairo.TableUtils;
 import io.questdb.client.Sender;
 import io.questdb.std.Misc;
 import io.questdb.std.Os;
+import io.questdb.std.str.Path;
 import io.questdb.test.AbstractBootstrapTest;
 import io.questdb.test.TestServerMain;
 import io.questdb.test.tools.TestUtils;
@@ -138,7 +138,7 @@ public class LineHttpSenderFailureTest extends AbstractBootstrapTest {
 
         public void stop() {
             serverMain = Misc.free(serverMain);
-            TableUtils.clearThreadLocals();
+            Path.clearThreadLocals();
         }
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -309,7 +309,7 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
                     throw err;
                 } finally {
                     sharedWorkerPool.halt();
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             } catch (Throwable err) {
                 LOG.error().$("Stopping ILP receiver because of an error").$(err).$();

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterTableLineTcpReceiverTest.java
@@ -39,6 +39,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.network.Net;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
@@ -139,7 +140,7 @@ public class AlterTableLineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     // a few rows may have made it into the active partition,
                     // as dropping it is concurrent with inserting
                     keepSending.set(false);
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     partitionDropperHalted.countDown();
                 }
             }, "partition-dropper");

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
@@ -37,6 +37,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.network.Net;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
@@ -122,7 +123,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                     }
                 } finally {
                     LOG.info().$("sender finished").$();
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     ilpProducerHalted.countDown();
                 }
             }, "ilp-producer");
@@ -140,7 +141,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                 } catch (SqlException e) {
                     partitionDropperProblem.set(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     // a few rows may have made it into the active partition,
                     // as dropping it is concurrent with inserting
                     keepSending.set(false);
@@ -412,7 +413,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                         }
                     } finally {
                         LOG.info().$("sender finished").$();
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         ilpProducerHalted.countDown();
                     }
                 }, "ilp-producer");
@@ -430,7 +431,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                     } catch (SqlException e) {
                         partitionDropperProblem.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         // a few rows may have made it into the active partition,
                         // as dropping it is concurrent with inserting
                         keepSending.set(false);
@@ -784,7 +785,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
                     }
                 } finally {
                     LOG.info().$("Stopped waiting for txn notification event").$();
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     // If subscribed to global writer event queue, unsubscribe here
                     // exit this method if alter executed
                     releaseAllLatch.countDown();

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverDropTableFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverDropTableFuzzTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cutlass.line.tcp;
 
-import io.questdb.cairo.TableUtils;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.log.Log;
@@ -34,6 +33,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.ObjList;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
+import io.questdb.std.str.Path;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -124,7 +124,7 @@ public class LineTcpReceiverDropTableFuzzTest extends AbstractLineTcpReceiverFuz
                 failureCounter.incrementAndGet();
                 Assert.fail("Drop table failed [e=" + e + ", sql=" + sql + "]");
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 dropsDone.countDown();
             }
         }).start();

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1610,7 +1610,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                         }
                     }
                 }
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 doneLatch.countDown();
             }).start();
 
@@ -1920,7 +1920,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
             //expected
         } finally {
             finished.await();
-            TableUtils.clearThreadLocals();
+            Path.clearThreadLocals();
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverUpdateFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverUpdateFuzzTest.java
@@ -27,7 +27,6 @@ package io.questdb.test.cutlass.line.tcp;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableReaderMetadata;
-import io.questdb.cairo.TableUtils;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.log.Log;
@@ -37,6 +36,7 @@ import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.ObjList;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
+import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.Overrides;
 import io.questdb.test.cutlass.line.tcp.load.LineData;
@@ -204,7 +204,7 @@ public class LineTcpReceiverUpdateFuzzTest extends AbstractLineTcpReceiverFuzzTe
                 Assert.fail("Update failed [e=" + e + ", updateSql=" + updateSql + "]");
                 failureCounter.incrementAndGet();
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
                 updatesDone.countDown();
             }
         }).start();

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGMultiStatementMessageTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGMultiStatementMessageTest.java
@@ -25,7 +25,6 @@
 package io.questdb.test.cutlass.pgwire;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.pgwire.PGWireServer;
 import io.questdb.griffin.SqlException;
@@ -34,6 +33,7 @@ import io.questdb.mp.WorkerPool;
 import io.questdb.network.SuspendEvent;
 import io.questdb.std.Misc;
 import io.questdb.std.Os;
+import io.questdb.std.str.Path;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -79,7 +79,7 @@ public class PGMultiStatementMessageTest extends BasePGTest {
                 } catch (SqlException e) {
                     throw new RuntimeException(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     try {
                         barrier.await();
                     } catch (InterruptedException e) {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -1088,7 +1088,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                         }
                     }, failureCounter);
                 } finally {
-                    clearThreadLocals();
+                    Path.clearThreadLocals();
                     end.countDown();
                 }
             });
@@ -1119,7 +1119,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                         }
                     }, failureCounter);
                 } finally {
-                    clearThreadLocals();
+                    Path.clearThreadLocals();
                     end.countDown();
                 }
             });
@@ -1209,7 +1209,6 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                         // Split partition by committing O3 to "2022-06-01"
                         ddl("insert into " + tableName + "(ts) select ts + 20 * 60 * 60 * 1000000L from " + tableName, sqlExecutionContext);
 
-                        //noinspection resource
                         Path path = Path.getThreadLocal(configuration.getRoot()).concat(token).concat("2022-06-01T200057-183001.1").concat("ts.d");
                         FilesFacade ff = configuration.getFilesFacade();
                         Assert.assertTrue(ff.exists(path.$()));

--- a/core/src/test/java/io/questdb/test/griffin/CopyTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CopyTest.java
@@ -27,7 +27,6 @@ package io.questdb.test.griffin;
 import io.questdb.PropServerConfiguration;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.PartitionBy;
-import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cutlass.text.Atomicity;
@@ -1116,7 +1115,7 @@ public class CopyTest extends AbstractCairoTest {
                     Os.sleep(1);
                 }
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             }
         });
     }
@@ -1210,7 +1209,7 @@ public class CopyTest extends AbstractCairoTest {
     }
 
     @FunctionalInterface
-    interface CopyRunnable {
+    public interface CopyRunnable {
         void run() throws Exception;
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DropIndexTest.java
@@ -394,7 +394,7 @@ public class DropIndexTest extends AbstractCairoTest {
                     concurrentDropIndexFailure.set(e);
                 } finally {
                     engine.releaseAllWriters();
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     endLatch.countDown();
                 }
             }).start();

--- a/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
@@ -126,7 +126,7 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
                                     "select 1, '1970-01-09T09'  from long_sequence(1)");
                         }
                     }
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                     done.incrementAndGet();
                 } catch (Throwable ex) {
                     LOG.error().$(ex).$();
@@ -143,7 +143,7 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
                             readers.get(i).reload();
                         }
                         Os.pause();
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 } catch (Throwable ex) {
                     LOG.error().$(ex).$();

--- a/core/src/test/java/io/questdb/test/griffin/O3Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3Test.java
@@ -146,7 +146,7 @@ public class O3Test extends AbstractO3Test {
                         e.printStackTrace();
                         errorCount.incrementAndGet();
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                         LOG.info().$("write is done").$();
                     }
                 });

--- a/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
@@ -844,7 +844,7 @@ public class SnapshotTest extends AbstractCairoTest {
             Thread controlThread1 = new Thread(() -> {
                 currentMicros = interval;
                 job.drain(0);
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             });
 
             controlThread1.start();
@@ -859,7 +859,7 @@ public class SnapshotTest extends AbstractCairoTest {
             Thread controlThread2 = new Thread(() -> {
                 currentMicros = 2 * interval;
                 job.drain(0);
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             });
 
             controlThread2.start();

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3223,12 +3223,12 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
         // NATIVE_SQL_COMPILER is excluded from TestUtils#assertMemoryLeak(),
         // so here we make sure that SQL compiler releases its memory on close.
 
-        TableUtils.clearThreadLocals();
+        Path.clearThreadLocals();
         long mem = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_SQL_COMPILER);
 
         new SqlCompilerImpl(engine).close();
 
-        TableUtils.clearThreadLocals();
+        Path.clearThreadLocals();
         long memAfter = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_SQL_COMPILER);
 
         Assert.assertEquals(mem, memAfter);

--- a/core/src/test/java/io/questdb/test/griffin/UpdateConcurrentTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UpdateConcurrentTest.java
@@ -27,7 +27,6 @@ package io.questdb.test.griffin;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.TableReader;
-import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.cairo.sql.Record;
@@ -41,6 +40,7 @@ import io.questdb.mp.SCSequence;
 import io.questdb.std.ThreadLocal;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.cairo.CursorPrinter;
@@ -197,7 +197,7 @@ public class UpdateConcurrentTest extends AbstractCairoTest {
                         LOG.error().$("writer error ").$(th).$();
                         exceptions.add(th);
                     }
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 });
                 threads.add(writer);
                 writer.start();
@@ -241,7 +241,7 @@ public class UpdateConcurrentTest extends AbstractCairoTest {
                         exceptions.add(th);
                     }
 
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 });
                 threads.add(reader);
                 reader.start();

--- a/core/src/test/java/io/questdb/test/griffin/wal/ConcurrentWalTableRenameTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/ConcurrentWalTableRenameTest.java
@@ -25,13 +25,13 @@
 package io.questdb.test.griffin.wal;
 
 import io.questdb.cairo.CairoException;
-import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Chars;
 import io.questdb.std.ObjList;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
@@ -94,7 +94,7 @@ public class ConcurrentWalTableRenameTest extends AbstractCairoTest {
                     } catch (Throwable e) {
                         ref.set(e);
                     } finally {
-                        TableUtils.clearThreadLocals();
+                        Path.clearThreadLocals();
                     }
                 }));
                 threads.getLast().start();
@@ -125,7 +125,7 @@ public class ConcurrentWalTableRenameTest extends AbstractCairoTest {
                 } catch (Throwable e) {
                     ref.set(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             }));
             threads.getLast().start();

--- a/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
@@ -42,6 +42,7 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.fuzz.FuzzTransaction;
 import io.questdb.test.fuzz.FuzzTransactionGenerator;
@@ -586,7 +587,7 @@ public class FuzzRunner {
             } catch (Throwable e) {
                 errors.add(e);
             } finally {
-                TableUtils.clearThreadLocals();
+                Path.clearThreadLocals();
             }
         });
     }
@@ -664,7 +665,7 @@ public class FuzzRunner {
         } catch (Throwable e) {
             errors.add(e);
         } finally {
-            TableUtils.clearThreadLocals();
+            Path.clearThreadLocals();
         }
     }
 
@@ -697,7 +698,7 @@ public class FuzzRunner {
             errors.add(e);
         } finally {
             Misc.freeObjList(readers);
-            TableUtils.clearThreadLocals();
+            Path.clearThreadLocals();
         }
     }
 
@@ -712,7 +713,7 @@ public class FuzzRunner {
         } catch (Throwable e) {
             errors.add(e);
         } finally {
-            TableUtils.clearThreadLocals();
+            Path.clearThreadLocals();
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
@@ -808,7 +808,7 @@ public class WalTableFailureTest extends AbstractCairoTest {
                 } catch (Throwable e) {
                     exception.set(e);
                 } finally {
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             });
             applyThread.start();

--- a/core/src/test/java/io/questdb/test/std/str/PathTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/PathTest.java
@@ -25,7 +25,6 @@
 package io.questdb.test.std.str;
 
 import io.questdb.cairo.TableToken;
-import io.questdb.cairo.TableUtils;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.*;
 import io.questdb.std.str.*;
@@ -522,7 +521,7 @@ public class PathTest {
                     Assert.fail(err.getMessage());
                 } finally {
                     completed.countDown();
-                    TableUtils.clearThreadLocals();
+                    Path.clearThreadLocals();
                 }
             });
         }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -618,7 +618,7 @@ public final class TestUtils {
     }
 
     public static void assertMemoryLeak(LeakProneCode runnable) throws Exception {
-        clearThreadLocals();
+        Path.clearThreadLocals();
         long mem = Unsafe.getMemUsed();
         long[] memoryUsageByTag = new long[MemoryTag.SIZE];
         for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {
@@ -637,7 +637,7 @@ public final class TestUtils {
         Assert.assertTrue("Initial allocated sockaddr count should be >= 0", sockAddrCount >= 0);
 
         runnable.run();
-        clearThreadLocals();
+        Path.clearThreadLocals();
         if (fileCount != Files.getOpenFileCount()) {
             Assert.assertEquals("file descriptors, expected: " + fileDebugInfo + ", actual: " + Files.getOpenFdDebugInfo(), fileCount, Files.getOpenFileCount());
         }


### PR DESCRIPTION
follow up for https://github.com/questdb/questdb/pull/4361
Ent PR: https://github.com/questdb/questdb-enterprise/pull/409

Path class had unnecessary dependency on TableUtils. This was causing Ent server to deadlock on shutdown.