### PR TITLE
fix(sql): race in parallel group by with many groups

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
@@ -184,12 +184,12 @@ public class GroupByIntHashSet {
             }
         } while (index != index0);
 
-        throw CairoException.critical(0).put("corrupt hash table");
+        throw CairoException.critical(0).put("corrupt int hash set");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {
         if (newCapacity < 0) {
-            throw CairoException.nonCritical().put("set capacity overflow");
+            throw CairoException.nonCritical().put("int hash set capacity overflow");
         }
 
         final int oldSize = size();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
@@ -172,6 +172,7 @@ public class GroupByIntHashSet {
     }
 
     private long probe(int key, long index) {
+        final long index0 = index;
         do {
             index = (index + 1) & mask;
             int k = keyAt(index);
@@ -181,7 +182,9 @@ public class GroupByIntHashSet {
             if (key == k) {
                 return -index - 1;
             }
-        } while (true);
+        } while (index != index0);
+
+        throw CairoException.critical(0).put("corrupt hash table");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
@@ -190,12 +190,12 @@ public class GroupByLong128HashSet {
             }
         } while (index != index0);
 
-        throw CairoException.critical(0).put("corrupt hash table");
+        throw CairoException.critical(0).put("corrupt long128 hash set");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {
         if (newCapacity < 0) {
-            throw CairoException.nonCritical().put("set capacity overflow");
+            throw CairoException.nonCritical().put("long128 hash set capacity overflow");
         }
 
         final int oldSize = size();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
@@ -176,6 +176,7 @@ public class GroupByLong128HashSet {
     }
 
     private long probe(long lo, long hi, long index) {
+        final long index0 = index;
         do {
             index = (index + 1) & mask;
             long p = keyAddrAt(index);
@@ -187,7 +188,9 @@ public class GroupByLong128HashSet {
             if (loKey == lo && hiKey == hi) {
                 return -index - 1;
             }
-        } while (true);
+        } while (index != index0);
+
+        throw CairoException.critical(0).put("corrupt hash table");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
@@ -198,12 +198,12 @@ public class GroupByLong256HashSet {
             }
         } while (index != index0);
 
-        throw CairoException.critical(0).put("corrupt hash table");
+        throw CairoException.critical(0).put("corrupt long256 hash set");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {
         if (newCapacity < 0) {
-            throw CairoException.nonCritical().put("set capacity overflow");
+            throw CairoException.nonCritical().put("long256 hash set capacity overflow");
         }
 
         final int oldSize = size();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
@@ -182,6 +182,7 @@ public class GroupByLong256HashSet {
     }
 
     private long probe(long k0, long k1, long k2, long k3, long index) {
+        final long index0 = index;
         do {
             index = (index + 1) & mask;
             long p = keyAddrAt(index);
@@ -195,7 +196,9 @@ public class GroupByLong256HashSet {
             if (k0Key == k0 && k1Key == k1 && k2Key == k2 && k3Key == k3) {
                 return -index - 1;
             }
-        } while (true);
+        } while (index != index0);
+
+        throw CairoException.critical(0).put("corrupt hash table");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
@@ -184,12 +184,12 @@ public class GroupByLongHashSet {
             }
         } while (index != index0);
 
-        throw CairoException.critical(0).put("corrupt hash table");
+        throw CairoException.critical(0).put("corrupt long hash set");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {
         if (newCapacity < 0) {
-            throw CairoException.nonCritical().put("set capacity overflow");
+            throw CairoException.nonCritical().put("long hash set capacity overflow");
         }
 
         final int oldSize = size();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
@@ -172,6 +172,7 @@ public class GroupByLongHashSet {
     }
 
     private long probe(long key, long index) {
+        final long index0 = index;
         do {
             index = (index + 1) & mask;
             long k = keyAt(index);
@@ -181,7 +182,9 @@ public class GroupByLongHashSet {
             if (key == k) {
                 return -index - 1;
             }
-        } while (true);
+        } while (index != index0);
+
+        throw CairoException.critical(0).put("corrupt hash table");
     }
 
     private void rehash(int newCapacity, int newSizeLimit) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
@@ -41,7 +41,6 @@ import java.io.Closeable;
 import java.util.concurrent.atomic.LongAdder;
 
 public class AsyncFilterAtom implements StatefulAtom, Closeable, Plannable {
-
     public static final LongAdder PRE_TOUCH_BLACK_HOLE = new LongAdder();
     private final IntList columnTypes;
     private final Function filter;
@@ -110,9 +109,10 @@ public class AsyncFilterAtom implements StatefulAtom, Closeable, Plannable {
             return -1;
         }
         if (workerId == -1 && owner) {
-            // Owner thread is free to use the original filter anytime.
+            // Owner thread is free to use its own filter anytime.
             return -1;
         }
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
@@ -109,10 +109,11 @@ public class AsyncFilterAtom implements StatefulAtom, Closeable, Plannable {
             return -1;
         }
         if (workerId == -1 && owner) {
-            // Owner thread is free to use its own filter anytime.
+            // Owner thread is free to use its own private filter anytime.
             return -1;
         }
-        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock
+        // to use shared resources.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
@@ -228,7 +228,7 @@ public class AsyncFilteredRecordCursorFactory extends AbstractRecordCursorFactor
         rows.clear();
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
-        final int filterId = atom.acquireFilter(workerId, owner, circuitBreaker);
+        final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
         final Function filter = atom.getFilter(filterId);
         try {
             for (long r = 0; r < frameRowCount; r++) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -349,9 +349,10 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
 
     public int maybeAcquire(int workerId, boolean owner, ExecutionCircuitBreaker circuitBreaker) {
         if (workerId == -1 && owner) {
-            // Owner thread is free to use the original functions anytime.
+            // Owner thread is free to use its own filter, function updaters, allocator, etc. anytime.
             return -1;
         }
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -164,22 +164,6 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
         }
     }
 
-    public int acquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
-        if (workerId == -1 && owner) {
-            // Owner thread is free to use the original functions anytime.
-            return -1;
-        }
-        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
-    }
-
-    public int acquire(int workerId, ExecutionCircuitBreaker circuitBreaker) {
-        if (workerId == -1) {
-            // Owner thread is free to use the original functions anytime.
-            return -1;
-        }
-        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
-    }
-
     @Override
     public void clear() {
         sharded = false;
@@ -351,12 +335,24 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
         }
     }
 
-    public boolean isMergeLockRequired() {
-        return perWorkerFunctionUpdaters != null;
-    }
-
     public boolean isSharded() {
         return sharded;
+    }
+
+    public int maybeAcquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
+        if (workerId == -1 && owner) {
+            // Owner thread is free to use the original functions anytime.
+            return -1;
+        }
+        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
+    }
+
+    public int maybeAcquire(int workerId, boolean owner, ExecutionCircuitBreaker circuitBreaker) {
+        if (workerId == -1 && owner) {
+            // Owner thread is free to use the original functions anytime.
+            return -1;
+        }
+        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 
     public Map mergeOwnerMap() {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -349,10 +349,12 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
 
     public int maybeAcquire(int workerId, boolean owner, ExecutionCircuitBreaker circuitBreaker) {
         if (workerId == -1 && owner) {
-            // Owner thread is free to use its own filter, function updaters, allocator, etc. anytime.
+            // Owner thread is free to use its own private filter, function updaters, allocator,
+            // etc. anytime.
             return -1;
         }
-        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock
+        // to use shared resources.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
@@ -249,9 +249,10 @@ public class AsyncGroupByNotKeyedAtom implements StatefulAtom, Closeable, Planna
 
     public int maybeAcquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
         if (workerId == -1 && owner) {
-            // Owner thread is free to use the original filter anytime.
+            // Owner thread is free to use its own filter, function updaters, etc. anytime.
             return -1;
         }
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
@@ -121,14 +121,6 @@ public class AsyncGroupByNotKeyedAtom implements StatefulAtom, Closeable, Planna
         }
     }
 
-    public int acquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
-        if (workerId == -1 && owner) {
-            // Owner thread is free to use the original filter anytime.
-            return -1;
-        }
-        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
-    }
-
     @Override
     public void clear() {
         ownerFunctionUpdater.updateEmpty(ownerMapValue);
@@ -253,6 +245,14 @@ public class AsyncGroupByNotKeyedAtom implements StatefulAtom, Closeable, Planna
             // DataUnavailableException thrown on worker threads when filtering.
             Function.initCursor(perWorkerFilters);
         }
+    }
+
+    public int maybeAcquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
+        if (workerId == -1 && owner) {
+            // Owner thread is free to use the original filter anytime.
+            return -1;
+        }
+        return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 
     public void release(int slotId) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedAtom.java
@@ -249,10 +249,11 @@ public class AsyncGroupByNotKeyedAtom implements StatefulAtom, Closeable, Planna
 
     public int maybeAcquire(int workerId, boolean owner, SqlExecutionCircuitBreaker circuitBreaker) {
         if (workerId == -1 && owner) {
-            // Owner thread is free to use its own filter, function updaters, etc. anytime.
+            // Owner thread is free to use its own private filter, function updaters, etc. anytime.
             return -1;
         }
-        // All other threads, e.g. worker or work stealing threads, must always acquire a lock.
+        // All other threads, e.g. worker or work stealing threads, must always acquire a lock
+        // to use shared resources.
         return perWorkerLocks.acquireSlot(workerId, circuitBreaker);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursorFactory.java
@@ -187,7 +187,7 @@ public class AsyncGroupByNotKeyedRecordCursorFactory extends AbstractRecordCurso
         record.init(frameMemory);
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
-        final int slotId = atom.acquire(workerId, owner, circuitBreaker);
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
         final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
         final SimpleMapValue value = atom.getMapValue(slotId);
         try {
@@ -247,7 +247,7 @@ public class AsyncGroupByNotKeyedRecordCursorFactory extends AbstractRecordCurso
         assert frameRowCount > 0;
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == frameSequence;
-        final int slotId = atom.acquire(workerId, owner, circuitBreaker);
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
         final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
         final SimpleMapValue value = atom.getMapValue(slotId);
         final CompiledFilter compiledFilter = atom.getCompiledFilter();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -298,7 +298,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
                     long cursor = subSeq.next();
                     if (cursor > -1) {
                         GroupByMergeShardTask task = queue.get(cursor);
-                        GroupByMergeShardJob.run(-1, task, subSeq, cursor);
+                        GroupByMergeShardJob.run(-1, task, subSeq, cursor, atom);
                         reclaimed++;
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -188,7 +188,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         record.init(frameMemory);
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
-        final int slotId = atom.acquire(workerId, owner, circuitBreaker);
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
         final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
         final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
         final RecordSink mapSink = atom.getMapSink(slotId);
@@ -353,7 +353,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         final AsyncGroupByAtom atom = frameSequence.getAtom();
 
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == frameSequence;
-        final int slotId = atom.acquire(workerId, owner, circuitBreaker);
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
         final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
         final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
         final CompiledFilter compiledFilter = atom.getCompiledFilter();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -301,7 +301,7 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
         if (frameSequence.getPageFrameAddressCache().hasColumnTops(task.getFrameIndex())) {
             // Use Java-based filter in case of a page frame with column tops.
             final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
-            final int filterId = atom.acquireFilter(workerId, owner, circuitBreaker);
+            final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
             final Function filter = atom.getFilter(filterId);
             try {
                 for (long r = 0; r < frameRowCount; r++) {

--- a/core/src/test/java/io/questdb/test/ServerMainQuerySmokeTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainQuerySmokeTest.java
@@ -267,7 +267,7 @@ public class ServerMainQuerySmokeTest extends AbstractBootstrapTest {
     }
 
     @Test
-    public void testServerMainParallelShardedGroupByLoadTest() throws Exception {
+    public void testServerMainParallelShardedGroupByLoadTest1() throws Exception {
         testServerMainParallelQueryLoadTest(
                 "CREATE TABLE tab as (" +
                         "  select (x * 864000000)::timestamp ts, ('k' || (x % 101))::symbol key, x:: double price, x::long quantity from long_sequence(10000)" +
@@ -296,6 +296,37 @@ public class ServerMainQuerySmokeTest extends AbstractBootstrapTest {
                         "1,k14,6599.64534842185\n" +
                         "1,k15,6600.325238210883\n" +
                         "1,k16,6601.005256016568\n"
+        );
+    }
+
+    @Test
+    public void testServerMainParallelShardedGroupByLoadTest2() throws Exception {
+        testServerMainParallelQueryLoadTest(
+                "CREATE TABLE tab as (" +
+                        "  select (x * 864000000)::timestamp ts, ('k' || (x % 101))::symbol key, x::long x from long_sequence(10000)" +
+                        ") timestamp (ts) PARTITION BY DAY",
+                "SELECT key, count_distinct(x) FROM tab ORDER BY key LIMIT 10",
+                "QUERY PLAN[VARCHAR]\n" +
+                        "Sort light lo: 10\n" +
+                        "  keys: [key]\n" +
+                        "    Async Group By workers: 4\n" +
+                        "      keys: [key]\n" +
+                        "      values: [count_distinct(x)]\n" +
+                        "      filter: null\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: tab\n",
+                "key[VARCHAR],count_distinct[BIGINT]\n" +
+                        "k0,99\n" +
+                        "k1,100\n" +
+                        "k10,99\n" +
+                        "k100,99\n" +
+                        "k11,99\n" +
+                        "k12,99\n" +
+                        "k13,99\n" +
+                        "k14,99\n" +
+                        "k15,99\n" +
+                        "k16,99\n"
         );
     }
 


### PR DESCRIPTION
When a parallel group by sharding takes place, it may happen that a work-stealing thread steals another thread's task and starts executing it as if it's the task's owner.

The fix makes the per-worker synchronization mandatory in such cases by checking the task's atom and comparing it with the thread's one.