### PR TITLE
chore(core): log sequencer close txn check as info instead of error

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV1.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV1.java
@@ -106,7 +106,7 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         if (txnMem.isOpen()) {
             long maxTxnInFile = txnMem.getLong(MAX_TXN_OFFSET_64);
             if (maxTxnInFile != maxTxn.get()) {
-                LOG.error().$("Max txn in the file ").$(maxTxnInFile).$(" but in memory is ").$(maxTxn.get()).$();
+                LOG.info().$("Max txn in the file ").$(maxTxnInFile).$(" but in memory is ").$(maxTxn.get()).$();
             }
         }
         txnMem.close(false);


### PR DESCRIPTION
The situation is BAU when the system is read-only and sequencer files are updated externally. Info level is good enough