### PR TITLE
Potential Memory leak and lack of input validation , updated influxDB

### DIFF
--- a/compat/src/test/java/io/questdb/compat/InfluxDBUtils.java
+++ b/compat/src/test/java/io/questdb/compat/InfluxDBUtils.java
@@ -37,6 +37,9 @@ import java.util.List;
 public class InfluxDBUtils {
 
     public static void assertRequestErrorContains(InfluxDB influxDB, List<String> points, String line, String... errors) {
+        if (points == null || line == null || errors == null) {
+            throw new IllegalArgumentException("All arguments must be non-null");
+        }
         points.add(line);
         try {
             influxDB.write(points);
@@ -48,10 +51,15 @@ public class InfluxDBUtils {
                 }
             }
         }
-        points.clear();
+        finally { 
+            points.clear();
+        }
     }
 
     public static void assertRequestOk(InfluxDB influxDB, List<String> points, String line) {
+        if (points == null || line == null) {
+            throw new IllegalArgumentException("All arguments must be non-null");
+        }
         points.add(line);
         influxDB.write(points);
         points.clear();


### PR DESCRIPTION
The assertRequestErrorContains() method calls points.clear() after the request has been processed . However, if an exception is thrown before this point, the points list may not be cleared, leading to a potential memory leak.  Added a finally block to ensure that points.clear() is always called, even if an exception is thrown.  

The assertRequestErrorContains() and assertRequestOk() methods do not perform any input validation on the points and line parameters. If these parameters are null or empty, the methods may throw a NullPointerException or behave unexpectedly. Consider adding input validation to these methods to prevent such issues.