### PR TITLE
chore(build): fix rust code formatting error

### DIFF
--- a/core/rust/qdbr/src/parquet_write/jni.rs
+++ b/core/rust/qdbr/src/parquet_write/jni.rs
@@ -219,7 +219,7 @@ fn version_from_i32(value: i32) -> Result<Version, ParquetError> {
 /// The `i64` value is expected to encode two `i32` values:
 /// - The higher 32 bits represent the `level_id`.
 /// - The lower 32 bits represent the optional `codec_id`.
-/// `let value: i64 = (3 << 32) | 2;` Gzip with level 3.
+///   `let value: i64 = (3 << 32) | 2;` Gzip with level 3.
 fn compression_from_i64(value: i64) -> Result<CompressionOptions, ParquetError> {
     let codec_id = value as i32;
     let level_id = (value >> 32) as i32;


### PR DESCRIPTION
fix rust code formatting error