### PR TITLE
feat(perf): reduce query latency when queried tables under heavy writing

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -2294,7 +2294,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     public void upsertColumnVersion(long partitionTimestamp, int columnIndex, long columnTop) {
         columnVersionWriter.upsert(partitionTimestamp, columnIndex, txWriter.txn, columnTop);
-        txWriter.updatePartitionColumnVersion(partitionTimestamp);
     }
 
     /**
@@ -7201,7 +7200,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                         txWriter.removeAttachedPartitions(sourcePartition);
                         columnVersionWriter.removePartition(sourcePartition);
-                        txWriter.updatePartitionColumnVersion(targetPartition);
                         partitionRemoveCandidates.add(sourcePartition, sourceNameTxn);
                         if (sourcePartition == minSplitPartitionTimestamp) {
                             minSplitPartitionTimestamp = getPartitionTimestampOrMax(partitionIndexLo + 1);

--- a/core/src/main/java/io/questdb/cairo/TxReader.java
+++ b/core/src/main/java/io/questdb/cairo/TxReader.java
@@ -40,7 +40,7 @@ public class TxReader implements Closeable, Mutable {
     public static final long PARTITION_SIZE_MASK = 0x80000FFFFFFFFFFFL;
     protected static final long DEFAULT_PARTITION_TIMESTAMP = 0L;
     protected static final int NONE_COL_STRUCTURE_VERSION = Integer.MIN_VALUE;
-    protected static final int PARTITION_COLUMN_VERSION_OFFSET = 3;
+    protected static final int PARTITION_FLAGS_OFFSET = 3;
     protected static final int PARTITION_MASKED_SIZE_OFFSET = 1;
     protected static final int PARTITION_MASK_READ_ONLY_BIT_OFFSET = 62;
     protected static final int PARTITION_NAME_TX_OFFSET = 2;
@@ -242,12 +242,12 @@ public class TxReader implements Closeable, Mutable {
         return partitionCeilMethod.ceil(timestamp);
     }
 
-    public long getPartitionColumnVersion(int i) {
-        return getPartitionColumnVersionByIndex(i * LONGS_PER_TX_ATTACHED_PARTITION);
+    public long getPartitionFlags(int partitionIndex) {
+        return getPartitionFlagsByIndex(partitionIndex * LONGS_PER_TX_ATTACHED_PARTITION);
     }
 
-    public long getPartitionColumnVersionByIndex(int index) {
-        return attachedPartitions.getQuick(index + PARTITION_COLUMN_VERSION_OFFSET);
+    private long getPartitionFlagsByIndex(int partitionRawIndex) {
+        return attachedPartitions.getQuick(partitionRawIndex + PARTITION_FLAGS_OFFSET);
     }
 
     public int getPartitionCount() {
@@ -534,7 +534,7 @@ public class TxReader implements Closeable, Mutable {
         } else {
             // Add transient row count as the only partition in attached partitions list
             attachedPartitions.setPos(LONGS_PER_TX_ATTACHED_PARTITION);
-            initPartitionAt(0, DEFAULT_PARTITION_TIMESTAMP, transientRowCount, -1L, columnVersion);
+            initPartitionAt(0, DEFAULT_PARTITION_TIMESTAMP, transientRowCount, -1L, 0L);
         }
     }
 
@@ -579,11 +579,11 @@ public class TxReader implements Closeable, Mutable {
         return attachedPartitions.binarySearchBlock(LONGS_PER_TX_ATTACHED_PARTITION_MSB, ts, BinarySearch.SCAN_UP);
     }
 
-    protected void initPartitionAt(int index, long partitionTimestampLo, long partitionSize, long partitionNameTxn, long columnVersion) {
+    protected void initPartitionAt(int index, long partitionTimestampLo, long partitionSize, long partitionNameTxn, long partitionFlags) {
         attachedPartitions.setQuick(index + PARTITION_TS_OFFSET, partitionTimestampLo);
         attachedPartitions.setQuick(index + PARTITION_MASKED_SIZE_OFFSET, partitionSize & PARTITION_SIZE_MASK);
         attachedPartitions.setQuick(index + PARTITION_NAME_TX_OFFSET, partitionNameTxn);
-        attachedPartitions.setQuick(index + PARTITION_COLUMN_VERSION_OFFSET, columnVersion);
+        attachedPartitions.setQuick(index + PARTITION_FLAGS_OFFSET, partitionFlags);
     }
 
     protected void switchRecord(int readBaseOffset, long readRecordSize) {

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -701,11 +701,6 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         return getLong(TX_OFFSET_TRANSIENT_ROW_COUNT_64);
     }
 
-    void updatePartitionColumnVersion(long partitionTimestamp) {
-        final int indexRaw = findAttachedPartitionRawIndexByLoTimestamp(partitionTimestamp);
-        attachedPartitions.set(indexRaw + PARTITION_COLUMN_VERSION_OFFSET, columnVersion);
-    }
-
     void updatePartitionSizeAndTxnByRawIndex(int index, long partitionSize) {
         recordStructureVersion++;
         updatePartitionSizeByRawIndex(index, partitionSize);

--- a/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SnapshotTest.java
@@ -1193,7 +1193,6 @@ public class SnapshotTest extends AbstractCairoTest {
                                         Assert.assertEquals(txReader0.getPartitionNameTxn(i), txReader1.getPartitionNameTxn(i));
                                         Assert.assertEquals(txReader0.getPartitionSize(i), txReader1.getPartitionSize(i));
                                         Assert.assertEquals(txReader0.getPartitionTimestampByIndex(i), txReader1.getPartitionTimestampByIndex(i));
-                                        Assert.assertEquals(txReader0.getPartitionColumnVersion(i), txReader1.getPartitionColumnVersion(i));
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #3664

Also, re-purposes 64bit in the partition table to be used for partition compression (parquet format).