### PR TITLE
fix(sql): add support for filling weeks ('w') in SAMPLE BY queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueNotKeyedRecordCursor.java
@@ -39,6 +39,7 @@ public class SampleByFillValueNotKeyedRecordCursor extends AbstractSplitVirtualR
     private boolean endFill = false;
     private boolean firstRun = true;
     private boolean gapFill = false;
+    private long upperBound = Long.MAX_VALUE;
 
     public SampleByFillValueNotKeyedRecordCursor(
             CairoConfiguration configuration,
@@ -112,7 +113,8 @@ public class SampleByFillValueNotKeyedRecordCursor extends AbstractSplitVirtualR
             nextSampleLocalEpoch = expectedLocalEpoch;
             endFill = false;
             gapFill = false;
-            return true;
+
+            return localEpoch < upperBound;
         }
         if (setActiveA(expectedLocalEpoch)) {
             return peeker.reset();
@@ -122,7 +124,7 @@ public class SampleByFillValueNotKeyedRecordCursor extends AbstractSplitVirtualR
 
         if (baseRecord == null && sampleToFunc != TimestampConstant.NULL && !endFill) {
             endFill = true;
-            final long upperBound = sampleToFunc.getTimestamp(null);
+            upperBound = sampleToFunc.getTimestamp(null);
             baseRecord = baseCursor.getRecord();
             nextSamplePeriod(upperBound);
         }
@@ -140,6 +142,7 @@ public class SampleByFillValueNotKeyedRecordCursor extends AbstractSplitVirtualR
     public void toTop() {
         super.toTop();
         endFill = false;
+        upperBound = Long.MAX_VALUE;
     }
 
     private boolean setActiveA(long expectedLocalEpoch) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/TimestampSamplerFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/TimestampSamplerFactory.java
@@ -117,6 +117,9 @@ public final class TimestampSamplerFactory {
             case 'd':
                 // days
                 return new MicroTimestampSampler(Timestamps.DAY_MICROS * interval);
+            case 'w':
+                // weeks
+                return new MicroTimestampSampler(Timestamps.WEEK_MICROS * interval);
             case 'M':
                 // months
                 return new MonthTimestampSampler((int) interval);

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -2743,7 +2743,6 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
         });
     }
 
-    // [NW] revisit
     @Test
     public void testSampleByFromToParallelSampleByRewriteMultipleFills() throws Exception {
         assertMemoryLeak(() -> {
@@ -3262,6 +3261,30 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
                     "2018-01-19T00:00:00.000000Z\tnull\tnull\n" +
                     "2018-01-24T00:00:00.000000Z\tnull\tnull\n" +
                     "2018-01-29T00:00:00.000000Z\tnull\tnull\n", unionQuery);
+        });
+    }
+
+    @Test
+    public void testSampleByFromToParallelSequentialEquivalence() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(SampleByTest.DDL_FROMTO);
+
+            final String parallel = "select ts, avg(x) from fromto\n" +
+                    "sample by 1w from '2017-12-20' to '2018-01-31' fill(null)";
+
+            // offset is ignored
+            final String sequential = parallel + " align to calendar with offset '10:00'";
+
+            final String result = "ts\tavg\n" +
+                    "2017-12-20T00:00:00.000000Z\tnull\n" +
+                    "2017-12-27T00:00:00.000000Z\t48.5\n" +
+                    "2018-01-03T00:00:00.000000Z\t264.5\n" +
+                    "2018-01-10T00:00:00.000000Z\t456.5\n" +
+                    "2018-01-17T00:00:00.000000Z\tnull\n" +
+                    "2018-01-24T00:00:00.000000Z\tnull\n";
+
+            assertSql(result, parallel);
+            assertSql(result, sequential);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -12114,6 +12114,40 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleFillWithWeekStride() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(DDL_FROMTO);
+
+            String query1 = "select ts, avg(x) from fromto\n" +
+                    "sample by 1w from '2017-12-20' to '2018-01-31' fill(null)";
+
+            String expected1 = "ts\tavg\n" +
+                    "2017-12-20T00:00:00.000000Z\tnull\n" +
+                    "2017-12-27T00:00:00.000000Z\t48.5\n" +
+                    "2018-01-03T00:00:00.000000Z\t264.5\n" +
+                    "2018-01-10T00:00:00.000000Z\t456.5\n" +
+                    "2018-01-17T00:00:00.000000Z\tnull\n" +
+                    "2018-01-24T00:00:00.000000Z\tnull\n";
+
+            assertSql(expected1, query1);
+
+            String query2 = "select ts, avg(x) from fromto\n" +
+                    "sample by 1w fill(null)";
+
+            assertSql("ts\tavg\n" +
+                    "2018-01-01T00:00:00.000000Z\t168.5\n" +
+                    "2018-01-08T00:00:00.000000Z\t408.5\n", query2);
+
+            String query3 = query1.replace("1w", "2w");
+
+            assertSql("ts\tavg\n" +
+                    "2017-12-20T00:00:00.000000Z\t48.5\n" +
+                    "2018-01-03T00:00:00.000000Z\t288.5\n" +
+                    "2018-01-17T00:00:00.000000Z\tnull\n", query3);
+        });
+    }
+
+    @Test
     public void testSamplePeriodInvalidWithNoUnits() throws Exception {
         testSampleByPeriodFails(
                 "select sum(a), k from x sample by 300/10 align to calendar",


### PR DESCRIPTION
This worked:

```sql
select pickup_datetime, first(fare_amount) as first_price from trips
sample by 1w 
limit 5
```

This didn't:

```sql
select pickup_datetime, first(fare_amount) as first_price from trips
sample by 1w fill(null)
limit 5
```
with error:

> unsupported interval qualifier

Now it works.

Also contains a fix for a separate issue with the new FROM-TO syntax, where the a sequential SAMPLE BY with FROM-TO and FILL would sometimes contain an extra row versus the parallel version. Both should be half-open and not include the final timestamp, especially since the bucket may not have the data you'd expect in it (or any at all) due to filtering.