### PR TITLE
feat(sql) Implement ESCAPE clause support for pattern matching

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -740,7 +740,24 @@ public class ExpressionParser {
                     case '8':
                     case '9':
                     case '\'':
+                    case 'e':
                     case 'E':
+
+                        if (SqlKeywords.isEscapeKeyword(tok)) {
+                            ExpressionNode firstNode = opStack.pop();
+                            ExpressionNode functionNode = opStack.pop();
+                            functionNode.paramCount = 3;
+                            CharSequence escapeSequence = SqlUtil.fetchNext(lexer);
+                            ExpressionNode escapeNode = SqlUtil.nextConstant(
+                                    expressionNodePool,
+                                    GenericLexer.immutableOf(escapeSequence),
+                                    lastPos
+                            );
+                            opStack.push(functionNode);
+                            opStack.push(escapeNode);
+                            opStack.push(firstNode);
+                            break;
+                        }
 
                         if (prevBranch != BRANCH_DOT_DEREFERENCE) {
                             // check if this is E'str'

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -741,8 +741,11 @@ public class ExpressionParser {
                     case '9':
                     case '\'':
                     case 'e':
+                        if (thisChar == 'e' && !SqlKeywords.isEscapeKeyword(tok)) {
+                            processDefaultBranch = true;
+                            break;
+                        }
                     case 'E':
-
                         if (SqlKeywords.isEscapeKeyword(tok)) {
                             ExpressionNode firstNode = opStack.pop();
                             ExpressionNode functionNode = opStack.pop();

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -497,6 +497,16 @@ public class SqlKeywords {
                 && (tok.charAt(4) | 32) == 'h';
     }
 
+    public static boolean isEscapeKeyword(CharSequence tok) {
+        return tok.length() == 6
+                && (tok.charAt(0) | 32) == 'e'
+                && (tok.charAt(1) | 32) == 's'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'a'
+                && (tok.charAt(4) | 32) == 'p'
+                && (tok.charAt(5) | 32) == 'e';
+    }
+
     public static boolean isExceptKeyword(CharSequence tok) {
         return tok.length() == 6
                 && (tok.charAt(0) | 32) == 'e'

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeStrFunctionFactory.java
@@ -27,7 +27,7 @@ package io.questdb.griffin.engine.functions.regex;
 public class ILikeStrFunctionFactory extends AbstractLikeStrFunctionFactory {
     @Override
     public String getSignature() {
-        return "ilike(SS)";
+        return "ilike(SSV)";
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/ILikeVarcharFunctionFactory.java
@@ -27,7 +27,7 @@ package io.questdb.griffin.engine.functions.regex;
 public class ILikeVarcharFunctionFactory extends AbstractLikeVarcharFunctionFactory {
     @Override
     public String getSignature() {
-        return "ilike(ØS)";
+        return "ilike(ØSV)";
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeStrFunctionFactory.java
@@ -27,7 +27,7 @@ package io.questdb.griffin.engine.functions.regex;
 public class LikeStrFunctionFactory extends AbstractLikeStrFunctionFactory {
     @Override
     public String getSignature() {
-        return "like(SS)";
+        return "like(SSV)";
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/LikeVarcharFunctionFactory.java
@@ -27,7 +27,7 @@ package io.questdb.griffin.engine.functions.regex;
 public class LikeVarcharFunctionFactory extends AbstractLikeVarcharFunctionFactory {
     @Override
     public String getSignature() {
-        return "like(ØS)";
+        return "like(ØSV)";
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -135,6 +135,11 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEscapeClause() throws SqlException {
+        x("'a' 'b' 'c' like", "'a' like 'b' escape 'c'");
+    }
+
+    @Test
     public void testCaseAsArrayIndex() throws SqlException {
         x(
                 "a b 1 3 4 case []",

--- a/core/src/test/java/io/questdb/test/griffin/SqlKeywordsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlKeywordsTest.java
@@ -164,6 +164,12 @@ public class SqlKeywordsTest {
     }
 
     @Test
+    public void testIsEscapeKeyword() {
+        Assert.assertTrue(SqlKeywords.isEscapeKeyword("escape"));
+        Assert.assertTrue(SqlKeywords.isEscapeKeyword("ESCAPE"));
+    }
+
+    @Test
     public void testLinear() {
         Assert.assertFalse(isLinearKeyword("12345"));
         Assert.assertFalse(isLinearKeyword("123456"));

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/ILikeFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/ILikeFunctionFactoryTest.java
@@ -32,6 +32,9 @@ import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 public class ILikeFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
@@ -556,5 +559,176 @@ public class ILikeFunctionFactoryTest extends AbstractCairoTest {
 
     private void assertLike(String expected, String query, boolean expectSize) throws SqlException {
         assertQuery(expected, query, null, true, expectSize);
+    }
+
+    @Test
+    public void testILikeEscapeAtEndRegConstFuncWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE '%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[5] found [tok='%docsZ', len=6] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testILikeEscapeAtEndRegConstFuncVarcharWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE '%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[5] found [tok='%docsZ', len=6] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testILikeEscapeAtEndRegExpFuncWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE '_%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[6] found [tok='_%docsZ', len=7] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testILikeEscapeAtEndRegExpFuncVarcharWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE '_%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[6] found [tok='_%docsZ', len=7] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testILikeEscapeOneSymbolWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is Z_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeEscapeOneSymbolVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is Z_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeEscapeThreeSymbolsWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is ZZZ_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeEscapeThreeSymbolsVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is ZZZ_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeEscapeTwoSymbols() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is ZZ_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeEscapeTwoSymbolsVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'The path is ZZ_Ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeNotRealEscapeWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('ZZ?ZD:Zpath');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'ZZZZ_ZZ%' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nZZ?ZD:Zpath\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeNotRealEscapeVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('ZZ?ZD:Zpath');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE 'ZZZZ_ZZ%' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nZZ?ZD:Zpath\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeInvalidUseEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name ILIKE '_%docsZ' ESCAPE 'ZZ';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[1] found [tok='ZZ', len=2] Escape symbol must be one character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/LikeFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/LikeFunctionFactoryTest.java
@@ -221,7 +221,7 @@ public class LikeFunctionFactoryTest extends AbstractCairoTest {
         String expected2 = "";
         Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
 
-        String expectedMessage = "[5] found [tok='%docs\\', len=6] LIKE pattern must not end with escape character";
+        String expectedMessage = "[5] found [tok='%docs\\', len=6] LIKE/ILIKE pattern must not end with escape character";
         String actualMessage = e.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }
@@ -236,7 +236,7 @@ public class LikeFunctionFactoryTest extends AbstractCairoTest {
         String expected2 = "";
         Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
 
-        String expectedMessage = "[5] found [tok='%docs\\', len=6] LIKE pattern must not end with escape character";
+        String expectedMessage = "[5] found [tok='%docs\\', len=6] LIKE/ILIKE pattern must not end with escape character";
         String actualMessage = e.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }
@@ -251,7 +251,7 @@ public class LikeFunctionFactoryTest extends AbstractCairoTest {
         String expected2 = "";
         Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
 
-        String expectedMessage = "[6] found [tok='_%docs\\', len=7] LIKE pattern must not end with escape character";
+        String expectedMessage = "[6] found [tok='_%docs\\', len=7] LIKE/ILIKE pattern must not end with escape character";
         String actualMessage = e.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }
@@ -266,7 +266,7 @@ public class LikeFunctionFactoryTest extends AbstractCairoTest {
         String expected2 = "";
         Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
 
-        String expectedMessage = "[6] found [tok='_%docs\\', len=7] LIKE pattern must not end with escape character";
+        String expectedMessage = "[6] found [tok='_%docs\\', len=7] LIKE/ILIKE pattern must not end with escape character";
         String actualMessage = e.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }
@@ -776,5 +776,176 @@ public class LikeFunctionFactoryTest extends AbstractCairoTest {
     private void assertLike(String expected, String query, boolean expectSize) throws SqlException {
         assertQuery(expected, query, null, true, expectSize);
         assertQuery(expected, query.replace("like", "ilike"), null, true, expectSize);
+    }
+
+    @Test
+    public void testLikeEscapeAtEndRegConstFuncWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE '%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[5] found [tok='%docsZ', len=6] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testLikeEscapeAtEndRegConstFuncVarcharWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE '%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[5] found [tok='%docsZ', len=6] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testLikeEscapeAtEndRegExpFuncWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE '_%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[6] found [tok='_%docsZ', len=7] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testLikeEscapeAtEndRegExpFuncVarcharWithEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE '_%docsZ' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[6] found [tok='_%docsZ', len=7] LIKE/ILIKE pattern must not end with escape character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testLikeEscapeOneSymbolWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is Z_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeEscapeOneSymbolVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is Z_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeEscapeThreeSymbolsWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is ZZZ_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeEscapeThreeSymbolsVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is ZZZ_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeEscapeTwoSymbols() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is ZZ_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeEscapeTwoSymbolsVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('The path is Z_ignore');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'The path is ZZ_ignore' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nThe path is Z_ignore\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeNotRealEscapeWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name string)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('ZZ?ZD:Zpath');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'ZZZZ_ZZ%' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nZZ?ZD:Zpath\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testLikeNotRealEscapeVarcharWithEscapeKeyword() throws Exception {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('ZZ?ZD:Zpath');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE 'ZZZZ_ZZ%' ESCAPE 'Z';";
+        String expected1 = "name\n";
+        String expected2 = "name\nZZ?ZD:Zpath\n";
+
+        assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true);
+    }
+
+    @Test
+    public void testILikeInvalidUseEscapeKeyword() {
+        String createTable = "CREATE TABLE myTable (name varchar)";
+        String insertRow = "INSERT INTO myTable  (name) VALUES ('.ZdocsZ');";
+
+        String query = "SELECT * FROM myTable WHERE name LIKE '_%docsZ' ESCAPE 'ZZ';";
+        String expected1 = "name\n";
+        String expected2 = "";
+        Exception e = assertThrows(SqlException.class, () -> assertQuery(expected1, query, createTable, null, insertRow, expected2, true, true, true));
+
+        String expectedMessage = "[1] found [tok='ZZ', len=2] Escape symbol must be one character";
+        String actualMessage = e.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 }


### PR DESCRIPTION
Regarding the third part of this issue [#2623 (comment)](https://github.com/questdb/questdb/issues/2623) by @bziobrowski.

Allows for explicit setting of an escape character in LIKE/ILIKE pattern matching. In the case where no character is provided, the backslash is kept as the default escape character.