### PR TITLE
Extracted the logic for printing functions, keywords, and types into separate methods for better readability and maintainability.

### DIFF
--- a/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
+++ b/utils/src/main/java/io/questdb/misc/SqlGrammarUtil.java
@@ -22,85 +22,76 @@
  *
  ******************************************************************************/
 
-package io.questdb.misc;
+ package io.questdb.misc;
 
-
-import io.questdb.cairo.ColumnType;
-import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.catalogue.Constants;
-
-import java.lang.reflect.Field;
-import java.util.*;
-
-public class SqlGrammarUtil {
-    private static void print(String header, Set<String> names) {
-        System.out.printf("%s:%n", header);
-        for (String name : names) {
-            System.out.printf("\"%s\",%n", name);
-        }
-        System.out.print("\n=====\n");
-    }
-
-    public static void main(String... args) {
-        // static
-        final Set<String> staticSet = new TreeSet<>();
-        Collections.addAll(
-                staticSet,
-                "&", "|", "^", "~", "[]",
-                "!=", "!~", "%", "*", "+",
-                "-", ".", "/", "<", "<=",
-                "<>", "<>all", "=", ">", ">="
-        );
-
-        // function names
-        final Set<String> names = new TreeSet<>();
-        for (FunctionFactory factory : ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader())) {
-            if (factory.getClass().getName().contains("test")) {
-                continue;
-            }
-            String signature = factory.getSignature();
-            String name = signature.substring(0, signature.indexOf('('));
-            if (staticSet.contains(name)) {
-                continue;
-            }
-            names.add(name);
-            // add != counterparts to equality function factories
-            if (factory.isBoolean()) {
-                if (name.equals("=")) {
-                    names.add("!=");
-                    names.add("<>");
-                } else if (name.equals("<")) {
-                    names.add("<=");
-                    names.add(">=");
-                    names.add(">");
-                }
-            }
-        }
-        print("FUNCTIONS", names);
-
-        // keywords
-        names.clear();
-        try {
-            Field field = Constants.class.getDeclaredField("KEYWORDS");
-            field.setAccessible(true);
-            for (CharSequence keyword : (CharSequence[]) field.get(null)) {
-                names.add((String) keyword);
-            }
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-        print("KEYWORDS", names);
-
-        // types
-        names.clear();
-        final Set<String> skipSet = new HashSet<>();
-        Collections.addAll(skipSet, "unknown", "regclass", "regprocedure", "VARARG", "text[]", "CURSOR", "RECORD", "PARAMETER");
-        for (int type = 1; type < ColumnType.NULL; type++) {
-            String name = ColumnType.nameOf(type);
-            if (!skipSet.contains(name)) {
-                names.add(name.toLowerCase());
-            }
-        }
-        print("TYPES", names);
-    }
-}
+ import io.questdb.cairo.ColumnType;
+ import io.questdb.griffin.FunctionFactory;
+ import io.questdb.griffin.engine.functions.catalogue.Constants;
+ 
+ import java.lang.reflect.Field;
+ import java.util.*;
+ 
+ public class SqlGrammarUtil {
+     private static final Set<String> STATIC_SET = new TreeSet<>(Arrays.asList("&", "|", "^", "~", "[]", "!=", "!~", "%", "*", "+", "-", ".", "/", "<", "<=", "<>", "<>all", "=", ">", ">="));
+     private static final Set<String> SKIP_SET = new HashSet<>(Arrays.asList("unknown", "regclass", "regprocedure", "VARARG", "text[]", "CURSOR", "RECORD", "PARAMETER"));
+ 
+     private static void print(String header, Set<String> names) {
+         System.out.printf("%s:%n", header);
+         names.forEach(name -> System.out.printf("\"%s\",%n", name));
+         System.out.print("\n=====\n");
+     }
+ 
+     private static void printFunctions() {
+         Set<String> names = new TreeSet<>();
+         for (FunctionFactory factory : ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader())) {
+             if (factory.getClass().getName().contains("test")) {
+                 continue;
+             }
+             String name = factory.getSignature().split("\\(")[0];
+             if (STATIC_SET.contains(name)) {
+                 continue;
+             }
+             names.add(name);
+             if (factory.isBoolean()) {
+                 if (name.equals("=")) {
+                     names.addAll(Arrays.asList("!=", "<>"));
+                 } else if (name.equals("<")) {
+                     names.addAll(Arrays.asList("<=", ">=", ">"));
+                 }
+             }
+         }
+         print("FUNCTIONS", names);
+     }
+ 
+     private static void printKeywords() throws NoSuchFieldException, IllegalAccessException {
+         Set<String> names = new TreeSet<>();
+         Field field = Constants.class.getDeclaredField("KEYWORDS");
+         field.setAccessible(true);
+         for (CharSequence keyword : (CharSequence[]) field.get(null)) {
+             names.add((String) keyword);
+         }
+         print("KEYWORDS", names);
+     }
+ 
+     private static void printTypes() {
+         Set<String> names = new TreeSet<>();
+         for (int type = 1; type < ColumnType.NULL; type++) {
+             String name = ColumnType.nameOf(type);
+             if (!SKIP_SET.contains(name)) {
+                 names.add(name.toLowerCase());
+             }
+         }
+         print("TYPES", names);
+     }
+ 
+     public static void main(String... args) {
+         printFunctions();
+         try {
+             printKeywords();
+         } catch (NoSuchFieldException | IllegalAccessException e) {
+             throw new RuntimeException(e);
+         }
+         printTypes();
+     }
+ }
+ 


### PR DESCRIPTION
Used Arrays.asList to initialize STATIC_SET and SKIP_SET which is more efficient and cleaner.
Used String.split to get the function name from the signature, which is more efficient than String.substring and String.indexOf.
Used a lambda expression in the print method to print each name, which is more concise and idiomatic in modern Java.
Used Arrays.asList to add multiple elements to the names set at once, which is more efficient and cleaner.