### PR TITLE
chore(test): Extend expected cardinality range for HyperLogLog

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/hyperloglog/HyperLogLogTestUtils.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/hyperloglog/HyperLogLogTestUtils.java
@@ -32,9 +32,10 @@ public class HyperLogLogTestUtils {
         // According to the paper 'HyperLogLog: the analysis of a near-optimal cardinality estimation algorithm.'
         // (https://hal.science/hal-00406166) the estimates provided by HyperLogLog are expected to be within
         // 3 standard errors of the exact count in 99% of all cases. The standard error is around 1.04 / sqrt(2^precision).
+        // To mitigate the likelihood of unreliable tests, we opt for a slightly wider range (increasing from 3 to 4 standard errors).
         double standardError = 1.04 / Math.sqrt(1 << precision);
-        double min = exact - (3 * standardError) * exact;
-        double max = exact + (3 * standardError) * exact;
+        double min = exact - (4 * standardError) * exact;
+        double max = exact + (4 * standardError) * exact;
         assertTrue(
                 "Estimated cardinality " + estimated + " for precision " + precision + " is not within the expected range of " + min + " to " + max,
                 estimated >= min && estimated <= max


### PR DESCRIPTION
closes https://github.com/questdb/questdb/issues/4426. 

This approach may seem a bit crude, but I believe it's the quickest way to address the issue. My suggestion is to give it a try, and if you continue to observe incorrect failures of HyperLogLogTest.testFuzz, please let me know. I'll try to figure out a more reliable method for testing this functionality. 