### PR TITLE
fix(ilp): add error message in server log about the line that caused receive buffer overflow

### DIFF
--- a/compat/src/test/java/io/questdb/compat/InfluxDBClientTest.java
+++ b/compat/src/test/java/io/questdb/compat/InfluxDBClientTest.java
@@ -103,22 +103,52 @@ public class InfluxDBClientTest extends AbstractTest {
                             "timestamp(ts) partition by DAY WAL WITH maxUncommittedRows=100"
             );
             List<String> lines = new ArrayList<>();
-            String goodLine = "wal_low_max_uncomitted,sym=aaa\n";
+            String goodLine = "wal_low_max_uncomitted,sym=aaa";
             for (int i = 0; i < count; i++) {
                 lines.add(goodLine);
             }
 
             // New column added
-            lines.add("wal_low_max_uncomitted i=123i\n");
+            lines.add("wal_low_max_uncomitted,sym i=123");
             try (final InfluxDB influxDB = InfluxDBUtils.getConnection(serverMain)) {
                 // Bad line which should roll back the transaction
-                assertRequestErrorContains(influxDB, lines, "ailed to parse line protocol:errors encountered on line(s):" +
-                        "\\nerror in line 10002: Could not parse entire line. Symbol value is missing: bla");
+                assertRequestErrorContains(influxDB, lines, "", "ailed to parse line protocol:errors encountered on line(s):" +
+                        "\\nerror in line 10001: Could not parse entire line. Symbol value is missing: sym");
             }
 
             serverMain.awaitTable("wal_low_max_uncomitted");
             serverMain.getEngine().print("SELECT count() FROM wal_low_max_uncomitted", sink);
             Assert.assertTrue(Chars.equals(sink, "count\n0\n"));
+        }
+    }
+
+    @Test
+    public void testLastEmptyLineIsOk() throws Exception {
+        int count = 10;
+        try (final ServerMain serverMain = ServerMain.create(root, new HashMap<String, String>() {{
+            put(PropertyKey.HTTP_RECEIVE_BUFFER_SIZE.getEnvVarName(), "2048");
+            put(PropertyKey.CAIRO_MAX_UNCOMMITTED_ROWS.getEnvVarName(), String.valueOf(count));
+        }})) {
+            serverMain.start();
+            serverMain.getEngine().compile(
+                    "create table wal_low_max_uncomitted(sym symbol, ts timestamp) " +
+                            "timestamp(ts) partition by DAY WAL WITH maxUncommittedRows=100"
+            );
+            List<String> lines = new ArrayList<>();
+            String goodLine = "wal_low_max_uncomitted,sym=aaa";
+            for (int i = 0; i < count; i++) {
+                lines.add(goodLine);
+            }
+
+            // \n added twice, automatically after every line in "lines" list and manually at the end of last line
+            lines.add("wal_low_max_uncomitted i=123\n");
+            try (final InfluxDB influxDB = InfluxDBUtils.getConnection(serverMain)) {
+                influxDB.write(lines);
+            }
+
+            serverMain.awaitTable("wal_low_max_uncomitted");
+            serverMain.getEngine().print("SELECT count() FROM wal_low_max_uncomitted", sink);
+            Assert.assertTrue(Chars.equals(sink, "count\n11\n"));
         }
     }
 
@@ -346,7 +376,7 @@ public class InfluxDBClientTest extends AbstractTest {
                 List<String> points = new ArrayList<>();
 
                 // Fail on first line
-                points.add("very_long_table_name_very_very_long,tag1=value1 " +
+                String line = "very_long_table_name_very_very_long,tag1=value1 " +
                         "very_long_field_name_very_very_long1=92827743.02924732," +
                         "very_long_field_name_very_very_long2=92827743.02924732," +
                         "very_long_field_name_very_very_long3=92827743.02924732," +
@@ -355,9 +385,9 @@ public class InfluxDBClientTest extends AbstractTest {
                         "very_long_field_name_very_very_long4=92827743.02924732," +
                         "very_long_field_name_very_very_long4=92827743.02924732," +
                         "very_long_field_name_very_very_long4=92827743.02924732," +
-                        "very_long_field=92827791");
+                        "very_long_field=92827791";
 
-                assertRequestErrorContains(influxDB, points, "{\"code\":\"request too large\"," +
+                assertRequestErrorContains(influxDB, points, line, "{\"code\":\"request too large\"," +
                         "\"message\":\"failed to parse line protocol:errors encountered on line(s):unable to read data: ILP line does not fit QuestDB ILP buffer size\"," +
                         "\"line\":1,\"errorId\":");
 
@@ -366,7 +396,7 @@ public class InfluxDBClientTest extends AbstractTest {
                         "very_long_field_name_very_very_long1=92827743.02924732," +
                         "very_long_field_name_very_very_long2=92827743.02924732," +
                         "very_long_field_name_very_very_long3=92827743.02924732");
-                points.add("very_long_table_name_very_very_long,tag1=value1 " +
+                String line2 = "very_long_table_name_very_very_long,tag1=value1 " +
                         "very_long_field_name_very_very_long1=92827743.02924732," +
                         "very_long_field_name_very_very_long2=92827743.02924732," +
                         "very_long_field_name_very_very_long3=92827743.02924732," +
@@ -375,9 +405,9 @@ public class InfluxDBClientTest extends AbstractTest {
                         "very_long_field_name_very_very_long4=92827743.02924732," +
                         "very_long_field_name_very_very_long4=92827743.02924732," +
                         "very_long_field_name_very_very_long4=92827743.02924732," +
-                        "very_long_field=92827791");
+                        "very_long_field=92827791";
 
-                assertRequestErrorContains(influxDB, points, "{\"code\":\"request too large\"," +
+                assertRequestErrorContains(influxDB, points, line2, "{\"code\":\"request too large\"," +
                         "\"message\":\"failed to parse line protocol:errors encountered on line(s):unable to read data: ILP line does not fit QuestDB ILP buffer size\"," +
                         "\"line\":2,\"errorId\":");
             }
@@ -621,9 +651,7 @@ public class InfluxDBClientTest extends AbstractTest {
             try (final InfluxDB influxDB = InfluxDBUtils.getConnection(serverMain)) {
                 influxDB.setLogLevel(InfluxDB.LogLevel.BASIC);
 
-                List<String> points = new ArrayList<>();
                 long milliTime = IntervalUtils.parseFloorPartialTimestamp("2022-02-24T05:00:00.000001Z");
-                points.add("m1,tag1=\"value1\" f1=1i,y=12i " + milliTime);
                 influxDB.write(Point.measurement("m1")
                         .tag("tag1", "\"value1\"")
                         .addField("f1", 1)

--- a/compat/src/test/java/io/questdb/compat/InfluxDBUtils.java
+++ b/compat/src/test/java/io/questdb/compat/InfluxDBUtils.java
@@ -37,6 +37,7 @@ import java.util.List;
 public class InfluxDBUtils {
 
     public static void assertRequestErrorContains(InfluxDB influxDB, List<String> points, String line, String... errors) {
+        assert errors.length > 0;
         points.add(line);
         try {
             influxDB.write(points);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorState.java
@@ -219,7 +219,7 @@ public class LineHttpProcessorState implements QuietCloseable, ConnectionAware {
             int errorStartPos = error.length();
             error.put("\nerror in line ").put(errorLine).put(": ");
             error.put(e.getFlyweightMessage());
-            logError(parser, errorStartPos, false);
+            logError(parser, errorStartPos);
             return Status.APPEND_ERROR;
         } catch (CommitFailedException ex) {
             if (ex.isTableDropped()) {
@@ -319,7 +319,7 @@ public class LineHttpProcessorState implements QuietCloseable, ConnectionAware {
                 error.put(": ").put(String.valueOf(parser.getErrorCode()));
                 break;
         }
-        logError(parser, errorPos, false);
+        logError(parser, errorPos);
         return Status.PARSE_ERROR;
     }
 
@@ -334,7 +334,7 @@ public class LineHttpProcessorState implements QuietCloseable, ConnectionAware {
         if (ex.getToken() != null) {
             error.put(": ").put(ex.getToken());
         }
-        logError(parser, errorPos, false);
+        logError(parser, errorPos);
         return Status.PARSE_ERROR;
     }
 
@@ -369,6 +369,10 @@ public class LineHttpProcessorState implements QuietCloseable, ConnectionAware {
                 .put(", error: ").put(ex.getClass().getCanonicalName());
         errorLine = line + 1;
         return Status.INTERNAL_ERROR;
+    }
+
+    private void logError(LineTcpParser parser, int errorPos) {
+        logError(parser, errorPos, false);
     }
 
     private void logError(LineTcpParser parser, int errorPos, boolean isError) {


### PR DESCRIPTION
When ILP line does not fit receive HTTP buffer there is nothing logged in the server logs, this is fixed in this PR.

Also after test refactoring this PR fixes a failure when the last line is nothing but `\n`character, this was considered to be a parse error but now will be tolerated and the message will be valid.

E.g. this is now a valid ILP request containing 1 line (\n chars written explicitly in this example):

```
table_a,sym=123 val=999i\n
\n
```