### PR TITLE
perf(core): speedup small transaction writing 50-100%

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -2915,7 +2915,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public double getWalSquashUncommittedRowsMultiplier() {
+        public double getWalLagRowsMultiplier() {
             return walSquashUncommittedRowsMultiplier;
         }
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -544,7 +544,7 @@ public interface CairoConfiguration {
      */
     long getWalSegmentRolloverSize();
 
-    double getWalSquashUncommittedRowsMultiplier();
+    double getWalLagRowsMultiplier();
 
     int getWalTxnNotificationQueueCapacity();
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -991,8 +991,8 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public double getWalSquashUncommittedRowsMultiplier() {
-        return getDelegate().getWalSquashUncommittedRowsMultiplier();
+    public double getWalLagRowsMultiplier() {
+        return getDelegate().getWalLagRowsMultiplier();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -889,6 +889,15 @@ public class CairoEngine implements Closeable, WriterSource {
         tableNameRegistry.dropTable(tableToken);
     }
 
+    /**
+     * Publishes notification of table transaction to the queue. The intent is to notify Apply2WalJob that
+     * there are WAL files to be merged into the table. Notification can fail if the queue is full, in
+     * which case it will have to be republished from a persisted storage. However, this method does not
+     * care about that.
+     *
+     * @param tableToken table token of the table that has to be processed by the Apply2WalJob
+     * @return true if the message was successfully put on the queue and false otherwise.
+     */
     public boolean notifyWalTxnCommitted(@NotNull TableToken tableToken) {
         final Sequence pubSeq = messageBus.getWalTxnNotificationPubSequence();
         while (true) {

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -987,7 +987,7 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public double getWalSquashUncommittedRowsMultiplier() {
+    public double getWalLagRowsMultiplier() {
         return 20;
     }
 

--- a/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
@@ -264,10 +264,10 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                 // nameTxn can be deleted
                 // -1 here is to compensate +1 added when partition version parsed from folder name
                 // See comments of why +1 added there in parsePartitionDateVersion()
-                purgePartition(tableToken, ff, path, "purging dropped partition directory [path=");
+                purgePartition(tableToken, ff, path, tableRootLen - tableToken.getDirNameUtf8().size() - 1, "purging dropped partition directory [path=");
                 lastTxn = nameTxn;
             } else {
-                LOG.info().$("cannot purge partition directory, locked for reading [path=").$(path).I$();
+                LOG.debug().$("cannot purge partition directory, locked for reading [path=").$sub(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
                 break;
             }
         }
@@ -352,21 +352,20 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                     // previousNameVersion can be deleted
                     // -1 here is to compensate +1 added when partition version parsed from folder name
                     // See comments of why +1 added there in parsePartitionDateVersion()
-                    LOG.info().$("purging overwritten partition directory [path=").$(path).I$();
-                    purgePartition(tableToken, ff, path, "purging overwritten partition directory [path=");
+                    purgePartition(tableToken, ff, path, tableRootLen - tableToken.getDirNameUtf8().size() - 1, "purging overwritten partition directory [path=");
                 } else {
-                    LOG.info().$("cannot purge overwritten partition directory, locked for reading [path=").$(path).I$();
+                    LOG.info().$("cannot purge overwritten partition directory, locked for reading path=").$sub(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
                 }
             }
         }
     }
 
-    private void purgePartition(TableToken tableToken, FilesFacade ff, Path path, String message) {
+    private void purgePartition(TableToken tableToken, FilesFacade ff, Path path, int pathLogSkip, String message) {
         if (engine.lockTableCreate(tableToken)) {
             try {
                 TableToken lastToken = engine.getUpdatedTableToken(tableToken);
                 if (lastToken == tableToken) {
-                    LOG.info().$(message).$(path).I$();
+                    LOG.info().$(message).$sub(pathLogSkip, path).I$();
                     ff.unlinkOrRemove(path, LOG);
                 } else {
                     // table is dropped and recreated since we started processing it.

--- a/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
@@ -267,7 +267,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                 purgePartition(tableToken, ff, path, tableRootLen - tableToken.getDirNameUtf8().size() - 1, "purging dropped partition directory [path=");
                 lastTxn = nameTxn;
             } else {
-                LOG.debug().$("cannot purge partition directory, locked for reading [path=").$sub(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
+                LOG.debug().$("cannot purge partition directory, locked for reading [path=").$substr(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
                 break;
             }
         }
@@ -354,18 +354,18 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
                     // See comments of why +1 added there in parsePartitionDateVersion()
                     purgePartition(tableToken, ff, path, tableRootLen - tableToken.getDirNameUtf8().size() - 1, "purging overwritten partition directory [path=");
                 } else {
-                    LOG.info().$("cannot purge overwritten partition directory, locked for reading path=").$sub(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
+                    LOG.info().$("cannot purge overwritten partition directory, locked for reading path=").$substr(tableRootLen - tableToken.getDirNameUtf8().size() - 1, path).I$();
                 }
             }
         }
     }
 
-    private void purgePartition(TableToken tableToken, FilesFacade ff, Path path, int pathLogSkip, String message) {
+    private void purgePartition(TableToken tableToken, FilesFacade ff, Path path, int pathFrom, String message) {
         if (engine.lockTableCreate(tableToken)) {
             try {
                 TableToken lastToken = engine.getUpdatedTableToken(tableToken);
                 if (lastToken == tableToken) {
-                    LOG.info().$(message).$sub(pathLogSkip, path).I$();
+                    LOG.info().$(message).$substr(pathFrom, path).I$();
                     ff.unlinkOrRemove(path, LOG);
                 } else {
                     // table is dropped and recreated since we started processing it.

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -605,7 +605,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_SIZE, -1L);
             openPartitionCount--;
 
-            LOG.debug().$("closed partition [path=").$sub(dbRootSize, path).$(", timestamp=").$ts(partitionTimestamp).I$();
+            LOG.debug().$("closed partition [path=").$substr(dbRootSize, path).$(", timestamp=").$ts(partitionTimestamp).I$();
         }
     }
 
@@ -872,7 +872,7 @@ public class TableReader implements Closeable, SymbolTableSource {
                 final long partitionSize = txFile.getPartitionSize(partitionIndex);
                 if (partitionSize > -1L) {
                     LOG.info()
-                            .$("open partition [path=").$sub(dbRootSize, path)
+                            .$("open partition [path=").$substr(dbRootSize, path)
                             .$(", rowCount=").$(partitionSize)
                             .$(", partitionIndex=").$(partitionIndex)
                             .$(", partitionCount=").$(partitionCount)

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -57,6 +57,7 @@ public class TableReader implements Closeable, SymbolTableSource {
     private final MillisecondClock clock;
     private final ColumnVersionReader columnVersionReader;
     private final CairoConfiguration configuration;
+    private final int dbRootSize;
     private final FilesFacade ff;
     private final int maxOpenPartitions;
     private final MessageBus messageBus;
@@ -103,7 +104,9 @@ public class TableReader implements Closeable, SymbolTableSource {
         this.messageBus = messageBus;
         try {
             this.path = new Path();
-            this.path.of(configuration.getRoot()).concat(this.tableToken.getDirName());
+            this.path.of(configuration.getRoot());
+            this.dbRootSize = this.path.size();
+            path.concat(this.tableToken.getDirName());
             this.rootLen = path.size();
             path.trimTo(rootLen);
 
@@ -602,7 +605,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_SIZE, -1L);
             openPartitionCount--;
 
-            LOG.debug().$("closed partition [path=").$(path).$(", timestamp=").$ts(partitionTimestamp).I$();
+            LOG.debug().$("closed partition [path=").$sub(dbRootSize, path).$(", timestamp=").$ts(partitionTimestamp).I$();
         }
     }
 
@@ -869,8 +872,8 @@ public class TableReader implements Closeable, SymbolTableSource {
                 final long partitionSize = txFile.getPartitionSize(partitionIndex);
                 if (partitionSize > -1L) {
                     LOG.info()
-                            .$("open partition ").$(path)
-                            .$(" [rowCount=").$(partitionSize)
+                            .$("open partition [path=").$sub(dbRootSize, path)
+                            .$(", rowCount=").$(partitionSize)
                             .$(", partitionIndex=").$(partitionIndex)
                             .$(", partitionCount=").$(partitionCount)
                             .I$();
@@ -1090,10 +1093,8 @@ public class TableReader implements Closeable, SymbolTableSource {
                         LOG.critical().$("Invalid var len column size [column=").$(name).$(", size=").$(dataSize).$(", path=").$(path).I$();
                         throw CairoException.critical(0).put("Invalid column size [column=").put(path).put(", size=").put(dataSize).put(']');
                     }
-                    if (columnRowCount > 0) {
-                        TableUtils.dFile(path.trimTo(plen), name, columnTxn);
-                        openOrCreateMemory(path, columns, primaryIndex, dataMem, dataSize);
-                    }
+                    TableUtils.dFile(path.trimTo(plen), name, columnTxn);
+                    openOrCreateMemory(path, columns, primaryIndex, dataMem, dataSize);
                 } else {
                     TableUtils.dFile(path.trimTo(plen), name, columnTxn);
                     openOrCreateMemory(

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1896,7 +1896,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     copiedToMemory = true;
                 } else {
                     // Wal column can are lazily mapped to improve performance. It works ok, except in this case
-                    // where access getAddress() calls be concurrent. Map the eagerly now.
+                    // where access getAddress() calls be concurrent. Map them eagerly now.
                     mmapWalColsEager();
 
                     timestampAddr = walTimestampColumn.addressOf(0);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1753,7 +1753,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Can commit without O3 and LAG has just enough rows
                         || (commitToTimestamp >= newMaxLagTimestamp && totalUncommitted > getMetaMaxUncommittedRows())
                         // Too many uncommitted transactions in LAG
-                        || (configuration.getWalMaxLagTxnCount() > 0 && txWriter.getLagTxnCount() > configuration.getWalMaxLagTxnCount());
+                        || (configuration.getWalMaxLagTxnCount() > 0 && txWriter.getLagTxnCount() >= configuration.getWalMaxLagTxnCount());
 
                 boolean canFastCommit = indexers.size() == 0 && applyFromWalLagToLastPartitionPossible(commitToTimestamp, txWriter.getLagRowCount(), txWriter.isLagOrdered(), txWriter.getMaxTimestamp(), txWriter.getLagMinTimestamp(), txWriter.getLagMaxTimestamp());
                 boolean lagOrderedNew = !isDeduplicationEnabled() && txWriter.isLagOrdered() && ordered && walLagMaxTimestampBefore <= o3TimestampMin;

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMORImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMORImpl.java
@@ -33,14 +33,9 @@ import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.str.LPSZ;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 // Contiguous mapped with offset readable memory
-// todo: investigate if we can map file from 0 offset and have the logic in this class done by the OS
 public class MemoryCMORImpl extends MemoryCMRImpl implements MemoryCMOR {
-    private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
     private static final Log LOG = LogFactory.getLog(MemoryCMORImpl.class);
-    private final long id = ID_GENERATOR.incrementAndGet();
     private long mapFileOffset;
     private long offset;
 
@@ -125,7 +120,7 @@ public class MemoryCMORImpl extends MemoryCMRImpl implements MemoryCMOR {
         } else {
             openFile(ff, name);
         }
-        mapLazy(ff, name, lo, hi);
+        mapLazy(lo, hi);
     }
 
     @Override
@@ -142,7 +137,7 @@ public class MemoryCMORImpl extends MemoryCMRImpl implements MemoryCMOR {
         return size + mapFileOffset - offset;
     }
 
-    private void mapLazy(FilesFacade ff, LPSZ name, long lo, long hi) {
+    private void mapLazy(long lo, long hi) {
         assert hi >= 0 && hi >= lo : "hi : " + hi + " lo : " + lo;
         if (hi > lo) {
             this.offset = lo;
@@ -185,6 +180,6 @@ public class MemoryCMORImpl extends MemoryCMRImpl implements MemoryCMOR {
         }
 
         // ---------------V leave a space here for alignment with open log message
-        LOG.debug().$("map  [fd=").$(fd).$(", pageSize=").$(size).$(", size=").$(this.size).$(']').$();
+        LOG.debug().$("map  [fd=").$(fd).$(", size=").$(this.size).$(']').$();
     }
 }

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMORImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMORImpl.java
@@ -161,10 +161,9 @@ public class MemoryCMORImpl extends MemoryCMRImpl implements MemoryCMOR {
 
     private void setSize0(long newSize) {
         try {
-            if (size > 0) {
+            if (size > 0 && pageAddress != 0) {
                 pageAddress = TableUtils.mremap(ff, fd, pageAddress, size, newSize, mapFileOffset, Files.MAP_RO, memoryTag);
             } else {
-                assert pageAddress == 0;
                 pageAddress = TableUtils.mapRO(ff, fd, newSize, mapFileOffset, memoryTag);
             }
             size = newSize;

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
@@ -147,7 +147,8 @@ public interface MemoryCR extends MemoryC, MemoryR {
         return false;
     }
 
-    default void map() {}
+    default void map() {
+    }
 
     class ByteSequenceView implements BinarySequence, Mutable {
         private long address;

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
@@ -147,6 +147,8 @@ public interface MemoryCR extends MemoryC, MemoryR {
         return false;
     }
 
+    default void map() {}
+
     class ByteSequenceView implements BinarySequence, Mutable {
         private long address;
         private long len = -1;

--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -120,7 +120,7 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
         }
         checkMissingWalTransactions();
         lastProcessedCount = unpublishedWalTxnCount;
-        return true;
+        return !notificationQueueIsFull;
     }
 
     private boolean checkSequencerTrackers() {

--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -49,6 +49,7 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
     private long lastProcessedCount = 0;
     private long lastRunMs;
     private Path threadLocalPath;
+    private boolean notificationQueueIsFull = false;
 
     public CheckWalTransactionsJob(CairoEngine engine) {
         this.engine = engine;
@@ -68,6 +69,10 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
     }
 
     public void checkNotifyOutstandingTxnInWal(@NotNull TableToken tableToken, long seqTxn) {
+        if (notificationQueueIsFull) {
+            return;
+        }
+
         if (
                 seqTxn < 0 && TableUtils.exists(
                         ff,
@@ -77,11 +82,11 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
                 ) == TableUtils.TABLE_EXISTS
         ) {
             // Dropped table
-            engine.notifyWalTxnCommitted(tableToken);
+            notificationQueueIsFull = !engine.notifyWalTxnCommitted(tableToken);
         } else {
             if (engine.getTableSequencerAPI().isTxnTrackerInitialised(tableToken)) {
                 if (engine.getTableSequencerAPI().notifyOnCheck(tableToken, seqTxn)) {
-                    engine.notifyWalTxnCommitted(tableToken);
+                    notificationQueueIsFull = !engine.notifyWalTxnCommitted(tableToken);
                 }
             } else {
                 LPSZ txnPath = threadLocalPath.trimTo(dbRoot.length()).concat(tableToken).concat(TableUtils.TXN_FILE_NAME).$();
@@ -89,7 +94,7 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
                     try (TxReader txReader = this.txReader.ofRO(txnPath, PartitionBy.NONE)) {
                         TableUtils.safeReadTxn(this.txReader, millisecondClock, spinLockTimeout);
                         if (engine.getTableSequencerAPI().initTxnTracker(tableToken, txReader.getSeqTxn(), seqTxn)) {
-                            engine.notifyWalTxnCommitted(tableToken);
+                            notificationQueueIsFull = !engine.notifyWalTxnCommitted(tableToken);
                         }
                     } catch (CairoException e) {
                         if (!e.errnoReadPathDoesNotExist()) {
@@ -104,11 +109,12 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
     @Override
     public boolean runSerially() {
         long unpublishedWalTxnCount = engine.getUnpublishedWalTxnCount();
-        if (unpublishedWalTxnCount == lastProcessedCount) {
+        if (unpublishedWalTxnCount == lastProcessedCount || notificationQueueIsFull) {
+            // when notification queue was full last run, re-evalute tables after a timeout
             final long t = millisecondClock.getTicks();
             if (lastRunMs + checkInterval < t) {
                 lastRunMs = t;
-                checkSequencerTrackers();
+                notificationQueueIsFull = !checkSequencerTrackers();
             }
             return false;
         }
@@ -117,14 +123,17 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
         return true;
     }
 
-    private void checkSequencerTrackers() {
+    private boolean checkSequencerTrackers() {
         engine.getTableTokens(tableTokenBucket, false);
         for (int i = 0, n = tableTokenBucket.size(); i < n; i++) {
             TableToken tableToken = tableTokenBucket.get(i);
             SeqTxnTracker tracker = engine.getTableSequencerAPI().getTxnTracker(tableToken);
             if (!tracker.isSuspended() && tracker.getWriterTxn() < tracker.getSeqTxn()) {
-                engine.notifyWalTxnCommitted(tableToken);
+                if (!engine.notifyWalTxnCommitted(tableToken)) {
+                    return false;
+                }
             }
         }
+        return true;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -114,7 +114,7 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
             final long t = millisecondClock.getTicks();
             if (lastRunMs + checkInterval < t) {
                 lastRunMs = t;
-                notificationQueueIsFull = !checkSequencerTrackers();
+                notificationQueueIsFull = !republishNotificationsFromTrackers();
             }
             return false;
         }
@@ -123,7 +123,7 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
         return !notificationQueueIsFull;
     }
 
-    private boolean checkSequencerTrackers() {
+    private boolean republishNotificationsFromTrackers() {
         engine.getTableTokens(tableTokenBucket, false);
         for (int i = 0, n = tableTokenBucket.size(); i < n; i++) {
             TableToken tableToken = tableTokenBucket.get(i);

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -63,7 +63,6 @@ public class WalWriter implements TableWriterAPI {
     private final AlterOperation alterOp = new AlterOperation();
     private final ObjList<MemoryMA> columns;
     private final CairoConfiguration configuration;
-    private final int dbRootSize;
     private final DdlListener ddlListener;
     private final WalEventWriter events;
     private final FilesFacade ff;
@@ -76,7 +75,8 @@ public class WalWriter implements TableWriterAPI {
     private final int mkDirMode;
     private final ObjList<Runnable> nullSetters;
     private final Path path;
-    private final int rootLen;
+    private final int pathRootSize;
+    private final int pathSize;
     private final RowImpl row = new RowImpl();
     private final LongList rowValueIsNotNull = new LongList();
     private final TableSequencerAPI sequencer;
@@ -132,9 +132,9 @@ public class WalWriter implements TableWriterAPI {
         this.walName = WAL_NAME_BASE + walId;
         this.walId = walId;
         this.path = new Path().of(configuration.getRoot());
-        this.dbRootSize = path.size();
+        this.pathRootSize = path.size();
         this.path.concat(tableToken).concat(walName);
-        this.rootLen = path.size();
+        this.pathSize = path.size();
         this.metrics = metrics;
         this.open = true;
         this.symbolMapMem = Vm.getMARInstance(configuration.getCommitMode());
@@ -272,7 +272,7 @@ public class WalWriter implements TableWriterAPI {
                     sync(commitMode);
                 }
                 final long seqTxn = getSequencerTxn();
-                LOG.info().$("committed data block [wal=").$sub(dbRootSize, path).$(Files.SEPARATOR).$(segmentId)
+                LOG.info().$("committed data block [wal=").$substr(pathRootSize, path).$(Files.SEPARATOR).$(segmentId)
                         .$(", segmentTxn=").$(lastSegmentTxn)
                         .$(", seqTxn=").$(seqTxn)
                         .$(", rowLo=").$(currentTxnStartRowNum).$(", roHi=").$(segmentRowCount)
@@ -490,7 +490,7 @@ public class WalWriter implements TableWriterAPI {
             segmentLockFd = -1;
             try {
                 createSegmentDir(newSegmentId);
-                path.trimTo(rootLen);
+                path.trimTo(pathSize);
                 SegmentColumnRollSink columnRollSink = createSegmentColumnRollSink();
                 rowValueIsNotNull.fill(0, columnCount, -1);
 
@@ -939,7 +939,7 @@ public class WalWriter implements TableWriterAPI {
         tempPath.of(configuration.getRoot()).concat(tableToken);
         int tempPathTripLen = tempPath.size();
 
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         TableUtils.offsetFileName(tempPath, columnName, columnNameTxn);
         TableUtils.offsetFileName(path, columnName, COLUMN_NAME_TXN_NONE);
         if (-1 == ff.hardLink(tempPath.$(), path.$())) {
@@ -953,7 +953,7 @@ public class WalWriter implements TableWriterAPI {
         }
 
         tempPath.trimTo(tempPathTripLen);
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         TableUtils.charFileName(tempPath, columnName, columnNameTxn);
         TableUtils.charFileName(path, columnName, COLUMN_NAME_TXN_NONE);
         if (-1 == ff.hardLink(tempPath.$(), path.$())) {
@@ -962,13 +962,13 @@ public class WalWriter implements TableWriterAPI {
                     .$(", to=").$(path)
                     .$(", errno=").$(ff.errno())
                     .I$();
-            removeSymbolFiles(path, rootLen, columnName);
+            removeSymbolFiles(path, pathSize, columnName);
             configureEmptySymbol(columnWriterIndex);
             return;
         }
 
         tempPath.trimTo(tempPathTripLen);
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         BitmapIndexUtils.keyFileName(tempPath, columnName, columnNameTxn);
         BitmapIndexUtils.keyFileName(path, columnName, COLUMN_NAME_TXN_NONE);
         if (-1 == ff.hardLink(tempPath.$(), path.$())) {
@@ -977,13 +977,13 @@ public class WalWriter implements TableWriterAPI {
                     .$(", to=").$(path)
                     .$(", errno=").$(ff.errno())
                     .I$();
-            removeSymbolFiles(path, rootLen, columnName);
+            removeSymbolFiles(path, pathSize, columnName);
             configureEmptySymbol(columnWriterIndex);
             return;
         }
 
         tempPath.trimTo(tempPathTripLen);
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         BitmapIndexUtils.valueFileName(tempPath, columnName, columnNameTxn);
         BitmapIndexUtils.valueFileName(path, columnName, COLUMN_NAME_TXN_NONE);
         if (-1 == ff.hardLink(tempPath.$(), path.$())) {
@@ -992,12 +992,12 @@ public class WalWriter implements TableWriterAPI {
                     .$(", to=").$(path)
                     .$(", errno=").$(ff.errno())
                     .I$();
-            removeSymbolFiles(path, rootLen, columnName);
+            removeSymbolFiles(path, pathSize, columnName);
             configureEmptySymbol(columnWriterIndex);
             return;
         }
 
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         SymbolMapReader symbolMapReader = new SymbolMapReaderImpl(
                 configuration,
                 path,
@@ -1099,7 +1099,7 @@ public class WalWriter implements TableWriterAPI {
     }
 
     private int createSegmentDir(int segmentId) {
-        path.trimTo(rootLen);
+        path.trimTo(pathSize);
         path.slash().put(segmentId);
         final int segmentPathLen = path.size();
         segmentLockFd = acquireSegmentLock();
@@ -1201,7 +1201,7 @@ public class WalWriter implements TableWriterAPI {
             lockName(path);
             walLockFd = TableUtils.lock(ff, path.$());
         } finally {
-            path.trimTo(rootLen);
+            path.trimTo(pathSize);
         }
 
         if (walLockFd == -1) {
@@ -1319,12 +1319,12 @@ public class WalWriter implements TableWriterAPI {
                 ff.fsyncAndClose(dirFd);
             }
             lastSegmentTxn = 0;
-            LOG.info().$("opened WAL segment [path=").$sub(dbRootSize, path).$('\'').I$();
+            LOG.info().$("opened WAL segment [path=").$substr(pathRootSize, path).$('\'').I$();
         } finally {
             if (oldSegmentLockFd > -1) {
                 releaseSegmentLock(oldSegmentId, oldSegmentLockFd, oldSegmentRows);
             }
-            path.trimTo(rootLen);
+            path.trimTo(pathSize);
         }
     }
 
@@ -1337,9 +1337,9 @@ public class WalWriter implements TableWriterAPI {
                         .$(", fd=").$(segmentLockFd)
                         .$(']').$();
             } else {
-                path.trimTo(rootLen).slash().put(segmentId);
+                path.trimTo(pathSize).slash().put(segmentId);
                 walDirectoryPolicy.rollbackDirectory(path);
-                path.trimTo(rootLen);
+                path.trimTo(pathSize);
             }
         } else {
             LOG.error()
@@ -1395,11 +1395,11 @@ public class WalWriter implements TableWriterAPI {
         initialSymbolCounts.set(index, -1);
         localSymbolIds.set(index, 0);
         symbolMapNullFlags.set(index, false);
-        removeSymbolFiles(path, rootLen, metadata.getColumnName(index));
+        removeSymbolFiles(path, pathSize, metadata.getColumnName(index));
     }
 
     private void renameColumnFiles(int columnType, CharSequence columnName, CharSequence newName) {
-        path.trimTo(rootLen).slash().put(segmentId);
+        path.trimTo(pathSize).slash().put(segmentId);
         final Path tempPath = Path.PATH.get().of(path);
 
         if (ColumnType.isVarSize(columnType)) {
@@ -1461,7 +1461,7 @@ public class WalWriter implements TableWriterAPI {
             // In this case we DO NOT roll back the last record in the events file.
             events.rollback();
         }
-        path.trimTo(rootLen).slash().put(newSegmentId);
+        path.trimTo(pathSize).slash().put(newSegmentId);
         events.openEventFile(path, path.size(), isTruncateFilesOnClose(), tableToken.isSystem());
         if (isCommittingData) {
             // When current transaction is not a data transaction but a column add transaction
@@ -1887,11 +1887,11 @@ public class WalWriter implements TableWriterAPI {
                     if (!rollSegmentOnNextRow) {
                         // this means we have rolled uncommitted rows to a new segment already
                         // we should switch metadata to this new segment
-                        path.trimTo(rootLen).slash().put(segmentId);
+                        path.trimTo(pathSize).slash().put(segmentId);
                         // this will close old _meta file and create the new one
                         metadata.switchTo(path, path.size(), isTruncateFilesOnClose());
                         openColumnFiles(columnName, columnType, columnIndex, path.size());
-                        path.trimTo(rootLen);
+                        path.trimTo(pathSize);
                     }
 
                     // if we did not have to roll uncommitted rows to a new segment
@@ -1904,14 +1904,14 @@ public class WalWriter implements TableWriterAPI {
                     if (securityContext != null) {
                         ddlListener.onColumnAdded(securityContext, metadata.getTableToken(), columnName);
                     }
-                    LOG.info().$("added column to WAL [path=").$sub(dbRootSize, path).$(", columnName=").utf8(columnName).$(", type=").$(ColumnType.nameOf(columnType)).I$();
+                    LOG.info().$("added column to WAL [path=").$substr(pathRootSize, path).$(", columnName=").utf8(columnName).$(", type=").$(ColumnType.nameOf(columnType)).I$();
                 } else {
                     throw CairoException.critical(0).put("column '").put(columnName)
                             .put("' was added, cannot apply commit because of concurrent table definition change");
                 }
             } else {
                 if (metadata.getColumnType(columnIndex) == columnType) {
-                    LOG.info().$("column has already been added by another WAL [path=").$sub(dbRootSize, path).$(", columnName=").utf8(columnName).I$();
+                    LOG.info().$("column has already been added by another WAL [path=").$substr(pathRootSize, path).$(", columnName=").utf8(columnName).I$();
                 } else {
                     throw CairoException.nonCritical().put("column '").put(columnName).put("' already exists");
                 }
@@ -1941,13 +1941,13 @@ public class WalWriter implements TableWriterAPI {
 
                         if (currentTxnStartRowNum == 0 || segmentRowCount == currentTxnStartRowNum) {
                             metadata.changeColumnType(columnName, newType);
-                            path.trimTo(rootLen).slash().put(segmentId);
+                            path.trimTo(pathSize).slash().put(segmentId);
 
                             markColumnRemoved(existingColumnIndex, existingColumnType);
                             if (!rollSegmentOnNextRow) {
                                 // this means we have rolled uncommitted rows to a new segment already
                                 // we should switch metadata to this new segment
-                                path.trimTo(rootLen).slash().put(segmentId);
+                                path.trimTo(pathSize).slash().put(segmentId);
                                 // this will close old _meta file and create the new one
                                 metadata.switchTo(path, path.size(), isTruncateFilesOnClose());
 
@@ -1960,7 +1960,7 @@ public class WalWriter implements TableWriterAPI {
                                 // if we did not have to roll uncommitted rows to a new segment
                                 // remove .i files when converting var type to fixed
                                 if (ColumnType.isVarSize(existingColumnType) && !ColumnType.isVarSize(newType)) {
-                                    path.trimTo(rootLen).slash().put(segmentId);
+                                    path.trimTo(pathSize).slash().put(segmentId);
                                     LPSZ lpsz = iFile(path, columnName);
                                     if (ff.exists(lpsz)) {
                                         ff.remove(lpsz);
@@ -1971,7 +1971,7 @@ public class WalWriter implements TableWriterAPI {
                             if (securityContext != null) {
                                 ddlListener.onColumnTypeChanged(securityContext, metadata.getTableToken(), columnName, existingColumnType, newType);
                             }
-                            path.trimTo(rootLen);
+                            path.trimTo(pathSize);
                         } else {
                             throw CairoException.critical(0).put("column '").put(columnName)
                                     .put("' was removed, cannot apply commit because of concurrent table definition change");
@@ -2025,7 +2025,7 @@ public class WalWriter implements TableWriterAPI {
                         if (!rollSegmentOnNextRow) {
                             // this means we have rolled uncommitted rows to a new segment already
                             // we should switch metadata to this new segment
-                            path.trimTo(rootLen).slash().put(segmentId);
+                            path.trimTo(pathSize).slash().put(segmentId);
                             // this will close old _meta file and create the new one
                             metadata.switchTo(path, path.size(), isTruncateFilesOnClose());
                         }
@@ -2034,8 +2034,8 @@ public class WalWriter implements TableWriterAPI {
                         // as part of rolling to a new segment
 
                         markColumnRemoved(index, type);
-                        path.trimTo(rootLen);
-                        LOG.info().$("removed column from WAL [path=").$sub(dbRootSize, path).$(Files.SEPARATOR).$(segmentId)
+                        path.trimTo(pathSize);
+                        LOG.info().$("removed column from WAL [path=").$substr(pathRootSize, path).$(Files.SEPARATOR).$(segmentId)
                                 .$(", columnName=").utf8(columnName).I$();
                     } else {
                         throw CairoException.critical(0).put("column '").put(columnName)
@@ -2074,7 +2074,7 @@ public class WalWriter implements TableWriterAPI {
                         if (!rollSegmentOnNextRow) {
                             // this means we have rolled uncommitted rows to a new segment already
                             // we should switch metadata to this new segment
-                            path.trimTo(rootLen).slash().put(segmentId);
+                            path.trimTo(pathSize).slash().put(segmentId);
                             // this will close old _meta file and create the new one
                             metadata.switchTo(path, path.size(), isTruncateFilesOnClose());
                             renameColumnFiles(columnType, columnName, newColumnName);
@@ -2087,8 +2087,8 @@ public class WalWriter implements TableWriterAPI {
                             ddlListener.onColumnRenamed(securityContext, metadata.getTableToken(), columnName, newColumnName);
                         }
 
-                        path.trimTo(rootLen);
-                        LOG.info().$("renamed column in WAL [path=").$sub(dbRootSize, path).$(Files.SEPARATOR).$(segmentId)
+                        path.trimTo(pathSize);
+                        LOG.info().$("renamed column in WAL [path=").$substr(pathRootSize, path).$(Files.SEPARATOR).$(segmentId)
                                 .$(", columnName=").utf8(columnName).$(", newColumnName=").utf8(newColumnName).I$();
                     } else {
                         throw CairoException.critical(0).put("column '").put(columnName)

--- a/core/src/main/java/io/questdb/log/AbstractLogRecord.java
+++ b/core/src/main/java/io/questdb/log/AbstractLogRecord.java
@@ -119,6 +119,20 @@ abstract class AbstractLogRecord implements LogRecord, Log {
     }
 
     @Override
+    public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+        if (sequence == null) {
+            sink().putAscii("null");
+        } else {
+            if (sequence.size() > skip) {
+                sink().putNonAscii(sequence.lo() + skip, sequence.hi());
+            } else {
+                sink().put(sequence);
+            }
+        }
+        return this;
+    }
+
+    @Override
     public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
         sink().putAscii(sequence, lo, hi);
         return this;

--- a/core/src/main/java/io/questdb/log/AbstractLogRecord.java
+++ b/core/src/main/java/io/questdb/log/AbstractLogRecord.java
@@ -266,10 +266,14 @@ abstract class AbstractLogRecord implements LogRecord, Log {
         if (sequence == null) {
             sink().putAscii("null");
         } else {
-            if (sequence.size() > from) {
+            if (from > -1 && sequence.size() > from) {
                 sink().putNonAscii(sequence.lo() + from, sequence.hi());
             } else {
-                sink().put(sequence);
+                sink()
+                        .put("WTF? substr? [from:").put(from)
+                        .put(", sequence=").put(sequence)
+                        .put(", size=").put(sequence.size())
+                        .put(']');
             }
         }
         return this;

--- a/core/src/main/java/io/questdb/log/AbstractLogRecord.java
+++ b/core/src/main/java/io/questdb/log/AbstractLogRecord.java
@@ -119,20 +119,6 @@ abstract class AbstractLogRecord implements LogRecord, Log {
     }
 
     @Override
-    public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
-        if (sequence == null) {
-            sink().putAscii("null");
-        } else {
-            if (sequence.size() > skip) {
-                sink().putNonAscii(sequence.lo() + skip, sequence.hi());
-            } else {
-                sink().put(sequence);
-            }
-        }
-        return this;
-    }
-
-    @Override
     public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
         sink().putAscii(sequence, lo, hi);
         return this;
@@ -190,12 +176,6 @@ abstract class AbstractLogRecord implements LogRecord, Log {
     @Override
     public LogRecord $(long l) {
         sink().put(l);
-        return this;
-    }
-
-    @Override
-    public LogRecord $uuid(long lo, long hi) {
-        Numbers.appendUuid(lo, hi, this);
         return this;
     }
 
@@ -282,6 +262,20 @@ abstract class AbstractLogRecord implements LogRecord, Log {
     }
 
     @Override
+    public LogRecord $substr(int from, @Nullable DirectUtf8Sequence sequence) {
+        if (sequence == null) {
+            sink().putAscii("null");
+        } else {
+            if (sequence.size() > from) {
+                sink().putNonAscii(sequence.lo() + from, sequence.hi());
+            } else {
+                sink().put(sequence);
+            }
+        }
+        return this;
+    }
+
+    @Override
     public LogRecord $ts(long x) {
         sink().putISODate(x);
         return this;
@@ -290,6 +284,12 @@ abstract class AbstractLogRecord implements LogRecord, Log {
     @Override
     public LogRecord $utf8(long lo, long hi) {
         sink().putNonAscii(lo, hi);
+        return this;
+    }
+
+    @Override
+    public LogRecord $uuid(long lo, long hi) {
+        Numbers.appendUuid(lo, hi, this);
         return this;
     }
 

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -886,11 +886,6 @@ public class LogFactory implements Closeable {
         }
 
         @Override
-        public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
-            return this;
-        }
-
-        @Override
         public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
             return this;
         }
@@ -936,11 +931,6 @@ public class LogFactory implements Closeable {
         }
 
         @Override
-        public LogRecord $uuid(long lo, long hi) {
-            return this;
-        }
-
-        @Override
         public LogRecord $(@Nullable Sinkable x) {
             return this;
         }
@@ -971,12 +961,22 @@ public class LogFactory implements Closeable {
         }
 
         @Override
+        public LogRecord $substr(int from, @Nullable DirectUtf8Sequence sequence) {
+            return this;
+        }
+
+        @Override
         public LogRecord $ts(long x) {
             return this;
         }
 
         @Override
         public LogRecord $utf8(long lo, long hi) {
+            return this;
+        }
+
+        @Override
+        public LogRecord $uuid(long lo, long hi) {
             return this;
         }
 

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -886,6 +886,11 @@ public class LogFactory implements Closeable {
         }
 
         @Override
+        public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+            return this;
+        }
+
+        @Override
         public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
             return this;
         }

--- a/core/src/main/java/io/questdb/log/LogRecord.java
+++ b/core/src/main/java/io/questdb/log/LogRecord.java
@@ -43,8 +43,6 @@ public interface LogRecord extends Utf8Sink {
 
     LogRecord $(@Nullable DirectUtf8Sequence sequence);
 
-    LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence);
-
     LogRecord $(@NotNull CharSequence sequence, int lo, int hi);
 
     LogRecord $(int x);
@@ -71,15 +69,17 @@ public interface LogRecord extends Utf8Sink {
 
     LogRecord $hexPadded(long value);
 
-    LogRecord $uuid(long lo, long hi);
-
     LogRecord $ip(long ip);
 
     LogRecord $size(long memoryBytes);
 
+    LogRecord $substr(int from, @Nullable DirectUtf8Sequence sequence);
+
     LogRecord $ts(long x);
 
     LogRecord $utf8(long lo, long hi);
+
+    LogRecord $uuid(long lo, long hi);
 
     default void I$() {
         $(']').$();

--- a/core/src/main/java/io/questdb/log/LogRecord.java
+++ b/core/src/main/java/io/questdb/log/LogRecord.java
@@ -43,6 +43,8 @@ public interface LogRecord extends Utf8Sink {
 
     LogRecord $(@Nullable DirectUtf8Sequence sequence);
 
+    LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence);
+
     LogRecord $(@NotNull CharSequence sequence, int lo, int hi);
 
     LogRecord $(int x);

--- a/core/src/main/java/io/questdb/log/NullLogRecord.java
+++ b/core/src/main/java/io/questdb/log/NullLogRecord.java
@@ -60,6 +60,11 @@ final class NullLogRecord implements LogRecord {
     }
 
     @Override
+    public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+        return this;
+    }
+
+    @Override
     public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
         return this;
     }

--- a/core/src/main/java/io/questdb/log/NullLogRecord.java
+++ b/core/src/main/java/io/questdb/log/NullLogRecord.java
@@ -60,7 +60,7 @@ final class NullLogRecord implements LogRecord {
     }
 
     @Override
-    public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+    public LogRecord $substr(int from, @Nullable DirectUtf8Sequence sequence) {
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -419,7 +419,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(20, configuration.getCairoConfiguration().getWalApplyLookAheadTransactionCount());
         Assert.assertEquals(4, configuration.getCairoConfiguration().getO3LagCalculationWindowsSize());
         Assert.assertEquals(200_000, configuration.getCairoConfiguration().getWalSegmentRolloverRowCount());
-        Assert.assertEquals(20.0d, configuration.getCairoConfiguration().getWalSquashUncommittedRowsMultiplier(), 0.00001);
+        Assert.assertEquals(20.0d, configuration.getCairoConfiguration().getWalLagRowsMultiplier(), 0.00001);
         Assert.assertEquals(-1, configuration.getCairoConfiguration().getWalMaxLagTxnCount());
         Assert.assertEquals(1048576, configuration.getCairoConfiguration().getWalDataAppendPageSize());
         Assert.assertEquals(262144, configuration.getCairoConfiguration().getSystemWalDataAppendPageSize());
@@ -1453,7 +1453,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(100, configuration.getWalWriterPoolMaxSegments());
         Assert.assertEquals(120, configuration.getO3LagCalculationWindowsSize());
         Assert.assertEquals(100, configuration.getWalSegmentRolloverRowCount());
-        Assert.assertEquals(42.2d, configuration.getWalSquashUncommittedRowsMultiplier(), 0.00001);
+        Assert.assertEquals(42.2d, configuration.getWalLagRowsMultiplier(), 0.00001);
         Assert.assertEquals(4242, configuration.getWalMaxLagTxnCount());
         Assert.assertEquals(262144, configuration.getWalDataAppendPageSize());
         Assert.assertEquals(524288, configuration.getSystemWalDataAppendPageSize());

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContiguousOffsetMappedMemoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContiguousOffsetMappedMemoryTest.java
@@ -120,6 +120,7 @@ public class ContiguousOffsetMappedMemoryTest extends AbstractTest {
 
                     memoryROffset.ofOffset(ff, path.$(), Files.PAGE_SIZE - 10, 2 * Files.PAGE_SIZE + 10, MemoryTag.NATIVE_DEFAULT);
                     try {
+                        memoryROffset.map();
                         memoryROffset.growToFileSize();
                         Assert.fail();
                     } catch (CairoException ex) {

--- a/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
@@ -1459,7 +1459,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     public void testTimestampSymbolDateAdd() throws Exception {
         assertQuery(
                 "dateadd\n" +
-                "2020-01-02T00:00:00.000000Z\n",
+                        "2020-01-02T00:00:00.000000Z\n",
                 "select dateadd('d', 1, cast('2020-01-01' as symbol))",
                 null,
                 null,

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bind/RegexpReplaceStrBindVariableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bind/RegexpReplaceStrBindVariableTest.java
@@ -57,8 +57,8 @@ public class RegexpReplaceStrBindVariableTest extends AbstractCairoTest {
 
                 TestUtils.assertEquals(
                         "regexp_replace\n" +
-                        "foobar\n" +
-                        "foobar\n" +
+                                "foobar\n" +
+                                "foobar\n" +
                                 "barbaz\n", sink
                 );
 

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -1276,6 +1276,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
             insert("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T01', 'a2a2')");
             insert("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T02', 'a2a2')");
             insert("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T03', 'a2a2')");
+            // Out of order
             insert("insert into " + tableName + " values (101, 'a1a1', 'str-1', '2022-02-24T02', 'a2a2')");
 
 
@@ -1668,7 +1669,15 @@ public class WalTableSqlTest extends AbstractCairoTest {
                 Assert.assertEquals("2022-02-24T01:00:00.000Z", Timestamps.toString(txReader.getLagMaxTimestamp()));
 
                 runApplyOnce();
+                txReader.unsafeLoadAll();
 
+                Assert.assertEquals(2, txReader.getLagTxnCount());
+                Assert.assertEquals(2, txReader.getLagRowCount());
+                Assert.assertFalse(txReader.isLagOrdered());
+                Assert.assertEquals(IntervalUtils.parseFloorPartialTimestamp("2022-02-24T00"), txReader.getLagMinTimestamp());
+                Assert.assertEquals(IntervalUtils.parseFloorPartialTimestamp("2022-02-24T01"), txReader.getLagMaxTimestamp());
+
+                runApplyOnce();
                 txReader.unsafeLoadAll();
 
                 Assert.assertEquals(0, txReader.getLagTxnCount());

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -97,9 +97,18 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
     }
 
     @Test
+    public void testInOrderSmallTxns() throws Exception {
+        Rnd rnd = generateRandom(LOG);
+        fuzzer.setFuzzCounts(false, 20000, 20000, 20, 10, 20, rnd.nextInt(10), 5, 2);
+        setFuzzProperties(rnd);
+        node1.setProperty(PropertyKey.CAIRO_WAL_MAX_LAG_TXN_COUNT, -1);
+        runFuzz(rnd);
+    }
+
+    @Test
     public void testChunkedSequencerWriting() throws Exception {
         Rnd rnd = generateRandom(LOG);
-        fuzzer.setFuzzCounts(false, 5_000, 200, 20, 10, 20, rnd.nextInt(10), 5, 2);
+        fuzzer.setFuzzCounts(false, 200, 200, 20, 10, 20, rnd.nextInt(10), 5, 2);
         setFuzzProperties(rnd);
         node1.setProperty(PropertyKey.CAIRO_DEFAULT_SEQ_PART_TXN_COUNT, 10);
         Assert.assertEquals(10, node1.getConfiguration().getDefaultSeqPartTxnCount());

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalWriterFuzzTest.java
@@ -108,7 +108,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
     @Test
     public void testChunkedSequencerWriting() throws Exception {
         Rnd rnd = generateRandom(LOG);
-        fuzzer.setFuzzCounts(false, 200, 200, 20, 10, 20, rnd.nextInt(10), 5, 2);
+        fuzzer.setFuzzCounts(false, 5_000, 200, 20, 10, 20, rnd.nextInt(10), 5, 2);
         setFuzzProperties(rnd);
         node1.setProperty(PropertyKey.CAIRO_DEFAULT_SEQ_PART_TXN_COUNT, 10);
         Assert.assertEquals(10, node1.getConfiguration().getDefaultSeqPartTxnCount());

--- a/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
@@ -578,7 +578,7 @@ public class LogAlertSocketTest {
         }
 
         @Override
-        public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+        public LogRecord $substr(int from, @Nullable DirectUtf8Sequence sequence) {
             throw new UnsupportedOperationException();
         }
 

--- a/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
+++ b/core/src/test/java/io/questdb/test/log/LogAlertSocketTest.java
@@ -578,6 +578,11 @@ public class LogAlertSocketTest {
         }
 
         @Override
+        public LogRecord $sub(int skip, @Nullable DirectUtf8Sequence sequence) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public LogRecord $(@NotNull CharSequence sequence, int lo, int hi) {
             sink.put(sequence, lo, hi);
             return this;


### PR DESCRIPTION
Every transaction written to WAL table has a fixed time needed to apply to the table columns. For small 1 line transactions this fixed overhead can make a big impact on overall throughput.

This PR reduces the time spent to apply a transaction and moves overall throughput from 3k transactions per second to 5k transactions per second in a simulated benchmark.

The changes are:
- avoid mmap/munmp WAL column files when data is copied using FDs (no mixed IO)
- optimise batching of rows in the last partition LAG area to reduce small, frequent full commits

Also, this PR reduces the logging by not logging full QuestDB paths to the files but only relative paths to the DB root directory.
