### PR TITLE
fix(core): fix column type change after table truncate can lead to invalid data in the column

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -870,7 +870,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
             // Set txn number in the column version file to mark the transaction where the column is added
             long firstPartitionTsm = columnVersionWriter.getColumnTopPartitionTimestamp(existingColIndex);
-            if (firstPartitionTsm == Long.MIN_VALUE) {
+            if (firstPartitionTsm == Long.MIN_VALUE && txWriter.getPartitionCount() > 0) {
                 firstPartitionTsm = txWriter.getPartitionTimestampByIndex(0);
             }
             columnVersionWriter.upsertDefaultTxnName(columnIndex, columnNameTxn, firstPartitionTsm);


### PR DESCRIPTION
The issue was found by fuzz tests.
Column top partition is not correctly set if Change Column Type SQL is run on the empty table directly after the truncate table operation. The result is that some partitions can return null values for the converted columns.