### PR TITLE
test(core): fix flaky CheckpointTest.testSuspendResumeWalPurgeJob()

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -44,7 +44,6 @@ import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
-import io.questdb.test.tools.StationaryMicrosClock;
 import io.questdb.test.tools.TestUtils;
 import org.junit.*;
 
@@ -60,7 +59,6 @@ public class CheckpointTest extends AbstractCairoTest {
 
     @BeforeClass
     public static void setUpStatic() throws Exception {
-        testMicrosClock = StationaryMicrosClock.INSTANCE;
         path = new Path();
         triggerFilePath = new Path();
         ff = testFilesFacade;
@@ -613,6 +611,7 @@ public class CheckpointTest extends AbstractCairoTest {
     @Test
     public void testCheckpointStatus() throws Exception {
         assertMemoryLeak(() -> {
+            currentMicros = 0;
             assertSql(
                     "in_progress\tstarted_at\n" +
                             "false\t\n",


### PR DESCRIPTION
This PR https://github.com/questdb/questdb/pull/4869 introduced the `StationaryMicrosClock` in `CheckpointTest.setUpStatic()`, which was necessary since `testCheckpointStatus()` relied on frozen clocks.

However, other tests, such as `testSuspendResumeWalPurgeJob()`, depend on the ability to manipulate time freely and fail with the `StationaryMicrosClock`.

This issue was mostly obscured because `CheckpointTest` resets the clock to the default (non-StationaryMicrosClock) after each test case. Therefore, `testSuspendResumeWalPurgeJob()` only fails when it runs as the first test case in `CheckpointTest`.

When another test runs first, it resets the clock back to normal after completion, and subsequent executions of `testSuspendResumeWalPurgeJob()` pass normally.

Fixes #4922

This fix removes the `StationaryMicrosClock`, and instead, `testCheckpointStatus()` sets the time via `currentMicros`.