### PR TITLE
feat(core): resume all suspended WAL tables on start up

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -504,6 +504,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private long pgWorkerNapThreshold;
     private long pgWorkerSleepThreshold;
     private long pgWorkerYieldThreshold;
+    private final long sequencerCheckInterval;
     private boolean stringToCharCastAllowed;
     private long symbolCacheWaitUsBeforeReload;
 
@@ -604,6 +605,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.walApplyLookAheadTransactionCount = getInt(properties, env, PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 20);
         this.tableTypeConversionEnabled = getBoolean(properties, env, PropertyKey.TABLE_TYPE_CONVERSION_ENABLED, true);
         this.tempRenamePendingTablePrefix = getString(properties, env, PropertyKey.CAIRO_WAL_TEMP_PENDING_RENAME_TABLE_PREFIX, "temp_5822f658-31f6-11ee-be56-0242ac120002");
+        this.sequencerCheckInterval = getLong(properties, env, PropertyKey.CAIRO_WAL_SEQUENCER_CHECK_INTERVAL, 10_000);
         if (tempRenamePendingTablePrefix.length() > maxFileNameLength - 4) {
             throw CairoException.critical(0).put("Temp pending table prefix is too long [")
                     .put(PropertyKey.CAIRO_MAX_FILE_NAME_LENGTH.toString()).put("=")
@@ -2797,6 +2799,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getWalPurgeInterval() {
             return walPurgeInterval;
+        }
+
+        @Override
+        public long getSequencerCheckInterval() {
+            return sequencerCheckInterval;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -431,6 +431,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_WAL_SEGMENT_ROLLOVER_SIZE("cairo.wal.segment.rollover.size"),
     CAIRO_WAL_WRITER_DATA_APPEND_PAGE_SIZE("cairo.wal.writer.data.append.page.size"),
     CAIRO_WAL_WRITER_EVENT_APPEND_PAGE_SIZE("cairo.wal.writer.event.append.page.size"),
+    CAIRO_WAL_SEQUENCER_CHECK_INTERVAL("cairo.wal.sequencer.check.interval"),
     CAIRO_SYSTEM_WAL_WRITER_DATA_APPEND_PAGE_SIZE("cairo.system.wal.writer.data.append.page.size"),
     CAIRO_SYSTEM_WAL_WRITER_EVENT_APPEND_PAGE_SIZE("cairo.system.wal.writer.event.append.page.size"),
     WAL_APPLY_WORKER_COUNT("wal.apply.worker.count"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -516,6 +516,8 @@ public interface CairoConfiguration {
 
     long getWalPurgeInterval();
 
+    long getSequencerCheckInterval();
+
     default int getWalPurgeWaitBeforeDelete() {
         return 0;
     }

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -946,6 +946,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public long getSequencerCheckInterval() {
+        return getDelegate().getSequencerCheckInterval();
+    }
+
+    @Override
     public int getWalPurgeWaitBeforeDelete() {
         return getDelegate().getWalPurgeWaitBeforeDelete();
     }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -285,7 +285,7 @@ public class CairoEngine implements Closeable, WriterSource {
                 Os.sleep(sleep *= 2);
             }
         }
-        throw CairoException.nonCritical().put("txn timed out [expectedTxn=").put(seqTxn).put(", writerTxn=").put(writerTxn);
+        throw CairoException.nonCritical().put("txn timed out [table=").put(tableName).put(", expectedTxn=").put(seqTxn).put(", writerTxn=").put(writerTxn);
     }
 
     @TestOnly

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -947,6 +947,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public long getSequencerCheckInterval() {
+        return 10_000;
+    }
+
+    @Override
     public int getWalRecreateDistressedSequencerAttempts() {
         return 3;
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -859,7 +859,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         try {
             commit();
 
-            LOG.info().$("converting column [table=").$(tableToken).$(", column=").$(columnName)
+            LOG.info().$("converting column [table=").$(tableToken).$(", column=").utf8(columnName)
                     .$(", from=").$(ColumnType.nameOf(existingType))
                     .$(", to=").$(ColumnType.nameOf(newType)).I$();
 
@@ -941,7 +941,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 path.trimTo(rootLen);
             }
         } catch (Throwable th) {
-            LOG.error().$("could not change column type [table=").$(tableToken.getTableName()).$(", column=").$(columnName)
+            LOG.error().$("could not change column type [table=").$(tableToken.getTableName()).$(", column=").utf8(columnName)
                     .$(", error=").$(th).I$();
             throw th;
         }

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -349,6 +349,8 @@ public class TableSequencerAPI implements QuietCloseable {
                     return sequencer;
                 })
         ) {
+            SeqTxnTracker seqTxnTracker = getSeqTxnTracker(tableToken);
+            seqTxnTracker.initTxns(0, 0, false);
             tableSequencer.unlockWrite();
         }
     }

--- a/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
+++ b/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
@@ -195,7 +195,7 @@ public class ConvertOperatorImpl implements Closeable {
                                     dstVarFd = Numbers.decodeHighInt(dstFds);
 
                                     LOG.info().$("converting column [at=").$(path.trimTo(pathTrimToLen))
-                                            .$(", column=").$(columnName)
+                                            .$(", column=").utf8(columnName)
                                             .$(", from=").$(ColumnType.nameOf(existingType))
                                             .$(", to=").$(ColumnType.nameOf(newType))
                                             .$(", rowCount=").$(rowCount)
@@ -225,7 +225,7 @@ public class ConvertOperatorImpl implements Closeable {
                         }
                     } catch (Throwable th) {
                         LOG.error().$("error converting column [at=").$(tableWriter.getTableToken().getDirNameUtf8())
-                                .$(", column=").$(columnName).$(", from=").$(ColumnType.nameOf(existingType))
+                                .$(", column=").utf8(columnName).$(", from=").$(ColumnType.nameOf(existingType))
                                 .$(", to=").$(ColumnType.nameOf(newType))
                                 .$(", error=").$(th).I$();
                         asyncProcessingErrorCount.incrementAndGet();
@@ -238,7 +238,7 @@ public class ConvertOperatorImpl implements Closeable {
             consumeConversionTasks(messageBus.getColumnTaskQueue(), queueCount, true);
             long elapsed = timer.getTicks() - start;
             LOG.info().$("completed column conversion [at=").$(tableWriter.getTableToken().getDirNameUtf8())
-                    .$(", column=").$(columnName).$(", from=").$(ColumnType.nameOf(existingType))
+                    .$(", column=").utf8(columnName).$(", from=").$(ColumnType.nameOf(existingType))
                     .$(", to=").$(ColumnType.nameOf(newType))
                     .$(", partitions=").$(partitionUpdated)
                     .$(", rows=").$(totalRows)
@@ -260,7 +260,7 @@ public class ConvertOperatorImpl implements Closeable {
 
                 if (!ok) {
                     LOG.critical().$("failed to convert column, column is corrupt [at=").$(tableWriter.getTableToken().getDirNameUtf8())
-                            .$(", column=").$(columnName).$(", from=").$(ColumnType.nameOf(existingType))
+                            .$(", column=").utf8(columnName).$(", from=").$(ColumnType.nameOf(existingType))
                             .$(", to=").$(ColumnType.nameOf(newType)).$(", srcFixFd=").$(srcFixFd)
                             .$(", srcVarFd=").$(srcVarFd).$(", partition").$ts(partitionTimestamp)
                             .I$();
@@ -270,7 +270,7 @@ public class ConvertOperatorImpl implements Closeable {
         } catch (Throwable th) {
             asyncProcessingErrorCount.incrementAndGet();
             LogRecord log = LOG.critical().$("failed to convert column, column is corrupt [at=").$(tableWriter.getTableToken().getDirNameUtf8())
-                    .$(", column=").$(columnName).$(", from=").$(ColumnType.nameOf(existingType))
+                    .$(", column=").utf8(columnName).$(", from=").$(ColumnType.nameOf(existingType))
                     .$(", to=").$(ColumnType.nameOf(newType))
                     .$(", srcFixFd=").$(srcFixFd).$(", srcVarFd=")
                     .$(srcVarFd).$(", partition").$ts(partitionTimestamp);

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -555,6 +555,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.system.wal.writer.event.append.page.size\tQDB_CAIRO_SYSTEM_WAL_WRITER_EVENT_APPEND_PAGE_SIZE\t16384\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.writer.event.append.page.size\tQDB_CAIRO_WAL_WRITER_EVENT_APPEND_PAGE_SIZE\t131072\tdefault\tfalse\tfalse\n" +
                                     "cairo.default.sequencer.part.txn.count\tQDB_CAIRO_DEFAULT_SEQUENCER_PART_TXN_COUNT\t0\tdefault\tfalse\tfalse\n" +
+                                    "cairo.wal.sequencer.check.interval\tQDB_CAIRO_WAL_SEQUENCER_CHECK_INTERVAL\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.legacy.string.column.type.default\tQDB_CAIRO_LEGACY_STRING_COLUMN_TYPE_DEFAULT\tfalse\tdefault\tfalse\tfalse\n"
                             )
                                     .split("\n");

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
@@ -435,7 +435,7 @@ abstract class AbstractLineHttpFuzzTest extends AbstractBootstrapTest {
 
     private Thread startAlterTableThread(CairoEngine engine, SOCountDownLatch threadPushFinished, AtomicInteger failureCounter) {
         Thread thread = new Thread(() -> {
-            int totalTestConversions = (int) (numOfLines * numOfTables * columnConvertProb);
+            int totalTestConversions = random.nextInt((int) (numOfLines * numOfTables * columnConvertProb));
             try (SqlExecutionContext executionContext = TestUtils.createSqlExecutionCtx(engine, 1)) {
                 while (totalTestConversions > 0 && threadPushFinished.getCount() > 0 && failureCounter.get() == 0) {
                     final CharSequence tableName = getTableName(random.nextInt(numOfTables));

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpFailureTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpFailureTest.java
@@ -330,7 +330,7 @@ public class LineHttpFailureTest extends AbstractBootstrapTest {
                         // Table is create but no line should be committed
                         TableToken tt = serverMain.getEngine().getTableTokenIfExists("line");
                         Assert.assertNotNull(tt);
-                        Assert.assertEquals(-1, getSeqTxn(serverMain, tt));
+                        Assert.assertEquals(0, getSeqTxn(serverMain, tt));
 
                         // Assert no Wal Writers are left in ILP http TUD cache
                         Assert.assertEquals(0, walWriterTaken.get());

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableFailureTest.java
@@ -1058,7 +1058,7 @@ public class WalTableFailureTest extends AbstractCairoTest {
 
             @Override
             public int openRW(LPSZ name, long opts) {
-                if (Utf8s.containsAscii(name, "x.d.") && attempt++ == 0) {
+                if (Utf8s.containsAscii(name, "x.d.") && attempt++ < 2) {
                     return -1;
                 }
                 return Files.openRW(name, opts);

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -1230,6 +1230,11 @@ public class WalTableSqlTest extends AbstractCairoTest {
             TableToken tableToken = engine.verifyTableName(tableName);
             Assert.assertTrue(engine.getTableSequencerAPI().isSuspended(tableToken));
             long notifications = engine.getMessageBus().getWalTxnNotificationPubSequence().current();
+            Assert.assertEquals(walNotification, notifications);
+
+            engine.getTableSequencerAPI().releaseAll();
+            drainWalQueue();
+            notifications = engine.getMessageBus().getWalTxnNotificationPubSequence().current();
             Assert.assertTrue(walNotification < notifications);
 
             // No notificaion second time


### PR DESCRIPTION
fixes #4013

Also periodically re-evaluates all unsuspended WAL tables to mitigate potential race condition of a table not being notified to `ApplyWal2TableJob`. This should eliminate issue found by fuzz test where a table is left unnotified without any errors:

```
java.lang.AssertionError: [-1] txn timed out [expectedTxn=21, writerTxn=-1
	at org.junit.Assert.fail(Assert.java:89)
	at io.questdb.test.cutlass.http.line.AbstractLineHttpFuzzTest.lambda$runTest$0(AbstractLineHttpFuzzTest.java:242)
	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:644)
	at io.questdb.test.cutlass.http.line.AbstractLineHttpFuzzTest.runTest(AbstractLineHttpFuzzTest.java:212)
	at io.questdb.test.cutlass.http.line.LineHttpReceiverFuzzTest.runTest(LineHttpReceiverFuzzTest.java:32)
	at io.questdb.test.cutlass.http.line.LineHttpReceiverFuzzTest.testAddConvertColumns(LineHttpReceiverFuzzTest.java:54)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.lang.Thread.run(Thread.java:829)

```



