### PR TITLE
perf(sql): use all available worker threads in parallel GROUP BY

### DIFF
--- a/core/src/main/java/io/questdb/MessageBus.java
+++ b/core/src/main/java/io/questdb/MessageBus.java
@@ -41,9 +41,21 @@ public interface MessageBus extends Closeable {
 
     SCSequence getColumnPurgeSubSeq();
 
+    MPSequence getColumnTaskPubSeq();
+
+    RingQueue<ColumnTask> getColumnTaskQueue();
+
+    MCSequence getColumnTaskSubSeq();
+
     CairoConfiguration getConfiguration();
 
     MPSequence getCopyRequestPubSeq();
+
+    MPSequence getGroupByAggregatePubSeq();
+
+    RingQueue<GroupByAggregateTask> getGroupByAggregateQueue();
+
+    MCSequence getGroupByAggregateSubSeq();
 
     MPSequence getGroupByMergeShardPubSeq();
 
@@ -62,12 +74,6 @@ public interface MessageBus extends Closeable {
     RingQueue<LatestByTask> getLatestByQueue();
 
     MCSequence getLatestBySubSeq();
-
-    MPSequence getColumnTaskPubSeq();
-
-    RingQueue<ColumnTask> getColumnTaskQueue();
-
-    MCSequence getColumnTaskSubSeq();
 
     MPSequence getO3CopyPubSeq();
 

--- a/core/src/main/java/io/questdb/MessageBusImpl.java
+++ b/core/src/main/java/io/questdb/MessageBusImpl.java
@@ -43,6 +43,9 @@ public class MessageBusImpl implements MessageBus {
     private final RingQueue<ColumnTask> columnTaskQueue;
     private final MCSequence columnTaskSubSeq;
     private final CairoConfiguration configuration;
+    private final MPSequence groupByAggregatePubSeq;
+    private final RingQueue<GroupByAggregateTask> groupByAggregateQueue;
+    private final MCSequence groupByAggregateSubSeq;
     private final MPSequence groupByMergeShardPubSeq;
     private final RingQueue<GroupByMergeShardTask> groupByMergeShardQueue;
     private final MCSequence groupByMergeShardSubSeq;
@@ -186,6 +189,10 @@ public class MessageBusImpl implements MessageBus {
         this.walTxnNotificationSubSequence = new MCSequence(walTxnNotificationQueue.getCycle());
         walTxnNotificationPubSequence.then(walTxnNotificationSubSequence).then(walTxnNotificationPubSequence);
 
+        this.groupByAggregateQueue = new RingQueue<>(GroupByAggregateTask::new, configuration.getGroupByAggregateQueueCapacity());
+        this.groupByAggregatePubSeq = new MPSequence(groupByAggregateQueue.getCycle());
+        this.groupByAggregateSubSeq = new MCSequence(groupByAggregateQueue.getCycle());
+        groupByAggregatePubSeq.then(groupByAggregateSubSeq).then(groupByAggregateSubSeq);
         this.groupByMergeShardQueue = new RingQueue<>(GroupByMergeShardTask::new, configuration.getGroupByMergeShardQueueCapacity());
         this.groupByMergeShardPubSeq = new MPSequence(groupByMergeShardQueue.getCycle());
         this.groupByMergeShardSubSeq = new MCSequence(groupByMergeShardQueue.getCycle());
@@ -259,6 +266,21 @@ public class MessageBusImpl implements MessageBus {
     @Override
     public MPSequence getCopyRequestPubSeq() {
         return textImportRequestPubSeq;
+    }
+
+    @Override
+    public MPSequence getGroupByAggregatePubSeq() {
+        return groupByAggregatePubSeq;
+    }
+
+    @Override
+    public RingQueue<GroupByAggregateTask> getGroupByAggregateQueue() {
+        return groupByAggregateQueue;
+    }
+
+    @Override
+    public MCSequence getGroupByAggregateSubSeq() {
+        return groupByAggregateSubSeq;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -88,6 +88,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final boolean cairoAttachPartitionCopy;
     private final String cairoAttachPartitionSuffix;
     private final CairoConfiguration cairoConfiguration = new PropCairoConfiguration();
+    private final int cairoGroupByAggregateQueueCapacity;
     private final int cairoGroupByMergeShardQueueCapacity;
     private final int cairoGroupByShardingThreshold;
     private final int cairoMaxCrashFiles;
@@ -1249,7 +1250,8 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             final int defaultReduceQueueCapacity = Math.min(2 * sharedWorkerCount, 64);
             this.cairoPageFrameReduceQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, defaultReduceQueueCapacity));
-            this.cairoGroupByMergeShardQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_MERGE_QUEUE_CAPACITY, defaultReduceQueueCapacity));
+            this.cairoGroupByAggregateQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_AGGREGATE_QUEUE_CAPACITY, sharedWorkerCount));
+            this.cairoGroupByMergeShardQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_MERGE_QUEUE_CAPACITY, sharedWorkerCount));
             this.cairoGroupByShardingThreshold = getInt(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 100_000);
             this.cairoPageFrameReduceRowIdListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY, 256));
             this.cairoPageFrameReduceColumnListCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY, 16));
@@ -2128,6 +2130,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getFloatToStrCastScale() {
             return sqlFloatToStrCastScale;
+        }
+
+        @Override
+        public int getGroupByAggregateQueueCapacity() {
+            return cairoGroupByAggregateQueueCapacity;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -94,6 +94,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_SQL_PARALLEL_FILTER_ENABLED("cairo.sql.parallel.filter.enabled"),
     CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED("cairo.sql.parallel.filter.pretouch.enabled"),
     CAIRO_SQL_PARALLEL_GROUPBY_ENABLED("cairo.sql.parallel.groupby.enabled"),
+    CAIRO_SQL_PARALLEL_GROUPBY_AGGREGATE_QUEUE_CAPACITY("cairo.sql.parallel.groupby.aggregate.queue.capacity"),
     CAIRO_SQL_PARALLEL_GROUPBY_MERGE_QUEUE_CAPACITY("cairo.sql.parallel.groupby.merge.shard.queue.capacity"),
     CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD("cairo.sql.parallel.groupby.sharding.threshold"),
     CAIRO_PAGE_FRAME_SHARD_COUNT("cairo.page.frame.shard.count"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -172,6 +172,8 @@ public interface CairoConfiguration {
 
     int getFloatToStrCastScale();
 
+    int getGroupByAggregateQueueCapacity();
+
     long getGroupByAllocatorDefaultChunkSize();
 
     long getGroupByAllocatorMaxChunkSize();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -281,6 +281,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getGroupByAggregateQueueCapacity() {
+        return getDelegate().getGroupByAggregateQueueCapacity();
+    }
+
+    @Override
     public long getGroupByAllocatorDefaultChunkSize() {
         return getDelegate().getGroupByAllocatorDefaultChunkSize();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -289,6 +289,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getGroupByAggregateQueueCapacity() {
+        return 32;
+    }
+
+    @Override
     public long getGroupByAllocatorDefaultChunkSize() {
         return 16 * 1024;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -315,6 +315,10 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
         }
     }
 
+    public boolean isMergeLockRequired() {
+        return perWorkerFunctionUpdaters != null;
+    }
+
     public boolean isSharded() {
         return sharded;
     }

--- a/core/src/main/java/io/questdb/tasks/GroupByAggregateTask.java
+++ b/core/src/main/java/io/questdb/tasks/GroupByAggregateTask.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.tasks;
+
+import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.mp.CountDownLatchSPI;
+import io.questdb.std.Mutable;
+
+public class GroupByAggregateTask implements Mutable {
+    private AsyncGroupByAtom atom;
+    private AtomicBooleanCircuitBreaker circuitBreaker;
+    private CountDownLatchSPI doneLatch;
+    private int particleIndex = -1;
+
+    @Override
+    public void clear() {
+        particleIndex = -1;
+        atom = null;
+        circuitBreaker = null;
+    }
+
+    public AsyncGroupByAtom getAtom() {
+        return atom;
+    }
+
+    public AtomicBooleanCircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    public CountDownLatchSPI getDoneLatch() {
+        return doneLatch;
+    }
+
+    public int getParticleIndex() {
+        return particleIndex;
+    }
+
+    public void of(AtomicBooleanCircuitBreaker circuitBreaker, CountDownLatchSPI doneLatch, AsyncGroupByAtom atom, int particleIndex) {
+        this.circuitBreaker = circuitBreaker;
+        this.doneLatch = doneLatch;
+        this.atom = atom;
+        this.particleIndex = particleIndex;
+    }
+}

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -338,6 +338,9 @@ query.timeout.sec=60
 # enables parallel GROUP BY execution; when enabled, parallel GROUP BY also requires at least 4 shared worker threads to take place
 #cairo.sql.parallel.groupby.enabled=true
 
+# aggregate queue capacity for parallel GROUP BY
+#cairo.sql.parallel.groupby.aggregate.queue.capacity=<auto>
+
 # merge queue capacity for parallel GROUP BY; used for parallel tasks that merge shard hash tables
 #cairo.sql.parallel.groupby.merge.shard.queue.capacity=<auto>
 

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -1380,6 +1380,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(1024, configuration.getPageFrameReduceQueueCapacity());
         Assert.assertEquals(8, configuration.getPageFrameReduceRowIdListCapacity());
         Assert.assertEquals(4, configuration.getPageFrameReduceColumnListCapacity());
+        Assert.assertEquals(1024, configuration.getGroupByAggregateQueueCapacity());
         Assert.assertEquals(2048, configuration.getGroupByMergeShardQueueCapacity());
         Assert.assertEquals(100, configuration.getGroupByShardingThreshold());
         Assert.assertEquals(4096, configuration.getGroupByAllocatorDefaultChunkSize());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -283,7 +283,8 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.sql.parallel.filter.enabled\tQDB_CAIRO_SQL_PARALLEL_FILTER_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.filter.pretouch.enabled\tQDB_CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.groupby.enabled\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
-                                    "cairo.sql.parallel.groupby.merge.shard.queue.capacity\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_MERGE_SHARD_QUEUE_CAPACITY\t4\tdefault\tfalse\tfalse\n" +
+                                    "cairo.sql.parallel.groupby.aggregate.queue.capacity\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_AGGREGATE_QUEUE_CAPACITY\t2\tdefault\tfalse\tfalse\n" +
+                                    "cairo.sql.parallel.groupby.merge.shard.queue.capacity\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_MERGE_SHARD_QUEUE_CAPACITY\t2\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.groupby.sharding.threshold\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD\t100000\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.rename.table.model.pool.capacity\tQDB_CAIRO_SQL_RENAME_TABLE_MODEL_POOL_CAPACITY\t16\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.sampleby.page.size\tQDB_CAIRO_SQL_SAMPLEBY_PAGE_SIZE\t0\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -137,6 +137,7 @@ cairo.sql.page.frame.min.rows=100
 cairo.sql.parallel.filter.enabled=false
 cairo.sql.parallel.filter.pretouch.enabled=false
 cairo.sql.parallel.groupby.enabled=false
+cairo.sql.parallel.groupby.aggregate.queue.capacity=1024
 cairo.sql.parallel.groupby.merge.shard.queue.capacity=2048
 cairo.sql.parallel.groupby.sharding.threshold=100
 cairo.page.frame.shard.count=128

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -317,6 +317,9 @@ query.timeout.sec=60
 # enables parallel GROUP BY execution; when enabled, parallel GROUP BY also requires at least 4 shared worker threads to take place
 #cairo.sql.parallel.groupby.enabled=true
 
+# aggregate queue capacity for parallel GROUP BY
+#cairo.sql.parallel.groupby.aggregate.queue.capacity=<auto>
+
 # merge queue capacity for parallel GROUP BY; used for parallel tasks that merge shard hash tables
 #cairo.sql.parallel.groupby.merge.shard.queue.capacity=<auto>
 


### PR DESCRIPTION
WIP

Introduces a separate queue for parallel GROUP BY and makes sure to use all available worker threads in aggregate and merge shards phases of GROUP BY pipeline.