### PR TITLE
chore(ui): upgrade web console version to 0.5.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.4.5</web.console.version>
+        <web.console.version>0.5.0</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
     </properties>


### PR DESCRIPTION
Upgrade web console version to 0.5.0

## Web Console changes
- Add WAL suspension info and resolution logic, add OS configuration warnings and resolution info [#291](https://github.com/questdb/ui/pull/291)
- Improve integration testing [#305](https://github.com/questdb/ui/pull/305)
- Add Telemetry tests [#298](https://github.com/questdb/ui/pull/298)
