### PR TITLE
chore(core): avoid megamorphism in hash tables used on hot path

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1415,7 +1415,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         }
     }
 
-    private void configurePortal(CharSequence portalName, CharSequence statementName) throws BadProtocolException {
+    private void configurePortal(@NotNull CharSequence portalName, CharSequence statementName) throws BadProtocolException {
         int index = namedPortalMap.keyIndex(portalName);
         if (index > -1) {
             Portal portal = namedPortalPool.pop();
@@ -1427,7 +1427,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         }
     }
 
-    private void configurePreparedStatement(CharSequence statementName) throws BadProtocolException {
+    private void configurePreparedStatement(@NotNull CharSequence statementName) throws BadProtocolException {
         // this is a PARSE message asking us to setup named SQL
         // we need to keep SQL text in case our SQL cache expires
         // as well as PG types of the bind variables, which we will need to configure setters

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InSymbolCursorFunctionFactory.java
@@ -178,12 +178,7 @@ public class InSymbolCursorFunctionFactory implements FunctionFactory {
                 } else {
                     int toIndex = valueSet.keyIndex(value);
                     if (toIndex > -1) {
-                        int index = this.valueSet.keyIndex(value);
-                        if (index < 0) {
-                            valueSet.addAt(toIndex, this.valueSet.keyAt(index));
-                        } else {
-                            valueSet.addAt(toIndex, Chars.toString(value));
-                        }
+                        valueSet.addAt(toIndex, Chars.toString(value));
                     }
                 }
             }

--- a/core/src/main/java/io/questdb/std/AbstractCharSequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/AbstractCharSequenceHashSet.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 
 public abstract class AbstractCharSequenceHashSet implements Mutable {
@@ -53,11 +55,11 @@ public abstract class AbstractCharSequenceHashSet implements Mutable {
         free = capacity;
     }
 
-    public boolean contains(CharSequence key) {
+    public boolean contains(@NotNull CharSequence key) {
         return keyIndex(key) < 0;
     }
 
-    public boolean excludes(CharSequence key) {
+    public boolean excludes(@NotNull CharSequence key) {
         return keyIndex(key) > -1;
     }
 
@@ -69,23 +71,19 @@ public abstract class AbstractCharSequenceHashSet implements Mutable {
         return keys[-index - 1];
     }
 
-    public int keyIndex(CharSequence key) {
+    public int keyIndex(@NotNull CharSequence key) {
         int index = Hash.spread(Chars.hashCode(key)) & mask;
-
         if (keys[index] == noEntryKey) {
             return index;
         }
-
         if (Chars.equals(key, keys[index])) {
             return -index - 1;
         }
-
         return probe(key, index);
     }
 
-    public int keyIndex(CharSequence key, int lo, int hi) {
+    public int keyIndex(@NotNull CharSequence key, int lo, int hi) {
         int index = Hash.spread(Chars.hashCode(key, lo, hi)) & mask;
-
         if (keys[index] == noEntryKey) {
             return index;
         }
@@ -96,7 +94,7 @@ public abstract class AbstractCharSequenceHashSet implements Mutable {
         return probe(key, lo, hi, index);
     }
 
-    public int remove(CharSequence key) {
+    public int remove(@NotNull CharSequence key) {
         int index = keyIndex(key);
         if (index < 0) {
             removeAt(index);

--- a/core/src/main/java/io/questdb/std/AbstractUtf8SequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/AbstractUtf8SequenceHashSet.java
@@ -27,6 +27,7 @@ package io.questdb.std;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
@@ -59,11 +60,11 @@ public abstract class AbstractUtf8SequenceHashSet implements Mutable {
         free = capacity;
     }
 
-    public boolean contains(Utf8Sequence key) {
+    public boolean contains(@NotNull Utf8Sequence key) {
         return keyIndex(key) < 0;
     }
 
-    public boolean excludes(Utf8Sequence key) {
+    public boolean excludes(@NotNull Utf8Sequence key) {
         return keyIndex(key) > -1;
     }
 
@@ -71,7 +72,7 @@ public abstract class AbstractUtf8SequenceHashSet implements Mutable {
         return keys[-index - 1];
     }
 
-    public int keyIndex(Utf8Sequence key) {
+    public int keyIndex(@NotNull Utf8Sequence key) {
         int hashCode = Utf8s.hashCode(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == noEntryKey) {
@@ -83,7 +84,7 @@ public abstract class AbstractUtf8SequenceHashSet implements Mutable {
         return probe(key, hashCode, index);
     }
 
-    public int keyIndex(Utf8Sequence key, int lo, int hi) {
+    public int keyIndex(@NotNull Utf8Sequence key, int lo, int hi) {
         int hashCode = Utf8s.hashCode(key, lo, hi);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == noEntryKey) {
@@ -96,7 +97,7 @@ public abstract class AbstractUtf8SequenceHashSet implements Mutable {
         return probe(key, hashCode, lo, hi, index);
     }
 
-    public int remove(Utf8Sequence key) {
+    public int remove(@NotNull Utf8Sequence key) {
         int index = keyIndex(key);
         if (index < 0) {
             removeAt(index);

--- a/core/src/main/java/io/questdb/std/CharSequenceBoolHashMap.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceBoolHashMap.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 
 
@@ -56,6 +58,7 @@ public class CharSequenceBoolHashMap extends AbstractCharSequenceHashSet {
         Arrays.fill(values, noEntryValue);
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (obj == null) {
             return false;
@@ -81,7 +84,7 @@ public class CharSequenceBoolHashMap extends AbstractCharSequenceHashSet {
         return true;
     }
 
-    public boolean get(CharSequence key) {
+    public boolean get(@NotNull CharSequence key) {
         return valueAt(keyIndex(key));
     }
 
@@ -89,11 +92,11 @@ public class CharSequenceBoolHashMap extends AbstractCharSequenceHashSet {
         return list;
     }
 
-    public boolean put(CharSequence key, boolean value) {
+    public boolean put(@NotNull CharSequence key, boolean value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public void putAll(CharSequenceBoolHashMap other) {
+    public void putAll(@NotNull CharSequenceBoolHashMap other) {
         CharSequence[] otherKeys = other.keys;
         boolean[] otherValues = other.values;
         for (int i = 0, n = otherKeys.length; i < n; i++) {
@@ -114,7 +117,7 @@ public class CharSequenceBoolHashMap extends AbstractCharSequenceHashSet {
         return true;
     }
 
-    public void putIfAbsent(CharSequence key, boolean value) {
+    public void putIfAbsent(@NotNull CharSequence key, boolean value) {
         int index = keyIndex(key);
         if (index > -1) {
             String keyString = Chars.toString(key);

--- a/core/src/main/java/io/questdb/std/CharSequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceHashSet.java
@@ -27,6 +27,7 @@ package io.questdb.std;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Sinkable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
@@ -62,7 +63,7 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
      * @param key immutable sequence of characters.
      * @return false if key is already in the set and true otherwise.
      */
-    public boolean add(CharSequence key) {
+    public boolean add(@Nullable CharSequence key) {
         if (key == null) {
             return addNull();
         }
@@ -76,13 +77,13 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
         return true;
     }
 
-    public final void addAll(CharSequenceHashSet that) {
+    public final void addAll(@NotNull CharSequenceHashSet that) {
         for (int i = 0, k = that.size(); i < k; i++) {
             add(that.get(i));
         }
     }
 
-    public void addAt(int index, CharSequence key) {
+    public void addAt(int index, @NotNull CharSequence key) {
         final String s = Chars.toString(key);
         keys[index] = s;
         list.add(s);
@@ -110,12 +111,12 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
     }
 
     @Override
-    public boolean contains(CharSequence key) {
+    public boolean contains(@Nullable CharSequence key) {
         return key == null ? hasNull : keyIndex(key) < 0;
     }
 
     @Override
-    public boolean excludes(CharSequence key) {
+    public boolean excludes(@Nullable CharSequence key) {
         return key == null ? !hasNull : keyIndex(key) > -1;
     }
 
@@ -136,7 +137,7 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
         return list.indexOf(keys[index]);
     }
 
-    public int getListIndexOf(CharSequence cs) {
+    public int getListIndexOf(@NotNull CharSequence cs) {
         return getListIndexAt(keyIndex(cs));
     }
 
@@ -147,7 +148,7 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
     }
 
     @Override
-    public int remove(CharSequence key) {
+    public int remove(@Nullable CharSequence key) {
         if (key == null) {
             return removeNull();
         }

--- a/core/src/main/java/io/questdb/std/CharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceIntHashMap.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 
 
@@ -56,11 +58,11 @@ public class CharSequenceIntHashMap extends AbstractCharSequenceHashSet {
         Arrays.fill(values, noEntryValue);
     }
 
-    public int get(CharSequence key) {
+    public int get(@NotNull CharSequence key) {
         return valueAt(keyIndex(key));
     }
 
-    public void increment(CharSequence key) {
+    public void increment(@NotNull CharSequence key) {
         int index = keyIndex(key);
         if (index < 0) {
             values[-index - 1] = values[-index - 1] + 1;
@@ -73,11 +75,11 @@ public class CharSequenceIntHashMap extends AbstractCharSequenceHashSet {
         return list;
     }
 
-    public boolean put(CharSequence key, int value) {
+    public boolean put(@NotNull CharSequence key, int value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public void putAll(CharSequenceIntHashMap other) {
+    public void putAll(@NotNull CharSequenceIntHashMap other) {
         CharSequence[] otherKeys = other.keys;
         int[] otherValues = other.values;
         for (int i = 0, n = otherKeys.length; i < n; i++) {
@@ -87,7 +89,7 @@ public class CharSequenceIntHashMap extends AbstractCharSequenceHashSet {
         }
     }
 
-    public boolean putAt(int index, CharSequence key, int value) {
+    public boolean putAt(int index, @NotNull CharSequence key, int value) {
         if (index < 0) {
             values[-index - 1] = value;
             return false;
@@ -98,7 +100,7 @@ public class CharSequenceIntHashMap extends AbstractCharSequenceHashSet {
         return true;
     }
 
-    public void putIfAbsent(CharSequence key, int value) {
+    public void putIfAbsent(@NotNull CharSequence key, int value) {
         int index = keyIndex(key);
         if (index > -1) {
             String keyString = Chars.toString(key);

--- a/core/src/main/java/io/questdb/std/CharSequenceLongHashMap.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceLongHashMap.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 
 
@@ -56,11 +58,11 @@ public class CharSequenceLongHashMap extends AbstractCharSequenceHashSet {
         Arrays.fill(values, noEntryValue);
     }
 
-    public long get(CharSequence key) {
+    public long get(@NotNull CharSequence key) {
         return valueAt(keyIndex(key));
     }
 
-    public void increment(CharSequence key) {
+    public void increment(@NotNull CharSequence key) {
         final int index = keyIndex(key);
         if (index < 0) {
             values[-index - 1] = values[-index - 1] + 1;
@@ -73,11 +75,11 @@ public class CharSequenceLongHashMap extends AbstractCharSequenceHashSet {
         return list;
     }
 
-    public boolean put(CharSequence key, long value) {
+    public boolean put(@NotNull CharSequence key, long value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public void putAll(CharSequenceLongHashMap other) {
+    public void putAll(@NotNull CharSequenceLongHashMap other) {
         final CharSequence[] otherKeys = other.keys;
         final long[] otherValues = other.values;
         for (int i = 0, n = otherKeys.length; i < n; i++) {
@@ -87,7 +89,7 @@ public class CharSequenceLongHashMap extends AbstractCharSequenceHashSet {
         }
     }
 
-    public boolean putAt(int index, CharSequence key, long value) {
+    public boolean putAt(int index, @NotNull CharSequence key, long value) {
         if (index < 0) {
             values[-index - 1] = value;
             return false;
@@ -98,7 +100,7 @@ public class CharSequenceLongHashMap extends AbstractCharSequenceHashSet {
         return true;
     }
 
-    public void putIfAbsent(CharSequence key, long value) {
+    public void putIfAbsent(@NotNull CharSequence key, long value) {
         final int index = keyIndex(key);
         if (index > -1) {
             final String keyString = Chars.toString(key);

--- a/core/src/main/java/io/questdb/std/CharSequenceObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceObjHashMap.java
@@ -24,6 +24,8 @@
 
 package io.questdb.std;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -53,7 +55,7 @@ public class CharSequenceObjHashMap<V> extends AbstractCharSequenceHashSet {
         list.clear();
     }
 
-    public V get(CharSequence key) {
+    public V get(@NotNull CharSequence key) {
         return valueAt(keyIndex(key));
     }
 
@@ -61,11 +63,11 @@ public class CharSequenceObjHashMap<V> extends AbstractCharSequenceHashSet {
         return list;
     }
 
-    public boolean put(CharSequence key, V value) {
+    public boolean put(@NotNull CharSequence key, V value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public void putAll(CharSequenceObjHashMap<V> other) {
+    public void putAll(@NotNull CharSequenceObjHashMap<V> other) {
         CharSequence[] otherKeys = other.keys;
         V[] otherValues = other.values;
         for (int i = 0, n = otherKeys.length; i < n; i++) {
@@ -75,7 +77,7 @@ public class CharSequenceObjHashMap<V> extends AbstractCharSequenceHashSet {
         }
     }
 
-    public boolean putAt(int index, CharSequence key, V value) {
+    public boolean putAt(int index, @NotNull CharSequence key, V value) {
         assert value != null;
         if (putAt0(index, key, value)) {
             list.add(key);

--- a/core/src/main/java/io/questdb/std/Utf8SequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/Utf8SequenceHashSet.java
@@ -26,6 +26,7 @@ package io.questdb.std;
 
 import io.questdb.std.str.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
@@ -61,7 +62,7 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
      * @param key immutable sequence of characters.
      * @return false if key is already in the set and true otherwise.
      */
-    public boolean add(Utf8Sequence key) {
+    public boolean add(@Nullable Utf8Sequence key) {
         if (key == null) {
             return addNull();
         }
@@ -75,13 +76,13 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
         return true;
     }
 
-    public final void addAll(Utf8SequenceHashSet that) {
+    public final void addAll(@NotNull Utf8SequenceHashSet that) {
         for (int i = 0, k = that.size(); i < k; i++) {
             add(that.get(i));
         }
     }
 
-    public void addAt(int index, Utf8Sequence key) {
+    public void addAt(int index, @NotNull Utf8Sequence key) {
         final Utf8String s = Utf8s.toUtf8String(key);
         keys[index] = s;
         hashCodes[index] = Utf8s.hashCode(key);
@@ -110,12 +111,12 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
     }
 
     @Override
-    public boolean contains(Utf8Sequence key) {
+    public boolean contains(@Nullable Utf8Sequence key) {
         return key == null ? hasNull : keyIndex(key) < 0;
     }
 
     @Override
-    public boolean excludes(Utf8Sequence key) {
+    public boolean excludes(@Nullable Utf8Sequence key) {
         return key == null ? !hasNull : keyIndex(key) > -1;
     }
 
@@ -131,15 +132,6 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
         return list;
     }
 
-    public int getListIndexAt(int keyIndex) {
-        int index = -keyIndex - 1;
-        return list.indexOf(keys[index]);
-    }
-
-    public int getListIndexOf(Utf8Sequence cs) {
-        return getListIndexAt(keyIndex(cs));
-    }
-
     @Override
     public Utf8Sequence keyAt(int index) {
         int index1 = -index - 1;
@@ -147,7 +139,7 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
     }
 
     @Override
-    public int remove(Utf8Sequence key) {
+    public int remove(@Nullable Utf8Sequence key) {
         if (key == null) {
             return removeNull();
         }

--- a/core/src/main/java/io/questdb/std/Utf8SequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8SequenceIntHashMap.java
@@ -28,6 +28,7 @@ package io.questdb.std;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
@@ -60,7 +61,7 @@ public class Utf8SequenceIntHashMap extends AbstractUtf8SequenceHashSet {
         Arrays.fill(values, noEntryValue);
     }
 
-    public int get(Utf8Sequence key) {
+    public int get(@NotNull Utf8Sequence key) {
         return valueAt(keyIndex(key));
     }
 
@@ -68,15 +69,15 @@ public class Utf8SequenceIntHashMap extends AbstractUtf8SequenceHashSet {
         return list;
     }
 
-    public boolean put(Utf8String key, int value) {
+    public boolean put(@NotNull Utf8String key, int value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean put(Utf8Sequence key, int value) {
+    public boolean put(@NotNull Utf8Sequence key, int value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public void putAll(Utf8SequenceIntHashMap other) {
+    public void putAll(@NotNull Utf8SequenceIntHashMap other) {
         Utf8Sequence[] otherKeys = other.keys;
         int[] otherValues = other.values;
         for (int i = 0, n = otherKeys.length; i < n; i++) {
@@ -86,7 +87,7 @@ public class Utf8SequenceIntHashMap extends AbstractUtf8SequenceHashSet {
         }
     }
 
-    public boolean putAt(int index, Utf8Sequence key, int value) {
+    public boolean putAt(int index, @NotNull Utf8Sequence key, int value) {
         if (index < 0) {
             values[-index - 1] = value;
             return false;
@@ -102,7 +103,7 @@ public class Utf8SequenceIntHashMap extends AbstractUtf8SequenceHashSet {
         return true;
     }
 
-    public boolean putAt(int index, Utf8String key, int value) {
+    public boolean putAt(int index, @NotNull Utf8String key, int value) {
         if (index < 0) {
             values[-index - 1] = value;
             return false;

--- a/core/src/main/java/io/questdb/std/Utf8SequenceObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8SequenceObjHashMap.java
@@ -28,6 +28,7 @@ package io.questdb.std;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
@@ -57,7 +58,7 @@ public class Utf8SequenceObjHashMap<V> extends AbstractUtf8SequenceHashSet {
         list.clear();
     }
 
-    public V get(Utf8Sequence key) {
+    public V get(@NotNull Utf8Sequence key) {
         return valueAt(keyIndex(key));
     }
 
@@ -65,15 +66,15 @@ public class Utf8SequenceObjHashMap<V> extends AbstractUtf8SequenceHashSet {
         return list;
     }
 
-    public boolean put(Utf8String key, V value) {
+    public boolean put(@NotNull Utf8String key, V value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean put(Utf8Sequence key, V value) {
+    public boolean put(@NotNull Utf8Sequence key, V value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean putAt(int index, Utf8Sequence key, V value) {
+    public boolean putAt(int index, @NotNull Utf8Sequence key, V value) {
         assert value != null;
         if (index < 0) {
             values[-index - 1] = value;
@@ -90,7 +91,7 @@ public class Utf8SequenceObjHashMap<V> extends AbstractUtf8SequenceHashSet {
         return true;
     }
 
-    public boolean putAt(int index, Utf8String key, V value) {
+    public boolean putAt(int index, @NotNull Utf8String key, V value) {
         assert value != null;
         if (index < 0) {
             values[-index - 1] = value;

--- a/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringIntHashMap.java
@@ -27,6 +27,7 @@ package io.questdb.std;
 import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
@@ -81,23 +82,23 @@ public class Utf8StringIntHashMap implements Mutable {
         Arrays.fill(values, noEntryValue);
     }
 
-    public boolean contains(DirectUtf8Sequence key) {
+    public boolean contains(@NotNull DirectUtf8Sequence key) {
         return keyIndex(key) < 0;
     }
 
-    public boolean excludes(DirectUtf8Sequence key) {
+    public boolean excludes(@NotNull DirectUtf8Sequence key) {
         return keyIndex(key) > -1;
     }
 
-    public int get(DirectUtf8Sequence key) {
+    public int get(@NotNull DirectUtf8Sequence key) {
         return valueAt(keyIndex(key));
     }
 
-    public int get(Utf8String key) {
+    public int get(@NotNull Utf8String key) {
         return valueAt(keyIndex(key));
     }
 
-    public int keyIndex(DirectUtf8Sequence key) {
+    public int keyIndex(@NotNull DirectUtf8Sequence key) {
         int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
@@ -109,7 +110,7 @@ public class Utf8StringIntHashMap implements Mutable {
         return probe(key, hashCode, index);
     }
 
-    public int keyIndex(Utf8String key) {
+    public int keyIndex(@NotNull Utf8String key) {
         int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
@@ -121,11 +122,11 @@ public class Utf8StringIntHashMap implements Mutable {
         return probe(key, hashCode, index);
     }
 
-    public boolean put(Utf8String key, int value) {
+    public boolean put(@NotNull Utf8String key, int value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean putAt(int index, Utf8String key, int value) {
+    public boolean putAt(int index, @NotNull Utf8String key, int value) {
         if (index < 0) {
             values[-index - 1] = value;
             return false;
@@ -134,7 +135,7 @@ public class Utf8StringIntHashMap implements Mutable {
         return true;
     }
 
-    public int remove(DirectUtf8Sequence key) {
+    public int remove(@NotNull DirectUtf8Sequence key) {
         int index = keyIndex(key);
         if (index < 0) {
             removeAt(index);

--- a/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
+++ b/core/src/main/java/io/questdb/std/Utf8StringObjHashMap.java
@@ -28,6 +28,7 @@ import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.DirectUtf8String;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
@@ -77,23 +78,23 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         list.clear();
     }
 
-    public boolean contains(DirectUtf8Sequence key) {
+    public boolean contains(@NotNull DirectUtf8Sequence key) {
         return keyIndex(key) < 0;
     }
 
-    public boolean excludes(DirectUtf8Sequence key) {
+    public boolean excludes(@NotNull DirectUtf8Sequence key) {
         return keyIndex(key) > -1;
     }
 
-    public V get(DirectUtf8Sequence key) {
+    public V get(@NotNull DirectUtf8Sequence key) {
         return valueAt(keyIndex(key));
     }
 
-    public V get(Utf8String key) {
+    public V get(@NotNull Utf8String key) {
         return valueAt(keyIndex(key));
     }
 
-    public int keyIndex(DirectUtf8Sequence key) {
+    public int keyIndex(@NotNull DirectUtf8Sequence key) {
         int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
@@ -105,7 +106,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         return probe(key, hashCode, index);
     }
 
-    public int keyIndex(Utf8String key) {
+    public int keyIndex(@NotNull Utf8String key) {
         int hashCode = Hash.hashUtf8(key);
         int index = Hash.spread(hashCode) & mask;
         if (keys[index] == null) {
@@ -121,15 +122,15 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         return list;
     }
 
-    public boolean put(Utf8String key, V value) {
+    public boolean put(@NotNull Utf8String key, V value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean put(DirectUtf8String key, V value) {
+    public boolean put(@NotNull DirectUtf8String key, V value) {
         return putAt(keyIndex(key), key, value);
     }
 
-    public boolean putAt(int index, Utf8String key, V value) {
+    public boolean putAt(int index, @NotNull Utf8String key, V value) {
         assert value != null;
         if (index < 0) {
             values[-index - 1] = value;
@@ -145,7 +146,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         return true;
     }
 
-    public boolean putAt(int index, DirectUtf8String key, V value) {
+    public boolean putAt(int index, @NotNull DirectUtf8String key, V value) {
         assert value != null;
         if (index < 0) {
             values[-index - 1] = value;
@@ -162,7 +163,7 @@ public class Utf8StringObjHashMap<V> implements Mutable {
         return true;
     }
 
-    public int remove(Utf8String key) {
+    public int remove(@NotNull Utf8String key) {
         int index = keyIndex(key);
         if (index < 0) {
             removeAt(index);

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -153,15 +153,24 @@ public final class Utf8s {
         return !(seqSize == 0 || seqSize < size) && equalsAsciiLowerCase(asciiEnds, seq, seqSize - size, seqSize);
     }
 
+    /**
+     * Return true if the sequences contain equal strings. Co-exists with
+     * {@link #equals(Utf8Sequence, Utf8Sequence)} merely to avoid megamorphism
+     * in {@link Utf8StringIntHashMap} and {@link Utf8StringObjHashMap}. Also, unlike
+     * the general equals method, this one doesn't allow nulls.
+     */
+    public static boolean equals(@NotNull DirectUtf8Sequence l, @NotNull Utf8String r) {
+        final int size = l.size();
+        return (size == r.size() && l.equalsAssumingSameSize(r, size));
+    }
+
     public static boolean equals(@Nullable Utf8Sequence l, @Nullable Utf8Sequence r) {
         if (l == null && r == null) {
             return true;
         }
-
         if (l == null || r == null) {
             return false;
         }
-
         final int size = l.size();
         return (size == r.size() && l.equalsAssumingSameSize(r, size));
     }
@@ -374,37 +383,6 @@ public final class Utf8s {
             }
         }
         return ll > rl;
-    }
-
-    /**
-     * Strictly less than (&lt;) comparison of two UTF8 sequences in lexicographical
-     * order. For example, for:
-     * l = aaaaa
-     * r = aaaaaaa
-     * the l &lt; r will produce "true", however for:
-     * l = bbbb
-     * r = aaaaaaa
-     * the l &lt; r will produce "false", because b &lt; a.
-     *
-     * @param l left sequence, can be null
-     * @param r right sequence, can be null
-     * @return if either l or r is "null", the return value false, otherwise sequences are compared lexicographically.
-     */
-    public static boolean lessThan(@Nullable Utf8Sequence l, @Nullable Utf8Sequence r) {
-        if (l == null || r == null) {
-            return false;
-        }
-
-        final int ll = l.size();
-        final int rl = r.size();
-        final int min = Math.min(ll, rl);
-        for (int i = 0; i < min; i++) {
-            final int k = Numbers.compareUnsigned(l.byteAt(i), r.byteAt(i));
-            if (k != 0) {
-                return k < 0;
-            }
-        }
-        return ll < rl;
     }
 
     public static int hashCode(@NotNull Utf8Sequence value) {
@@ -656,6 +634,37 @@ public final class Utf8s {
             }
         }
         return -1;
+    }
+
+    /**
+     * Strictly less than (&lt;) comparison of two UTF8 sequences in lexicographical
+     * order. For example, for:
+     * l = aaaaa
+     * r = aaaaaaa
+     * the l &lt; r will produce "true", however for:
+     * l = bbbb
+     * r = aaaaaaa
+     * the l &lt; r will produce "false", because b &lt; a.
+     *
+     * @param l left sequence, can be null
+     * @param r right sequence, can be null
+     * @return if either l or r is "null", the return value false, otherwise sequences are compared lexicographically.
+     */
+    public static boolean lessThan(@Nullable Utf8Sequence l, @Nullable Utf8Sequence r) {
+        if (l == null || r == null) {
+            return false;
+        }
+
+        final int ll = l.size();
+        final int rl = r.size();
+        final int min = Math.min(ll, rl);
+        for (int i = 0; i < min; i++) {
+            final int k = Numbers.compareUnsigned(l.byteAt(i), r.byteAt(i));
+            if (k != 0) {
+                return k < 0;
+            }
+        }
+        return ll < rl;
     }
 
     public static boolean lessThan(@Nullable Utf8Sequence l, @Nullable Utf8Sequence r, boolean negated) {

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -154,10 +154,14 @@ public final class Utf8s {
     }
 
     /**
-     * Return true if the sequences contain equal strings. Co-exists with
+     * Checks if the given UTF-8 sequences contain equal strings. Co-exists with
      * {@link #equals(Utf8Sequence, Utf8Sequence)} merely to avoid megamorphism
      * in {@link Utf8StringIntHashMap} and {@link Utf8StringObjHashMap}. Also, unlike
      * the general equals method, this one doesn't allow nulls.
+     *
+     * @param l left sequence to compare
+     * @param r right sequence to compare
+     * @return true if the sequences contain equal strings, false otherwise
      */
     public static boolean equals(@NotNull DirectUtf8Sequence l, @NotNull Utf8String r) {
         final int size = l.size();


### PR DESCRIPTION
`Utf8StringIntHashMap` and `Utf8StringObjHashMap` are used in symbol cache and ILP hot path. The lookups are mostly done for `DirectUtf8Sequence`, so introducing `equals(DirectUtf8Sequence, Utf8String)` overload in parallel to the existing `equals(Utf8Sequence, Utf8Sequence)` gets rid of megamorphism in the hash table calls.