### PR TITLE
feat(ilp): ILP client allows to cancel the current row

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -452,6 +452,10 @@ public abstract class HttpClient implements QuietCloseable {
             return this;
         }
 
+        public void trimContentToLen(int contentLen) {
+            ptr = contentStart + contentLen;
+        }
+
         public Request url(CharSequence url) {
             assert state == STATE_URL;
             state = STATE_URL_DONE;

--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
@@ -93,6 +93,11 @@ public class LineTcpSender extends AbstractLineSender {
     }
 
     @Override
+    public void cancelRow() {
+        throw new LineSenderException("cancelRow() not supported by TCP transport");
+    }
+
+    @Override
     public void flush() {
         validateNotClosed();
         sendAll();

--- a/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
@@ -55,6 +55,11 @@ public class LineUdpSender extends AbstractLineSender {
     }
 
     @Override
+    public void cancelRow() {
+        throw new LineSenderException("cancelRow() not supported by UDP transport");
+    }
+
+    @Override
     public final AbstractLineSender timestampColumn(CharSequence name, Instant value) {
         writeFieldName(name).put((value.getEpochSecond() * Timestamps.SECOND_NANOS + value.getNano()) / 1000);
         return this;


### PR DESCRIPTION
This is useful when you start a row and then realize the row is invalid and cannot be sent to the QuestDB server.

This can occur when you cannot validate data upfront, for example, when you receive them in a streaming fashion.

This API is implemented only for the HTTP transport, as the TCP transport can flush at any time. The HTTP transport flushes only after finishing a row.

Some other clients - for example C# - already support this feature. 