### PR TITLE
fix(http): Ensure REST interface consistently returns HTTP 408 on timeouts

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -307,9 +307,14 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             }
             try {
                 doResumeSend(state, context, sqlExecutionContext);
-            } catch (CairoError | CairoException e) {
+            } catch (CairoError e) {
                 internalError(context.getChunkedResponse(), context.getLastRequestBytesSent(), e.getFlyweightMessage(),
                         400, e, state, context.getMetrics()
+                );
+            } catch (CairoException e) {
+                int statusCode = e.isInterruption() && !e.isCancellation() ? 408 : 400;
+                internalError(context.getChunkedResponse(), context.getLastRequestBytesSent(), e.getFlyweightMessage(),
+                        statusCode, e, state, context.getMetrics()
                 );
             }
         }

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -3786,7 +3786,7 @@ public class IODispatcherTest extends AbstractTest {
                         "\\{\"query\":\"select \\* from test_data_unavailable\\(1, 10\\)\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
                         "select * from test_data_unavailable(1, 10)",
                         null, null, null, null,
-                        "400"
+                        "408" // Request Timeout
                 ));
     }
 


### PR DESCRIPTION
Before this change, if a request timed out after execution had started, the REST interface would return HTTP 408 (Request Timeout) as expected. However, if the request timed out before execution began, it would incorrectly return HTTP 400.

This PR corrects this behavior to consistently return HTTP 408 in both scenarios.

Additionally, this PR fixes a flaky test: `testJsonQueryErrorOnDataUnavailableEventNeverFired()`. This test was occasionally failing on the slower Windows CI environments. Specifically, the test expected an HTTP 400 error, but would receive an HTTP 408 when the query timed out before starting.