### PR TITLE
chore(test): renable dedup insert fuzz test

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
@@ -41,7 +41,6 @@ import io.questdb.test.fuzz.FuzzTransaction;
 import io.questdb.test.fuzz.FuzzTransactionOperation;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -50,7 +49,6 @@ import java.util.stream.Collectors;
 
 import static io.questdb.test.tools.TestUtils.assertEquals;
 
-@Ignore
 public class DedupInsertFuzzTest extends AbstractFuzzTest {
 
     @Test


### PR DESCRIPTION
The dedup fuzz test was ignored by the Varchar PR: https://github.com/questdb/questdb/pull/4193 I am assuming it was meant to be temporary while
the varchar impl was incomplete. I see no good reason to have it disabled/ignored now.