### PR TITLE
test(core): GroupBy{Int,Long}HashSet(Fuzz)Test - deal with a random generator yielding duplicates

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByIntHashSetFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByIntHashSetFuzzTest.java
@@ -34,7 +34,9 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class GroupByIntHashSetTest extends AbstractCairoTest {
+import java.util.Set;
+
+public class GroupByIntHashSetFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testFuzzWithIntNullAsNoKeyValue() throws Exception {
@@ -91,12 +93,15 @@ public class GroupByIntHashSetTest extends AbstractCairoTest {
                 set.setAllocator(allocator);
                 set.of(0);
 
+                Set<Integer> referenceSet = new java.util.HashSet<>();
                 for (int i = 0; i < N; i++) {
-                    set.add(rnd.nextPositiveInt());
+                    int val = rnd.nextPositiveInt();
+                    set.add(val);
+                    referenceSet.add(val);
                 }
 
-                Assert.assertEquals(N, set.size());
-                Assert.assertTrue(set.capacity() >= N);
+                Assert.assertEquals(referenceSet.size(), set.size());
+                Assert.assertTrue(set.capacity() >= referenceSet.size());
 
                 rnd.reset(seed0, seed1);
 
@@ -107,11 +112,13 @@ public class GroupByIntHashSetTest extends AbstractCairoTest {
                 set.of(0);
                 rnd.reset(seed0, seed1);
 
+                referenceSet.clear();
                 for (int i = 0; i < N; i++) {
                     int val = rnd.nextPositiveInt();
                     long index = set.keyIndex(val);
-                    Assert.assertTrue(index >= 0);
+                    Assert.assertTrue(index >= 0 || referenceSet.contains(val));
                     set.addAt(index, val);
+                    referenceSet.add(val);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLongHashSetFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/GroupByLongHashSetFuzzTest.java
@@ -34,7 +34,9 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class GroupByLongHashSetTest extends AbstractCairoTest {
+import java.util.Set;
+
+public class GroupByLongHashSetFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testFuzzWithLongNullAsNoKeyValue() throws Exception {
@@ -91,12 +93,15 @@ public class GroupByLongHashSetTest extends AbstractCairoTest {
                 set.setAllocator(allocator);
                 set.of(0);
 
+                Set<Long> referenceSet = new java.util.HashSet<>();
                 for (int i = 0; i < N; i++) {
-                    set.add(rnd.nextPositiveLong() + 1);
+                    long val = rnd.nextPositiveLong() + 1;
+                    set.add(val);
+                    referenceSet.add(val);
                 }
 
-                Assert.assertEquals(N, set.size());
-                Assert.assertTrue(set.capacity() >= N);
+                Assert.assertEquals(referenceSet.size(), set.size());
+                Assert.assertTrue(set.capacity() >= referenceSet.size());
 
                 rnd.reset(seed0, seed1);
 
@@ -107,11 +112,13 @@ public class GroupByLongHashSetTest extends AbstractCairoTest {
                 set.of(0);
                 rnd.reset(seed0, seed1);
 
+                referenceSet.clear();
                 for (int i = 0; i < N; i++) {
                     long val = rnd.nextPositiveLong() + 1;
                     long index = set.keyIndex(val);
-                    Assert.assertTrue(index >= 0);
+                    Assert.assertTrue(index >= 0 || referenceSet.contains(val));
                     set.addAt(index, val);
+                    referenceSet.add(val);
                 }
             }
         });


### PR DESCRIPTION
Also: add Fuzz to classname so it's picked up by the CI fuzzer