### PR TITLE
fix(http): client to process data received before TLS close_notification

### DIFF
--- a/core/src/main/java/io/questdb/network/JavaTlsClientSocket.java
+++ b/core/src/main/java/io/questdb/network/JavaTlsClientSocket.java
@@ -214,8 +214,13 @@ public final class JavaTlsClientSocket implements Socket {
                     case OK:
                         break;
                     case CLOSED:
-                        log.error().$("Attempt to receive from a closed SSLEngine").$();
-                        return -1;
+                        log.debug().$("SSL engine closed").$();
+                        // We received a TLS close notification from the server. We don't expect any further data from this connection.
+                        // If we have some previously unwrapped data then let's return it so the caller has a chance to process them.
+                        // If a caller calls recv() again and we have no remaining plaintext to return, we will return -1 so the
+                        // caller learned that the connection is closed.
+                        // If we have no plaintext data to return now then we can immediately indicate that we are done with the connection.
+                        return plainBytesReceived == 0 ? -1 : plainBytesReceived;
                 }
             }
         } catch (SSLException e) {


### PR DESCRIPTION
Bug description:
1. HTTP server sends a response immediately followed by TLS close_notification
2. Client unwrap the response and does another receive/unwrap iteration.
3. This unwraps the close notification and recv() return -1. Even there were some plaintext data to be processed

This change make recv() to return received plaintext if there is any.

I discovered this while testing against QuestDB Cloud. I suspect there is an HTTP proxy which behaves differently than QuestDB builtin HTTP server. 