### PR TITLE
fix(sql): fix edge case when using parallel sample by with fill

### DIFF
--- a/core/rust/qdbr/src/parquet_write/jni.rs
+++ b/core/rust/qdbr/src/parquet_write/jni.rs
@@ -219,7 +219,7 @@ fn version_from_i32(value: i32) -> Result<Version, ParquetError> {
 /// The `i64` value is expected to encode two `i32` values:
 /// - The higher 32 bits represent the `level_id`.
 /// - The lower 32 bits represent the optional `codec_id`.
-/// `let value: i64 = (3 << 32) | 2;` Gzip with level 3.
+///   `let value: i64 = (3 << 32) | 2;` Gzip with level 3.
 fn compression_from_i64(value: i64) -> Result<CompressionOptions, ParquetError> {
     let codec_id = value as i32;
     let level_id = (value >> 32) as i32;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -236,6 +236,13 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                         nextBucketTimestamp = minTimestamp;
                     }
 
+                    // if there are no records, then timestamps won't be set correctly i.e
+                    // therefore bucket index is garbage
+                    // check for this and fall out, since we can't fill
+                    if (bucketIndex < 0) {
+                        return false;
+                    }
+
                     while (recordWasPresent()) {
                         moveToNextBucket();
                     }


### PR DESCRIPTION
Closes https://github.com/questdb/questdb/issues/4847

Support for parallel sample by with a fill clause was added in https://github.com/questdb/questdb/pull/4733

However, an edge case was missed. If no `FROM-TO` clause is provided, and all records are filtered out by the `WHERE` clause, then the `FillRangeRecordCursorFactory` was improperly initialised.

This change ensures that errors are not thrown when looking up what buckets to fill, by enforcing bucket index >= 0.
