### PR TITLE
chore(core): fix column conversions

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1950,7 +1950,6 @@ public class WalWriter implements TableWriterAPI {
 
                                 if (segmentRowCount == 0) {
                                     openColumnFiles(columnName, newType, newColumnIndex, path.size());
-                                    // If teh old column has .i file, we need to remove it
                                 }
                             }
 
@@ -1958,7 +1957,6 @@ public class WalWriter implements TableWriterAPI {
                                 // if we did not have to roll uncommitted rows to a new segment
                                 // remove .i files when converting var type to fixed
                                 if (ColumnType.isVarSize(existingColumnType) && !ColumnType.isVarSize(newType)) {
-                                    path.trimTo(rootLen);
                                     path.trimTo(rootLen).slash().put(segmentId);
                                     iFile(path, columnName);
                                     if (ff.exists(path)) {

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzChangeColumnTypeOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzChangeColumnTypeOperation.java
@@ -137,8 +137,8 @@ public class FuzzChangeColumnTypeOperation implements FuzzTransactionOperation {
                 int newColType = changeColumnTypeTo(rnd, columnType);
 
                 int capacity = 1 << (5 + rnd.nextInt(3));
-                boolean indexFlag = ColumnType.isSymbol(newColType) && rnd.nextBoolean();
-                int indexValueBlockCapacity = 1 << (5 + rnd.nextInt(15));
+                boolean indexFlag = ColumnType.isSymbol(newColType) && (columnType == ColumnType.BOOLEAN || columnType == ColumnType.BYTE);
+                int indexValueBlockCapacity = (columnType == ColumnType.BOOLEAN) ? 4 : 128;
                 boolean cacheSymbolMap = ColumnType.isSymbol(newColType) && rnd.nextBoolean();
                 transaction.operationList.add(new FuzzChangeColumnTypeOperation(columnName, newColType, capacity, indexFlag, indexValueBlockCapacity, cacheSymbolMap));
                 transaction.structureVersion = metadataVersion;

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
@@ -799,10 +799,10 @@ public class AlterTableChangeColumnTypeTest extends AbstractCairoTest {
             TableToken xTbl = engine.verifyTableName("x");
 
             Path path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.d");
-            Assert.assertTrue(Files.exists(path));
+            Assert.assertTrue(Files.exists(path.$()));
 
             path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.i");
-            Assert.assertFalse(Files.exists(path));
+            Assert.assertFalse(Files.exists(path.$()));
 
             insert("insert into x(s, timestamp) values(1, '2024-02-04T00:00:00.000Z')", sqlExecutionContext);
             drainWalQueue();

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
@@ -790,23 +790,25 @@ public class AlterTableChangeColumnTypeTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testWalConversionFromVarToFixedDoesNotLeaveAuxFiles() throws SqlException {
+    public void testWalConversionFromVarToFixedDoesNotLeaveAuxFiles() throws Exception {
         assumeWal();
-        ddl("create table x (s string, timestamp timestamp) timestamp (timestamp) PARTITION BY HOUR WAL;");
-        ddl("alter table x alter column s type int;");
+        assertMemoryLeak(() -> {
+            ddl("create table x (s string, timestamp timestamp) timestamp (timestamp) PARTITION BY HOUR WAL;");
+            ddl("alter table x alter column s type int;");
 
-        TableToken xTbl = engine.verifyTableName("x");
+            TableToken xTbl = engine.verifyTableName("x");
 
-        Path path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.d");
-        Assert.assertTrue(Files.exists(path));
+            Path path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.d");
+            Assert.assertTrue(Files.exists(path));
 
-        path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.i");
-        Assert.assertFalse(Files.exists(path));
+            path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.i");
+            Assert.assertFalse(Files.exists(path));
 
-        insert("insert into x(s, timestamp) values(1, '2024-02-04T00:00:00.000Z')", sqlExecutionContext);
-        drainWalQueue();
+            insert("insert into x(s, timestamp) values(1, '2024-02-04T00:00:00.000Z')", sqlExecutionContext);
+            drainWalQueue();
 
-        assertSql("s\n1\n", "select s from x limit -1");
+            assertSql("s\n1\n", "select s from x limit -1");
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
@@ -26,15 +26,18 @@ package io.questdb.test.griffin;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.wal.WalWriter;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.NumericException;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8String;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -784,6 +787,26 @@ public class AlterTableChangeColumnTypeTest extends AbstractCairoTest {
             assumeNonWal();
             testConvertVarToFixed("varchar");
         });
+    }
+
+    @Test
+    public void testWalConversionFromVarToFixedDoesNotLeaveAuxFiles() throws SqlException {
+        assumeWal();
+        ddl("create table x (s string, timestamp timestamp) timestamp (timestamp) PARTITION BY HOUR WAL;");
+        ddl("alter table x alter column s type int;");
+
+        TableToken xTbl = engine.verifyTableName("x");
+
+        Path path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.d");
+        Assert.assertTrue(Files.exists(path));
+
+        path = Path.getThreadLocal(engine.getConfiguration().getRoot()).concat(xTbl).concat("wal1").concat("0").concat("s.i");
+        Assert.assertFalse(Files.exists(path));
+
+        insert("insert into x(s, timestamp) values(1, '2024-02-04T00:00:00.000Z')", sqlExecutionContext);
+        drainWalQueue();
+
+        assertSql("s\n1\n", "select s from x limit -1");
     }
 
     @Test


### PR DESCRIPTION
On Windows column conversion for WAL tables can fail if the column is converted from var length to fix length and then dropped and another var column is renamed to that tname. In this case `.i` file remains in WAL segment folder on the first step and the renaming to the existing file name is not supported on Windows, so the last step fails. The fix is to remove `.i` file in WAL segment when column conversion is done.

Second change is to prevent "Not enough space" error at fuzz tests when a column is converted to an indexed symbol. For that the conversion adds indexes only when the source type os Boolean or Byte.
