### PR TITLE
test(sql): fix flaky testServerMainCreateWalTableInVolume()

### DIFF
--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -344,23 +344,14 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
                 CairoEngine engine = qdb.getEngine();
                 TableToken tableToken = createPopulateTable(engine, compiler, context, tableName, true, true, false);
                 assertTableExists(tableToken, true, true);
-                long t = System.currentTimeMillis();
-                while (true) {
-                    try {
-                        assertSql(
-                                compiler,
-                                context,
-                                "SELECT min(ts), max(ts), count() FROM " + tableName + " SAMPLE BY 1d ALIGN TO CALENDAR",
-                                new StringSink(),
-                                TABLE_START_CONTENT
-                        );
-                        break;
-                    } catch (AssertionError e) {
-                        if (System.currentTimeMillis() - t > 5000) {
-                            throw e;
-                        }
-                    }
-                }
+                qdb.awaitTxn(tableName, 1);
+                assertSql(
+                        compiler,
+                        context,
+                        "SELECT min(ts), max(ts), count() FROM " + tableName + " SAMPLE BY 1d ALIGN TO CALENDAR",
+                        new StringSink(),
+                        TABLE_START_CONTENT
+                );
                 dropTable(compiler, context, tableToken);
             }
         });


### PR DESCRIPTION
The original code was flooding the system with (parallel?) SAMPLE BY queries until it returned the expected results.

There are 2 issues with this approach:
1. minor one: if the query occasionally returns wrong results then the test won't catch it
2. bigger one: it looks like the WAL Apply Job was starved due almost 5k SAMPLE BY queries running in the span of 5s. See the log: https://gist.githubusercontent.com/jerrinot/2efdc5d35f3d1cfbdad2fda78375db2a/raw/d51368ae264f262f1e64a6ad1cdce244d0ac3900/gistfile1.txt There are 5k queries, none of them returns the expected result. Only after the failure there is a log message about WAL being ejected.

We know the test populate the table atomically (INSERT ATOMIC INTO ...) thus we can await for the tx to be applied and then simply assert the expected result. Once.