### PR TITLE
fix(sql): IN with NULLs and STRINGs sometimes may return the wrong result

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InStrFunctionFactory.java
@@ -69,7 +69,7 @@ public class InStrFunctionFactory implements FunctionFactory {
                 case ColumnType.STRING:
                 case ColumnType.VARCHAR:
                 case ColumnType.SYMBOL:
-                    if (func.isRuntimeConstant()) { // bind variables
+                    if (func.isRuntimeConstant() && !func.isNullConstant()) { // bind variables
                         if (deferredValues == null) {
                             deferredValues = new ObjList<>();
                         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InVarcharFunctionFactory.java
@@ -72,7 +72,7 @@ public class InVarcharFunctionFactory implements FunctionFactory {
                 case ColumnType.STRING:
                 case ColumnType.VARCHAR:
                 case ColumnType.SYMBOL:
-                    if (func.isRuntimeConstant()) { // bind variables
+                    if (func.isRuntimeConstant() && !func.isNullConstant()) { // bind variables
                         if (deferredValues == null) {
                             deferredValues = new ObjList<>();
                         }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
@@ -60,7 +60,7 @@ public class InStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Test
     public void testWithNulls() throws SqlException {
-        call("xy", "xy", null).andAssert(true);
+        call(null, "xy", null).andAssert(true);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
@@ -59,6 +59,11 @@ public class InStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
+    public void testWithNulls() throws SqlException {
+        call("xy", "xy", null).andAssert(true);
+    }
+
+    @Test
     public void testZeroArgs() {
         try {
             call("xx").andAssert(false);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InVarcharFunctionFactoryTest.java
@@ -59,6 +59,11 @@ public class InVarcharFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
+    public void testWithNulls() throws SqlException {
+        call(null, "xy", null).andAssert(true);
+    }
+
+    @Test
     public void testZeroArgs() {
         try {
             call(utf8("xx")).andAssert(false);


### PR DESCRIPTION
Closes https://github.com/questdb/questdb/issues/4496

The `NullConstant` args were being added to the deferred symbol list. This isn't initialised until `init()`.

However, the result was requested early by `functionToConstant0` meaning it wasn't being picked up.

Fix is to stop `NullConstant` being deferred.