### PR TITLE
chore(core): add support for varchar-typed arguments to functions

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -354,7 +354,7 @@ public final class ColumnType {
     }
 
     private static boolean isIPv4Cast(int fromType, int toType) {
-        return (fromType == STRING && toType == IPv4);
+        return (fromType == STRING || fromType == VARCHAR) && toType == IPv4;
     }
 
     private static boolean isImplicitParsingCast(int fromType, int toType) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7891,6 +7891,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         void putGeoStr(int columnIndex, CharSequence value);
 
+        default void putGeoVarchar(int columnIndex, Utf8Sequence value) {
+            putGeoStr(columnIndex, value.asAsciiCharSequence());
+        }
+
         void putIPv4(int columnIndex, int value);
 
         void putInt(int columnIndex, int value);

--- a/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
+++ b/core/src/main/java/io/questdb/griffin/RecordToRowCopierUtils.java
@@ -111,6 +111,7 @@ public class RecordToRowCopierUtils {
         int wPutSymChar = asm.poolInterfaceMethod(TableWriter.Row.class, "putSym", "(IC)V");
         int wPutStr = asm.poolInterfaceMethod(TableWriter.Row.class, "putStr", "(ILjava/lang/CharSequence;)V");
         int wPutGeoStr = asm.poolInterfaceMethod(TableWriter.Row.class, "putGeoStr", "(ILjava/lang/CharSequence;)V");
+        int wPutGeoVarchar = asm.poolInterfaceMethod(TableWriter.Row.class, "putGeoVarchar", "(ILio/questdb/std/str/Utf8Sequence;)V");
         int wPutVarchar = asm.poolInterfaceMethod(TableWriter.Row.class, "putVarchar", "(ILio/questdb/std/str/Utf8Sequence;)V");
 
         int implicitCastCharAsByte = asm.poolMethod(SqlUtil.class, "implicitCastCharAsByte", "(CI)B");
@@ -141,6 +142,7 @@ public class RecordToRowCopierUtils {
         int implicitCastVarcharAsChar = asm.poolMethod(SqlUtil.class, "implicitCastVarcharAsChar", "(Lio/questdb/std/str/Utf8Sequence;)C");
         int implicitCastVarcharAsFloat = asm.poolMethod(SqlUtil.class, "implicitCastVarcharAsFloat", "(Lio/questdb/std/str/Utf8Sequence;)F");
         int implicitCastVarcharAsDouble = asm.poolMethod(SqlUtil.class, "implicitCastVarcharAsDouble", "(Lio/questdb/std/str/Utf8Sequence;)D");
+        int implicitCastVarcharAsLong256 = asm.poolMethod(SqlUtil.class, "implicitCastVarcharAsLong256", "(Lio/questdb/std/str/Utf8Sequence;)Lio/questdb/griffin/engine/functions/constants/Long256Constant;");
 
         int implicitCastIntAsShort = asm.poolMethod(SqlUtil.class, "implicitCastIntAsShort", "(I)S");
         int implicitCastLongAsShort = asm.poolMethod(SqlUtil.class, "implicitCastLongAsShort", "(J)S");
@@ -687,6 +689,18 @@ public class RecordToRowCopierUtils {
                         case ColumnType.DATE:
                             asm.invokeInterface(rGetVarchar);
                             asm.invokeStatic(transferVarcharToDateCol);
+                            break;
+                        case ColumnType.GEOBYTE:
+                        case ColumnType.GEOSHORT:
+                        case ColumnType.GEOINT:
+                        case ColumnType.GEOLONG:
+                            asm.invokeInterface(rGetVarchar);
+                            asm.invokeInterface(wPutGeoVarchar, 2);
+                            break;
+                        case ColumnType.LONG256:
+                            asm.invokeInterface(rGetVarchar);
+                            asm.invokeStatic(implicitCastVarcharAsLong256);
+                            asm.invokeInterface(wPutLong256, 2);
                             break;
                         default:
                             assert false;

--- a/core/src/main/java/io/questdb/griffin/SqlUtil.java
+++ b/core/src/main/java/io/questdb/griffin/SqlUtil.java
@@ -672,6 +672,10 @@ public class SqlUtil {
         return factory.pop();
     }
 
+    public static Long256Constant implicitCastVarcharAsLong256(Utf8Sequence value) {
+        return implicitCastStrAsLong256(value.asAsciiCharSequence());
+    }
+
     public static void implicitCastStrAsLong256(CharSequence value, Long256Acceptor long256Acceptor) {
         if (value != null) {
             Long256FromCharSequenceDecoder.decode(value, 0, value.length(), long256Acceptor);

--- a/core/src/test/java/io/questdb/test/griffin/VarcharConversionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/VarcharConversionTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class VarcharConversionTest extends AbstractCairoTest {
+
+    @Test
+    public void testConvertToIpv4() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (c_varchar varchar)");
+            ddl("create table y (c_ipv4 ipv4)");
+            insert("insert into x values('127.0.0.1')");
+            insert("insert into y select * from x");
+            assertSql("c_ipv4\n127.0.0.1\n", "y");
+        });
+    }
+
+    @Test
+    public void testConvertToLong256() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (c_varchar varchar)");
+            ddl("create table y (c_long256 long256)");
+            insert("insert into x values('0x1')");
+            insert("insert into y select * from x");
+            assertSql("c_long256\n0x01\n", "y");
+        });
+    }
+
+    @Test
+    public void testConvertToGeohash() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x (c_varchar varchar)");
+            ddl("create table y (c_geohash geohash(2B))");
+            insert("insert into x values('sr')");
+            insert("insert into y select * from x");
+            assertSql("c_geohash\n11\n", "y");
+        });
+    }
+}


### PR DESCRIPTION
The second `insert` below is currently failing due to the lack of support for converting VARCHAR to LONG256. A similar problem exists for GEOHASH and IPv4. Equivalent expressions with STRING work.

```sql
create table x (c_varchar varchar);
create table y (c_long256 long256);
insert into x values('0x1');
insert into y select * from x;
```

The PR adds simple support for these by relying on the fact that the strings involved are pure ASCII, so it just uses `Utf8Sequence.asAsciiSequence()`.