### PR TITLE
fix(sql): bug for negative upper bound (second argument) in BETWEEN operator

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -984,12 +984,14 @@ public class ExpressionParser {
                         int operatorType = op.type;
 
                         if (thisChar == '-' || thisChar == '~') {
+                            assert prevBranch != BRANCH_BETWEEN_START; // BRANCH_BETWEEN_START will be processed as default branch, so prevBranch must be BRANCH_OPERATOR in this case
                             switch (prevBranch) {
                                 case BRANCH_OPERATOR:
                                 case BRANCH_LEFT_PARENTHESIS:
                                 case BRANCH_COMMA:
                                 case BRANCH_NONE:
                                 case BRANCH_CASE_CONTROL:
+                                case BRANCH_BETWEEN_END: // handle unary minus for second operand of BETWEEN operator: BETWEEN x AND -y
                                     // we have unary minus
                                     operatorType = OperatorExpression.UNARY;
                                     break;

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -80,6 +80,22 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testBetweenWithNegativeBounds() throws Exception {
+        assertQuery(
+                "select-virtual -(5) between (-(10),-(1)) column from (long_sequence(1))",
+                "SELECT -5 BETWEEN -10 AND -1"
+        );
+        assertQuery(
+                "select-virtual -(5) between (-(10),-(1)) column from (long_sequence(1))",
+                "SELECT -5 BETWEEN -10 AND (-1)"
+        );
+        assertQuery(
+                "select-virtual -(5) between (-(10),-(1)) column from (long_sequence(1))",
+                "SELECT -5 BETWEEN (-10) AND -1"
+        );
+    }
+
+    @Test
     public void testACBetweenOrClause() throws Exception {
         assertWindowSyntaxError(
                 "select a,b, f(c) over (partition by b order by ts #FRAME between 12 preceding or 23 following) from xyz",


### PR DESCRIPTION
Just started reading `QuestDB` code (purely for fun) and find out that manual implementation of SQL parser looks pretty fragile. Turned out that following query parsed with syntax error:

```
$> SELECT -5 BETWEEN -10 AND -1
too few arguments for 'between' [found=2,expected=3]
```

This PR fixes parser for this case (the fix is simple: one branch type were missed for unary `-` and `~` signs).

Also have off-topic question: why to implement sql parser manually and not to use some parser generators which can derive AST parser from grammar definition?