### PR TITLE
chore(core): fix SQL query logging

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -62,7 +62,7 @@ public class QueryProgress extends AbstractRecordCursorFactory {
     }
 
     public static void logEnd(long sqlId, CharSequence sqlText, SqlExecutionContext executionContext, long beginNanos) {
-        LOG.info()
+        LOG.infoW()
                 .$("fin [id=").$(sqlId)
                 .$(", sql=`").$(sqlText).$('`')
                 .$(", principal=").$(executionContext.getSecurityContext().getPrincipal())
@@ -80,7 +80,7 @@ public class QueryProgress extends AbstractRecordCursorFactory {
     ) {
         final int errno = e instanceof CairoException ? ((CairoException) e).getErrno() : 0;
         final int pos = e instanceof FlyweightMessageContainer ? ((FlyweightMessageContainer) e).getPosition() : 0;
-        LOG.error()
+        LOG.errorW()
                 .$("err")
                 .$(" [id=").$(sqlId)
                 .$(", sql=`").$(sqlText).$('`')
@@ -98,7 +98,7 @@ public class QueryProgress extends AbstractRecordCursorFactory {
             CharSequence sqlText,
             SqlExecutionContext executionContext
     ) {
-        LOG.info()
+        LOG.infoW()
                 .$("exe")
                 .$(" [id=").$(sqlId)
                 .$(", sql=`").$(sqlText).$('`')


### PR DESCRIPTION
SQL query logging should be done in sync mode, so it can be traced back always what queries were run.

required by https://github.com/questdb/questdb-enterprise/pull/433