### PR TITLE
fix(sql): fix SQL error when bind variables used within the IN() function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InCharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InCharFunctionFactory.java
@@ -89,14 +89,14 @@ public class InCharFunctionFactory implements FunctionFactory {
         if (var.isConstant()) {
             return BooleanConstant.of(set.contains(var.getChar(null)));
         }
-        return new InDubleConstFunction(var, set);
+        return new InCharConstFunction(var, set);
     }
 
-    private static class InDubleConstFunction extends BooleanFunction implements UnaryFunction {
+    private static class InCharConstFunction extends BooleanFunction implements UnaryFunction {
         private final Function arg;
         private final IntHashSet set;
 
-        public InDubleConstFunction(Function arg, IntHashSet set) {
+        public InCharConstFunction(Function arg, IntHashSet set) {
             this.arg = arg;
             this.set = set;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/InTimestampTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/InTimestampTimestampFunctionFactory.java
@@ -72,10 +72,11 @@ public class InTimestampTimestampFunctionFactory implements FunctionFactory {
             }
             if (!func.isConstant()) {
                 allConst = false;
-            }
 
-            if (!func.isRuntimeConstant()) {
-                allRuntimeConst = false;
+                // allRuntimeConst can mean a mix of constants and runtime constants
+                if (!func.isRuntimeConstant()) {
+                    allRuntimeConst = false;
+                }
             }
         }
 
@@ -350,5 +351,4 @@ public class InTimestampTimestampFunctionFactory implements FunctionFactory {
             sink.val(args, 1);
         }
     }
-
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
@@ -60,21 +60,24 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
         validateColumnTypes(args, argPositions, true);
 
         final int numberOfPairs = (args.size() - 1) / 2;
+        if (numberOfPairs == 0) {
+            throw SqlException.position(argPositions.getLast()).put("not enough arguments for l2price");
+        }
+        final IntList positions = new IntList();
+        positions.addAll(argPositions);
         switch (numberOfPairs) {
-            case 0:
-                throw SqlException.position(argPositions.getLast()).put("not enough arguments for l2price");
             case 1:
-                return new L2PriceFunction1(new ObjList<>(args), argPositions);
+                return new L2PriceFunction1(new ObjList<>(args), positions);
             case 2:
-                return new L2PriceFunction2(new ObjList<>(args), argPositions);
+                return new L2PriceFunction2(new ObjList<>(args), positions);
             case 3:
-                return new L2PriceFunction3(new ObjList<>(args), argPositions);
+                return new L2PriceFunction3(new ObjList<>(args), positions);
             case 4:
-                return new L2PriceFunction4(new ObjList<>(args), argPositions);
+                return new L2PriceFunction4(new ObjList<>(args), positions);
             case 5:
-                return new L2PriceFunction5(new ObjList<>(args), argPositions);
+                return new L2PriceFunction5(new ObjList<>(args), positions);
             default:
-                return new L2PriceFunctionN(new ObjList<>(args), argPositions);
+                return new L2PriceFunctionN(new ObjList<>(args), positions);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
@@ -57,6 +57,8 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
             return target;
         }
 
+        validateColumnTypes(args, argPositions, true);
+
         final int numberOfPairs = (args.size() - 1) / 2;
         if (numberOfPairs == 0) {
             throw SqlException.position(argPositions.getLast()).put("not enough arguments for l2price");
@@ -79,7 +81,7 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
         }
     }
 
-    private static boolean allowedColumnType(int type) {
+    private static boolean allowedColumnType(int type, boolean allowUndefined) {
         switch (type) {
             case ColumnType.BYTE:
             case ColumnType.SHORT:
@@ -88,14 +90,16 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
             case ColumnType.FLOAT:
             case ColumnType.DOUBLE:
                 return true;
+            case ColumnType.UNDEFINED:
+                return allowUndefined;
             default:
                 return false;
         }
     }
 
-    private static void validateColumnTypes(ObjList<Function> args, IntList argPositions) throws SqlException {
+    private static void validateColumnTypes(ObjList<Function> args, IntList argPositions, boolean allowUndefined) throws SqlException {
         for (int i = 0, n = args.size(); i < n; i++) {
-            if (!allowedColumnType(args.getQuick(i).getType())) {
+            if (!allowedColumnType(args.getQuick(i).getType(), allowUndefined)) {
                 if (!args.getQuick(i).isNullConstant()) {
                     throw SqlException.position(argPositions.getQuick(i))
                             .put("l2price requires arguments of type `DOUBLE`, or convertible to `DOUBLE`, not `")
@@ -128,7 +132,7 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             MultiArgFunction.super.init(symbolTableSource, executionContext);
-            validateColumnTypes(args, argPositions);
+            validateColumnTypes(args, argPositions, false);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
@@ -57,8 +57,6 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
             return target;
         }
 
-        validateColumnTypes(args, argPositions, true);
-
         final int numberOfPairs = (args.size() - 1) / 2;
         if (numberOfPairs == 0) {
             throw SqlException.position(argPositions.getLast()).put("not enough arguments for l2price");
@@ -81,7 +79,7 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
         }
     }
 
-    private static boolean allowedColumnType(int type, boolean allowUndefined) {
+    private static boolean allowedColumnType(int type) {
         switch (type) {
             case ColumnType.BYTE:
             case ColumnType.SHORT:
@@ -90,16 +88,14 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
             case ColumnType.FLOAT:
             case ColumnType.DOUBLE:
                 return true;
-            case ColumnType.UNDEFINED:
-                return allowUndefined;
             default:
                 return false;
         }
     }
 
-    private static void validateColumnTypes(ObjList<Function> args, IntList argPositions, boolean allowUndefined) throws SqlException {
+    private static void validateColumnTypes(ObjList<Function> args, IntList argPositions) throws SqlException {
         for (int i = 0, n = args.size(); i < n; i++) {
-            if (!allowedColumnType(args.getQuick(i).getType(), allowUndefined)) {
+            if (!allowedColumnType(args.getQuick(i).getType())) {
                 if (!args.getQuick(i).isNullConstant()) {
                     throw SqlException.position(argPositions.getQuick(i))
                             .put("l2price requires arguments of type `DOUBLE`, or convertible to `DOUBLE`, not `")
@@ -132,7 +128,7 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             MultiArgFunction.super.init(symbolTableSource, executionContext);
-            validateColumnTypes(args, argPositions, false);
+            validateColumnTypes(args, argPositions);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
@@ -70,7 +70,9 @@ public class ConcatFunctionFactory implements FunctionFactory {
         if (allConst) {
             return new ConstConcatFunction(new ObjList<>(args), argPositions);
         }
-        return new ConcatFunction(new ObjList<>(args), argPositions);
+        final IntList positions = new IntList();
+        positions.addAll(argPositions);
+        return new ConcatFunction(new ObjList<>(args), positions);
     }
 
     private static void populateAdapters(ObjList<TypeAdapter> adapters, ObjList<Function> functions, IntList argPositions) throws SqlException {

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -7988,7 +7988,7 @@ create table tab as (
                     assertResultSet(
                             "QUERY PLAN[VARCHAR]\n" +
                                     "Async Filter workers: 2\n" +
-                                    "  filter: (to_str(ts) in [Wednesday] or to_str(ts) in [$0::" + stringType + ",$1::" + stringType + "])\n" +
+                                    "  filter: to_str(ts) in [$0::string,'Wednesday',$1::string]\n" +
                                     "    DataFrame\n" +
                                     "        Row forward scan\n" +
                                     "        Frame forward scan on: tab\n",
@@ -10323,7 +10323,8 @@ create table tab as (
                             engine,
                             pool,
                             registry,
-                            createPGSqlExecutionContextFactory(workerCount, workerCount, queryStartedCountDownLatch, null, registry))
+                            createPGSqlExecutionContextFactory(workerCount, workerCount, queryStartedCountDownLatch, null, registry)
+                    )
             ) {
                 Assert.assertNotNull(server);
                 int iteration = 0;

--- a/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
@@ -1303,7 +1303,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
                     "from long_sequence(48L)");
 
             assertTimestampTtFailedQuery("Invalid date", "select min(nts), max(nts) from tt where nts > 'invalid'");
-            assertTimestampTtFailedQuery("STRING constant expected", "select min(nts), max(nts) from tt where '2020-01-01' in ( NaN)");
+            assertTimestampTtFailedQuery("cannot compare STRING with type DOUBLE", "select min(nts), max(nts) from tt where '2020-01-01' in ( NaN)");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bool/InStrFunctionFactoryTest.java
@@ -35,7 +35,7 @@ public class InStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Test
     public void testBadConstant() {
-        assertFailure(12, "STRING constant expected", "xv", "an", 10);
+        assertFailure(12, "cannot compare STRING with type INT", "xv", "an", 10);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/LevelTwoPriceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/LevelTwoPriceFunctionFactoryTest.java
@@ -120,31 +120,22 @@ public class LevelTwoPriceFunctionFactoryTest extends AbstractFunctionFactoryTes
                     "limit -1;");
 
             assertFailure(
-                    "[1891] l2price requires arguments of type `DOUBLE`, or convertible to `DOUBLE`, not `STRING`.",
+                    "[869] l2price requires arguments of type `DOUBLE`, or convertible to `DOUBLE`, not `STRING`.",
                     "with recent_trades as\n" +
                             "(\n" +
                             "    select \n" +
                             "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 1 preceding and 1 preceding) as amount1,\n" +
                             "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 2 preceding and 2 preceding) as amount2,\n" +
                             "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 3 preceding and 3 preceding) as amount3,\n" +
-                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 4 preceding and 4 preceding) as amount4,\n" +
-                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 5 preceding and 5 preceding) as amount5,\n" +
-                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as amount6,\n" +
-                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as amount7,\n" +
                             "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 1 preceding and 1 preceding) as price1,\n" +
                             "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 2 preceding and 2 preceding) as price2,\n" +
-                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 3 preceding and 3 preceding) as price3,\n" +
-                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 4 preceding and 4 preceding) as price4,\n" +
-                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 5 preceding and 5 preceding) as price5,\n" +
-                            "     FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as price6,\n" +
-                            "     FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as price7\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 3 preceding and 3 preceding) as price3\n" +
                             "    from btc_trades\n" +
                             "    where side = 'buy'\n" +
                             "    limit -12\n" +
                             ")\n" +
-                            "select l2price(0.0015, amount1, price1, amount2, price2, amount3, price3, \n" +
-                            "amount4, price4, amount5, 'string fail', amount6, price6) from recent_trades\n" +
-                            "limit -1;"
+                            "select l2price(0.0015, amount1, price1, amount2, 'string fail', amount3, price3),\n" +
+                            "l2price(0.0015, amount2, price2) from recent_trades"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/LevelTwoPriceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/LevelTwoPriceFunctionFactoryTest.java
@@ -119,6 +119,33 @@ public class LevelTwoPriceFunctionFactoryTest extends AbstractFunctionFactoryTes
                     "amount4, price4, amount5, price5, amount6, price6) from recent_trades\n" +
                     "limit -1;");
 
+            assertFailure(
+                    "[1891] l2price requires arguments of type `DOUBLE`, or convertible to `DOUBLE`, not `STRING`.",
+                    "with recent_trades as\n" +
+                            "(\n" +
+                            "    select \n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 1 preceding and 1 preceding) as amount1,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 2 preceding and 2 preceding) as amount2,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 3 preceding and 3 preceding) as amount3,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 4 preceding and 4 preceding) as amount4,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 5 preceding and 5 preceding) as amount5,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as amount6,\n" +
+                            "    FIRST_VALUE(amount) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as amount7,\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 1 preceding and 1 preceding) as price1,\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 2 preceding and 2 preceding) as price2,\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 3 preceding and 3 preceding) as price3,\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 4 preceding and 4 preceding) as price4,\n" +
+                            "    FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 5 preceding and 5 preceding) as price5,\n" +
+                            "     FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as price6,\n" +
+                            "     FIRST_VALUE(price) over(partition by symbol order by timestamp rows between 6 preceding and 6 preceding) as price7\n" +
+                            "    from btc_trades\n" +
+                            "    where side = 'buy'\n" +
+                            "    limit -12\n" +
+                            ")\n" +
+                            "select l2price(0.0015, amount1, price1, amount2, price2, amount3, price3, \n" +
+                            "amount4, price4, amount5, 'string fail', amount6, price6) from recent_trades\n" +
+                            "limit -1;"
+            );
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ConcatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ConcatFunctionFactoryTest.java
@@ -147,7 +147,7 @@ public class ConcatFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testCursor() throws Exception {
         assertException(
-                "select concat('hehe', select max(a) from test)",
+                "select concat('hehe', select max(a) from test), concat('hoho', 'haha')",
                 "create table test as (select cast(x as varchar) a, timestamp_sequence(0, 1000000) ts from long_sequence(100))",
                 22,
                 "unsupported type: CURSOR"


### PR DESCRIPTION
Fixes various SQL failures caused by holding onto transient object and int lists, where the lists contain function objects and SQL positions.
When these lists are mutated, the SQL execution fails.
The fix is to create copies of these lists, and keep the reference to the copies instead of the original lists.