### PR TITLE
fix(sql): missing UUID and IPv4 literal support in coalesce function and switch statement

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlUtil.java
+++ b/core/src/main/java/io/questdb/griffin/SqlUtil.java
@@ -534,7 +534,7 @@ public class SqlUtil {
             try {
                 return Numbers.parseIPv4(value);
             } catch (NumericException exception) {
-                throw ImplicitCastException.instance().put("invalid ipv4 format: ").put(value);
+                throw ImplicitCastException.instance().put("invalid IPv4 format: ").put(value);
             }
         }
         return Numbers.IPv4_NULL;
@@ -545,7 +545,7 @@ public class SqlUtil {
             try {
                 return Numbers.parseIPv4(value);
             } catch (NumericException exception) {
-                throw ImplicitCastException.instance().put("invalid ipv4 format: ").put(value);
+                throw ImplicitCastException.instance().put("invalid IPv4 format: ").put(value);
             }
         }
         return Numbers.IPv4_NULL;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToUuidFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastStrToUuidFunctionFactory.java
@@ -65,6 +65,7 @@ public final class CastStrToUuidFunctionFactory implements FunctionFactory {
     }
 
     public static class Func extends AbstractCastToUuidFunction {
+
         public Func(Function arg) {
             super(arg);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
@@ -208,6 +208,8 @@ public class CaseCommon {
         typeEscalationMap.put(Numbers.encodeLowHighInts(INT, DOUBLE), DOUBLE);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(IPv4, IPv4), IPv4);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(IPv4, STRING), IPv4);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(IPv4, VARCHAR), IPv4);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(LONG, BYTE), LONG);
         typeEscalationMap.put(Numbers.encodeLowHighInts(LONG, SHORT), LONG);
@@ -238,12 +240,14 @@ public class CaseCommon {
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, VARCHAR), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, CHAR), STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, UUID), UUID);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, IPv4), IPv4);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, STRING), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, VARCHAR), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, SYMBOL), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, CHAR), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, UUID), UUID);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, IPv4), IPv4);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(SYMBOL, STRING), STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(SYMBOL, VARCHAR), VARCHAR);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseCommon.java
@@ -176,6 +176,8 @@ public class CaseCommon {
         castFactories.put(Numbers.encodeLowHighInts(LONG256, SYMBOL), new CastLong256ToSymbolFunctionFactory());
         castFactories.put(Numbers.encodeLowHighInts(UUID, STRING), new CastUuidToStrFunctionFactory());
         castFactories.put(Numbers.encodeLowHighInts(UUID, VARCHAR), new CastUuidToVarcharFunctionFactory());
+        castFactories.put(Numbers.encodeLowHighInts(STRING, UUID), new CastStrToUuidFunctionFactory());
+        castFactories.put(Numbers.encodeLowHighInts(VARCHAR, UUID), new CastVarcharToUuidFunctionFactory());
     }
 
     static {
@@ -235,11 +237,13 @@ public class CaseCommon {
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, SYMBOL), STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, VARCHAR), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, CHAR), STRING);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(STRING, UUID), UUID);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, STRING), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, VARCHAR), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, SYMBOL), VARCHAR);
         typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, CHAR), VARCHAR);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(VARCHAR, UUID), UUID);
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(SYMBOL, STRING), STRING);
         typeEscalationMap.put(Numbers.encodeLowHighInts(SYMBOL, VARCHAR), VARCHAR);
@@ -248,8 +252,11 @@ public class CaseCommon {
 
         typeEscalationMap.put(Numbers.encodeLowHighInts(BOOLEAN, BOOLEAN), BOOLEAN);
 
-        typeEscalationMap.put(Numbers.encodeLowHighInts(LONG256, LONG256), LONG256);
         typeEscalationMap.put(Numbers.encodeLowHighInts(UUID, UUID), UUID);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(UUID, STRING), UUID);
+        typeEscalationMap.put(Numbers.encodeLowHighInts(UUID, VARCHAR), UUID);
+
+        typeEscalationMap.put(Numbers.encodeLowHighInts(LONG256, LONG256), LONG256);
         typeEscalationMap.put(Numbers.encodeLowHighInts(BINARY, BINARY), BINARY);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
@@ -64,7 +64,12 @@ public class CoalesceFunctionFactory implements FunctionFactory {
         final int argsSize = args.size();
         int returnType = -1;
         for (int i = 0; i < argsSize; i++) {
-            returnType = CaseCommon.getCommonType(returnType, args.getQuick(i).getType(), argPositions.getQuick(i), "coalesce cannot be used with bind variables");
+            returnType = CaseCommon.getCommonType(
+                    returnType,
+                    args.getQuick(i).getType(),
+                    argPositions.getQuick(i),
+                    "coalesce cannot be used with bind variables"
+            );
         }
 
         for (int i = 0; i < argsSize; i++) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
@@ -69,14 +69,17 @@ public class SwitchFunctionFactory implements FunctionFactory {
             throw SqlException.$(argPositions.getQuick(0), "bind variable is not supported here, please use column instead");
         }
 
-        final Function elseBranch;
+        Function elseBranch;
+        final int elseBranchPosition;
         int returnType = -1;
         if (n % 2 == 0) {
             elseBranch = args.getLast();
+            elseBranchPosition = argPositions.getLast();
             returnType = elseBranch.getType();
             n--;
         } else {
             elseBranch = null;
+            elseBranchPosition = -1;
         }
 
         for (int i = 1; i < n; i += 2) {
@@ -109,6 +112,17 @@ public class SwitchFunctionFactory implements FunctionFactory {
                             configuration,
                             sqlExecutionContext
                     )
+            );
+        }
+
+        // don't forget to cast the else branch function
+        if (elseBranch != null) {
+            elseBranch = CaseCommon.getCastFunction(
+                    elseBranch,
+                    elseBranchPosition,
+                    returnType,
+                    configuration,
+                    sqlExecutionContext
             );
         }
 

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -82,7 +82,7 @@ public class IPv4Test extends AbstractCairoTest {
 
             sqlExecutionContext.getBindVariableService().clear();
             sqlExecutionContext.getBindVariableService().setStr("ip", "foobar");
-            assertException("x where b = :ip", 0, "invalid ipv4 format: foobar");
+            assertException("x where b = :ip", 0, "invalid IPv4 format: foobar");
         });
     }
 
@@ -852,11 +852,11 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testGreaterThanEqIPv4BadStr() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "column\n" +
-                        "false\n",
-                "select ipv4 '34.11.45.3' >= ipv4 'apple'"
-        ));
+        assertException(
+                "select ipv4 '34.11.45.3' >= ipv4 'apple'",
+                33,
+                "invalid IPv4 constant"
+        );
     }
 
     @Test
@@ -1003,105 +1003,16 @@ public class IPv4Test extends AbstractCairoTest {
                         "\n" +
                         "\n" +
                         "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
-                        "\n" +
                         "\n",
-                "select ip & ipv4 'apple' from test",
+                "select ip & cast(s as ipv4) from test",
                 "create table test as " +
                         "(" +
                         "  select" +
                         "    rnd_int(1,20,0)::ipv4 ip," +
                         "    rnd_int(0,1000,0) bytes," +
+                        "    'apple' s," +
                         "    timestamp_sequence(0,100000000) k" +
-                        "  from long_sequence(100)" +
+                        "  from long_sequence(10)" +
                         ") ",
                 null,
                 true,
@@ -1111,11 +1022,11 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testIPv4BitwiseAndFailsConst() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "column\n" +
-                        "\n",
-                "select ipv4 '1.1.1.1' & ipv4 '0.0.1'"
-        ));
+        assertException(
+                "select ipv4 '1.1.1.1' & ipv4 '0.0.1'",
+                29,
+                "invalid IPv4 constant"
+        );
     }
 
     @Test
@@ -1363,20 +1274,20 @@ public class IPv4Test extends AbstractCairoTest {
     }
 
     @Test
+    public void testIPv4BitwiseFails() throws Exception {
+        assertException(
+                "select ~ ipv4 'apple'",
+                14,
+                "invalid IPv4 constant"
+        );
+    }
+
+    @Test
     public void testIPv4BitwiseNotConst() throws Exception {
         assertMemoryLeak(() -> assertSql(
                 "column\n" +
                         "254.254.254.254\n",
                 "select ~ ipv4 '1.1.1.1'"
-        ));
-    }
-
-    @Test
-    public void testIPv4BitwiseNotFails() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "column\n" +
-                        "\n",
-                "select ~ ipv4 'apple'"
         ));
     }
 
@@ -1826,9 +1737,10 @@ public class IPv4Test extends AbstractCairoTest {
                             "0.0.0.218\n" +
                             "0.0.0.34\n" +
                             "0.0.0.90\n" +
-                            "\n" +
-                            "0.0.0.161\n" +
-                            "0.0.0.188\n" +
+                            "0.0.0.114\n" +
+                            "0.0.0.23\n" +
+                            "0.0.0.150\n" +
+                            "0.0.0.147\n" +
                             "\n" +
                             "0.0.0.29\n" +
                             "0.0.0.159\n",
@@ -2063,6 +1975,8 @@ public class IPv4Test extends AbstractCairoTest {
                             "0.0.0.4\n" +
                             "0.0.0.4\n" +
                             "0.0.0.4\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.4\n" +
                             "0.0.0.4\n",
                     "select * from test where ip <<= '0.0.0.4'"
             );
@@ -2276,6 +2190,9 @@ public class IPv4Test extends AbstractCairoTest {
 
             assertSql(
                     "ip\n" +
+                            "0.0.0.1\n" +
+                            "0.0.0.1\n" +
+                            "0.0.0.1\n" +
                             "0.0.0.1\n",
                     "select * from test where ipv4 '0.0.0.1' = ip"
             );
@@ -2289,25 +2206,22 @@ public class IPv4Test extends AbstractCairoTest {
 
             assertSql(
                     "ip\n" +
+                            "0.0.0.5\n" +
+                            "0.0.0.2\n" +
+                            "\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.5\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.4\n" +
                             "\n" +
                             "0.0.0.5\n" +
                             "0.0.0.4\n" +
-                            "\n" +
+                            "0.0.0.2\n" +
+                            "0.0.0.2\n" +
                             "0.0.0.4\n" +
-                            "0.0.0.5\n" +
-                            "0.0.0.4\n" +
-                            "\n" +
-                            "0.0.0.5\n" +
-                            "\n" +
                             "0.0.0.3\n" +
-                            "0.0.0.2\n" +
-                            "\n" +
-                            "0.0.0.5\n" +
-                            "0.0.0.4\n" +
-                            "0.0.0.2\n" +
-                            "0.0.0.2\n" +
-                            "\n" +
-                            "\n",
+                            "0.0.0.5\n",
                     "select * from test where ip != ipv4 '0.0.0.1'"
             );
         });
@@ -2320,25 +2234,22 @@ public class IPv4Test extends AbstractCairoTest {
 
             assertSql(
                     "ip\n" +
+                            "0.0.0.5\n" +
+                            "0.0.0.2\n" +
+                            "\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.5\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.4\n" +
+                            "0.0.0.4\n" +
                             "\n" +
                             "0.0.0.5\n" +
                             "0.0.0.4\n" +
-                            "\n" +
+                            "0.0.0.2\n" +
+                            "0.0.0.2\n" +
                             "0.0.0.4\n" +
-                            "0.0.0.5\n" +
-                            "0.0.0.4\n" +
-                            "\n" +
-                            "0.0.0.5\n" +
-                            "\n" +
                             "0.0.0.3\n" +
-                            "0.0.0.2\n" +
-                            "\n" +
-                            "0.0.0.5\n" +
-                            "0.0.0.4\n" +
-                            "0.0.0.2\n" +
-                            "0.0.0.2\n" +
-                            "\n" +
-                            "\n",
+                            "0.0.0.5\n",
                     "select * from test where ipv4 '0.0.0.1' != ip"
             );
         });
@@ -2351,25 +2262,6 @@ public class IPv4Test extends AbstractCairoTest {
 
             assertSql(
                     "ip\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
-                            "\n" +
                             "\n" +
                             "\n" +
                             "\n" +
@@ -3251,14 +3143,10 @@ public class IPv4Test extends AbstractCairoTest {
     @Test
     public void testIPv4NegContainsEqSubnetNoMask() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table test as (select rnd_int(0,5,2)::ipv4 ip from long_sequence(100))");
+            ddl("create table test as (select rnd_int(0,5,2)::ipv4 ip from long_sequence(20))");
 
             assertSql(
                     "ip\n" +
-                            "0.0.0.4\n" +
-                            "0.0.0.4\n" +
-                            "0.0.0.4\n" +
-                            "0.0.0.4\n" +
                             "0.0.0.4\n" +
                             "0.0.0.4\n" +
                             "0.0.0.4\n",
@@ -4670,7 +4558,7 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testImplicitCastStrIPv4BadStr() throws Exception {
-        assertException("select 'dhukdsvhiu' < ipv4 '1.1.1.1'", 0, "invalid ipv4 format: dhukdsvhiu");
+        assertException("select 'dhukdsvhiu' < ipv4 '1.1.1.1'", 0, "invalid IPv4 format: dhukdsvhiu");
     }
 
     @Test
@@ -5323,7 +5211,7 @@ public class IPv4Test extends AbstractCairoTest {
     public void testInvalidConstantInEqFilter() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table x (b ipv4)");
-            assertExceptionNoLeakCheck("x where b = 'foobar'", 0, "invalid ipv4 format: foobar");
+            assertExceptionNoLeakCheck("x where b = 'foobar'", 0, "invalid IPv4 format: foobar");
         });
     }
 
@@ -6176,11 +6064,11 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testStrIPv4CastOverflow() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "cast\n" +
-                        "\n",
-                "select ipv4 '256.5.5.5'"
-        ));
+        assertException(
+                "select ipv4 '256.5.5.5'",
+                12,
+                "invalid IPv4 constant"
+        );
     }
 
     @Test
@@ -6392,128 +6280,23 @@ public class IPv4Test extends AbstractCairoTest {
                 "ip1\tip2\n" +
                         "0.0.0.1\t0.0.0.1\n" +
                         "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.5\t0.0.0.5\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "\t\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "\t\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "\t\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "\t\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "\t\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "\t\n" +
-                        "0.0.0.5\t0.0.0.5\n" +
-                        "\t\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "0.0.0.3\t0.0.0.3\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "\t\n" +
-                        "\t\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "\t\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
-                        "0.0.0.8\t0.0.0.8\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "0.0.0.5\t0.0.0.5\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "\t\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.5\t0.0.0.5\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "\t\n" +
-                        "0.0.0.5\t0.0.0.5\n" +
-                        "\t\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
-                        "\t\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.2\t0.0.0.2\n" +
-                        "0.0.0.1\t0.0.0.1\n" +
-                        "0.0.0.7\t0.0.0.7\n" +
                         "0.0.0.5\t0.0.0.5\n" +
                         "0.0.0.3\t0.0.0.3\n" +
                         "0.0.0.1\t0.0.0.1\n" +
-                        "\t\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "0.0.0.9\t0.0.0.9\n" +
+                        "0.0.0.7\t0.0.0.7\n" +
                         "0.0.0.1\t0.0.0.1\n" +
+                        "0.0.0.7\t0.0.0.7\n" +
+                        "\t\n" +
                         "0.0.0.5\t0.0.0.5\n" +
-                        "0.0.0.4\t0.0.0.4\n" +
-                        "0.0.0.6\t0.0.0.6\n" +
-                        "0.0.0.8\t0.0.0.8\n",
+                        "0.0.0.7\t0.0.0.7\n" +
+                        "\t\n",
                 "select * from test where ip1 = ip2",
                 "create table test as " +
                         "(" +
                         "  select" +
                         "    rnd_int(0,9,0)::ipv4 ip1," +
                         "    rnd_int(0,9,0)::ipv4 ip2" +
-                        "  from long_sequence(1000)" +
+                        "  from long_sequence(100)" +
                         ")",
                 null,
                 true,
@@ -6523,20 +6306,23 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testWhereInvalidIPv4() throws Exception {
-        assertQuery(
-                "ip\tbytes\tk\n",
-                "select * from test where ip = ipv4 'hello'",
-                "create table test as " +
-                        "(" +
-                        "  select" +
-                        "    rnd_int(1,5,0)::ipv4 ip," +
-                        "    rnd_int(0,1000,0) bytes," +
-                        "    timestamp_sequence(0,100000000) k" +
-                        "  from long_sequence(100)" +
-                        ") timestamp(k)",
-                "k",
-                true,
-                false
-        );
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table test as " +
+                            "(" +
+                            "  select" +
+                            "    rnd_int(1,5,0)::ipv4 ip," +
+                            "    rnd_int(0,1000,0) bytes," +
+                            "    timestamp_sequence(0,100000000) k" +
+                            "  from long_sequence(100)" +
+                            ") timestamp(k)"
+            );
+
+            assertExceptionNoLeakCheck(
+                    "select * from test where ip = 'apple'",
+                    0,
+                    "invalid IPv4 format"
+            );
+        });
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/OrderByRadixSortTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByRadixSortTest.java
@@ -155,6 +155,11 @@ public class OrderByRadixSortTest extends AbstractCairoTest {
         assertQuery(
                 "a\n" +
                         "\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
                         "0.0.0.1\n" +
                         "0.0.0.2\n" +
                         "0.0.0.3\n" +
@@ -164,11 +169,6 @@ public class OrderByRadixSortTest extends AbstractCairoTest {
                         "0.0.0.7\n" +
                         "0.0.0.8\n" +
                         "0.0.0.9\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
                         "255.255.255.246\n" +
                         "255.255.255.247\n" +
                         "255.255.255.248\n" +
@@ -209,11 +209,6 @@ public class OrderByRadixSortTest extends AbstractCairoTest {
                         "255.255.255.248\n" +
                         "255.255.255.247\n" +
                         "255.255.255.246\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
-                        "128.0.0.0\n" +
                         "0.0.0.9\n" +
                         "0.0.0.8\n" +
                         "0.0.0.7\n" +
@@ -223,6 +218,11 @@ public class OrderByRadixSortTest extends AbstractCairoTest {
                         "0.0.0.3\n" +
                         "0.0.0.2\n" +
                         "0.0.0.1\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
+                        "\n" +
                         "\n",
                 "select * from x order by a desc;",
                 "create table x as (" +

--- a/core/src/test/java/io/questdb/test/griffin/SqlUtilTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlUtilTest.java
@@ -100,14 +100,14 @@ public class SqlUtilTest {
             SqlUtil.implicitCastStrAsIPv4("77823.23232.23232.33");
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("invalid ipv4 format: 77823.23232.23232.33", e.getFlyweightMessage());
+            TestUtils.assertEquals("invalid IPv4 format: 77823.23232.23232.33", e.getFlyweightMessage());
         }
 
         try {
             SqlUtil.implicitCastStrAsIPv4("hello");
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("invalid ipv4 format: hello", e.getFlyweightMessage());
+            TestUtils.assertEquals("invalid IPv4 format: hello", e.getFlyweightMessage());
         }
     }
 
@@ -149,14 +149,14 @@ public class SqlUtilTest {
             SqlUtil.implicitCastStrAsIPv4(new Utf8String("77823.23232.23232.33"));
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("invalid ipv4 format: 77823.23232.23232.33", e.getFlyweightMessage());
+            TestUtils.assertEquals("invalid IPv4 format: 77823.23232.23232.33", e.getFlyweightMessage());
         }
 
         try {
             SqlUtil.implicitCastStrAsIPv4(new Utf8String("hello"));
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("invalid ipv4 format: hello", e.getFlyweightMessage());
+            TestUtils.assertEquals("invalid IPv4 format: hello", e.getFlyweightMessage());
         }
     }
 
@@ -251,6 +251,198 @@ public class SqlUtilTest {
     }
 
     @Test
+    public void testParseStrChar() {
+        Assert.assertEquals(0, SqlUtil.implicitCastStrAsChar(null));
+        Assert.assertEquals(0, SqlUtil.implicitCastStrAsChar(""));
+        Assert.assertEquals('a', SqlUtil.implicitCastStrAsChar("a"));
+        // arabic
+        Assert.assertEquals('ع', SqlUtil.implicitCastStrAsChar("ع"));
+
+        try {
+            SqlUtil.implicitCastStrAsChar("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> CHAR]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrDate() {
+        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsDate(null));
+        Assert.assertEquals("2022-11-20T10:30:55.123Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20T10:30:55.123Z")));
+        Assert.assertEquals("2022-11-20T10:30:55.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 10:30:55Z")));
+        Assert.assertEquals("2022-11-20T00:00:00.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 Z")));
+        Assert.assertEquals("2022-11-20T00:00:00.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20")));
+        Assert.assertEquals("2022-11-20T10:30:55.123Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 10:30:55.123Z")));
+        Assert.assertEquals("1970-01-01T00:00:00.200Z", Dates.toString(SqlUtil.implicitCastStrAsDate("200")));
+        Assert.assertEquals("1969-12-31T23:59:59.100Z", Dates.toString(SqlUtil.implicitCastStrAsDate("-900")));
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsDate("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> DATE]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrDouble() {
+        //noinspection SimplifiableAssertion
+        Assert.assertFalse(SqlUtil.implicitCastStrAsDouble(null) == SqlUtil.implicitCastStrAsDouble(null));
+        Assert.assertEquals(9.901E62, SqlUtil.implicitCastStrAsDouble("990.1e60"), 0.001);
+
+        // overflow
+        try {
+            SqlUtil.implicitCastStrAsDouble("1e450");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `1e450` [STRING -> DOUBLE]", e.getFlyweightMessage());
+        }
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsDouble("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> DOUBLE]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrFloat() {
+        //noinspection SimplifiableAssertion
+        Assert.assertFalse(SqlUtil.implicitCastStrAsFloat(null) == SqlUtil.implicitCastStrAsFloat(null));
+        Assert.assertEquals(990.1, SqlUtil.implicitCastStrAsFloat("990.1"), 0.001);
+        Assert.assertEquals(-899.23, SqlUtil.implicitCastStrAsFloat("-899.23"), 0.001);
+
+        // overflow
+        try {
+            SqlUtil.implicitCastStrAsFloat("1e210");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `1e210` [STRING -> FLOAT]", e.getFlyweightMessage());
+        }
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsFloat("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> FLOAT]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrInt() {
+        Assert.assertEquals(Numbers.INT_NULL, SqlUtil.implicitCastStrAsInt(null));
+        Assert.assertEquals(22222123, SqlUtil.implicitCastStrAsInt("22222123"));
+        Assert.assertEquals(-2222232, SqlUtil.implicitCastStrAsInt("-2222232"));
+
+        // overflow
+        try {
+            SqlUtil.implicitCastStrAsInt("77823232322323233");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `77823232322323233` [STRING -> INT]", e.getFlyweightMessage());
+        }
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsInt("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> INT]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrLong() {
+        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsLong(null));
+        Assert.assertEquals(222221211212123L, SqlUtil.implicitCastStrAsLong("222221211212123"));
+        Assert.assertEquals(222221211212123L, SqlUtil.implicitCastStrAsLong("222221211212123L"));
+        Assert.assertEquals(-222221211212123L, SqlUtil.implicitCastStrAsLong("-222221211212123"));
+        Assert.assertEquals(-222221211212123L, SqlUtil.implicitCastStrAsLong("-222221211212123L"));
+
+        // overflow
+        try {
+            SqlUtil.implicitCastStrAsLong("778232323223232389080898083");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `778232323223232389080898083` [STRING -> LONG]", e.getFlyweightMessage());
+        }
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsLong("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> LONG]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrShort() {
+        Assert.assertEquals(0, SqlUtil.implicitCastStrAsShort(null));
+        Assert.assertEquals(22222, SqlUtil.implicitCastStrAsShort("22222"));
+        Assert.assertEquals(-22222, SqlUtil.implicitCastStrAsShort("-22222"));
+
+        // overflow
+        try {
+            SqlUtil.implicitCastStrAsShort("77823232323");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `77823232323` [STRING -> SHORT]", e.getFlyweightMessage());
+        }
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsShort("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> SHORT]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrTimestamp() {
+        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsTimestamp(null));
+        Assert.assertEquals("2022-11-20T10:30:55.123999Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20T10:30:55.123999Z")));
+        Assert.assertEquals("2022-11-20T10:30:55.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 10:30:55Z")));
+        Assert.assertEquals("2022-11-20T00:00:00.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 Z")));
+        Assert.assertEquals("2022-11-20T10:30:55.123000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 10:30:55.123Z")));
+        Assert.assertEquals("1970-01-01T00:00:00.000200Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("200")));
+        Assert.assertEquals("1969-12-31T23:59:59.999100Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("-900")));
+
+        // not a number
+        try {
+            SqlUtil.implicitCastStrAsTimestamp("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> TIMESTAMP]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
+    public void testParseStrVarcharAsTimestamp0() {
+        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastVarcharAsTimestamp(null));
+        Assert.assertEquals("2022-11-20T10:30:55.123999Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20T10:30:55.123999Z")));
+        Assert.assertEquals("2022-11-20T10:30:55.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 10:30:55Z")));
+        Assert.assertEquals("2022-11-20T00:00:00.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 Z")));
+        Assert.assertEquals("2022-11-20T10:30:55.123000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 10:30:55.123Z")));
+        Assert.assertEquals("1970-01-01T00:00:00.000200Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("200")));
+        Assert.assertEquals("1969-12-31T23:59:59.999100Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("-900")));
+
+        // not a number
+        try {
+            SqlUtil.implicitCastVarcharAsTimestamp("hello");
+            Assert.fail();
+        } catch (ImplicitCastException e) {
+            TestUtils.assertEquals("inconvertible value: `hello` [VARCHAR -> TIMESTAMP]", e.getFlyweightMessage());
+        }
+    }
+
+    @Test
     public void testParseVarcharByte() {
         Utf8StringSink sink = new Utf8StringSink();
         Assert.assertEquals(0, SqlUtil.implicitCastVarcharAsByte(null));
@@ -284,22 +476,6 @@ public class SqlUtilTest {
     }
 
     @Test
-    public void testParseStrChar() {
-        Assert.assertEquals(0, SqlUtil.implicitCastStrAsChar(null));
-        Assert.assertEquals(0, SqlUtil.implicitCastStrAsChar(""));
-        Assert.assertEquals('a', SqlUtil.implicitCastStrAsChar("a"));
-        // arabic
-        Assert.assertEquals('ع', SqlUtil.implicitCastStrAsChar("ع"));
-
-        try {
-            SqlUtil.implicitCastStrAsChar("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> CHAR]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
     public void testParseVarcharChar() {
         Utf8StringSink sink = new Utf8StringSink();
         Assert.assertEquals(0, SqlUtil.implicitCastVarcharAsChar(null));
@@ -324,27 +500,6 @@ public class SqlUtilTest {
         }
     }
 
-
-    @Test
-    public void testParseStrDate() {
-        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsDate(null));
-        Assert.assertEquals("2022-11-20T10:30:55.123Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20T10:30:55.123Z")));
-        Assert.assertEquals("2022-11-20T10:30:55.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 10:30:55Z")));
-        Assert.assertEquals("2022-11-20T00:00:00.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 Z")));
-        Assert.assertEquals("2022-11-20T00:00:00.000Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20")));
-        Assert.assertEquals("2022-11-20T10:30:55.123Z", Dates.toString(SqlUtil.implicitCastStrAsDate("2022-11-20 10:30:55.123Z")));
-        Assert.assertEquals("1970-01-01T00:00:00.200Z", Dates.toString(SqlUtil.implicitCastStrAsDate("200")));
-        Assert.assertEquals("1969-12-31T23:59:59.100Z", Dates.toString(SqlUtil.implicitCastStrAsDate("-900")));
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsDate("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> DATE]", e.getFlyweightMessage());
-        }
-    }
-
     @Test
     public void testParseVarcharDate() {
         Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastVarcharAsDate(null));
@@ -362,29 +517,6 @@ public class SqlUtilTest {
             Assert.fail();
         } catch (ImplicitCastException e) {
             TestUtils.assertEquals("inconvertible value: `hello` [VARCHAR -> DATE]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
-    public void testParseStrDouble() {
-        //noinspection SimplifiableAssertion
-        Assert.assertFalse(SqlUtil.implicitCastStrAsDouble(null) == SqlUtil.implicitCastStrAsDouble(null));
-        Assert.assertEquals(9.901E62, SqlUtil.implicitCastStrAsDouble("990.1e60"), 0.001);
-
-        // overflow
-        try {
-            SqlUtil.implicitCastStrAsDouble("1e450");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `1e450` [STRING -> DOUBLE]", e.getFlyweightMessage());
-        }
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsDouble("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> DOUBLE]", e.getFlyweightMessage());
         }
     }
 
@@ -451,54 +583,6 @@ public class SqlUtilTest {
         }
     }
 
-
-    @Test
-    public void testParseStrFloat() {
-        //noinspection SimplifiableAssertion
-        Assert.assertFalse(SqlUtil.implicitCastStrAsFloat(null) == SqlUtil.implicitCastStrAsFloat(null));
-        Assert.assertEquals(990.1, SqlUtil.implicitCastStrAsFloat("990.1"), 0.001);
-        Assert.assertEquals(-899.23, SqlUtil.implicitCastStrAsFloat("-899.23"), 0.001);
-
-        // overflow
-        try {
-            SqlUtil.implicitCastStrAsFloat("1e210");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `1e210` [STRING -> FLOAT]", e.getFlyweightMessage());
-        }
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsFloat("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> FLOAT]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
-    public void testParseStrInt() {
-        Assert.assertEquals(Numbers.INT_NULL, SqlUtil.implicitCastStrAsInt(null));
-        Assert.assertEquals(22222123, SqlUtil.implicitCastStrAsInt("22222123"));
-        Assert.assertEquals(-2222232, SqlUtil.implicitCastStrAsInt("-2222232"));
-
-        // overflow
-        try {
-            SqlUtil.implicitCastStrAsInt("77823232322323233");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `77823232322323233` [STRING -> INT]", e.getFlyweightMessage());
-        }
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsInt("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> INT]", e.getFlyweightMessage());
-        }
-    }
-
     @Test
     public void testParseVarcharInt() {
         Utf8StringSink sink = new Utf8StringSink();
@@ -529,31 +613,6 @@ public class SqlUtilTest {
             Assert.fail();
         } catch (ImplicitCastException e) {
             TestUtils.assertEquals("inconvertible value: `hello` [VARCHAR -> INT]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
-    public void testParseStrLong() {
-        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsLong(null));
-        Assert.assertEquals(222221211212123L, SqlUtil.implicitCastStrAsLong("222221211212123"));
-        Assert.assertEquals(222221211212123L, SqlUtil.implicitCastStrAsLong("222221211212123L"));
-        Assert.assertEquals(-222221211212123L, SqlUtil.implicitCastStrAsLong("-222221211212123"));
-        Assert.assertEquals(-222221211212123L, SqlUtil.implicitCastStrAsLong("-222221211212123L"));
-
-        // overflow
-        try {
-            SqlUtil.implicitCastStrAsLong("778232323223232389080898083");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `778232323223232389080898083` [STRING -> LONG]", e.getFlyweightMessage());
-        }
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsLong("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> LONG]", e.getFlyweightMessage());
         }
     }
 
@@ -598,29 +657,6 @@ public class SqlUtilTest {
     }
 
     @Test
-    public void testParseStrShort() {
-        Assert.assertEquals(0, SqlUtil.implicitCastStrAsShort(null));
-        Assert.assertEquals(22222, SqlUtil.implicitCastStrAsShort("22222"));
-        Assert.assertEquals(-22222, SqlUtil.implicitCastStrAsShort("-22222"));
-
-        // overflow
-        try {
-            SqlUtil.implicitCastStrAsShort("77823232323");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `77823232323` [STRING -> SHORT]", e.getFlyweightMessage());
-        }
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsShort("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> SHORT]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
     public void testParseVarcharShort() {
         Assert.assertEquals(0, SqlUtil.implicitCastVarcharAsShort(null));
         Utf8StringSink sink = new Utf8StringSink();
@@ -648,44 +684,6 @@ public class SqlUtilTest {
             Assert.fail();
         } catch (ImplicitCastException e) {
             TestUtils.assertEquals("inconvertible value: `hello` [VARCHAR -> SHORT]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
-    public void testParseStrTimestamp() {
-        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastStrAsTimestamp(null));
-        Assert.assertEquals("2022-11-20T10:30:55.123999Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20T10:30:55.123999Z")));
-        Assert.assertEquals("2022-11-20T10:30:55.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 10:30:55Z")));
-        Assert.assertEquals("2022-11-20T00:00:00.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 Z")));
-        Assert.assertEquals("2022-11-20T10:30:55.123000Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("2022-11-20 10:30:55.123Z")));
-        Assert.assertEquals("1970-01-01T00:00:00.000200Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("200")));
-        Assert.assertEquals("1969-12-31T23:59:59.999100Z", Timestamps.toUSecString(SqlUtil.implicitCastStrAsTimestamp("-900")));
-
-        // not a number
-        try {
-            SqlUtil.implicitCastStrAsTimestamp("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [STRING -> TIMESTAMP]", e.getFlyweightMessage());
-        }
-    }
-
-    @Test
-    public void testParseStrVarcharAsTimestamp0() {
-        Assert.assertEquals(Numbers.LONG_NULL, SqlUtil.implicitCastVarcharAsTimestamp(null));
-        Assert.assertEquals("2022-11-20T10:30:55.123999Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20T10:30:55.123999Z")));
-        Assert.assertEquals("2022-11-20T10:30:55.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 10:30:55Z")));
-        Assert.assertEquals("2022-11-20T00:00:00.000000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 Z")));
-        Assert.assertEquals("2022-11-20T10:30:55.123000Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("2022-11-20 10:30:55.123Z")));
-        Assert.assertEquals("1970-01-01T00:00:00.000200Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("200")));
-        Assert.assertEquals("1969-12-31T23:59:59.999100Z", Timestamps.toUSecString(SqlUtil.implicitCastVarcharAsTimestamp("-900")));
-
-        // not a number
-        try {
-            SqlUtil.implicitCastVarcharAsTimestamp("hello");
-            Assert.fail();
-        } catch (ImplicitCastException e) {
-            TestUtils.assertEquals("inconvertible value: `hello` [VARCHAR -> TIMESTAMP]", e.getFlyweightMessage());
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -911,6 +911,53 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testIPv4ToVarcharCast() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table tanc as (" +
+                            "select rnd_int() % 1000 x," +
+                            " rnd_varchar() a," +
+                            " rnd_varchar() b," +
+                            " rnd_varchar() c" +
+                            " from long_sequence(20)" +
+                            ")"
+            );
+
+            assertSql(
+                    "x\tcase\n" +
+                            "-920\t\n" +
+                            "363\t127.0.0.1\n" +
+                            "367\t127.0.0.1\n" +
+                            "895\t127.0.0.1\n" +
+                            "-6\t\n" +
+                            "-440\t\n" +
+                            "905\t127.0.0.1\n" +
+                            "-212\t\n" +
+                            "569\t127.0.0.1\n" +
+                            "204\t127.0.0.1\n" +
+                            "-845\t\n" +
+                            "768\t127.0.0.1\n" +
+                            "343\t127.0.0.1\n" +
+                            "797\t127.0.0.1\n" +
+                            "34\t127.0.0.1\n" +
+                            "-365\t\n" +
+                            "895\t127.0.0.1\n" +
+                            "416\t127.0.0.1\n" +
+                            "-765\t\n" +
+                            "754\t127.0.0.1\n",
+                    "select \n" +
+                            "    x,\n" +
+                            "    case\n" +
+                            "        when x < 0 then a\n" +
+                            "        when x > 100 and x < 200 then b\n" +
+                            "        else '127.0.0.1'::ipv4" +
+                            "    end \n" +
+                            "from tanc"
+            );
+        });
+    }
+
+    @Test
     public void testInt() throws Exception {
         assertQuery(
                 "x\tcase\n" +
@@ -1164,32 +1211,6 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
                         "from tanc",
                 88,
                 "inconvertible types: INT -> VARCHAR [from=INT, to=VARCHAR]"
-        );
-    }
-
-    @Test
-    public void testIpv4ToVarcharCast() throws Exception {
-        ddl(
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(20)" +
-                        ")"
-        );
-
-        assertException(
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else '127.0.0.1'::ipv4" +
-                        "    end \n" +
-                        "from tanc",
-                114,
-                "inconvertible types: IPv4 -> VARCHAR [from=IPv4, to=VARCHAR]"
         );
     }
 
@@ -1794,28 +1815,34 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testUuidToVarcharCast() throws Exception {
-        ddl(
-                "create table tanc as (" +
-                        "select rnd_int() % 1000 x," +
-                        " rnd_varchar() a," +
-                        " rnd_varchar() b," +
-                        " rnd_varchar() c" +
-                        " from long_sequence(5)" +
-                        ")"
-        );
+        assertMemoryLeak(() -> {
+            ddl(
+                    "create table tanc as (" +
+                            "select rnd_int() % 1000 x," +
+                            " rnd_varchar() a," +
+                            " rnd_varchar() b," +
+                            " rnd_varchar() c" +
+                            " from long_sequence(5)" +
+                            ")"
+            );
 
-        assertException(
-                "select \n" +
-                        "    x,\n" +
-                        "    case\n" +
-                        "        when x < 0 then a\n" +
-                        "        when x > 100 and x < 200 then b\n" +
-                        "        else 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid" +
-                        "    end \n" +
-                        "from tanc",
-                141,
-                "inconvertible types: UUID -> VARCHAR [from=UUID, to=VARCHAR]"
-        );
+            assertSql(
+                    "x\tcase\n" +
+                            "-920\t\n" +
+                            "363\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n" +
+                            "367\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n" +
+                            "895\ta0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\n" +
+                            "-6\t\n",
+                    "select \n" +
+                            "    x,\n" +
+                            "    case\n" +
+                            "        when x < 0 then a\n" +
+                            "        when x > 100 and x < 200 then b\n" +
+                            "        else 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid" +
+                            "    end \n" +
+                            "from tanc"
+            );
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
@@ -40,6 +40,66 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCoalesceIPv4InvalidStringLiteral() throws Exception {
+        assertException(
+                "select coalesce('192.168.1.1'::ipv4, 'foobar')",
+                37,
+                "invalid IPv4 constant"
+        );
+    }
+
+    @Test
+    public void testCoalesceIPv4InvalidVarcharLiteral() throws Exception {
+        assertException(
+                "select coalesce('192.168.1.1'::ipv4, 'foobar'::varchar)",
+                45,
+                "invalid IPv4 constant"
+        );
+    }
+
+    @Test
+    public void testCoalesceIPv4StringLiteral() throws Exception {
+        assertQuery(
+                "c1\tc2\tx\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "1.1.96.238\t127.0.0.1\t1.1.96.238\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "127.0.0.1\t127.0.0.1\t\n",
+                "select coalesce(x, '127.0.0.1') as c1, coalesce('127.0.0.1', x) as c2, x \n" +
+                        "from t",
+                "create table t as (" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_ipv4('1.1.1.1/16', 2) ELSE NULL END as x " +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testCoalesceIPv4VarcharLiteral() throws Exception {
+        assertQuery(
+                "c1\tc2\tx\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "1.1.96.238\t127.0.0.1\t1.1.96.238\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "127.0.0.1\t127.0.0.1\t\n" +
+                        "127.0.0.1\t127.0.0.1\t\n",
+                "select coalesce(x, '127.0.0.1'::varchar) as c1, coalesce('127.0.0.1'::varchar, x) as c2, x \n" +
+                        "from t",
+                "create table t as (" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_ipv4('1.1.1.1/16', 2) ELSE NULL END as x " +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testCoalesceLong256() throws Exception {
         assertQuery(
                 "c1\tc2\ta\tb\tx\n" +
@@ -82,6 +142,24 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
                 null,
                 true,
                 true
+        );
+    }
+
+    @Test
+    public void testCoalesceUuidInvalidStringLiteral() throws Exception {
+        assertException(
+                "select coalesce('00000000-0000-0000-0000-000000000000'::uuid, 'foobar')",
+                62,
+                "invalid UUID constant"
+        );
+    }
+
+    @Test
+    public void testCoalesceUuidInvalidVarcharLiteral() throws Exception {
+        assertException(
+                "select coalesce('00000000-0000-0000-0000-000000000000'::uuid, 'foobar'::varchar)",
+                70,
+                "invalid UUID constant"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
+
     @Before
     public void setUp3() {
         SharedRandom.RANDOM.set(new Rnd());
@@ -62,7 +63,7 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCoalesceUUID() throws Exception {
+    public void testCoalesceUuid() throws Exception {
         assertQuery(
                 "c1\tc2\ta\tb\tx\n" +
                         "0010cde8-12ce-40ee-8010-a928bb8b9650\t0010cde8-12ce-40ee-8010-a928bb8b9650\t\t0010cde8-12ce-40ee-8010-a928bb8b9650\t\n" +
@@ -73,9 +74,72 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
                 "select coalesce(a, b, x) as c1, coalesce(a, b) c2, a, b, x \n" +
                         "from t",
                 "create table t as (" +
-                        "select CASE WHEN x % 2 = 0 THEN rnd_uuid4() ELSE CAST(NULL as UUID) END as x," +
-                        " CASE WHEN x % 4 = 0 THEN rnd_uuid4() ELSE CAST(NULL as UUID) END as a," +
-                        " CASE WHEN x % 4 = 1 THEN rnd_uuid4() ELSE CAST(NULL as UUID) END as b" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_uuid4() ELSE NULL END as x," +
+                        " CASE WHEN x % 4 = 0 THEN rnd_uuid4() ELSE NULL END as a," +
+                        " CASE WHEN x % 4 = 1 THEN rnd_uuid4() ELSE NULL END as b" +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testCoalesceUuidNull() throws Exception {
+        assertQuery(
+                "c1\tc2\tx\n" +
+                        "\t\t\n" +
+                        "0010cde8-12ce-40ee-8010-a928bb8b9650\t0010cde8-12ce-40ee-8010-a928bb8b9650\t0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
+                        "\t\t\n" +
+                        "9f9b2131-d49f-4d1d-ab81-39815c50d341\t9f9b2131-d49f-4d1d-ab81-39815c50d341\t9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
+                        "\t\t\n",
+                "select coalesce(x, null) as c1, coalesce(null, x) c2, x \n" +
+                        "from t",
+                "create table t as (" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_uuid4() ELSE NULL END as x " +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testCoalesceUuidStringLiteral() throws Exception {
+        assertQuery(
+                "c1\tc2\tx\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n" +
+                        "0010cde8-12ce-40ee-8010-a928bb8b9650\t00000000-0000-0000-0000-000000000000\t0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n" +
+                        "9f9b2131-d49f-4d1d-ab81-39815c50d341\t00000000-0000-0000-0000-000000000000\t9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n",
+                "select coalesce(x, '00000000-0000-0000-0000-000000000000') as c1, coalesce('00000000-0000-0000-0000-000000000000', x) as c2, x \n" +
+                        "from t",
+                "create table t as (" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_uuid4() ELSE NULL END as x " +
+                        " from long_sequence(5)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testCoalesceUuidVarcharLiteral() throws Exception {
+        assertQuery(
+                "c1\tc2\tx\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n" +
+                        "0010cde8-12ce-40ee-8010-a928bb8b9650\t00000000-0000-0000-0000-000000000000\t0010cde8-12ce-40ee-8010-a928bb8b9650\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n" +
+                        "9f9b2131-d49f-4d1d-ab81-39815c50d341\t00000000-0000-0000-0000-000000000000\t9f9b2131-d49f-4d1d-ab81-39815c50d341\n" +
+                        "00000000-0000-0000-0000-000000000000\t00000000-0000-0000-0000-000000000000\t\n",
+                "select coalesce(x, '00000000-0000-0000-0000-000000000000'::varchar) as c1, coalesce('00000000-0000-0000-0000-000000000000'::varchar, x) as c2, x \n" +
+                        "from t",
+                "create table t as (" +
+                        "select CASE WHEN x % 2 = 0 THEN rnd_uuid4() ELSE NULL END as x " +
                         " from long_sequence(5)" +
                         ")",
                 null,

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/SwitchFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/SwitchFunctionFactoryTest.java
@@ -408,6 +408,53 @@ public class SwitchFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCastValueToIPv4_1() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select x, rnd_ipv4('54.23.11.87/8', 2) ip from long_sequence(5))");
+            assertSql(
+                    "x\tip\tk\n" +
+                            "1\t54.206.96.238\t54.206.96.238\n" +
+                            "2\t\t\n" +
+                            "3\t54.98.173.21\t127.0.0.1\n" +
+                            "4\t54.15.250.138\t127.0.0.1\n" +
+                            "5\t\t127.0.0.1\n",
+                    "select \n" +
+                            "    x,\n" +
+                            "    ip,\n" +
+                            "    case x\n" +
+                            "        when 1 then ip\n" +
+                            "        when 2 then null\n" +
+                            "        else '127.0.0.1'\n" +
+                            "    end k\n" +
+                            "from x"
+            );
+        });
+    }
+
+    @Test
+    public void testCastValueToIPv4_2() throws Exception {
+        assertMemoryLeak(() -> {
+            ddl("create table x as (select x, rnd_ipv4('54.23.11.87/8', 2) ip from long_sequence(5))");
+            assertSql(
+                    "x\tip\tk\n" +
+                            "1\t54.206.96.238\t192.168.1.1\n" +
+                            "2\t\t\n" +
+                            "3\t54.98.173.21\t54.98.173.21\n" +
+                            "4\t54.15.250.138\t54.15.250.138\n" +
+                            "5\t\t\n",
+                    "select \n" +
+                            "    x,\n" +
+                            "    ip,\n" +
+                            "    case x\n" +
+                            "        when 1 then '192.168.1.1'\n" +
+                            "        else ip\n" +
+                            "    end k\n" +
+                            "from x"
+            );
+        });
+    }
+
+    @Test
     public void testCastValueToLong256() throws Exception {
         ddl(
                 "create table tanc as (" +


### PR DESCRIPTION
Fixes missing UUID and IPv4 literal in `coalesce` function and `switch` statement. With this path, it's enough to write `coalesce(x, '00000000-0000-0000-0000-000000000000')` instead of `coalesce(x, cast('00000000-0000-0000-0000-000000000000' as uuid))`.