### PR TITLE
feat(ilp): Sender config string can disable individual flush types separately

### DIFF
--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -532,11 +532,12 @@ public interface Sender extends Closeable {
          * @return this instance for method chaining
          */
         public LineSenderBuilder autoFlushIntervalMillis(int autoFlushIntervalMillis) {
-            if (this.autoFlushIntervalMillis != PARAMETER_NOT_SET_EXPLICITLY) {
+            if (this.autoFlushIntervalMillis != PARAMETER_NOT_SET_EXPLICITLY && this.autoFlushIntervalMillis != Integer.MAX_VALUE) {
                 throw new LineSenderException("auto flush interval was already configured ")
                         .put("[autoFlushIntervalMillis=").put(this.autoFlushIntervalMillis).put("]");
-            } else if (this.autoFlushRows == AUTO_FLUSH_DISABLED) {
-                throw new LineSenderException("cannot set auto flush interval when auto-flush is disabled");
+            }
+            if (this.autoFlushIntervalMillis == Integer.MAX_VALUE && autoFlushIntervalMillis != Integer.MAX_VALUE) {
+                throw new LineSenderException("cannot set auto flush interval when interval based auto-flush is already disabled");
             }
             if (autoFlushIntervalMillis <= 0) {
                 throw new LineSenderException("auto flush interval cannot be negative ")
@@ -559,6 +560,8 @@ public interface Sender extends Closeable {
          * Setting this to 1 means that the Sender will send each row to a server immediately after it is added. This
          * effectively disables batching and may lead to a significant performance degradation.
          * <br>
+         * Setting this to 0 disables row-based auto-flush. Interval-based auto-flush remains enabled.
+         * <p>
          * You cannot set this value when auto-flush is disabled. See {@link #disableAutoFlush()}.
          *
          * @param autoFlushRows maximum number of rows that can be buffered locally before they are sent to a server.
@@ -569,14 +572,14 @@ public interface Sender extends Closeable {
          * @see #autoFlushIntervalMillis(int)
          */
         public LineSenderBuilder autoFlushRows(int autoFlushRows) {
-            if (this.autoFlushRows > 0) {
+            if (this.autoFlushRows != PARAMETER_NOT_SET_EXPLICITLY && this.autoFlushRows != AUTO_FLUSH_DISABLED) {
                 throw new LineSenderException("auto flush rows was already configured ")
                         .put("[autoFlushRows=").put(this.autoFlushRows).put("]");
-            } else if (this.autoFlushRows == AUTO_FLUSH_DISABLED) {
-                throw new LineSenderException("cannot set auto flush rows when auto-flush is disabled");
+            } else if (this.autoFlushRows == AUTO_FLUSH_DISABLED && autoFlushRows != AUTO_FLUSH_DISABLED) {
+                throw new LineSenderException("cannot set auto flush rows when auto-flush is already disabled");
             }
-            if (autoFlushRows < 1) {
-                throw new LineSenderException("auto flush rows has to be positive ")
+            if (autoFlushRows < 0) {
+                throw new LineSenderException("auto flush rows cannot be negative ")
                         .put("[autoFlushRows=").put(autoFlushRows).put("]");
             }
             this.autoFlushRows = autoFlushRows;
@@ -627,7 +630,7 @@ public interface Sender extends Closeable {
                 long actualMaxRetriesNanos = retryTimeoutMillis == PARAMETER_NOT_SET_EXPLICITLY ? DEFAULT_MAX_RETRY_NANOS : retryTimeoutMillis * 1_000_000L;
                 long actualMinRequestThroughput = minRequestThroughput == PARAMETER_NOT_SET_EXPLICITLY ? DEFAULT_MIN_REQUEST_THROUGHPUT : minRequestThroughput;
                 long actualAutoFlushIntervalMillis;
-                if (autoFlushRows == AUTO_FLUSH_DISABLED) {
+                if (autoFlushIntervalMillis == Integer.MAX_VALUE) {
                     actualAutoFlushIntervalMillis = Long.MAX_VALUE;
                 } else {
                     actualAutoFlushIntervalMillis = TimeUnit.MILLISECONDS.toNanos(autoFlushIntervalMillis == PARAMETER_NOT_SET_EXPLICITLY ? DEFAULT_AUTO_FLUSH_INTERVAL_MILLIS : autoFlushIntervalMillis);
@@ -698,11 +701,17 @@ public interface Sender extends Closeable {
          * @see #maxBufferCapacity(int)
          */
         public LineSenderBuilder disableAutoFlush() {
-            if (this.autoFlushRows != -1) {
+            if (this.autoFlushRows != PARAMETER_NOT_SET_EXPLICITLY && this.autoFlushRows != AUTO_FLUSH_DISABLED) {
                 throw new LineSenderException("auto flush rows was already configured ")
                         .put("[autoFlushRows=").put(this.autoFlushRows).put("]");
             }
+            if (this.autoFlushIntervalMillis != PARAMETER_NOT_SET_EXPLICITLY && this.autoFlushIntervalMillis != Integer.MAX_VALUE) {
+                throw new LineSenderException("auto flush interval was already configured ")
+                        .put("[autoFlushIntervalMillis=").put(this.autoFlushIntervalMillis).put("]");
+            }
+
             this.autoFlushRows = AUTO_FLUSH_DISABLED;
+            this.autoFlushIntervalMillis = Integer.MAX_VALUE;
             return this;
         }
 
@@ -881,16 +890,26 @@ public interface Sender extends Closeable {
                     bufferCapacity(initBufferSize);
                 } else if (Chars.equals("auto_flush_rows", sink)) {
                     pos = getValue(configurationString, pos, sink, "auto_flush_rows");
-                    int autoFlushRows = parseIntValue(sink, "auto_flush_rows");
-                    if (autoFlushRows < 1) {
-                        throw new LineSenderException("invalid auto_flush_rows [value=").put(autoFlushRows).put("]");
+                    int autoFlushRows;
+                    if (Chars.equalsIgnoreCase("off", sink)) {
+                        autoFlushRows = 0;
+                    } else {
+                        autoFlushRows = parseIntValue(sink, "auto_flush_rows");
+                        if (autoFlushRows < 1) {
+                            throw new LineSenderException("invalid auto_flush_rows [value=").put(autoFlushRows).put("]");
+                        }
                     }
                     autoFlushRows(autoFlushRows);
                 } else if (Chars.equals("auto_flush_interval", sink)) {
                     pos = getValue(configurationString, pos, sink, "auto_flush_interval");
-                    int autoFlushInterval = parseIntValue(sink, "auto_flush_interval");
-                    if (autoFlushInterval < 1) {
-                        throw new LineSenderException("invalid auto_flush_interval [value=").put(autoFlushInterval).put("]");
+                    int autoFlushInterval;
+                    if (Chars.equalsIgnoreCase("off", sink)) {
+                        autoFlushInterval = Integer.MAX_VALUE;
+                    } else {
+                        autoFlushInterval = parseIntValue(sink, "auto_flush_interval");
+                        if (autoFlushInterval < 1) {
+                            throw new LineSenderException("invalid auto_flush_interval [value=").put(autoFlushInterval).put("]");
+                        }
                     }
                     autoFlushIntervalMillis(autoFlushInterval);
                 } else if (Chars.equals("auto_flush", sink)) {

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
@@ -153,8 +153,9 @@ public final class LineHttpSender implements Sender {
             return;
         }
         try {
-            if (autoFlushRows != 0) {
-                // autoFlushRows == 0 means that auto-flush is disabled
+            if (autoFlushRows != 0 || flushIntervalNanos != Long.MAX_VALUE) {
+                // either row-based or time-based auto flushing is enabled
+                // => let's auto-flush on close
                 flush0(true);
             }
         } finally {

--- a/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
+++ b/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
@@ -170,7 +170,7 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             try {
                 Sender.builder(Sender.Transport.HTTP).disableAutoFlush().autoFlushIntervalMillis(1);
             } catch (LineSenderException e) {
-                TestUtils.assertContains(e.getMessage(), "cannot set auto flush interval when auto-flush is disabled");
+                TestUtils.assertContains(e.getMessage(), "cannot set auto flush interval when interval based auto-flush is already disabled");
             }
         });
     }
@@ -187,17 +187,11 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
     }
 
     @Test
-    public void testAutoFlushRowsMustBePositive() {
-        try (Sender ignored = Sender.builder(Sender.Transport.HTTP).autoFlushRows(0).build()) {
-            fail("auto-flush must be positive");
-        } catch (LineSenderException e) {
-            TestUtils.assertContains(e.getMessage(), "auto flush rows has to be positive [autoFlushRows=0]");
-        }
-
+    public void testAutoFlushRowsCannotBeNegative() {
         try (Sender ignored = Sender.builder(Sender.Transport.HTTP).autoFlushRows(-1).build()) {
             fail("auto-flush must be positive");
         } catch (LineSenderException e) {
-            TestUtils.assertContains(e.getMessage(), "auto flush rows has to be positive [autoFlushRows=-1]");
+            TestUtils.assertContains(e.getMessage(), "auto flush rows cannot be negative [autoFlushRows=-1]");
         }
     }
 
@@ -272,12 +266,15 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrError("http::addr=localhost:8080;auto_flush_rows=0;", "invalid auto_flush_rows [value=0]");
             assertConfStrError("http::addr=localhost:8080;auto_flush_rows=notanumber;", "invalid auto_flush_rows [value=notanumber]");
             assertConfStrError("http::addr=localhost:8080;auto_flush=invalid;", "invalid auto_flush [value=invalid, allowed-values=[on, off]]");
-            assertConfStrError("http::addr=localhost:8080;auto_flush=off;auto_flush_rows=100;", "cannot set auto flush rows when auto-flush is disabled");
+            assertConfStrError("http::addr=localhost:8080;auto_flush=off;auto_flush_rows=100;", "cannot set auto flush rows when auto-flush is already disabled");
             assertConfStrError("http::addr=localhost:8080;auto_flush_rows=100;auto_flush=off;", "auto flush rows was already configured [autoFlushRows=100]");
             assertConfStrError("HTTP::addr=localhost;", "invalid schema [schema=HTTP, supported-schemas=[http, https, tcp, tcps]]");
             assertConfStrError("HTTPS::addr=localhost;", "invalid schema [schema=HTTPS, supported-schemas=[http, https, tcp, tcps]]");
             assertConfStrError("TCP::addr=localhost;", "invalid schema [schema=TCP, supported-schemas=[http, https, tcp, tcps]]");
             assertConfStrError("TCPS::addr=localhost;", "invalid schema [schema=TCPS, supported-schemas=[http, https, tcp, tcps]]");
+            assertConfStrError("http::addr=localhost;auto_flush=off;auto_flush_interval=1;", "cannot set auto flush interval when interval based auto-flush is already disabled");
+            assertConfStrError("http::addr=localhost;auto_flush=off;auto_flush_rows=1;", "cannot set auto flush rows when auto-flush is already disabled");
+
 
             assertConfStrOk("addr=localhost:8080", "auto_flush_rows=100");
             assertConfStrOk("addr=localhost:8080", "auto_flush=on", "auto_flush_rows=100");
@@ -285,6 +282,13 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrOk("addr=localhost", "auto_flush=on");
             assertConfStrOk("http::addr=localhost;auto_flush=off;");
             assertConfStrOk("http::addr=localhost;");
+            assertConfStrOk("http::addr=localhost;auto_flush_interval=off;");
+            assertConfStrOk("http::addr=localhost;auto_flush_rows=off;");
+            assertConfStrOk("http::addr=localhost;auto_flush_interval=off;auto_flush_rows=off;");
+            assertConfStrOk("http::addr=localhost;auto_flush_interval=off;auto_flush_rows=1;");
+            assertConfStrOk("http::addr=localhost;auto_flush_rows=off;auto_flush_interval=1;");
+            assertConfStrOk("http::addr=localhost;auto_flush_interval=off;auto_flush_rows=off;auto_flush=off;");
+            assertConfStrOk("http::addr=localhost;auto_flush=off;auto_flush_interval=off;auto_flush_rows=off;");
             assertConfStrOk("http::addr=localhost:8080;");
             assertConfStrOk("http::addr=localhost:8080;token=foo;");
             assertConfStrOk("http::addr=localhost:8080;token=foo=bar;");


### PR DESCRIPTION
Without this change it is only possible to disable both interval and row-based flushes via auto_flush=off. It's also possible to set auto_flush_interval or auto_flush_rows to a 'very large value' but that's not very elegant.

This PR allows
- `auto_flush_interval=off` - disables interval-based auto-flushing, but keeps row-based flushed enabled. 
- `auto_flush_rows=off` - disables row-based flushes, but keeps interval-based flushes intact

The idea is copied from the Python client