### PR TITLE
feat(Support exclusive and half-open intervals in BETWEEN expressions #4746

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -742,6 +742,19 @@ public class SqlKeywords {
                 && (tok.charAt(1) | 32) == 'n';
     }
 
+    public static boolean isInclusiveKeyword(CharSequence tok) {
+        return tok.length() == 9
+                && (tok.charAt(0) | 32) == 'i'
+                && (tok.charAt(1) | 32) == 'n'
+                && (tok.charAt(2) | 32) == 'c'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 's'
+                && (tok.charAt(6) | 32) == 'i'
+                && (tok.charAt(7) | 32) == 'v'
+                && (tok.charAt(8) | 32) == 'e';
+    }
+
     public static boolean isIndexKeyword(CharSequence tok) {
         return tok.length() == 5
                 && (tok.charAt(0) | 32) == 'i'
@@ -1220,6 +1233,14 @@ public class SqlKeywords {
                 && (tok.charAt(1) | 32) == 'n'
                 && (tok.charAt(2) | 32) == 'l'
                 && (tok.charAt(3) | 32) == 'y';
+    }
+
+    public static boolean isOpenKeyword(CharSequence tok) {
+        return tok.length() == 4
+                && (tok.charAt(0) | 32) == 'o'
+                && (tok.charAt(1) | 32) == 'p'
+                && (tok.charAt(2) | 32) == 'e'
+                && (tok.charAt(3) | 32) == 'n';
     }
 
     public static boolean isOrKeyword(CharSequence tok) {

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -2204,6 +2204,29 @@ public class SqlParser {
                                 throw SqlException.$(lexer.lastTokenPosition(), "RANGE with offset PRECEDING/FOLLOWING requires exactly one ORDER BY column");
                             }
 
+                            tok = tok(lexer, "'inclusive' 'exclusive' 'right' 'left'");
+                            if(isInclusiveKeyword(tok)) {
+                                model.setBetweenType(1);
+                            } else if(isExclusiveKeyword(tok)) {
+                                model.setBetweenType(2);
+                            } else if(isRightKeyword(tok)) {
+                                tok = tok(lexer, "'open'");
+                                if(isOpenKeyword(tok)) {
+                                    model.setBetweenType(3);
+                                } else {
+                                    throw SqlException.$(lexer.lastTokenPosition(), "'open' expected");
+                                }
+                            } else if(isLeftKeyword(tok)) {
+                                tok = tok(lexer, "'open'");
+                                if(isOpenKeyword(tok)) {
+                                    model.setBetweenType(4);
+                                } else {
+                                    throw SqlException.$(lexer.lastTokenPosition(), "'open' expected");
+                                }
+                            } else {
+                                throw SqlException.$(lexer.lastTokenPosition(), "'inclusive' 'exclusive' 'right' 'left' expected");
+                            }
+
                             tok = tok(lexer, "'exclude' or ')' expected");
 
                             if (isExcludeKeyword(tok)) {


### PR DESCRIPTION
QuestDB supports BETWEEN expressions:

`WHERE timestamp BETWEEN x AND y`

These expressions serve as a convenient syntax for representing inclusive intervals. This is syntax sugar for:

`WHERE timestamp >= x AND timestamp <= y`

For many applications, an inclusive interval is fine. However, other types of intervals can be useful to represent: inclusive, exclusive, left-open, and right-open.

We could extend the BETWEEN syntax to support these intervals.

This can also serve as a small performance optimisation since both conditions will be calculated in a single function call.
