### PR TITLE
ci(build): fix rhel Docker image build

### DIFF
--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt
             docker buildx create --use
             docker buildx build --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly .
-            docker buildx build --build-arg tag_name=nightly base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
+            docker buildx build --build-arg tag_name=nightly --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 

--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt
             docker buildx create --use
             docker buildx build --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly .
-            docker buildx build --build-arg tag_name=nightly --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
+            docker buildx build --build-arg tag_name=master --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 

--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt
             docker buildx create --use
             docker buildx build --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly .
-            docker buildx build --build-arg tag_name=master --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:nightly-redhat-ubi .
+            docker buildx build --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64,linux/arm64 --push -t questdb/questdb:nightly-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
@@ -53,6 +53,6 @@ jobs:
             docker buildx create --use
             export branch_name=$(echo $(tag) | sed -e 's/^refs\/heads\///')
             docker buildx build --build-arg tag_name=$branch_name --platform linux/amd64 --push -t questdb/questdb:$(hub_tag_name) .
-            docker buildx build --build-arg tag_name=$branch_name base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64 --push -t questdb/questdb:$(hub_tag_name)-redhat-ubi .
+            docker buildx build --build-arg tag_name=$branch_name --build-arg base_image=registry.access.redhat.com/ubi8/ubi --platform linux/amd64,linux/arm64 --push -t questdb/questdb:$(hub_tag_name)-redhat-ubi .
           workingDirectory: core
         condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -63,8 +63,8 @@ LABEL name=QuestDB \
     vendor=QuestDB \
     summary="Provides the latest release of QuestDB" \
     description="QuestDB is an open source time-series database for fast ingest and SQL queries" \
-    version=$tag_name \
-    release=$tag_name \
+    version=${tag_name:-master} \
+    release=${tag_name:-master} \
     maintainer=QuestDB \
     url="https://github.com/questdb/questdb"
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -64,7 +64,9 @@ LABEL name=QuestDB \
     summary="Provides the latest release of QuestDB" \
     description="QuestDB is an open source time-series database for fast ingest and SQL queries" \
     version=$tag_name \
-    release=$tag_name
+    release=$tag_name \
+    maintainer=QuestDB \
+    url="https://github.com/questdb/questdb"
 
 
 # Create questdb user and group


### PR DESCRIPTION
Missed a flag (and an architecture) in my previous command because I was using podman locally. Tested the exact command using docker and it works.

Also overrides 2 additional image tags that were written in the base image by redhat

I tested the docker build (without the `--push` flag) on an x86 ec2 instance 

fixes https://github.com/questdb/questdb/pull/4783

