### PR TITLE
feat(sql): support PowerBI via the existing PostgreSQL driver

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -177,7 +177,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
     private long recvBufferWriteOffset = 0;
     private boolean replyAndContinue;
     private PGResumeCallback resumeCallback;
-    private Rnd rnd;
+    private final Rnd rnd;
     private long sendBuffer;
     private long sendBufferLimit;
     private long sendBufferPtr;
@@ -1362,7 +1362,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         try {
             if (parameterValueCount > 0) {
                 //client doesn't need to specify any type in Parse message and can just use types returned in ParameterDescription message
-                if (this.activeParsePhaseBindVariableCount == parameterValueCount || activeBindVariableTypes.size() > 0) {
+                if (activeBindVariableTypes.size() > 0) {
                     lo = bindValuesUsingSetters(lo, msgLimit, parameterValueCount);
                 } else {
                     lo = bindValuesAsStrings(lo, msgLimit, parameterValueCount);
@@ -1374,10 +1374,10 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             throw e;
         }
 
+        short columnFormatCodeCount = getShort(lo, msgLimit, "could not read result set column format codes");
         if (activeTypesAndSelect != null) {
             bindSelectColumnFormats.clear();
 
-            short columnFormatCodeCount = getShort(lo, msgLimit, "could not read result set column format codes");
             if (columnFormatCodeCount > 0) {
 
                 final RecordMetadata m = activeTypesAndSelect.getFactory().getMetadata();
@@ -1491,7 +1491,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
 
         // initialize activeBindVariableTypes from bind variable service
         final int n = bindVariableService.getIndexedVariableCount();
-        if (sendParameterDescription && n > 0 && activeBindVariableTypes.size() == 0) {
+        if (n > 0 && activeBindVariableTypes.size() == 0) {
             activeBindVariableTypes.setPos(n);
             for (int i = 0; i < n; i++) {
                 final Function f = bindVariableService.getFunction(i);
@@ -2710,7 +2710,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
                     currentCursor = currentFactory.getCursor(sqlExecutionContext);
                     recompileStale = false;
                     // cache random if it was replaced
-                    rnd = sqlExecutionContext.getRandom();
+//                    rnd = sqlExecutionContext.getRandom();
                 } catch (TableReferenceOutOfDateException e) {
                     if (retries == maxRecompileAttempts) {
                         throw SqlException.$(0, e.getFlyweightMessage());

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGOids.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGOids.java
@@ -61,11 +61,14 @@ public class PGOids {
     public static final int PG_PUBLIC_OID = 2200;
     public static final int PG_TIMESTAMP = 1114;
     public static final IntList PG_TYPE_OIDS = new IntList();
+    public static final IntList PG_TYPE_PROC_OIDS = new IntList();
 
     public static final char[] PG_TYPE_TO_CATEGORY = new char[14];
     public static final CharSequence[] PG_TYPE_TO_DEFAULT = new CharSequence[14];
     public static final short[] PG_TYPE_TO_LENGTH = new short[14];
     public static final CharSequence[] PG_TYPE_TO_NAME = new CharSequence[14];
+    public static final CharSequence[] PG_TYPE_TO_PROC_NAME = new CharSequence[14];
+    public static final CharSequence[] PG_TYPE_TO_PROC_SRC = new CharSequence[14];
     public static final IntIntHashMap PG_TYPE_TO_SIZE_MAP = new IntIntHashMap();
     public static final int PG_UUID = 2950;
     public static final int PG_INTERNAL = 2281;
@@ -164,6 +167,22 @@ public class PGOids {
         PG_TYPE_OIDS.add(PG_INTERNAL);
         PG_TYPE_OIDS.add(PG_OID);
 
+        // these values are taken from PostgresSQL pg_proc view
+        PG_TYPE_PROC_OIDS.add(2432);
+        PG_TYPE_PROC_OIDS.add(2474);
+        PG_TYPE_PROC_OIDS.add(2426);
+        PG_TYPE_PROC_OIDS.add(2424);
+        PG_TYPE_PROC_OIDS.add(2406);
+        PG_TYPE_PROC_OIDS.add(2404);
+        PG_TYPE_PROC_OIDS.add(2434);
+        PG_TYPE_PROC_OIDS.add(2408);
+        PG_TYPE_PROC_OIDS.add(2436);
+        PG_TYPE_PROC_OIDS.add(2412);
+        PG_TYPE_PROC_OIDS.add(2568);
+        PG_TYPE_PROC_OIDS.add(2961);
+        PG_TYPE_PROC_OIDS.add(0); // INTERNAL
+        PG_TYPE_PROC_OIDS.add(2418); // OID
+
         PG_TYPE_TO_SIZE_MAP.put(PG_FLOAT8, Double.BYTES);
         PG_TYPE_TO_SIZE_MAP.put(PG_FLOAT4, Float.BYTES);
         PG_TYPE_TO_SIZE_MAP.put(PG_INT4, Integer.BYTES);
@@ -187,6 +206,11 @@ public class PGOids {
         PG_TYPE_TO_NAME[11] = "uuid";
         PG_TYPE_TO_NAME[12] = "internal";
         PG_TYPE_TO_NAME[13] = "oid";
+
+        for (int i = 0, n = PG_TYPE_TO_NAME.length; i < n; i++) {
+            PG_TYPE_TO_PROC_NAME[i] = PG_TYPE_TO_NAME[i] + "_recv";
+            PG_TYPE_TO_PROC_SRC[i] = PG_TYPE_TO_NAME[i] + "recv";
+        }
 
         PG_TYPE_TO_CATEGORY[0] = 'S';
         PG_TYPE_TO_CATEGORY[1] = 'D';

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGOids.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGOids.java
@@ -62,13 +62,15 @@ public class PGOids {
     public static final int PG_TIMESTAMP = 1114;
     public static final IntList PG_TYPE_OIDS = new IntList();
 
-    public static final char[] PG_TYPE_TO_CATEGORY = new char[12];
-    public static final CharSequence[] PG_TYPE_TO_DEFAULT = new CharSequence[12];
-    public static final short[] PG_TYPE_TO_LENGTH = new short[12];
-    public static final CharSequence[] PG_TYPE_TO_NAME = new CharSequence[12];
+    public static final char[] PG_TYPE_TO_CATEGORY = new char[14];
+    public static final CharSequence[] PG_TYPE_TO_DEFAULT = new CharSequence[14];
+    public static final short[] PG_TYPE_TO_LENGTH = new short[14];
+    public static final CharSequence[] PG_TYPE_TO_NAME = new CharSequence[14];
     public static final IntIntHashMap PG_TYPE_TO_SIZE_MAP = new IntIntHashMap();
     public static final int PG_UUID = 2950;
+    public static final int PG_INTERNAL = 2281;
     public static final int PG_VARCHAR = 1043;
+    public static final int PG_OID = 26;
     public static final int X_PG_BOOL = ((PG_BOOL >> 24) & 0xff) | ((PG_BOOL << 8) & 0xff0000) | ((PG_BOOL >> 8) & 0xff00) | ((PG_BOOL << 24) & 0xff000000);
     public static final int X_B_PG_BOOL = 1 | X_PG_BOOL;
     public static final int X_PG_BYTEA = ((PG_BYTEA >> 24) & 0xff) | ((PG_BYTEA << 8) & 0xff0000) | ((PG_BYTEA >> 8) & 0xff00) | ((PG_BYTEA << 24) & 0xff000000);
@@ -159,6 +161,8 @@ public class PGOids {
         PG_TYPE_OIDS.add(PG_BYTEA);
         PG_TYPE_OIDS.add(PG_DATE);
         PG_TYPE_OIDS.add(PG_UUID);
+        PG_TYPE_OIDS.add(PG_INTERNAL);
+        PG_TYPE_OIDS.add(PG_OID);
 
         PG_TYPE_TO_SIZE_MAP.put(PG_FLOAT8, Double.BYTES);
         PG_TYPE_TO_SIZE_MAP.put(PG_FLOAT4, Float.BYTES);
@@ -181,6 +185,8 @@ public class PGOids {
         PG_TYPE_TO_NAME[9] = "binary";
         PG_TYPE_TO_NAME[10] = "date";
         PG_TYPE_TO_NAME[11] = "uuid";
+        PG_TYPE_TO_NAME[12] = "internal";
+        PG_TYPE_TO_NAME[13] = "oid";
 
         PG_TYPE_TO_CATEGORY[0] = 'S';
         PG_TYPE_TO_CATEGORY[1] = 'D';
@@ -194,6 +200,8 @@ public class PGOids {
         PG_TYPE_TO_CATEGORY[9] = 'U';
         PG_TYPE_TO_CATEGORY[10] = 'D';
         PG_TYPE_TO_CATEGORY[11] = 'U';
+        PG_TYPE_TO_CATEGORY[12] = 'P';
+        PG_TYPE_TO_CATEGORY[13] = 'N';
 
         PG_TYPE_TO_LENGTH[0] = -1;
         PG_TYPE_TO_LENGTH[1] = 8;
@@ -207,6 +215,8 @@ public class PGOids {
         PG_TYPE_TO_LENGTH[9] = -1;
         PG_TYPE_TO_LENGTH[10] = 8;
         PG_TYPE_TO_LENGTH[11] = 16;
+        PG_TYPE_TO_LENGTH[12] = 8;
+        PG_TYPE_TO_LENGTH[13] = 4;
 
         PG_TYPE_TO_DEFAULT[0] = null;
         PG_TYPE_TO_DEFAULT[1] = null;
@@ -220,5 +230,7 @@ public class PGOids {
         PG_TYPE_TO_DEFAULT[9] = null;
         PG_TYPE_TO_DEFAULT[10] = null;
         PG_TYPE_TO_DEFAULT[11] = null;
+        PG_TYPE_TO_DEFAULT[12] = null;
+        PG_TYPE_TO_DEFAULT[13] = null;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
@@ -33,7 +33,7 @@ import io.questdb.std.QuietCloseable;
 
 /**
  * Unlike other TypesAnd* classes, this one doesn't self-return to a pool. That's because
- * it's used for multi-threaded calls to {@link io.questdb.std.ConcurrentAssociativeCache}.
+ * it's used for multithreaded calls to {@link io.questdb.std.ConcurrentAssociativeCache}.
  */
 public class TypesAndSelect implements QuietCloseable {
     private final IntList types = new IntList();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgProcFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgProcFunctionFactory.java
@@ -24,16 +24,26 @@
 
 package io.questdb.griffin.engine.functions.catalogue;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.griffin.engine.functions.GenericRecordCursorFactory;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
 
-public class PgProcFunctionFactory extends AbstractEmptyCatalogueFunctionFactory {
+public class PgProcFunctionFactory implements FunctionFactory {
     private static final RecordMetadata METADATA;
 
-    public PgProcFunctionFactory() {
-        super("pg_proc()", METADATA);
+    @Override
+    public String getSignature() {
+        return "pg_proc()";
     }
 
     @Override
@@ -41,10 +51,54 @@ public class PgProcFunctionFactory extends AbstractEmptyCatalogueFunctionFactory
         return true;
     }
 
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+        return new CursorFunction(
+                new GenericRecordCursorFactory(
+                        METADATA,
+                        new ProcCatalogueCursor(),
+                        false
+                )
+        );
+    }
+
     static {
         final GenericRecordMetadata metadata = new GenericRecordMetadata();
         metadata.add(new TableColumnMetadata("oid", ColumnType.INT));
         metadata.add(new TableColumnMetadata("proname", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("pronamespace", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("proowner", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("prolang", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("procost", ColumnType.FLOAT));
+        metadata.add(new TableColumnMetadata("prorows", ColumnType.FLOAT));
+        metadata.add(new TableColumnMetadata("provariadic", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("prosupport", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("prokind", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("prosecdef", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("proleakproof", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("proisstrict", ColumnType.BOOLEAN));
+
+        metadata.add(new TableColumnMetadata("proretset", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("provolatile", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("proparallel", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("pronargs", ColumnType.SHORT));
+        metadata.add(new TableColumnMetadata("pronargdefaults", ColumnType.SHORT));
+        metadata.add(new TableColumnMetadata("prorettype", ColumnType.INT));
+
+        // proargtypes - skipping, oidvector
+        // proallargtypes - skipping, oid[]
+        // proargmodes - skipping, char[]
+        // proargnames  - skipping, text[]
+        // proargdefaults - skipping, pg_node_tree
+        // protrftypes - skipping, oid[]
+
+        metadata.add(new TableColumnMetadata("prosrc", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("probin", ColumnType.STRING));
+
+        // prosqlbody - skipping, pg_node_tree
+        // proconfig - skippping, text[]
+        // proacl - skipping, aclitem[]
+
         METADATA = metadata;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgProcFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgProcFunctionFactory.java
@@ -56,7 +56,7 @@ public class PgProcFunctionFactory implements FunctionFactory {
         return new CursorFunction(
                 new GenericRecordCursorFactory(
                         METADATA,
-                        new ProcCatalogueCursor(),
+                        new PgProcCatalogueCursor(),
                         false
                 )
         );
@@ -77,7 +77,6 @@ public class PgProcFunctionFactory implements FunctionFactory {
         metadata.add(new TableColumnMetadata("prosecdef", ColumnType.BOOLEAN));
         metadata.add(new TableColumnMetadata("proleakproof", ColumnType.BOOLEAN));
         metadata.add(new TableColumnMetadata("proisstrict", ColumnType.BOOLEAN));
-
         metadata.add(new TableColumnMetadata("proretset", ColumnType.BOOLEAN));
         metadata.add(new TableColumnMetadata("provolatile", ColumnType.CHAR));
         metadata.add(new TableColumnMetadata("proparallel", ColumnType.CHAR));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgTypeCatalogueCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgTypeCatalogueCursor.java
@@ -31,20 +31,19 @@ import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cutlass.pgwire.PGOids;
 import io.questdb.std.Numbers;
 
 import static io.questdb.cutlass.pgwire.PGOids.*;
 
-class ProcCatalogueCursor implements NoRandomAccessRecordCursor {
+class PgTypeCatalogueCursor implements NoRandomAccessRecordCursor {
     static final RecordMetadata METADATA;
     private static final int rowCount = PG_TYPE_OIDS.size();
     public final int[] intValues = new int[METADATA.getColumnCount()];
-    private final TypeCatalogueRecord record = new TypeCatalogueRecord();
+    private final PgTypeCatalogueRecord record = new PgTypeCatalogueRecord();
     private int row = -1;
 
-    public ProcCatalogueCursor() {
-        this.intValues[4] = PGOids.PG_PUBLIC_OID;
+    public PgTypeCatalogueCursor() {
+        this.intValues[4] = PG_PUBLIC_OID;
     }
 
     @Override
@@ -83,7 +82,7 @@ class ProcCatalogueCursor implements NoRandomAccessRecordCursor {
         row = -1;
     }
 
-    class TypeCatalogueRecord implements Record {
+    class PgTypeCatalogueRecord implements Record {
 
         @Override
         public boolean getBool(int col) {
@@ -157,7 +156,6 @@ class ProcCatalogueCursor implements NoRandomAccessRecordCursor {
         metadata.add(new TableColumnMetadata("typreceive", ColumnType.INT));
         metadata.add(new TableColumnMetadata("typdelim", ColumnType.INT));
         metadata.add(new TableColumnMetadata("typinput", ColumnType.INT));
-
         metadata.add(new TableColumnMetadata("typowner", ColumnType.INT));
         metadata.add(new TableColumnMetadata("typlen", ColumnType.SHORT));
         metadata.add(new TableColumnMetadata("typbyval", ColumnType.BOOLEAN));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgTypeFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgTypeFunctionFactory.java
@@ -49,8 +49,8 @@ public class PgTypeFunctionFactory implements FunctionFactory {
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
         return new CursorFunction(
                 new GenericRecordCursorFactory(
-                        TypeCatalogueCursor.METADATA,
-                        new TypeCatalogueCursor(),
+                        PgTypeCatalogueCursor.METADATA,
+                        new PgTypeCatalogueCursor(),
                         false
                 )
         );

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/ProcCatalogueCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/ProcCatalogueCursor.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.catalogue;
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cutlass.pgwire.PGOids;
+import io.questdb.std.Numbers;
+
+import static io.questdb.cutlass.pgwire.PGOids.*;
+
+class ProcCatalogueCursor implements NoRandomAccessRecordCursor {
+    static final RecordMetadata METADATA;
+    private static final int rowCount = PG_TYPE_OIDS.size();
+    public final int[] intValues = new int[METADATA.getColumnCount()];
+    private final TypeCatalogueRecord record = new TypeCatalogueRecord();
+    private int row = -1;
+
+    public ProcCatalogueCursor() {
+        this.intValues[4] = PGOids.PG_PUBLIC_OID;
+    }
+
+    @Override
+    public void close() {
+        row = -1;
+    }
+
+    @Override
+    public Record getRecord() {
+        return record;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (++row < rowCount) {
+            intValues[0] = PG_TYPE_OIDS.get(row);
+            intValues[9] = Numbers.INT_NULL;
+            intValues[10] = 0;
+            intValues[11] = 0;
+            intValues[12] = 0;
+            intValues[13] = 0;
+            intValues[21] = 0;//typndims
+            intValues[22] = 0;//typcollation
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public long size() {
+        return rowCount;
+    }
+
+    @Override
+    public void toTop() {
+        row = -1;
+    }
+
+    class TypeCatalogueRecord implements Record {
+
+        @Override
+        public boolean getBool(int col) {
+            //typisdefined
+            return col == 18;
+        }
+
+        @Override
+        public char getChar(int col) {
+            if (col == 8) {
+                return PG_TYPE_TO_CATEGORY[row];
+            }
+            if (col == 19) {//typalign
+                return 'c';//char alignment
+            }
+            if (col == 20) {//typstorage
+                return 'p';//plain
+            }
+            return 'b';
+        }
+
+        @Override
+        public int getInt(int col) {
+            return intValues[col];
+        }
+
+        @Override
+        public short getShort(int col) {
+            if (col == 15) {
+                return PG_TYPE_TO_LENGTH[row];
+            }
+
+            return -1;
+        }
+
+        @Override
+        public CharSequence getStrA(int col) {
+            if (col == 1) {
+                return PG_TYPE_TO_NAME[row];
+            }
+            if (col == 23) {
+                return PG_TYPE_TO_DEFAULT[row];
+            }
+            return null;
+        }
+
+        @Override
+        public CharSequence getStrB(int col) {
+            return getStrA(col);
+        }
+
+        @Override
+        public int getStrLen(int col) {
+            return TableUtils.lengthOf(getStrA(col));
+        }
+    }
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(new TableColumnMetadata("oid", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typname", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("typbasetype", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typarray", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typnamespace", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typnotnull", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("typtypmod", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typtype", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("typcategory", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("typrelid", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typelem", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typreceive", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typdelim", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typinput", ColumnType.INT));
+
+        metadata.add(new TableColumnMetadata("typowner", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typlen", ColumnType.SHORT));
+        metadata.add(new TableColumnMetadata("typbyval", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("typispreferred", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("typisdefined", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("typalign", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("typstorage", ColumnType.CHAR));
+        metadata.add(new TableColumnMetadata("typndims", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typcollation", ColumnType.INT));
+        metadata.add(new TableColumnMetadata("typdefault", ColumnType.STRING));
+
+        METADATA = metadata;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/DBeaverTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DBeaverTest.java
@@ -44,7 +44,9 @@ public class DBeaverTest extends AbstractCairoTest {
                         "public\t16\t2200\tbool\tb\tnull\tfalse\t\tnull\t\t\t\t0\n" +
                         "public\t17\t2200\tbinary\tb\tnull\tfalse\t\tnull\t\t\t\t0\n" +
                         "public\t1082\t2200\tdate\tb\tnull\tfalse\t\tnull\t\t\t\t0\n" +
-                        "public\t2950\t2200\tuuid\tb\tnull\tfalse\t\tnull\t\t\t\t0\n",
+                        "public\t2950\t2200\tuuid\tb\tnull\tfalse\t\tnull\t\t\t\t0\n" +
+                        "public\t2281\t2200\tinternal\tb\tnull\tfalse\t\tnull\t\t\t\t0\n" +
+                        "public\t26\t2200\toid\tb\tnull\tfalse\t\tnull\t\t\t\t0\n",
                 "SELECT ns.nspname, typ_and_elem_type.*,\n" +
                         "   CASE\n" +
                         "       WHEN typtype IN ('b', 'e', 'p') THEN 0           -- First base types, enums, pseudo-types\n" +
@@ -165,11 +167,13 @@ public class DBeaverTest extends AbstractCairoTest {
                         "20\t20\tint8\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "21\t21\tint2\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t2\tfalse\tfalse\ttrue\tc\tp\t0\t0\t0\t\t\t\n" +
                         "23\t23\tint4\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t4\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
+                        "26\t26\toid\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t4\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "700\t700\tfloat4\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t4\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "701\t701\tfloat8\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "1043\t1043\tvarchar\t0\t0\t2200\tfalse\t0\tb\tS\tnull\t0\t0\t0\t0\t0\t-1\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "1082\t1082\tdate\t0\t0\t2200\tfalse\t0\tb\tD\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "1114\t1114\ttimestamp\t0\t0\t2200\tfalse\t0\tb\tD\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
+                        "2281\t2281\tinternal\t0\t0\t2200\tfalse\t0\tb\tP\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n" +
                         "2950\t2950\tuuid\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t16\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\t\t\t\n",
                 "SELECT t.oid as oid1,t.*,c.relkind,format_type(nullif(t.typbasetype, 0), t.typtypmod) as base_type_name, d.description\n" +
                         "FROM pg_catalog.pg_type t\n" +

--- a/core/src/test/java/io/questdb/test/griffin/PowerBiTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/PowerBiTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class PowerBiTest extends AbstractCairoTest {
+
+    @Test
+    public void testGetTypes() throws Exception {
+        // PowerBI runs this SQL on connection startup
+        assertQuery(
+                "nspname\ttypname\toid\ttyprelid\ttypbasetype\ttype\telemoid\tord\n" +
+                        "public\tvarchar\t1043\tnull\t0\tb\t0\t0\n" +
+                        "public\ttimestamp\t1114\tnull\t0\tb\t0\t0\n" +
+                        "public\tfloat8\t701\tnull\t0\tb\t0\t0\n" +
+                        "public\tfloat4\t700\tnull\t0\tb\t0\t0\n" +
+                        "public\tint4\t23\tnull\t0\tb\t0\t0\n" +
+                        "public\tint2\t21\tnull\t0\tb\t0\t0\n" +
+                        "public\tchar\t18\tnull\t0\tb\t0\t0\n" +
+                        "public\tint8\t20\tnull\t0\tb\t0\t0\n" +
+                        "public\tbool\t16\tnull\t0\tb\t0\t0\n" +
+                        "public\tbinary\t17\tnull\t0\tb\t0\t0\n" +
+                        "public\tdate\t1082\tnull\t0\tb\t0\t0\n" +
+                        "public\tuuid\t2950\tnull\t0\tb\t0\t0\n" +
+                        "public\tinternal\t2281\tnull\t0\tb\t0\t0\n" +
+                        "public\toid\t26\tnull\t0\tb\t0\t0\n",
+                "SELECT ns.nspname, a.typname, a.oid, a.typrelid, a.typbasetype,\n" +
+                        "CASE WHEN pg_proc.proname='array_recv' THEN 'a' ELSE a.typtype END AS type,\n" +
+                        "CASE\n" +
+                        "  WHEN pg_proc.proname='array_recv' THEN a.typelem\n" +
+                        "  WHEN a.typtype='r' THEN rngsubtype\n" +
+                        "  ELSE 0\n" +
+                        "END AS elemoid,\n" +
+                        "CASE\n" +
+                        "  WHEN pg_proc.proname IN ('array_recv','oidvectorrecv') THEN 3    /* Arrays last */\n" +
+                        "  WHEN a.typtype='r' THEN 2                                        /* Ranges before */\n" +
+                        "  WHEN a.typtype='d' THEN 1                                        /* Domains before */\n" +
+                        "  ELSE 0                                                           /* Base types first */\n" +
+                        "END AS ord\n" +
+                        "FROM pg_type AS a\n" +
+                        "JOIN pg_namespace AS ns ON (ns.oid = a.typnamespace)\n" +
+                        "JOIN pg_proc ON pg_proc.oid = a.typreceive\n" +
+                        "LEFT OUTER JOIN pg_class AS cls ON (cls.oid = a.typrelid)\n" +
+                        "LEFT OUTER JOIN pg_type AS b ON (b.oid = a.typelem)\n" +
+                        "LEFT OUTER JOIN pg_class AS elemcls ON (elemcls.oid = b.typrelid)\n" +
+                        "LEFT OUTER JOIN pg_range ON (pg_range.rngtypid = a.oid) \n" +
+                        "WHERE\n" +
+                        "  a.typtype IN ('b', 'r', 'e', 'd') OR         /* Base, range, enum, domain */\n" +
+                        "  (a.typtype = 'c' AND cls.relkind='c') OR /* User-defined free-standing composites (not table composites) by default */\n" +
+                        "  (pg_proc.proname='array_recv' AND (\n" +
+                        "    b.typtype IN ('b', 'r', 'e', 'd') OR       /* Array of base, range, enum, domain */\n" +
+                        "    (b.typtype = 'p' AND b.typname IN ('record', 'void')) OR /* Arrays of special supported pseudo-types */\n" +
+                        "    (b.typtype = 'c' AND elemcls.relkind='c')  /* Array of user-defined free-standing composites (not table composites) */\n" +
+                        "  )) OR\n" +
+                        "  (a.typtype = 'p' AND a.typname IN ('record', 'void'))  /* Some special supported pseudo-types */\n" +
+                        "ORDER BY ord",
+                null,
+                true,
+                false
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/PgTypeFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/PgTypeFunctionFactoryTest.java
@@ -45,7 +45,9 @@ public class PgTypeFunctionFactoryTest extends AbstractCairoTest {
                         "16\tbool\t0\t0\t2200\tfalse\t0\tb\tB\tnull\t0\t0\t0\t0\t0\t1\tfalse\tfalse\ttrue\tc\tp\t0\t0\tfalse\n" +
                         "17\tbinary\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t-1\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
                         "1082\tdate\t0\t0\t2200\tfalse\t0\tb\tD\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
-                        "2950\tuuid\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t16\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n",
+                        "2950\tuuid\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t16\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
+                        "2281\tinternal\t0\t0\t2200\tfalse\t0\tb\tP\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
+                        "26\toid\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t4\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n",
                 "pg_type;",
                 "create table x(a int)",
                 null,
@@ -69,7 +71,9 @@ public class PgTypeFunctionFactoryTest extends AbstractCairoTest {
                         "16\tbool\t0\t0\t2200\tfalse\t0\tb\tB\tnull\t0\t0\t0\t0\t0\t1\tfalse\tfalse\ttrue\tc\tp\t0\t0\tfalse\n" +
                         "17\tbinary\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t-1\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
                         "1082\tdate\t0\t0\t2200\tfalse\t0\tb\tD\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
-                        "2950\tuuid\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t16\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n",
+                        "2950\tuuid\t0\t0\t2200\tfalse\t0\tb\tU\tnull\t0\t0\t0\t0\t0\t16\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
+                        "2281\tinternal\t0\t0\t2200\tfalse\t0\tb\tP\tnull\t0\t0\t0\t0\t0\t8\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n" +
+                        "26\toid\t0\t0\t2200\tfalse\t0\tb\tN\tnull\t0\t0\t0\t0\t0\t4\tfalse\tfalse\ttrue\tc\tp\t0\t0\t\n",
                 "pg_catalog.pg_type;",
                 "create table x(a int)",
                 null,


### PR DESCRIPTION
This is essentially a rewrite of PGWire Server. It was motivated by the list below. It is also the list of issues that have been addressed in the current server:

- current server is a spaghetti full of hacks that are hard to follow
- current server does not implement pipelining (which is why PowerBI does not work)
- current server does not implement protocol correctly:
   - response is sent on 'E' message instead of 'S'
   - portals are just aliases for prepared statement, whereas portal is mean to be a pagination. facility whereas prepared statement is factory cache
   - binary, string and varchar bind variable values are referenced from receive buffer. This buffer is liable to shift and be reused. Binary implemented a "freeze" hack, whereas others did not.
   - the aforementioned "freeze" hack also does not work should we run out of receive buffer capacity. When this happens the outcome is nondeterministic
   - P/S workflow doesn't work
- current server state machine is based on callbacks. This is deficient and nondeterministic when network starts flaking in those callbacks. The symptom would be spurious server-side disconnects.
- bug where prepared statement for "create table" or "drop table" will only be executed once and only once. Even if "create" and "drop" are interleaved in a loop.
-  
## Notes on the portals

It is unclear from the documentation https://www.postgresql.org/docs/current/protocol-flow.html if it is possible to create multiple portals for any given prepared statement. From what I understood, named portals are used to page SQL results. For us this means that "prepared statement" is `RecordCursorFactory`. Every time prepared statement is used. - a new cursor is created. On other hand "named portal" is our `RecordCursor`. There is nothing to say that PG Frontend will not create multiple named portals against our `RecordCursorFactory`. However, we cannot have more than one cursor instance in Factory.

In this implementation, every time named portal is created - we create new `RecordCustorFactory` for it from the existing SQL text. The cursor of the portal is not closed at the end of the execution. The Frontend has to close it explicitly.

I figured out that multiple portals is a possibility from Cockroach Doc: https://www.cockroachlabs.com/docs/stable/postgresql-compatibility