### PR TITLE
feat(http): add support for `nm=true` query parameter in text export (/exp) to exclude metadata

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -319,16 +319,18 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
                         // fall through
 
                     case JsonQueryProcessorState.QUERY_METADATA:
-                        state.columnIndex = 0;
-                        while (state.columnIndex < columnCount) {
-                            if (state.columnIndex > 0) {
-                                response.putAscii(state.delimiter);
+                        if (!state.noMeta) {
+                            state.columnIndex = 0;
+                            while (state.columnIndex < columnCount) {
+                                if (state.columnIndex > 0) {
+                                    response.putAscii(state.delimiter);
+                                }
+                                response.putQuote().escapeJsonStr(state.metadata.getColumnName(state.columnIndex)).putQuote();
+                                state.columnIndex++;
+                                response.bookmark();
                             }
-                            response.putQuote().escapeJsonStr(state.metadata.getColumnName(state.columnIndex)).putQuote();
-                            state.columnIndex++;
-                            response.bookmark();
+                            response.putEOL();
                         }
-                        response.putEOL();
                         state.queryState = JsonQueryProcessorState.QUERY_RECORD_START;
                         response.bookmark();
                         // fall through

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -83,15 +83,14 @@ import static io.questdb.test.tools.TestUtils.drainWalQueue;
 import static org.junit.Assert.assertTrue;
 
 public class IODispatcherTest extends AbstractTest {
-    public static final String JSON_DDL_RESPONSE = "0c\r\n" +
-            "{\"ddl\":\"OK\"}\r\n" +
-            "00\r\n" +
-            "\r\n";
     public static final String INSERT_QUERY_RESPONSE = "0c\r\n" +
             "{\"dml\":\"OK\"}\r\n" +
             "00\r\n" +
             "\r\n";
-
+    public static final String JSON_DDL_RESPONSE = "0c\r\n" +
+            "{\"ddl\":\"OK\"}\r\n" +
+            "00\r\n" +
+            "\r\n";
     private static final RescheduleContext EmptyRescheduleContext = (retry) -> {
     };
     private static final Log LOG = LogFactory.getLog(IODispatcherTest.class);
@@ -5766,6 +5765,21 @@ public class IODispatcherTest extends AbstractTest {
                 Net.close(fd);
             }
         }, false);
+    }
+
+    @Test
+    public void testNoMetadataInTextExport() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(2)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((engine) -> {
+                    CharSequenceObjHashMap<String> queryParams = new CharSequenceObjHashMap<>();
+                    queryParams.put("nm", "true");
+                    queryParams.put("query", "select 42 from long_sequence(1);");
+                    testHttpClient.assertGet("/exp", "42\r\n", queryParams, null, null);
+                });
     }
 
     @Test


### PR DESCRIPTION
Add `nm=true` as a query parameter to exclude headers in CSV exports. This is useful for scripting data-based monitoring tasks.

Example, return ingestion lag in milliseconds:
```
$ curl -G "http://localhost:9000/exp" --data-urlencode "query=SELECT (now () - max(timestamp)) / 1000 from trades;" --data-urlencode "nm=true"
210
```

This returns only the query result, omitting any metadata, which allows monitoring without requiring additional post-processing.

Additionally, the `nm` parameter was already supported in the JSON (/exec) endpoint, and this PR improves the consistency of the QuestDB REST interface.

Fixes #4629