### PR TITLE
perf(sql): reduce unnecessary TableReader partition reloads

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -484,7 +484,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private int lineUdpBindIPV4Address;
     private int lineUdpDefaultPartitionBy;
     private int lineUdpPort;
-    private boolean logLevelVerbose;
+    private final boolean logLevelVerbose;
     private MimeTypesCache mimeTypesCache;
     private long minIdleMsBeforeWriterRelease;
     private int netTestConnectionBufferSize;
@@ -1004,7 +1004,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.defaultSymbolCapacity = getInt(properties, env, PropertyKey.CAIRO_DEFAULT_SYMBOL_CAPACITY, 256);
             this.fileOperationRetryCount = getInt(properties, env, PropertyKey.CAIRO_FILE_OPERATION_RETRY_COUNT, 30);
             this.idleCheckInterval = getLong(properties, env, PropertyKey.CAIRO_IDLE_CHECK_INTERVAL, 5 * 60 * 1000L);
-            this.inactiveReaderMaxOpenPartitions = getInt(properties, env, PropertyKey.CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS, 128);
+            this.inactiveReaderMaxOpenPartitions = getInt(properties, env, PropertyKey.CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS, 10000);
             this.inactiveReaderTTL = getLong(properties, env, PropertyKey.CAIRO_INACTIVE_READER_TTL, 120_000);
             this.inactiveWriterTTL = getLong(properties, env, PropertyKey.CAIRO_INACTIVE_WRITER_TTL, 600_000);
             this.inactiveWalWriterTTL = getLong(properties, env, PropertyKey.CAIRO_WAL_INACTIVE_WRITER_TTL, 120_000);

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -101,7 +101,6 @@ public class TableReader implements Closeable, SymbolTableSource {
         this.ff = configuration.getFilesFacade();
         this.tableToken = tableToken;
         this.messageBus = messageBus;
-        txPartitionVersion = -1;
         try {
             this.path = new Path();
             this.path.of(configuration.getRoot());
@@ -148,6 +147,7 @@ public class TableReader implements Closeable, SymbolTableSource {
                 openPartitionInfo.setQuick(baseOffset, partitionTimestamp);
                 openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_SIZE, -1L); // -1L means it is not open
                 openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_NAME_TXN, txFile.getPartitionNameTxn(i));
+                // -2 means it is not open, -1 is reserved as a valid not-found result of columnVersionReader.getMaxPartitionVersion()
                 openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_COLUMN_VERSION, -2);
             }
             columnTops = new LongList(capacity / 2);

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -80,9 +80,9 @@ public class TableReader implements Closeable, SymbolTableSource {
     private long rowCount;
     private TableToken tableToken;
     private long tempMem8b = Unsafe.malloc(8, MemoryTag.NATIVE_TABLE_READER);
-    private long txColumnVersion = -1;
-    private long txPartitionVersion = -1;
-    private long txTruncateVersion = -1;
+    private long txColumnVersion;
+    private long txPartitionVersion;
+    private long txTruncateVersion;
     private long txn = TableUtils.INITIAL_TXN;
     private boolean txnAcquired = false;
 
@@ -101,6 +101,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         this.ff = configuration.getFilesFacade();
         this.tableToken = tableToken;
         this.messageBus = messageBus;
+        txPartitionVersion = -1;
         try {
             this.path = new Path();
             this.path.of(configuration.getRoot());
@@ -121,6 +122,9 @@ public class TableReader implements Closeable, SymbolTableSource {
             txFile = new TxReader(ff).ofRO(path.trimTo(rootLen).concat(TXN_FILE_NAME).$(), partitionBy);
             path.trimTo(rootLen);
             reloadSlow(false);
+            txPartitionVersion = txFile.getPartitionTableVersion();
+            txColumnVersion = txFile.getColumnVersion();
+            txTruncateVersion = txFile.getTruncateVersion();
             columnCount = metadata.getColumnCount();
             columnCountShl = getColumnBits(columnCount);
             openSymbolMaps();
@@ -144,7 +148,7 @@ public class TableReader implements Closeable, SymbolTableSource {
                 openPartitionInfo.setQuick(baseOffset, partitionTimestamp);
                 openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_SIZE, -1L); // -1L means it is not open
                 openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_NAME_TXN, txFile.getPartitionNameTxn(i));
-                openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_COLUMN_VERSION, columnVersionReader.getMaxPartitionVersion(partitionTimestamp));
+                openPartitionInfo.setQuick(baseOffset + PARTITIONS_SLOT_OFFSET_COLUMN_VERSION, -2);
             }
             columnTops = new LongList(capacity / 2);
             columnTops.setPos(capacity / 2);
@@ -869,7 +873,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             if (ff.exists(path.$())) {
                 final long partitionSize = txFile.getPartitionSize(partitionIndex);
                 if (partitionSize > -1L) {
-                    LOG.debug()
+                    LOG.info()
                             .$("open partition [path=").$substr(dbRootSize, path)
                             .$(", rowCount=").$(partitionSize)
                             .$(", partitionIndex=").$(partitionIndex)
@@ -879,7 +883,8 @@ public class TableReader implements Closeable, SymbolTableSource {
                     openPartitionColumns(partitionIndex, path, getColumnBase(partitionIndex), partitionSize);
                     openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_SIZE, partitionSize);
                     openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_NAME_TXN, partitionNameTxn);
-                    openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_COLUMN_VERSION, columnVersionReader.getVersion());
+                    final long partitionTimestamp = openPartitionInfo.getQuick(partitionIndex * PARTITIONS_SLOT_SIZE);
+                    openPartitionInfo.setQuick(offset + PARTITIONS_SLOT_OFFSET_COLUMN_VERSION, columnVersionReader.getMaxPartitionVersion(partitionTimestamp));
                     if (!isReopen) {
                         openPartitionCount++;
                     }

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -171,7 +171,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(256, configuration.getCairoConfiguration().getDefaultSymbolCapacity());
         Assert.assertEquals(30, configuration.getCairoConfiguration().getFileOperationRetryCount());
         Assert.assertEquals(300000, configuration.getCairoConfiguration().getIdleCheckInterval());
-        Assert.assertEquals(128, configuration.getCairoConfiguration().getInactiveReaderMaxOpenPartitions());
+        Assert.assertEquals(10000, configuration.getCairoConfiguration().getInactiveReaderMaxOpenPartitions());
         Assert.assertEquals(120_000, configuration.getCairoConfiguration().getInactiveReaderTTL());
         Assert.assertEquals(600_000, configuration.getCairoConfiguration().getInactiveWriterTTL());
         Assert.assertEquals(256, configuration.getCairoConfiguration().getIndexValueBlockSize());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -177,7 +177,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.fast.map.load.factor\tQDB_CAIRO_FAST_MAP_LOAD_FACTOR\t0.7\tdefault\tfalse\tfalse\n" +
                                     "cairo.file.operation.retry.count\tQDB_CAIRO_FILE_OPERATION_RETRY_COUNT\t30\tdefault\tfalse\tfalse\n" +
                                     "cairo.idle.check.interval\tQDB_CAIRO_IDLE_CHECK_INTERVAL\t300000\tdefault\tfalse\tfalse\n" +
-                                    "cairo.inactive.reader.max.open.partitions\tQDB_CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS\t128\tdefault\tfalse\tfalse\n" +
+                                    "cairo.inactive.reader.max.open.partitions\tQDB_CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.inactive.reader.ttl\tQDB_CAIRO_INACTIVE_READER_TTL\t120000\tdefault\tfalse\tfalse\n" +
                                     "cairo.inactive.writer.ttl\tQDB_CAIRO_INACTIVE_WRITER_TTL\t600000\tdefault\tfalse\tfalse\n" +
                                     "cairo.index.value.block.size\tQDB_CAIRO_INDEX_VALUE_BLOCK_SIZE\t256\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/griffin/ReaderReloadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ReaderReloadFuzzTest.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.std.*;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Utf8s;
+import io.questdb.test.fuzz.FuzzTransaction;
+import io.questdb.test.griffin.wal.AbstractFuzzTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ReaderReloadFuzzTest extends AbstractFuzzTest {
+    @Test
+    public void testReaderDoesNotReopenFilesFuzz() throws Exception {
+        Rnd rnd = generateRandom(LOG);
+        fuzzer.setFuzzProbabilities(
+                0,
+                0,
+                0,
+                0,
+                0.05,
+                0.05,
+                0,
+                0.2,
+                0,
+                0.5,
+                0,
+                0
+        );
+
+        fuzzer.setFuzzCounts(
+                rnd.nextBoolean(),
+                rnd.nextInt(2_000_000),
+                rnd.nextInt(1000),
+                rnd.nextInt(3),
+                rnd.nextInt(5),
+                rnd.nextInt(1000),
+                rnd.nextInt(1_000_000),
+                5 + rnd.nextInt(10)
+        );
+
+        setFuzzProperties(1, getRndO3PartitionSplit(rnd), getRndO3PartitionSplitMaxCount(rnd), 10 * Numbers.SIZE_1MB, 3);
+        runFuzzWithWithReload(rnd);
+    }
+
+    protected void runFuzzWithWithReload(Rnd rnd) throws Exception {
+        // Snapshot is not supported on Windows.
+        Assume.assumeFalse(Os.isWindows());
+        boolean testHardLinkCheckpoint = rnd.nextBoolean();
+
+        AtomicLong openFileCount = new AtomicLong();
+        FilesFacade ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (Utf8s.containsAscii(name, "2000-01-01") && Utf8s.containsAscii(name, "ts.d")) {
+                    openFileCount.incrementAndGet();
+                }
+                return super.openRO(name);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            int size = rnd.nextInt(16 * 1024 * 1024);
+            node1.setProperty(PropertyKey.DEBUG_CAIRO_O3_COLUMN_MEMORY_SIZE, size);
+            if (testHardLinkCheckpoint) {
+                node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, "100G");
+            }
+
+            String tableNameNonWal = testName.getMethodName() + "_non_wal";
+            fuzzer.createInitialTable(tableNameNonWal, false, 100);
+            String tableNameWal = testName.getMethodName();
+            TableToken walTable = fuzzer.createInitialTable(tableNameWal, true, 100);
+
+            insert("insert into " + tableNameWal + "(ts) values ('2000-01-01')");
+            drainWalQueue();
+
+            try (TableReader reader = engine.getReader(walTable)) {
+                reader.openPartition(0);
+
+                reader.goPassive();
+
+                ObjList<FuzzTransaction> transactions = fuzzer.generateTransactions(tableNameNonWal, rnd);
+                int snapshotIndex = 1 + rnd.nextInt(transactions.size() - 1);
+
+                ObjList<FuzzTransaction> beforeSnapshot = new ObjList<>();
+                beforeSnapshot.addAll(transactions, 0, snapshotIndex);
+                ObjList<FuzzTransaction> afterSnapshot = new ObjList<>();
+                afterSnapshot.addAll(transactions, snapshotIndex, transactions.size());
+
+                fuzzer.applyToWal(beforeSnapshot, tableNameWal, rnd.nextInt(2) + 1, rnd);
+                drainWalQueue();
+
+                Assert.assertFalse("table suspended", engine.getTableSequencerAPI().isSuspended(walTable));
+                long openFiles = openFileCount.get();
+
+                reader.goActive();
+                reader.openPartition(0);
+                Assert.assertEquals("unaffected partition should not be reloaded, file open count should stay the same", openFiles, openFileCount.get());
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/ReaderReloadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ReaderReloadFuzzTest.java
@@ -58,9 +58,10 @@ public class ReaderReloadFuzzTest extends AbstractFuzzTest {
                 0
         );
 
+        // Basic load to keep the test lite, we just want to fuzz different transaction types, not intensive inserting
         fuzzer.setFuzzCounts(
                 rnd.nextBoolean(),
-                rnd.nextInt(2_000_000),
+                rnd.nextInt(2_000),
                 rnd.nextInt(1000),
                 rnd.nextInt(3),
                 rnd.nextInt(5),


### PR DESCRIPTION
Reduce performance hit by re-opening table partitions

- generously bump table reader max open partitions to 10,000 from 128. This will keep up to 10k partitions open in the Table Readers instead of current 128
- optmise partition reload logic to not reload all the partitions every time a new partition is added/change in the table

This will speed up query execution for the tables with many partitions, like hourly partitions