### PR TITLE
fix(core): 💥 breaking change - enforce fail-fast on NFS

### DIFF
--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -48,6 +48,7 @@ public final class Files {
     public static final int FILES_RENAME_OK = 0;
     public static final int MAP_RO = 1;
     public static final int MAP_RW = 2;
+    public static final int NFS_MAGIC = 0x6969;
     public static final long PAGE_SIZE;
     public static final int POSIX_FADV_RANDOM;
     public static final int POSIX_FADV_SEQUENTIAL;


### PR DESCRIPTION
NFS is known to cause issues. It is better to fail at startup rather than pretending everything is fine, only to inevitably encounter problems later. Although NFS has never been supported, this is the first time we are enforcing this, which could be a breaking change for some users.

When NFS is detected QuestDB startup fails with this error:
```
Error: Unsupported Filesystem Detected.
QuestDB cannot start because the '/tmp/dbroot-fixes' is located on an NFS filesystem, which is not supported. Please relocate your 'db root' to a supported filesystem to continue.
For a list of supported filesystems and further guidance, please visit: https://questdb.io/docs/deployment/capacity-planning/#supported-filesystems [path=/tmp/dbroot-fixes/db, kind=db, fs=NFS]
```

We don't enforce this for `sql copy input` where it's OK. (but it's still enforced for the SQL COPY working dir)