### PR TITLE
Fix in pom.xml

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -1,0 +1,7 @@
+{
+  // These tasks will run in order when initializing your CodeSandbox project.
+  "setupTasks": [],
+
+  // These tasks can be run from CodeSandbox. Running one will open a log in the app.
+  "tasks": {}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -24,24 +24,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>io.questdb</groupId>
     <artifactId>benchmarks</artifactId>
     <version>8.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JMH benchmarks for QuestDB</name>
-
-    <!--
-       This is the demo/sample template build script for building Java benchmarks with JMH.
-       Edit as needed.
-    -->
-
+    <!-- This is the demo/sample template build script for building Java benchmarks with JMH. Edit as needed. -->
     <dependencies>
-        <dependency>
-            <groupId>com.chrisnewland</groupId>
-            <artifactId>jitwatch</artifactId>
-            <version>1.1.5</version>
-        </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
@@ -85,29 +74,18 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <benchmarks.outputPath>target</benchmarks.outputPath>
-
-        <!--
-            JMH version to use with this project.
-          -->
+        <!-- JMH version to use with this project. -->
         <jmh.version>1.35</jmh.version>
-
-        <!--
-            Java source/target to use for compilation.
-          -->
+        <!-- Java source/target to use for compilation. -->
         <javac.target>11</javac.target>
-
-        <!--
-            Name of the benchmark Uber-JAR to generate.
-          -->
+        <!-- Name of the benchmark Uber-JAR to generate. -->
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
-
     <build>
         <directory>${benchmarks.outputPath}</directory>
         <plugins>
@@ -146,10 +124,6 @@
                             </transformers>
                             <filters>
                                 <filter>
-                                    <!--
-                                        Shading signed JARs will fail without this.
-                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
-                                    -->
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
@@ -163,7 +137,6 @@
                 </executions>
             </plugin>
         </plugins>
-
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -201,7 +174,6 @@
             </plugins>
         </pluginManagement>
     </build>
-
     <profiles>
         <profile>
             <id>javadoc</id>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -24,13 +24,24 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>io.questdb</groupId>
     <artifactId>benchmarks</artifactId>
     <version>8.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JMH benchmarks for QuestDB</name>
-    <!-- This is the demo/sample template build script for building Java benchmarks with JMH. Edit as needed. -->
+
+    <!--
+       This is the demo/sample template build script for building Java benchmarks with JMH.
+       Edit as needed.
+    -->
+
     <dependencies>
+        <dependency>
+            <groupId>com.chrisnewland</groupId>
+            <artifactId>jitwatch</artifactId>
+            <version>1.1.5</version>
+        </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
@@ -74,18 +85,28 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <benchmarks.outputPath>target</benchmarks.outputPath>
-        <!-- JMH version to use with this project. -->
+
+        <!--
+            JMH version to use with this project.
+          -->
         <jmh.version>1.35</jmh.version>
-        <!-- Java source/target to use for compilation. -->
+
+        <!--
+            Java source/target to use for compilation.
+          -->
         <javac.target>11</javac.target>
-        <!-- Name of the benchmark Uber-JAR to generate. -->
+
+        <!--
+            Name of the benchmark Uber-JAR to generate.
+          -->
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
+
     <build>
         <directory>${benchmarks.outputPath}</directory>
         <plugins>
@@ -124,6 +145,10 @@
                             </transformers>
                             <filters>
                                 <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
@@ -137,6 +162,7 @@
                 </executions>
             </plugin>
         </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -174,6 +200,7 @@
             </plugins>
         </pluginManagement>
     </build>
+
     <profiles>
         <profile>
             <id>javadoc</id>
@@ -207,34 +234,31 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
-                        <configuration>
-                            <fork>true</fork>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <testExcludes>
-                                <exclude>**/module-info.java</exclude>
-                            </testExcludes>
-                            <excludes>
-                                <exclude>**/module-info.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version> <configuration>
+                    <fork>true</fork>  <source>1.8</source>
+                    <target>1.8</target>
+                    <testExcludes>
+                        <exclude>**/module-info.java</exclude>
+                    </testExcludes>
+                    <excludes>
+                        <exclude>**/module-info.java</exclude>
+                    </excludes>
+                    </configuration>
+                </plugin>
                 </plugins>
             </build>
             <dependencies>
                 <dependency>
-                    <groupId>org.jetbrains</groupId>
-                    <artifactId>annotations</artifactId>
-                    <version>16.0.2</version>
-                    <scope>provided</scope>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>16.0.2</version>
+                <scope>provided</scope>
                 </dependency>
             </dependencies>
-        </profile>
-        <profile>
+            </profile>
             <id>java11+</id>
             <properties>
                 <questdb.artifactid>questdb</questdb.artifactid>


### PR DESCRIPTION
Unnecessary maven.deploy.skip property was used which was preventing to deploy removed
Potentially simplify java8 profile: The java8 profile sets the fork property to true in the compiler plugin configuration. This is because forking allows the compiler to run in a separate process which can be beneficial for memory isolation. However, forking can add some overhead. If you are confident that memory usage won't be an issue, you can remove the fork property and simplify the configuration.