### PR TITLE
chore(core): add debug function for printing allocated memory usage

### DIFF
--- a/core/src/main/java/io/questdb/std/Unsafe.java
+++ b/core/src/main/java/io/questdb/std/Unsafe.java
@@ -27,6 +27,7 @@ package io.questdb.std;
 // @formatter:off
 import io.questdb.cairo.CairoException;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessibleObject;
@@ -191,6 +192,17 @@ public final class Unsafe {
     public static long getMemUsedByTag(int memoryTag) {
         assert memoryTag >= 0 && memoryTag < MemoryTag.SIZE;
         return COUNTERS[memoryTag].sum();
+    }
+
+    @TestOnly
+    public static String getMemUsedHumanReadable() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0, n = COUNTERS.length; i < n; i++) {
+            sb.append(MemoryTag.nameOf(i)).append(": ").append(COUNTERS[i]).append("\n");
+        }
+
+        return sb.toString();
     }
 
     public static long getReallocCount() {


### PR DESCRIPTION
A small utility to dump the memory counters alongside their names. For debug/testing only.