### PR TITLE
fix(http): csv uploads with header and a single data row have their schema ignored

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -666,7 +666,7 @@ public class ImportIODispatcherTest extends AbstractTest {
                     });
 
                     new SendAndReceiveRequestBuilder().execute(
-                            "POST /upload?name=single_row_with_schema&partitionBy=NONE&forceHeader=fals[%E2%80%A6]v=false&delimiter=&atomicity=skipCol&maxUncommitedRows=500000 HTTP/1.1\r\n" +
+                            "POST /upload?name=single_row_with_schema&partitionBy=NONE&forceHeader=true&delimiter=&atomicity=skipCol&maxUncommitedRows=500000 HTTP/1.1\r\n" +
                                     "Host: localhost:9001\r\n" +
                                     "User-Agent: curl/7.64.0\r\n" +
                                     "Accept: */*\r\n" +
@@ -735,7 +735,7 @@ public class ImportIODispatcherTest extends AbstractTest {
                     TableToken tableToken = new TableToken("single_row_with_schema", "single_row_with_schema", 0, false, false, false);
                     try (TableReader reader = new TableReader(engine.getConfiguration(), tableToken)) {
                         TableReaderMetadata meta = reader.getMetadata();
-                        Assert.assertEquals(5, meta.getColumnCount());
+                        Assert.assertEquals(3, meta.getColumnCount());
                         Assert.assertEquals(ColumnType.LONG, meta.getColumnType("a"));
                         Assert.assertEquals(ColumnType.SYMBOL, meta.getColumnType("b"));
                         Assert.assertFalse(meta.isColumnIndexed(1));


### PR DESCRIPTION
Closes: https://github.com/questdb/questdb/issues/4905

If you upload a CSV such as this:

```
a,b,c
1,a,2
```

With schema: `(a LONG, b SYMBOL, c LONG)`

You instead get a table with schema: `(f0 CHAR, f1 CHAR, f2 CHAR)`.

The schema is sent by the UI, and is processed in some fashion by the database, but does not seem to be applied.