### PR TITLE
perf(sql): speed up SQL COPY and REST API CSV import

### DIFF
--- a/benchmarks/src/main/java/org/questdb/CsvLexerBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CsvLexerBenchmark.java
@@ -43,7 +43,6 @@ public class CsvLexerBenchmark {
         // https://github.com/CODAIT/redrock/blob/master/twitter-decahose/src/main/resources/Location/worldcitiespop.txt.gz
         final String pathToCsv = "/home/vlad/Downloads/worldcitiespop.txt";
 
-
         long buf = Unsafe.malloc(BUF_SIZE, MemoryTag.NATIVE_DEFAULT);
         try {
             try (Path path = new Path().of(pathToCsv).$()) {

--- a/benchmarks/src/main/java/org/questdb/CsvTextLexerBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CsvTextLexerBenchmark.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.cutlass.text.CsvTextLexer;
+import io.questdb.cutlass.text.DefaultTextConfiguration;
+import io.questdb.std.Misc;
+import io.questdb.std.Rnd;
+import io.questdb.std.str.DirectUtf8Sink;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class CsvTextLexerBenchmark {
+
+    private static final long BUFFER_SIZE = 1024 * 1024;
+    private static final int COLUMNS = 105;
+    private DirectUtf8Sink input;
+    private CsvTextLexer lexer;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CsvTextLexerBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(3)
+                // Uncomment to collect a flame graph via async-profiler:
+                //.addProfiler(AsyncProfiler.class, "output=flamegraph")
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        this.input = new DirectUtf8Sink(BUFFER_SIZE);
+        this.lexer = new CsvTextLexer(new DefaultTextConfiguration());
+
+        Rnd rnd = new Rnd();
+        long lineLenEstimate = 0;
+        long nowUs = System.nanoTime() / 1000;
+        while (input.size() < (BUFFER_SIZE - lineLenEstimate)) {
+            // The CSV structure is the same as in the ClickBench input file: https://datasets.clickhouse.com/hits_compatible/hits.csv.gz
+            input.put(rnd.nextLong()) // WatchID
+                    .put(",").put(rnd.nextInt(2)) // JavaEnable
+                    .put(",").putQuoted(rnd.nextString(20 + rnd.nextInt(100))) // Title
+                    .put(",").put(rnd.nextInt(2)) // GoodEvent
+                    .put(",\"").putISODate(nowUs + rnd.nextLong(1_000)).put('"') // EventTime
+                    .put(",\"").putISODate(nowUs + rnd.nextLong(1_000)).put('"') // Eventdate
+                    .put(",").put(rnd.nextPositiveInt()) // CounterID
+                    .put(",").put(rnd.nextPositiveInt()) // ClientIP
+                    .put(",").put(rnd.nextPositiveInt()) // RegionID
+                    .put(",").put(rnd.nextPositiveLong()) // UserID
+                    .put(",").put(rnd.nextInt(2)) // CounterClass
+                    .put(",").put(rnd.nextInt(32)) // OS
+                    .put(",").put(rnd.nextInt(100)) // UserAgent
+                    .put(",").putQuoted(rnd.nextString(40 + rnd.nextInt(40))) // URL
+                    .put(",").putQuoted(rnd.nextString(20 + rnd.nextInt(10))) // Referer
+                    .put(",").put(rnd.nextInt(2)) // IsRefresh
+                    .put(",").put(rnd.nextInt(1000)) // RefererCategoryID
+                    .put(",").put(rnd.nextPositiveInt()) // RefererRegionID
+                    .put(",").put(rnd.nextInt(1000)) // URLCategoryID
+                    .put(",").put(rnd.nextPositiveInt()) // URLRegionID
+                    .put(",").put(rnd.nextInt(1000)) // ResolutionWidth
+                    .put(",").put(rnd.nextInt(1000)) // ResolutionHeight
+                    .put(",").put(rnd.nextInt(1000)) // ResolutionDepth
+                    .put(",").put(rnd.nextInt(128)) // FlashMajor
+                    .put(",").put(rnd.nextInt(128)) // FlashMinor
+                    .put(",").put(rnd.nextInt(128)) // FlashMinor2
+                    .put(",").put(rnd.nextInt(128)) // NetMajor
+                    .put(",").put(rnd.nextInt(128)) // NetMinor
+                    .put(",").put(rnd.nextInt(100)) // UserAgentMajor
+                    .put(",").putQuoted(rnd.nextString(20 + rnd.nextInt(10))) // UserAgentMinor
+                    .put(",").put(rnd.nextInt(2)) // CookieEnable
+                    .put(",").put(rnd.nextInt(2)) // JavascriptEnable
+                    .put(",").put(rnd.nextInt(2)) // IsMobile
+                    .put(",").putQuoted(rnd.nextString(20 + rnd.nextInt(10))) // MobilePhoneModel
+                    .put(",").putQuoted(rnd.nextString(20 + rnd.nextInt(10))) // Params
+                    .put(",").put(rnd.nextInt()) // IPNetworkID
+                    .put(",").put(rnd.nextPositiveInt()) // TraficSourceID
+                    .put(",").put(rnd.nextInt(10)) // SearchEngineID
+                    .put(",").putQuoted(rnd.nextString(30 + rnd.nextInt(30))) // SearchPhrase
+                    .put(",").put(rnd.nextInt(10)) // AdvEngineID
+                    .put(",").put(rnd.nextInt(2)) // IsArtifical
+                    .put(",").put(rnd.nextInt(1000)) // WindowClientWidth
+                    .put(",").put(rnd.nextInt(1000)) // WindowClientHeight
+                    .put(",").put(rnd.nextInt(10)) // ClientTimeZone
+                    .put(",\"").putISODate(nowUs + rnd.nextLong(1_000)).put('"') // ClientEventTime
+                    .put(",").put(rnd.nextInt(100)) // SilverlightVersion1
+                    .put(",").put(rnd.nextInt(100)) // SilverlightVersion2
+                    .put(",").put(rnd.nextShort()) // SilverlightVersion3
+                    .put(",").put(rnd.nextInt(100)) // SilverlightVersion4
+                    .put(",").putQuoted(rnd.nextString(10)) // PageCharset
+                    .put(",").put(rnd.nextShort()) // CodeVersion
+                    .put(",").put(rnd.nextInt(2)) // IsLink
+                    .put(",").put(rnd.nextInt(2)) // IsDownload
+                    .put(",").put(rnd.nextInt(2)) // IsNotBounce
+                    .put(",").put(rnd.nextPositiveLong()) // FUniqID
+                    .put(",").putQuoted(rnd.nextString(40 + rnd.nextInt(40))) // OriginalURL
+                    .put(",").put(rnd.nextPositiveInt()) // HID
+                    .put(",").put(rnd.nextInt(2)) // IsOldCounter
+                    .put(",").put(rnd.nextInt(2)) // IsEvent
+                    .put(",").put(rnd.nextInt(2)) // IsNotBounce
+                    .put(",").put(rnd.nextInt(2)) // DontCountHits
+                    .put(",").put(rnd.nextInt(2)) // WithHash
+                    .put(",").put(rnd.nextChar()) // HitColor
+                    .put(",\"").putISODate(nowUs + rnd.nextLong(1_000)).put('"') // LocalEventTime
+                    .put(",").put(rnd.nextInt(100)) // Age
+                    .put(",").put(rnd.nextInt(10)) // Sex
+                    .put(",").put(rnd.nextInt(100)) // Income
+                    .put(",").put(rnd.nextInt(100)) // Interests
+                    .put(",").put(rnd.nextInt(100)) // Robotness
+                    .put(",").put(rnd.nextInt()) // RemoteIP
+                    .put(",").put(rnd.nextInt()) // WindowName
+                    .put(",").put(rnd.nextInt()) // OpenerName
+                    .put(",").put(rnd.nextInt(1000)) // HistoryLength
+                    .put(",").putQuoted(rnd.nextString(2)) // BrowserLanguage
+                    .put(",").putQuoted(rnd.nextString(2)) // BrowserCountry
+                    .put(",").putQuoted(rnd.nextString(10)) // SocialNetwork
+                    .put(",").putQuoted(rnd.nextString(5)) // SocialAction
+                    .put(",").put(rnd.nextInt(500)) // HTTPError
+                    .put(",").put(rnd.nextInt(10000)) // SendTiming
+                    .put(",").put(rnd.nextInt(10000)) // DNSTiming
+                    .put(",").put(rnd.nextInt(10000)) // ConnectTiming
+                    .put(",").put(rnd.nextInt(10000)) // ResponseStartTiming
+                    .put(",").put(rnd.nextInt(10000)) // ResponseEndTiming
+                    .put(",").put(rnd.nextInt(10000)) // FetchTiming
+                    .put(",").put(rnd.nextInt(100)) // SocialSourceNetworkID
+                    .put(",").putQuoted(rnd.nextString(32)) // SocialSourcePage
+                    .put(",").put(rnd.nextLong(10000)) // ParamPrice
+                    .put(",").put(rnd.nextLong(100)) // ParamOrderID
+                    .put(",").putQuoted(rnd.nextString(16)) // ParamCurrency
+                    .put(",").put(rnd.nextLong(100)) // ParamCurrencyID
+                    .put(",").putQuoted(rnd.nextString(16)) // OpenstatServiceName
+                    .put(",").put(rnd.nextLong(10000)) // OpenstatCampaignID
+                    .put(",").putQuoted(rnd.nextString(32)) // OpenstatAdID
+                    .put(",").put(rnd.nextLong(10000)) // OpenstatSourceID
+                    .put(",").putQuoted(rnd.nextString(16)) // UTMSource
+                    .put(",").putQuoted(rnd.nextString(16)) // UTMMedium
+                    .put(",").putQuoted(rnd.nextString(16)) // UTMCampaign
+                    .put(",").putQuoted(rnd.nextString(16)) // UTMContent
+                    .put(",").putQuoted(rnd.nextString(16)) // UTMTerm
+                    .put(",").putQuoted(rnd.nextString(16)) // FromTag
+                    .put(",").put(rnd.nextInt(2)) // HasGCLID
+                    .put(",").put(rnd.nextPositiveLong()) // RefererHash
+                    .put(",").put(rnd.nextPositiveLong()) // URLHash
+                    .put(",").put(rnd.nextInt(1000000)) // CLID
+                    .put("\n");
+            if (lineLenEstimate == 0) {
+                lineLenEstimate = 3L * input.size();
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        this.input = Misc.free(input);
+    }
+
+    @Benchmark
+    public void testParse(Blackhole bh) {
+        long bufLo = input.lo();
+        long bufHi = input.hi();
+
+        AtomicInteger counter = new AtomicInteger();
+
+        CsvTextLexer.Listener listener = (line, fields, hi) -> {
+            bh.consume(line);
+            for (int i = 0, n = fields.size(); i < n; i++) {
+                bh.consume(fields.getQuick(i));
+            }
+        };
+        for (int i = 0; i < COLUMNS; i++) {
+            counter.set(0);
+            lexer.setupLimits(Integer.MAX_VALUE, listener);
+            lexer.parse(bufLo, bufHi);
+            lexer.parseLast();
+        }
+        bh.consume(counter.get());
+    }
+}

--- a/benchmarks/src/main/java/org/questdb/CutlassLexerTest.java
+++ b/benchmarks/src/main/java/org/questdb/CutlassLexerTest.java
@@ -79,17 +79,14 @@ public class CutlassLexerTest {
         lpLexer.withParser(new LineUdpParser() {
             @Override
             public void onError(int position, int state, int code) {
-
             }
 
             @Override
             public void onEvent(CachedCharSequence token, int type, CharSequenceCache cache) {
-
             }
 
             @Override
             public void onLineEnd(CharSequenceCache cache) {
-
             }
         });
     }

--- a/benchmarks/src/main/java/org/questdb/LineTcpParserBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/LineTcpParserBenchmark.java
@@ -25,10 +25,9 @@
 package org.questdb;
 
 import io.questdb.cutlass.line.tcp.LineTcpParser;
-import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
-import io.questdb.std.Unsafe;
-import io.questdb.std.str.FlyweightDirectUtf16Sink;
+import io.questdb.std.str.DirectUtf8Sink;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
@@ -43,21 +42,33 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class LineTcpParserBenchmark {
 
-    private static final long BUFFER_SIZE = 32768;
-    private final long bufHi;
-    private final long bufLo;
-    private final LineTcpParser parser;
+    private static final long BUFFER_SIZE = 1024 * 1024;
 
-    public LineTcpParserBenchmark() {
-        this.bufLo = Unsafe.malloc(BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+    private DirectUtf8Sink input;
+    private LineTcpParser parser;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(LineTcpParserBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(3)
+                // Uncomment to collect a flame graph via async-profiler:
+                //.addProfiler(AsyncProfiler.class, "output=flamegraph")
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        this.input = new DirectUtf8Sink(BUFFER_SIZE);
         this.parser = new LineTcpParser(false, false);
 
         Rnd rnd = new Rnd();
         long lineLenEstimate = 0;
-        FlyweightDirectUtf16Sink sink = new FlyweightDirectUtf16Sink();
-        sink.of(bufLo, bufLo + BUFFER_SIZE);
-        while (sink.length() < (BUFFER_SIZE - lineLenEstimate)) {
-            sink.put("cpu")
+        while (input.size() < (BUFFER_SIZE - lineLenEstimate)) {
+            input.put("cpu")
                     .put(",hostname=host_").put(String.valueOf(rnd.nextInt(1000)))
                     .put(",region=central_").put(rnd.nextString(32))
                     .put(",rack=").put(String.valueOf(rnd.nextInt(16)))
@@ -80,28 +91,21 @@ public class LineTcpParserBenchmark {
                     .put(",usage_guest_nice=").put(String.valueOf(rnd.nextInt(100))).put("i")
                     .put(" 1451606400000000000\n");
             if (lineLenEstimate == 0) {
-                lineLenEstimate = 3L * sink.length();
+                lineLenEstimate = 3L * input.size();
             }
         }
-
-        this.bufHi = bufLo + sink.length();
     }
 
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder()
-                .include(LineTcpParserBenchmark.class.getSimpleName())
-                .warmupIterations(1)
-                .measurementIterations(3)
-                // Uncomment to collect a flame graph via async-profiler:
-//                .addProfiler(AsyncProfiler.class, "output=flamegraph")
-                .forks(1)
-                .build();
-
-        new Runner(opt).run();
+    @TearDown
+    public void tearDown() {
+        this.input = Misc.free(input);
     }
 
     @Benchmark
     public void testParse(Blackhole bh) {
+        long bufLo = input.lo();
+        long bufHi = input.hi();
+
         long bufPos = bufLo;
         while (bufPos < bufHi) {
             parser.of(bufPos);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -77,7 +77,7 @@ public class LineTcpParser {
 
     private static final Log LOG = LogFactory.getLog(LineTcpParser.class);
 
-    private static final boolean[] controlChars;
+    private static final boolean[] controlBytes;
     private final DirectUtf8String charSeq = new DirectUtf8String();
     private final ObjList<ProtoEntity> entityCache = new ObjList<>();
     private final DirectUtf8String measurementName = new DirectUtf8String();
@@ -189,10 +189,9 @@ public class LineTcpParser {
 
         // Main parsing loop
         while (bufAt < bufHi) {
-            // take the byte
             byte b = Unsafe.getUnsafe().getByte(bufAt);
 
-            if (nEscapedChars == 0 && b >= 0 && !controlChars[b]) {
+            if (nEscapedChars == 0 && !controlBytes[b & 0xff]) {
                 // hot path
                 nextValueCanBeOpenQuote = false;
                 bufAt++;
@@ -265,7 +264,7 @@ public class LineTcpParser {
                     if (nextValueCanBeOpenQuote && ++nQuoteCharacters == 1) {
                         // This means that the processing resumed from "
                         // and it's allowed to start quoted value at this point
-                        bufAt += 1;
+                        bufAt++;
                         // parse quoted value
                         if (!prepareQuotedEntity(bufAt - 1, bufHi)) {
                             // parsing not successful
@@ -802,9 +801,13 @@ public class LineTcpParser {
 
     static {
         char[] chars = new char[]{'\n', '\r', '=', ',', ' ', '\\', '"', '\0', '/'};
-        controlChars = new boolean[Byte.MAX_VALUE];
+        controlBytes = new boolean[256];
         for (char ch : chars) {
-            controlChars[ch] = true;
+            controlBytes[ch] = true;
+        }
+        // non-ascii chars require special handling
+        for (int i = 128; i < 256; i++) {
+            controlBytes[i] = true;
         }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
@@ -114,14 +114,10 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
             while (ptr < hi) {
                 if (!eol && !delayedOutQuote && ptr < hi - 7) {
                     long word = Unsafe.getUnsafe().getLong(ptr);
-                    long xor1 = word ^ MASK_NEW_LINE;
-                    long xor2 = word ^ MASK_CR;
-                    long xor3 = word ^ MASK_QUOTE;
-                    long xor4 = word ^ getDelimiterMask();
-                    long zeroBytesWord = SwarUtils.checkZeroByte(xor1)
-                            | SwarUtils.checkZeroByte(xor2)
-                            | SwarUtils.checkZeroByte(xor3)
-                            | SwarUtils.checkZeroByte(xor4);
+                    long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
+                            | SwarUtils.checkZeroByte(word ^ MASK_CR)
+                            | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
+                            | SwarUtils.checkZeroByte(word ^ getDelimiterMask());
                     if (zeroBytesWord == 0) {
                         ptr += 7;
                         this.fieldHi += 7;
@@ -324,14 +320,10 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
             while (ptr < hi) {
                 if (!eol && !rollBufferUnusable && !useLineRollBuf && !delayedOutQuote && ptr < hi - 7) {
                     long word = Unsafe.getUnsafe().getLong(ptr);
-                    long xor1 = word ^ MASK_NEW_LINE;
-                    long xor2 = word ^ MASK_CR;
-                    long xor3 = word ^ MASK_QUOTE;
-                    long xor4 = word ^ getDelimiterMask();
-                    long zeroBytesWord = SwarUtils.checkZeroByte(xor1)
-                            | SwarUtils.checkZeroByte(xor2)
-                            | SwarUtils.checkZeroByte(xor3)
-                            | SwarUtils.checkZeroByte(xor4);
+                    long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
+                            | SwarUtils.checkZeroByte(word ^ MASK_CR)
+                            | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
+                            | SwarUtils.checkZeroByte(word ^ getDelimiterMask());
                     if (zeroBytesWord == 0) {
                         ptr += 7;
                         this.fieldHi += 7;

--- a/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
@@ -114,16 +114,16 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
             while (ptr < hi) {
                 if (!eol && !delayedOutQuote && ptr < hi - 7) {
                     long word = Unsafe.getUnsafe().getLong(ptr);
-                    long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
-                            | SwarUtils.checkZeroByte(word ^ MASK_CR)
-                            | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
-                            | SwarUtils.checkZeroByte(word ^ getDelimiterMask());
+                    long zeroBytesWord = SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
+                            | SwarUtils.markZeroBytes(word ^ MASK_CR)
+                            | SwarUtils.markZeroBytes(word ^ MASK_QUOTE)
+                            | SwarUtils.markZeroBytes(word ^ getDelimiterMask());
                     if (zeroBytesWord == 0) {
                         ptr += 7;
                         this.fieldHi += 7;
                         continue;
                     } else {
-                        long idx = SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                        long idx = SwarUtils.indexOfFirstMarkedByte(zeroBytesWord);
                         ptr += idx;
                         this.fieldHi += idx;
                     }
@@ -320,25 +320,25 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
             while (ptr < hi) {
                 if (!eol && !rollBufferUnusable && !useLineRollBuf && !delayedOutQuote && ptr < hi - 7) {
                     long word = Unsafe.getUnsafe().getLong(ptr);
-                    long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
-                            | SwarUtils.checkZeroByte(word ^ MASK_CR)
-                            | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
-                            | SwarUtils.checkZeroByte(word ^ getDelimiterMask());
+                    long zeroBytesWord = SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
+                            | SwarUtils.markZeroBytes(word ^ MASK_CR)
+                            | SwarUtils.markZeroBytes(word ^ MASK_QUOTE)
+                            | SwarUtils.markZeroBytes(word ^ getDelimiterMask());
                     if (zeroBytesWord == 0) {
                         ptr += 7;
                         this.fieldHi += 7;
                         continue;
                     } else {
-                        long idx = SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                        long idx = SwarUtils.indexOfFirstMarkedByte(zeroBytesWord);
                         ptr += idx;
                         this.fieldHi += idx;
                     }
                 }
 
-                final byte c = Unsafe.getUnsafe().getByte(ptr++);
+                final byte b = Unsafe.getUnsafe().getByte(ptr++);
 
-                if (checkState(ptr, c)) {
-                    doSwitch(lo, ptr, c);
+                if (checkState(ptr, b)) {
+                    doSwitch(lo, ptr, b);
                 }
             }
         } catch (LineLimitException ignore) {

--- a/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
@@ -412,9 +412,8 @@ public class CopyTask {
                     while (ptr < hi) {
                         if (ptr < hi - 7) {
                             long word = Unsafe.getUnsafe().getLong(ptr);
-                            long xor1 = word ^ MASK_NEW_LINE;
-                            long xor2 = word ^ MASK_QUOTE;
-                            long zeroBytesWord = SwarUtils.checkZeroByte(xor1) | SwarUtils.checkZeroByte(xor2);
+                            long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
+                                    | SwarUtils.checkZeroByte(word ^ MASK_QUOTE);
                             if (zeroBytesWord == 0) {
                                 ptr += 7;
                                 continue;

--- a/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
@@ -61,9 +61,10 @@ public class CopyTask {
     public static final byte STATUS_FINISHED = 1;
     public static final byte STATUS_STARTED = 0;
     private static final Log LOG = LogFactory.getLog(CopyTask.class);
+    private static final long MASK_NEW_LINE = SwarUtils.broadcast((byte) '\n');
+    private static final long MASK_QUOTE = SwarUtils.broadcast((byte) '"');
     private static final IntObjHashMap<String> PHASE_NAME_MAP = new IntObjHashMap<>();
     private static final IntObjHashMap<String> STATUS_NAME_MAP = new IntObjHashMap<>();
-
     private final PhaseBoundaryCheck phaseBoundaryCheck = new PhaseBoundaryCheck();
     private final PhaseBuildSymbolIndex phaseBuildSymbolIndex = new PhaseBuildSymbolIndex();
     private final PhaseIndexing phaseIndexing = new PhaseIndexing();
@@ -387,7 +388,7 @@ public class CopyTask {
         public void run(long fileBufPtr, long fileBufSize) throws TextException {
             long offset = chunkStart;
 
-            //output vars
+            // output vars
             long quotes = 0;
             long[] nlCount = new long[2];
             long[] nlFirst = new long[]{-1, -1};
@@ -409,10 +410,23 @@ public class CopyTask {
                     ptr = fileBufPtr;
 
                     while (ptr < hi) {
-                        final byte c = Unsafe.getUnsafe().getByte(ptr++);
-                        if (c == '"') {
+                        if (ptr < hi - 7) {
+                            long word = Unsafe.getUnsafe().getLong(ptr);
+                            long xor1 = word ^ MASK_NEW_LINE;
+                            long xor2 = word ^ MASK_QUOTE;
+                            long zeroBytesWord = SwarUtils.checkZeroByte(xor1) | SwarUtils.checkZeroByte(xor2);
+                            if (zeroBytesWord == 0) {
+                                ptr += 7;
+                                continue;
+                            } else {
+                                ptr += SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                            }
+                        }
+
+                        final byte b = Unsafe.getUnsafe().getByte(ptr++);
+                        if (b == '"') {
                             quotes++;
-                        } else if (c == '\n') {
+                        } else if (b == '\n') {
                             nlCount[(int) (quotes & 1)]++;
                             if (nlFirst[(int) (quotes & 1)] == -1) {
                                 nlFirst[(int) (quotes & 1)] = offset + (ptr - fileBufPtr);
@@ -851,7 +865,6 @@ public class CopyTask {
                 Path path,
                 Path tmpPath
         ) throws TextException {
-
             this.utf8Sink = utf8Sink;
 
             final CairoConfiguration configuration = engine.getConfiguration();

--- a/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
@@ -412,13 +412,13 @@ public class CopyTask {
                     while (ptr < hi) {
                         if (ptr < hi - 7) {
                             long word = Unsafe.getUnsafe().getLong(ptr);
-                            long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
-                                    | SwarUtils.checkZeroByte(word ^ MASK_QUOTE);
+                            long zeroBytesWord = SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
+                                    | SwarUtils.markZeroBytes(word ^ MASK_QUOTE);
                             if (zeroBytesWord == 0) {
                                 ptr += 7;
                                 continue;
                             } else {
-                                ptr += SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                                ptr += SwarUtils.indexOfFirstMarkedByte(zeroBytesWord);
                             }
                         }
 

--- a/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
@@ -490,14 +490,10 @@ public class CsvFileIndexer implements Closeable, Mutable {
         while (ptr < hi) {
             if (!rollBufferUnusable && !useFieldRollBuf && !delayedOutQuote && ptr < hi - 7) {
                 long word = Unsafe.getUnsafe().getLong(ptr);
-                long xor1 = word ^ MASK_NEW_LINE;
-                long xor2 = word ^ MASK_CR;
-                long xor3 = word ^ MASK_QUOTE;
-                long xor4 = word ^ columnDelimiterMask;
-                long zeroBytesWord = SwarUtils.checkZeroByte(xor1)
-                        | SwarUtils.checkZeroByte(xor2)
-                        | SwarUtils.checkZeroByte(xor3)
-                        | SwarUtils.checkZeroByte(xor4);
+                long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
+                        | SwarUtils.checkZeroByte(word ^ MASK_CR)
+                        | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
+                        | SwarUtils.checkZeroByte(word ^ columnDelimiterMask);
                 if (zeroBytesWord == 0) {
                     ptr += 7;
                     this.fieldHi += 7;

--- a/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
@@ -61,6 +61,9 @@ public class CsvFileIndexer implements Closeable, Mutable {
     public static final long INDEX_ENTRY_SIZE = 2 * Long.BYTES;
     public static final CharSequence INDEX_FILE_NAME = "index.m";
     private static final Log LOG = LogFactory.getLog(CsvFileIndexer.class);
+    private static final long MASK_CR = SwarUtils.broadcast((byte) '\r');
+    private static final long MASK_NEW_LINE = SwarUtils.broadcast((byte) '\n');
+    private static final long MASK_QUOTE = SwarUtils.broadcast((byte) '"');
     // A guess at how long could a timestamp string be, including long day, month name, etc.
     // since we're only interested in timestamp field/col there's no point buffering whole line
     // we'll copy field part to buffer only if current field is designated timestamp
@@ -85,6 +88,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
     private boolean cancelled = false;
     private @Nullable ExecutionCircuitBreaker circuitBreaker;
     private byte columnDelimiter;
+    private long columnDelimiterMask;
     private boolean delayedOutQuote;
     private boolean eol;
     private int errorCount = 0;
@@ -168,6 +172,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
         this.partitionFloorMethod = null;
         this.partitionDirFormatMethod = null;
         this.columnDelimiter = -1;
+        this.columnDelimiterMask = 0;
 
         closeOutputFiles();
         closeSortBuffer();
@@ -265,7 +270,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
     }
 
     public void indexLine(long ptr, long lo) throws TextException {
-        //this is fine because Long.MIN_VALUE is treated as null and would be rejected by partitioned tables
+        // this is fine because Long.MIN_VALUE is treated as null and would be rejected by partitioned tables
         if (timestampValue == Long.MIN_VALUE) {
             return;
         }
@@ -326,6 +331,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
         this.partitionDirFormatMethod = PartitionBy.getPartitionDirFormatMethod(partitionBy);
         this.offset = 0;
         this.columnDelimiter = columnDelimiter;
+        this.columnDelimiterMask = SwarUtils.broadcast(columnDelimiter);
         if (timestampIndex < 0) {
             throw TextException.$("Timestamp index is not set [value=").put(timestampIndex).put(']');
         }
@@ -482,15 +488,35 @@ public class CsvFileIndexer implements Closeable, Mutable {
         long ptr = lo;
 
         while (ptr < hi) {
-            final byte c = Unsafe.getUnsafe().getByte(ptr++);
+            if (!rollBufferUnusable && !useFieldRollBuf && !delayedOutQuote && ptr < hi - 7) {
+                long word = Unsafe.getUnsafe().getLong(ptr);
+                long xor1 = word ^ MASK_NEW_LINE;
+                long xor2 = word ^ MASK_CR;
+                long xor3 = word ^ MASK_QUOTE;
+                long xor4 = word ^ columnDelimiterMask;
+                long zeroBytesWord = SwarUtils.checkZeroByte(xor1)
+                        | SwarUtils.checkZeroByte(xor2)
+                        | SwarUtils.checkZeroByte(xor3)
+                        | SwarUtils.checkZeroByte(xor4);
+                if (zeroBytesWord == 0) {
+                    ptr += 7;
+                    this.fieldHi += 7;
+                    continue;
+                } else {
+                    long idx = SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                    ptr += idx;
+                    this.fieldHi += idx;
+                }
+            }
 
+            final byte b = Unsafe.getUnsafe().getByte(ptr++);
             if (rollBufferUnusable) {
-                eol(ptr, c);
+                eol(ptr, b);
                 continue;
             }
 
             if (useFieldRollBuf) {
-                putToRollBuf(c);
+                putToRollBuf(b);
                 if (rollBufferUnusable) {
                     continue;
                 }
@@ -498,16 +524,16 @@ public class CsvFileIndexer implements Closeable, Mutable {
 
             this.fieldHi++;
 
-            if (delayedOutQuote && c != '"') {
+            if (delayedOutQuote && b != '"') {
                 inQuote = delayedOutQuote = false;
             }
 
-            if (c == columnDelimiter) {
+            if (b == columnDelimiter) {
                 onColumnDelimiter(lo, ptr);
-            } else if (c == '"') {
+            } else if (b == '"') {
                 checkEol(lo);
                 onQuote();
-            } else if (c == '\n' || c == '\r') {
+            } else if (b == '\n' || b == '\r') {
                 onLineEnd(ptr, lo);
             } else {
                 checkEol(lo);
@@ -561,7 +587,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
         }
     }
 
-    //roll timestamp field if it's split over  read buffer boundaries
+    // roll timestamp field if it's split over read buffer boundaries
     private void rollField(long hi) {
         // lastLineStart is an offset from 'lo'
         // 'lo' is the address of incoming buffer
@@ -594,9 +620,9 @@ public class CsvFileIndexer implements Closeable, Mutable {
     private void stashField(int fieldIndex, long ptr) {
         if (fieldIndex == timestampIndex && !header) {
             if (lastQuotePos > -1) {
-                timestampField.of(this.fieldLo, lastQuotePos - 1);
+                timestampField.of(fieldLo, lastQuotePos - 1);
             } else {
-                timestampField.of(this.fieldLo, this.fieldHi - 1);
+                timestampField.of(fieldLo, fieldHi - 1);
             }
 
             parseTimestamp();
@@ -652,7 +678,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
         final MemoryPMARImpl memory;
         final long partitionKey;
         int chunkNumber;
-        long dataSize;//partition data size in bytes
+        long dataSize; // partition data size in bytes
         long indexChunkSize;
 
         IndexOutputFile(FilesFacade ff, Path path, long partitionKey) {

--- a/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
@@ -490,16 +490,16 @@ public class CsvFileIndexer implements Closeable, Mutable {
         while (ptr < hi) {
             if (!rollBufferUnusable && !useFieldRollBuf && !delayedOutQuote && ptr < hi - 7) {
                 long word = Unsafe.getUnsafe().getLong(ptr);
-                long zeroBytesWord = SwarUtils.checkZeroByte(word ^ MASK_NEW_LINE)
-                        | SwarUtils.checkZeroByte(word ^ MASK_CR)
-                        | SwarUtils.checkZeroByte(word ^ MASK_QUOTE)
-                        | SwarUtils.checkZeroByte(word ^ columnDelimiterMask);
+                long zeroBytesWord = SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
+                        | SwarUtils.markZeroBytes(word ^ MASK_CR)
+                        | SwarUtils.markZeroBytes(word ^ MASK_QUOTE)
+                        | SwarUtils.markZeroBytes(word ^ columnDelimiterMask);
                 if (zeroBytesWord == 0) {
                     ptr += 7;
                     this.fieldHi += 7;
                     continue;
                 } else {
-                    long idx = SwarUtils.indexOfFirstNonZeroByte(zeroBytesWord);
+                    long idx = SwarUtils.indexOfFirstMarkedByte(zeroBytesWord);
                     ptr += idx;
                     this.fieldHi += idx;
                 }

--- a/core/src/main/java/io/questdb/cutlass/text/GenericTextLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/GenericTextLexer.java
@@ -24,8 +24,11 @@
 
 package io.questdb.cutlass.text;
 
+import io.questdb.std.SwarUtils;
+
 public class GenericTextLexer extends AbstractTextLexer {
     private byte delimiter;
+    private long delimiterMask;
 
     public GenericTextLexer(TextConfiguration textConfiguration) {
         super(textConfiguration);
@@ -33,18 +36,25 @@ public class GenericTextLexer extends AbstractTextLexer {
 
     public void of(byte delimiter) {
         this.delimiter = delimiter;
+        this.delimiterMask = SwarUtils.broadcast(delimiter);
     }
 
-    protected void doSwitch(long lo, long ptr, byte c) throws LineLimitException {
-        if (c == delimiter) {
+    @Override
+    protected void doSwitch(long lo, long hi, byte b) throws LineLimitException {
+        if (b == delimiter) {
             onColumnDelimiter(lo);
-        } else if (c == '"') {
+        } else if (b == '"') {
             onQuote();
-        } else if (c == '\n' || c == '\r') {
-            onLineEnd(ptr);
+        } else if (b == '\n' || b == '\r') {
+            onLineEnd(hi);
         } else {
             checkEol(lo);
         }
+    }
+
+    @Override
+    protected long getDelimiterMask() {
+        return delimiterMask;
     }
 }
 

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -476,7 +476,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
         }
     }
 
-    //returns list with N chunk boundaries
+    // returns list with N chunk boundaries
     public LongList phaseBoundaryCheck(long fileLength) throws TextImportException {
         phasePrologue(CopyTask.PHASE_BOUNDARY_CHECK);
         assert (workerCount > 0 && minChunkSize > 0);

--- a/core/src/main/java/io/questdb/std/SwarUtils.java
+++ b/core/src/main/java/io/questdb/std/SwarUtils.java
@@ -6,7 +6,7 @@
  *    \__\_\\__,_|\___||___/\__|____/|____/
  *
  *  Copyright (c) 2014-2019 Appsicle
- *  Copyright (c) 2019-2024 QuestDB
+ *  Copyright (c) 2019-2023 QuestDB
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,39 +22,35 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.text;
+package io.questdb.std;
 
-import io.questdb.std.SwarUtils;
+public final class SwarUtils {
 
-public class CsvTextLexer extends AbstractTextLexer {
-    private static final long MASK_COMMA = SwarUtils.broadcast((byte) ',');
-
-    public CsvTextLexer(TextConfiguration textConfiguration) {
-        super(textConfiguration);
+    private SwarUtils() {
     }
 
-    @Override
-    protected void doSwitch(long lo, long hi, byte b) throws LineLimitException {
-        switch (b) {
-            case ',':
-                onColumnDelimiter(lo);
-                break;
-            case '"':
-                onQuote();
-                break;
-            case '\n':
-            case '\r':
-                onLineEnd(hi);
-                break;
-            default:
-                checkEol(lo);
-                break;
-        }
+    /**
+     * Broadcasts the given byte to a long.
+     */
+    public static long broadcast(byte b) {
+        return 0x101010101010101L * (b & 0xffL);
     }
 
-    @Override
-    protected long getDelimiterMask() {
-        return MASK_COMMA;
+    /**
+     * Returns non-zero result in case if the input contains a zero byte.
+     * <p>
+     * Each zero byte of the input is replaced with 0x80 in the output.
+     * Each non-zero byte is replaced with zero byte.
+     */
+    public static long checkZeroByte(long w) {
+        return ((w - 0x0101010101010101L) & ~(w) & 0x8080808080808080L);
+    }
+
+    /**
+     * Returns index of lowest (LE) non-zero byte in the input number
+     * or 7 in case if the number is zero.
+     */
+    public static long indexOfFirstNonZeroByte(long w) {
+        return ((((w - 1) & 0x101010101010101L) * 0x101010101010101L) >> 56) - 1;
     }
 }
-

--- a/core/src/main/java/io/questdb/std/SwarUtils.java
+++ b/core/src/main/java/io/questdb/std/SwarUtils.java
@@ -37,20 +37,20 @@ public final class SwarUtils {
     }
 
     /**
+     * Returns index of lowest (LE) non-zero byte in the input number
+     * or 7 in case if the number is zero.
+     */
+    public static long indexOfFirstMarkedByte(long w) {
+        return ((((w - 1) & 0x101010101010101L) * 0x101010101010101L) >> 56) - 1;
+    }
+
+    /**
      * Returns non-zero result in case if the input contains a zero byte.
      * <p>
      * Each zero byte of the input is replaced with 0x80 in the output.
      * Each non-zero byte is replaced with zero byte.
      */
-    public static long checkZeroByte(long w) {
+    public static long markZeroBytes(long w) {
         return ((w - 0x0101010101010101L) & ~(w) & 0x8080808080808080L);
-    }
-
-    /**
-     * Returns index of lowest (LE) non-zero byte in the input number
-     * or 7 in case if the number is zero.
-     */
-    public static long indexOfFirstNonZeroByte(long w) {
-        return ((((w - 1) & 0x101010101010101L) * 0x101010101010101L) >> 56) - 1;
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
@@ -1441,7 +1441,6 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
 
     @Test
     public void testImportURingEnqueueFails() throws Exception {
-
         Assume.assumeTrue(configuration.getIOURingFacade().isAvailable());
 
         class TestIOURing extends IOURingImpl {

--- a/core/src/test/java/io/questdb/test/std/SwarUtilsTest.java
+++ b/core/src/test/java/io/questdb/test/std/SwarUtilsTest.java
@@ -43,32 +43,32 @@ public class SwarUtilsTest {
     }
 
     @Test
-    public void testCheckZeroByte() {
-        Assert.assertEquals(0x0L, SwarUtils.checkZeroByte(-1L));
-        Assert.assertEquals(0x0L, SwarUtils.checkZeroByte(Long.MAX_VALUE));
-        Assert.assertEquals(0x8080808080808080L, SwarUtils.checkZeroByte(0L));
-        Assert.assertEquals(0x8080808080808000L, SwarUtils.checkZeroByte(1L));
-        Assert.assertEquals(0x8080808080800080L, SwarUtils.checkZeroByte(1L << 9));
-        Assert.assertEquals(0x8080808080008080L, SwarUtils.checkZeroByte(1L << 17));
-        Assert.assertEquals(0x8080808000808080L, SwarUtils.checkZeroByte(1L << 25));
-        Assert.assertEquals(0x8080800080808080L, SwarUtils.checkZeroByte(1L << 33));
-        Assert.assertEquals(0x8080008080808080L, SwarUtils.checkZeroByte(1L << 41));
-        Assert.assertEquals(0x8000808080808080L, SwarUtils.checkZeroByte(1L << 49));
-        Assert.assertEquals(0x0080808080808080L, SwarUtils.checkZeroByte(1L << 57));
-        Assert.assertEquals(0x0080808080808080L, SwarUtils.checkZeroByte(Long.MIN_VALUE));
+    public void testIndexOfFirstMarkedByte() {
+        Assert.assertEquals(7, SwarUtils.indexOfFirstMarkedByte(0L));
+        Assert.assertEquals(0, SwarUtils.indexOfFirstMarkedByte(0x8080808080808080L));
+        Assert.assertEquals(0, SwarUtils.indexOfFirstMarkedByte(0x0000000000000080L));
+        Assert.assertEquals(1, SwarUtils.indexOfFirstMarkedByte(0x0000000000008000L));
+        Assert.assertEquals(2, SwarUtils.indexOfFirstMarkedByte(0x0000000000800000L));
+        Assert.assertEquals(3, SwarUtils.indexOfFirstMarkedByte(0x0000000080000000L));
+        Assert.assertEquals(4, SwarUtils.indexOfFirstMarkedByte(0x0000008000000000L));
+        Assert.assertEquals(5, SwarUtils.indexOfFirstMarkedByte(0x0000800000000000L));
+        Assert.assertEquals(6, SwarUtils.indexOfFirstMarkedByte(0x0080000000000000L));
+        Assert.assertEquals(7, SwarUtils.indexOfFirstMarkedByte(0x8000000000000000L));
     }
 
     @Test
-    public void testIndexOfFirstNonZeroByte() {
-        Assert.assertEquals(7, SwarUtils.indexOfFirstNonZeroByte(0L));
-        Assert.assertEquals(0, SwarUtils.indexOfFirstNonZeroByte(0x8080808080808080L));
-        Assert.assertEquals(0, SwarUtils.indexOfFirstNonZeroByte(0x0000000000000080L));
-        Assert.assertEquals(1, SwarUtils.indexOfFirstNonZeroByte(0x0000000000008000L));
-        Assert.assertEquals(2, SwarUtils.indexOfFirstNonZeroByte(0x0000000000800000L));
-        Assert.assertEquals(3, SwarUtils.indexOfFirstNonZeroByte(0x0000000080000000L));
-        Assert.assertEquals(4, SwarUtils.indexOfFirstNonZeroByte(0x0000008000000000L));
-        Assert.assertEquals(5, SwarUtils.indexOfFirstNonZeroByte(0x0000800000000000L));
-        Assert.assertEquals(6, SwarUtils.indexOfFirstNonZeroByte(0x0080000000000000L));
-        Assert.assertEquals(7, SwarUtils.indexOfFirstNonZeroByte(0x8000000000000000L));
+    public void testMarkZeroBytes() {
+        Assert.assertEquals(0x0L, SwarUtils.markZeroBytes(-1L));
+        Assert.assertEquals(0x0L, SwarUtils.markZeroBytes(Long.MAX_VALUE));
+        Assert.assertEquals(0x8080808080808080L, SwarUtils.markZeroBytes(0L));
+        Assert.assertEquals(0x8080808080808000L, SwarUtils.markZeroBytes(1L));
+        Assert.assertEquals(0x8080808080800080L, SwarUtils.markZeroBytes(1L << 9));
+        Assert.assertEquals(0x8080808080008080L, SwarUtils.markZeroBytes(1L << 17));
+        Assert.assertEquals(0x8080808000808080L, SwarUtils.markZeroBytes(1L << 25));
+        Assert.assertEquals(0x8080800080808080L, SwarUtils.markZeroBytes(1L << 33));
+        Assert.assertEquals(0x8080008080808080L, SwarUtils.markZeroBytes(1L << 41));
+        Assert.assertEquals(0x8000808080808080L, SwarUtils.markZeroBytes(1L << 49));
+        Assert.assertEquals(0x0080808080808080L, SwarUtils.markZeroBytes(1L << 57));
+        Assert.assertEquals(0x0080808080808080L, SwarUtils.markZeroBytes(Long.MIN_VALUE));
     }
 }

--- a/core/src/test/java/io/questdb/test/std/SwarUtilsTest.java
+++ b/core/src/test/java/io/questdb/test/std/SwarUtilsTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.std;
+
+import io.questdb.std.SwarUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SwarUtilsTest {
+
+    @Test
+    public void testBroadcast() {
+        Assert.assertEquals(0, SwarUtils.broadcast((byte) 0));
+        Assert.assertEquals(0x0101010101010101L, SwarUtils.broadcast((byte) 1));
+        Assert.assertEquals(0x0202020202020202L, SwarUtils.broadcast((byte) 2));
+        Assert.assertEquals(0x2a2a2a2a2a2a2a2aL, SwarUtils.broadcast((byte) 42));
+        Assert.assertEquals(0x7f7f7f7f7f7f7f7fL, SwarUtils.broadcast(Byte.MAX_VALUE));
+        Assert.assertEquals(0xffffffffffffffffL, SwarUtils.broadcast((byte) -1));
+        Assert.assertEquals(0xfefefefefefefefeL, SwarUtils.broadcast((byte) -2));
+        Assert.assertEquals(0x8080808080808080L, SwarUtils.broadcast(Byte.MIN_VALUE));
+    }
+
+    @Test
+    public void testCheckZeroByte() {
+        Assert.assertEquals(0x0L, SwarUtils.checkZeroByte(-1L));
+        Assert.assertEquals(0x0L, SwarUtils.checkZeroByte(Long.MAX_VALUE));
+        Assert.assertEquals(0x8080808080808080L, SwarUtils.checkZeroByte(0L));
+        Assert.assertEquals(0x8080808080808000L, SwarUtils.checkZeroByte(1L));
+        Assert.assertEquals(0x8080808080800080L, SwarUtils.checkZeroByte(1L << 9));
+        Assert.assertEquals(0x8080808080008080L, SwarUtils.checkZeroByte(1L << 17));
+        Assert.assertEquals(0x8080808000808080L, SwarUtils.checkZeroByte(1L << 25));
+        Assert.assertEquals(0x8080800080808080L, SwarUtils.checkZeroByte(1L << 33));
+        Assert.assertEquals(0x8080008080808080L, SwarUtils.checkZeroByte(1L << 41));
+        Assert.assertEquals(0x8000808080808080L, SwarUtils.checkZeroByte(1L << 49));
+        Assert.assertEquals(0x0080808080808080L, SwarUtils.checkZeroByte(1L << 57));
+        Assert.assertEquals(0x0080808080808080L, SwarUtils.checkZeroByte(Long.MIN_VALUE));
+    }
+
+    @Test
+    public void testIndexOfFirstNonZeroByte() {
+        Assert.assertEquals(7, SwarUtils.indexOfFirstNonZeroByte(0L));
+        Assert.assertEquals(0, SwarUtils.indexOfFirstNonZeroByte(0x8080808080808080L));
+        Assert.assertEquals(0, SwarUtils.indexOfFirstNonZeroByte(0x0000000000000080L));
+        Assert.assertEquals(1, SwarUtils.indexOfFirstNonZeroByte(0x0000000000008000L));
+        Assert.assertEquals(2, SwarUtils.indexOfFirstNonZeroByte(0x0000000000800000L));
+        Assert.assertEquals(3, SwarUtils.indexOfFirstNonZeroByte(0x0000000080000000L));
+        Assert.assertEquals(4, SwarUtils.indexOfFirstNonZeroByte(0x0000008000000000L));
+        Assert.assertEquals(5, SwarUtils.indexOfFirstNonZeroByte(0x0000800000000000L));
+        Assert.assertEquals(6, SwarUtils.indexOfFirstNonZeroByte(0x0080000000000000L));
+        Assert.assertEquals(7, SwarUtils.indexOfFirstNonZeroByte(0x8000000000000000L));
+    }
+}


### PR DESCRIPTION
Results for SQL COPY in clickbench (optimized schema with varchar), c6a.metal:

Before:
```
2024-04-05T17:00:05.272708Z I i.q.c.t.ParallelCsvFileImporter import complete [importId=085572760f310fd8, file=`/home/ubuntu/ClickBench/questdb/hits.csv`', time=153s]
```

After:
```
2024-04-05T19:33:29.855367Z I i.q.c.t.ParallelCsvFileImporter import complete [importId=6678835cfb20a947, file=`/home/ubuntu/ClickBench/questdb/hits.csv`', time=127s]
```

### Comparison for all stages

Before:
```
2024-04-05T16:57:31.915697Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=analyze_file_structure, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T16:57:35.823696Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=boundary_check, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=3s, errors=0]
2024-04-05T16:57:52.984694Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=indexing, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=17s, errors=0]
2024-04-05T17:00:02.362526Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=partition_import, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=129s, errors=0]
2024-04-05T17:00:02.507203Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=symbol_table_merge, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T17:00:04.502289Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=update_symbol_keys, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=1s, errors=0]
2024-04-05T17:00:04.502480Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=build_symbol_index, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T17:00:04.503360Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=move_partitions, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T17:00:04.634925Z I i.q.c.t.ParallelCsvFileImporter finished [importId=085572760f310fd8, phase=attach_partitions, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
```

After:
```
2024-04-05T19:31:22.151939Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=analyze_file_structure, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T19:31:25.201965Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=boundary_check, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=3s, errors=0]
2024-04-05T19:31:33.850889Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=indexing, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=8s, errors=0]
2024-04-05T19:33:27.542270Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=partition_import, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=113s, errors=0]
2024-04-05T19:33:27.634467Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=symbol_table_merge, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T19:33:29.195984Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=update_symbol_keys, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=1s, errors=0]
2024-04-05T19:33:29.196209Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=build_symbol_index, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T19:33:29.197285Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=move_partitions, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
2024-04-05T19:33:29.222566Z I i.q.c.t.ParallelCsvFileImporter finished [importId=6678835cfb20a947, phase=attach_partitions, file=`/home/ubuntu/ClickBench/questdb/hits.csv`, duration=0s, errors=0]
```

### Microbenchmarks

Before:
```
Benchmark                        Mode  Cnt       Score       Error  Units
CsvTextLexerBenchmark.testParse  avgt    3  257946.332 ± 25624.637  us/op
```

After:
```
Benchmark                        Mode  Cnt       Score       Error  Units
CsvTextLexerBenchmark.testParse  avgt    3  176653.536 ± 11096.986  us/op
```