### PR TITLE
ci(build): improve method of installing LLVM coverage tools

### DIFF
--- a/ci/templates/install-llvm.yml
+++ b/ci/templates/install-llvm.yml
@@ -4,20 +4,11 @@ parameters:
 steps:
   - bash: |
       set -eux
-      # Fetch and execute LLVM installation script
-      wget https://apt.llvm.org/llvm.sh
-      sudo bash llvm.sh
-      # CURRENT_LLVM_STABLE in the script tells which version it installed. Extract it from the script: 
-      export $(grep CURRENT_LLVM_STABLE= llvm.sh)
-      # ... and set a task variable to its value
-      echo "##vso[task.setvariable variable=LLVM_VERSION]$CURRENT_LLVM_STABLE"
-
-      # Explicitly install version-specific llvm package, in case the script didn't do it:
-      sudo apt-get install llvm-$CURRENT_LLVM_STABLE
-
-      # Check existence of the commands we'll use
-      export PATH=/usr/lib/llvm-$CURRENT_LLVM_STABLE/bin:$PATH
+      rustup component add llvm-tools-preview
+      LLVM_TOOLS_PATH=$(dirname $(find $HOME/.rustup -name llvm-profdata))
+      export PATH=$LLVM_TOOLS_PATH:$PATH
       llvm-profdata --version
       llvm-cov --version
+      echo "##vso[task.setvariable variable=LLVM_TOOLS_PATH]$LLVM_TOOLS_PATH"
     displayName: "Install LLVM coverage tools"
     condition: ${{ parameters.shouldRun }}

--- a/ci/templates/install-llvm.yml
+++ b/ci/templates/install-llvm.yml
@@ -7,6 +7,7 @@ steps:
       rustup component add llvm-tools-preview
       LLVM_TOOLS_PATH=$(dirname $(find $HOME/.rustup -name llvm-profdata))
       export PATH=$LLVM_TOOLS_PATH:$PATH
+      set +x
       llvm-profdata --version
       llvm-cov --version
       echo "##vso[task.setvariable variable=LLVM_TOOLS_PATH]$LLVM_TOOLS_PATH"

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -169,7 +169,7 @@ steps:
       artifactName: jacoco-coverage
   - bash: |
       set -eux
-      export PATH=/usr/lib/llvm-$LLVM_VERSION/bin:$PATH
+      export PATH=$LLVM_TOOLS_PATH:$PATH
       # List profraw files for debugging purposes
       find . -name \*.profraw
       CANDIDATE_FILES="core/rust/qdbr/questdbr-cargo-test.profraw core/questdbr-junit.profraw"

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -143,7 +143,7 @@ stages:
                 -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
           - bash: |
               set -eux
-              export PATH=/usr/lib/llvm-$LLVM_VERSION/bin:$PATH
+              export PATH=$LLVM_TOOLS_PATH:$PATH
               ls -al $(Pipeline.Workspace)/rust-llvm-coverage
 
               # Merge partial profdata files into the complete report

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -95,13 +95,13 @@ stages:
           CODE_COVERAGE_TOOL_OPTION: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.CODE_COVERAGE_TOOL_OPTION']]
           COVERAGE_DIFF: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.COVERAGE_DIFF']]
           SHOULD_RUN: >-
-            ${{ if and(
+            $[ and(
               or(
                 eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'),
                 eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
               ),
               eq(variables['System.PullRequest.IsFork'], 'false')
-            ) 'true' else 'false'}} 
+            )] 
 
         # Coverage Job is required to run by a validation rule, but there's no point in running the steps
         # if there were no code changes. Therefore we define SHOULD_RUN and use it as a condition in all steps.

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -101,7 +101,7 @@ stages:
                 eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
               ),
               eq(variables['System.PullRequest.IsFork'], 'false')
-            ) }}true${{ else }}false 
+            ) 'true' else 'false'}} 
 
         # Coverage Job is required to run by a validation rule, but there's no point in running the steps
         # if there were no code changes. Therefore we define SHOULD_RUN and use it as a condition in all steps.

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -103,8 +103,6 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
-          - bash: echo "$(SHOULD_RUN)"
-            displayName: Print SHOULD_RUN value
           - download: current
             artifact: jacoco-coverage
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -174,7 +174,7 @@ stages:
               wget https://raw.githubusercontent.com/eriwen/lcov-to-cobertura-xml/master/lcov_cobertura/lcov_cobertura.py
               python3 lcov_cobertura.py questdbr.lcov.dat --output cobertura.xml --base-dir core/rust/qdbr/src
             displayName: "Merge partial Rust reports"
-            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
 
           - bash: |
               set -eux

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -94,14 +94,16 @@ stages:
           RUST_SOURCE_CODE_CHANGED: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.RUST_SOURCE_CODE_CHANGED']]
           CODE_COVERAGE_TOOL_OPTION: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.CODE_COVERAGE_TOOL_OPTION']]
           COVERAGE_DIFF: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.COVERAGE_DIFF']]
-        condition: |
-          and(
+          SHOULD_RUN: >
+            and(
               or(
-                  eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'),
-                  eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
+                eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'),
+                eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
               ),
               eq(variables['System.PullRequest.IsFork'], 'false')
-          )
+            )
+        # Coverage Job is required to run by a validation rule, but there's no point in running the steps
+        # if there were no code changes. Therefore we define SHOULD_RUN and use it as a condition in all steps.
         steps:
           - checkout: self
             fetchDepth: 1
@@ -109,21 +111,21 @@ stages:
             submodules: false
           - download: current
             artifact: jacoco-coverage
-            condition: eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
           - download: current
             artifact: rust-llvm-coverage
-            condition: eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
           - template: templates/install-llvm.yml
             parameters:
-              shouldRun: eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true')
+              shouldRun: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
           - task: Cache@2
-            condition: eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
             inputs:
               key: '"questdb_main" | "maven"'
               path: $(MAVEN_CACHE_FOLDER)
           - task: Maven@3
             displayName: "Compile with Maven"
-            condition: eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
             inputs:
               mavenPomFile: "core/pom.xml"
               mavenOptions: "$(MAVEN_OPTS)"
@@ -132,7 +134,7 @@ stages:
               jdkVersionOption: "1.11"
           - task: Maven@3
             displayName: "Merge partial JaCoCo reports"
-            condition: eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
             inputs:
               mavenPomFile: "ci/jacoco-merge.xml"
               goals: "verify"
@@ -172,7 +174,7 @@ stages:
               wget https://raw.githubusercontent.com/eriwen/lcov-to-cobertura-xml/master/lcov_cobertura/lcov_cobertura.py
               python3 lcov_cobertura.py questdbr.lcov.dat --output cobertura.xml --base-dir core/rust/qdbr/src
             displayName: "Merge partial Rust reports"
-            condition: eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true')
+            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true')
 
           - bash: |
               set -eux
@@ -187,3 +189,4 @@ stages:
                 $COVER_ARGS --repo "questdb/questdb" --pr $(System.PullRequest.PullRequestNumber) \
                 -t $(DIFF_COVER_THRESHOLD_PCT) --github-token $(GH_TOKEN)
             displayName: "Post combined report to GitHub"
+            condition: eq(variables['SHOULD_RUN'], 'true')

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -94,14 +94,7 @@ stages:
           RUST_SOURCE_CODE_CHANGED: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.RUST_SOURCE_CODE_CHANGED']]
           CODE_COVERAGE_TOOL_OPTION: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.CODE_COVERAGE_TOOL_OPTION']]
           COVERAGE_DIFF: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.COVERAGE_DIFF']]
-          SHOULD_RUN: >-
-            $[ and(
-              or(
-                eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'),
-                eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
-              ),
-              eq(variables['System.PullRequest.IsFork'], 'false')
-            )] 
+          SHOULD_RUN: $[ and( or( eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo') ), eq(variables['System.PullRequest.IsFork'], 'false') )]
 
         # Coverage Job is required to run by a validation rule, but there's no point in running the steps
         # if there were no code changes. Therefore we define SHOULD_RUN and use it as a condition in all steps.
@@ -110,6 +103,8 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
+          - bash: echo "$(SHOULD_RUN)"
+            displayName: Print SHOULD_RUN value
           - download: current
             artifact: jacoco-coverage
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -94,14 +94,15 @@ stages:
           RUST_SOURCE_CODE_CHANGED: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.RUST_SOURCE_CODE_CHANGED']]
           CODE_COVERAGE_TOOL_OPTION: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.CODE_COVERAGE_TOOL_OPTION']]
           COVERAGE_DIFF: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.COVERAGE_DIFF']]
-          SHOULD_RUN: >
-            and(
+          SHOULD_RUN: >-
+            ${{ if and(
               or(
                 eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'),
                 eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo')
               ),
               eq(variables['System.PullRequest.IsFork'], 'false')
-            )
+            ) }}true${{ else }}false 
+
         # Coverage Job is required to run by a validation rule, but there's no point in running the steps
         # if there were no code changes. Therefore we define SHOULD_RUN and use it as a condition in all steps.
         steps:

--- a/core/rust/qdbr/src/lib.rs
+++ b/core/rust/qdbr/src/lib.rs
@@ -22,16 +22,16 @@
  *
  ******************************************************************************/
 
-mod parquet_read;
-mod parquet_write;
-
 extern crate core;
 pub extern crate jni;
 
+use jni::{JNIEnv, objects::JClass};
 use jni::sys::jlong;
-use jni::{objects::JClass, JNIEnv};
 use once_cell::sync::Lazy;
 use rayon::{ThreadPool, ThreadPoolBuilder};
+
+mod parquet_read;
+mod parquet_write;
 
 pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
     let num_threads = std::env::var("QUESTDB_MAX_THREADS") // TODO: Use a proper config system
@@ -58,6 +58,7 @@ pub extern "system" fn Java_io_questdb_std_Os_initRust(_env: JNIEnv, _class: JCl
     if std::env::var("RUST_BACKTRACE").is_err() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
+    println!("Qdbr init");
 }
 
 #[no_mangle]

--- a/core/rust/qdbr/src/lib.rs
+++ b/core/rust/qdbr/src/lib.rs
@@ -22,16 +22,16 @@
  *
  ******************************************************************************/
 
+mod parquet_read;
+mod parquet_write;
+
 extern crate core;
 pub extern crate jni;
 
-use jni::{JNIEnv, objects::JClass};
 use jni::sys::jlong;
+use jni::{objects::JClass, JNIEnv};
 use once_cell::sync::Lazy;
 use rayon::{ThreadPool, ThreadPoolBuilder};
-
-mod parquet_read;
-mod parquet_write;
 
 pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
     let num_threads = std::env::var("QUESTDB_MAX_THREADS") // TODO: Use a proper config system
@@ -58,7 +58,6 @@ pub extern "system" fn Java_io_questdb_std_Os_initRust(_env: JNIEnv, _class: JCl
     if std::env::var("RUST_BACKTRACE").is_err() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
-    println!("Qdbr init");
 }
 
 #[no_mangle]

--- a/core/src/main/java/io/questdb/std/histogram/org/HdrHistogram/package-info.java
+++ b/core/src/main/java/io/questdb/std/histogram/org/HdrHistogram/package-info.java
@@ -1,26 +1,26 @@
-///*******************************************************************************
-// *     ___                  _   ____  ____
-// *    / _ \ _   _  ___  ___| |_|  _ \| __ )
-// *   | | | | | | |/ _ \/ __| __| | | |  _ \
-// *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
-// *    \__\_\\__,_|\___||___/\__|____/|____/
-// *
-// *  Copyright (c) 2014-2019 Appsicle
-// *  Copyright (c) 2019-2024 QuestDB
-// *
-// *  Licensed under the Apache License, Version 2.0 (the "License");
-// *  you may not use this file except in compliance with the License.
-// *  You may obtain a copy of the License at
-// *
-// *  http://www.apache.org/licenses/LICENSE-2.0
-// *
-// *  Unless required by applicable law or agreed to in writing, software
-// *  distributed under the License is distributed on an "AS IS" BASIS,
-// *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// *  See the License for the specific language governing permissions and
-// *  limitations under the License.
-// *
-// ******************************************************************************/
+/* ******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
 
 // Written by Gil Tene of Azul Systems, and released to the public domain,
 // as explained at http://creativecommons.org/publicdomain/zero/1.0/
@@ -311,5 +311,3 @@
  */
 
 package io.questdb.std.histogram.org.HdrHistogram;
-
-


### PR DESCRIPTION
Use rustup to install them, this avoids the inevitable version mismatch the previous method would result in.