### PR TITLE
Removal of exception for manually deleted partitions from the filesystem.

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
@@ -737,7 +737,7 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
             int day = PartitionBy.DAY;
             int partitionToCheck = 0;
             String partitionDirBaseName = "2020-01-02";
-            int deletedPartitionIndex = 0;
+            int deletedPartitionIndex = 1;
             int rowCount = 10000;
             testPartitionDirDeleted(null, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 1, rowCount, rowCount / 5);
         }
@@ -1032,11 +1032,7 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
 
                 if (expected == null) {
                     // Don't check that partition open fails if it's already opened
-
-                    // If partition cannot be opened assigns 0 instead of throwing an error to prevent breaking other SQL statements.
-                    if(reader.openPartition(deletedPartitionIndex) != 0){
-                        Assert.assertEquals(totalPartitionRowCount, reader.openPartition(deletedPartitionIndex));
-                    }
+                    Assert.assertEquals(0, reader.openPartition(deletedPartitionIndex));
                 } else {
                     // Should throw something meaningful
                     try {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
@@ -745,44 +745,35 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
 
     @Test
     public void testPartitionDeletedFromDiskWithoutDropByDay() throws Exception {
-        String expected = "[0] Partition '2020-01-02' does not exist in table 'src' directory. " +
-                "Run [ALTER TABLE src DROP PARTITION LIST '2020-01-02'] " +
-                "to repair the table or restore the partition directory.";
         String startDate = "2020-01-01";
         int day = PartitionBy.DAY;
         int partitionToCheck = 0;
-        String partitionDirBaseName = "2020-01-02";
+        String nonExistentPartitionDirName = "2020-01-02";
         int deletedPartitionIndex = 1;
         int rowCount = 10000;
-        testPartitionDirDeleted(expected, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 1, rowCount, rowCount / 5);
+        testPartitionDirDeleted(null, startDate, day, partitionToCheck, nonExistentPartitionDirName, deletedPartitionIndex, 5, 1, rowCount, rowCount / 5);
     }
 
     @Test
     public void testPartitionDeletedFromDiskWithoutDropByDayNoVersionInErrorMsg() throws Exception {
-        String expected = "[0] Partition '2020-01-02' does not exist in table 'src' directory. " +
-                "Run [ALTER TABLE src DROP PARTITION LIST '2020-01-02'] " +
-                "to repair the table or restore the partition directory.";
         String startDate = "2020-01-01";
         int day = PartitionBy.DAY;
         int partitionToCheck = 0;
         String partitionDirBaseName = "2020-01-02";
         int deletedPartitionIndex = 1;
         int rowCount = 1000;
-        testPartitionDirDeleted(expected, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 5, rowCount, rowCount / 5);
+        testPartitionDirDeleted(null, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 5, rowCount, rowCount / 5);
     }
 
     @Test
     public void testPartitionDeletedFromDiskWithoutDropByMonth() throws Exception {
-        String expected = "[0] Partition '2020-02' does not exist in table 'src' directory. " +
-                "Run [ALTER TABLE src DROP PARTITION LIST '2020-02'] " +
-                "to repair the table or restore the partition directory.";
         String startDate = "2020-01-01";
         int day = PartitionBy.MONTH;
         int partitionToCheck = 0;
         String partitionDirBaseName = "2020-02";
         int deletedPartitionIndex = 1;
         int rowCount = 10000;
-        testPartitionDirDeleted(expected, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 1, rowCount, 2039);
+        testPartitionDirDeleted(null, startDate, day, partitionToCheck, partitionDirBaseName, deletedPartitionIndex, 5, 1, rowCount, 2039);
     }
 
     @Test
@@ -799,16 +790,13 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
 
     @Test
     public void testPartitionDeletedFromDiskWithoutDropByWeek() throws Exception {
-        String expected = "[0] Partition '2020-W02' does not exist in table 'src' directory. " +
-                "Run [ALTER TABLE src DROP PARTITION LIST '2020-W02'] " +
-                "to repair the table or restore the partition directory.";
         String startDate = "2020-01-01";
         int day = PartitionBy.WEEK;
         int partitionToCheck = 0;
         String folderToDelete = "2020-W02";
         int deletedPartitionIndex = 1;
         int rowCount = 10000;
-        testPartitionDirDeleted(expected, startDate, day, partitionToCheck, folderToDelete, deletedPartitionIndex, 5, 1, rowCount, 1428);
+        testPartitionDirDeleted(null, startDate, day, partitionToCheck, folderToDelete, deletedPartitionIndex, 5, 1, rowCount, 1428);
     }
 
     @Test
@@ -1044,7 +1032,11 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
 
                 if (expected == null) {
                     // Don't check that partition open fails if it's already opened
-                    Assert.assertEquals(totalPartitionRowCount, reader.openPartition(deletedPartitionIndex));
+
+                    // If partition cannot be opened assigns 0 instead of throwing an error to prevent breaking other SQL statements.
+                    if(reader.openPartition(deletedPartitionIndex) != 0){
+                        Assert.assertEquals(totalPartitionRowCount, reader.openPartition(deletedPartitionIndex));
+                    }
                 } else {
                     // Should throw something meaningful
                     try {

--- a/core/src/test/java/io/questdb/test/griffin/DistinctIntKeyTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctIntKeyTest.java
@@ -149,11 +149,15 @@ public class DistinctIntKeyTest extends AbstractCairoTest {
                 Assert.assertTrue(Files.rmdir(path, true));
             }
 
-            try {
-                assertExceptionNoLeakCheck("select DISTINCT i from tab order by 1 LIMIT 3");
-            } catch (CairoException e) {
-                TestUtils.assertContains(e.getFlyweightMessage(), "Partition '2020-02' does not exist in table 'tab' directory");
-            }
+            assertQuery(
+                    "count\n" +
+                            "0\n",
+                    "SELECT count(i) FROM tab WHERE ts IN '2020-02'",
+                    null,
+                    false,
+                    true
+            );
+
         });
     }
 }


### PR DESCRIPTION
https://github.com/questdb/questdb/issues/4107
Returning size 0 from TableReader helps with not blocking all queries on table while still giving a user a chance to run the drop partition command or investigate why folder was deleted.

Alternative approaches, I considered:
- executing code similar to dropping the partition from TableReader where exception is created.
- detaching the partition.