### PR TITLE
test(sql): fuzz tests use strLen as maximum varchar length

### DIFF
--- a/core/src/test/java/io/questdb/test/fuzz/FuzzInsertOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzInsertOperation.java
@@ -196,9 +196,14 @@ public class FuzzInsertOperation implements FuzzTransactionOperation {
                                 break;
 
                             case ColumnType.VARCHAR:
+                                if (isNull) {
+                                    row.putVarchar(index, null);
+                                    break;
+                                }
                                 utf8StringSink.clear();
-                                rnd.nextUtf8Str(strLen, utf8StringSink);
-                                row.putVarchar(index, isNull ? null : utf8StringSink);
+                                int varcharLen = strLen > 0 ? rnd.nextInt(strLen) : 0;
+                                rnd.nextUtf8Str(varcharLen, utf8StringSink);
+                                row.putVarchar(index, utf8StringSink);
                                 break;
 
                             case ColumnType.STRING:


### PR DESCRIPTION
Fuzz tests now treat `strLen` parameters as the maximum possible size for Binary, String, and Varchar columns. Previously, for Varchar columns, it would always generate UTF-8 strings with `strLen` codepoints, resulting in multi-gigabyte O3 transactions causing out-of-memory errors.

This change makes Varchar values consistent with String and Binary: strLen is the maximum size, but each value can be anything between 0 and strLen in length.

An additional benefit of this change is that fuzz tests now exercise fully inlined Varchar values as well.