### PR TITLE
fix(core): fix potentially corrupt storage of STRING column after data inserting

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -846,7 +846,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             columnType,
                             columnSize,
                             columnTop,
-                            Math.abs(mappedAddress) - columnTop * columnSize,
+                            mappedAddress - columnTop * columnSize,
                             oooColAddress,
                             mappedAddress,
                             mapSize,

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -752,7 +752,7 @@ public final class TableUtils {
                         .$(", error=").utf8(ex.getFlyweightMessage()).I$();
                 Os.pause();
             } else {
-                LOG.error().$("metadata read timeout [timeout=").$(spinLockTimeout).utf8("μs]").$();
+                LOG.error().$("metadata read timeout [timeout=").$(spinLockTimeout).utf8("ms]").$();
                 throw CairoException.critical(ex.getErrno()).put("Metadata read timeout. Last error: ").put(ex.getFlyweightMessage());
             }
         } else {


### PR DESCRIPTION
The bug was found by fuzz testing.

If a STRING column with a column top goes through partition squashing it corrupts the storage and cannot be read back.