### PR TITLE
feat(sql): add spread_bps function for finance

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/FinanceUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/FinanceUtils.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.finance;
+
+import io.questdb.std.Numbers;
+
+public class FinanceUtils {
+
+    public static double mid(double bid, double ask) {
+        if (Numbers.isNull(bid) || Numbers.isNull(ask)) {
+            return Double.NaN;
+        }
+        return ((ask + bid) / 2.0);
+    }
+
+    public static double spread(double bid, double ask) {
+        if (Numbers.isNull(bid) || Numbers.isNull(ask)) {
+            return Double.NaN;
+        } else {
+            return (ask - bid);
+        }
+    }
+
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/MidPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/MidPriceFunctionFactory.java
@@ -33,7 +33,6 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BinaryFunction;
 import io.questdb.griffin.engine.functions.DoubleFunction;
 import io.questdb.std.IntList;
-import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class MidPriceFunctionFactory implements FunctionFactory {
@@ -60,11 +59,7 @@ public class MidPriceFunctionFactory implements FunctionFactory {
         public double getDouble(Record rec) {
             final double b = bid.getDouble(rec);
             final double a = ask.getDouble(rec);
-
-            if (Numbers.isNull(b) || Numbers.isNull(a)) {
-                return Double.NaN;
-            }
-            return ((a + b) / 2.0);
+            return FinanceUtils.mid(b, a);
         }
 
         @Override

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -128,6 +128,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.finance.SpreadFunctionFactory,
             io.questdb.griffin.engine.functions.finance.MidPriceFunctionFactory,
             io.questdb.griffin.engine.functions.finance.WeightedMidPriceFunctionFactory,
+            io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory,
 
 
             // query activity functions

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -26,6 +26,7 @@ io.questdb.griffin.engine.functions.finance.LevelTwoPriceFunctionFactory
 io.questdb.griffin.engine.functions.finance.SpreadFunctionFactory
 io.questdb.griffin.engine.functions.finance.MidPriceFunctionFactory
 io.questdb.griffin.engine.functions.finance.WeightedMidPriceFunctionFactory
+io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory
 
 io.questdb.griffin.engine.functions.activity.CancelQueryFunctionFactory
 io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/SpreadBpsFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/SpreadBpsFunctionFactoryTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.finance;
+
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class SpreadBpsFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testNullBehavior() throws Exception {
+        final String expected = "spread_bps\nnull\n";
+        assertQuery(expected, "select spread_bps(NULL, 1.0)");
+        assertQuery(expected, "select spread_bps(1.0, NULL)");
+        assertQuery(expected, "select spread_bps(NULL, NULL)");
+    }
+
+    @Test
+    public void testSpreadBps() throws Exception {
+        assertQuery("spread_bps\n0.0\n", "select spread_bps(2.0, 2.0)");
+        assertQuery("spread_bps\n10000.0\n", "select spread_bps(1.0, 3.0)");
+        assertQuery("spread_bps\n20000.0\n", "select spread_bps(0.0, 4.0)");
+        assertQuery("spread_bps\n6666.666666666666\n", "select spread_bps(1.0, 2.0)");
+        assertQuery("spread_bps\n1538.4615384615386\n", "select spread_bps(1.5, 1.75)");
+        assertQuery("spread_bps\n707.3954983922836\n", "select spread_bps(1.5, 1.61)");
+        assertQuery("spread_bps\nnull\n", "select spread_bps(0.0,0.0)");
+        assertQuery("spread_bps\nnull\n", "select spread_bps(-1.0,1.0)");
+        assertQuery("spread_bps\n-20000.0\n", "select spread_bps(-1.0,0.0)");
+        assertQuery("spread_bps\n-6666.666666666666\n", "select spread_bps(-2.0,-1.0)");
+        assertQuery("spread_bps\n-6666.658666661067\n", "select spread_bps(-2.22222,-1.111111)");
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new SpreadBpsFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/SpreadFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/SpreadFunctionFactoryTest.java
@@ -31,8 +31,17 @@ import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
 import org.junit.Test;
 
 public class SpreadFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
     @Test
-    public void testMidPrice() throws Exception {
+    public void testNullBehavior() throws Exception {
+        final String expected = "spread\nnull\n";
+        assertQuery(expected, "select spread(NULL, 1.0)");
+        assertQuery(expected, "select spread(1.0, NULL)");
+        assertQuery(expected, "select spread(NULL, NULL)");
+    }
+
+    @Test
+    public void testSpread() throws Exception {
         assertQuery("spread\n0.0\n", "select spread(2.0, 2.0)");
         assertQuery("spread\n2.0\n", "select spread(1.0, 3.0)");
         assertQuery("spread\n4.0\n", "select spread(0.0, 4.0)");
@@ -44,23 +53,6 @@ public class SpreadFunctionFactoryTest extends AbstractFunctionFactoryTest {
         assertQuery("spread\n1.0\n", "select spread(-1.0,0.0)");
         assertQuery("spread\n1.0\n", "select spread(-2.0,-1.0)");
         assertQuery("spread\n1.1111090000000001\n", "select spread(-2.22222,-1.111111)");
-    }
-
-    @Test
-    public void testNonFiniteNumber() throws Exception {
-        final String expected = "spread\nnull\n";
-        assertQuery(expected, "select spread(NULL, 1.0)");
-        assertQuery(expected, "select spread(1.0, NULL)");
-        assertQuery(expected, "select spread(NULL, NULL)");
-    }
-
-    @Test
-    public void testNullBehavior() throws Exception {
-        final String expected = "spread\nnull\n";
-        assertQuery(expected, "select spread(NULL, 1.0)");
-        assertQuery(expected, "select spread(1.0, NULL)");
-        assertQuery(expected, "select spread(NULL, NULL)");
-
     }
 
     @Override


### PR DESCRIPTION
Adds a spread_bps function. This is the quoted spread in basis points i.e `spread / mid * 10k`

Part of https://github.com/questdb/questdb/issues/4620