### PR TITLE
ci(build): add redhat ubi docker build

### DIFF
--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt
             docker buildx create --use
             docker buildx build --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly .
-            docker buildx build --build-arg tag_name=$branch_name base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
+            docker buildx build --build-arg tag_name=nightly base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 

--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - bash: |
-          export hub_tag_name=$(git describe --tags)-$(tag_name)  
+          export hub_tag_name=$(git describe --tags)-$(tag_name)
           echo hub_tag_name=$hub_tag_name
           echo "##vso[task.setvariable variable=hub_tag_name]$hub_tag_name"
         name: check_changes
@@ -40,6 +40,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt
             docker buildx create --use
             docker buildx build --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly .
+            docker buildx build --build-arg tag_name=$branch_name base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
@@ -52,5 +53,6 @@ jobs:
             docker buildx create --use
             export branch_name=$(echo $(tag) | sed -e 's/^refs\/heads\///')
             docker buildx build --build-arg tag_name=$branch_name --platform linux/amd64 --push -t questdb/questdb:$(hub_tag_name) .
+            docker buildx build --build-arg tag_name=$branch_name base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:$(hub_tag_name)-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,7 +1,7 @@
 ARG base_image=debian:bookworm-slim
-ARG tag_name
 
 FROM debian:bookworm
+ARG tag_name
 
 ENV GOSU_VERSION=1.14
 ENV JDK_VERSION=17.0.11.9-1
@@ -45,6 +45,7 @@ RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     ./gosu nobody true
 
 FROM ${base_image}
+ARG tag_name
 
 WORKDIR /app
 
@@ -62,8 +63,8 @@ LABEL name=QuestDB \
     vendor=QuestDB \
     summary="Provides the latest release of QuestDB" \
     description="QuestDB is an open source time-series database for fast ingest and SQL queries" \
-    version=${tag_name} \
-    release=${tag_name}
+    version=$tag_name \
+    release=$tag_name
 
 
 # Create questdb user and group

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,11 +1,13 @@
-FROM debian:bookworm
+ARG base_image=debian:bookworm-slim
 ARG tag_name
+
+FROM debian:bookworm
 
 ENV GOSU_VERSION=1.14
 ENV JDK_VERSION=17.0.11.9-1
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip -y
+    && apt-get install --no-install-recommends git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip -y
 
 RUN wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list && \
@@ -42,7 +44,7 @@ RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     ./gosu --version && \
     ./gosu nobody true
 
-FROM debian:bookworm-slim
+FROM ${base_image}
 
 WORKDIR /app
 
@@ -51,6 +53,18 @@ COPY --from=0 /build/questdb/core/target/gosu /usr/local/bin/gosu
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+
+# Add license information
+RUN mkdir /licenses
+COPY LICENSE.txt /licenses
+
+LABEL name=QuestDB \
+    vendor=QuestDB \
+    summary="Provides the latest release of QuestDB" \
+    description="QuestDB is an open source time-series database for fast ingest and SQL queries" \
+    version=${tag_name} \
+    release=${tag_name}
+
 
 # Create questdb user and group
 RUN groupadd -g 10001 questdb && \
@@ -64,6 +78,9 @@ WORKDIR /var/lib/questdb
 EXPOSE 9000/tcp
 EXPOSE 8812/tcp
 EXPOSE 9009/tcp
+
+USER questdb
+
 
 #
 # Run QuestDB when the container launches

--- a/core/LICENSE.txt
+++ b/core/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Adds docker builds based on the [redhat ubi](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) to become compliant with [preflight checks](https://github.com/redhat-openshift-ecosystem/openshift-preflight) for RedHat certification.

One of the requirements is adding a license file to `/licenses` inside the image. Since I didn't want to expand our Docker build context (for build speed optimization), and we can't add files to an image from outside the context (not even symlinked), I copied the license file to the build context root (`./core`).