### PR TITLE
fix(build): revert changed test class regex

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <javac.target>11</javac.target>
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
-        <test.include>%regex[.*[^o]\.class]</test.include><!-- exclude module-info.class-->
+        <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
         <web.console.version>0.5.1</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>


### PR DESCRIPTION
Maven Surefire plugin uses a very peculiar syntax for `%regex[...]` -- when the "regex" ends in ".class", it's taken literally and the dot does not mean "any character", but a literal `.`.

So the backslash that I added in an earlier PR should not be there.