### PR TITLE
fix(sql): symbol cannot be set to CACHE immediately after setting it to NOCACHE

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -53,6 +53,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     private final int maxHash;
     private final int symbolCapacity;
     private final SymbolValueCountCollector valueCountCollector;
+    private boolean cached_flag;
     private boolean nullValue = false;
     private MemoryMARW offsetMem;
     private int symbolIndexInTxWriter;
@@ -125,8 +126,10 @@ public class SymbolMapWriter implements Closeable, MapWriter {
 
             if (useCache) {
                 this.cache = new CharSequenceIntHashMap(symbolCapacity, 0.3, CharSequenceIntHashMap.NO_ENTRY_VALUE);
+                cached_flag = true;
             } else {
                 this.cache = null;
+                cached_flag = false;
             }
 
             this.symbolIndexInTxWriter = symbolIndexInTxWriter;
@@ -198,7 +201,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     }
 
     public boolean isCached() {
-        return cache != null;
+        return cached_flag;
     }
 
     @Override
@@ -268,6 +271,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     @Override
     public void updateCacheFlag(boolean flag) {
         offsetMem.putBool(HEADER_CACHE_ENABLED, flag);
+        cached_flag = flag;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -53,7 +53,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     private final int maxHash;
     private final int symbolCapacity;
     private final SymbolValueCountCollector valueCountCollector;
-    private boolean cached_flag;
+    private boolean cachedFlag;
     private boolean nullValue = false;
     private MemoryMARW offsetMem;
     private int symbolIndexInTxWriter;
@@ -126,10 +126,10 @@ public class SymbolMapWriter implements Closeable, MapWriter {
 
             if (useCache) {
                 this.cache = new CharSequenceIntHashMap(symbolCapacity, 0.3, CharSequenceIntHashMap.NO_ENTRY_VALUE);
-                cached_flag = true;
+                cachedFlag = true;
             } else {
                 this.cache = null;
-                cached_flag = false;
+                cachedFlag = false;
             }
 
             this.symbolIndexInTxWriter = symbolIndexInTxWriter;
@@ -201,7 +201,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     }
 
     public boolean isCached() {
-        return cached_flag;
+        return cachedFlag;
     }
 
     @Override
@@ -271,7 +271,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
     @Override
     public void updateCacheFlag(boolean flag) {
         offsetMem.putBool(HEADER_CACHE_ENABLED, flag);
-        cached_flag = flag;
+        cachedFlag = flag;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -822,10 +822,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final MapWriter symbolMapWriter = symbolMapWriters.getQuick(columnIndex);
         if (symbolMapWriter.isCached() != cache) {
             symbolMapWriter.updateCacheFlag(cache);
-        } else {
-            return;
+            updateMetaStructureVersion();
+            txWriter.bumpTruncateVersion();
         }
-        updateMetaStructureVersion();
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
@@ -257,6 +257,32 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterTableCacheAndNocache() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("CREATE TABLE foo ( a SYMBOL )");
+            drainWalQueue();
+
+            String header = "column\ttype\tindexed\tindexBlockCapacity\tsymbolCached\tsymbolCapacity\tdesignated\tupsertKey\n";
+            String left = "a\tSYMBOL\tfalse\t256\t";
+            String right = "\t128\tfalse\tfalse\n";
+
+            // check its true by default
+            assertSql(header + left + "true" + right, "table_columns('foo')");
+
+            ddl("ALTER TABLE foo ALTER COLUMN a NOCACHE");
+            drainWalQueue();
+            // check its false now
+            assertSql(header + left + "false" + right, "table_columns('foo')");
+
+            ddl("ALTER TABLE foo ALTER COLUMN a CACHE");
+            drainWalQueue();
+            // check its true again
+            assertSql(header + left + "true" + right, "table_columns('foo')");
+
+        });
+    }
+
+    @Test
     public void testAlterTableFailsToUpgradeConcurrently() throws Exception {
         runAlterOnBusyTable(
                 (writer, reader) -> {

--- a/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/DispatcherWriterQueueTest.java
@@ -276,6 +276,7 @@ public class DispatcherWriterQueueTest extends AbstractCairoTest {
 
             ddl("ALTER TABLE foo ALTER COLUMN a CACHE");
             drainWalQueue();
+
             // check its true again
             assertSql(header + left + "true" + right, "table_columns('foo')");
 


### PR DESCRIPTION
In `SymbolMapWriter`, there is a condition to determine whether the symbol is or isn't cached:

https://github.com/questdb/questdb/blob/753485fb4427b9317a98921c59031d300d4cc2da/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java#L200-L202

This checks whether or not there are values in-memory in a cache.

In `TableWriter`, there is a `changeCacheFlag` method:

https://github.com/questdb/questdb/blob/753485fb4427b9317a98921c59031d300d4cc2da/core/src/main/java/io/questdb/cairo/TableWriter.java#L817-L829

This is used to toggle the flag on or off.

Starting with `CACHE` enabled, the `SymbolMapWriter` is loaded and cache initialised.

When setting it to `NOCACHE`, `SymbolMapWriter` will run `updateCacheFlag`:

https://github.com/questdb/questdb/blob/753485fb4427b9317a98921c59031d300d4cc2da/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java#L269-L271

This writes the new flag value. However, it does not null `cache` or dispose of `SymbolMapWriter`.

When trying to reinitialise this to `CACHE`, the condition is checked. But since the `cache` object has not been nulled, it is a noop, and the `CACHE` flag is not written to disk.

A first attempt to resolve was to change `isCached()` to rely on the disk value:

<img width="441" alt="image" src="https://github.com/user-attachments/assets/ddc0da7b-ed98-4625-a364-98e663fb7392">

This will then break a number of tests in `FullFwdPartitionFrameCursorTest`:

<img width="447" alt="image" src="https://github.com/user-attachments/assets/33cb55cb-91de-45c3-a629-efe567423eeb">


**The fix**

The fix is to add a separate cache flag, and to bump truncate version in txWriter to make sure all readers and writers see the change.
