### PR TITLE
fix(sql): fix stuck parallel group by query due to incorrect query timeout handling

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByMergeShardJob.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByMergeShardJob.java
@@ -50,8 +50,9 @@ public class GroupByMergeShardJob extends AbstractQueueConsumerJob<GroupByMergeS
         task.clear();
         subSeq.done(cursor);
 
-        final int slotId = atom.acquire(workerId, circuitBreaker);
+        int slotId = -1;
         try {
+            slotId = atom.acquire(workerId, circuitBreaker);
             if (circuitBreaker.checkIfTripped()) {
                 return;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/VectorAggregateEntry.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/VectorAggregateEntry.java
@@ -91,8 +91,9 @@ public class VectorAggregateEntry implements Mutable {
             return;
         }
 
-        final int slot = perWorkerLocks.acquireSlot(workerId, circuitBreaker);
+        int slot = -1;
         try {
+            slot = perWorkerLocks.acquireSlot(workerId, circuitBreaker);
             if (pRosti != null) {
                 long oldSize = Rosti.getAllocMemory(pRosti[slot]);
                 if (!func.aggregate(pRosti[slot], keyAddress, valueAddress, valueCount, columnSizeShr, slot)) {


### PR DESCRIPTION
Fixes #4418

`PerWorkerLocks#acquireSlot()` may throw while the code wasn't properly counting down the latch in that case.