### PR TITLE
ci(build): simplify Rust code coverage

### DIFF
--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -90,9 +90,6 @@ steps:
         eq(variables['testset'], 'all'),
         eq(variables['SOURCE_CODE_CHANGED'], 'true')
       )
-  - bash: echo "##vso[task.setvariable variable=LLVM_PROFILE_FILE]questdbr-junit.profraw"
-    displayName: "LLVM_PROFILE_FILE=questdbr-junit.profraw"
-    condition: startsWith(variables['testset'], 'coverage')
   - task: Maven@3
     displayName: "Run tests with Coverage"
     inputs:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -217,6 +217,8 @@
                         <QDB_CLIENT_CONF>
                             tcp::addr=localhost:9002;user=testUser1;token=UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw=;
                         </QDB_CLIENT_CONF>
+                        <!-- Used by cargo when running a test with code coverage -->
+                        <LLVM_PROFILE_FILE>questdbr-junit.profraw</LLVM_PROFILE_FILE>
                     </environmentVariables>
                 </configuration>
             </plugin>

--- a/core/rust/qdbr/src/lib.rs
+++ b/core/rust/qdbr/src/lib.rs
@@ -22,11 +22,10 @@
  *
  ******************************************************************************/
 
-mod parquet_read;
-mod parquet_write;
-
 extern crate core;
 pub extern crate jni;
+mod parquet_read;
+mod parquet_write;
 
 use jni::sys::jlong;
 use jni::{objects::JClass, JNIEnv};
@@ -58,6 +57,7 @@ pub extern "system" fn Java_io_questdb_std_Os_initRust(_env: JNIEnv, _class: JCl
     if std::env::var("RUST_BACKTRACE").is_err() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
+    println!("mock line of code");
 }
 
 #[no_mangle]

--- a/core/rust/qdbr/src/lib.rs
+++ b/core/rust/qdbr/src/lib.rs
@@ -22,10 +22,11 @@
  *
  ******************************************************************************/
 
-extern crate core;
-pub extern crate jni;
 mod parquet_read;
 mod parquet_write;
+
+extern crate core;
+pub extern crate jni;
 
 use jni::sys::jlong;
 use jni::{objects::JClass, JNIEnv};
@@ -57,7 +58,6 @@ pub extern "system" fn Java_io_questdb_std_Os_initRust(_env: JNIEnv, _class: JCl
     if std::env::var("RUST_BACKTRACE").is_err() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
-    println!("mock line of code");
 }
 
 #[no_mangle]


### PR DESCRIPTION
Removes the cumbersome way in which an environment variable was being set, moves that to pom.xml