### PR TITLE
perf(sql): avoid full scans for certain `LIMIT -N` scenarios

### DIFF
--- a/core/src/main/java/io/questdb/cairo/LimitPartitionFrameCursor.java
+++ b/core/src/main/java/io/questdb/cairo/LimitPartitionFrameCursor.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cairo;
+
+import io.questdb.cairo.sql.PartitionFrame;
+import io.questdb.cairo.sql.RecordCursor;
+import org.jetbrains.annotations.Nullable;
+
+public class LimitPartitionFrameCursor extends AbstractFullPartitionFrameCursor {
+    // User-defined limit. If negative, then
+    // reading begins from the nth row from the end; if positive, then
+    // reading begins from the nth row from the beginning. Currently only
+    // negative limits are supported.
+    private long limit = 0;
+
+    // First partition from which to begin reading
+    private int partitionLo = 0;
+
+    // Row at which to begin reading (if partitionIndex == partitionLo).
+    // If limit is non-zero, this number is set to -1, which cause the implementation
+    // to calculate the actual offset.
+    private long firstRowLo = 0;
+
+    @Override
+    public void calculateSize(RecordCursor.Counter counter) {
+        calculateFirstPartitionAndRow();
+
+        while (partitionIndex < partitionHi) {
+            long hi = getTableReader().openPartition(partitionIndex);
+            if (hi > 0) {
+                if (partitionIndex == partitionLo) {
+                    hi -= firstRowLo;
+                }
+                counter.add(hi);
+            }
+            partitionIndex++;
+        }
+    }
+
+    @Override
+    public long size() {
+        long size = super.size();
+        size = Math.min(size, Math.abs(limit));
+        return size;
+    }
+
+    /**
+     * Sets the limit, either positive or negative.
+     * If limit is negative, then it is counted from the end
+     */
+    public void setLimit(long n) {
+        if (n > 0) {
+            throw new UnsupportedOperationException("only negative limits for now!");
+        }
+        if (n == 0) {
+            limit = firstRowLo = 0;
+        } else if (n != limit) {
+            // our limit has changed, signal that we need to recalculate the offsets
+            limit = n;
+            firstRowLo = -1;
+        }
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    private void calculateFirstPartitionAndRow() {
+        if (firstRowLo > -1) {
+            return; // already calculated
+        }
+
+        int curPart = partitionHi - 1; // iterator
+        long readableRows = -limit;
+
+        while (curPart > -1) {
+            long numRows = getTableReader().openPartition(curPart);
+
+            if (numRows < 1) {
+                // partition unreadable
+                curPart--;
+                continue;
+            }
+
+            if (readableRows > numRows) {
+                // e.g. numRows = 100, readableRows = 500
+                readableRows -= numRows;
+                curPart--;
+            } else {
+                // offset begins in this partition, somewhere;
+                // e.g. numRows = 100; readableRows = 5; which means that we start reading
+                // at row 95, or numRows - readableRows
+                firstRowLo = numRows - readableRows;
+                partitionIndex = partitionLo = curPart;
+                return;
+            }
+        }
+
+        if (readableRows > 0) {
+            // more results than rows?
+            firstRowLo = 0;
+            partitionLo = 0;
+        }
+    }
+
+    public @Nullable PartitionFrame next() {
+        calculateFirstPartitionAndRow();
+
+        while (partitionIndex < partitionHi) {
+            final long hi = getTableReader().openPartition(partitionIndex);
+            if (hi < 1) {
+                // this partition is missing, skip
+                partitionIndex++;
+            } else {
+                frame.partitionIndex = partitionIndex;
+                frame.rowLo = partitionIndex == partitionLo ? firstRowLo : 0;
+                frame.rowHi = hi;
+                partitionIndex++;
+                return frame;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void toTop() {
+        partitionIndex = partitionLo;
+    }
+}

--- a/core/src/main/java/io/questdb/cairo/LimitPartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/LimitPartitionFrameCursorFactory.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cairo;
+
+import io.questdb.cairo.sql.PartitionFrameCursor;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.Misc;
+
+public class LimitPartitionFrameCursorFactory extends AbstractPartitionFrameCursorFactory {
+    private final LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor();
+
+    public LimitPartitionFrameCursorFactory(TableToken tableToken, long tableVersion, GenericRecordMetadata metadata,
+                                            long limit) {
+        super(tableToken, tableVersion, metadata);
+        cursor.setLimit(limit);
+    }
+
+    @Override
+    public PartitionFrameCursor getCursor(SqlExecutionContext executionContext, int order) throws SqlException {
+        if (order != ORDER_ASC && order != ORDER_ANY) {
+            throw SqlException.$(0, "Unsupported order; only ASC/ANY supported for this cursor");
+        }
+
+        final TableReader reader = getReader(executionContext);
+        try {
+            return cursor.of(reader);
+        } catch (Throwable th) {
+            Misc.free(reader);
+            throw th;
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER_ASC;
+    }
+
+    @Override
+    public boolean hasInterval() {
+        return false;
+    }
+
+    @Override
+    public boolean followedLimitAdvice() {
+        return true;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        if (sink.getOrder() == ORDER_DESC) {
+            sink.type("Frame backward scan");
+        } else {
+            sink.type("Frame limit scan lo: " + Math.abs(cursor.getLimit()));
+        }
+        super.toPlan(sink);
+    }
+}

--- a/core/src/main/java/io/questdb/cairo/sql/PartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PartitionFrameCursorFactory.java
@@ -97,4 +97,8 @@ public interface PartitionFrameCursorFactory extends Sinkable, Closeable, Planna
     default void toSink(@NotNull CharSink<?> sink) {
         throw new UnsupportedOperationException();
     }
+
+    default boolean followedLimitAdvice() {
+        return false;
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/join/AbstractJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AbstractJoinRecordCursorFactory.java
@@ -40,4 +40,9 @@ public abstract class AbstractJoinRecordCursorFactory extends AbstractRecordCurs
         this.masterFactory = masterFactory;
         this.slaveFactory = slaveFactory;
     }
+
+    @Override
+    public boolean followedLimitAdvice() {
+        return masterFactory.followedLimitAdvice();
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AbstractPageFrameRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AbstractPageFrameRecordCursorFactory.java
@@ -116,6 +116,11 @@ abstract class AbstractPageFrameRecordCursorFactory extends AbstractRecordCursor
         return pageFrameCursor.of(partitionFrameCursor);
     }
 
+    @Override
+    public boolean followedLimitAdvice() {
+        return partitionFrameCursorFactory.followedLimitAdvice();
+    }
+
     protected abstract RecordCursor initRecordCursor(
             PageFrameCursor frameCursor,
             SqlExecutionContext executionContext

--- a/core/src/test/java/io/questdb/test/cairo/LimitPartitionFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/LimitPartitionFrameCursorTest.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.cairo.*;
+import io.questdb.cairo.sql.PartitionFrame;
+import io.questdb.std.Rnd;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LimitPartitionFrameCursorTest extends AbstractCairoTest {
+    @Test
+    public void testLimit() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            TableModel model = new TableModel(configuration, "x", PartitionBy.DAY).
+                    col("a", ColumnType.INT).
+                    col("b", ColumnType.INT).
+                    timestamp();
+            AbstractCairoTest.create(model);
+
+            long timestamp;
+            final Rnd rnd = new Rnd();
+            // format arguments: (day, hour)
+            String fmtBase = "1970-01-%02dT%02d:00:00.000Z";
+            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+                // Partitions are done by day; provide 5 entries per partition, for ten days
+                for (int day = 1; day < 11; ++day) {
+                    for (int hour = 0; hour < 10; ++hour) {
+                        String curTs = String.format(fmtBase, day, hour);
+                        timestamp = TimestampFormatUtils.parseTimestamp(curTs);
+                        TableWriter.Row row = writer.newRow(timestamp);
+
+                        // todo: are these random rows required for something?
+                        row.putInt(0, rnd.nextInt());
+                        row.putInt(1, rnd.nextInt());
+                        row.append();
+                    }
+                }
+                writer.commit();
+
+                try (
+                        TableReader reader = newOffPoolReader(configuration, "x");
+                        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor()
+                ) {
+                    cursor.setLimit(-1);
+                    cursor.of(reader);
+
+                    PartitionFrame frame = cursor.next();
+                    // we should only have one frame here..
+                    Assert.assertEquals(frame.getRowLo(), 9);
+                    Assert.assertEquals(frame.getRowHi(), 10);
+                    Assert.assertEquals(frame.getPartitionIndex(), reader.getPartitionCount() - 1);
+                    Assert.assertNull(cursor.next()); // only one result, simple..
+
+                    Assert.assertEquals(1, cursor.size());
+                }
+
+                try (
+                        TableReader reader = newOffPoolReader(configuration, "x");
+                        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor()
+                ) {
+                    // consume entire last partition
+                    cursor.setLimit(-10);
+                    cursor.of(reader);
+                    PartitionFrame frame = cursor.next();
+                    // we should only have one frame here..
+                    Assert.assertEquals(frame.getRowLo(), 0);
+                    Assert.assertEquals(frame.getRowHi(), 10);
+                    Assert.assertEquals(frame.getPartitionIndex(), reader.getPartitionCount() - 1);
+                    Assert.assertNull(cursor.next()); // consume entire partition, ok so far
+
+                    Assert.assertEquals(10, cursor.size());
+                }
+
+                try (
+                        TableReader reader = newOffPoolReader(configuration, "x");
+                        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor()
+                ) {
+                    // consume entire last partition, and partially consume the next one
+                    cursor.setLimit(-15);
+                    cursor.of(reader);
+                    PartitionFrame frame = cursor.next();
+
+                    // we should only have one frame here..
+                    Assert.assertEquals(frame.getRowLo(), 5);
+                    Assert.assertEquals(frame.getRowHi(), 10);
+                    Assert.assertEquals(frame.getPartitionIndex(), reader.getPartitionCount() - 2);
+
+                    frame = cursor.next();
+                    Assert.assertNotNull(frame);
+                    Assert.assertEquals(frame.getRowLo(), 0);
+                    Assert.assertEquals(frame.getRowHi(), 10);
+
+                    frame = cursor.next();
+                    Assert.assertNull(frame);
+                    Assert.assertEquals(15, cursor.size());
+                }
+
+                // try with limit = num rows
+                try (
+                        TableReader reader = newOffPoolReader(configuration, "x");
+                        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor()
+                ) {
+                    Assert.assertEquals(100, reader.size());
+                    cursor.setLimit(-100);
+                    cursor.of(reader);
+                    long count = 0;
+                    for (PartitionFrame frame = cursor.next(); frame != null; frame = cursor.next()) {
+                        count += frame.getRowHi() - frame.getRowLo();
+                    }
+
+                    Assert.assertEquals(100, count);
+                    Assert.assertEquals(100, cursor.size());
+                }
+
+                // try with limit > num rows
+                try (
+                        TableReader reader = newOffPoolReader(configuration, "x");
+                        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor()
+                ) {
+                    Assert.assertEquals(100, reader.size());
+                    cursor.setLimit(-200);
+                    cursor.of(reader);
+                    long count = 0;
+                    for (PartitionFrame frame = cursor.next(); frame != null; frame = cursor.next()) {
+                        count += frame.getRowHi() - frame.getRowLo();
+                    }
+                    Assert.assertEquals(100, count);
+                    Assert.assertEquals(100, cursor.size());
+                }
+            }
+        });
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLimitNotNegativeUnsupported() {
+        LimitPartitionFrameCursor cursor = new LimitPartitionFrameCursor();
+        cursor.setLimit(10);
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/OrderByNothingRowSkippingTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByNothingRowSkippingTest.java
@@ -66,7 +66,7 @@ public class OrderByNothingRowSkippingTest extends AbstractCairoTest {
     public void testSelectLastN() throws Exception {
         prepare_unordered_noTs_table();
 
-        assertQuery("l\n8\n2\n5\n", "select l from tab limit -3");
+        assertQuery("l\n8\n2\n5\n", "select l from tab limit -3", true);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -4680,8 +4680,8 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
                     "0xc78d67954cb7866695b5e08df69df8819fc909a43f149089c143a3bb982af031\n" +
                     "0x6ddedcf7415306f799ce31489578cac77b0ec57771d6e9f27c517f53d504487d\n" +
                     "0xa38b2ad7fbc79d366f9b5d1b162ba472613f1eb5f98a2df86a7f0ebbd1d28a95\n";
-            printSqlResult(expected, "t limit -5", null, true, false);
-            printSqlResult(expected, "l256 limit -5", null, true, false);
+            printSqlResult(expected, "t limit -5", null, true, true);
+            printSqlResult(expected, "l256 limit -5", null, true, true);
         });
     }
 


### PR DESCRIPTION
Closes #4726

This commit tries to push down negative `LIMIT` clauses in order to avoid a full table scan.

Previously, a `JOIN ... LIMIT -N` would trigger a full scan (going through the entire result set, and only returning the last N rows). This commit tries to push down this requirement at the partition level in cases where there are no filter constraints on the scan itself. Specifically, this is when the query (or subquery) is sorted by the timestamp, in which case, a simple seeking into the relevant partition/row is enough.

This optimization can also potentially be used in other cases where negative offsets are used, as the current implementation utilizes a backwards scan and sort; but the sort step can also be eliminated if there are no other constraints.


Relative performance with various query types. The optimization here is for the `JOIN LIMIT -10` variant, which would have had the same performance profile as `JOIN LIMIT -10,-1` (which isn't covered by this fix)

```
JOIN LIMIT -10                 471.80
JOIN LIMIT -10,-1              6707.18
JOIN LIMIT 10                  182.68
JOIN LIMIT 10,19               109.76
... LIMIT -10                  98.42
... LIMIT 10                   77.55
```