### PR TITLE
chore(sql): speed up regexp_replace(varchar) with single group

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexUtils.java
@@ -44,6 +44,14 @@ final class RegexUtils {
         if (regex == null) {
             throw SqlException.$(position, "NULL regex");
         }
+        return createMatcher(regex, position);
+    }
+
+    @NotNull
+    public static Matcher createMatcher(CharSequence regex, int position) throws SqlException {
+        if (regex == null) {
+            throw SqlException.$(position, "NULL regex");
+        }
         try {
             return Pattern.compile(Chars.toString(regex)).matcher("");
         } catch (PatternSyntaxException e) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
@@ -24,6 +24,22 @@
 
 package io.questdb.griffin.engine.functions.regex;
 
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.StrFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.*;
+import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8s;
+
+import java.util.regex.Matcher;
+
 /**
  * This is tactical implementation of regex replace over varchar column.
  * It exploits the ability of a varchar column to return a CharSequence view of the sequence.
@@ -32,6 +48,144 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
     @Override
     public String getSignature() {
         return "regexp_replace(ØSS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        final Function value = args.getQuick(0);
+        final Function pattern = args.getQuick(1);
+        final int patternPos = argPositions.getQuick(1);
+        final Function replacement = args.getQuick(2);
+        final int replacementPos = argPositions.getQuick(2);
+        validateInputs(pattern, patternPos, replacement, replacementPos);
+
+        if (!pattern.isRuntimeConstant() && !replacement.isRuntimeConstant()) {
+            final CharSequence patternStr = pattern.getStrA(null);
+            if (patternStr == null) {
+                throw SqlException.$(patternPos, "NULL regex");
+            }
+            CharSequence replacementStr = replacement.getStrA(null);
+            if (replacementStr == null) {
+                throw SqlException.$(replacementPos, "NULL replacement");
+            }
+            // Optimize for patterns like "^https?://(?:www\.)?([^/]+)/.*$" and replacements like "$1".
+            if (patternStr.length() > 2 && patternStr.charAt(0) == '^' && patternStr.charAt(patternStr.length() - 1) == '$'
+                    && replacementStr.length() > 1 && replacementStr.charAt(0) == '$') {
+                final Matcher matcher = RegexUtils.createMatcher(pattern, patternPos);
+                try {
+                    final int group = Numbers.parseInt(replacementStr, 1, replacementStr.length());
+                    if (group > matcher.groupCount()) {
+                        throw SqlException.$(replacementPos, "No group ").put(group);
+                    }
+                    return new SingleGroupFunc(value, matcher, Chars.toString(replacementStr), group, position);
+                } catch (NumericException ignore) {
+                }
+            }
+        }
+
+        final int maxLength = configuration.getStrFunctionMaxBufferLength();
+        return new Func(value, pattern, patternPos, replacement, replacementPos, maxLength, position);
+    }
+
+    private static class SingleGroupFunc extends StrFunction implements UnaryFunction {
+        private static final int INITIAL_SINK_CAPACITY = 16;
+        private final int functionPos;
+        private final int group;
+        private final Matcher matcher;
+        private final String replacement;
+        private final DirectUtf16Sink utf16SinkA;
+        private final DirectUtf16Sink utf16SinkB;
+        private final Function value;
+
+        public SingleGroupFunc(Function value, Matcher matcher, String replacement, int group, int functionPos) {
+            try {
+                this.value = value;
+                this.matcher = matcher;
+                this.replacement = replacement;
+                this.group = group;
+                this.functionPos = functionPos;
+                this.utf16SinkA = new DirectUtf16Sink(INITIAL_SINK_CAPACITY);
+                this.utf16SinkB = new DirectUtf16Sink(INITIAL_SINK_CAPACITY);
+            } catch (Throwable th) {
+                close();
+                throw th;
+            }
+        }
+
+        @Override
+        public void close() {
+            UnaryFunction.super.close();
+            Misc.free(utf16SinkA);
+            Misc.free(utf16SinkB);
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public CharSequence getStrA(Record rec) {
+            return getStr(rec, utf16SinkA);
+        }
+
+        @Override
+        public CharSequence getStrB(Record rec) {
+            return getStr(rec, utf16SinkB);
+        }
+
+        @Override
+        public boolean isConstant() {
+            return false;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
+        @Override
+        public boolean isRuntimeConstant() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val("regexp_replace(").val(value).val(',').val(matcher.pattern().toString()).val(',').val(replacement).val(')');
+        }
+
+        private CharSequence getStr(Record rec, DirectUtf16Sink utf16Sink) {
+            Utf8Sequence us = value.getVarcharA(rec);
+            if (us == null) {
+                return null;
+            }
+
+            utf16Sink.clear();
+            if (us.isAscii()) {
+                // We want monomorphism in later matcher.reset() call,
+                // so we always deal with the sink.
+                utf16Sink.putAscii(us);
+            } else {
+                Utf8s.utf8ToUtf16(us, utf16Sink);
+            }
+
+            matcher.reset(utf16Sink);
+            try {
+                if (!matcher.find()) {
+                    // Same here: we want monomorphism for the returned types.
+                    return utf16Sink.subSequence(0, utf16Sink.length());
+                }
+                return utf16Sink.subSequence(matcher.start(group), matcher.end(group));
+            } catch (Exception e) {
+                throw CairoException.nonCritical().put("regexp_replace failed [position=").put(functionPos).put(", ex=").put(e.getMessage()).put(']');
+            }
+        }
     }
 }
 

--- a/core/src/main/java/io/questdb/std/str/DirectUtf16Sink.java
+++ b/core/src/main/java/io/questdb/std/str/DirectUtf16Sink.java
@@ -107,15 +107,25 @@ public class DirectUtf16Sink implements MutableUtf16Sink, DirectCharSequence, Cl
     @Override
     public Utf16Sink put(char @NotNull [] chars, int start, int len) {
         int l2 = len * 2;
-
         if (lo + l2 >= hi) {
             resize((int) Math.max(capacity * 2L, (lo - ptr + l2) * 2L));
         }
-
         for (int i = 0; i < len; i++) {
             Unsafe.getUnsafe().putChar(lo + i * 2L, chars[i + start]);
         }
+        this.lo += l2;
+        return this;
+    }
 
+    public Utf16Sink putAscii(@NotNull Utf8Sequence us) {
+        int l = us.size();
+        int l2 = l * 2;
+        if (lo + l2 >= hi) {
+            resize(Math.max(capacity * 2L, (lo - ptr + l2) * 2L));
+        }
+        for (int i = 0; i < l; i++) {
+            Unsafe.getUnsafe().putChar(lo + i * 2L, (char) us.byteAt(i));
+        }
         this.lo += l2;
         return this;
     }
@@ -154,7 +164,6 @@ public class DirectUtf16Sink implements MutableUtf16Sink, DirectCharSequence, Cl
     }
 
     private class FloatingCharSequence extends AbstractCharSequence {
-
         private int len;
         private int startIndex;
 


### PR DESCRIPTION
The trick is to avoid litter generated by `matcher.appendReplacement()` and get rid of megamorphism in the input and returned types.

```sql
-- master 22.5s
-- patch 11.5s
SELECT * FROM (SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '$1') AS k, AVG(length(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM hits WHERE Referer IS NOT NULL GROUP BY k) WHERE c > 100000 ORDER BY l DESC LIMIT 25;
```