### PR TITLE
fix(core): fix potential crash when writing with dedup key on on varchar, string column key

### DIFF
--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -198,7 +198,7 @@ public class ServerMain implements Closeable {
     }
 
     public void awaitTxn(String tableName, long txn) {
-        getEngine().awaitTxn(tableName, txn, 1, TimeUnit.SECONDS);
+        getEngine().awaitTxn(tableName, txn, 15, TimeUnit.SECONDS);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/DedupColumnCommitAddresses.java
+++ b/core/src/main/java/io/questdb/cairo/DedupColumnCommitAddresses.java
@@ -79,12 +79,12 @@ public class DedupColumnCommitAddresses implements Closeable {
         return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + RESERVED5);
     }
 
-    public static long getLagVarSize(long dedupBlockAddress, int keyIndex) {
-        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + O3_VAR_DATA_LEN_64);
+    public static long getColVarDataLen(long dedupBlockAddress, int keyIndex) {
+        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + COL_VAR_DATA_LEN_64);
     }
 
-    public static long getVarDataLen(long dedupBlockAddress, int keyIndex) {
-        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + COL_VAR_DATA_LEN_64);
+    public static long getO3VarDataLen(long dedupBlockAddress, int keyIndex) {
+        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + O3_VAR_DATA_LEN_64);
     }
 
     public static void setColAddressValues(

--- a/core/src/main/java/io/questdb/cairo/DedupColumnCommitAddresses.java
+++ b/core/src/main/java/io/questdb/cairo/DedupColumnCommitAddresses.java
@@ -33,9 +33,9 @@ import java.io.Closeable;
  * The data structure has to match dedup_column struct in dedup.cpp
  */
 public class DedupColumnCommitAddresses implements Closeable {
+    public static final long NULL = 0;
     // The data structure in below offsets has to match dedup_column struct in dedup.cpp
     private static final long COL_TYPE_32 = 0L;
-    public static final long NULL = 0;
     private static final long VAL_SIZE_32 = COL_TYPE_32 + 4L;
     private static final long COL_TOP_64 = VAL_SIZE_32 + 4L;
     private static final long COL_DATA_64 = COL_TOP_64 + 8L;
@@ -54,28 +54,6 @@ public class DedupColumnCommitAddresses implements Closeable {
     private static final int RECORD_BYTES = (int) (NULL_VAL_256 + 32L);
     private PagedDirectLongList addresses;
     private int columnCount;
-
-    public long allocateBlock() {
-        if (columnCount == 0) {
-            return -1;
-        }
-        return addresses.allocateBlock();
-    }
-
-    public void clear(long dedupColSinkAddr) {
-        Vect.memset(dedupColSinkAddr, (long) columnCount * RECORD_BYTES, 0);
-    }
-
-    public void clear() {
-        if (addresses != null) {
-            addresses.clear();
-        }
-    }
-
-    @Override
-    public void close() {
-        addresses = Misc.free(addresses);
-    }
 
     public static long getAddress(long dedupCommitAddr) {
         return dedupCommitAddr;
@@ -101,12 +79,12 @@ public class DedupColumnCommitAddresses implements Closeable {
         return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + RESERVED5);
     }
 
-    public static long getVarDataLen(long dedupBlockAddress, int keyIndex) {
-        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + COL_VAR_DATA_LEN_64);
+    public static long getLagVarSize(long dedupBlockAddress, int keyIndex) {
+        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + O3_VAR_DATA_LEN_64);
     }
 
-    public int getColumnCount() {
-        return columnCount;
+    public static long getVarDataLen(long dedupBlockAddress, int keyIndex) {
+        return Unsafe.getUnsafe().getLong(dedupBlockAddress + (long) keyIndex * RECORD_BYTES + COL_VAR_DATA_LEN_64);
     }
 
     public static void setColAddressValues(
@@ -186,6 +164,32 @@ public class DedupColumnCommitAddresses implements Closeable {
     ) {
         Unsafe.getUnsafe().putLong(addr + RESERVED4, reserved4);
         Unsafe.getUnsafe().putLong(addr + RESERVED5, reserved5);
+    }
+
+    public long allocateBlock() {
+        if (columnCount == 0) {
+            return -1;
+        }
+        return addresses.allocateBlock();
+    }
+
+    public void clear(long dedupColSinkAddr) {
+        Vect.memset(dedupColSinkAddr, (long) columnCount * RECORD_BYTES, 0);
+    }
+
+    public void clear() {
+        if (addresses != null) {
+            addresses.clear();
+        }
+    }
+
+    @Override
+    public void close() {
+        addresses = Misc.free(addresses);
+    }
+
+    public int getColumnCount() {
+        return columnCount;
     }
 
     public void setDedupColumnCount(int dedupColumnCount) {

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -961,7 +961,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
 
                 final long varMappedAddress = DedupColumnCommitAddresses.getColReserved4(dedupColSinkAddr, i);
                 if (varMappedAddress > 0) {
-                    final long varMappedLength = DedupColumnCommitAddresses.getVarDataLen(dedupColSinkAddr, i);
+                    final long varMappedLength = DedupColumnCommitAddresses.getColVarDataLen(dedupColSinkAddr, i);
                     TableUtils.mapAppendColumnBufferRelease(ff, varMappedAddress, 0, varMappedLength, mapMemTag);
                     final long varFd = DedupColumnCommitAddresses.getColReserved5(dedupColSinkAddr, i);
                     ff.close(varFd);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4618,7 +4618,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                     mapAppendColumnBufferRelease(lagAuxAddr, lagAuxMemOffset, mapAuxSize);
 
-                    long mapVarSize = DedupColumnCommitAddresses.getLagVarSize(dedupCommitAddr, i);
+                    long mapVarSize = DedupColumnCommitAddresses.getO3VarDataLen(dedupCommitAddr, i);
                     if (mapVarSize > 0) {
                         long lagVarAddr = DedupColumnCommitAddresses.getColReserved4(dedupCommitAddr, i);
                         long lagVarMemOffset = DedupColumnCommitAddresses.getColReserved5(dedupCommitAddr, i);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4618,11 +4618,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                     mapAppendColumnBufferRelease(lagAuxAddr, lagAuxMemOffset, mapAuxSize);
 
-                    long mapVarSize = DedupColumnCommitAddresses.getVarDataLen(dedupCommitAddr, i);
+                    long mapVarSize = DedupColumnCommitAddresses.getLagVarSize(dedupCommitAddr, i);
                     if (mapVarSize > 0) {
                         long lagVarAddr = DedupColumnCommitAddresses.getColReserved4(dedupCommitAddr, i);
                         long lagVarMemOffset = DedupColumnCommitAddresses.getColReserved5(dedupCommitAddr, i);
-                        mapAppendColumnBufferRelease(lagVarAddr, lagVarMemOffset, mapVarSize);
+                        assert mapVarSize > lagVarMemOffset;
+                        mapAppendColumnBufferRelease(lagVarAddr, lagVarMemOffset, mapVarSize - lagVarMemOffset);
                     }
                 }
             }
@@ -5231,6 +5232,23 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    private long mapAppendColumnBufferDD(MemoryMA column, long offset, long size, boolean rw) {
+        if (size == 0) {
+            return 0;
+        }
+
+        column.jumpTo(offset + size);
+        long address = column.map(offset, size);
+
+        // column could not provide necessary length of buffer
+        // because perhaps its internal buffer is not big enough
+        if (address != 0) {
+            return address;
+        } else {
+            return -TableUtils.mapAppendColumnBuffer(ff, column.getFd(), offset, size, rw, MemoryTag.MMAP_PARALLEL_IMPORT);
+        }
+    }
+
     private long mapAppendColumnBuffer(MemoryMA column, long offset, long size, boolean rw) {
         if (size == 0) {
             return 0;
@@ -5253,6 +5271,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             TableUtils.mapAppendColumnBufferRelease(ff, -address, offset, size, MemoryTag.MMAP_TABLE_WRITER);
         }
     }
+
+    private void mapAppendColumnBufferReleaseDD(long address, long offset, long size) {
+        if (address < 0) {
+            TableUtils.mapAppendColumnBufferRelease(ff, -address, offset, size, MemoryTag.MMAP_PARALLEL_IMPORT);
+        }
+    }
+
 
     private void mmapWalColsEager() {
         for (int i = 0, n = walMappedColumns.size(); i < n; i++) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -5232,23 +5232,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
-    private long mapAppendColumnBufferDD(MemoryMA column, long offset, long size, boolean rw) {
-        if (size == 0) {
-            return 0;
-        }
-
-        column.jumpTo(offset + size);
-        long address = column.map(offset, size);
-
-        // column could not provide necessary length of buffer
-        // because perhaps its internal buffer is not big enough
-        if (address != 0) {
-            return address;
-        } else {
-            return -TableUtils.mapAppendColumnBuffer(ff, column.getFd(), offset, size, rw, MemoryTag.MMAP_PARALLEL_IMPORT);
-        }
-    }
-
     private long mapAppendColumnBuffer(MemoryMA column, long offset, long size, boolean rw) {
         if (size == 0) {
             return 0;
@@ -5271,13 +5254,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             TableUtils.mapAppendColumnBufferRelease(ff, -address, offset, size, MemoryTag.MMAP_TABLE_WRITER);
         }
     }
-
-    private void mapAppendColumnBufferReleaseDD(long address, long offset, long size) {
-        if (address < 0) {
-            TableUtils.mapAppendColumnBufferRelease(ff, -address, offset, size, MemoryTag.MMAP_PARALLEL_IMPORT);
-        }
-    }
-
 
     private void mmapWalColsEager() {
         for (int i = 0, n = walMappedColumns.size(); i < n; i++) {

--- a/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
@@ -156,7 +156,7 @@ public class DedupInsertFuzzTest extends AbstractFuzzTest {
     @Test
     public void testDedupWithRandomShiftAndStepAndVarcharKeyAndColumnTops() throws Exception {
         assertMemoryLeak(() -> {
-            Rnd rnd = generateRandom(LOG, 1675744587249333L, 1725382495801L);
+            Rnd rnd = generateRandom(LOG);
 
             String tableName = testName.getMethodName();
             compile(


### PR DESCRIPTION
Fixes crash found by fuzz test. The problem is that an incorrect size was used when unmapping the deduplication data.