### PR TITLE
fix(sql): fix wrong results returned from parallel WHERE and GROUP BY for some function keys

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/StrTypeConstant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/StrTypeConstant.java
@@ -29,7 +29,6 @@ import io.questdb.griffin.TypeConstant;
 import io.questdb.griffin.engine.functions.StrFunction;
 
 public class StrTypeConstant extends StrFunction implements TypeConstant {
-
     public static final StrTypeConstant INSTANCE = new StrTypeConstant();
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToStrDateFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToStrDateFunctionFactory.java
@@ -89,15 +89,15 @@ public class ToStrDateFunctionFactory implements FunctionFactory {
         final DateFormat format;
         final CharSequence formatStr;
         final DateLocale locale;
-        final StringSink sink1;
-        final StringSink sink2;
+        final StringSink sinkA;
+        final StringSink sinkB;
 
         public ToCharDateVCFFunc(Function arg, DateFormat format, DateLocale locale, CharSequence formatStr) {
             this.arg = arg;
             this.format = format;
             this.locale = locale;
-            this.sink1 = new StringSink();
-            this.sink2 = new StringSink();
+            this.sinkA = new StringSink();
+            this.sinkB = new StringSink();
             this.formatStr = formatStr;
         }
 
@@ -108,23 +108,28 @@ public class ToStrDateFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return toSink(rec, sink1);
+            return toSink(rec, sinkA);
         }
 
         @Override
         public CharSequence getStrB(Record rec) {
-            return toSink(rec, sink2);
+            return toSink(rec, sinkB);
         }
 
         @Override
         public int getStrLen(Record rec) {
             long value = arg.getDate(rec);
-            if (value == Numbers.LONG_NULL) {
-                return -1;
+            if (value != Numbers.LONG_NULL) {
+                sinkA.clear();
+                toSink(value, sinkA);
+                return sinkA.length();
             }
-            sink1.clear();
-            toSink(value, sink1);
-            return sink1.length();
+            return -1;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override
@@ -135,12 +140,12 @@ public class ToStrDateFunctionFactory implements FunctionFactory {
         @Nullable
         private CharSequence toSink(Record rec, StringSink sink) {
             final long value = arg.getDate(rec);
-            if (value == Numbers.LONG_NULL) {
-                return null;
+            if (value != Numbers.LONG_NULL) {
+                sink.clear();
+                toSink(value, sink);
+                return sink;
             }
-            sink.clear();
-            toSink(value, sink);
-            return sink;
+            return null;
         }
 
         private void toSink(long value, Utf16Sink sink) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadFunctionFactory.java
@@ -62,10 +62,9 @@ public class LPadFunctionFactory implements FunctionFactory {
     }
 
     public static class LPadFunc extends StrFunction implements BinaryFunction {
-
         private final Function lenFunc;
         private final int maxLength;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -92,7 +91,7 @@ public class LPadFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(final Record rec) {
-            return lPad(strFunc.getStrA(rec), lenFunc.getInt(rec), sink);
+            return lPad(strFunc.getStrA(rec), lenFunc.getInt(rec), sinkA);
         }
 
         @Override
@@ -109,6 +108,11 @@ public class LPadFunctionFactory implements FunctionFactory {
             } else {
                 return TableUtils.NULL_LEN;
             }
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable
@@ -134,5 +138,4 @@ public class LPadFunctionFactory implements FunctionFactory {
             return null;
         }
     }
-
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadStrFunctionFactory.java
@@ -58,11 +58,10 @@ public class LPadStrFunctionFactory implements FunctionFactory {
     }
 
     public static class LPadStrFunc extends StrFunction implements TernaryFunction {
-
         private final Function fillTextFunc;
         private final Function lenFunc;
         private final int maxLength;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -95,7 +94,7 @@ public class LPadStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(final Record rec) {
-            return lPadStr(strFunc.getStrA(rec), lenFunc.getInt(rec), fillTextFunc.getStrA(rec), sink);
+            return lPadStr(strFunc.getStrA(rec), lenFunc.getInt(rec), fillTextFunc.getStrA(rec), sinkA);
         }
 
         @Override
@@ -113,6 +112,11 @@ public class LPadStrFunctionFactory implements FunctionFactory {
             } else {
                 return TableUtils.NULL_LEN;
             }
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LPadVarcharFunctionFactory.java
@@ -63,10 +63,9 @@ public class LPadVarcharFunctionFactory implements FunctionFactory {
     }
 
     public static class LPadFunc extends VarcharFunction implements BinaryFunction {
-
         private final Function lenFunc;
         private final int maxLength;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function strFunc;
 
@@ -93,12 +92,17 @@ public class LPadVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public Utf8Sequence getVarcharA(final Record rec) {
-            return lPad(strFunc.getVarcharA(rec), lenFunc.getInt(rec), sink);
+            return lPad(strFunc.getVarcharA(rec), lenFunc.getInt(rec), sinkA);
         }
 
         @Override
         public Utf8Sequence getVarcharB(final Record rec) {
             return lPad(strFunc.getVarcharB(rec), lenFunc.getInt(rec), sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LTrimFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LTrimFunctionFactory.java
@@ -45,9 +45,9 @@ public class LTrimFunctionFactory implements FunctionFactory {
             if (arg.getStrA(null) == null) {
                 return StrConstant.NULL;
             } else {
-                return new TrimConstFunction(args.getQuick(0), TrimType.LTRIM);
+                return new TrimStrConstFunction(args.getQuick(0), TrimType.LTRIM);
             }
         }
-        return new TrimFunction(args.getQuick(0), TrimType.LTRIM);
+        return new TrimStrFunction(args.getQuick(0), TrimType.LTRIM);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LTrimStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LTrimStrFunctionFactory.java
@@ -32,22 +32,28 @@ import io.questdb.griffin.engine.functions.constants.StrConstant;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
-public class RTrimFunctionFactory implements FunctionFactory {
+public class LTrimStrFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "rtrim(S)";
+        return "ltrim(S)";
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         final Function arg = args.get(0);
         if (arg.isConstant()) {
             if (arg.getStrA(null) == null) {
                 return StrConstant.NULL;
             } else {
-                return new TrimStrConstFunction(args.getQuick(0), TrimType.RTRIM);
+                return new TrimStrConstFunction(args.getQuick(0), TrimType.LTRIM);
             }
         }
-        return new TrimStrFunction(args.getQuick(0), TrimType.RTRIM);
+        return new TrimStrFunction(args.getQuick(0), TrimType.LTRIM);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LeftStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LeftStrFunctionFactory.java
@@ -74,9 +74,8 @@ public class LeftStrFunctionFactory implements FunctionFactory {
     }
 
     private static class ConstCountFunc extends StrFunction implements UnaryFunction {
-
         private final int count;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -92,7 +91,7 @@ public class LeftStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return getStr0(rec, sink);
+            return getStr0(rec, sinkA);
         }
 
         @Override
@@ -104,6 +103,11 @@ public class LeftStrFunctionFactory implements FunctionFactory {
         public int getStrLen(Record rec) {
             int len = strFunc.getStrLen(rec);
             return len != TableUtils.NULL_LEN ? getPos(len) : TableUtils.NULL_LEN;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override
@@ -130,9 +134,8 @@ public class LeftStrFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends StrFunction implements BinaryFunction {
-
         private final Function countFunc;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -158,7 +161,7 @@ public class LeftStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return getStr0(rec, sink);
+            return getStr0(rec, sinkA);
         }
 
         @Override
@@ -174,6 +177,11 @@ public class LeftStrFunctionFactory implements FunctionFactory {
                 return getPos(len, count);
             }
             return TableUtils.NULL_LEN;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/LeftVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/LeftVarcharFunctionFactory.java
@@ -75,9 +75,8 @@ public class LeftVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class ConstCountFunc extends VarcharFunction implements UnaryFunction {
-
         private final int count;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function varcharFunc;
 
@@ -93,12 +92,17 @@ public class LeftVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public @Nullable Utf8Sequence getVarcharA(Record rec) {
-            return getVarchar0(rec, sink);
+            return getVarchar0(rec, sinkA);
         }
 
         @Override
         public @Nullable Utf8Sequence getVarcharB(Record rec) {
             return getVarchar0(rec, sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override
@@ -129,9 +133,8 @@ public class LeftVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends VarcharFunction implements BinaryFunction {
-
         private final Function countFunc;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function varcharFunc;
 
@@ -157,12 +160,17 @@ public class LeftVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public @Nullable Utf8Sequence getVarcharA(Record rec) {
-            return getVarchar0(rec, sink);
+            return getVarchar0(rec, sinkA);
         }
 
         @Override
         public @Nullable Utf8Sequence getVarcharB(Record rec) {
             return getVarchar0(rec, sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadFunctionFactory.java
@@ -62,10 +62,9 @@ public class RPadFunctionFactory implements FunctionFactory {
     }
 
     public static class RPadFunc extends StrFunction implements BinaryFunction {
-
         private final Function lenFunc;
         private final int maxLength;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -92,7 +91,7 @@ public class RPadFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(final Record rec) {
-            return rPad(strFunc.getStrA(rec), lenFunc.getInt(rec), sink);
+            return rPad(strFunc.getStrA(rec), lenFunc.getInt(rec), sinkA);
         }
 
         @Override
@@ -109,6 +108,11 @@ public class RPadFunctionFactory implements FunctionFactory {
             } else {
                 return TableUtils.NULL_LEN;
             }
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadStrFunctionFactory.java
@@ -63,11 +63,10 @@ public class RPadStrFunctionFactory implements FunctionFactory {
     }
 
     public static class RPadStrFunc extends StrFunction implements TernaryFunction {
-
         private final Function fillTextFunc;
         private final Function lenFunc;
         private final int maxLength;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -100,7 +99,7 @@ public class RPadStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(final Record rec) {
-            return rPadStr(strFunc.getStrA(rec), lenFunc.getInt(rec), fillTextFunc.getStrA(rec), sink);
+            return rPadStr(strFunc.getStrA(rec), lenFunc.getInt(rec), fillTextFunc.getStrA(rec), sinkA);
         }
 
         @Override
@@ -118,6 +117,11 @@ public class RPadStrFunctionFactory implements FunctionFactory {
             } else {
                 return TableUtils.NULL_LEN;
             }
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadVarcharFunctionFactory.java
@@ -63,10 +63,9 @@ public class RPadVarcharFunctionFactory implements FunctionFactory {
     }
 
     public static class RPadFunc extends VarcharFunction implements BinaryFunction {
-
         private final Function lenFunc;
         private final int maxLength;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function strFunc;
 
@@ -93,12 +92,17 @@ public class RPadVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public Utf8Sequence getVarcharA(final Record rec) {
-            return rPad(strFunc.getVarcharA(rec), lenFunc.getInt(rec), sink);
+            return rPad(strFunc.getVarcharA(rec), lenFunc.getInt(rec), sinkA);
         }
 
         @Override
         public Utf8Sequence getVarcharB(final Record rec) {
             return rPad(strFunc.getVarcharB(rec), lenFunc.getInt(rec), sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadVarcharVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RPadVarcharVarcharFunctionFactory.java
@@ -106,7 +106,6 @@ public class RPadVarcharVarcharFunctionFactory implements FunctionFactory {
     }
 
     public static class RPadVarcharFunc extends VarcharFunction implements TernaryFunction {
-
         protected final Function fillTextFunc;
         protected final Function lenFunc;
         protected final int maxLength;
@@ -149,6 +148,11 @@ public class RPadVarcharVarcharFunctionFactory implements FunctionFactory {
         @Override
         public Utf8Sequence getVarcharB(final Record rec) {
             return rPadVarchar(strFunc.getVarcharB(rec), lenFunc.getInt(rec), fillTextFunc.getVarcharB(rec), sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RTrimFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RTrimFunctionFactory.java
@@ -45,9 +45,9 @@ public class RTrimFunctionFactory implements FunctionFactory {
             if (arg.getStrA(null) == null) {
                 return StrConstant.NULL;
             } else {
-                return new TrimConstFunction(args.getQuick(0), TrimType.RTRIM);
+                return new TrimStrConstFunction(args.getQuick(0), TrimType.RTRIM);
             }
         }
-        return new TrimFunction(args.getQuick(0), TrimType.RTRIM);
+        return new TrimStrFunction(args.getQuick(0), TrimType.RTRIM);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RTrimStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RTrimStrFunctionFactory.java
@@ -32,22 +32,28 @@ import io.questdb.griffin.engine.functions.constants.StrConstant;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
-public class LTrimFunctionFactory implements FunctionFactory {
+public class RTrimStrFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
-        return "ltrim(S)";
+        return "rtrim(S)";
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         final Function arg = args.get(0);
         if (arg.isConstant()) {
             if (arg.getStrA(null) == null) {
                 return StrConstant.NULL;
             } else {
-                return new TrimStrConstFunction(args.getQuick(0), TrimType.LTRIM);
+                return new TrimStrConstFunction(args.getQuick(0), TrimType.RTRIM);
             }
         }
-        return new TrimStrFunction(args.getQuick(0), TrimType.LTRIM);
+        return new TrimStrFunction(args.getQuick(0), TrimType.RTRIM);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ReplaceStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ReplaceStrFunctionFactory.java
@@ -79,11 +79,10 @@ public class ReplaceStrFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends StrFunction implements TernaryFunction {
-
         private final int maxLength;
         private final Function newSubStr;
         private final Function oldSubStr;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function value;
 
@@ -113,8 +112,8 @@ public class ReplaceStrFunctionFactory implements FunctionFactory {
         public CharSequence getStrA(Record rec) {
             final CharSequence value = this.value.getStrA(rec);
             if (value != null) {
-                sink.clear();
-                return (CharSequence) replace(value, oldSubStr.getStrA(rec), newSubStr.getStrA(rec), sink);
+                sinkA.clear();
+                return (CharSequence) replace(value, oldSubStr.getStrA(rec), newSubStr.getStrA(rec), sinkA);
             }
             return null;
         }
@@ -148,7 +147,7 @@ public class ReplaceStrFunctionFactory implements FunctionFactory {
             }
         }
 
-        //if result is null then return null; otherwise return sink
+        // if result is null then return null; otherwise return sink
         private Utf16Sink replace(@NotNull CharSequence value, CharSequence term, CharSequence withWhat, Utf16Sink sink) throws CairoException {
             int valueLen = value.length();
             if (valueLen < 1) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ReplaceVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ReplaceVarcharFunctionFactory.java
@@ -161,15 +161,14 @@ public class ReplaceVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends VarcharFunction implements TernaryFunction {
-
         private final Function lookFor;
         private final int maxSize;
         private final Function replaceWith;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function value;
 
-        Func(Function value, Function lookFor, Function replaceWith, int maxSize) {
+        public Func(Function value, Function lookFor, Function replaceWith, int maxSize) {
             this.value = value;
             this.lookFor = lookFor;
             this.replaceWith = replaceWith;
@@ -195,8 +194,8 @@ public class ReplaceVarcharFunctionFactory implements FunctionFactory {
         public Utf8Sequence getVarcharA(Record rec) {
             final Utf8Sequence value = this.value.getVarcharA(rec);
             if (value != null) {
-                sink.clear();
-                return replace(value, lookFor.getVarcharA(rec), replaceWith.getVarcharA(rec), sink, maxSize);
+                sinkA.clear();
+                return replace(value, lookFor.getVarcharA(rec), replaceWith.getVarcharA(rec), sinkA, maxSize);
             }
             return null;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RightStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RightStrFunctionFactory.java
@@ -74,9 +74,8 @@ public class RightStrFunctionFactory implements FunctionFactory {
     }
 
     private static class ConstCountFunc extends StrFunction implements UnaryFunction {
-
         private final int count;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -92,7 +91,7 @@ public class RightStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return getStr0(rec, sink);
+            return getStr0(rec, sinkA);
         }
 
         @Override
@@ -105,6 +104,11 @@ public class RightStrFunctionFactory implements FunctionFactory {
             final int len = strFunc.getStrLen(rec);
             final int pos = len == TableUtils.NULL_LEN ? 0 : getPos(len);
             return len - pos;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override
@@ -131,9 +135,8 @@ public class RightStrFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends StrFunction implements BinaryFunction {
-
         private final Function countFunc;
-        private final StringSink sink = new StringSink();
+        private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
         private final Function strFunc;
 
@@ -159,7 +162,7 @@ public class RightStrFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return getStr0(rec, sink);
+            return getStr0(rec, sinkA);
         }
 
         @Override
@@ -175,6 +178,11 @@ public class RightStrFunctionFactory implements FunctionFactory {
                 return len - (len == TableUtils.NULL_LEN ? 0 : getPos(len, count));
             }
             return TableUtils.NULL_LEN;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/RightVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/RightVarcharFunctionFactory.java
@@ -75,9 +75,8 @@ public class RightVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class ConstCountFunc extends VarcharFunction implements UnaryFunction {
-
         private final int count;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function varcharFunc;
 
@@ -93,12 +92,17 @@ public class RightVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public @Nullable Utf8Sequence getVarcharA(Record rec) {
-            return getVarchar0(rec, sink);
+            return getVarchar0(rec, sinkA);
         }
 
         @Override
         public @Nullable Utf8Sequence getVarcharB(Record rec) {
             return getVarchar0(rec, sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Override
@@ -129,9 +133,8 @@ public class RightVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class Func extends VarcharFunction implements BinaryFunction {
-
         private final Function countFunc;
-        private final Utf8StringSink sink = new Utf8StringSink();
+        private final Utf8StringSink sinkA = new Utf8StringSink();
         private final Utf8StringSink sinkB = new Utf8StringSink();
         private final Function varcharFunc;
 
@@ -157,12 +160,17 @@ public class RightVarcharFunctionFactory implements FunctionFactory {
 
         @Override
         public @Nullable Utf8Sequence getVarcharA(Record rec) {
-            return getVarchar0(rec, sink);
+            return getVarchar0(rec, sinkA);
         }
 
         @Override
         public @Nullable Utf8Sequence getVarcharB(Record rec) {
             return getVarchar0(rec, sinkB);
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartCharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartCharFunctionFactory.java
@@ -144,6 +144,11 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
             }
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         @Nullable
         private CharSequence getStrWithClear(Record rec, StringSink sink) {
             sink.clear();
@@ -179,7 +184,7 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
                 if (end == -1) {
                     end = str.length();
                 }
-            } else {    // if index is negative, returns index-from-last field
+            } else { // if index is negative, returns index-from-last field
                 if (index == -1) {
                     end = str.length();
                 } else {
@@ -210,8 +215,14 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
         private final char delimiter;
         private final int index;
 
-        public SplitPartConstDelimiterConstIndexFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition,
-                                                         char delimiter, int index) {
+        public SplitPartConstDelimiterConstIndexFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition,
+                char delimiter,
+                int index
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
             this.delimiter = delimiter;
             this.index = index;
@@ -231,8 +242,13 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
     private static class SplitPartConstDelimiterFunction extends AbstractSplitPartFunction {
         private final char delimiter;
 
-        public SplitPartConstDelimiterFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition,
-                                               char delimiter) {
+        public SplitPartConstDelimiterFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition,
+                char delimiter
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
             this.delimiter = delimiter;
         }
@@ -251,8 +267,13 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
     private static class SplitPartConstIndexFunction extends AbstractSplitPartFunction {
         private final int index;
 
-        public SplitPartConstIndexFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition,
-                                           int index) {
+        public SplitPartConstIndexFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition,
+                int index
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
             this.index = index;
         }
@@ -269,7 +290,13 @@ public class SplitPartCharFunctionFactory implements FunctionFactory {
     }
 
     private static class SplitPartFunction extends AbstractSplitPartFunction implements TernaryFunction {
-        public SplitPartFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition) {
+
+        public SplitPartFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartFunctionFactory.java
@@ -168,6 +168,11 @@ public class SplitPartFunctionFactory implements FunctionFactory {
             }
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         private StringSink getStrWithClear(Record rec, StringSink sink) {
             sink.clear();
             CharSequence str = strFunc.getStrA(rec);
@@ -186,8 +191,13 @@ public class SplitPartFunctionFactory implements FunctionFactory {
     private static class SplitPartConstIndexFunction extends AbstractSplitPartFunction {
         private final int index;
 
-        public SplitPartConstIndexFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition,
-                                           int index) {
+        public SplitPartConstIndexFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition,
+                int index
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
             this.index = index;
         }
@@ -199,7 +209,13 @@ public class SplitPartFunctionFactory implements FunctionFactory {
     }
 
     private static class SplitPartFunction extends AbstractSplitPartFunction implements TernaryFunction {
-        public SplitPartFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition) {
+
+        public SplitPartFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartVarcharFunctionFactory.java
@@ -51,7 +51,13 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         final Function varcharFunc = args.getQuick(0);
         final Function delimiterFunc = args.getQuick(1);
         final Function indexFunc = args.getQuick(2);
@@ -98,7 +104,7 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
             if (end == -1) {
                 end = len;
             }
-        } else {    // if index is negative, returns index-from-last field
+        } else { // if index is negative, returns index-from-last field
             if (index == -1) {
                 end = size;
             } else {
@@ -176,6 +182,11 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
             }
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         @Nullable
         private Utf8StringSink getVarcharWithClear(Record rec, Utf8StringSink sink) {
             sink.clear();
@@ -196,8 +207,13 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
     private static class SplitPartVarcharConstIndexFunction extends AbstractSplitPartVarcharFunction {
         private final int index;
 
-        public SplitPartVarcharConstIndexFunction(Function strFunc, Function delimiterFunc, Function indexFunc, int indexPosition,
-                                                  int index) {
+        public SplitPartVarcharConstIndexFunction(
+                Function strFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition,
+                int index
+        ) {
             super(strFunc, delimiterFunc, indexFunc, indexPosition);
             this.index = index;
         }
@@ -209,7 +225,13 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class SplitPartVarcharFunction extends AbstractSplitPartVarcharFunction implements TernaryFunction {
-        public SplitPartVarcharFunction(Function varcharFunc, Function delimiterFunc, Function indexFunc, int indexPosition) {
+
+        public SplitPartVarcharFunction(
+                Function varcharFunc,
+                Function delimiterFunc,
+                Function indexFunc,
+                int indexPosition
+        ) {
             super(varcharFunc, delimiterFunc, indexFunc, indexPosition);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ToCharBinFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ToCharBinFunctionFactory.java
@@ -45,14 +45,20 @@ public class ToCharBinFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         return new ToCharBinFunc(args.getQuick(0));
     }
 
     private static class ToCharBinFunc extends StrFunction implements UnaryFunction {
         private final Function arg;
-        private final StringSink sink1 = new StringSink();
-        private final StringSink sink2 = new StringSink();
+        private final StringSink sinkA = new StringSink();
+        private final StringSink sinkB = new StringSink();
 
         public ToCharBinFunc(Function arg) {
             this.arg = arg;
@@ -70,12 +76,12 @@ public class ToCharBinFunctionFactory implements FunctionFactory {
 
         @Override
         public CharSequence getStrA(Record rec) {
-            return toSink(rec, sink1);
+            return toSink(rec, sinkA);
         }
 
         @Override
         public CharSequence getStrB(Record rec) {
-            return toSink(rec, sink2);
+            return toSink(rec, sinkB);
         }
 
         @Override
@@ -97,6 +103,11 @@ public class ToCharBinFunctionFactory implements FunctionFactory {
             return count;
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         @Nullable
         private CharSequence toSink(Record rec, StringSink sink) {
             final BinarySequence sequence = arg.getBin(rec);
@@ -107,6 +118,5 @@ public class ToCharBinFunctionFactory implements FunctionFactory {
             Chars.toSink(sequence, sink);
             return sink;
         }
-
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimStrFunctionFactory.java
@@ -32,22 +32,28 @@ import io.questdb.griffin.engine.functions.constants.StrConstant;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
-public class TrimFunctionFactory implements FunctionFactory {
+public class TrimStrFunctionFactory implements FunctionFactory {
     @Override
     public String getSignature() {
         return "trim(S)";
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         final Function arg = args.getQuick(0);
         if (arg.isConstant()) {
             if (arg.getStrA(null) == null) {
                 return StrConstant.NULL;
             } else {
-                return new TrimConstFunction(args.getQuick(0), TrimType.TRIM);
+                return new TrimStrConstFunction(args.getQuick(0), TrimType.TRIM);
             }
         }
-        return new TrimFunction(args.getQuick(0), TrimType.TRIM);
+        return new TrimStrFunction(args.getQuick(0), TrimType.TRIM);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimVarcharFunctionFactory.java
@@ -50,8 +50,11 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
 
     @Override
     public Function newInstance(
-            int position, ObjList<Function> args, IntList argPositions,
-            CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
     ) {
         final Function arg = args.get(0);
         if (!arg.isConstant()) {
@@ -68,11 +71,10 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
     }
 
     private static class ConstFunc extends VarcharFunction implements UnaryFunction {
-
         private final Function arg;
         private final DirectUtf8Sink sink;
 
-        ConstFunc(Function arg, TrimType type) {
+        public ConstFunc(Function arg, TrimType type) {
             this.arg = arg;
             Utf8Sequence value = getArg().getVarcharA(null);
             if (value == null) {
@@ -117,11 +119,11 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
 
     private static class Func extends VarcharFunction implements UnaryFunction {
         private final Function arg;
-        private final DirectUtf8Sink sink1 = new DirectUtf8Sink(4);
-        private final DirectUtf8Sink sink2 = new DirectUtf8Sink(4);
+        private final DirectUtf8Sink sinkA = new DirectUtf8Sink(4);
+        private final DirectUtf8Sink sinkB = new DirectUtf8Sink(4);
         private final TrimType type;
 
-        Func(Function arg, TrimType type) {
+        public Func(Function arg, TrimType type) {
             this.arg = arg;
             this.type = type;
         }
@@ -129,8 +131,8 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
         @Override
         public void close() {
             UnaryFunction.super.close();
-            sink1.close();
-            sink2.close();
+            sinkA.close();
+            sinkB.close();
         }
 
         @Override
@@ -156,9 +158,9 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
             if (utf8Sequence == null) {
                 return null;
             }
-            sink1.clear();
-            trim(type, utf8Sequence, sink1);
-            return sink1;
+            sinkA.clear();
+            trim(type, utf8Sequence, sinkA);
+            return sinkA;
         }
 
         @Override
@@ -167,9 +169,9 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
             if (charSequence == null) {
                 return null;
             }
-            sink2.clear();
-            trim(type, charSequence, sink2);
-            return sink2;
+            sinkB.clear();
+            trim(type, charSequence, sinkB);
+            return sinkB;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/TouchTableFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/TouchTableFunctionFactory.java
@@ -118,6 +118,11 @@ public class TouchTableFunctionFactory implements FunctionFactory {
             this.sqlExecutionContext = executionContext;
         }
 
+        @Override
+        public boolean isReadThreadSafe() {
+            return false;
+        }
+
         private void clearCounters() {
             dataPages = 0;
             indexKeyPages = 0;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -942,8 +942,8 @@ open module io.questdb {
 
             // trim
             io.questdb.griffin.engine.functions.str.TrimStrFunctionFactory,
-            io.questdb.griffin.engine.functions.str.LTrimFunctionFactory,
-            io.questdb.griffin.engine.functions.str.RTrimFunctionFactory,
+            io.questdb.griffin.engine.functions.str.LTrimStrFunctionFactory,
+            io.questdb.griffin.engine.functions.str.RTrimStrFunctionFactory,
             io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.LTrimVarcharFunctionFactory,
             io.questdb.griffin.engine.functions.str.RTrimVarcharFunctionFactory,

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -23,8 +23,6 @@
  ******************************************************************************/
 
 import io.questdb.griffin.FunctionFactory;
-import io.questdb.griffin.engine.functions.json.JsonExtractTypedFunctionFactory;
-import io.questdb.griffin.engine.functions.json.JsonExtractVarcharFunctionFactory;
 
 open module io.questdb {
     requires transitive jdk.unsupported;
@@ -864,8 +862,8 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.ReplaceVarcharFunctionFactory,
 
             // json_extract()
-            JsonExtractVarcharFunctionFactory,
-            JsonExtractTypedFunctionFactory,
+            io.questdb.griffin.engine.functions.json.JsonExtractVarcharFunctionFactory,
+            io.questdb.griffin.engine.functions.json.JsonExtractTypedFunctionFactory,
 
             // regexp_replace()
             io.questdb.griffin.engine.functions.regex.RegexpReplaceStrFunctionFactory,
@@ -943,7 +941,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.str.QuoteIdentVarcharFunctionFactory,
 
             // trim
-            io.questdb.griffin.engine.functions.str.TrimFunctionFactory,
+            io.questdb.griffin.engine.functions.str.TrimStrFunctionFactory,
             io.questdb.griffin.engine.functions.str.LTrimFunctionFactory,
             io.questdb.griffin.engine.functions.str.RTrimFunctionFactory,
             io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -925,7 +925,7 @@ io.questdb.griffin.engine.functions.str.RPadVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.RPadVarcharVarcharFunctionFactory
 
 # Trim
-io.questdb.griffin.engine.functions.str.TrimFunctionFactory
+io.questdb.griffin.engine.functions.str.TrimStrFunctionFactory
 io.questdb.griffin.engine.functions.str.LTrimFunctionFactory
 io.questdb.griffin.engine.functions.str.RTrimFunctionFactory
 io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -926,8 +926,8 @@ io.questdb.griffin.engine.functions.str.RPadVarcharVarcharFunctionFactory
 
 # Trim
 io.questdb.griffin.engine.functions.str.TrimStrFunctionFactory
-io.questdb.griffin.engine.functions.str.LTrimFunctionFactory
-io.questdb.griffin.engine.functions.str.RTrimFunctionFactory
+io.questdb.griffin.engine.functions.str.LTrimStrFunctionFactory
+io.questdb.griffin.engine.functions.str.RTrimStrFunctionFactory
 io.questdb.griffin.engine.functions.str.TrimVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.LTrimVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.RTrimVarcharFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -2516,6 +2516,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Test
     public void testParallelToStrFunctionKeyGroupBy() throws Exception {
+        // This query doesn't use filter, so we don't care about JIT.
+        Assume.assumeTrue(enableJitCompiler);
         testParallelSymbolKeyGroupBy(
                 "SELECT to_str(ts, 'yyyy-MM-dd') ts, max(price) FROM tab ORDER BY ts LIMIT 5",
                 "ts\tmax\n" +

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -2515,6 +2515,19 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelToStrFunctionKeyGroupBy() throws Exception {
+        testParallelSymbolKeyGroupBy(
+                "SELECT to_str(ts, 'yyyy-MM-dd') ts, max(price) FROM tab ORDER BY ts LIMIT 5",
+                "ts\tmax\n" +
+                        "1970-01-01\t99.0\n" +
+                        "1970-01-02\t199.0\n" +
+                        "1970-01-03\t299.0\n" +
+                        "1970-01-04\t399.0\n" +
+                        "1970-01-05\t499.0\n"
+        );
+    }
+
+    @Test
     public void testStringKeyGroupByEmptyTable() throws Exception {
         // This query doesn't use filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);

--- a/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimestampQueryTest.java
@@ -50,10 +50,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testCast2AsValidColumnNameTouchFunction() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table xyz(time timestamp, cast2 geohash(8c)) timestamp(time) partition by DAY;";
-            ddl(createStmt);
-            //insert
+            ddl("create table xyz(time timestamp, cast2 geohash(8c)) timestamp(time) partition by DAY;");
             insert("INSERT INTO xyz VALUES(1609459199000000, #u33d8b12)");
             String expected = "touch\n{\"data_pages\": 2, \"index_key_pages\":0, \"index_values_pages\": 0}\n";
             String query = "select touch(select time, cast2 from xyz);";
@@ -65,10 +62,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testCastAsValidColumnNameSelectTest() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table xyz(time timestamp, \"cast\" geohash(8c)) timestamp(time) partition by DAY;";
-            ddl(createStmt);
-            //insert
+            ddl("create table xyz(time timestamp, \"cast\" geohash(8c)) timestamp(time) partition by DAY;");
             insert("INSERT INTO xyz VALUES(1609459199000000, #u33d8b12)");
             String expected = "time\tcast\n" +
                     "2020-12-31T23:59:59.000000Z\tu33d8b12\n";
@@ -97,10 +91,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualityTimestampFormatYearAndMonthNegativeTest() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -120,10 +111,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualityTimestampFormatYearAndMonthPositiveTest() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -140,10 +128,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualityTimestampFormatYearOnlyNegativeTest() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -159,10 +144,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualityTimestampFormatYearOnlyPositiveTest() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -179,10 +161,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualsToTimestampFormatYearMonthDay() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -199,10 +178,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualsToTimestampFormatYearMonthDayHour() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -219,10 +195,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualsToTimestampFormatYearMonthDayHourMinute() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -239,10 +212,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualsToTimestampFormatYearMonthDayHourMinuteSecond() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -259,10 +229,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testEqualsToTimestampWithMicrosecond() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000001)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000001Z\n";
@@ -288,10 +255,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLMoreThanOrEqualsToTimestampFormatYearOnlyPositiveTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -308,10 +272,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLMoreThanTimestampFormatYearOnlyPositiveTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -328,10 +289,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanOrEqualsToTimestampFormatYearOnlyNegativeTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -347,10 +305,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanOrEqualsToTimestampFormatYearOnlyNegativeTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -366,10 +321,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanOrEqualsToTimestampFormatYearOnlyPositiveTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -386,10 +338,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanOrEqualsToTimestampFormatYearOnlyPositiveTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -406,10 +355,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanTimestampFormatYearOnlyNegativeTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -425,10 +371,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanTimestampFormatYearOnlyNegativeTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -444,10 +387,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanTimestampFormatYearOnlyPositiveTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -464,10 +404,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testLessThanTimestampFormatYearOnlyPositiveTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -484,10 +421,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMinOnTimestampEmptyResutlSetIsNull() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -502,10 +436,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanOrEqualsToTimestampFormatYearOnlyNegativeTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -521,10 +452,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanOrEqualsToTimestampFormatYearOnlyNegativeTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -540,10 +468,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanOrEqualsToTimestampFormatYearOnlyPositiveTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -560,10 +485,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanTimestampFormatYearOnlyNegativeTest1() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -579,10 +501,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanTimestampFormatYearOnlyNegativeTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -598,9 +517,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testMoreThanTimestampFormatYearOnlyPositiveTest2() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             //insert
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
@@ -620,7 +537,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
         currentMicros = 0;
         assertMemoryLeak(() -> {
             // Create table
-            // One hour step timestamps from epoch for 32 then skip 48 etc for 10 iterations
+            // One-hour step timestamps from epoch for 32 then skip 48 etc for 10 iterations
             final int count = 32;
             final int skip = 48;
             final int iterations = 10;
@@ -645,7 +562,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
             }
             final long end = start;
 
-            // Search with 3 hour window every 22 hours
+            // Search with 3-hour window every 22 hours
             int min = Integer.MAX_VALUE;
             int max = Integer.MIN_VALUE;
             for (currentMicros = 0; currentMicros < end; currentMicros += 22 * hour) {
@@ -667,10 +584,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     public void testNowIsSameForAllQueryParts() throws Exception {
         currentMicros = 0;
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "now1\tnow2\tsymbol\ttimestamp\n" +
                     "1970-01-01T00:00:00.000000Z\t1970-01-01T00:00:00.000000Z\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -689,8 +603,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     public void testNowPerformsBinarySearchOnTimestamp() throws Exception {
         currentMicros = 0;
         assertMemoryLeak(() -> {
-            //create table
-            // One hour step timestamps from epoch for 2000 steps
+            // One-hour step timestamps from epoch for 2000 steps
             final int count = 200;
             String createStmt = "create table xts as (select timestamp_sequence(0, 3600L * 1000 * 1000) ts from long_sequence(" + count + ")) timestamp(ts) partition by DAY";
             SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.000000Z'");
@@ -764,33 +677,60 @@ public class TimestampQueryTest extends AbstractCairoTest {
 
     @Test
     public void testTimestampDifferentThanFixedValue() throws Exception {
-        assertQuery("t\n" +
-                "1970-01-01T00:00:01.000000Z\n" +
-                "1970-01-01T00:00:02.000000Z\n", "select t from x where t != to_timestamp('1970-01-01:00:00:00', 'yyyy-MM-dd:HH:mm:ss') ", "create table x as (select timestamp_sequence(0, 1000000) t from long_sequence(3)) timestamp(t)", "t", null, null, true, true, false);
+        assertQuery(
+                "t\n" +
+                        "1970-01-01T00:00:01.000000Z\n" +
+                        "1970-01-01T00:00:02.000000Z\n",
+                "select t from x where t != to_timestamp('1970-01-01:00:00:00', 'yyyy-MM-dd:HH:mm:ss') ",
+                "create table x as (select timestamp_sequence(0, 1000000) t from long_sequence(3)) timestamp(t)",
+                "t",
+                null,
+                null,
+                true,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampDifferentThanNonFixedValue() throws Exception {
-        assertQuery("t\n" +
-                "1970-01-01T00:00:00.000000Z\n" +
-                "1970-01-01T00:00:01.000000Z\n", "select t from x where t != to_timestamp('201' || rnd_long(0,9,0),'yyyy')", "create table x as (select timestamp_sequence(0, 1000000) t from long_sequence(2)) timestamp(t)", "t", null, null, true, false, false);
+        assertQuery(
+                "t\n" +
+                        "1970-01-01T00:00:00.000000Z\n" +
+                        "1970-01-01T00:00:01.000000Z\n",
+                "select t from x where t != to_timestamp('201' || rnd_long(0,9,0),'yyyy')",
+                "create table x as (select timestamp_sequence(0, 1000000) t from long_sequence(2)) timestamp(t)",
+                "t",
+                null,
+                null,
+                true,
+                false,
+                false
+        );
     }
 
     @Test
     public void testTimestampInDay1orDay2() throws Exception {
-        assertQuery("min\tmax\n\t\n", "select min(nts), max(nts) from tt where nts IN '2020-01-01' or nts IN '2020-01-02'", "create table tt (dts timestamp, nts timestamp) timestamp(dts)", null, "insert into tt " +
-                "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
-                "from long_sequence(48L)", "min\tmax\n" +
-                "2020-01-01T00:00:00.000000Z\t2020-01-02T23:00:00.000000Z\n", false, true, false);
+        assertQuery(
+                "min\tmax\n\t\n",
+                "select min(nts), max(nts) from tt where nts IN '2020-01-01' or nts IN '2020-01-02'",
+                "create table tt (dts timestamp, nts timestamp) timestamp(dts)",
+                null,
+                "insert into tt " +
+                        "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
+                        "from long_sequence(48L)",
+                "min\tmax\n" +
+                        "2020-01-01T00:00:00.000000Z\t2020-01-02T23:00:00.000000Z\n",
+                false,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampIntervalPartitionDay() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert as select
+            ddl("create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("insert into interval_test select x, timestamp_sequence(" +
                     "'2022-11-19T00:00:00', " +
                     Timestamps.DAY_MICROS + ") FROM long_sequence(5)");
@@ -813,10 +753,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampIntervalPartitionMonth() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by MONTH";
-            ddl(createStmt);
-            //insert as select
+            ddl("create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by MONTH");
             insert("insert into interval_test select x, timestamp_sequence(" +
                     "'2022-11-19T00:00:00', " +
                     Timestamps.DAY_MICROS * 30 + ") FROM long_sequence(5)");
@@ -839,10 +776,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampIntervalPartitionWeek() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by WEEK";
-            ddl(createStmt);
-            //insert as select
+            ddl("create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by WEEK");
             insert("insert into interval_test select x, timestamp_sequence(" +
                     "'2022-11-19T00:00:00', " +
                     Timestamps.WEEK_MICROS + ") FROM long_sequence(5)");
@@ -865,10 +799,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampIntervalPartitionYear() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by YEAR";
-            ddl(createStmt);
-            //insert as select
+            ddl("create table interval_test(seq_num long, timestamp timestamp) timestamp(timestamp) partition by YEAR");
             insert("insert into interval_test select x, timestamp_sequence(" +
                     "'2022-11-19T00:00:00', " +
                     Timestamps.DAY_MICROS * 365 + ") FROM long_sequence(5)");
@@ -890,38 +821,55 @@ public class TimestampQueryTest extends AbstractCairoTest {
 
     @Test
     public void testTimestampMin() throws Exception {
-        assertQuery("nts\tmin\n" +
-                "nts\t\n", "select 'nts', min(nts) from tt where nts > '2020-01-01T00:00:00.000000Z'", "create table tt (dts timestamp, nts timestamp) timestamp(dts)", null, "insert into tt " +
-                "select timestamp_sequence(1577836800000000L, 10L), timestamp_sequence(1577836800000000L, 10L) " +
-                "from long_sequence(2L)", "nts\tmin\n" +
-                "nts\t2020-01-01T00:00:00.000010Z\n", false, true, false);
+        assertQuery(
+                "nts\tmin\n" +
+                        "nts\t\n",
+                "select 'nts', min(nts) from tt where nts > '2020-01-01T00:00:00.000000Z'",
+                "create table tt (dts timestamp, nts timestamp) timestamp(dts)",
+                null,
+                "insert into tt " +
+                        "select timestamp_sequence(1577836800000000L, 10L), timestamp_sequence(1577836800000000L, 10L) " +
+                        "from long_sequence(2L)",
+                "nts\tmin\n" +
+                        "nts\t2020-01-01T00:00:00.000010Z\n",
+                false,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampOpSymbolColumns() throws Exception {
-        assertQuery("a\tk\n" +
-                "1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.030000Z\n" +
-                "1970-01-01T00:00:00.050000Z\t1970-01-01T00:00:00.040000Z\n", "select a, k from x where k < cast(a as timestamp)", "create table x as (select cast(concat('1970-01-01T00:00:00.0', (case when x > 3 then x else x - 1 end), '0000Z') as symbol) a, timestamp_sequence(0, 10000) k from long_sequence(5)) timestamp(k)", "k", null, null, true, false, false);
+        assertQuery(
+                "a\tk\n" +
+                        "1970-01-01T00:00:00.040000Z\t1970-01-01T00:00:00.030000Z\n" +
+                        "1970-01-01T00:00:00.050000Z\t1970-01-01T00:00:00.040000Z\n",
+                "select a, k from x where k < cast(a as timestamp)",
+                "create table x as (select cast(concat('1970-01-01T00:00:00.0', (case when x > 3 then x else x - 1 end), '0000Z') as symbol) a, timestamp_sequence(0, 10000) k from long_sequence(5)) timestamp(k)",
+                "k",
+                null,
+                null,
+                true,
+                false,
+                false
+        );
     }
 
     @Test
     public void testTimestampParseWithYearMonthDayTHourMinuteSecondAndIncompleteMillisTimeZone() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
             String query = "select * from ob_mem_snapshot";
             printSqlResult(expected, query, "timestamp", true, true);
-            //2 millisec characters
+            // 2 ms characters
             expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
             query = "SELECT * FROM ob_mem_snapshot where timestamp IN '2020-12-31T23:59:59.00Z'";
             printSqlResult(expected, query, "timestamp", true, true);
-            //1 millisec character
+            // 1 ms character
             expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
             query = "SELECT * FROM ob_mem_snapshot where timestamp IN '2020-12-31T23:59:59.0Z'";
@@ -933,10 +881,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampParseWithYearMonthDayTHourMinuteSecondTimeZone() throws Exception {
         assertMemoryLeak(() -> {
-            //create table
-            String createStmt = "create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY";
-            ddl(createStmt);
-            //insert
+            ddl("create table ob_mem_snapshot (symbol int,  me_seq_num long,  timestamp timestamp) timestamp(timestamp) partition by DAY");
             insert("INSERT INTO ob_mem_snapshot  VALUES(1, 1, 1609459199000000)");
             String expected = "symbol\tme_seq_num\ttimestamp\n" +
                     "1\t1\t2020-12-31T23:59:59.000000Z\n";
@@ -951,19 +896,26 @@ public class TimestampQueryTest extends AbstractCairoTest {
 
     @Test
     public void testTimestampStringComparison() throws Exception {
-        assertQuery("min\tmax\n\t\n", "select min(nts), max(nts) from tt where nts = '2020-01-01'", "create table tt (dts timestamp, nts timestamp) timestamp(dts)", null, "insert into tt " +
-                "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
-                "from long_sequence(48L)", "min\tmax\n" +
-                "2020-01-01T00:00:00.000000Z\t2020-01-01T00:00:00.000000Z\n", false, true, false);
+        assertQuery(
+                "min\tmax\n\t\n",
+                "select min(nts), max(nts) from tt where nts = '2020-01-01'",
+                "create table tt (dts timestamp, nts timestamp) timestamp(dts)",
+                null,
+                "insert into tt " +
+                        "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
+                        "from long_sequence(48L)",
+                "min\tmax\n" +
+                        "2020-01-01T00:00:00.000000Z\t2020-01-01T00:00:00.000000Z\n",
+                false,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampStringComparisonBetween() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1131,10 +1083,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonBetweenInvalidValue() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1152,10 +1101,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonInString() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1224,10 +1170,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonInVarchar() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1293,10 +1236,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonInvalidValue() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1310,10 +1250,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonNonConst() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1330,10 +1267,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampStringComparisonWithString() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1376,25 +1310,42 @@ public class TimestampQueryTest extends AbstractCairoTest {
 
     @Test
     public void testTimestampStringDateAdd() throws Exception {
-        assertQuery("dateadd\n" +
-                "2020-01-02T00:00:00.000000Z\n", "select dateadd('d', 1, '2020-01-01')", null, null, null, null, true, true, false);
+        assertQuery(
+                "dateadd\n" +
+                        "2020-01-02T00:00:00.000000Z\n",
+                "select dateadd('d', 1, '2020-01-01')",
+                null,
+                null,
+                null,
+                null,
+                true,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampSymbolComparison() throws Exception {
-        assertQuery("min\tmax\n\t\n", "select min(nts), max(nts) from tt where nts = cast('2020-01-01' as symbol)", "create table tt (dts timestamp, nts timestamp) timestamp(dts)", null, "insert into tt " +
-                "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
-                "from long_sequence(48L)", "min\tmax\n" +
-                "2020-01-01T00:00:00.000000Z\t2020-01-01T00:00:00.000000Z\n", false, true, false);
+        assertQuery(
+                "min\tmax\n\t\n",
+                "select min(nts), max(nts) from tt where nts = cast('2020-01-01' as symbol)",
+                "create table tt (dts timestamp, nts timestamp) timestamp(dts)",
+                null,
+                "insert into tt " +
+                        "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
+                        "from long_sequence(48L)",
+                "min\tmax\n" +
+                        "2020-01-01T00:00:00.000000Z\t2020-01-01T00:00:00.000000Z\n",
+                false,
+                true,
+                false
+        );
     }
 
     @Test
     public void testTimestampSymbolComparisonBetweenInvalidValue() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1412,10 +1363,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     @Test
     public void testTimestampSymbolComparisonInvalidValue() throws Exception {
         assertMemoryLeak(() -> {
-            // create table
-            String createStmt = "create table tt (dts timestamp, nts timestamp) timestamp(dts)";
-            ddl(createStmt);
-
+            ddl("create table tt (dts timestamp, nts timestamp) timestamp(dts)");
             // insert same values to dts (designated) as nts (non-designated) timestamp
             insert("insert into tt " +
                     "select timestamp_sequence(1577836800000000L, 60*60*1000000L), timestamp_sequence(1577836800000000L, 60*60*1000000L) " +
@@ -1437,7 +1385,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
             String expected = "dts\tts\n" +
                     "2021-04-02T23:59:59.354820Z\t2021-04-02T23:59:59.354820Z\n";
 
-            assertQuery(
+            assertQueryNoLeakCheck(
                     expected,
                     "tt where dts > cast('2021-04-02T13:45:49.207Z' as symbol) and dts < cast('2021-04-03 13:45:49.207' as symbol)",
                     "dts",
@@ -1445,7 +1393,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
                     true
             );
 
-            assertQuery(
+            assertQueryNoLeakCheck(
                     expected,
                     "tt where ts > cast('2021-04-02T13:45:49.207Z' as symbol) and ts < cast('2021-04-03 13:45:49.207' as symbol)",
                     "dts",
@@ -1459,7 +1407,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     public void testTimestampSymbolDateAdd() throws Exception {
         assertQuery(
                 "dateadd\n" +
-                "2020-01-02T00:00:00.000000Z\n",
+                        "2020-01-02T00:00:00.000000Z\n",
                 "select dateadd('d', 1, cast('2020-01-01' as symbol))",
                 null,
                 null,
@@ -1491,7 +1439,7 @@ public class TimestampQueryTest extends AbstractCairoTest {
     }
 
     private void assertTimestampTtFailedQuery0(String sql, String contains) throws Exception {
-        assertException(sql, -1, contains);
+        assertExceptionNoLeakCheck(sql, -1, contains);
     }
 
     private void assertTimestampTtQuery(String expected, String query) throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bind/RegexpReplaceStrBindVariableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bind/RegexpReplaceStrBindVariableTest.java
@@ -57,9 +57,10 @@ public class RegexpReplaceStrBindVariableTest extends AbstractCairoTest {
 
                 TestUtils.assertEquals(
                         "regexp_replace\n" +
-                        "foobar\n" +
-                        "foobar\n" +
-                                "barbaz\n", sink
+                                "foobar\n" +
+                                "foobar\n" +
+                                "barbaz\n",
+                        sink
                 );
 
                 bindVariableService.setStr(0, null);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/LTrimStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/LTrimStrFunctionFactoryTest.java
@@ -26,13 +26,13 @@ package io.questdb.test.griffin.engine.functions.str;
 
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.LTrimStrFunctionFactory;
 import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
-import io.questdb.griffin.engine.functions.str.RTrimFunctionFactory;
 import org.junit.Test;
 
-public class RTrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class LTrimStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
     @Test
-    public void testEmptyRTrimSpace() throws SqlException {
+    public void testEmptyLTrimSpace() throws SqlException {
         call("").andAssert("");
         call(" ").andAssert("");
         call("    ").andAssert("");
@@ -40,22 +40,22 @@ public class RTrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testNoRTrimSpace() throws SqlException {
-        call("     abc").andAssert("     abc");
+    public void testLTrimSpace() throws SqlException {
+        call("    abc     ").andAssert("abc     ");
+        call("     abc").andAssert("abc");
+        call(" a b c ").andAssert("a b c ");
+    }
+
+    @Test
+    public void testNoLTrimSpace() throws SqlException {
+        call("abc     ").andAssert("abc     ");
         call("a b c").andAssert("a b c");
         call("kkk").andAssert("kkk");
         call("()  /  {}").andAssert("()  /  {}");
     }
 
-    @Test
-    public void testRTrimSpace() throws SqlException {
-        call("    abc     ").andAssert("    abc");
-        call("abc     ").andAssert("abc");
-        call(" a b c ").andAssert(" a b c");
-    }
-
     @Override
     protected FunctionFactory getFunctionFactory() {
-        return new RTrimFunctionFactory();
+        return new LTrimStrFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/RTrimStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/RTrimStrFunctionFactoryTest.java
@@ -26,13 +26,13 @@ package io.questdb.test.griffin.engine.functions.str;
 
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.RTrimStrFunctionFactory;
 import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
-import io.questdb.griffin.engine.functions.str.LTrimFunctionFactory;
 import org.junit.Test;
 
-public class LTrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class RTrimStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
     @Test
-    public void testEmptyLTrimSpace() throws SqlException {
+    public void testEmptyRTrimSpace() throws SqlException {
         call("").andAssert("");
         call(" ").andAssert("");
         call("    ").andAssert("");
@@ -40,22 +40,22 @@ public class LTrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
-    public void testLTrimSpace() throws SqlException {
-        call("    abc     ").andAssert("abc     ");
-        call("     abc").andAssert("abc");
-        call(" a b c ").andAssert("a b c ");
-    }
-
-    @Test
-    public void testNoLTrimSpace() throws SqlException {
-        call("abc     ").andAssert("abc     ");
+    public void testNoRTrimSpace() throws SqlException {
+        call("     abc").andAssert("     abc");
         call("a b c").andAssert("a b c");
         call("kkk").andAssert("kkk");
         call("()  /  {}").andAssert("()  /  {}");
     }
 
+    @Test
+    public void testRTrimSpace() throws SqlException {
+        call("    abc     ").andAssert("    abc");
+        call("abc     ").andAssert("abc");
+        call(" a b c ").andAssert(" a b c");
+    }
+
     @Override
     protected FunctionFactory getFunctionFactory() {
-        return new LTrimFunctionFactory();
+        return new RTrimStrFunctionFactory();
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TrimStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TrimStrFunctionFactoryTest.java
@@ -26,11 +26,11 @@ package io.questdb.test.griffin.engine.functions.str;
 
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.functions.str.TrimStrFunctionFactory;
 import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
-import io.questdb.griffin.engine.functions.str.TrimFunctionFactory;
 import org.junit.Test;
 
-public class TrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
+public class TrimStrFunctionFactoryTest extends AbstractFunctionFactoryTest {
     @Test
     public void testEmptyOrNullTrimSpace() throws SqlException {
         call("").andAssert("");
@@ -56,6 +56,6 @@ public class TrimFunctionFactoryTest extends AbstractFunctionFactoryTest {
 
     @Override
     protected FunctionFactory getFunctionFactory() {
-        return new TrimFunctionFactory();
+        return new TrimStrFunctionFactory();
     }
 }


### PR DESCRIPTION
The list of problematic SQL functions:
* `to_str()` for timestamp and date
* `lpad()`
* `rpad()`
* `left()`
* `right()`
* `split_part()`
* `to_char()`
* `touch()`