### PR TITLE
fix(sql): set default directory for read_parquet() and SQL COPY

### DIFF
--- a/core/src/main/java/io/questdb/Bootstrap.java
+++ b/core/src/main/java/io/questdb/Bootstrap.java
@@ -102,7 +102,7 @@ public class Bootstrap {
         // before we set up the logger, we need to copy the conf file
         final byte[] buffer = new byte[1024 * 1024];
         try {
-            copyConfResource(rootDirectory, false, buffer, "conf/log.conf", null);
+            copyResource(rootDirectory, false, buffer, "conf/log.conf", null);
         } catch (IOException e) {
             throw new BootstrapException("Could not extract log configuration file");
         }
@@ -113,6 +113,12 @@ public class Bootstrap {
             LogFactory.configureRootDir(rootDirectory);
         }
         log = LogFactory.getLog(LOG_NAME);
+
+        try {
+            copyResource(rootDirectory, false, buffer, "import/readme.txt", null);
+        } catch (IOException e) {
+            throw new BootstrapException("Could not create the default import directory");
+        }
 
         // report copyright and architecture
         log.advisoryW()
@@ -366,15 +372,6 @@ public class Bootstrap {
         return new CairoEngine(getConfiguration().getCairoConfiguration(), getMetrics());
     }
 
-    private static void copyConfResource(String dir, boolean force, byte[] buffer, String res, Log log) throws IOException {
-        File out = new File(dir, res);
-        try (InputStream is = ServerMain.class.getResourceAsStream("/io/questdb/site/" + res)) {
-            if (is != null) {
-                copyInputStream(force, buffer, out, is, log);
-            }
-        }
-    }
-
     private static void copyInputStream(boolean force, byte[] buffer, File out, InputStream is, Log log) throws IOException {
         final boolean exists = out.exists();
         if (force || !exists) {
@@ -398,6 +395,15 @@ public class Bootstrap {
         }
         if (log != null) {
             log.debugW().$("skipped [path=").$(out).I$();
+        }
+    }
+
+    private static void copyResource(String dir, boolean force, byte[] buffer, String res, Log log) throws IOException {
+        File out = new File(dir, res);
+        try (InputStream is = ServerMain.class.getResourceAsStream("/io/questdb/site/" + res)) {
+            if (is != null) {
+                copyInputStream(force, buffer, out, is, log);
+            }
         }
     }
 
@@ -470,17 +476,17 @@ public class Bootstrap {
     }
 
     private void extractConfDir(byte[] buffer) throws IOException {
-        copyConfResource(rootDirectory, false, buffer, "conf/date.formats", log);
+        copyResource(rootDirectory, false, buffer, "conf/date.formats", log);
         try {
-            copyConfResource(rootDirectory, true, buffer, "conf/mime.types", log);
+            copyResource(rootDirectory, true, buffer, "conf/mime.types", log);
         } catch (IOException exception) {
             // conf can be read-only, this is not critical
             if (exception.getMessage() == null || (!exception.getMessage().contains("Read-only file system") && !exception.getMessage().contains("Permission denied"))) {
                 throw exception;
             }
         }
-        copyConfResource(rootDirectory, false, buffer, "conf/server.conf", log);
-        copyConfResource(rootDirectory, false, buffer, "conf/log.conf", log);
+        copyResource(rootDirectory, false, buffer, "conf/server.conf", log);
+        copyResource(rootDirectory, false, buffer, "conf/log.conf", log);
     }
 
     private void extractSite0(String publicDir, byte[] buffer, String thisVersion) throws IOException {

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -637,7 +637,8 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         this.dbDirectory = getString(properties, env, PropertyKey.CAIRO_ROOT, DB_DIRECTORY);
         String tmpRoot;
-        if (new File(this.dbDirectory).isAbsolute()) {
+        boolean absDbDir = new File(this.dbDirectory).isAbsolute();
+        if (absDbDir) {
             this.root = this.dbDirectory;
             this.confRoot = rootSubdir(this.root, CONFIG_DIRECTORY); // ../conf
             this.snapshotRoot = rootSubdir(this.root, SNAPSHOT_DIRECTORY); // ../snapshot
@@ -647,6 +648,30 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.confRoot = new File(root, CONFIG_DIRECTORY).getAbsolutePath();
             this.snapshotRoot = new File(root, SNAPSHOT_DIRECTORY).getAbsolutePath();
             tmpRoot = new File(root, TMP_DIRECTORY).getAbsolutePath();
+        }
+
+        String configuredCairoSqlCopyRoot = getString(properties, env, PropertyKey.CAIRO_SQL_COPY_ROOT, "import");
+        if (!Chars.empty(configuredCairoSqlCopyRoot)) {
+            if (new File(configuredCairoSqlCopyRoot).isAbsolute()) {
+                this.cairoSqlCopyRoot = configuredCairoSqlCopyRoot;
+            } else {
+                if (absDbDir) {
+                    this.cairoSqlCopyRoot = rootSubdir(this.root, configuredCairoSqlCopyRoot); // ../import
+                } else {
+                    this.cairoSqlCopyRoot = new File(root, configuredCairoSqlCopyRoot).getAbsolutePath();
+                }
+            }
+            String cairoSqlCopyWorkRoot = getString(properties, env, PropertyKey.CAIRO_SQL_COPY_WORK_ROOT, tmpRoot);
+            this.cairoSqlCopyWorkRoot = getCanonicalPath(cairoSqlCopyWorkRoot);
+            if (pathEquals(root, this.cairoSqlCopyWorkRoot)
+                    || pathEquals(this.root, this.cairoSqlCopyWorkRoot)
+                    || pathEquals(this.confRoot, this.cairoSqlCopyWorkRoot)
+                    || pathEquals(this.snapshotRoot, this.cairoSqlCopyWorkRoot)) {
+                throw new ServerConfigurationException("Configuration value for " + PropertyKey.CAIRO_SQL_COPY_WORK_ROOT.getPropertyPath() + " can't point to root, data, conf or snapshot dirs. ");
+            }
+        } else {
+            this.cairoSqlCopyRoot = null;
+            this.cairoSqlCopyWorkRoot = null;
         }
 
         this.cairoAttachPartitionSuffix = getString(properties, env, PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, TableUtils.ATTACHABLE_DIR_MARKER);
@@ -1064,21 +1089,6 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             try (JsonLexer lexer = new JsonLexer(1024, 1024)) {
                 inputFormatConfiguration.parseConfiguration(PropServerConfiguration.class, lexer, confRoot, sqlCopyFormatsFile);
-            }
-
-            this.cairoSqlCopyRoot = getString(properties, env, PropertyKey.CAIRO_SQL_COPY_ROOT, null);
-            String cairoSqlCopyWorkRoot = getString(properties, env, PropertyKey.CAIRO_SQL_COPY_WORK_ROOT, tmpRoot);
-            if (cairoSqlCopyRoot != null) {
-                this.cairoSqlCopyWorkRoot = getCanonicalPath(cairoSqlCopyWorkRoot);
-            } else {
-                this.cairoSqlCopyWorkRoot = null;
-            }
-
-            if (pathEquals(root, this.cairoSqlCopyWorkRoot)
-                    || pathEquals(this.root, this.cairoSqlCopyWorkRoot)
-                    || pathEquals(this.confRoot, this.cairoSqlCopyWorkRoot)
-                    || pathEquals(this.snapshotRoot, this.cairoSqlCopyWorkRoot)) {
-                throw new ServerConfigurationException("Configuration value for " + PropertyKey.CAIRO_SQL_COPY_WORK_ROOT.getPropertyPath() + " can't point to root, data, conf or snapshot dirs. ");
             }
 
             String cairoSQLCopyIdSupplier = getString(properties, env, PropertyKey.CAIRO_SQL_COPY_ID_SUPPLIER, "random");
@@ -2875,6 +2885,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public double getWalLagRowsMultiplier() {
+            return walSquashUncommittedRowsMultiplier;
+        }
+
+        @Override
         public long getWalMaxLagSize() {
             return walMaxLagSize;
         }
@@ -2912,11 +2927,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public long getWalSegmentRolloverSize() {
             return walSegmentRolloverSize;
-        }
-
-        @Override
-        public double getWalLagRowsMultiplier() {
-            return walSquashUncommittedRowsMultiplier;
         }
 
         @Override

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -397,8 +397,9 @@ query.timeout.sec=60
 # name of file with user's set of date and timestamp formats
 #cairo.sql.copy.formats.file=/text_loader.json
 
-# input root directory, where copy command reads files from
-#cairo.sql.copy.root=null
+# input root directory, where COPY command and read_parquet() function read files from
+# relative paths are resolved against the server root directory
+cairo.sql.copy.root=import
 
 # input work directory, where temporary import files are created, by default it's located in tmp directory inside the server root directory
 #cairo.sql.copy.work.root=null

--- a/core/src/main/resources/io/questdb/site/import/readme.txt
+++ b/core/src/main/resources/io/questdb/site/import/readme.txt
@@ -1,0 +1,8 @@
+This is the default directory for the SQL COPY command and the read_parquet() SQL function.
+Drop files here to import data into QuestDB.
+
+You can change the default directory by setting the cairo.sql.copy.root property in server.conf.
+
+See:
+- CSV import: https://questdb.io/docs/guides/import-csv/
+- Reading external Parquet files: https://questdb.io/docs/reference/function/parquet/

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -369,8 +369,9 @@ query.timeout.sec=60
 # name of file with user's set of date and timestamp formats
 #cairo.sql.copy.formats.file=/text_loader.json
 
-# input root directory, where copy command reads files from
-#cairo.sql.copy.root=null
+# input root directory, where COPY command and read_parquet() function read files from
+# relative paths are resolved against the server root directory
+cairo.sql.copy.root=import
 
 # input work directory, where temporary import files are created, by default it's located in tmp directory inside the server root directory
 #cairo.sql.copy.work.root=null


### PR DESCRIPTION
Default `cairo.sql.copy.root` is no longer empty by default. This allows to use read_parquet() and SQL COPY functions without changing config and restarts.

Also, sql.copy.root can be now relative - such paths are resolved against server root directory.

This is meant to reduce friction for new users.