### PR TITLE
feat(sql): add vwma (volume-weighted moving average) function support

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -4001,7 +4001,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 if (qc.isWindowColumn()) {
                     final WindowColumn ac = (WindowColumn) qc;
                     final ExpressionNode ast = qc.getAst();
-                    if (ast.paramCount > 1) {
+                    if (ast.paramCount > 2) {
                         throw SqlException.$(ast.position, "too many arguments");
                     }
 
@@ -4232,7 +4232,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 if (qc.isWindowColumn()) {
                     final WindowColumn ac = (WindowColumn) qc;
                     final ExpressionNode ast = qc.getAst();
-                    if (ast.paramCount > 1) {
+                    if (ast.paramCount > 2) {
                         throw SqlException.$(ast.position, "too many arguments");
                     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/TwoColumnDoubleWindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/TwoColumnDoubleWindowFunction.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+ package io.questdb.griffin.engine.functions.window;
+
+ import io.questdb.cairo.ArrayColumnTypes;
+ import io.questdb.cairo.sql.Function;
+ import io.questdb.cairo.sql.Record;
+ import io.questdb.cairo.sql.ScalarFunction;
+ import io.questdb.cairo.sql.SymbolTableSource;
+ import io.questdb.griffin.PlanSink;
+ import io.questdb.griffin.SqlException;
+ import io.questdb.griffin.SqlExecutionContext;
+ import io.questdb.griffin.engine.functions.DoubleFunction;
+ import io.questdb.griffin.engine.orderby.RecordComparatorCompiler;
+ import io.questdb.griffin.engine.window.WindowFunction;
+ import io.questdb.std.IntList;
+ 
+ public abstract class TwoColumnDoubleWindowFunction extends DoubleFunction implements WindowFunction, ScalarFunction {
+     protected final Function arg1;
+     protected final Function arg2;
+     protected int columnIndex;
+ 
+     public TwoColumnDoubleWindowFunction(Function arg1, Function arg2) {
+         this.arg1 = arg1;
+         this.arg2 = arg2;
+     }
+ 
+     @Override
+     public void close() {
+         arg1.close();
+         arg2.close();
+     }
+ 
+     @Override
+     public double getDouble(Record rec) {
+         //unused
+         throw new UnsupportedOperationException();
+     }
+ 
+     @Override
+     public abstract String getName();
+ 
+     @Override
+     public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+         super.init(symbolTableSource, executionContext);
+         arg1.init(symbolTableSource, executionContext);
+         arg2.init(symbolTableSource, executionContext);
+     }
+ 
+     @Override
+     public void initRecordComparator(RecordComparatorCompiler recordComparatorCompiler, ArrayColumnTypes chainTypes, IntList order) {
+     }
+ 
+     @Override
+     public void reset() {
+ 
+     }
+ 
+     @Override
+     public void setColumnIndex(int columnIndex) {
+         this.columnIndex = columnIndex;
+     }
+ 
+     @Override
+     public void toPlan(PlanSink sink) {
+         sink.val(getName());
+         sink.val('(').val(arg1).val(')');
+         sink.val('(').val(arg2).val(')');
+         sink.val(" over ()");
+     }
+ 
+     @Override
+     public void toTop() {
+         arg1.toTop();
+         arg2.toTop();
+     }
+ }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/TwoColumnPartitionedDoubleWindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/TwoColumnPartitionedDoubleWindowFunction.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+ package io.questdb.griffin.engine.functions.window;
+
+ import io.questdb.cairo.RecordSink;
+ import io.questdb.cairo.Reopenable;
+ import io.questdb.cairo.map.Map;
+ import io.questdb.cairo.sql.Function;
+ import io.questdb.cairo.sql.SymbolTableSource;
+ import io.questdb.cairo.sql.VirtualRecord;
+ import io.questdb.griffin.PlanSink;
+ import io.questdb.griffin.SqlException;
+ import io.questdb.griffin.SqlExecutionContext;
+ import io.questdb.std.Misc;
+ 
+ abstract class TwoColumnPartitionedDoubleWindowFunction extends TwoColumnDoubleWindowFunction implements Reopenable {
+     protected final Map map;
+     protected final VirtualRecord partitionByRecord;
+     protected final RecordSink partitionBySink;
+ 
+     public TwoColumnPartitionedDoubleWindowFunction(Map map, VirtualRecord partitionByRecord, RecordSink partitionBySink, Function arg1, Function arg2) {
+         super(arg1, arg2);
+         this.map = map;
+         this.partitionByRecord = partitionByRecord;
+         this.partitionBySink = partitionBySink;
+     }
+ 
+     @Override
+     public void close() {
+         super.close();
+         map.close();
+         Misc.freeObjList(partitionByRecord.getFunctions());
+     }
+ 
+     @Override
+     public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+         super.init(symbolTableSource, executionContext);
+         Function.init(partitionByRecord.getFunctions(), symbolTableSource, executionContext);
+     }
+ 
+     @Override
+     public void reopen() {
+         map.reopen();
+     }
+ 
+     @Override
+     public void reset() {
+         map.close();
+     }
+ 
+     @Override
+     public void toPlan(PlanSink sink) {
+         sink.val(getName());
+         sink.val('(').val(arg1).val(')');
+         sink.val('(').val(arg2).val(')');
+         sink.val(" over (");
+         sink.val("partition by ");
+         sink.val(partitionByRecord.getFunctions());
+         sink.val(')');
+     }
+ 
+     @Override
+     public void toTop() {
+         super.toTop();
+         map.clear();
+     }
+ }
+ 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
@@ -3,6 +3,7 @@ package io.questdb.griffin.engine.functions.window;
 import org.jetbrains.annotations.NotNull;
 
 import io.questdb.cairo.*;
+import io.questdb.cairo.map.*;
 import io.questdb.cairo.sql.*;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.sql.Record;
@@ -18,6 +19,8 @@ import io.questdb.std.*;
 
 public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
 
+    public static final ArrayColumnTypes VWMA_COLUMN_TYPES;
+    public static final ArrayColumnTypes VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES;
     private static final String NAME = "vwma";
 
     @Override
@@ -59,35 +62,485 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
             }
         }
 
+        int exclusionKind = windowContext.getExclusionKind();
+        int exclusionKindPos = windowContext.getExclusionKindPos();
+        if (exclusionKind != WindowColumn.EXCLUDE_NO_OTHERS
+                && exclusionKind != WindowColumn.EXCLUDE_CURRENT_ROW) {
+            throw SqlException.$(exclusionKindPos, "only EXCLUDE NO OTHERS and EXCLUDE CURRENT ROW exclusion modes are supported");
+        }
+
+        if (exclusionKind == WindowColumn.EXCLUDE_CURRENT_ROW) {
+            // assumes frame doesn't use 'following'
+            if (rowsHi == Long.MAX_VALUE) {
+                throw SqlException.$(exclusionKindPos, "EXCLUDE CURRENT ROW not supported with UNBOUNDED FOLLOWING frame boundary");
+            }
+
+            if (rowsHi == 0) {
+                rowsHi = -1;
+            }
+            if (rowsHi < rowsLo) {
+                throw SqlException.$(exclusionKindPos, "end of window is higher than start of window due to exclusion mode");
+            }
+        }
+
         int framingMode = windowContext.getFramingMode();
         if (framingMode == WindowColumn.FRAMING_GROUPS) {
             throw SqlException.$(position, "function not implemented for given window parameters");
         }
 
-        // between unbounded preceding and current row
-        if (rowsLo == Long.MIN_VALUE && rowsHi == 0) {
-            return new VwmaOverUnboundedRowsFrameFunction(args.get(0), args.get(1));
-        } // between current row and current row
-        else if (rowsLo == 0 && rowsLo == rowsHi) {
-            return new VwmaOverCurrentRowFunction(args.get(0), args.get(1));
-        } // whole result set
-        else if (rowsLo == Long.MIN_VALUE && rowsHi == Long.MAX_VALUE) {
-            return new VwmaOverWholeResultSetFunction(args.get(0), args.get(1));
-        } // between [unbounded | x] preceding and [x preceding | current row]
-        else {
-            MemoryARW mem = Vm.getARWInstance(
-                    configuration.getSqlWindowStorePageSize(),
-                    configuration.getSqlWindowStoreMaxPages(),
-                    MemoryTag.NATIVE_CIRCULAR_BUFFER
-            );
-            return new VwmaOverRowsFrameFunction(
-                    args.get(0),
-                    args.get(1),
-                    rowsLo,
-                    rowsHi,
-                    mem
-            );
-        }        
+        RecordSink partitionBySink = windowContext.getPartitionBySink();
+        ColumnTypes partitionByKeyTypes = windowContext.getPartitionByKeyTypes();
+        VirtualRecord partitionByRecord = windowContext.getPartitionByRecord();
+
+        if (partitionByRecord != null) {
+            
+            if (framingMode == WindowColumn.FRAMING_ROWS) {
+            // between unbounded preceding and current row
+                if (rowsLo == Long.MIN_VALUE && rowsHi == 0) {
+                    Map map = MapFactory.createOrderedMap(
+                            configuration,
+                            partitionByKeyTypes,
+                            VWMA_COLUMN_TYPES
+                    );
+
+                    return new VwmaOverUnboundedPartitionRowsFrameFunction(
+                            map,
+                            partitionByRecord,
+                            partitionBySink,
+                            args.get(0),
+                            args.get(1)
+                    );
+                } // between current row and current row
+                else if (rowsLo == 0 && rowsLo == rowsHi) {
+                    return new VwmaOverCurrentRowFunction(args.get(0), args.get(1));
+                } // whole partition
+                else if (rowsLo == Long.MIN_VALUE && rowsHi == Long.MAX_VALUE) {
+                    Map map = MapFactory.createOrderedMap(
+                            configuration,
+                            partitionByKeyTypes,
+                            VWMA_COLUMN_TYPES
+                    );
+
+                    return new VwmaOverPartitionFunction(
+                            map,
+                            partitionByRecord,
+                            partitionBySink,
+                            args.get(0),
+                            args.get(1)
+                    );
+                }
+                //between [unbounded | x] preceding and [x preceding | current row]
+                else {
+                    ArrayColumnTypes columnTypes = new ArrayColumnTypes();
+                    columnTypes.add(ColumnType.DOUBLE); // sum
+                    columnTypes.add(ColumnType.LONG); // current frame size
+                    columnTypes.add(ColumnType.LONG); // position of current oldest element
+                    columnTypes.add(ColumnType.LONG); // start offset of native array
+
+                    Map map = null;
+                    MemoryARW mem = null;
+                    try {
+                        map = MapFactory.createOrderedMap(
+                                configuration,
+                                partitionByKeyTypes,
+                                VWMA_COLUMN_TYPES
+                        );
+                        mem = Vm.getARWInstance(
+                                configuration.getSqlWindowStorePageSize(),
+                                configuration.getSqlWindowStoreMaxPages(),
+                                MemoryTag.NATIVE_CIRCULAR_BUFFER
+                        );
+
+                        // moving average over preceding N rows
+                        return new VwmaOverPartitionRowsFrameFunction(
+                                map,
+                                partitionByRecord,
+                                partitionBySink,
+                                rowsLo,
+                                rowsHi,
+                                args.get(0),
+                                args.get(1),
+                                mem
+                        );
+                    } catch (Throwable th) {
+                        Misc.free(map);
+                        Misc.free(mem);
+                        throw th;
+                    }
+                }
+            }
+        }
+        else{
+            // between unbounded preceding and current row
+
+            if (rowsLo == Long.MIN_VALUE && rowsHi == 0) {
+                return new VwmaOverUnboundedRowsFrameFunction(args.get(0), args.get(1));
+            } // between current row and current row
+            else if (rowsLo == 0 && rowsLo == rowsHi) {
+                return new VwmaOverCurrentRowFunction(args.get(0), args.get(1));
+            } // whole result set
+            else if (rowsLo == Long.MIN_VALUE && rowsHi == Long.MAX_VALUE) {
+                return new VwmaOverWholeResultSetFunction(args.get(0), args.get(1));
+            } // between [unbounded | x] preceding and [x preceding | current row]
+            else {
+                MemoryARW mem = Vm.getARWInstance(
+                        configuration.getSqlWindowStorePageSize(),
+                        configuration.getSqlWindowStoreMaxPages(),
+                        MemoryTag.NATIVE_CIRCULAR_BUFFER
+                );
+                return new VwmaOverRowsFrameFunction(
+                        args.get(0),
+                        args.get(1),
+                        rowsLo,
+                        rowsHi,
+                        mem
+                );
+            }        
+        }
+        throw SqlException.$(position, "function not implemented for given window parameters");
+    }
+
+    // Handles:
+    // - vwma(a) over (partition by x rows between unbounded preceding and current row)
+    // - vwma(a) over (partition by x order by ts range between unbounded preceding and current row)
+    // Doesn't require value buffering.
+    static class VwmaOverUnboundedPartitionRowsFrameFunction extends TwoColumnPartitionedDoubleWindowFunction {
+        private double vwma;
+
+        public VwmaOverUnboundedPartitionRowsFrameFunction(Map map, VirtualRecord partitionByRecord, RecordSink partitionBySink, Function arg1, Function arg2) {
+            super(map, partitionByRecord, partitionBySink, arg1, arg2);
+        }
+
+        @Override
+        public void computeNext(Record record) {
+            partitionByRecord.of(record);
+            MapKey key = map.withKey();
+            key.put(partitionByRecord, partitionBySink);
+            MapValue value = key.createValue();
+
+            double notional;
+            double volumeSum;
+
+            if (value.isNew()) {
+                notional = 0;
+                volumeSum = 0;
+            } else {
+                notional = value.getDouble(0);
+                volumeSum = value.getDouble(1);
+            }
+
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);
+
+            if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0) {
+                notional += price * volume;
+                volumeSum += volume;
+
+                value.putDouble(0, notional);
+                value.putDouble(1, volumeSum);
+            }
+
+            vwma = volumeSum != 0 ? notional / volumeSum : Double.NaN;
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            return vwma;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.ZERO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            computeNext(record);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(NAME);
+            sink.val('(').val(arg1).val(')');
+            sink.val('(').val(arg2).val(')');
+            sink.val(" over (");
+            sink.val("partition by ");
+            sink.val(partitionByRecord.getFunctions());
+            sink.val(" rows between unbounded preceding and current row )");
+        }
+    }
+
+    // handles vwma() over (partition by x)
+    // order by is absent so default frame mode includes all rows in partition
+    static class VwmaOverPartitionFunction extends TwoColumnPartitionedDoubleWindowFunction {
+
+        public VwmaOverPartitionFunction(Map map, VirtualRecord partitionByRecord, RecordSink partitionBySink, Function arg1, Function arg2) {
+            super(map, partitionByRecord, partitionBySink, arg1, arg2);
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.TWO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);
+
+            if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0) {
+                partitionByRecord.of(record);
+                MapKey key = map.withKey();
+                key.put(partitionByRecord, partitionBySink);
+                MapValue value = key.createValue();
+
+                double volumeSum;
+                double notional;
+
+                if (value.isNew()) {
+                    volumeSum = volume;
+                    notional = price * volume;
+                } else {
+                    volumeSum = value.getDouble(1) + volume;
+                    notional = value.getDouble(0) + price * volume;
+                }
+                value.putDouble(0, notional);
+                value.putDouble(1, volumeSum);
+            }
+        }
+
+        @Override
+        public void pass2(Record record, long recordOffset, WindowSPI spi) {
+            partitionByRecord.of(record);
+            MapKey key = map.withKey();
+            key.put(partitionByRecord, partitionBySink);
+            MapValue value = key.findValue();
+
+            double val = value != null ? value.getDouble(0) : Double.NaN;
+
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), val);
+        }
+
+        @Override
+        public void preparePass2() {
+            RecordCursor cursor = map.getCursor();
+            MapRecord record = map.getRecord();
+            while (cursor.hasNext()) {
+                MapValue value = record.getValue();
+                double volumeSum = value.getDouble(1);
+                if (volumeSum > 0) {
+                    double notional = value.getDouble(0);
+                    value.putDouble(0, notional / volumeSum);
+                }
+            }
+        }
+    }
+
+    // handles vwma() over (partition by x [order by o] rows between y and z)
+    // removable cumulative aggregation
+    static class VwmaOverPartitionRowsFrameFunction extends TwoColumnPartitionedDoubleWindowFunction {
+
+        //number of values we need to keep to compute over frame
+        // (can be bigger than frame because we've to buffer values between rowsHi and current row )
+        private final int bufferSize;
+
+        private final boolean frameIncludesCurrentValue;
+        private final boolean frameLoBounded;
+        private final int frameSize;
+        // holds fixed-size ring buffers of double values
+        private final MemoryARW memory;
+        private double vwma;
+        private double notional;
+        private double volumeSum;
+
+
+        public VwmaOverPartitionRowsFrameFunction(
+                Map map,
+                VirtualRecord partitionByRecord,
+                RecordSink partitionBySink,
+                long rowsLo,
+                long rowsHi,
+                Function arg1,
+                Function arg2,
+                MemoryARW memory
+        ) {
+            super(map, partitionByRecord, partitionBySink, arg1, arg2);
+
+            if (rowsLo > Long.MIN_VALUE) {
+                frameSize = (int) (rowsHi - rowsLo + (rowsHi < 0 ? 1 : 0));
+                bufferSize = (int) Math.abs(rowsLo);
+                frameLoBounded = true;
+            } else {
+                frameSize = 1;
+                bufferSize = (int) Math.abs(rowsHi);
+                frameLoBounded = false;
+            }
+            frameIncludesCurrentValue = rowsHi == 0;
+
+            this.memory = memory;
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            memory.close();
+        }
+
+        @Override
+        public void computeNext(Record record) {
+            // map stores:
+            // 0 - sum, never store NaN in it
+            // 1 - current number of non-null rows in frame
+            // 2 - (0-based) index of oldest value [0, bufferSize]
+            // 3 - native array start offset (relative to memory address)
+            // we keep nulls in window and reject them when computing vwma
+
+            partitionByRecord.of(record);
+            MapKey key = map.withKey();
+            key.put(partitionByRecord, partitionBySink);
+            MapValue value = key.createValue();
+
+            long loIdx;//current index of lo frame value ('oldest')
+            long startOffset;
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);
+
+            if (value.isNew()) {
+
+                loIdx = 0;
+                startOffset = memory.appendAddressFor((long) bufferSize * Double.BYTES) - memory.getPageAddress(0);
+                if (frameIncludesCurrentValue && Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0) {
+                    notional = price * volume;
+                    volumeSum = volume;
+                    vwma = price;
+                } else {
+                    notional = 0.0;
+                    vwma = Double.NaN;
+                    volumeSum = 0.0;
+                }
+
+                for (int i = 0; i < bufferSize; i++) {
+                    memory.putDouble(startOffset + (long) i * Double.BYTES, Double.NaN);
+                }
+            } else {
+                notional = value.getDouble(0);
+                volumeSum = value.getDouble(1);
+                loIdx = value.getLong(2);
+                startOffset = value.getLong(3);
+
+                //compute value using top frame element (that could be current or previous row)
+                double hiValuePrice = frameIncludesCurrentValue ? price : memory.getDouble(startOffset + ((loIdx + frameSize - 1) % bufferSize) * Double.BYTES);
+                double hiValueVolume = frameIncludesCurrentValue ? volume : memory.getDouble(startOffset + ((loIdx + frameSize - 1) % bufferSize) * Double.BYTES);
+
+                if (Numbers.isFinite(hiValuePrice) && Numbers.isFinite(hiValueVolume) && hiValueVolume > 0.0) {
+                    volumeSum += hiValueVolume;
+                    notional += hiValuePrice * hiValueVolume;
+                }
+
+                //here sum is correct for current row
+                if (volumeSum != 0) {
+                    vwma = notional / volumeSum;
+                } else {
+                    vwma = Double.NaN;
+                }
+
+
+                if (frameLoBounded) {
+                    //remove the oldest element
+                    double loValuePrice = memory.getDouble(startOffset + loIdx * Double.BYTES);
+                    double loValueVolume = memory.getDouble(startOffset + (loIdx + 1) * Double.BYTES);
+
+                    if (Numbers.isFinite(loValuePrice) && Numbers.isFinite(loValueVolume) && loValueVolume > 0.0){
+                        notional -= (loValuePrice * loValueVolume);
+                        volumeSum -= loValueVolume;
+                    }
+                }
+            }
+
+            value.putDouble(0, notional);
+            value.putDouble(1, volumeSum);
+            value.putLong(2, (loIdx + 1) % bufferSize);
+            value.putLong(3, startOffset);//not necessary because it doesn't change
+            memory.putDouble(startOffset + loIdx * Double.BYTES, price);
+            memory.putDouble(startOffset + (loIdx + 1) * Double.BYTES, volume);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            return vwma;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.ZERO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            computeNext(record);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
+        }
+
+        @Override
+        public void reopen() {
+            super.reopen();
+            // memory will allocate on first use
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            vwma = Double.NaN;
+            notional = 0.0;
+            volumeSum = 0.0;
+            memory.close();
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(getName());
+            sink.val('(').val(arg1).val(')');
+            sink.val('(').val(arg2).val(')');
+            sink.val(" over (");
+            sink.val("partition by ");
+            sink.val(partitionByRecord.getFunctions());
+
+            sink.val(" rows between ");
+            if (frameLoBounded) {
+                sink.val(bufferSize);
+            } else {
+                sink.val("unbounded");
+            }
+            sink.val(" preceding and ");
+            if (frameIncludesCurrentValue) {
+                sink.val("current row");
+            } else {
+                sink.val(bufferSize - frameSize).val(" preceding");
+            }
+            sink.val(')');
+        }
+
+        @Override
+        public void toTop() {
+            super.toTop();
+            memory.truncate();
+        }
     }
 
     // Handles vwma() over (rows between unbounded preceding and current row); there's no partition by.
@@ -351,6 +804,7 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
                     volumeSum -= loValueVolume;
 
                     count--;
+                                        
                 }
             }
 
@@ -392,6 +846,7 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
             count = 0;
             loIdx = 0;
             notional = 0.0;
+            volumeSum = 0.0;
         }
 
         @Override
@@ -422,6 +877,7 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
             count = 0;
             loIdx = 0;
             notional = 0.0;
+            volumeSum = 0.0;
             initBuffer();
         }
 
@@ -430,5 +886,17 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
                 buffer.putDouble((long) i * Double.BYTES, Double.NaN);
             }
         }
+    }
+    
+    static {
+        VWMA_COLUMN_TYPES = new ArrayColumnTypes();
+        VWMA_COLUMN_TYPES.add(ColumnType.DOUBLE);
+        VWMA_COLUMN_TYPES.add(ColumnType.LONG);
+
+        VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES = new ArrayColumnTypes();
+        VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES.add(ColumnType.DOUBLE);// sum
+        VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES.add(ColumnType.LONG);// current frame size
+        VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES.add(ColumnType.LONG);// position of current oldest element
+        VWMA_OVER_PARTITION_ROWS_COLUMN_TYPES.add(ColumnType.LONG);// start offset of native array
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
@@ -4,14 +4,13 @@ import org.jetbrains.annotations.NotNull;
 
 import io.questdb.cairo.*;
 import io.questdb.cairo.sql.*;
-import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.vm.api.MemoryARW;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory.AvgOverCurrentRowFunction;
 import io.questdb.griffin.engine.window.WindowContext;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.model.WindowColumn;
@@ -67,13 +66,13 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
 
         // between unbounded preceding and current row
         if (rowsLo == Long.MIN_VALUE && rowsHi == 0) {
-            return new AvgOverUnboundedRowsFrameFunction(args.get(0));
+            return new VwmaOverUnboundedRowsFrameFunction(args.get(0), args.get(1));
         } // between current row and current row
         else if (rowsLo == 0 && rowsLo == rowsHi) {
-            return new AvgOverCurrentRowFunction(args.get(0));
+            return new VwmaOverCurrentRowFunction(args.get(0), args.get(1));
         } // whole result set
         else if (rowsLo == Long.MIN_VALUE && rowsHi == Long.MAX_VALUE) {
-            return new AvgOverWholeResultSetFunction(args.get(0));
+            return new VwmaOverWholeResultSetFunction(args.get(0), args.get(1));
         } // between [unbounded | x] preceding and [x preceding | current row]
         else {
             MemoryARW mem = Vm.getARWInstance(
@@ -91,31 +90,34 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
         }        
     }
 
-    // Handles avg() over (rows between unbounded preceding and current row); there's no partition by.
-    static class AvgOverUnboundedRowsFrameFunction extends BaseDoubleWindowFunction {
+    // Handles vwma() over (rows between unbounded preceding and current row); there's no partition by.
+    static class VwmaOverUnboundedRowsFrameFunction extends TwoColumnDoubleWindowFunction {
 
-        private double avg;
+        private double vwma = 0;
         private long count = 0;
-        private double sum = 0.0;
+        private double volumeSum = 0.0;
+        private double notional = 0.0;
 
-        public AvgOverUnboundedRowsFrameFunction(Function arg) {
-            super(arg);
+        public VwmaOverUnboundedRowsFrameFunction(Function arg1, Function arg2) {
+            super(arg1, arg2);
         }
 
         @Override
         public void computeNext(Record record) {
-            double d = arg.getDouble(record);
-            if (Numbers.isFinite(d)) {
-                sum += d;
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);            
+            if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0) {
+                notional += price * volume;
+                volumeSum += volume;
                 count++;
             }
 
-            avg = count != 0 ? sum / count : Double.NaN;
+            vwma = count != 0 ? notional / volumeSum : Double.NaN;
         }
 
         @Override
         public double getDouble(Record rec) {
-            return avg;
+            return vwma;
         }
 
         @Override
@@ -132,42 +134,45 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
             computeNext(record);
 
-            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), avg);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
         }
 
         @Override
         public void reset() {
             super.reset();
-            avg = Double.NaN;
+            vwma = Double.NaN;
             count = 0;
-            sum = 0.0;
+            notional = 0.0;
+            volumeSum = 0.0;
         }
 
         @Override
         public void toPlan(PlanSink sink) {
             sink.val(NAME);
-            sink.val('(').val(arg).val(')');
+            sink.val('(').val(arg1).val(')');
+            sink.val('(').val(arg2).val(')');
             sink.val(" over (rows between unbounded preceding and current row)");
         }
 
         @Override
         public void toTop() {
             super.toTop();
-
-            avg = Double.NaN;
+            vwma = Double.NaN;
             count = 0;
-            sum = 0.0;
+            volumeSum = 0.0;
+            notional = 0.0;
         }
-    }
+    }    
 
-    // avg() over () - empty clause, no partition by no order by, no frame == default frame
-    static class AvgOverWholeResultSetFunction extends BaseDoubleWindowFunction {
-        private double avg;
-        private long count;
-        private double sum;
+    // vwma() over () - empty clause, no partition by no order by, no frame == default frame
+    static class VwmaOverWholeResultSetFunction extends TwoColumnDoubleWindowFunction {
+        private double vwma = 0;
+        private long count = 0;
+        private double volumeSum = 0.0;
+        private double notional = 0.0;
 
-        public AvgOverWholeResultSetFunction(Function arg) {
-            super(arg);
+        public VwmaOverWholeResultSetFunction(Function arg1, Function arg2) {
+            super(arg1, arg2);
         }
 
         @Override
@@ -182,40 +187,83 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            double d = arg.getDouble(record);
-            if (Numbers.isFinite(d)) {
-                sum += d;
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);
+
+            if (Numbers.isFinite(price) && Numbers.isFinite(volume) && volume > 0.0) {
+                volumeSum += volume;
+                notional += price * volume;
                 count++;
             }
         }
 
         @Override
         public void pass2(Record record, long recordOffset, WindowSPI spi) {
-            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), avg);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
         }
 
         @Override
         public void preparePass2() {
-            avg = count > 0 ? sum / count : Double.NaN;
+            vwma = count > 0 ? notional / volumeSum : Double.NaN;
         }
 
         @Override
         public void reset() {
             super.reset();
-            avg = Double.NaN;
+            vwma = Double.NaN;
             count = 0;
-            sum = 0.0;
+            notional = 0.0;
+            volumeSum = 0.0;
         }
 
         @Override
         public void toTop() {
             super.toTop();
-
-            avg = Double.NaN;
+            vwma = Double.NaN;
             count = 0;
-            sum = 0.0;
+            notional = 0.0;
+            volumeSum = 0.0;
         }
-    } 
+
+    }
+
+
+    // (rows between current row and current row) processes 1-element-big set, so simply it returns expression value
+    static class VwmaOverCurrentRowFunction extends TwoColumnDoubleWindowFunction {
+
+        private double vwma = 0;
+
+        VwmaOverCurrentRowFunction(Function arg1, Function arg2) {
+            super(arg1, arg2);
+        }
+
+        @Override
+        public void computeNext(Record record) {
+            vwma = arg1.getDouble(record) / arg2.getDouble(record);
+
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            return vwma;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return ZERO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            computeNext(record);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
+        }
+    }
     
     static class VwmaOverRowsFrameFunction extends TwoColumnDoubleWindowFunction implements Reopenable {
         private final MemoryARW buffer;
@@ -233,7 +281,7 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
         public VwmaOverRowsFrameFunction(@NotNull Function arg0, @NotNull Function arg1, long rowsLo, long rowsHi, MemoryARW memory) {
             super(arg0, arg1);
             
-            assert rowsLo != Long.MIN_VALUE || rowsHi != 0; // use AvgOverUnboundedRowsFrameFunction in case of (Long.MIN_VALUE, 0) range
+            assert rowsLo != Long.MIN_VALUE || rowsHi != 0; // use VwmaOverUnboundedRowsFrameFunction in case of (Long.MIN_VALUE, 0) range
             if (rowsLo > Long.MIN_VALUE) {
                 frameSize = (int) (rowsHi - rowsLo + (rowsHi < 0 ? 1 : 0));
                 bufferSize = (int) Math.abs(rowsLo);//number of values we need to keep to compute over frame
@@ -266,9 +314,6 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
             double price = arg1.getDouble(record);
             double volume = arg2.getDouble(record);
 
-            System.out.println("PRICE "+ price);
-            System.out.println("VOLUME "+ volume);
-
             //compute value using top frame element (that could be current or previous row)
             double hiValuePrice = price;
             double hiValueVolume = volume;
@@ -282,17 +327,11 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
                 hiValueVolume = buffer.getDouble((long) (loIdx % bufferSize) * Double.BYTES);
             }
 
-            System.out.println("HI VALUE PRICE "+ hiValuePrice);
-            System.out.println("HI VALUE VOLUME "+ hiValueVolume);
-
             if (Numbers.isFinite(hiValueVolume) && Numbers.isFinite(hiValuePrice) && hiValueVolume > 0.0d) {
                 volumeSum += hiValueVolume;
                 notional += hiValuePrice * hiValueVolume;
                 count++;
             }
-
-            System.out.println("VOLUME SUM "+ volumeSum);
-            System.out.println("NOTIONAL "+ notional);
 
             if (count != 0) {
                 vwma = notional / volumeSum;
@@ -310,9 +349,6 @@ public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
                 if (Numbers.isFinite(loValueVolume) && Numbers.isFinite(loValuePrice) && loValueVolume > 0) {
                     notional -= loValueVolume * loValuePrice;
                     volumeSum -= loValueVolume;
-
-                    System.out.println("NOTIONAL POST REMOVE "+ notional);
-                    System.out.println("VOLUMESUM POST REMOVE "+ volumeSum);
 
                     count--;
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/VwmaDoubleWindowFunctionFactory.java
@@ -1,0 +1,398 @@
+package io.questdb.griffin.engine.functions.window;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.vm.api.MemoryARW;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory.AvgOverCurrentRowFunction;
+import io.questdb.griffin.engine.window.WindowContext;
+import io.questdb.griffin.engine.window.WindowFunction;
+import io.questdb.griffin.model.WindowColumn;
+import io.questdb.std.*;
+
+public class VwmaDoubleWindowFunctionFactory implements FunctionFactory {
+
+    private static final String NAME = "vwma";
+
+    @Override
+    public String getSignature() {
+        return NAME + "(DD)";
+    }
+
+    @Override
+    public boolean isWindow() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        final WindowContext windowContext = sqlExecutionContext.getWindowContext();
+        if (windowContext.isEmpty()) {
+            throw SqlException.emptyWindowContext(position);
+        }
+
+        long rowsLo = windowContext.getRowsLo();
+        long rowsHi = windowContext.getRowsHi();
+
+        if (!windowContext.isDefaultFrame()) {
+            if (rowsLo > 0) {
+                throw SqlException.$(windowContext.getRowsLoKindPos(), "frame start supports UNBOUNDED PRECEDING, _number_ PRECEDING and CURRENT ROW only");
+            }
+            if (rowsHi > 0) {
+                if (rowsHi != Long.MAX_VALUE) {
+                    throw SqlException.$(windowContext.getRowsHiKindPos(), "frame end supports _number_ PRECEDING and CURRENT ROW only");
+                } else if (rowsLo != Long.MIN_VALUE) {
+                    throw SqlException.$(windowContext.getRowsHiKindPos(), "frame end supports UNBOUNDED FOLLOWING only when frame start is UNBOUNDED PRECEDING");
+                }
+            }
+        }
+
+        int framingMode = windowContext.getFramingMode();
+        if (framingMode == WindowColumn.FRAMING_GROUPS) {
+            throw SqlException.$(position, "function not implemented for given window parameters");
+        }
+
+        // between unbounded preceding and current row
+        if (rowsLo == Long.MIN_VALUE && rowsHi == 0) {
+            return new AvgOverUnboundedRowsFrameFunction(args.get(0));
+        } // between current row and current row
+        else if (rowsLo == 0 && rowsLo == rowsHi) {
+            return new AvgOverCurrentRowFunction(args.get(0));
+        } // whole result set
+        else if (rowsLo == Long.MIN_VALUE && rowsHi == Long.MAX_VALUE) {
+            return new AvgOverWholeResultSetFunction(args.get(0));
+        } // between [unbounded | x] preceding and [x preceding | current row]
+        else {
+            MemoryARW mem = Vm.getARWInstance(
+                    configuration.getSqlWindowStorePageSize(),
+                    configuration.getSqlWindowStoreMaxPages(),
+                    MemoryTag.NATIVE_CIRCULAR_BUFFER
+            );
+            return new VwmaOverRowsFrameFunction(
+                    args.get(0),
+                    args.get(1),
+                    rowsLo,
+                    rowsHi,
+                    mem
+            );
+        }        
+    }
+
+    // Handles avg() over (rows between unbounded preceding and current row); there's no partition by.
+    static class AvgOverUnboundedRowsFrameFunction extends BaseDoubleWindowFunction {
+
+        private double avg;
+        private long count = 0;
+        private double sum = 0.0;
+
+        public AvgOverUnboundedRowsFrameFunction(Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public void computeNext(Record record) {
+            double d = arg.getDouble(record);
+            if (Numbers.isFinite(d)) {
+                sum += d;
+                count++;
+            }
+
+            avg = count != 0 ? sum / count : Double.NaN;
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            return avg;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.ZERO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            computeNext(record);
+
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), avg);
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            avg = Double.NaN;
+            count = 0;
+            sum = 0.0;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(NAME);
+            sink.val('(').val(arg).val(')');
+            sink.val(" over (rows between unbounded preceding and current row)");
+        }
+
+        @Override
+        public void toTop() {
+            super.toTop();
+
+            avg = Double.NaN;
+            count = 0;
+            sum = 0.0;
+        }
+    }
+
+    // avg() over () - empty clause, no partition by no order by, no frame == default frame
+    static class AvgOverWholeResultSetFunction extends BaseDoubleWindowFunction {
+        private double avg;
+        private long count;
+        private double sum;
+
+        public AvgOverWholeResultSetFunction(Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.TWO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            double d = arg.getDouble(record);
+            if (Numbers.isFinite(d)) {
+                sum += d;
+                count++;
+            }
+        }
+
+        @Override
+        public void pass2(Record record, long recordOffset, WindowSPI spi) {
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), avg);
+        }
+
+        @Override
+        public void preparePass2() {
+            avg = count > 0 ? sum / count : Double.NaN;
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            avg = Double.NaN;
+            count = 0;
+            sum = 0.0;
+        }
+
+        @Override
+        public void toTop() {
+            super.toTop();
+
+            avg = Double.NaN;
+            count = 0;
+            sum = 0.0;
+        }
+    } 
+    
+    static class VwmaOverRowsFrameFunction extends TwoColumnDoubleWindowFunction implements Reopenable {
+        private final MemoryARW buffer;
+        private final int bufferSize;
+        private final boolean frameIncludesCurrentValue;
+        private final boolean frameLoBounded;
+        private final int frameSize;
+        protected double externalNotional = 0;
+        private double vwma = 0;
+        private long count = 0;
+        private int loIdx = 0;
+        private double volumeSum = 0.0;
+        private double notional = 0.0;
+
+        public VwmaOverRowsFrameFunction(@NotNull Function arg0, @NotNull Function arg1, long rowsLo, long rowsHi, MemoryARW memory) {
+            super(arg0, arg1);
+            
+            assert rowsLo != Long.MIN_VALUE || rowsHi != 0; // use AvgOverUnboundedRowsFrameFunction in case of (Long.MIN_VALUE, 0) range
+            if (rowsLo > Long.MIN_VALUE) {
+                frameSize = (int) (rowsHi - rowsLo + (rowsHi < 0 ? 1 : 0));
+                bufferSize = (int) Math.abs(rowsLo);//number of values we need to keep to compute over frame
+                frameLoBounded = true;
+            } else {
+                frameSize = (int) Math.abs(rowsHi);
+                bufferSize = frameSize;
+                frameLoBounded = false;
+            }
+
+            frameIncludesCurrentValue = rowsHi == 0;
+            this.buffer = memory;
+            try {
+                initBuffer();
+            } catch (Throwable t) {
+                close();
+                throw t;
+            }
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            buffer.close();
+        }
+
+        @Override
+        public void computeNext(Record record) {
+
+            double price = arg1.getDouble(record);
+            double volume = arg2.getDouble(record);
+
+            System.out.println("PRICE "+ price);
+            System.out.println("VOLUME "+ volume);
+
+            //compute value using top frame element (that could be current or previous row)
+            double hiValuePrice = price;
+            double hiValueVolume = volume;
+
+            if (frameLoBounded && !frameIncludesCurrentValue) {
+                hiValuePrice = buffer.getDouble((long) ((loIdx + frameSize - 1) % bufferSize) * Double.BYTES);
+                hiValueVolume = buffer.getDouble((long) ((loIdx + frameSize - 1) % bufferSize) * Double.BYTES);
+
+            } else if (!frameLoBounded && !frameIncludesCurrentValue) {
+                hiValuePrice = buffer.getDouble((long) (loIdx % bufferSize) * Double.BYTES);
+                hiValueVolume = buffer.getDouble((long) (loIdx % bufferSize) * Double.BYTES);
+            }
+
+            System.out.println("HI VALUE PRICE "+ hiValuePrice);
+            System.out.println("HI VALUE VOLUME "+ hiValueVolume);
+
+            if (Numbers.isFinite(hiValueVolume) && Numbers.isFinite(hiValuePrice) && hiValueVolume > 0.0d) {
+                volumeSum += hiValueVolume;
+                notional += hiValuePrice * hiValueVolume;
+                count++;
+            }
+
+            System.out.println("VOLUME SUM "+ volumeSum);
+            System.out.println("NOTIONAL "+ notional);
+
+            if (count != 0) {
+                vwma = notional / volumeSum;
+                externalNotional = notional;
+            } else {
+                vwma = Double.NaN;
+                externalNotional = Double.NaN;
+            }
+
+            if (frameLoBounded) {
+                //remove the oldest element with newest
+                double loValuePrice = buffer.getDouble((long) loIdx * Double.BYTES);
+                double loValueVolume = buffer.getDouble((long) (loIdx + 1) * Double.BYTES);
+                
+                if (Numbers.isFinite(loValueVolume) && Numbers.isFinite(loValuePrice) && loValueVolume > 0) {
+                    notional -= loValueVolume * loValuePrice;
+                    volumeSum -= loValueVolume;
+
+                    System.out.println("NOTIONAL POST REMOVE "+ notional);
+                    System.out.println("VOLUMESUM POST REMOVE "+ volumeSum);
+
+                    count--;
+                }
+            }
+
+            buffer.putDouble((long) loIdx * Double.BYTES, price);
+            buffer.putDouble((long) (loIdx + 1) * Double.BYTES, volume);
+            loIdx = (loIdx + 1) % bufferSize;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public int getPassCount() {
+            return WindowFunction.ZERO_PASS;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            computeNext(record);
+            Unsafe.getUnsafe().putDouble(spi.getAddress(recordOffset, columnIndex), vwma);
+        }
+
+        @Override
+        public void reopen() {
+            vwma = 0;
+            count = 0;
+            loIdx = 0;
+            notional = 0.0;
+            initBuffer();
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            buffer.close();
+            vwma = 0;
+            count = 0;
+            loIdx = 0;
+            notional = 0.0;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(getName());
+            sink.val('(').val(arg1).val(')');
+            sink.val('(').val(arg2).val(')');
+            sink.val(" over (");
+            sink.val(" rows between ");
+            if (frameLoBounded) {
+                sink.val(bufferSize);
+            } else {
+                sink.val("unbounded");
+            }
+            sink.val(" preceding and ");
+            if (frameIncludesCurrentValue) {
+                sink.val("current row");
+            } else {
+                sink.val(bufferSize - frameSize).val(" preceding");
+            }
+            sink.val(')');
+        }
+
+        @Override
+        public void toTop() {
+            super.toTop();
+            vwma = 0;
+            count = 0;
+            loIdx = 0;
+            notional = 0.0;
+            initBuffer();
+        }
+
+        private void initBuffer() {
+            for (int i = 0; i < bufferSize; i++) {
+                buffer.putDouble((long) i * Double.BYTES, Double.NaN);
+            }
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -22,977 +22,978 @@
  *
  ******************************************************************************/
 
-import io.questdb.griffin.FunctionFactory;
+ import io.questdb.griffin.FunctionFactory;
 
-open module io.questdb {
-    requires transitive jdk.unsupported;
-    requires static org.jetbrains.annotations;
-    requires static java.management;
-    requires jdk.unsupported.desktop;
-    requires jdk.management;
-
-    uses io.questdb.griffin.FunctionFactory;
-    exports io.questdb;
-    exports io.questdb.cairo;
-    exports io.questdb.cairo.vm;
-    exports io.questdb.cairo.map;
-    exports io.questdb.cairo.sql;
-    exports io.questdb.cairo.pool;
-    exports io.questdb.cairo.pool.ex;
-    exports io.questdb.cairo.security;
-
-    exports io.questdb.cutlass;
-    exports io.questdb.cutlass.http;
-    exports io.questdb.cutlass.http.processors;
-    exports io.questdb.cutlass.http.ex;
-    exports io.questdb.cutlass.json;
-    exports io.questdb.cutlass.line;
-    exports io.questdb.cutlass.line.udp;
-    exports io.questdb.cutlass.line.tcp;
-    exports io.questdb.cutlass.line.http;
-    exports io.questdb.cutlass.pgwire;
-    exports io.questdb.cutlass.text;
-    exports io.questdb.cutlass.text.types;
-
-    exports io.questdb.griffin;
-    exports io.questdb.griffin.engine;
-    exports io.questdb.griffin.model;
-    exports io.questdb.griffin.engine.functions;
-    exports io.questdb.griffin.engine.functions.rnd;
-    exports io.questdb.griffin.engine.functions.bind;
-    exports io.questdb.griffin.engine.functions.bool;
-    exports io.questdb.griffin.engine.functions.cast;
-    exports io.questdb.griffin.engine.functions.catalogue;
-    exports io.questdb.griffin.engine.functions.columns;
-    exports io.questdb.griffin.engine.functions.conditional;
-    exports io.questdb.griffin.engine.functions.constants;
-    exports io.questdb.griffin.engine.functions.date;
-    exports io.questdb.griffin.engine.functions.eq;
-    exports io.questdb.griffin.engine.functions.groupby;
-    exports io.questdb.griffin.engine.functions.lt;
-    exports io.questdb.griffin.engine.functions.math;
-    exports io.questdb.griffin.engine.functions.regex;
-    exports io.questdb.griffin.engine.functions.str;
-    exports io.questdb.griffin.engine.functions.test;
-    exports io.questdb.griffin.engine.functions.geohash;
-    exports io.questdb.griffin.engine.functions.bin;
-    exports io.questdb.griffin.engine.functions.lock;
-    exports io.questdb.griffin.engine.functions.window;
-    exports io.questdb.griffin.engine.functions.table;
-    exports io.questdb.griffin.engine.groupby;
-    exports io.questdb.griffin.engine.groupby.vect;
-    exports io.questdb.griffin.engine.orderby;
-    exports io.questdb.griffin.engine.window;
-    exports io.questdb.griffin.engine.table;
-    exports io.questdb.jit;
-    exports io.questdb.std;
-    exports io.questdb.std.datetime;
-    exports io.questdb.std.datetime.microtime;
-    exports io.questdb.std.datetime.millitime;
-    exports io.questdb.std.str;
-    exports io.questdb.std.ex;
-    exports io.questdb.std.fastdouble;
-    exports io.questdb.network;
-    exports io.questdb.log;
-    exports io.questdb.mp;
-    exports io.questdb.tasks;
-    exports io.questdb.metrics;
-    exports io.questdb.cairo.vm.api;
-    exports io.questdb.cairo.mig;
-    exports io.questdb.griffin.engine.join;
-    exports io.questdb.griffin.engine.ops;
-    exports io.questdb.cairo.sql.async;
-    exports io.questdb.cutlass.http.client;
-    exports io.questdb.griffin.engine.functions.long128;
-    exports io.questdb.cairo.wal;
-    exports io.questdb.cairo.wal.seq;
-    exports io.questdb.cutlass.auth;
-    exports io.questdb.cutlass.line.tcp.auth;
-    exports io.questdb.cairo.frm;
-    exports io.questdb.cairo.frm.file;
-    exports io.questdb.std.histogram.org.HdrHistogram;
-    exports io.questdb.client;
-    exports io.questdb.std.bytes;
-    exports io.questdb.std.histogram.org.HdrHistogram.packedarray;
-    exports io.questdb.client.impl;
-    exports io.questdb.griffin.engine.groupby.hyperloglog;
-    exports io.questdb.griffin.engine.functions.finance;
-    exports io.questdb.std.filewatch;
-
-    provides FunctionFactory with
-
-            // finance
-            io.questdb.griffin.engine.functions.finance.LevelTwoPriceFunctionFactory,
-            io.questdb.griffin.engine.functions.finance.SpreadFunctionFactory,
-
-
-            // query activity functions
-            io.questdb.griffin.engine.functions.activity.CancelQueryFunctionFactory,
-            io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory,
-
-            // test functions
-            io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestNPEFactory,
-            io.questdb.griffin.engine.functions.test.TestSumTDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestSumStringGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestSleepFunctionFactory,
-
-            // bool
-            io.questdb.griffin.engine.functions.bool.OrFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.AndFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.NotFunctionFactory,
-
-            // [] operators
-            io.questdb.griffin.engine.functions.array.StrArrayDereferenceFunctionFactory,
-            io.questdb.griffin.engine.functions.array.IntArrayDereferenceHackFunctionFactory,
-            // '=' operators
-            io.questdb.griffin.engine.functions.eq.EqStrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqVarcharStrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqByteFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqShortFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqIntFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqLongFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqLong128FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqLong256StrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqStrCharFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqSymStrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqSymCharFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqCharCharFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqIntStrCFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqDateFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqBooleanCharFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqBinaryFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqGeoHashGeoHashFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqGeoHashStrFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqUuidFunctionFactory,
-            io.questdb.griffin.engine.functions.eq.EqUuidStrFunctionFactory,
-
-            //contains
-            io.questdb.griffin.engine.functions.eq.ContainsIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.ContainsEqIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.NegContainsEqIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.eq.NegContainsIPv4FunctionFactory,
-
-            //nullif
-            io.questdb.griffin.engine.functions.conditional.NullIfCharFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.NullIfDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.NullIfIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.NullIfIntFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.NullIfLongFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.NullIfStrFunctionFactory,
-
-//                   '<' operator
-            io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtDateFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtStrIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtStrVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtVarcharStrFunctionFactory,
-            io.questdb.griffin.engine.functions.lt.LtVarcharFunctionFactory,
-
-//                   '+' operator
-            io.questdb.griffin.engine.functions.math.AddIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AddLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AddFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AddDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AddLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.date.AddLongToTimestampFunctionFactory,
-//                     '-' operator,
-            io.questdb.griffin.engine.functions.math.NegIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.NegDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.NegFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.math.NegLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.NegShortFunctionFactory,
-            io.questdb.griffin.engine.functions.math.NegByteFunctionFactory,
-
-            io.questdb.griffin.engine.functions.math.SubDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SubIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SubLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SubTimestampFunctionFactory,
-//                     '/' operator,
-            io.questdb.griffin.engine.functions.math.DivDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.DivFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.math.DivLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.DivIntFunctionFactory,
-//                     '%' operator,
-            io.questdb.griffin.engine.functions.math.RemIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RemLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RemDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RemFloatFunctionFactory,
-//                     '*' operator,
-            io.questdb.griffin.engine.functions.math.MulFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.math.MulDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.MulLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.MulIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AbsIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AbsShortFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AbsLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AbsDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.LnDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.LogDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SqrtDoubleFunctionFactory,
-//                     'trigonometric'
-            io.questdb.griffin.engine.functions.math.SinDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.CosDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.TanDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.CotDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AsinDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AcosDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.AtanDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.Atan2DoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.PIDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RadiansDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.DegreesDoubleFunctionFactory,
-//                     '~=',
-            io.questdb.griffin.engine.functions.regex.MatchStrFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.MatchCharFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.MatchVarcharFunctionFactory,
-//                    like
-            io.questdb.griffin.engine.functions.regex.LikeStrFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.LikeVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.ILikeStrFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.ILikeVarcharFunctionFactory,
-//                     '!~',
-            io.questdb.griffin.engine.functions.regex.NotMatchStrFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.NotMatchVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.NotMatchCharFunctionFactory,
-//                     'to_char',
-            io.questdb.griffin.engine.functions.date.ToStrDateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToStrTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.str.ToCharBinFunctionFactory,
-//                     'length',
-            io.questdb.griffin.engine.functions.str.LengthStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LengthVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LengthSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LengthBinFunctionFactory,
-//                     random generator functions,
-            io.questdb.griffin.engine.functions.rnd.LongSequenceFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndIntFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndIPv4CCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndIntCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndStrFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndStrRndListFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndVarcharListFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndDoubleCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndFloatCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndShortCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndShortFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndDateCCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndLongCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndLongFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndUuidFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndUUIDCFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampSequenceFunctionFactory,
-            io.questdb.griffin.engine.functions.long128.LongsToLong128FunctionFactory,
-            io.questdb.griffin.engine.functions.long256.LongsToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.uuid.LongsToUuidFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampShuffleFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampFloorFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampCeilFunctionFactory,
-            io.questdb.griffin.engine.functions.date.DateTruncFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndByteCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndBinCCCFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndSymbolListFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndStringListFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndCharFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndLong256NFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndByteFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndBinFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndDateFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.ListFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndGeoHashFunctionFactory,
-            io.questdb.griffin.engine.functions.rnd.RndLogFunctionFactory,
-//                  date conversion functions,
-            io.questdb.griffin.engine.functions.date.SysdateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToTimestampVCFunctionFactory,
-            io.questdb.griffin.engine.functions.date.VarcharToTimestampVCFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.date.VarcharToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.date.SystimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.date.NowFunctionFactory,
-            io.questdb.griffin.engine.functions.date.HourOfDayFunctionFactory,
-            io.questdb.griffin.engine.functions.date.DayOfMonthFunctionFactory,
-            io.questdb.griffin.engine.functions.date.DayOfWeekFunctionFactory,
-            io.questdb.griffin.engine.functions.date.DayOfWeekSundayFirstFunctionFactory,
-            io.questdb.griffin.engine.functions.date.MinuteOfHourFunctionFactory,
-            io.questdb.griffin.engine.functions.date.SecondOfMinuteFunctionFactory,
-            io.questdb.griffin.engine.functions.date.WeekOfYearFunctionFactory,
-            io.questdb.griffin.engine.functions.date.YearFunctionFactory,
-            io.questdb.griffin.engine.functions.date.MonthOfYearFunctionFactory,
-            io.questdb.griffin.engine.functions.date.DaysPerMonthFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ExtractFromTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.date.MicrosOfSecondFunctionFactory,
-            io.questdb.griffin.engine.functions.date.MillisOfSecondFunctionFactory,
-            io.questdb.griffin.engine.functions.date.IsLeapYearFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampDiffFunctionFactory,
-            io.questdb.griffin.engine.functions.date.TimestampAddFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.VarcharToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToPgDateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.VarcharToPgDateFunctionFactory,
-            io.questdb.griffin.engine.functions.date.PgPostmasterStartTimeFunctionFactory,
-//                  cast functions,
-//                  cast double to ...,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDoubleToTimestampFunctionFactory,
-//                  cast float to ...,
-            io.questdb.griffin.engine.functions.cast.CastFloatToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastFloatToTimestampFunctionFactory,
-//                  cast short to ...,
-            io.questdb.griffin.engine.functions.cast.CastShortToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastShortToBooleanFunctionFactory,
-//                  cast int to ...,
-            io.questdb.griffin.engine.functions.cast.CastIntToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIntToIPv4FunctionFactory,
-//                  cast ipv4 to ...
-            io.questdb.griffin.engine.functions.cast.CastIPv4ToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIPv4ToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastIPv4ToIntFunctionFactory,
-//                  cast long to ...,
-            io.questdb.griffin.engine.functions.cast.CastLongToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastNullTypeFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLongToGeoHashFunctionFactory,
-//                  cast long256 to ...,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastLong256ToBooleanFunctionFactory,
-//                  cast date to ...,
-            io.questdb.griffin.engine.functions.cast.CastDateToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastDateToBooleanFunctionFactory,
-//                  cast timestamp to ...,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastTimestampToBooleanFunctionFactory,
-//                  cast byte to ...,
-            io.questdb.griffin.engine.functions.cast.CastByteToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastByteToBooleanFunctionFactory,
-//                  cast boolean to ...,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastBooleanToBooleanFunctionFactory,
-//                  cast char to ...,
-            io.questdb.griffin.engine.functions.cast.CastCharToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToTimestampFunctionFactory,
-//                  cast str to ...,
-            io.questdb.griffin.engine.functions.cast.CastStrToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastCharToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToRegClassFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToRegProcedureFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToStrArrayFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToBinaryFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToGeoHashFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastStrToUuidFunctionFactory,
-
-//                  cast varchar to ...,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToBooleanFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToGeoHashFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToUuidFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastVarcharToSymbolFunctionFactory,
-
-//                  cast symbol to ...
-            io.questdb.griffin.engine.functions.cast.CastSymbolToIntFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToLong256FunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToLongFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToShortFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToByteFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToCharFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToDateFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastSymbolToTimestampFunctionFactory,
-
-//                  cast uuid to ...
-            io.questdb.griffin.engine.functions.cast.CastUuidToStrFunctionFactory,
-            io.questdb.griffin.engine.functions.cast.CastUuidToVarcharFunctionFactory,
-
-//                  cast geohash to ...
-            io.questdb.griffin.engine.functions.cast.CastGeoHashToGeoHashFunctionFactory,
-
-
-            // cast helpers
-            io.questdb.griffin.engine.functions.cast.VarcharCastHelperFunctionFactory,
-//                  'in'
-            io.questdb.griffin.engine.functions.bool.InSymbolCursorFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InStrFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InCharFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InLongFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InSymbolFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InTimestampStrFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InTimestampVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InTimestampTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.BetweenTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.InUuidFunctionFactory,
-//                  'all'
-            io.questdb.griffin.engine.functions.bool.AllNotEqStrFunctionFactory,
-            io.questdb.griffin.engine.functions.bool.AllNotEqVarcharFunctionFactory,
-//                  'agg' group by function
-            io.questdb.griffin.engine.functions.groupby.StringAggGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.StringAggVarcharGroupByFunctionFactory,
-//                  'sum' group by function
-            io.questdb.griffin.engine.functions.groupby.SumDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.SumFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.SumIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.SumLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.SumLong256GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.KSumDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.NSumDoubleGroupByFunctionFactory,
-//                  'last' group by function
-            io.questdb.griffin.engine.functions.groupby.LastDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastShortGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastBooleanGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastByteGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastVarcharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastGeoHashGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastUuidGroupByFunctionFactory,
-//                  'last_not_null' group by function
-            io.questdb.griffin.engine.functions.groupby.LastNotNullCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullGeoHashGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullVarcharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.LastNotNullUuidGroupByFunctionFactory,
-//                  'first' group by function
-            io.questdb.griffin.engine.functions.groupby.FirstDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstShortGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstBooleanGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstByteGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstGeoHashGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstUuidGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstVarcharGroupByFunctionFactory,
-//                  'first_not_null' group by function
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullGeoHashGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullVarcharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.FirstNotNullUuidGroupByFunctionFactory,
-//                  'max' group
-            io.questdb.griffin.engine.functions.groupby.MaxDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxBooleanGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MaxVarcharGroupByFunctionFactory,
-//                  'min' group
-            io.questdb.griffin.engine.functions.groupby.MinDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinBooleanGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinCharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinTimestampGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinDateGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.MinVarcharGroupByFunctionFactory,
-//                  'count' group by function
-            io.questdb.griffin.engine.functions.groupby.CountGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountFloatGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountGeoHashGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountLong256GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountStrGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountVarcharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctStringGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctVarcharGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctSymbolGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctLong256GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctIPv4GroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.CountDistinctUuidGroupByFunctionFactory,
-//                  'approx_count_distinct' group by function
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIntGroupByDefaultFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIntGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByDefaultFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByDefaultFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByFunctionFactory,
-            //      'haversine_dist_degree' group by function
-            io.questdb.griffin.engine.functions.groupby.HaversineDistDegreeGroupByFunctionFactory,
-            //      'approx_percentile' group by function
-            io.questdb.griffin.engine.functions.groupby.ApproxPercentileDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxPercentileDoubleGroupByDefaultFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxPercentileLongGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.ApproxPercentileLongGroupByDefaultFunctionFactory,
-//                  'isOrdered'
-            io.questdb.griffin.engine.functions.groupby.IsIPv4OrderedGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.IsLongOrderedGroupByFunctionFactory,
-//                  round()
-            io.questdb.griffin.engine.functions.math.RoundDoubleZeroScaleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RoundDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RoundDownDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RoundUpDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.RoundHalfEvenDoubleFunctionFactory,
-//                  ceil()
-            io.questdb.griffin.engine.functions.math.CeilDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.CeilFloatFunctionFactory,
-//                  ceil()
-            io.questdb.griffin.engine.functions.math.CeilingDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.CeilingFloatFunctionFactory,
-//                  exp()
-            io.questdb.griffin.engine.functions.math.ExpDoubleFunctionFactory,
-//                  floor()
-            io.questdb.griffin.engine.functions.math.FloorDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.FloorFloatFunctionFactory,
-//                  sign()
-            io.questdb.griffin.engine.functions.math.SignByteFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SignDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SignFloatFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SignIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SignLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.SignShortFunctionFactory,
-//                  case conditional statement
-            io.questdb.griffin.engine.functions.conditional.CaseFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.SwitchFunctionFactory,
-            io.questdb.griffin.engine.functions.conditional.CoalesceFunctionFactory,
-//                  PostgreSQL catalogue functions
-            io.questdb.griffin.engine.functions.catalogue.PgAttrDefFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgAttrDefFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgAttributeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgAttributeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgClassFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgClassFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgIndexFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgIndexFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgRolesFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgRolesFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.InformationSchemaFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.InformationSchemaColumnsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.InformationSchemaTablesFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgTypeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgDescriptionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgNamespaceFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgNamespaceFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgLocksFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgLocksFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.IsTableVisibleCatalogueFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.UserByIdCatalogueFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgTypeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.VersionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CurrentDatabaseFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentDatabaseFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CurrentSchemasFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemasFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CurrentSettingFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CurrentSchemaFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemaFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CurrentUserFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.CursorDereferenceFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgDescriptionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgExtensionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgExtensionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgInheritsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgInheritsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.SessionUserFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgGetPartKeyDefFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetPartKeyDefFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgGetSITExprFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetSITExprFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetSIExprFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgGetSIExprFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.FormatTypeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgProcFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgRangeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgGetKeywordsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.ShowTablesFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.KeywordsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.FunctionListFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.WalTableListFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.WalTransactionsFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.FlushQueryCacheFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedAgeFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgIsInRecoveryFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgIsInRecoveryFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.TxIDCurrentFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedTxIDCurrentFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgDatabaseFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedPgDatabaseFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PgShDescriptionFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.SimulateCrashFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.PrefixedVersionFunctionFactory,
-
-//            PostgreSQL advisory locks functions
-            io.questdb.griffin.engine.functions.lock.AdvisoryUnlockAll,
-//                  concat()
-            io.questdb.griffin.engine.functions.str.ConcatFunctionFactory,
-            // replace()
-            io.questdb.griffin.engine.functions.str.ReplaceStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.ReplaceVarcharFunctionFactory,
-            // regexp_replace()
-            io.questdb.griffin.engine.functions.regex.RegexpReplaceStrFunctionFactory,
-            io.questdb.griffin.engine.functions.regex.RegexpReplaceVarcharFunctionFactory,
-//                  avg()
-            io.questdb.griffin.engine.functions.groupby.AvgDoubleGroupByFunctionFactory,
-            io.questdb.griffin.engine.functions.groupby.AvgBooleanGroupByFunctionFactory,
-//                  vwap()
-            io.questdb.griffin.engine.functions.groupby.VwapDoubleGroupByFunctionFactory,
-//                 stddev()
-            io.questdb.griffin.engine.functions.groupby.StdDevGroupByFunctionFactory,
-//                 stddev_samp()
-            io.questdb.griffin.engine.functions.groupby.StdDevSampleGroupByFunctionFactory,
-//                 stddev_pop()
-            io.questdb.griffin.engine.functions.groupby.StdDevPopGroupByFunctionFactory,
-//                 variance()
-            io.questdb.griffin.engine.functions.groupby.VarGroupByFunctionFactory,
-//                 var_samp()
-            io.questdb.griffin.engine.functions.groupby.VarSampleGroupByFunctionFactory,
-//                 var_pop()
-            io.questdb.griffin.engine.functions.groupby.VarPopGroupByFunctionFactory,
-//                 covar_samp()
-            io.questdb.griffin.engine.functions.groupby.CovarSampleGroupByFunctionFactory,
-//                 covar_pop()
-            io.questdb.griffin.engine.functions.groupby.CovarPopGroupByFunctionFactory,
-//                 corr()
-            io.questdb.griffin.engine.functions.groupby.CorrGroupByFunctionFactory,
-//                  ^
-            io.questdb.griffin.engine.functions.math.PowDoubleFunctionFactory,
-            io.questdb.griffin.engine.functions.table.AllTablesFunctionFactory,
-            io.questdb.griffin.engine.functions.table.TableColumnsFunctionFactory,
-            io.questdb.griffin.engine.functions.table.TablePartitionsFunctionFactory,
-            io.questdb.griffin.engine.functions.table.TouchTableFunctionFactory,
-            io.questdb.griffin.engine.functions.table.ReaderPoolFunctionFactory,
-            io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory,
-            io.questdb.griffin.engine.functions.table.TableWriterMetricsFunctionFactory,
-            io.questdb.griffin.engine.functions.table.MemoryMetricsFunctionFactory,
-
-            // strpos
-            io.questdb.griffin.engine.functions.str.StrPosFunctionFactory,
-            io.questdb.griffin.engine.functions.str.StrPosCharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.StrPosVarcharFunctionFactory,
-            // position
-            io.questdb.griffin.engine.functions.str.PositionFunctionFactory,
-            io.questdb.griffin.engine.functions.str.PositionVarcharFunctionFactory,
-            // Change string case
-            io.questdb.griffin.engine.functions.str.ToUppercaseFunctionFactory,
-            io.questdb.griffin.engine.functions.str.ToUppercaseVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.ToLowercaseFunctionFactory,
-            io.questdb.griffin.engine.functions.str.ToLowercaseVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LowerFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.UpperFunctionFactory,
-            io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory,
-            // left/right
-            io.questdb.griffin.engine.functions.str.LeftStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LeftVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RightStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RightVarcharFunctionFactory,
-            // Pad strings
-            io.questdb.griffin.engine.functions.str.LPadFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LPadStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RPadFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RPadStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LPadVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LPadVarcharVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RPadVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RPadVarcharVarcharFunctionFactory,
-            // size_pretty
-            io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory,
-            // substring
-            io.questdb.griffin.engine.functions.str.SubStringFunctionFactory,
-            io.questdb.griffin.engine.functions.str.SubStringVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory,
-            io.questdb.griffin.engine.functions.str.QuoteIdentVarcharFunctionFactory,
-
-            // trim
-            io.questdb.griffin.engine.functions.str.TrimFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LTrimFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RTrimFunctionFactory,
-            io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LTrimVarcharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RTrimVarcharFunctionFactory,
-
-            // starts_with
-            io.questdb.griffin.engine.functions.str.StartsWithStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.StartsWithVarcharFunctionFactory,
-            // split_part
-            io.questdb.griffin.engine.functions.str.SplitPartFunctionFactory,
-            io.questdb.griffin.engine.functions.str.SplitPartCharFunctionFactory,
-            io.questdb.griffin.engine.functions.str.SplitPartVarcharFunctionFactory,
-
-            // window functions
-            io.questdb.griffin.engine.functions.window.RowNumberFunctionFactory,
-            io.questdb.griffin.engine.functions.window.RankFunctionFactory,
-            io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory,
-            io.questdb.griffin.engine.functions.window.FirstValueDoubleWindowFunctionFactory,
-            io.questdb.griffin.engine.functions.window.SumDoubleWindowFunctionFactory,
-
-            // metadata functions
-            io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory,
-            io.questdb.griffin.engine.functions.metadata.InstanceNameFunctionFactory,
-            io.questdb.griffin.engine.functions.metadata.InstanceRGBFunctionFactory,
-            // geohash functions
-            io.questdb.griffin.engine.functions.geohash.GeoHashFromCoordinatesFunctionFactory,
-            // bin functions
-            io.questdb.griffin.engine.functions.bin.Base64FunctionFactory,
-            // bit operations
-            io.questdb.griffin.engine.functions.math.BitwiseAndLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseOrLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseNotLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseXorLongFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseAndIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseAndIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseAndIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseAndStrIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseOrIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseOrIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseOrStrIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseOrIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseNotIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseNotIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseNotIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.BitwiseXorIntFunctionFactory,
-
-            // ipv4 operators
-            io.questdb.griffin.engine.functions.math.IPv4PlusIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IntPlusIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4MinusIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4StrMinusIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4MinusIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4StrPlusIntFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IntPlusIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4StrMinusIPv4StrFunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4StrMinusIPv4FunctionFactory,
-            io.questdb.griffin.engine.functions.math.IPv4MinusIPv4StrFunctionFactory,
-
-            // ipv4 functions
-            io.questdb.griffin.engine.functions.math.IPv4StrNetmaskFunctionFactory,
-
-            io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory,
-            io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory,
-
-            io.questdb.griffin.engine.functions.catalogue.TypeOfFunctionFactory
-            ;
-}
+ open module io.questdb {
+     requires transitive jdk.unsupported;
+     requires static org.jetbrains.annotations;
+     requires static java.management;
+     requires jdk.unsupported.desktop;
+     requires jdk.management;
+ 
+     uses io.questdb.griffin.FunctionFactory;
+     exports io.questdb;
+     exports io.questdb.cairo;
+     exports io.questdb.cairo.vm;
+     exports io.questdb.cairo.map;
+     exports io.questdb.cairo.sql;
+     exports io.questdb.cairo.pool;
+     exports io.questdb.cairo.pool.ex;
+     exports io.questdb.cairo.security;
+ 
+     exports io.questdb.cutlass;
+     exports io.questdb.cutlass.http;
+     exports io.questdb.cutlass.http.processors;
+     exports io.questdb.cutlass.http.ex;
+     exports io.questdb.cutlass.json;
+     exports io.questdb.cutlass.line;
+     exports io.questdb.cutlass.line.udp;
+     exports io.questdb.cutlass.line.tcp;
+     exports io.questdb.cutlass.line.http;
+     exports io.questdb.cutlass.pgwire;
+     exports io.questdb.cutlass.text;
+     exports io.questdb.cutlass.text.types;
+ 
+     exports io.questdb.griffin;
+     exports io.questdb.griffin.engine;
+     exports io.questdb.griffin.model;
+     exports io.questdb.griffin.engine.functions;
+     exports io.questdb.griffin.engine.functions.rnd;
+     exports io.questdb.griffin.engine.functions.bind;
+     exports io.questdb.griffin.engine.functions.bool;
+     exports io.questdb.griffin.engine.functions.cast;
+     exports io.questdb.griffin.engine.functions.catalogue;
+     exports io.questdb.griffin.engine.functions.columns;
+     exports io.questdb.griffin.engine.functions.conditional;
+     exports io.questdb.griffin.engine.functions.constants;
+     exports io.questdb.griffin.engine.functions.date;
+     exports io.questdb.griffin.engine.functions.eq;
+     exports io.questdb.griffin.engine.functions.groupby;
+     exports io.questdb.griffin.engine.functions.lt;
+     exports io.questdb.griffin.engine.functions.math;
+     exports io.questdb.griffin.engine.functions.regex;
+     exports io.questdb.griffin.engine.functions.str;
+     exports io.questdb.griffin.engine.functions.test;
+     exports io.questdb.griffin.engine.functions.geohash;
+     exports io.questdb.griffin.engine.functions.bin;
+     exports io.questdb.griffin.engine.functions.lock;
+     exports io.questdb.griffin.engine.functions.window;
+     exports io.questdb.griffin.engine.functions.table;
+     exports io.questdb.griffin.engine.groupby;
+     exports io.questdb.griffin.engine.groupby.vect;
+     exports io.questdb.griffin.engine.orderby;
+     exports io.questdb.griffin.engine.window;
+     exports io.questdb.griffin.engine.table;
+     exports io.questdb.jit;
+     exports io.questdb.std;
+     exports io.questdb.std.datetime;
+     exports io.questdb.std.datetime.microtime;
+     exports io.questdb.std.datetime.millitime;
+     exports io.questdb.std.str;
+     exports io.questdb.std.ex;
+     exports io.questdb.std.fastdouble;
+     exports io.questdb.network;
+     exports io.questdb.log;
+     exports io.questdb.mp;
+     exports io.questdb.tasks;
+     exports io.questdb.metrics;
+     exports io.questdb.cairo.vm.api;
+     exports io.questdb.cairo.mig;
+     exports io.questdb.griffin.engine.join;
+     exports io.questdb.griffin.engine.ops;
+     exports io.questdb.cairo.sql.async;
+     exports io.questdb.cutlass.http.client;
+     exports io.questdb.griffin.engine.functions.long128;
+     exports io.questdb.cairo.wal;
+     exports io.questdb.cairo.wal.seq;
+     exports io.questdb.cutlass.auth;
+     exports io.questdb.cutlass.line.tcp.auth;
+     exports io.questdb.cairo.frm;
+     exports io.questdb.cairo.frm.file;
+     exports io.questdb.std.histogram.org.HdrHistogram;
+     exports io.questdb.client;
+     exports io.questdb.std.bytes;
+     exports io.questdb.std.histogram.org.HdrHistogram.packedarray;
+     exports io.questdb.client.impl;
+     exports io.questdb.griffin.engine.groupby.hyperloglog;
+     exports io.questdb.griffin.engine.functions.finance;
+     exports io.questdb.std.filewatch;
+ 
+     provides FunctionFactory with
+ 
+             // finance
+             io.questdb.griffin.engine.functions.finance.LevelTwoPriceFunctionFactory,
+ 
+ 
+             // query activity functions
+             io.questdb.griffin.engine.functions.activity.CancelQueryFunctionFactory,
+             io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory,
+ 
+             // test functions
+             io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestNPEFactory,
+             io.questdb.griffin.engine.functions.test.TestSumTDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestSumStringGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.test.TestSleepFunctionFactory,
+ 
+             // bool
+             io.questdb.griffin.engine.functions.bool.OrFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.AndFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.NotFunctionFactory,
+ 
+             // [] operators
+             io.questdb.griffin.engine.functions.array.StrArrayDereferenceFunctionFactory,
+             io.questdb.griffin.engine.functions.array.IntArrayDereferenceHackFunctionFactory,
+             // '=' operators
+             io.questdb.griffin.engine.functions.eq.EqStrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqVarcharStrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqByteFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqShortFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqIntFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqLongFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqLong128FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqLong256StrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqStrCharFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqSymStrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqSymCharFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqCharCharFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqIntStrCFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqDateFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqBooleanCharFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqBinaryFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqGeoHashGeoHashFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqGeoHashStrFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqUuidFunctionFactory,
+             io.questdb.griffin.engine.functions.eq.EqUuidStrFunctionFactory,
+ 
+             //contains
+             io.questdb.griffin.engine.functions.eq.ContainsIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.ContainsEqIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.NegContainsEqIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.eq.NegContainsIPv4FunctionFactory,
+ 
+             //nullif
+             io.questdb.griffin.engine.functions.conditional.NullIfCharFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.NullIfDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.NullIfIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.NullIfIntFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.NullIfLongFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.NullIfStrFunctionFactory,
+ 
+ //                   '<' operator
+             io.questdb.griffin.engine.functions.lt.LtDoubleVVFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtDateFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtIntFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtStrIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtCharFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtStrFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtLongFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtStrVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtVarcharStrFunctionFactory,
+             io.questdb.griffin.engine.functions.lt.LtVarcharFunctionFactory,
+ 
+ //                   '+' operator
+             io.questdb.griffin.engine.functions.math.AddIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AddLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AddFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AddDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AddLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.date.AddLongToTimestampFunctionFactory,
+ //                     '-' operator,
+             io.questdb.griffin.engine.functions.math.NegIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.NegDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.NegFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.math.NegLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.NegShortFunctionFactory,
+             io.questdb.griffin.engine.functions.math.NegByteFunctionFactory,
+ 
+             io.questdb.griffin.engine.functions.math.SubDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SubIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SubLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SubTimestampFunctionFactory,
+ //                     '/' operator,
+             io.questdb.griffin.engine.functions.math.DivDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.DivFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.math.DivLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.DivIntFunctionFactory,
+ //                     '%' operator,
+             io.questdb.griffin.engine.functions.math.RemIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RemLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RemDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RemFloatFunctionFactory,
+ //                     '*' operator,
+             io.questdb.griffin.engine.functions.math.MulFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.math.MulDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.MulLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.MulIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AbsIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AbsShortFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AbsLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AbsDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.LnDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.LogDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SqrtDoubleFunctionFactory,
+ //                     'trigonometric'
+             io.questdb.griffin.engine.functions.math.SinDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.CosDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.TanDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.CotDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AsinDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AcosDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.AtanDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.Atan2DoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.PIDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RadiansDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.DegreesDoubleFunctionFactory,
+ //                     '~=',
+             io.questdb.griffin.engine.functions.regex.MatchStrFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.MatchCharFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.MatchVarcharFunctionFactory,
+ //                    like
+             io.questdb.griffin.engine.functions.regex.LikeStrFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.LikeVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.ILikeStrFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.ILikeVarcharFunctionFactory,
+ //                     '!~',
+             io.questdb.griffin.engine.functions.regex.NotMatchStrFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.NotMatchVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.NotMatchCharFunctionFactory,
+ //                     'to_char',
+             io.questdb.griffin.engine.functions.date.ToStrDateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToStrTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.str.ToCharBinFunctionFactory,
+ //                     'length',
+             io.questdb.griffin.engine.functions.str.LengthStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LengthVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LengthSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LengthBinFunctionFactory,
+ //                     random generator functions,
+             io.questdb.griffin.engine.functions.rnd.LongSequenceFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndIntFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndIPv4CCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndIntCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndStrFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndStrRndListFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndVarcharListFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndDoubleCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndFloatCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndShortCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndShortFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndDateCCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndLongCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndLongFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndUuidFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndUUIDCFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampSequenceFunctionFactory,
+             io.questdb.griffin.engine.functions.long128.LongsToLong128FunctionFactory,
+             io.questdb.griffin.engine.functions.long256.LongsToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.uuid.LongsToUuidFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampShuffleFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampFloorFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampCeilFunctionFactory,
+             io.questdb.griffin.engine.functions.date.DateTruncFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndByteCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndBinCCCFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndSymbolListFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndStringListFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndCharFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndLong256NFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndByteFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndBinFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndDateFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.ListFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndGeoHashFunctionFactory,
+             io.questdb.griffin.engine.functions.rnd.RndLogFunctionFactory,
+ //                  date conversion functions,
+             io.questdb.griffin.engine.functions.date.SysdateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToTimestampVCFunctionFactory,
+             io.questdb.griffin.engine.functions.date.VarcharToTimestampVCFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.date.VarcharToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.date.SystimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.date.NowFunctionFactory,
+             io.questdb.griffin.engine.functions.date.HourOfDayFunctionFactory,
+             io.questdb.griffin.engine.functions.date.DayOfMonthFunctionFactory,
+             io.questdb.griffin.engine.functions.date.DayOfWeekFunctionFactory,
+             io.questdb.griffin.engine.functions.date.DayOfWeekSundayFirstFunctionFactory,
+             io.questdb.griffin.engine.functions.date.MinuteOfHourFunctionFactory,
+             io.questdb.griffin.engine.functions.date.SecondOfMinuteFunctionFactory,
+             io.questdb.griffin.engine.functions.date.WeekOfYearFunctionFactory,
+             io.questdb.griffin.engine.functions.date.YearFunctionFactory,
+             io.questdb.griffin.engine.functions.date.MonthOfYearFunctionFactory,
+             io.questdb.griffin.engine.functions.date.DaysPerMonthFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ExtractFromTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.date.MicrosOfSecondFunctionFactory,
+             io.questdb.griffin.engine.functions.date.MillisOfSecondFunctionFactory,
+             io.questdb.griffin.engine.functions.date.IsLeapYearFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampDiffFunctionFactory,
+             io.questdb.griffin.engine.functions.date.TimestampAddFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.VarcharToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToPgDateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.VarcharToPgDateFunctionFactory,
+             io.questdb.griffin.engine.functions.date.PgPostmasterStartTimeFunctionFactory,
+ //                  cast functions,
+ //                  cast double to ...,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDoubleToTimestampFunctionFactory,
+ //                  cast float to ...,
+             io.questdb.griffin.engine.functions.cast.CastFloatToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastFloatToTimestampFunctionFactory,
+ //                  cast short to ...,
+             io.questdb.griffin.engine.functions.cast.CastShortToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastShortToBooleanFunctionFactory,
+ //                  cast int to ...,
+             io.questdb.griffin.engine.functions.cast.CastIntToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIntToIPv4FunctionFactory,
+ //                  cast ipv4 to ...
+             io.questdb.griffin.engine.functions.cast.CastIPv4ToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIPv4ToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastIPv4ToIntFunctionFactory,
+ //                  cast long to ...,
+             io.questdb.griffin.engine.functions.cast.CastLongToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastNullTypeFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLongToGeoHashFunctionFactory,
+ //                  cast long256 to ...,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastLong256ToBooleanFunctionFactory,
+ //                  cast date to ...,
+             io.questdb.griffin.engine.functions.cast.CastDateToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastDateToBooleanFunctionFactory,
+ //                  cast timestamp to ...,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastTimestampToBooleanFunctionFactory,
+ //                  cast byte to ...,
+             io.questdb.griffin.engine.functions.cast.CastByteToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastByteToBooleanFunctionFactory,
+ //                  cast boolean to ...,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastBooleanToBooleanFunctionFactory,
+ //                  cast char to ...,
+             io.questdb.griffin.engine.functions.cast.CastCharToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToTimestampFunctionFactory,
+ //                  cast str to ...,
+             io.questdb.griffin.engine.functions.cast.CastStrToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastCharToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToRegClassFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToRegProcedureFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToStrArrayFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToBinaryFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToGeoHashFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastStrToUuidFunctionFactory,
+ 
+ //                  cast varchar to ...,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToBooleanFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToGeoHashFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToUuidFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastVarcharToSymbolFunctionFactory,
+ 
+ //                  cast symbol to ...
+             io.questdb.griffin.engine.functions.cast.CastSymbolToIntFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToLong256FunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToLongFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToShortFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToByteFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToCharFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToDateFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastSymbolToTimestampFunctionFactory,
+ 
+ //                  cast uuid to ...
+             io.questdb.griffin.engine.functions.cast.CastUuidToStrFunctionFactory,
+             io.questdb.griffin.engine.functions.cast.CastUuidToVarcharFunctionFactory,
+ 
+ //                  cast geohash to ...
+             io.questdb.griffin.engine.functions.cast.CastGeoHashToGeoHashFunctionFactory,
+ 
+ 
+             // cast helpers
+             io.questdb.griffin.engine.functions.cast.VarcharCastHelperFunctionFactory,
+ //                  'in'
+             io.questdb.griffin.engine.functions.bool.InSymbolCursorFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InStrFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InCharFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InLongFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InSymbolFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InTimestampStrFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InTimestampVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InTimestampTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.BetweenTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.InUuidFunctionFactory,
+ //                  'all'
+             io.questdb.griffin.engine.functions.bool.AllNotEqStrFunctionFactory,
+             io.questdb.griffin.engine.functions.bool.AllNotEqVarcharFunctionFactory,
+ //                  'agg' group by function
+             io.questdb.griffin.engine.functions.groupby.StringAggGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.StringAggVarcharGroupByFunctionFactory,
+ //                  'sum' group by function
+             io.questdb.griffin.engine.functions.groupby.SumDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.SumFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.SumIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.SumLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.SumLong256GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.KSumDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.NSumDoubleGroupByFunctionFactory,
+ //                  'last' group by function
+             io.questdb.griffin.engine.functions.groupby.LastDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastShortGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastBooleanGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastByteGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastVarcharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastGeoHashGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastUuidGroupByFunctionFactory,
+ //                  'last_not_null' group by function
+             io.questdb.griffin.engine.functions.groupby.LastNotNullCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullGeoHashGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullVarcharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.LastNotNullUuidGroupByFunctionFactory,
+ //                  'first' group by function
+             io.questdb.griffin.engine.functions.groupby.FirstDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstShortGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstBooleanGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstByteGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstGeoHashGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstUuidGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstVarcharGroupByFunctionFactory,
+ //                  'first_not_null' group by function
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullGeoHashGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullVarcharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.FirstNotNullUuidGroupByFunctionFactory,
+ //                  'max' group
+             io.questdb.griffin.engine.functions.groupby.MaxDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxBooleanGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MaxVarcharGroupByFunctionFactory,
+ //                  'min' group
+             io.questdb.griffin.engine.functions.groupby.MinDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinBooleanGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinCharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinTimestampGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinDateGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.MinVarcharGroupByFunctionFactory,
+ //                  'count' group by function
+             io.questdb.griffin.engine.functions.groupby.CountGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountFloatGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountGeoHashGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountLong256GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountStrGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountVarcharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctStringGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctVarcharGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctSymbolGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctLong256GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctIPv4GroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.CountDistinctUuidGroupByFunctionFactory,
+ //                  'approx_count_distinct' group by function
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIntGroupByDefaultFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIntGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByDefaultFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByDefaultFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByFunctionFactory,
+             //      'haversine_dist_degree' group by function
+             io.questdb.griffin.engine.functions.groupby.HaversineDistDegreeGroupByFunctionFactory,
+             //      'approx_percentile' group by function
+             io.questdb.griffin.engine.functions.groupby.ApproxPercentileDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxPercentileDoubleGroupByDefaultFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxPercentileLongGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.ApproxPercentileLongGroupByDefaultFunctionFactory,
+ //                  'isOrdered'
+             io.questdb.griffin.engine.functions.groupby.IsIPv4OrderedGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.IsLongOrderedGroupByFunctionFactory,
+ //                  round()
+             io.questdb.griffin.engine.functions.math.RoundDoubleZeroScaleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RoundDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RoundDownDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RoundUpDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.RoundHalfEvenDoubleFunctionFactory,
+ //                  ceil()
+             io.questdb.griffin.engine.functions.math.CeilDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.CeilFloatFunctionFactory,
+ //                  ceil()
+             io.questdb.griffin.engine.functions.math.CeilingDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.CeilingFloatFunctionFactory,
+ //                  exp()
+             io.questdb.griffin.engine.functions.math.ExpDoubleFunctionFactory,
+ //                  floor()
+             io.questdb.griffin.engine.functions.math.FloorDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.FloorFloatFunctionFactory,
+ //                  sign()
+             io.questdb.griffin.engine.functions.math.SignByteFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SignDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SignFloatFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SignIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SignLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.SignShortFunctionFactory,
+ //                  case conditional statement
+             io.questdb.griffin.engine.functions.conditional.CaseFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.SwitchFunctionFactory,
+             io.questdb.griffin.engine.functions.conditional.CoalesceFunctionFactory,
+ //                  PostgreSQL catalogue functions
+             io.questdb.griffin.engine.functions.catalogue.PgAttrDefFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgAttrDefFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgAttributeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgAttributeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgClassFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgClassFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgIndexFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgIndexFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgRolesFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgRolesFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.InformationSchemaFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.InformationSchemaColumnsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.InformationSchemaTablesFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgTypeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgDescriptionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgNamespaceFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgNamespaceFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgLocksFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgLocksFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.IsTableVisibleCatalogueFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.UserByIdCatalogueFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgTypeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.VersionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CurrentDatabaseFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentDatabaseFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CurrentSchemasFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemasFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CurrentSettingFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CurrentSchemaFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedCurrentSchemaFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CurrentUserFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.CursorDereferenceFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgDescriptionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgExtensionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgExtensionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgInheritsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgInheritsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.SessionUserFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgGetPartKeyDefFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetPartKeyDefFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgGetSITExprFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetSITExprFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetSIExprFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgGetSIExprFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.FormatTypeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgProcFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgRangeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgGetKeywordsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.ShowTablesFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.KeywordsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.FunctionListFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.WalTableListFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.WalTransactionsFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.FlushQueryCacheFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedAgeFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgIsInRecoveryFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgIsInRecoveryFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.TxIDCurrentFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedTxIDCurrentFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgDatabaseFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedPgDatabaseFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PgShDescriptionFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.SimulateCrashFunctionFactory,
+             io.questdb.griffin.engine.functions.catalogue.PrefixedVersionFunctionFactory,
+ 
+ //            PostgreSQL advisory locks functions
+             io.questdb.griffin.engine.functions.lock.AdvisoryUnlockAll,
+ //                  concat()
+             io.questdb.griffin.engine.functions.str.ConcatFunctionFactory,
+             // replace()
+             io.questdb.griffin.engine.functions.str.ReplaceStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.ReplaceVarcharFunctionFactory,
+             // regexp_replace()
+             io.questdb.griffin.engine.functions.regex.RegexpReplaceStrFunctionFactory,
+             io.questdb.griffin.engine.functions.regex.RegexpReplaceVarcharFunctionFactory,
+ //                  avg()
+             io.questdb.griffin.engine.functions.groupby.AvgDoubleGroupByFunctionFactory,
+             io.questdb.griffin.engine.functions.groupby.AvgBooleanGroupByFunctionFactory,
+ //                  vwap()
+             io.questdb.griffin.engine.functions.groupby.VwapDoubleGroupByFunctionFactory,
+ //                 stddev()
+             io.questdb.griffin.engine.functions.groupby.StdDevGroupByFunctionFactory,
+ //                 stddev_samp()
+             io.questdb.griffin.engine.functions.groupby.StdDevSampleGroupByFunctionFactory,
+ //                 stddev_pop()
+             io.questdb.griffin.engine.functions.groupby.StdDevPopGroupByFunctionFactory,
+ //                 variance()
+             io.questdb.griffin.engine.functions.groupby.VarGroupByFunctionFactory,
+ //                 var_samp()
+             io.questdb.griffin.engine.functions.groupby.VarSampleGroupByFunctionFactory,
+ //                 var_pop()
+             io.questdb.griffin.engine.functions.groupby.VarPopGroupByFunctionFactory,
+ //                 covar_samp()
+             io.questdb.griffin.engine.functions.groupby.CovarSampleGroupByFunctionFactory,
+ //                 covar_pop()
+             io.questdb.griffin.engine.functions.groupby.CovarPopGroupByFunctionFactory,
+ //                 corr()
+             io.questdb.griffin.engine.functions.groupby.CorrGroupByFunctionFactory,
+ //                  ^
+             io.questdb.griffin.engine.functions.math.PowDoubleFunctionFactory,
+             io.questdb.griffin.engine.functions.table.AllTablesFunctionFactory,
+             io.questdb.griffin.engine.functions.table.TableColumnsFunctionFactory,
+             io.questdb.griffin.engine.functions.table.TablePartitionsFunctionFactory,
+             io.questdb.griffin.engine.functions.table.TouchTableFunctionFactory,
+             io.questdb.griffin.engine.functions.table.ReaderPoolFunctionFactory,
+             io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory,
+             io.questdb.griffin.engine.functions.table.TableWriterMetricsFunctionFactory,
+             io.questdb.griffin.engine.functions.table.MemoryMetricsFunctionFactory,
+ 
+             // strpos
+             io.questdb.griffin.engine.functions.str.StrPosFunctionFactory,
+             io.questdb.griffin.engine.functions.str.StrPosCharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.StrPosVarcharFunctionFactory,
+             // position
+             io.questdb.griffin.engine.functions.str.PositionFunctionFactory,
+             io.questdb.griffin.engine.functions.str.PositionVarcharFunctionFactory,
+             // Change string case
+             io.questdb.griffin.engine.functions.str.ToUppercaseFunctionFactory,
+             io.questdb.griffin.engine.functions.str.ToUppercaseVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.ToLowercaseFunctionFactory,
+             io.questdb.griffin.engine.functions.str.ToLowercaseVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LowerFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.UpperFunctionFactory,
+             io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory,
+             // left/right
+             io.questdb.griffin.engine.functions.str.LeftStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LeftVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RightStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RightVarcharFunctionFactory,
+             // Pad strings
+             io.questdb.griffin.engine.functions.str.LPadFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LPadStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RPadFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RPadStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LPadVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LPadVarcharVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RPadVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RPadVarcharVarcharFunctionFactory,
+             // size_pretty
+             io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory,
+             // substring
+             io.questdb.griffin.engine.functions.str.SubStringFunctionFactory,
+             io.questdb.griffin.engine.functions.str.SubStringVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.QuoteIdentFunctionFactory,
+             io.questdb.griffin.engine.functions.str.QuoteIdentVarcharFunctionFactory,
+ 
+             // trim
+             io.questdb.griffin.engine.functions.str.TrimFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LTrimFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RTrimFunctionFactory,
+             io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.LTrimVarcharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.RTrimVarcharFunctionFactory,
+ 
+             // starts_with
+             io.questdb.griffin.engine.functions.str.StartsWithStrFunctionFactory,
+             io.questdb.griffin.engine.functions.str.StartsWithVarcharFunctionFactory,
+             // split_part
+             io.questdb.griffin.engine.functions.str.SplitPartFunctionFactory,
+             io.questdb.griffin.engine.functions.str.SplitPartCharFunctionFactory,
+             io.questdb.griffin.engine.functions.str.SplitPartVarcharFunctionFactory,
+ 
+             // window functions
+             io.questdb.griffin.engine.functions.window.RowNumberFunctionFactory,
+             io.questdb.griffin.engine.functions.window.RankFunctionFactory,
+             io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory,
+             io.questdb.griffin.engine.functions.window.FirstValueDoubleWindowFunctionFactory,
+             io.questdb.griffin.engine.functions.window.SumDoubleWindowFunctionFactory,
+             io.questdb.griffin.engine.functions.window.VwmaDoubleWindowFunctionFactory,
+ 
+             // metadata functions
+             io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory,
+             io.questdb.griffin.engine.functions.metadata.InstanceNameFunctionFactory,
+             io.questdb.griffin.engine.functions.metadata.InstanceRGBFunctionFactory,
+             // geohash functions
+             io.questdb.griffin.engine.functions.geohash.GeoHashFromCoordinatesFunctionFactory,
+             // bin functions
+             io.questdb.griffin.engine.functions.bin.Base64FunctionFactory,
+             // bit operations
+             io.questdb.griffin.engine.functions.math.BitwiseAndLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseOrLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseNotLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseXorLongFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseAndIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseAndIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseAndIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseAndStrIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseOrIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseOrIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseOrStrIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseOrIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseNotIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseNotIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseNotIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.BitwiseXorIntFunctionFactory,
+ 
+             // ipv4 operators
+             io.questdb.griffin.engine.functions.math.IPv4PlusIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IntPlusIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4MinusIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4StrMinusIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4MinusIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4StrPlusIntFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IntPlusIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4StrMinusIPv4StrFunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4StrMinusIPv4FunctionFactory,
+             io.questdb.griffin.engine.functions.math.IPv4MinusIPv4StrFunctionFactory,
+ 
+             // ipv4 functions
+             io.questdb.griffin.engine.functions.math.IPv4StrNetmaskFunctionFactory,
+ 
+             io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory,
+             io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory,
+ 
+             io.questdb.griffin.engine.functions.catalogue.TypeOfFunctionFactory
+             ;
+ }
+ 

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -927,6 +927,7 @@ io.questdb.griffin.engine.functions.window.RankFunctionFactory
 io.questdb.griffin.engine.functions.window.AvgDoubleWindowFunctionFactory
 io.questdb.griffin.engine.functions.window.FirstValueDoubleWindowFunctionFactory
 io.questdb.griffin.engine.functions.window.SumDoubleWindowFunctionFactory
+io.questdb.griffin.engine.functions.window.VwmaDoubleWindowFunctionFactory
 
 # metadata functions
 io.questdb.griffin.engine.functions.metadata.BuildFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -3290,7 +3290,9 @@ public class WindowFunctionTest extends AbstractCairoTest {
                     RowNumberFunctionFactory.class,
                     AvgDoubleWindowFunctionFactory.class,
                     SumDoubleWindowFunctionFactory.class,
-                    FirstValueDoubleWindowFunctionFactory.class};
+                    FirstValueDoubleWindowFunctionFactory.class,
+                    VwmaDoubleWindowFunctionFactory.class
+                };
 
             int position = -1;
             ObjList<Function> args = new ObjList<>();


### PR DESCRIPTION
This fixes [https://github.com/questdb/questdb/issues/4727](url). In particular, it creates a window function vwma(double price, double volume) that calculates the volume-weighted moving average over n rows of a table. Since this is a big PR (and my first one, so a bit unfamiliar with the process), I was thinking maybe receiving some feedback on the current code direction before writing up unit tests (I assume just editing WindowFunctionUnitTest is fine?) Thank you!

Following is a screenshot of a sample table called book, along with the output of vwma() that computes the moving average across two rows. I used a very simple ordering metric but imagine that something like execution time can be plugged in easily.

<img width="1659" alt="Screenshot 2024-07-04 at 11 24 19 PM" src="https://github.com/questdb/questdb/assets/87921417/44a634b1-f572-4459-ac73-eaef5124923e">
<img width="1619" alt="Screenshot 2024-07-04 at 11 39 30 PM" src="https://github.com/questdb/questdb/assets/87921417/8abab9f1-d286-4046-b607-4e464c2a995a">


NOTE: Support for partition-by clause is still in progress, but the vwma function should work with queries only using the order-by clause. Will complete and update this shortly. 
