### PR TITLE
chore(core): zero out unused inlined varchar bytes

### DIFF
--- a/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
@@ -100,7 +100,9 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
                 // size is known to be at most 4 bits
                 auxMem.putByte((byte) ((size << HEADER_FLAGS_WIDTH) | flags));
                 auxMem.putVarchar(value, 0, size);
-                auxMem.skip(VARCHAR_MAX_BYTES_FULLY_INLINED - size);
+                for (int i = size; i < VARCHAR_MAX_BYTES_FULLY_INLINED; i++) {
+                    auxMem.putByte((byte) 0);
+                }
                 offset = dataMem.getAppendOffset();
             } else {
                 if (size >= LENGTH_LIMIT_BYTES) {


### PR DESCRIPTION
When the varchar is 9 bytes or less, we store it fully within the auxiliary vector. Currently we just write the data bytes, and don't zero out the padding up to 9 bytes. This adds code that zeroes them out, as needed for JIT operations.