### PR TITLE
fix(ilp): make trailing semicolon in client configuration optional

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/Function.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Function.java
@@ -176,6 +176,16 @@ public interface Function extends Closeable, StatefulAtom, Plannable {
      */
     int getVarcharSize(Record rec);
 
+    /**
+     * Returns true if function is constant, i.e. its value does not require
+     * any input from the record.
+     * <p>
+     * Constant functions can evaluated by passing a null record to {@link #getStr(Record, Utf16Sink)}
+     * or other methods. This often happens inside FunctionFactory at query planning stage.
+     *
+     * @return true if function is constant
+     * @see #isRuntimeConstant()
+     */
     default boolean isConstant() {
         return false;
     }

--- a/core/src/main/java/io/questdb/client/impl/ConfStringParser.java
+++ b/core/src/main/java/io/questdb/client/impl/ConfStringParser.java
@@ -183,9 +183,7 @@ public final class ConfStringParser {
                 output.put(c);
             }
         }
-        output.clear();
-        output.put("missing trailing semicolon at position ").put(pos);
-        return -1;
+        return pos;
     }
 
     private static boolean invalidIdentifierChar(char c) {

--- a/core/src/main/java/io/questdb/griffin/FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionFactory.java
@@ -69,9 +69,10 @@ public interface FunctionFactory {
      * </ul>
      * <p>
      * Lower-case letters will require arguments to be constant expressions. Upper-case letters allow both constant and
-     * variable expressions.
+     * non-constant expressions.
      *
      * @return signature, for example "substr(SII)"
+     * @see Function#isConstant()
      */
     String getSignature();
 

--- a/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
+++ b/core/src/test/java/io/questdb/test/client/LineSenderBuilderTest.java
@@ -235,7 +235,6 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
     public void testConfString() throws Exception {
         assertMemoryLeak(() -> {
             assertConfStrError("foo", "invalid schema [schema=foo, supported-schemas=[http, https, tcp, tcps]]");
-            assertConfStrError("http::addr=bar", "invalid address [error=missing trailing semicolon at position 14]");
             assertConfStrError("badschema::addr=bar;", "invalid schema [schema=badschema, supported-schemas=[http, https, tcp, tcps]]");
             assertConfStrError("http::addr=localhost:-1;", "invalid port [port=-1]");
             assertConfStrError("http::auto_flush=on;", "addr is missing");
@@ -253,7 +252,6 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrError("tcp::addr=localhost;retry_timeout=;", "retry_timeout cannot be empty");
             assertConfStrError("tcp::addr=localhost;max_buf_size=;", "max_buf_size cannot be empty");
             assertConfStrError("tcp::addr=localhost;init_buf_size=;", "init_buf_size cannot be empty");
-            assertConfStrError("tcp::addr=localhost;invali=", "invalid parameter [error=missing trailing semicolon at position 27]");
             assertConfStrError("tcp::Řaddr=localhost;", "invalid configuration string [error=key must be consist of alpha-numerical ascii characters and underscore, not 'Ř' at position 5]");
             assertConfStrError("http::addr=localhost:8080;tls_verify=unsafe_off;", "TSL validation disabled, but TLS was not enabled");
             assertConfStrError("http::addr=localhost:8080;tls_verify=bad;", "invalid tls_verify [value=bad, allowed-values=[on, unsafe_off]]");
@@ -282,11 +280,25 @@ public class LineSenderBuilderTest extends AbstractLineTcpReceiverTest {
             assertConfStrOk("addr=localhost", "auto_flush=on");
 
             runInContext(r -> {
-                String tcpAddr = "tcp::addr=localhost:" + bindPort + ";";
-                assertConfStrOk(tcpAddr + "auto_flush_bytes=1024;");
-                assertConfStrOk(tcpAddr + "init_buf_size=1024;");
-                assertConfStrOk(tcpAddr + "init_buf_size=1024;auto_flush_bytes=1024;");
-                assertConfStrOk(tcpAddr + "auto_flush_bytes=1024;init_buf_size=1024;");
+                String tcpAddr = "tcp::addr=localhost:" + bindPort;
+                assertConfStrOk(tcpAddr);
+
+                assertConfStrOk(tcpAddr + ";auto_flush_bytes=1024");
+                assertConfStrOk(tcpAddr + ";auto_flush_bytes=1024;");
+
+                assertConfStrOk(tcpAddr + ";init_buf_size=1024");
+                assertConfStrOk(tcpAddr + ";init_buf_size=1024;");
+
+                assertConfStrOk(tcpAddr + ";init_buf_size=1024;auto_flush_bytes=1024");
+                assertConfStrOk(tcpAddr + ";init_buf_size=1024;auto_flush_bytes=1024;");
+
+                assertConfStrOk(tcpAddr + ";auto_flush_bytes=1024;init_buf_size=1024");
+                assertConfStrOk(tcpAddr + ";auto_flush_bytes=1024;init_buf_size=1024;");
+
+                assertConfStrOk(tcpAddr + ";unknown=foo");
+                assertConfStrOk(tcpAddr + ";unknown=foo;");
+                assertConfStrOk(tcpAddr + ";unknown_empty=");
+                assertConfStrOk(tcpAddr + ";unknown_empty=;");
             });
             assertConfStrError("tcp::addr=localhost;auto_flush_bytes=1024;init_buf_size=2048;", "TCP transport requires init_buf_size and auto_flush_bytes to be set to the same value [init_buf_size=2048, auto_flush_bytes=1024]");
             assertConfStrError("tcp::addr=localhost;init_buf_size=1024;auto_flush_bytes=2048;", "TCP transport requires init_buf_size and auto_flush_bytes to be set to the same value [init_buf_size=1024, auto_flush_bytes=2048]");

--- a/core/src/test/java/io/questdb/test/client/impl/ConfStringParserTest.java
+++ b/core/src/test/java/io/questdb/test/client/impl/ConfStringParserTest.java
@@ -158,7 +158,7 @@ public final class ConfStringParserTest {
         assertHasNext(config, pos);
         pos = assertNextKeyValueOk(config, pos, "host", "localhost");
         pos = assertNextKeyOk(config, pos, "port");
-        pos = assertNextValueError(config, pos, "missing trailing semicolon at position 30");
+        pos = assertNextValueOk(config, pos, "9000");
         assertNoNext(config, pos);
     }
 
@@ -217,7 +217,7 @@ public final class ConfStringParserTest {
         pos = assertSchemaOk(config, "http");
         assertHasNext(config, pos);
         pos = assertNextKeyOk(config, pos, "foo");
-        pos = assertNextValueError(config, pos, "missing trailing semicolon at position 15");
+        pos = assertNextValueOk(config, pos, "bar;");
         assertNoNext(config, pos);
 
         config = "https::foo=;;;;;";


### PR DESCRIPTION
This change updates the Java client to handle client configuration
strings without requiring a trailing semicolon, aligning it
with the behavior of other clients.

Originally, the trailing semicolon was mandated to help detect
accidentally truncated configuration strings. However, this has
led to user frustration, as semicolons are commonly perceived
as option delimiters rather than terminators, leading to a tendency
to omit the final semicolon.

This update removes the requirement, reducing potential
user errors and improving consistency across different clients.