### PR TITLE
chore(sql): timezone aware variants of newly added time functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/TodayWithTimezoneFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/TodayWithTimezoneFunctionFactory.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+
+public class TodayWithTimezoneFunctionFactory implements FunctionFactory {
+    private static final String SIGNATURE = "today(S)";
+
+    @Override
+    public String getSignature() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new TodayWithTimestampFunction(args.getQuick(0));
+    }
+
+    private static class TodayWithTimestampFunction extends TimestampFunction implements Function {
+        private final Function timezone;
+        private SqlExecutionContext context;
+
+        public TodayWithTimestampFunction(Function timezone) {
+            this.timezone = timezone;
+        }
+
+        @Override
+        public long getTimestamp(Record rec) {
+            final CharSequence tz = timezone.getStrA(rec);
+            long now = context.getNow();
+            if (tz != null) {
+                try {
+                    now = Timestamps.toTimezone(now, TimestampFormatUtils.EN_LOCALE, tz);
+                } catch (NumericException e) {
+                    return Long.MIN_VALUE;
+                }
+            }
+            return Timestamps.floorDD(now);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+            executionContext.initNow();
+            context = executionContext;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public boolean isRuntimeConstant() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(SIGNATURE);
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/TomorrowWithTimezoneFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/TomorrowWithTimezoneFunctionFactory.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+
+public class TomorrowWithTimezoneFunctionFactory implements FunctionFactory {
+    private static final String SIGNATURE = "tomorrow(S)";
+
+    @Override
+    public String getSignature() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new TomorrowWithTimestampFunction(args.getQuick(0));
+    }
+
+    private static class TomorrowWithTimestampFunction extends TimestampFunction implements Function {
+        private final Function timezone;
+        private SqlExecutionContext context;
+
+        public TomorrowWithTimestampFunction(Function timezone) {
+            this.timezone = timezone;
+        }
+
+        @Override
+        public long getTimestamp(Record rec) {
+            final CharSequence tz = timezone.getStrA(rec);
+            long now = context.getNow();
+            if (tz != null) {
+                try {
+                    now = Timestamps.toTimezone(now, TimestampFormatUtils.EN_LOCALE, tz);
+                } catch (NumericException e) {
+                    return Long.MIN_VALUE;
+                }
+            }
+            return Timestamps.floorDD(Timestamps.addDays(now, 1));
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+            executionContext.initNow();
+            context = executionContext;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public boolean isRuntimeConstant() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(SIGNATURE);
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/YesterdayWithTimezoneFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/YesterdayWithTimezoneFunctionFactory.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.TimestampFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+
+public class YesterdayWithTimezoneFunctionFactory implements FunctionFactory {
+    private static final String SIGNATURE = "yesterday(S)";
+
+    @Override
+    public String getSignature() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new YesterdayWithTimestampFunction(args.getQuick(0));
+    }
+
+    private static class YesterdayWithTimestampFunction extends TimestampFunction implements Function {
+        private final Function timezone;
+        private SqlExecutionContext context;
+
+        public YesterdayWithTimestampFunction(Function timezone) {
+            this.timezone = timezone;
+        }
+
+        @Override
+        public long getTimestamp(Record rec) {
+            final CharSequence tz = timezone.getStrA(rec);
+            long now = context.getNow();
+            if (tz != null) {
+                try {
+                    now = Timestamps.toTimezone(now, TimestampFormatUtils.EN_LOCALE, tz);
+                } catch (NumericException e) {
+                    return Long.MIN_VALUE;
+                }
+            }
+            return Timestamps.floorDD(Timestamps.addDays(now, -1));
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+            executionContext.initNow();
+            context = executionContext;
+        }
+
+        @Override
+        public boolean isReadThreadSafe() {
+            return true;
+        }
+
+        @Override
+        public boolean isRuntimeConstant() {
+            return true;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(SIGNATURE);
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -332,8 +332,11 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.date.TimestampCeilFunctionFactory,
             io.questdb.griffin.engine.functions.date.DateTruncFunctionFactory,
             io.questdb.griffin.engine.functions.date.TodayFunctionFactory,
+            io.questdb.griffin.engine.functions.date.TodayWithTimezoneFunctionFactory,
             io.questdb.griffin.engine.functions.date.TomorrowFunctionFactory,
+            io.questdb.griffin.engine.functions.date.TomorrowWithTimezoneFunctionFactory,
             io.questdb.griffin.engine.functions.date.YesterdayFunctionFactory,
+            io.questdb.griffin.engine.functions.date.YesterdayWithTimezoneFunctionFactory,
 
             io.questdb.griffin.engine.functions.rnd.RndByteCCFunctionFactory,
             io.questdb.griffin.engine.functions.rnd.RndBinCCCFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -295,8 +295,11 @@ io.questdb.griffin.engine.functions.date.TimestampCeilFunctionFactory
 io.questdb.griffin.engine.functions.date.DateTruncFunctionFactory
 io.questdb.griffin.engine.functions.date.PgPostmasterStartTimeFunctionFactory
 io.questdb.griffin.engine.functions.date.TodayFunctionFactory
+io.questdb.griffin.engine.functions.date.TodayWithTimezoneFunctionFactory
 io.questdb.griffin.engine.functions.date.TomorrowFunctionFactory
+io.questdb.griffin.engine.functions.date.TomorrowWithTimezoneFunctionFactory
 io.questdb.griffin.engine.functions.date.YesterdayFunctionFactory
+io.questdb.griffin.engine.functions.date.YesterdayWithTimezoneFunctionFactory
 
 # cast functions
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TodayTomorrowYesterdayTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TodayTomorrowYesterdayTest.java
@@ -37,13 +37,28 @@ public class TodayTomorrowYesterdayTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTodayWithTimezone() throws Exception {
+        assertSql("column\ntrue\n", "select date_trunc('day', to_timezone(now(), 'Antarctica/McMurdo')) = today('Antarctica/McMurdo')");
+    }
+
+    @Test
     public void testTomorrow() throws Exception {
         assertSql("cast\n" + Timestamps.floorDD(Timestamps.addDays(Os.currentTimeMicros(), 1)) + "\n", "select tomorrow()::long");
     }
 
     @Test
+    public void testTomorrowWithTimezone() throws Exception {
+        assertSql("column\ntrue\n", "select date_trunc('day', to_timezone(dateadd('d', 1, now()), 'Antarctica/McMurdo')) = tomorrow('Antarctica/McMurdo')");
+    }
+
+    @Test
     public void testYesterday() throws Exception {
         assertSql("cast\n" + Timestamps.floorDD(Timestamps.addDays(Os.currentTimeMicros(), -1)) + "\n", "select yesterday()::long");
+    }
+
+    @Test
+    public void testYesterdayWithTimezone() throws Exception {
+        assertSql("column\ntrue\n", "select date_trunc('day', to_timezone(dateadd('d', -1, now()), 'Antarctica/McMurdo')) = yesterday('Antarctica/McMurdo')");
     }
 
 }


### PR DESCRIPTION
The original functions work only with UTC. These versions take a string parameter with a timezone.