### PR TITLE
fix(sql): fix memory leak in pg_class() cursor function

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -3292,11 +3292,14 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
-    public void testCursorInSelectNotAliased() throws SqlException {
-        assertQuery(
-                "select-virtual pg_class, pg_class . n column from (long_sequence(2) cross join select-cursor [pg_catalog.pg_class() pg_class] pg_catalog.pg_class() pg_class from (pg_catalog.pg_class()) _xQdbA1)",
-                "select pg_catalog.pg_class(), (pg_catalog.pg_class()).n from long_sequence(2)"
-        );
+    public void testCursorInSelectNotAliased() throws Exception {
+        assertMemoryLeak(() -> {
+            assertQuery(
+                    "select-virtual pg_class, pg_class . n column from (long_sequence(2) cross join select-cursor [pg_catalog.pg_class() pg_class] pg_catalog.pg_class() pg_class from (pg_catalog.pg_class()) _xQdbA1)",
+                    "select pg_catalog.pg_class(), (pg_catalog.pg_class()).n from long_sequence(2)"
+            );
+        });
+
     }
 
     @Test


### PR DESCRIPTION
sql optimizer wasn't closing a function cursor factory properly in some paths.
in most cases it's harmless since cursor function usually do not allocate native
memory. pg_class() does. this change makes sure the factory is properly closed.