### PR TITLE
perf(sql): improve performance of length(VARCHAR)

### DIFF
--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -660,7 +660,7 @@ public final class Utf8s {
         for (; i < size; i++) {
             int c = value.byteAt(i);
             int x = c & 0x80;
-            int y = (~c & 0x40) << 1;
+            int y = ~c << 1;
             int delta = (x & y) >>> 7;
             continuationByteCount += delta;
         }

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -652,7 +652,7 @@ public final class Utf8s {
         for (; i <= size - Long.BYTES; i += Long.BYTES) {
             long c = value.longAt(i);
             long x = c & 0x8080808080808080L;
-            long y = (~c & 0x4040404040404040L) << 1;
+            long y = ~c << 1;
             long swarDelta = x & y;
             int delta = Long.bitCount(swarDelta);
             continuationByteCount += delta;

--- a/core/src/main/java/io/questdb/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8s.java
@@ -641,6 +641,12 @@ public final class Utf8s {
         return -1;
     }
 
+    /**
+     * Returns the length of the UTF-8 sequence as the count of code points.
+     * NOTE: this number is different from the length of the equivalent Java String,
+     * which counts UTF-16 code words. A surrogate pair encodes one code point, but
+     * counts as two in the length of a Java String.
+     */
     public static int length(Utf8Sequence value) {
         if (value == null) {
             return TableUtils.NULL_LEN;


### PR DESCRIPTION
Uses a SWAR technique to count the UTF-8 continuation bytes and subtract that from the total size of the VARCHAR.

Benchmark results:

```plain
STRING:

select * from (
    select title t1, title2 t2 from hits
) where length(t1) > 10;


VARCHAR:

select * from (
    select title t1, title2 t2 from hits
) where length(t2) > 10;


master:

STRING
10.8 s

VARCHAR
12 s


branch:

STRING
10.8 s

VARCHAR
9.5 s
```