### PR TITLE
feat(sql): add milliseconds and microseconds support to dateadd

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampAddFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampAddFunctionFactory.java
@@ -195,6 +195,8 @@ public class TimestampAddFunctionFactory implements FunctionFactory {
     }
 
     static {
+        addFunctions.extendAndSet('u', Timestamps::addMicros);
+        addFunctions.extendAndSet('T', Timestamps::addMillis);
         addFunctions.extendAndSet('s', Timestamps::addSeconds);
         addFunctions.extendAndSet('m', Timestamps::addMinutes);
         addFunctions.extendAndSet('h', Timestamps::addHours);

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -120,6 +120,10 @@ public final class Timestamps {
 
     public static long addPeriod(long lo, char type, int period) {
         switch (type) {
+            case 'u':
+                return Timestamps.addMicros(lo, period);
+            case 'T':
+                return Timestamps.addMillis(lo, period);
             case 's':
                 return Timestamps.addSeconds(lo, period);
             case 'm':
@@ -141,6 +145,14 @@ public final class Timestamps {
 
     public static long addSeconds(long micros, int seconds) {
         return micros + seconds * SECOND_MICROS;
+    }
+
+    public static long addMillis(long micros, int millis) {
+        return micros + millis * MILLI_MICROS;
+    }
+
+    public static long addMicros(long micros, int more_micros) {
+        return micros + more_micros;
     }
 
     public static long addWeeks(long micros, int weeks) {

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -151,7 +151,7 @@ public final class Timestamps {
         return micros + millis * MILLI_MICROS;
     }
 
-    public static long addMicros(long micros, int more_micros) {
+    public static long addMicros(long micros, int moreMicros) {
         return micros + more_micros;
     }
 

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -152,7 +152,7 @@ public final class Timestamps {
     }
 
     public static long addMicros(long micros, int moreMicros) {
-        return micros + more_micros;
+        return micros + moreMicros;
     }
 
     public static long addWeeks(long micros, int weeks) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
@@ -267,6 +267,16 @@ public class TimestampAddFunctionFactoryTest extends AbstractFunctionFactoryTest
     }
 
     @Test
+    public void testLeftNaNMilli() throws SqlException {
+        call('T', 5, Numbers.LONG_NaN).andAssert(Double.NaN, 0.0001);
+    }
+
+    @Test
+    public void testLeftNaNMicro() throws SqlException {
+        call('u', 5, Numbers.LONG_NaN).andAssert(Double.NaN, 0.0001);
+    }
+
+    @Test
     public void testLeftNaNWeek() throws SqlException {
         call('w', 5, Numbers.LONG_NaN).andAssert(Double.NaN, 0.0001);
     }
@@ -327,6 +337,16 @@ public class TimestampAddFunctionFactoryTest extends AbstractFunctionFactoryTest
     }
 
     @Test
+    public void testRightNaNMilli() throws SqlException {
+        call('T', Numbers.INT_NaN, 1587275359886758L).andAssert(Double.NaN, 0.0001);
+    }
+
+    @Test
+    public void testRightNaNMicro() throws SqlException {
+        call('u', Numbers.INT_NaN, 1587275359886758L).andAssert(Double.NaN, 0.0001);
+    }
+
+    @Test
     public void testRightNaNWeek() throws SqlException {
         call('w', Numbers.INT_NaN, 1587275359886758L).andAssert(Double.NaN, 0.0001);
     }
@@ -342,8 +362,28 @@ public class TimestampAddFunctionFactoryTest extends AbstractFunctionFactoryTest
     }
 
     @Test
+    public void testMilliSimple() throws SqlException {
+        call('T', 5, 1587275359886758L).andAssert(1587275359891758L, 0.0001);
+    }
+
+    @Test
+    public void testMicroSimple() throws SqlException {
+        call('T', 5, 1587275359886758L).andAssert(1587275359891758L, 0.0001);
+    }
+
+    @Test
     public void testSecondSimpleNeg() throws SqlException {
         call('s', -5, 1587275359886758L).andAssert(1587275354886758L, 0.0001);
+    }
+
+    @Test
+    public void testMilliSimpleNeg() throws SqlException {
+        call('T', -5, 1587275359886758L).andAssert(1587275359881758L, 0.0001);
+    }
+
+    @Test
+    public void testMicroSimpleNeg() throws SqlException {
+        call('u', -5, 1587275359886758L).andAssert(1587275359886753L, 0.0001);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
@@ -368,7 +368,7 @@ public class TimestampAddFunctionFactoryTest extends AbstractFunctionFactoryTest
 
     @Test
     public void testMicroSimple() throws SqlException {
-        call('u', 5, 1587275359886758L).andAssert(1587275359891758L, 0.0001);
+        call('u', 5, 1587275359886758L).andAssert(1587275359886763L, 0.0001);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampAddFunctionFactoryTest.java
@@ -368,7 +368,7 @@ public class TimestampAddFunctionFactoryTest extends AbstractFunctionFactoryTest
 
     @Test
     public void testMicroSimple() throws SqlException {
-        call('T', 5, 1587275359886758L).andAssert(1587275359891758L, 0.0001);
+        call('u', 5, 1587275359886758L).andAssert(1587275359891758L, 0.0001);
     }
 
     @Test


### PR DESCRIPTION
Added 'T' and 'u' as possible values to dateadd, so we can add millis and microseconds to a timestamp