### PR TITLE
fix(sql): fix SAMPLE BY and GROUP BY not grouping when used with column aliases

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -1743,7 +1743,7 @@ public class SqlOptimiser implements Mutable {
             // It might be the case that we previously added the column to
             // the translating model, but not to the inner one.
             alias = map.valueAtQuick(index);
-            if (innerModel != null && innerModel.getColumnNameToAliasMap().excludes(alias)) {
+            if (innerModel != null && innerModel.getAliasToColumnMap().excludes(alias)) {
                 innerModel.addBottomUpColumn(nextColumn(alias), true);
             }
         }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -628,8 +628,22 @@ public class SampleByTest extends AbstractCairoTest {
                     "select symbol, sum(amount) + 2 * vwap(price, amount), " +
                             "cast(to_timezone(dateadd('h', 2, timestamp),'EST') as double) + sum(amount)" +
                             "from (" +
-                            "   select symbol, amount, price,  timestamp_floor('5m', timestamp) as timestamp from trades" +
+                            "   select symbol, amount, price, timestamp_floor('5m', timestamp) as timestamp from trades" +
                             ")\n");
+
+            assertSql("symbol\tsum\ttimestamp_floor\tlast_timestamp\n" +
+                            "a\t0.6390492980774742\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:03:00.000000Z\n" +
+                            "c\t2.3759005540157383\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:09:00.000000Z\n" +
+                            "b\t1.6749086742799453\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:07:00.000000Z\n",
+                    "select symbol, sum(amount), timestamp_floor('1d', timestamp), last(timestamp) last_timestamp " +
+                            "from trades\n");
+
+            assertSql("symbol\tsum\ttimestamp\tlast_timestamp\n" +
+                            "a\t0.6390492980774742\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:03:00.000000Z\n" +
+                            "c\t2.3759005540157383\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:09:00.000000Z\n" +
+                            "b\t1.6749086742799453\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:07:00.000000Z\n",
+                    "select symbol, sum(amount), timestamp_floor('1d', timestamp) timestamp, last(timestamp) last_timestamp " +
+                            "from trades\n");
         });
     }
 
@@ -4877,6 +4891,26 @@ public class SampleByTest extends AbstractCairoTest {
                     "select symbol || 'abcd' as symbol, sum(amount), vwap(price, amount), dateadd('h', 2, to_timezone(timestamp,'EST')) + 1000000L NYTime\n" +
                             "from trades\n" +
                             "sample by 5m"
+            );
+
+            assertSampleByFlavours(
+                    "symbol\tsum\tprice\tlast_timestamp\n" +
+                            "a\t0.6390492980774742\t0.22452340856088226\t2022-02-24T00:03:00.000000Z\n" +
+                            "c\t2.3759005540157383\t0.7675673070796104\t2022-02-24T00:09:00.000000Z\n" +
+                            "b\t1.6749086742799453\t0.3100545983862456\t2022-02-24T00:07:00.000000Z\n",
+                    "select symbol, sum(amount), last(price) price, last(timestamp) last_timestamp\n" +
+                            "from trades\n" +
+                            "sample by 1h"
+            );
+
+            assertSampleByFlavours(
+                    "symbol\tsum\tprice\ttimestamp\tlast_timestamp\n" +
+                            "a\t0.6390492980774742\t0.22452340856088226\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:03:00.000000Z\n" +
+                            "c\t2.3759005540157383\t0.7675673070796104\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:09:00.000000Z\n" +
+                            "b\t1.6749086742799453\t0.3100545983862456\t2022-02-24T00:00:00.000000Z\t2022-02-24T00:07:00.000000Z\n",
+                    "select symbol, sum(amount), last(price) price, timestamp, max(timestamp) last_timestamp\n" +
+                            "from trades\n" +
+                            "sample by 1d"
             );
         });
     }


### PR DESCRIPTION
fixes #4501

This used to work

```SQL
select symbol, sum(amount), timestamp_floor('1d', timestamp), last(timestamp) last_timestamp
from trades w where timestamp > dateadd('d', -1, now());
```

and return few hundred rows on [https://demo.questdb.io](demo). 
But if an alias added to the `timestamp_floor` column

```SQL
select symbol, sum(amount), timestamp_floor('1d', timestamp) "timestamp", last(timestamp) last_timestamp
from trades w where timestamp > dateadd('d', -1, now());
```

the query suddenly returns 700k rows.