### PR TITLE
chore(sql): remove unnecessary round function calls in FillRangeRecordCursor

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -343,6 +343,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         private boolean notAtEndOfBitset() {
+            assert finalBucketIndex != -1;
             if (rangeBound == RANGE_LOWER_BOUND || rangeBound == RANGE_UNBOUNDED || nextBucketTimestamp == maxTimestamp) {
                 return bucketIndex < finalBucketIndex;
             } else {
@@ -375,6 +376,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         private boolean recordWasPresent() {
+            assert finalBucketIndex != -1;
             return presentRecords.get(bucketIndex) && bucketIndex <= finalBucketIndex;
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -177,6 +177,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private RecordCursor baseCursor;
         private Record baseRecord;
         private int bucketIndex;
+        private int finalBucketIndex;
         private long fromTimestamp;
         private boolean gapFilling;
         private long maxTimestamp;
@@ -229,6 +230,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 // otherwise, we need to use bitset to fill
                 if (!gapFilling) {
                     gapFilling = true;
+                    finalBucketIndex = timestampSampler.bucketIndex(maxTimestamp);
 
                     // we need to get up to date, since the sampler started at unix epoch, not min timestamp
                     if (rangeBound == RANGE_UPPER_BOUND || rangeBound == RANGE_UNBOUNDED) {
@@ -270,6 +272,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             gapFilling = false;
             baseRecord = null;
             bucketIndex = 0;
+            finalBucketIndex = -1;
         }
 
         private Function getFillFunction(int col) {
@@ -341,9 +344,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
 
         private boolean notAtEndOfBitset() {
             if (rangeBound == RANGE_LOWER_BOUND || rangeBound == RANGE_UNBOUNDED || nextBucketTimestamp == maxTimestamp) {
-                return bucketIndex < timestampSampler.bucketIndex(maxTimestamp);
+                return bucketIndex < finalBucketIndex;
             } else {
-                return bucketIndex <= timestampSampler.bucketIndex(maxTimestamp);
+                return bucketIndex <= finalBucketIndex;
             }
         }
 
@@ -372,7 +375,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         private boolean recordWasPresent() {
-            return presentRecords.get(bucketIndex) && bucketIndex <= timestampSampler.bucketIndex(maxTimestamp);
+            return presentRecords.get(bucketIndex) && bucketIndex <= finalBucketIndex;
         }
 
         private class FillRangeRecord implements Record {


### PR DESCRIPTION
The `bucketIndex()` function was being called even when `maxTimestamp` could not change. This has been amended.