### PR TITLE
chore(log): set containerized system property to default true

### DIFF
--- a/core/src/main/java/io/questdb/Bootstrap.java
+++ b/core/src/main/java/io/questdb/Bootstrap.java
@@ -59,11 +59,11 @@ import static io.questdb.griffin.engine.functions.str.SizePrettyFunctionFactory.
 public class Bootstrap {
 
     public static final String CONFIG_FILE = "/server.conf";
+    public static final String CONTAINERIZED_SYSTEM_PROPERTY = "containerized";
     public static final String SWITCH_USE_DEFAULT_LOG_FACTORY_CONFIGURATION = "--use-default-log-factory-configuration";
     private static final String LOG_NAME = "server-main";
     private static final String PUBLIC_VERSION_TXT = "version.txt";
     private static final String PUBLIC_ZIP = "/io/questdb/site/public.zip";
-    public static final String CONTAINERIZED_SYSTEM_PROPERTY = "containerized";
     private final String banner;
     private final BuildInformation buildInformation;
     private final ServerConfiguration config;
@@ -459,6 +459,14 @@ public class Bootstrap {
         ff.remove(path.$());
     }
 
+    private void copyLogConfResource(byte[] buffer) throws IOException {
+        if (Chars.equalsIgnoreCaseNc("false", System.getProperty(CONTAINERIZED_SYSTEM_PROPERTY))) {
+            copyConfResource(rootDirectory, false, buffer, "conf/non_containerized_log.conf", "conf/log.conf", null);
+        } else {
+            copyConfResource(rootDirectory, false, buffer, "conf/log.conf", null);
+        }
+    }
+
     private void createHelloFile(String helloMsg) {
         final File helloFile = new File(rootDirectory, "hello.txt");
         final File growingFile = new File(rootDirectory, helloFile.getName() + ".tmp");
@@ -485,14 +493,6 @@ public class Bootstrap {
         }
         copyConfResource(rootDirectory, false, buffer, "conf/server.conf", log);
         copyLogConfResource(buffer);
-    }
-
-    private void copyLogConfResource(byte[] buffer) throws IOException {
-        if (Chars.equalsIgnoreCaseNc("true", System.getProperty(CONTAINERIZED_SYSTEM_PROPERTY))) {
-            copyConfResource(rootDirectory, false, buffer, "conf/log.conf", null);
-        } else {
-            copyConfResource(rootDirectory, false, buffer, "conf/non_containerized_log.conf", "conf/log.conf", null);
-        }
     }
 
     private void extractSite0(String publicDir, byte[] buffer, String thisVersion) throws IOException {


### PR DESCRIPTION
https://github.com/questdb/questdb/pull/4810 added the `-Dcontainerized` system property, which points the Bootstrap to the [stdout-enabled log.conf](https://github.com/questdb/questdb/blob/master/core/src/main/resources/io/questdb/site/conf/log.conf) when set to `true`.

This needs to be set in the docker entrypoint, otherwise we log to disk using the [non-containerized log.conf](https://github.com/questdb/questdb/blob/master/core/src/main/resources/io/questdb/site/conf/non_containerized_log.conf).

Evidence:
Locally, on my branch, I build a docker image with my updated `docker-entrypoint.sh`:
```
docker buildx build --build-arg tag_name=steve/fix-docker-entrypoint --platform linux/amd64 -t sklarsa/questdb:test .
```
And when I run it, I get all the logs
```
➜  core git:(steve/fix-docker-entrypoint) docker run sklarsa/questdb:test               
No arguments found in the configuration, start with default arguments
Running as questdb user
Log configuration loaded from: /var/lib/questdb/conf/log.conf
2024-08-05T18:21:47.152129Z A server-main QuestDB 8.1.1-SNAPSHOT. Copyright (C) 2014-2024, all rights reserved.
2024-08-05T18:21:47.238172Z A server-main linux-amd64 [AVX512,10, 64 bits, 12 processors]
2024-08-05T18:21:47.238251Z A server-main fs.file-max checked [limit=1073741816]
2024-08-05T18:21:47.238327Z A server-main vm.max_map_count checked [limit=1048576]
2024-08-05T18:21:47.253834Z I server-main extracted [path=/var/lib/questdb/public/vendor.2be15.js]
2024-08-05T18:21:47.253988Z I server-main extracted [path=/var/lib/questdb/public/index.html]
2024-08-05T18:21:47.254348Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/base/common/worker/simpleWorker.nls.it.js]
2024-08-05T18:21:47.254438Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/base/common/worker/simpleWorker.nls.ja.js.LICENSE.txt]
2024-08-05T18:21:47.254827Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.nls.js]
...
```

Now compare this with `questdb/questdb:nightly`, where most of the logs are not redirected to stdout, but instead saved to `/var/lib/questdb/log`. Nightly was last built 16 hours ago, on the most recent commit (`aac4cf7`)
```
➜  core git:(steve/fix-docker-entrypoint) docker run questdb/questdb:nightly            
No arguments found in the configuration, start with default arguments
Running as questdb user
Created log directory: /var/lib/questdb/log
Log configuration loaded from: /var/lib/questdb/conf/log.conf
2024-08-05T18:22:44.522164Z A http-min-server listening on 0.0.0.0:9003 [fd=99 backlog=4]
```

Running the latest release, 8.1.0, the problem does not exist:
```
➜  core git:(0f75adc0f) docker run questdb/questdb:latest   
No arguments found in the configuration, start with default arguments
Running as questdb user
Log configuration loaded from: /var/lib/questdb/conf/log.conf
2024-08-05T18:31:32.252625Z A server-main QuestDB 8.1.0. Copyright (C) 2014-2024, all rights reserved.
2024-08-05T18:31:32.336652Z A server-main linux-amd64 [AVX512,10, 64 bits, 12 processors]
2024-08-05T18:31:32.336745Z A server-main fs.file-max checked [limit=1073741816]
2024-08-05T18:31:32.336823Z A server-main vm.max_map_count checked [limit=1048576]
2024-08-05T18:31:32.352842Z I server-main extracted [path=/var/lib/questdb/public/vendor.2be15.js]
2024-08-05T18:31:32.353849Z I server-main extracted [path=/var/lib/questdb/public/qdb.1be29.js]
2024-08-05T18:31:32.354095Z I server-main extracted [path=/var/lib/questdb/public/qdb.1be29.css]
2024-08-05T18:31:32.354240Z I server-main extracted [path=/var/lib/questdb/public/assets/questdb-logotype.svg]
2024-08-05T18:31:32.354333Z I server-main extracted [path=/var/lib/questdb/public/assets/upload.svg]
2024-08-05T18:31:32.354408Z I server-main extracted [path=/var/lib/questdb/public/assets/line.svg]
2024-08-05T18:31:32.354489Z I server-main extracted [path=/var/lib/questdb/public/assets/create-table.svg]
2024-08-05T18:31:32.354561Z I server-main extracted [path=/var/lib/questdb/public/assets/favicon.svg]
2024-08-05T18:31:32.354792Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/loader.js]
2024-08-05T18:31:32.354874Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/loader.js.LICENSE.txt]
2024-08-05T18:31:32.355256Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.nls.js]
2024-08-05T18:31:32.366224Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.js]
2024-08-05T18:31:32.366342Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.nls.js.LICENSE.txt]
2024-08-05T18:31:32.366418Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/edito
...
```




