### PR TITLE
chore(core): remove jemalloc from no-jre build

### DIFF
--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="AntConfiguration">
-    <buildFile url="file://$PROJECT_DIR$/core/rust/intellij_triggers.xml">
-      <executeOn event="beforeCompilation" target="qdbr-build" />
-    </buildFile>
+    <buildFile url="file://$PROJECT_DIR$/core/rust/intellij_triggers.xml" />
   </component>
 </project>

--- a/core/src/main/assembly/no-jre.xml
+++ b/core/src/main/assembly/no-jre.xml
@@ -33,10 +33,6 @@
             <source>../LICENSE.txt</source>
             <outputDirectory>questdb-${artifact.version}-no-jre-bin</outputDirectory>
         </file>
-        <file>
-            <source>src/main/bin/${jemalloc.so}</source>
-            <outputDirectory>questdb-${artifact.version}-no-jre-bin</outputDirectory>
-        </file>
     </files>
     <dependencySets>
         <dependencySet>


### PR DESCRIPTION
Build on master incorrectly packages `libjemalloc.so` into no-jre distribution. This PR removes `libjemalloc.so` from no-jre.