### PR TITLE
fix(core): fix potential data loss when non-WAL table dropped and created with same name

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -1367,6 +1367,9 @@ public class CairoEngine implements Closeable, WriterSource {
         fromPath.of(root).concat(fromTableToken).$();
 
         TableToken toTableToken = lockTableName(toTableName, fromTableToken.getTableId(), false);
+        while (!lockTableCreate(toTableToken)) {
+            Os.pause();
+        }
 
         if (toTableToken == null) {
             LOG.error()
@@ -1397,6 +1400,7 @@ public class CairoEngine implements Closeable, WriterSource {
             return toTableToken;
         } finally {
             tableNameRegistry.unlockTableName(toTableToken);
+            unLockTableCreate(toTableToken);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -1367,9 +1367,6 @@ public class CairoEngine implements Closeable, WriterSource {
         fromPath.of(root).concat(fromTableToken).$();
 
         TableToken toTableToken = lockTableName(toTableName, fromTableToken.getTableId(), false);
-        while (!lockTableCreate(toTableToken)) {
-            Os.pause();
-        }
 
         if (toTableToken == null) {
             LOG.error()
@@ -1377,6 +1374,9 @@ public class CairoEngine implements Closeable, WriterSource {
                     .$("', to='").utf8(toTableName)
                     .I$();
             throw CairoException.nonCritical().put("Rename target exists");
+        }
+        while (!lockTableCreate(toTableToken)) {
+            Os.pause();
         }
 
         if (ff.exists(toPath.of(root).concat(toTableToken).$())) {

--- a/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
@@ -24,7 +24,7 @@
 
 package io.questdb.cairo;
 
-import io.questdb.MessageBus;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.wal.WalUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -46,6 +46,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
 
     private final static Log LOG = LogFactory.getLog(O3PartitionPurgeJob.class);
     private final CairoConfiguration configuration;
+    private final CairoEngine engine;
     private final Utf8StringSink[] fileNameSinks;
     private final AtomicBoolean halted = new AtomicBoolean(false);
     private final ObjList<DirectLongList> partitionList;
@@ -53,11 +54,12 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
     private final ObjList<TxReader> txnReaders;
     private final ObjList<TxnScoreboard> txnScoreboards;
 
-    public O3PartitionPurgeJob(MessageBus messageBus, DatabaseSnapshotAgent snapshotAgent, int workerCount) {
-        super(messageBus.getO3PurgeDiscoveryQueue(), messageBus.getO3PurgeDiscoverySubSeq());
+    public O3PartitionPurgeJob(CairoEngine engine, DatabaseSnapshotAgent snapshotAgent, int workerCount) {
+        super(engine.getMessageBus().getO3PurgeDiscoveryQueue(), engine.getMessageBus().getO3PurgeDiscoverySubSeq());
         try {
+            this.engine = engine;
             this.snapshotAgent = snapshotAgent;
-            this.configuration = messageBus.getConfiguration();
+            this.configuration = engine.getMessageBus().getConfiguration();
             this.fileNameSinks = new Utf8StringSink[workerCount];
             this.partitionList = new ObjList<>(workerCount);
             this.txnScoreboards = new ObjList<>(workerCount);
@@ -127,130 +129,6 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
         }
     }
 
-    private static void processDetachedPartition(
-            FilesFacade ff,
-            Path path,
-            int tableRootLen,
-            TxReader txReader,
-            TxnScoreboard txnScoreboard,
-            long partitionTimestamp,
-            int partitionBy,
-            DirectLongList partitionList,
-            int lo,
-            int hi
-    ) {
-        // Partition is dropped or not fully committed.
-        // It is only possible to delete when there are no readers
-        long lastTxn = txReader.getTxn();
-        for (int i = hi - 2, n = lo - 1; i > n; i -= 2) {
-            long nameTxn = partitionList.get(i);
-
-            // If last committed transaction number is 4, TableWriter can write partition with ending .4 and .3
-            // If the version on disk is .2 (nameTxn == 3) can remove it if the lastTxn > 3, e.g. when nameTxn < lastTxn
-            boolean rangeUnlocked = nameTxn < lastTxn && txnScoreboard.isRangeAvailable(nameTxn, lastTxn);
-
-            path.trimTo(tableRootLen);
-            TableUtils.setPathForPartition(path, partitionBy, partitionTimestamp, nameTxn - 1);
-            path.$();
-
-            if (rangeUnlocked) {
-                // nameTxn can be deleted
-                // -1 here is to compensate +1 added when partition version parsed from folder name
-                // See comments of why +1 added there in parsePartitionDateVersion()
-                LOG.info().$("purging dropped partition directory [path=").$(path).I$();
-                ff.unlinkOrRemove(path, LOG);
-                lastTxn = nameTxn;
-            } else {
-                LOG.info().$("cannot purge partition directory, locked for reading [path=").$(path).I$();
-                break;
-            }
-        }
-    }
-
-    private static void processPartition(
-            FilesFacade ff,
-            Path path,
-            int tableRootLen,
-            TxReader txReader,
-            TxnScoreboard txnScoreboard,
-            long partitionTimestamp,
-            int partitionBy,
-            DirectLongList partitionList,
-            int lo,
-            int hi
-    ) {
-        boolean partitionInTxnFile = txReader.findAttachedPartitionRawIndexByLoTimestamp(partitionTimestamp) >= 0;
-        if (partitionInTxnFile) {
-            processPartition0(
-                    ff,
-                    path,
-                    tableRootLen,
-                    txReader,
-                    txnScoreboard,
-                    partitionTimestamp,
-                    partitionBy,
-                    partitionList,
-                    lo,
-                    hi
-            );
-        } else {
-            processDetachedPartition(
-                    ff,
-                    path,
-                    tableRootLen,
-                    txReader,
-                    txnScoreboard,
-                    partitionTimestamp,
-                    partitionBy,
-                    partitionList,
-                    lo,
-                    hi
-            );
-        }
-    }
-
-    private static void processPartition0(
-            FilesFacade ff,
-            Path path,
-            int tableRootLen,
-            TxReader txReader,
-            TxnScoreboard txnScoreboard,
-            long partitionTimestamp,
-            int partitionBy,
-            DirectLongList partitionList,
-            int lo,
-            int hi
-    ) {
-        long lastCommittedPartitionName = txReader.getPartitionNameTxnByPartitionTimestamp(partitionTimestamp);
-        if (lastCommittedPartitionName > -1) {
-            assert hi <= partitionList.size();
-            // lo points to the beginning element in partitionList, hi next after last
-            // each partition folder represented by a pair in the partitionList (partition version, partition timestamp)
-            // Skip first pair, start from second and check if it can be deleted.
-            for (int i = lo + 2; i < hi; i += 2) {
-                long nextNameVersion = Math.min(lastCommittedPartitionName + 1, partitionList.get(i));
-                long previousNameVersion = partitionList.get(i - 2);
-
-                boolean rangeUnlocked = previousNameVersion < nextNameVersion
-                        && txnScoreboard.isRangeAvailable(previousNameVersion, nextNameVersion);
-
-                path.trimTo(tableRootLen);
-                TableUtils.setPathForPartition(path, partitionBy, partitionTimestamp, previousNameVersion - 1);
-                path.$();
-
-                if (rangeUnlocked) {
-                    // previousNameVersion can be deleted
-                    // -1 here is to compensate +1 added when partition version parsed from folder name
-                    // See comments of why +1 added there in parsePartitionDateVersion()
-                    LOG.info().$("purging overwritten partition directory [path=").$(path).I$();
-                    ff.unlinkOrRemove(path, LOG);
-                } else {
-                    LOG.info().$("cannot purge overwritten partition directory, locked for reading [path=").$(path).I$();
-                }
-            }
-        }
-    }
-
     private void discoverPartitions(
             FilesFacade ff,
             Utf8StringSink fileNameSink,
@@ -302,6 +180,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                     if (i > lo + 2 ||
                             (i > 0 && txReader.findAttachedPartitionRawIndexByLoTimestamp(partitionTimestamp) < 0)) {
                         processPartition(
+                                tableToken,
                                 ff,
                                 path,
                                 tableRootLen,
@@ -321,6 +200,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
             // Tail
             if (n > lo + 2 || txReader.getPartitionRowCountByTimestamp(partitionTimestamp) < 0) {
                 processPartition(
+                        tableToken,
                         ff,
                         path,
                         tableRootLen,
@@ -333,6 +213,10 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                         n
                 );
             }
+        } catch (TableReferenceOutOfDateException e) {
+            // table is dropped and recreated since we started processing it.
+            // abort the table processing
+            LOG.info().$("table reference out of date, aborting [table=").$(tableToken.getDirName()).I$();
         } catch (CairoException ex) {
             // It is possible that table is dropped while this async job was in the queue.
             // so it can be not too bad. Log error and continue work on the queue
@@ -347,6 +231,156 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
             txnScoreboard.clear();
         }
         LOG.info().$("processed [table=").$(tableToken).I$();
+    }
+
+    private void processDetachedPartition(
+            TableToken tableToken,
+            FilesFacade ff,
+            Path path,
+            int tableRootLen,
+            TxReader txReader,
+            TxnScoreboard txnScoreboard,
+            long partitionTimestamp,
+            int partitionBy,
+            DirectLongList partitionList,
+            int lo,
+            int hi
+    ) {
+        // Partition is dropped or not fully committed.
+        // It is only possible to delete when there are no readers
+        long lastTxn = txReader.getTxn();
+        for (int i = hi - 2, n = lo - 1; i > n; i -= 2) {
+            long nameTxn = partitionList.get(i);
+
+            // If last committed transaction number is 4, TableWriter can write partition with ending .4 and .3
+            // If the version on disk is .2 (nameTxn == 3) can remove it if the lastTxn > 3, e.g. when nameTxn < lastTxn
+            boolean rangeUnlocked = nameTxn < lastTxn && txnScoreboard.isRangeAvailable(nameTxn, lastTxn);
+
+            path.trimTo(tableRootLen);
+            TableUtils.setPathForPartition(path, partitionBy, partitionTimestamp, nameTxn - 1);
+            path.$();
+
+            if (rangeUnlocked) {
+                // nameTxn can be deleted
+                // -1 here is to compensate +1 added when partition version parsed from folder name
+                // See comments of why +1 added there in parsePartitionDateVersion()
+                purgePartition(tableToken, ff, path, "purging dropped partition directory [path=");
+                lastTxn = nameTxn;
+            } else {
+                LOG.info().$("cannot purge partition directory, locked for reading [path=").$(path).I$();
+                break;
+            }
+        }
+    }
+
+    private void processPartition(
+            TableToken tableToken,
+            FilesFacade ff,
+            Path path,
+            int tableRootLen,
+            TxReader txReader,
+            TxnScoreboard txnScoreboard,
+            long partitionTimestamp,
+            int partitionBy,
+            DirectLongList partitionList,
+            int lo,
+            int hi
+    ) {
+        boolean partitionInTxnFile = txReader.findAttachedPartitionRawIndexByLoTimestamp(partitionTimestamp) >= 0;
+        if (partitionInTxnFile) {
+            processPartition0(
+                    tableToken,
+                    ff,
+                    path,
+                    tableRootLen,
+                    txReader,
+                    txnScoreboard,
+                    partitionTimestamp,
+                    partitionBy,
+                    partitionList,
+                    lo,
+                    hi
+            );
+        } else {
+            processDetachedPartition(
+                    tableToken,
+                    ff,
+                    path,
+                    tableRootLen,
+                    txReader,
+                    txnScoreboard,
+                    partitionTimestamp,
+                    partitionBy,
+                    partitionList,
+                    lo,
+                    hi
+            );
+        }
+    }
+
+    private void processPartition0(
+            TableToken tableToken,
+            FilesFacade ff,
+            Path path,
+            int tableRootLen,
+            TxReader txReader,
+            TxnScoreboard txnScoreboard,
+            long partitionTimestamp,
+            int partitionBy,
+            DirectLongList partitionList,
+            int lo,
+            int hi
+    ) {
+        long lastCommittedPartitionName = txReader.getPartitionNameTxnByPartitionTimestamp(partitionTimestamp);
+        if (lastCommittedPartitionName > -1) {
+            assert hi <= partitionList.size();
+            // lo points to the beginning element in partitionList, hi next after last
+            // each partition folder represented by a pair in the partitionList (partition version, partition timestamp)
+            // Skip first pair, start from second and check if it can be deleted.
+            for (int i = lo + 2; i < hi; i += 2) {
+                long nextNameVersion = Math.min(lastCommittedPartitionName + 1, partitionList.get(i));
+                long previousNameVersion = partitionList.get(i - 2);
+
+                boolean rangeUnlocked = previousNameVersion < nextNameVersion
+                        && txnScoreboard.isRangeAvailable(previousNameVersion, nextNameVersion);
+
+                path.trimTo(tableRootLen);
+                TableUtils.setPathForPartition(path, partitionBy, partitionTimestamp, previousNameVersion - 1);
+                path.$();
+
+                if (rangeUnlocked) {
+                    // previousNameVersion can be deleted
+                    // -1 here is to compensate +1 added when partition version parsed from folder name
+                    // See comments of why +1 added there in parsePartitionDateVersion()
+                    LOG.info().$("purging overwritten partition directory [path=").$(path).I$();
+                    purgePartition(tableToken, ff, path, "purging overwritten partition directory [path=");
+                } else {
+                    LOG.info().$("cannot purge overwritten partition directory, locked for reading [path=").$(path).I$();
+                }
+            }
+        }
+    }
+
+    private void purgePartition(TableToken tableToken, FilesFacade ff, Path path, String message) {
+        if (engine.lockTableCreate(tableToken)) {
+            try {
+                TableToken lastToken = engine.getUpdatedTableToken(tableToken);
+                if (lastToken == tableToken) {
+                    LOG.info().$(message).$(path).I$();
+                    ff.unlinkOrRemove(path, LOG);
+                } else {
+                    // table is dropped and recreated since we started processing it.
+                    // abort the table processing
+                    throw new TableReferenceOutOfDateException();
+                }
+            } finally {
+                engine.unLockTableCreate(tableToken);
+            }
+        } else {
+            // table is dropped and recreated since we started processing it.
+            // abort the table processing
+            throw new TableReferenceOutOfDateException();
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/mp/WorkerPoolUtils.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPoolUtils.java
@@ -74,7 +74,7 @@ public class WorkerPoolUtils {
     public static void setupWriterJobs(WorkerPool workerPool, CairoEngine cairoEngine) throws SqlException {
         final MessageBus messageBus = cairoEngine.getMessageBus();
         final O3PartitionPurgeJob purgeDiscoveryJob = new O3PartitionPurgeJob(
-                messageBus,
+                cairoEngine,
                 cairoEngine.getSnapshotAgent(),
                 workerPool.getWorkerCount()
         );

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionFromSoftLinkTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAttachPartitionFromSoftLinkTest.java
@@ -1067,7 +1067,7 @@ public class AlterTableAttachPartitionFromSoftLinkTest extends AbstractAlterTabl
     private static void runO3PartitionPurgeJob() {
         engine.releaseAllReaders();
         engine.releaseAllWriters();
-        try (O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1)) {
+        try (O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1)) {
             while (purgeJob.run(0)) {
                 Os.pause();
             }

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -67,7 +67,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     @BeforeClass
     public static void setUpStatic() throws Exception {
         AbstractCairoTest.setUpStatic();
-        purgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1);
+        purgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1);
     }
 
     @AfterClass

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDropActivePartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDropActivePartitionTest.java
@@ -975,7 +975,7 @@ public class AlterTableDropActivePartitionTest extends AbstractCairoTest {
         assertSql(expected, tableName);
 
         workerPool = new TestWorkerPool(1);
-        O3PartitionPurgeJob partitionPurgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1);
+        O3PartitionPurgeJob partitionPurgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1);
         workerPool.assign(partitionPurgeJob);
         workerPool.freeOnExit(partitionPurgeJob);
         workerPool.start(); // closed by assertTableX

--- a/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
@@ -655,6 +655,9 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
             }
 
             dropTable.set(true);
+            if (Os.isWindows()) {
+                engine.releaseInactive();
+            }
             purgeJob.drain(0);
             dropTable.set(false);
             recreateTable.join();
@@ -704,6 +707,9 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
             }
 
             dropTable.set(true);
+            if (Os.isWindows()) {
+                engine.releaseInactive();
+            }
             purgeJob.drain(0);
             dropTable.set(false);
             recreateTable.join();

--- a/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3PartitionPurgeTest.java
@@ -666,6 +666,56 @@ public class O3PartitionPurgeTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTableRecreatedViaRenameInBeforePartitionDirDelete() throws Exception {
+        AtomicBoolean dropTable = new AtomicBoolean();
+        Thread recreateTable = new Thread(() -> {
+            try {
+                drop("drop table tbl");
+                ddl("create table tbl1 as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY");
+                ddl("rename table tbl1 to tbl");
+            } catch (Throwable e) {
+                LOG.info().$("Failed to recreate table: ").$(e).$();
+            } finally {
+                Path.clearThreadLocals();
+            }
+        });
+
+        FilesFacade ff = new TestFilesFacadeImpl() {
+            @Override
+            public boolean unlinkOrRemove(Path path, Log LOG) {
+                if (dropTable.get() && Utf8s.endsWithAscii(path, "1970-01-10")) {
+                    recreateTable.start();
+                    Os.sleep(50);
+                }
+                int checkedType = isSoftLink(path) ? Files.DT_LNK : Files.DT_UNKNOWN;
+                return unlinkOrRemove(path, checkedType, LOG);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            ddl("create table tbl as (select x, cast('1970-01-10T10' as timestamp) ts from long_sequence(1)) timestamp(ts) partition by DAY");
+
+            // This should lock partition 1970-01-10.1 to not do delete in writer
+            try (TableReader rdr = getReader("tbl")) {
+                rdr.openPartition(0);
+
+                // ooo insert
+                insert("insert into tbl select 4, '1970-01-10T07'");
+            }
+
+            dropTable.set(true);
+            purgeJob.drain(0);
+            dropTable.set(false);
+            recreateTable.join();
+
+            try (TableReader rdr = getReader("tbl")) {
+                rdr.openPartition(0);
+            }
+        });
+    }
+
+
+    @Test
     public void testTableWriterDeletePartitionWhenNoReadersOpen() throws Exception {
         String tableName = "tbl";
 

--- a/core/src/test/java/io/questdb/test/griffin/VacuumTablePartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/VacuumTablePartitionTest.java
@@ -50,7 +50,7 @@ public class VacuumTablePartitionTest extends AbstractCairoTest {
             }
 
             // cleanup
-            try (O3PartitionPurgeJob purgeDiscoveryJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1)) {
+            try (O3PartitionPurgeJob purgeDiscoveryJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1)) {
                 purgeDiscoveryJob.drain(0);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/FuzzRunner.java
@@ -203,7 +203,7 @@ public class FuzzRunner {
         TableReader rdr1 = getReader(tableName);
         TableReader rdr2 = getReader(tableName);
         try (
-                O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1)
+                O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1)
         ) {
             int transactionSize = transactions.size();
             Rnd rnd = new Rnd();
@@ -597,7 +597,7 @@ public class FuzzRunner {
 
     private void drainWalQueue(Rnd applyRnd, String tableName) {
         try (ApplyWal2TableJob walApplyJob = new ApplyWal2TableJob(engine, 1, 1);
-             O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1);
+             O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1);
              TableReader rdr1 = getReaderHandleTableDropped(tableName);
              TableReader rdr2 = getReaderHandleTableDropped(tableName)
         ) {
@@ -675,7 +675,7 @@ public class FuzzRunner {
     private void runPurgePartitionJob(AtomicInteger done, AtomicInteger forceReaderReload, ConcurrentLinkedQueue<Throwable> errors, Rnd runRnd, String tableNameBase, int tableCount, boolean multiTable) {
         ObjList<TableReader> readers = new ObjList<>();
         try {
-            try (O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine.getMessageBus(), engine.getSnapshotAgent(), 1)) {
+            try (O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine, engine.getSnapshotAgent(), 1)) {
                 int forceReloadNum = forceReaderReload.get();
                 for (int i = 0; i < tableCount; i++) {
                     String tableNameWal = multiTable ? getWalParallelApplyTableName(tableNameBase, i) : tableNameBase;


### PR DESCRIPTION
The problem found by fuzz tests. 
When a non-WAL table is re-created with the same name (dropped and created with the same name) the partition purge job can drop a partition of the new table. This is relevant log:

```
2024-05-20T21:52:11.600808Z I i.q.t.f.FuzzDropCreateTableOperation dropping table testWalAddRemoveCommitDropFuzz_nonwal~
2024-05-20T21:52:11.619260Z I i.q.c.p.WriterPool created [table=`testWalAddRemoveCommitDropFuzz_nonwal~`, thread=31]
2024-05-20T21:52:11.619370Z I i.q.c.TableWriter open 'testWalAddRemoveCommitDropFuzz_nonwal'
2024-05-20T21:52:11.622014Z I i.q.c.CairoEngine unlocked [table=`testWalAddRemoveCommitDropFuzz_nonwal`]
2024-05-20T21:52:11.622049Z I i.q.c.p.WriterPool >> [table=`testWalAddRemoveCommitDropFuzz_nonwal~`, thread=31]
2024-05-20T21:52:11.625181Z I i.q.c.TableWriter switched partition [path='/tmp/junit13872316854020729115/dbRoot/testWalAddRemoveCommitDropFuzz_nonwal~/2022-02-25']
2024-05-20T21:52:11.635168Z I i.q.c.O3PartitionPurgeJob purging dropped partition directory [path=/tmp/junit13872316854020729115/dbRoot/testWalAddRemoveCommitDropFuzz_nonwal~/2022-02-24T172921-000001.6]
2024-05-20T21:52:11.635202Z I i.q.c.O3PartitionPurgeJob purging dropped partition directory [path=/tmp/junit13872316854020729115/dbRoot/testWalAddRemoveCommitDropFuzz_nonwal~/2022-02-25]
```

that eventually lead to 

```
2024-05-20T21:52:11.8031636Z io.questdb.cairo.CairoException: [0] Partition '2022-02-25' does not exist in table 'testWalAddRemoveCommitDropFuzz_nonwal' directory. Run [ALTER TABLE testWalAddRemoveCommitDropFuzz_nonwal DROP PARTITION LIST '2022-02-25'] to repair the table or restore the partition directory.
```

The fix is to introduce a table create a lock that `O3PartitionPurgeJob` will hold for a short period when it tries to remove the partition folder. The lock will not allow to create a new table in the partition directory

