### PR TITLE
chore(core): remove unnecessary closing of update operation

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -69,7 +69,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         }
     };
     private static final IntList castGroups = new IntList();
-    private static final boolean[][] columnConverstionSupport = new boolean[ColumnType.NULL][ColumnType.NULL];
+    private static final boolean[][] columnConversionSupport = new boolean[ColumnType.NULL][ColumnType.NULL];
     @SuppressWarnings("FieldMayBeFinal")
     private static Log LOG = LogFactory.getLog(SqlCompilerImpl.class);
     protected final AlterOperationBuilder alterOperationBuilder;
@@ -370,9 +370,9 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
 
     private static void addSupportedConversion(short fromType, short... toTypes) {
         for (short toType : toTypes) {
-            columnConverstionSupport[fromType][toType] = true;
+            columnConversionSupport[fromType][toType] = true;
             // Make it symmetrical
-            columnConverstionSupport[toType][fromType] = true;
+            columnConversionSupport[toType][fromType] = true;
         }
     }
 
@@ -681,7 +681,8 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                                 columnName,
                                 tableMetadata,
                                 columnIndex,
-                                executionContext);
+                                executionContext
+                        );
                     } else {
                         throw SqlException.$(lexer.lastTokenPosition(), "'add', 'drop', 'cache' or 'nocache' expected").put(" found '").put(tok).put('\'');
                     }
@@ -2563,7 +2564,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
     }
 
     private boolean isCompatibleColumnTypeChange(int from, int to) {
-        return columnConverstionSupport[ColumnType.tagOf(from)][ColumnType.tagOf(to)];
+        return columnConversionSupport[ColumnType.tagOf(from)][ColumnType.tagOf(to)];
     }
 
     private void lightlyValidateInsertModel(InsertModel model) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/OperationDispatcher.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/OperationDispatcher.java
@@ -77,9 +77,6 @@ public abstract class OperationDispatcher<T extends AbstractOperation> {
                     closeOnDone
             );
             return future;
-        } catch (Throwable th) {
-            operation.close();
-            throw th;
         } finally {
             if (closeOnDone && isDone) {
                 operation.close();


### PR DESCRIPTION
Closing an update operation in OperationDispatcher can be issue if the UPDATE is cached.

required by https://github.com/questdb/questdb-enterprise/pull/431