### PR TITLE
perf: regain trust to the binary search

### DIFF
--- a/core/src/main/java/io/questdb/std/IntLongPriorityQueue.java
+++ b/core/src/main/java/io/questdb/std/IntLongPriorityQueue.java
@@ -90,25 +90,12 @@ public class IntLongPriorityQueue {
         return v;
     }
 
-    private int binSearch(long v) {
-        if (size < 65) {
-            return scanSearch(v);
-        } else {
-            return binSearch0(v);
-        }
-    }
-
     @SuppressWarnings("StatementWithEmptyBody")
-    private int binSearch0(long v) {
+    private int binSearch(long v) {
         int low = 0;
         int high = size;
 
-        while (low < high) {
-
-            if (high - low < 65) {
-                return scanSearch(v);
-            }
-
+        while (high - low > 65) {
             int mid = (low + high - 1) >>> 1;
             long midVal = buf.getQuick(mid);
 
@@ -122,11 +109,11 @@ public class IntLongPriorityQueue {
                 return mid;
             }
         }
-        return low;
+        return scanSearch(v, low);
     }
 
-    private int scanSearch(long v) {
-        for (int i = 0; i < size; i++) {
+    private int scanSearch(long v, int low) {
+        for (int i = low; i < size; i++) {
             if (buf.getQuick(i) > v) {
                 return i;
             }

--- a/core/src/main/java/io/questdb/std/IntPriorityQueue.java
+++ b/core/src/main/java/io/questdb/std/IntPriorityQueue.java
@@ -65,25 +65,12 @@ public class IntPriorityQueue {
         limit++;
     }
 
-    private int binSearch(int v) {
-        if (limit < 65) {
-            return scanSearch(v);
-        } else {
-            return binSearch0(v);
-        }
-    }
-
     @SuppressWarnings("StatementWithEmptyBody")
-    private int binSearch0(int v) {
+    private int binSearch(int v) {
         int low = 0;
         int high = limit;
 
-        while (low < high) {
-
-            if (high - low < 65) {
-                return scanSearch(v);
-            }
-
+        while (high - low > 65) {
             int mid = (low + high - 1) >>> 1;
             int midVal = buffer[mid];
 
@@ -97,7 +84,7 @@ public class IntPriorityQueue {
                 return mid;
             }
         }
-        return low;
+        return scanSearch(v, low);
     }
 
     private void resize() {
@@ -106,8 +93,8 @@ public class IntPriorityQueue {
         buffer = tmp;
     }
 
-    private int scanSearch(int v) {
-        for (int i = 0; i < limit; i++) {
+    private int scanSearch(int v, int low) {
+        for (int i = low; i < limit; i++) {
             if (buffer[i] > v) {
                 return i;
             }

--- a/core/src/main/java/io/questdb/std/LongMatrix.java
+++ b/core/src/main/java/io/questdb/std/LongMatrix.java
@@ -50,11 +50,7 @@ public class LongMatrix {
         int low = 0;
         int high = pos;
 
-        while (low < high) {
-            if (high - low < 65) {
-                return scanSearch(v, index);
-            }
-
+        while (high - low > 65) {
             int mid = (low + high - 1) >>> 1;
             long midVal = get(mid, index);
 
@@ -65,7 +61,7 @@ public class LongMatrix {
             else
                 return mid;
         }
-        return -(low + 1);
+        return scanSearch(v, index, low);
     }
 
     public void deleteRow(int r) {
@@ -113,9 +109,9 @@ public class LongMatrix {
         return pos++;
     }
 
-    private int scanSearch(long v, int index) {
+    private int scanSearch(long v, int index, int low) {
         int sz = size();
-        for (int i = 0; i < sz; i++) {
+        for (int i = low; i < sz; i++) {
             long f = get(i, index);
             if (f == v) {
                 return i;

--- a/core/src/main/java/io/questdb/std/ObjLongMatrix.java
+++ b/core/src/main/java/io/questdb/std/ObjLongMatrix.java
@@ -53,10 +53,7 @@ public class ObjLongMatrix<T> {
         int low = 0;
         int high = pos;
 
-        while (low < high) {
-            if (high - low < 65) {
-                return scanSearch(v, index);
-            }
+        while (high - low > 65) {
 
             int mid = (low + high - 1) >>> 1;
             long midVal = get(mid, index);
@@ -69,7 +66,7 @@ public class ObjLongMatrix<T> {
                 return mid;
             }
         }
-        return -(low + 1);
+        return scanSearch(v, index, low);
     }
 
     public void deleteRow(int r) {
@@ -131,9 +128,9 @@ public class ObjLongMatrix<T> {
         return pos++;
     }
 
-    private int scanSearch(long v, int index) {
+    private int scanSearch(long v, int index, int low) {
         int sz = size();
-        for (int i = 0; i < sz; i++) {
+        for (int i = low; i < sz; i++) {
             long f = get(i, index);
             if (f == v) {
                 return i;


### PR DESCRIPTION
## Context

Algorithms labor union reported that `QuestDB` (QDB) violates right of "binary search algorithm" (BSA) by forcing it to work but not using any results of its work. BSA earned trust by countless applications in the production - so complain is valid and QDB must respect rights of the algorithm.

During audit 4 violations were found. 

One concrete example is here (commit hash: a077bee58d1d44a8d6ee33f373422d87bd057155, file: `IntLongPriorityQueue.java`, line: 109, [link](https://github.com/questdb/questdb/blob/a077bee58d1d44a8d6ee33f373422d87bd057155/core/src/main/java/io/questdb/std/IntLongPriorityQueue.java#L109))
```java
private int binSearch0(long v) {
    int low = 0;
    int high = size;

    while (low < high) {

        if (high - low < 65) {
            return scanSearch(v); // binary search work completely ignored, so rude!
        }

        int mid = (low + high - 1) >>> 1;
        long midVal = buf.getQuick(mid);

        if (midVal < v)
            low = mid + 1;
        else if (midVal > v)
            high = mid;
        else {
            while (++mid < high && buf.getQuick(mid) == v) {
            }
            return mid;
        }
    }
    return low;
}
```

QDB must respect rights of algorithms, especially such honorable as BSA. PR fixes this uncomfortable situation. 

Hope that all legal rights of algorithms will be respected in such amazing project as QDB 