### PR TITLE
fix(sql): fix incorrect results for parallel group by with symbol like filter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/BinaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/BinaryFunction.java
@@ -69,6 +69,7 @@ public interface BinaryFunction extends Function {
         return getLeft().isReadThreadSafe() && getRight().isReadThreadSafe();
     }
 
+    @Override
     default boolean isRuntimeConstant() {
         final Function l = getLeft();
         final Function r = getRight();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/UnaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/UnaryFunction.java
@@ -58,6 +58,7 @@ public interface UnaryFunction extends Function {
         return getArg().isReadThreadSafe();
     }
 
+    @Override
     default boolean isRuntimeConstant() {
         return getArg().isRuntimeConstant();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/BinBindVariable.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/BinBindVariable.java
@@ -32,7 +32,7 @@ import io.questdb.griffin.engine.functions.BinFunction;
 import io.questdb.std.BinarySequence;
 
 public class BinBindVariable extends BinFunction implements ScalarFunction {
-    private final BinarySequence value;
+    BinarySequence value;
 
     public BinBindVariable(BinarySequence value) {
         this.value = value;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bind/BinBindVariable.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bind/BinBindVariable.java
@@ -32,7 +32,7 @@ import io.questdb.griffin.engine.functions.BinFunction;
 import io.questdb.std.BinarySequence;
 
 public class BinBindVariable extends BinFunction implements ScalarFunction {
-    BinarySequence value;
+    private final BinarySequence value;
 
     public BinBindVariable(BinarySequence value) {
         this.value = value;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/AllNotEqStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/AllNotEqStrFunctionFactory.java
@@ -87,11 +87,6 @@ public class AllNotEqStrFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return false;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(arg).val(" <> all ").val(set);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/AllNotEqVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/AllNotEqVarcharFunctionFactory.java
@@ -33,7 +33,10 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.constants.BooleanConstant;
-import io.questdb.std.*;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Utf8SequenceHashSet;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8StringSink;
 
@@ -88,11 +91,6 @@ public class AllNotEqVarcharFunctionFactory implements FunctionFactory {
         public boolean getBool(Record rec) {
             final Utf8Sequence str = arg.getVarcharA(rec);
             return str != null && set.excludes(str);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return false;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
@@ -191,16 +191,10 @@ public class InSymbolCursorFunctionFactory implements FunctionFactory {
     }
 
     private static class StrInNullCursorFunction extends BooleanFunction implements UnaryFunction {
-
         private final Function valueArg;
 
         public StrInNullCursorFunction(Function valueArg) {
             this.valueArg = valueArg;
-        }
-
-        @Override
-        public void close() {
-            UnaryFunction.super.close();
         }
 
         @Override
@@ -214,23 +208,12 @@ public class InSymbolCursorFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            valueArg.init(symbolTableSource, executionContext);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return valueArg.isReadThreadSafe();
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(valueArg).val(" in null");
         }
     }
 
     private static class SymbolInCursorFunction extends BooleanFunction implements BinaryFunction {
-
         private final Function cursorArg;
         private final Record.CharSequenceFunction func;
         private final IntHashSet symbolKeys = new IntHashSet();
@@ -313,16 +296,10 @@ public class InSymbolCursorFunctionFactory implements FunctionFactory {
     }
 
     private static class SymbolInNullCursorFunction extends BooleanFunction implements UnaryFunction {
-
         private final Function valueArg;
 
         public SymbolInNullCursorFunction(Function valueArg) {
             this.valueArg = valueArg;
-        }
-
-        @Override
-        public void close() {
-            UnaryFunction.super.close();
         }
 
         @Override
@@ -333,16 +310,6 @@ public class InSymbolCursorFunctionFactory implements FunctionFactory {
         @Override
         public boolean getBool(Record rec) {
             return valueArg.getInt(rec) == SymbolTable.VALUE_IS_NULL;
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            valueArg.init(symbolTableSource, executionContext);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return valueArg.isReadThreadSafe();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InTimestampStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InTimestampStrFunctionFactory.java
@@ -149,7 +149,6 @@ public class InTimestampStrFunctionFactory implements FunctionFactory {
             return right;
         }
 
-
         @Override
         public boolean isReadThreadSafe() {
             return false;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/columns/Long256Column.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/columns/Long256Column.java
@@ -65,11 +65,6 @@ public class Long256Column extends Long256Function implements ScalarFunction {
     }
 
     @Override
-    public boolean isReadThreadSafe() {
-        return true;
-    }
-
-    @Override
     public void toPlan(PlanSink sink) {
         sink.putColumnName(columnIndex);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/eq/EqSymStrFunctionFactory.java
@@ -50,7 +50,13 @@ public class EqSymStrFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         // there are optimisation opportunities
         // 1. when one of args is constant null comparison can boil down to checking
         //    length of non-constant (must be -1)
@@ -91,13 +97,13 @@ public class EqSymStrFunctionFactory implements FunctionFactory {
 
         @Override
         public boolean getBool(Record rec) {
-            return negated != (arg().getInt(rec) == valueIndex);
+            return negated != (arg.getInt(rec) == valueIndex);
         }
 
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            arg().init(symbolTableSource, executionContext);
-            final StaticSymbolTable symbolTable = arg().getStaticSymbolTable();
+            arg.init(symbolTableSource, executionContext);
+            final StaticSymbolTable symbolTable = ((SymbolFunction) arg).getStaticSymbolTable();
             assert symbolTable != null;
             valueIndex = symbolTable.keyOf(constant);
         }
@@ -105,10 +111,6 @@ public class EqSymStrFunctionFactory implements FunctionFactory {
         @Override
         public boolean isConstant() {
             return valueIndex == SymbolTable.VALUE_NOT_FOUND;
-        }
-
-        SymbolFunction arg() {
-            return (SymbolFunction) arg;
         }
     }
 
@@ -157,20 +159,16 @@ public class EqSymStrFunctionFactory implements FunctionFactory {
 
         @Override
         public boolean getBool(Record rec) {
-            return negated != (exists && arg().getInt(rec) == valueIndex);
+            return negated != (exists && arg.getInt(rec) == valueIndex);
         }
 
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            arg().init(symbolTableSource, executionContext);
-            StaticSymbolTable staticSymbolTable = arg().getStaticSymbolTable();
+            arg.init(symbolTableSource, executionContext);
+            StaticSymbolTable staticSymbolTable = ((SymbolFunction) arg).getStaticSymbolTable();
             assert staticSymbolTable != null : "Static symbol table is null for func with static isSymbolTableStatic returning true";
             valueIndex = staticSymbolTable.keyOf(constant);
             exists = (valueIndex != SymbolTable.VALUE_NOT_FOUND);
-        }
-
-        SymbolFunction arg() {
-            return (SymbolFunction) arg;
         }
     }
 
@@ -190,7 +188,6 @@ public class EqSymStrFunctionFactory implements FunctionFactory {
             if (a == null) {
                 return negated != (b == null);
             }
-
             return negated != Chars.equalsNc(a, b);
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLong256GroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountLong256GroupByFunctionFactory.java
@@ -64,6 +64,5 @@ public class CountLong256GroupByFunctionFactory implements FunctionFactory {
         } else {
             return new CountLong256GroupByFunction(arg);
         }
-
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeStrFunctionFactory.java
@@ -267,11 +267,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" like ");
@@ -299,11 +294,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         public boolean getBool(Record rec) {
             CharSequence cs = value.getStrA(rec);
             return Chars.endsWith(cs, pattern);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return true;
         }
 
         @Override
@@ -339,11 +329,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" ilike ");
@@ -374,11 +359,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" ilike ");
@@ -405,11 +385,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         public boolean getBool(Record rec) {
             CharSequence cs = value.getStrA(rec);
             return Chars.startsWithLowerCase(cs, pattern);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return true;
         }
 
         @Override
@@ -476,11 +451,6 @@ public abstract class AbstractLikeStrFunctionFactory implements FunctionFactory 
         public boolean getBool(Record rec) {
             CharSequence cs = value.getStrA(rec);
             return Chars.startsWith(cs, pattern);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return true;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/AbstractLikeVarcharFunctionFactory.java
@@ -24,7 +24,6 @@
 
 package io.questdb.griffin.engine.functions.regex;
 
-
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
@@ -227,11 +226,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" like ");
@@ -270,11 +264,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" like ");
@@ -305,11 +294,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" like ");
@@ -336,11 +320,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         public boolean getBool(Record rec) {
             Utf8Sequence us = value.getVarcharA(rec);
             return us != null && Utf8s.containsLowerCaseAscii(us, pattern);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return true;
         }
 
         @Override
@@ -374,11 +353,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" ilike ");
@@ -408,11 +382,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         }
 
         @Override
-        public boolean isReadThreadSafe() {
-            return true;
-        }
-
-        @Override
         public void toPlan(PlanSink sink) {
             sink.val(value);
             sink.val(" ilike ");
@@ -439,11 +408,6 @@ public abstract class AbstractLikeVarcharFunctionFactory implements FunctionFact
         public boolean getBool(Record rec) {
             Utf8Sequence us = value.getVarcharA(rec);
             return us != null && Utf8s.startsWith(us, pattern);
-        }
-
-        @Override
-        public boolean isReadThreadSafe() {
-            return true;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SizePrettyFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SizePrettyFunctionFactory.java
@@ -45,9 +45,7 @@ public class SizePrettyFunctionFactory implements FunctionFactory {
     // Bytes, Kilo, Mega, Giga, Tera, Peta, Exa, Zetta
     // bytes, kibibyte, mebibyte, gibibyte, tebibyte, pebibyte, exbibyte, zebibyte
     // B, KiB, MiB, GiB, TiB, PiB, EiB, ZiB (this last is out of range for a long)
-
     private static final char[] SCALE = {'B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z'};
-
 
     public static void toSizePretty(StringSink sink, long size) {
         sink.clear();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/AvgDoubleVectorAggregateFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/AvgDoubleVectorAggregateFunction.java
@@ -128,13 +128,6 @@ public class AvgDoubleVectorAggregateFunction extends DoubleFunction implements 
     }
 
     @Override
-    public boolean isReadThreadSafe() {
-        // group-by functions are not stateless when values are computed
-        // however, once values are calculated, the read becomes stateless
-        return false;
-    }
-
-    @Override
     public boolean merge(long pRostiA, long pRostiB) {
         return Rosti.keyedIntSumDoubleMerge(pRostiA, pRostiB, valueOffset);
     }

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -2101,14 +2101,24 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelStringKeyLikeFilter() throws Exception {
+        final String fullResult = "key\tcount\n" +
+                "k0\t1600\n" +
+                "k1\t1600\n" +
+                "k2\t1600\n" +
+                "k3\t1600\n" +
+                "k4\t1600\n";
         testParallelStringAndVarcharKeyGroupBy(
-                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                "SELECT key, count(*) FROM tab WHERE key like '%0' ORDER BY key",
                 "key\tcount\n" +
-                        "k0\t1600\n" +
-                        "k1\t1600\n" +
-                        "k2\t1600\n" +
-                        "k3\t1600\n" +
-                        "k4\t1600\n"
+                        "k0\t1600\n",
+                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like 'k_' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like '%k%' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like '%foobarbaz%' ORDER BY key",
+                "key\tcount\n"
         );
     }
 
@@ -2442,14 +2452,24 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelSymbolKeyLikeFilter() throws Exception {
+        final String fullResult = "key\tcount\n" +
+                "k0\t1600\n" +
+                "k1\t1600\n" +
+                "k2\t1600\n" +
+                "k3\t1600\n" +
+                "k4\t1600\n";
         testParallelSymbolKeyGroupBy(
-                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                "SELECT key, count(*) FROM tab WHERE key like '%0' ORDER BY key",
                 "key\tcount\n" +
-                        "k0\t1600\n" +
-                        "k1\t1600\n" +
-                        "k2\t1600\n" +
-                        "k3\t1600\n" +
-                        "k4\t1600\n"
+                        "k0\t1600\n",
+                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like 'k_' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like '%k%' ORDER BY key",
+                fullResult,
+                "SELECT key, count(*) FROM tab WHERE key like '%foobarbaz%' ORDER BY key",
+                "key\tcount\n"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -2100,6 +2100,31 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelStringKeyLikeFilter() throws Exception {
+        testParallelStringAndVarcharKeyGroupBy(
+                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                "key\tcount\n" +
+                        "k0\t1600\n" +
+                        "k1\t1600\n" +
+                        "k2\t1600\n" +
+                        "k3\t1600\n" +
+                        "k4\t1600\n"
+        );
+    }
+
+    @Test
+    public void testParallelStringKeyNotLikeFilter() throws Exception {
+        testParallelStringAndVarcharKeyGroupBy(
+                "SELECT key, count(*) FROM tab WHERE key not like 'k0%' ORDER BY key",
+                "key\tcount\n" +
+                        "k1\t1600\n" +
+                        "k2\t1600\n" +
+                        "k3\t1600\n" +
+                        "k4\t1600\n"
+        );
+    }
+
+    @Test
     public void testParallelStringKeyedFirstFunction() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
@@ -2412,6 +2437,31 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "key\tvwap\tsum\n" +
                         "k1\t2682.7321472695826\t1638800.0\n" +
                         "k2\t2683.4065201284266\t1639600.0\n"
+        );
+    }
+
+    @Test
+    public void testParallelSymbolKeyLikeFilter() throws Exception {
+        testParallelSymbolKeyGroupBy(
+                "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
+                "key\tcount\n" +
+                        "k0\t1600\n" +
+                        "k1\t1600\n" +
+                        "k2\t1600\n" +
+                        "k3\t1600\n" +
+                        "k4\t1600\n"
+        );
+    }
+
+    @Test
+    public void testParallelSymbolKeyNotLikeFilter() throws Exception {
+        testParallelSymbolKeyGroupBy(
+                "SELECT key, count(*) FROM tab WHERE key not like 'k0%' ORDER BY key",
+                "key\tcount\n" +
+                        "k1\t1600\n" +
+                        "k2\t1600\n" +
+                        "k3\t1600\n" +
+                        "k4\t1600\n"
         );
     }
 


### PR DESCRIPTION
For queries like `SELECT key, count(*) FROM tab WHERE key like '%foobar%' ORDER BY key;` filter functions were not cloned. This led to incorrect results returned by the query.

Also, cleans up `isReadThreadSafe` overrides to make them consistent.