### PR TITLE
docs(ilp): changed examples to use trades table

### DIFF
--- a/examples/src/main/java/com/example/sender/AuthExample.java
+++ b/examples/src/main/java/com/example/sender/AuthExample.java
@@ -9,15 +9,17 @@ public class AuthExample {
         // 2. "testUser1" with KID portion from your JSON Web Key
         // 3. token with the D portion of your JSON Web Key
         try (Sender sender = Sender.fromConfig("tcp::addr=localhost:9009;user=testUser1;token=GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }

--- a/examples/src/main/java/com/example/sender/AuthTlsExample.java
+++ b/examples/src/main/java/com/example/sender/AuthTlsExample.java
@@ -5,15 +5,17 @@ import io.questdb.client.Sender;
 public class AuthTlsExample {
     public static void main(String[] args) {
         try (Sender sender = Sender.fromConfig("tcps::addr=clever-black-363-c1213c97.ilp.b04c.questdb.net:32074;user=admin;token=GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }

--- a/examples/src/main/java/com/example/sender/BasicExample.java
+++ b/examples/src/main/java/com/example/sender/BasicExample.java
@@ -5,15 +5,17 @@ import io.questdb.client.Sender;
 public class BasicExample {
     public static void main(String[] args) {
         try (Sender sender = Sender.fromConfig("tcp::addr=localhost:9009;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }

--- a/examples/src/main/java/com/example/sender/HttpAdvancedExample.java
+++ b/examples/src/main/java/com/example/sender/HttpAdvancedExample.java
@@ -10,15 +10,17 @@ public class HttpAdvancedExample {
         // auto_flush_rows=100000 - Sets maximum number of rows to be sent in a single request to 100,000.
         // auto_flush_interval=5000 - Sets maximum interval between requests to 5 seconds - to avoid long lags in low-throughput scenarios.
         try (Sender sender = Sender.fromConfig("https::addr=localhost:9000;tls_verify=unsafe_off;retry_timeout=20000;auto_flush_rows=100000;auto_flush_interval=5000;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }

--- a/examples/src/main/java/com/example/sender/HttpExample.java
+++ b/examples/src/main/java/com/example/sender/HttpExample.java
@@ -5,15 +5,17 @@ import io.questdb.client.Sender;
 public class HttpExample {
     public static void main(String[] args) {
         try (Sender sender = Sender.fromConfig("http::addr=localhost:9000;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }

--- a/examples/src/main/java/com/example/sender/HttpsAuthExample.java
+++ b/examples/src/main/java/com/example/sender/HttpsAuthExample.java
@@ -4,16 +4,18 @@ import io.questdb.client.Sender;
 
 public class HttpsAuthExample {
     public static void main(String[] args) {
-        try (Sender sender = Sender.fromConfig("https::addr=localhost:9000;username=Aladdin;password=OpenSesame;")) {
-            sender.table("weather_sensor")
-                    .symbol("id", "toronto1")
-                    .doubleColumn("temperature", 23.5)
-                    .doubleColumn("humidity", 0.49)
+        try (Sender sender = Sender.fromConfig("https::addr=localhost:9000;username=admin;password=quest;")) {
+            sender.table("trades")
+                    .symbol("symbol", "ETH-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 2615.54)
+                    .doubleColumn("amount", 0.00044)
                     .atNow();
-            sender.table("weather_sensor")
-                    .symbol("id", "dubai2")
-                    .doubleColumn("temperature", 41.2)
-                    .doubleColumn("humidity", 0.34)
+            sender.table("trades")
+                    .symbol("symbol", "TC-USD")
+                    .symbol("side", "sell")
+                    .doubleColumn("price", 39269.98)
+                    .doubleColumn("amount", 0.001)
                     .atNow();
         }
     }


### PR DESCRIPTION
Changed examples to use trades data, rather than sensors. These examples are pulled directly to the docs