### PR TITLE
fix: directory path before .project,  a wildcard "*" at the end of th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,12 @@ core/cmake-build-debug-coverage
 core/cmake-build-release
 core/cmake-build-minsizerel
 core/CMakeCache.txt
-**/.project
+core/.project
 **/.settings
 **/.classpath
 **/build
 **/CMakeFiles
 .envrc
 .vscode
-core/rust/qdbr/target
+core/rust/qdbr/target/*
+


### PR DESCRIPTION
…e path.

1.specified the directory path before .project :core/.project 2.added a wildcard * at the end of the path to exclude all contents within the target directory:core/rust/qdbr/target/*