### PR TITLE
Update pom.xml

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>${project.version}</version>
+            <version>8.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -42,6 +42,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <build>
@@ -51,8 +53,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -72,7 +74,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -80,19 +82,19 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.0.0-M7</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The provided Maven pom.xml file does not have any syntax errors and should work as intended. However, there are some areas that could be improved or clarified:

Version Specification:

The questdb dependency version is specified as ${project.version}, which refers to the parent project's version. While this works if questdb and this project have the same versioning scheme, it might be clearer to explicitly specify the version. Dependency Version for questdb:

Check if the questdb version you are using is correct and that 8.0.0-SNAPSHOT exists in your repository. Using SNAPSHOT versions can sometimes lead to issues if the dependency is not properly deployed. Plugin Configuration:

The maven-surefire-plugin version 2.17 is quite old. Consider updating it to a more recent version to take advantage of bug fixes and new features. The same goes for other plugins like maven-compiler-plugin and maven-jar-plugin.

Key Changes:

Explicitly set the questdb dependency version to 8.0.0-SNAPSHOT. Updated plugin versions to more recent ones where applicable. Added maven.compiler.source and maven.compiler.target properties to the <properties> section and referenced them in the maven-compiler-plugin configuration for consistency. These changes help ensure compatibility and take advantage of improvements and bug fixes in newer plugin versions.