### PR TITLE
feat(ilp): breaking change💥 - ILP creates VARCHAR instead of STRING columns

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -1226,7 +1226,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     log.info().$("invalid default column type for integer ").$(integerDefaultColumnTypeName).$(", will use LONG").$();
                     this.integerDefaultColumnType = ColumnType.LONG;
                 }
-                this.useLegacyStringDefault = getBoolean(properties, env, PropertyKey.LINE_USE_LEGACY_STRING_DEFAULT, true);
+                this.useLegacyStringDefault = getBoolean(properties, env, PropertyKey.LINE_USE_LEGACY_STRING_DEFAULT, false);
             }
 
             this.ilpAutoCreateNewColumns = getBoolean(properties, env, PropertyKey.LINE_AUTO_CREATE_NEW_COLUMNS, true);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -215,6 +215,6 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
 
     @Override
     public boolean isUseLegacyStringDefault() {
-        return true;
+        return false;
     }
 }

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -335,7 +335,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(1023, configuration.getCairoConfiguration().getWriterTickRowsCountMod());
         Assert.assertEquals(ColumnType.DOUBLE, configuration.getLineTcpReceiverConfiguration().getDefaultColumnTypeForFloat());
         Assert.assertEquals(ColumnType.LONG, configuration.getLineTcpReceiverConfiguration().getDefaultColumnTypeForInteger());
-        Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().isUseLegacyStringDefault());
+        Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().isUseLegacyStringDefault());
         Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().getDisconnectOnError());
 
         Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -482,7 +482,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "line.udp.receive.buffer.size\tQDB_LINE_UDP_RECEIVE_BUFFER_SIZE\t4096\tconf\tfalse\tfalse\n" +
                                     "line.udp.timestamp\tQDB_LINE_UDP_TIMESTAMP\tn\tdefault\tfalse\tfalse\n" +
                                     "line.udp.unicast\tQDB_LINE_UDP_UNICAST\tfalse\tdefault\tfalse\tfalse\n" +
-                                    "line.use.legacy.string.default\tQDB_LINE_USE_LEGACY_STRING_DEFAULT\ttrue\tdefault\tfalse\tfalse\n" +
+                                    "line.use.legacy.string.default\tQDB_LINE_USE_LEGACY_STRING_DEFAULT\tfalse\tdefault\tfalse\tfalse\n" +
                                     "metrics.enabled\tQDB_METRICS_ENABLED\tfalse\tconf\tfalse\tfalse\n" +
                                     "net.test.connection.buffer.size\tQDB_NET_TEST_CONNECTION_BUFFER_SIZE\t64\tdefault\tfalse\tfalse\n" +
                                     "pg.binary.param.count.capacity\tQDB_PG_BINARY_PARAM_COUNT_CAPACITY\t2\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/load/TableData.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/load/TableData.java
@@ -56,6 +56,12 @@ public class TableData {
         }
     }
 
+    public synchronized void clear() {
+        rows.clear();
+        index.clear();
+        writePermits.set(0);
+    }
+
     public synchronized CharSequence generateRows(TableReaderMetadata metadata) {
         final StringBuilder sb = new StringBuilder();
         final ObjList<CharSequence> columns = new ObjList<>();
@@ -103,12 +109,6 @@ public class TableData {
         writePermits.decrementAndGet();
     }
 
-    public synchronized void clear() {
-        rows.clear();
-        index.clear();
-        writePermits.set(0);
-    }
-
     public synchronized int size() {
         int count = 0;
         for (int i = 0, n = rows.size(); i < n; i++) {
@@ -130,6 +130,7 @@ public class TableData {
                 return "null";
             case STRING:
             case SYMBOL:
+            case VARCHAR:
             case TIMESTAMP:
                 return "";
             default:


### PR DESCRIPTION
ILP implicit column creation for string data now defaults to VARCHAR columns instead of STRING. VARCHAR type uses less disk space and is faster than STRING for most operations. Most users should use VARCHAR columns instead of STRING columns.

If for any reason VARCHAR type is not yet usable for a given use case, then you can opt-out by setting this configuration option: line.use.legacy.string.default=true. You can also explicitly create a target table instead of relying on ILP implicit creation.