### PR TITLE
pgwire 2.0: Fix Rust hex tests

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/AbstractTypeContainer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/AbstractTypeContainer.java
@@ -50,6 +50,14 @@ public abstract class AbstractTypeContainer<T extends AbstractTypeContainer<?>> 
         }
     }
 
+    public void copyOutTypeDescriptionTypesTo(IntList outTypeDescriptionTypes) {
+        for (int i = 0, n = types.size(); i < n; i++) {
+            int nativeType = types.getQuick(i);
+            int pgType = PGOids.getTypeOid(nativeType);
+            outTypeDescriptionTypes.add(pgType);
+        }
+    }
+
     @Override
     public void defineBindVariables(BindVariableService bindVariableService) throws SqlException {
         defineBindVariables(types, bindVariableService);

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -269,16 +269,6 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         transactionState = NO_TRANSACTION;
     }
 
-    private void freePipelineEntriesFrom(CharSequenceObjHashMap<PGPipelineEntry> cache) {
-        ObjList<CharSequence> names = cache.keys();
-        for (int i = 0, n = names.size(); i < n; i++) {
-            PGPipelineEntry pe = cache.get(names.getQuick(i));
-            pe.setStateClosed(true);
-            Misc.free(pe);
-        }
-        cache.clear();
-    }
-
     @Override
     public void clearSuspendEvent() {
         suspendEvent = Misc.free(suspendEvent);
@@ -501,6 +491,16 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         if (bufferRemainingSize > 0) {
             sendBuffer(bufferRemainingOffset, bufferRemainingSize);
         }
+    }
+
+    private void freePipelineEntriesFrom(CharSequenceObjHashMap<PGPipelineEntry> cache) {
+        ObjList<CharSequence> names = cache.keys();
+        for (int i = 0, n = names.size(); i < n; i++) {
+            PGPipelineEntry pe = cache.get(names.getQuick(i));
+            pe.setStateClosed(true);
+            Misc.free(pe);
+        }
+        cache.clear();
     }
 
     @Nullable

--- a/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
@@ -94,9 +94,12 @@ public class TypesAndSelect implements QuietCloseable, TypeContainer {
         factory = Misc.free(factory);
     }
 
-    public void copyParameterTypes(IntList outTypeDescriptionTypes) {
-        outTypeDescriptionTypes.clear();
-        outTypeDescriptionTypes.addAll(pgParameterTypes);
+    public void copyOutTypeDescriptionTypesTo(IntList outTypeDescriptionTypes) {
+        for (int i = 0, n = bindVariableTypes.size(); i < n; i++) {
+            int nativeType = bindVariableTypes.getQuick(i);
+            int pgType = PGOids.getTypeOid(nativeType);
+            outTypeDescriptionTypes.add(pgType);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/TypesAndSelect.java
@@ -94,6 +94,11 @@ public class TypesAndSelect implements QuietCloseable, TypeContainer {
         factory = Misc.free(factory);
     }
 
+    public void copyParameterTypes(IntList outTypeDescriptionTypes) {
+        outTypeDescriptionTypes.clear();
+        outTypeDescriptionTypes.addAll(pgParameterTypes);
+    }
+
     @Override
     public void defineBindVariables(BindVariableService bindVariableService) throws SqlException {
         AbstractTypeContainer.defineBindVariables(pgParameterTypes, bindVariableService);


### PR DESCRIPTION
There are still `testInsertTableDoesNotExistSimple[NO_WAL]` and `testSchemasCall[NO_WAL]` failing. 
That wasn't the case before, it's now failing even in `vi_pg_pipeline` - I'll explore it too. 


edit: `testInsertTableDoesNotExistSimple[NO_WAL]` and `testSchemasCall[NO_WAL]` are failing due to JDBC driver being upgraded here: https://github.com/jerrinot/questdb/blame/96e0f5c1e77977487c56462a154a505498e9de93/core/pom.xml#L707