### PR TITLE
fix(sql): FILL(LINEAR) regression in 7.4.1

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
@@ -714,9 +714,8 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
                 return;
             }
 
-            if (!managedCursor.hasNext()) {
-                throw new AssertionError();
-            }
+            final boolean good = managedCursor.hasNext();
+            assert good;
 
             final long timestamp = managedRecord.getTimestamp(timestampIndex);
             if (rules != null) {


### PR DESCRIPTION
Fixes bug introduced in https://github.com/questdb/questdb/pull/4392

`managedCursor.toTop()` resets the state of the cursor. However, this change is not propagated to the inner records until `managedRecord.hasNext()` is called. `.hasNext()` applies the state change to the records, and is not just a predicate.

An assertion was raised against `managedRecord.hasNext()` which would be called correctly in debug builds, but would be elided in release builds, causing breakage to FILL(LINEAR), as the record's position would not be reset to top.