### PR TITLE
chore(core): fix flapping test

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
@@ -332,7 +332,6 @@ public abstract class AbstractMultiTenantPool<T extends PoolTenant<T>> extends A
                             casFailures++;
                             if (deadline == Long.MAX_VALUE) {
                                 r.goodbye();
-                                Unsafe.arrayPutOrdered(e.allocations, i, UNALLOCATED);
                                 LOG.info().$("shutting down. '").utf8(r.getTableToken().getDirName()).$("' is left behind").$();
                                 leftBehind = r.getTableToken();
                             }

--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -87,12 +87,9 @@ public class ReaderPool extends AbstractMultiTenantPool<ReaderPool.R> {
             if (isOpen()) {
                 goPassive();
                 final AbstractMultiTenantPool<R> pool = this.pool;
-                if (pool != null && entry != null) {
-                    if (pool.returnToPool(this)) {
-                        return;
-                    }
+                if (pool == null || entry == null || !pool.returnToPool(this)) {
+                    super.close();
                 }
-                super.close();
             }
         }
 

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -677,7 +677,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 pool.unlock(uTableToken);
             } finally {
                 // Release readers on failure
-                // In OSX the number of shared memory system wide can be quite small
+                // In OSX the number of shared memory system-wide can be quite small
                 // close readers to release shared memory
                 for (int i = 0, n = readers.size(); i < n; i++) {
                     TableReader reader = readers.get(i);


### PR DESCRIPTION
```
024-04-04T20:37:39.1253070Z 2024-04-04T20:37:38.901214Z I i.q.t.AbstractTest Starting test ReaderPoolTest#testGetAndCloseRace^M
2024-04-04T20:37:39.1253900Z 2024-04-04T20:37:38.902602Z I i.q.c.TableNameRegistryStore reloading tables file [path=/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/junit8640915225145085674/dbRoot/tables.d.0, threadId=1318]^M
2024-04-04T20:37:39.1254730Z io.questdb.cairo.CairoException: [0] double close [table=xyz~, index=0]^M
2024-04-04T20:37:39.1255180Z <->at io.questdb.cairo.CairoException.instance(CairoException.java:310)^M
2024-04-04T20:37:39.1255640Z <->at io.questdb.cairo.CairoException.critical(CairoException.java:69)^M
2024-04-04T20:37:39.1256120Z <->at io.questdb.cairo.pool.AbstractMultiTenantPool.returnToPool(AbstractMultiTenantPool.java:387)^M
2024-04-04T20:37:39.1256610Z <->at io.questdb.cairo.pool.ReaderPool$R.close(ReaderPool.java:91)^M
2024-04-04T20:37:39.1257050Z <->at io.questdb.test.cairo.pool.ReaderPoolTest.lambda$testGetAndCloseRace$15(ReaderPoolTest.java:472)^M
2024-04-04T20:37:39.1257720Z <->at java.base/java.lang.Thread.run(Thread.java:829)^M
```