### PR TITLE
feat(ilp): add ILP traffic volume metrics - TCP, HTTP

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -248,6 +248,10 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         return totalBytesSent;
     }
 
+    public long getTotalReceived() {
+        return totalReceived;
+    }
+
     public boolean handleClientOperation(int operation, HttpRequestProcessorSelector selector, RescheduleContext rescheduleContext)
             throws HeartBeatException, PeerIsSlowToReadException, ServerDisconnectException, PeerIsSlowToWriteException {
         boolean keepGoing;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
@@ -148,8 +148,8 @@ public class LineHttpProcessor implements HttpRequestProcessor, HttpMultipartCon
             state.setSendStatus(SendStatus.HEADER);
             context.simpleResponse().sendStatusNoContent(204);
             Metrics metrics = engine.getMetrics();
-            long totalReceivedHttpBytes = metrics.line().totalHttpBytesGauge().getValue();
-            metrics.line().totalHttpBytesGauge().setValue(totalReceivedHttpBytes + context.getTotalReceived());
+            long totalReceivedHttpBytes = metrics.line().totalIlpHttpBytesGauge().getValue();
+            metrics.line().totalIlpHttpBytesGauge().setValue(totalReceivedHttpBytes + context.getTotalReceived());
         } else {
             state.setSendStatus(SendStatus.HEADER);
             sendErrorHeader(context);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.http.processors;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cutlass.http.*;
 import io.questdb.log.Log;
@@ -146,6 +147,9 @@ public class LineHttpProcessor implements HttpRequestProcessor, HttpMultipartCon
         if (state.isOk()) {
             state.setSendStatus(SendStatus.HEADER);
             context.simpleResponse().sendStatusNoContent(204);
+            Metrics metrics = engine.getMetrics();
+            long totalReceivedHttpBytes = metrics.line().totalHttpBytesGauge().getValue();
+            metrics.line().totalHttpBytesGauge().setValue(totalReceivedHttpBytes + context.getTotalReceived());
         } else {
             state.setSendStatus(SendStatus.HEADER);
             sendErrorHeader(context);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
@@ -147,15 +147,13 @@ public class LineHttpProcessor implements HttpRequestProcessor, HttpMultipartCon
         if (state.isOk()) {
             state.setSendStatus(SendStatus.HEADER);
             context.simpleResponse().sendStatusNoContent(204);
-            Metrics metrics = engine.getMetrics();
-            long totalReceivedHttpBytes = metrics.line().totalIlpHttpBytesGauge().getValue();
-            metrics.line().totalIlpHttpBytesGauge().setValue(totalReceivedHttpBytes + context.getTotalReceived());
         } else {
             state.setSendStatus(SendStatus.HEADER);
             sendErrorHeader(context);
             state.setSendStatus(SendStatus.CONTENT);
             sendErrorContent(context);
         }
+        engine.getMetrics().line().totalIlpHttpBytesGauge().add(context.getTotalReceived());
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
@@ -30,12 +30,24 @@ import io.questdb.metrics.MetricsRegistry;
 public class LineMetrics {
 
     private final LongGauge connectionCountGauge;
+    private final LongGauge totalTcpBytesGauge;
+    private final LongGauge totalHttpBytesGauge;
 
     public LineMetrics(MetricsRegistry metricsRegistry) {
         this.connectionCountGauge = metricsRegistry.newLongGauge("line_tcp_connections");
+        this.totalTcpBytesGauge = metricsRegistry.newLongGauge("line_tcp_recv_bytes");
+        this.totalHttpBytesGauge = metricsRegistry.newLongGauge("line_http_recv_bytes");
     }
 
     public LongGauge connectionCountGauge() {
         return connectionCountGauge;
+    }
+
+    public LongGauge totalTcpBytesGauge() {
+        return totalTcpBytesGauge;
+    }
+
+    public LongGauge totalHttpBytesGauge() {
+        return totalHttpBytesGauge;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
@@ -30,24 +30,24 @@ import io.questdb.metrics.MetricsRegistry;
 public class LineMetrics {
 
     private final LongGauge connectionCountGauge;
-    private final LongGauge totalTcpBytesGauge;
-    private final LongGauge totalHttpBytesGauge;
+    private final LongGauge totalIlpTcpBytesGauge;
+    private final LongGauge totalIlpHttpBytesGauge;
 
     public LineMetrics(MetricsRegistry metricsRegistry) {
         this.connectionCountGauge = metricsRegistry.newLongGauge("line_tcp_connections");
-        this.totalTcpBytesGauge = metricsRegistry.newLongGauge("line_tcp_recv_bytes");
-        this.totalHttpBytesGauge = metricsRegistry.newLongGauge("line_http_recv_bytes");
+        this.totalIlpTcpBytesGauge = metricsRegistry.newLongGauge("line_tcp_recv_bytes");
+        this.totalIlpHttpBytesGauge = metricsRegistry.newLongGauge("line_http_recv_bytes");
     }
 
     public LongGauge connectionCountGauge() {
         return connectionCountGauge;
     }
 
-    public LongGauge totalTcpBytesGauge() {
-        return totalTcpBytesGauge;
+    public LongGauge totalIlpTcpBytesGauge() {
+        return totalIlpTcpBytesGauge;
     }
 
-    public LongGauge totalHttpBytesGauge() {
-        return totalHttpBytesGauge;
+    public LongGauge totalIlpHttpBytesGauge() {
+        return totalIlpHttpBytesGauge;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -432,8 +432,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
         final int orig = bufferRemaining;
         if (bufferRemaining > 0 && !peerDisconnected) {
             int bytesRead = socket.recv(recvBufPos, bufferRemaining);
-            long totalReceivedTcpBytes = metrics.line().totalIlpTcpBytesGauge().getValue();
-            metrics.line().totalIlpTcpBytesGauge().setValue(totalReceivedTcpBytes + bytesRead);
+            metrics.line().totalIlpTcpBytesGauge().add(bytesRead);
             if (bytesRead > 0) {
                 recvBufPos += bytesRead;
                 bufferRemaining -= bytesRead;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -432,6 +432,8 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
         final int orig = bufferRemaining;
         if (bufferRemaining > 0 && !peerDisconnected) {
             int bytesRead = socket.recv(recvBufPos, bufferRemaining);
+            long totalReceivedTcpBytes = metrics.line().totalTcpBytesGauge().getValue();
+            metrics.line().totalTcpBytesGauge().setValue(totalReceivedTcpBytes + bytesRead);
             if (bytesRead > 0) {
                 recvBufPos += bytesRead;
                 bufferRemaining -= bytesRead;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -432,8 +432,8 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
         final int orig = bufferRemaining;
         if (bufferRemaining > 0 && !peerDisconnected) {
             int bytesRead = socket.recv(recvBufPos, bufferRemaining);
-            long totalReceivedTcpBytes = metrics.line().totalTcpBytesGauge().getValue();
-            metrics.line().totalTcpBytesGauge().setValue(totalReceivedTcpBytes + bytesRead);
+            long totalReceivedTcpBytes = metrics.line().totalIlpTcpBytesGauge().getValue();
+            metrics.line().totalIlpTcpBytesGauge().setValue(totalReceivedTcpBytes + bytesRead);
             if (bytesRead > 0) {
                 recvBufPos += bytesRead;
                 bufferRemaining -= bytesRead;


### PR DESCRIPTION
This is in reference to #4751 - adding two new CountGauge to keep track of HTTP and TCP bytes in LineMetrics.