### PR TITLE
feat(sql):  breaking change 💥 - support for count(distinct col) and string_agg(distinct col)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -992,6 +992,22 @@ public class ExpressionParser {
                         }
                         processDefaultBranch = true;
                         break;
+                    case 'O':
+                    case 'o':
+                        processDefaultBranch = true;
+                        if (SqlKeywords.isOrderKeyword(tok) && opStack.size() > 2) {
+                            ExpressionNode en = opStack.peek();
+                            if (en.type == ExpressionNode.CONSTANT) {
+                                en = opStack.peek(1);
+                                if (en.type == ExpressionNode.CONTROL && Chars.equals(en.token, '(')) {
+                                    en = opStack.peek(2);
+                                    if (en.type == ExpressionNode.LITERAL && Chars.equalsIgnoreCase(en.token, "string_distinct_agg")) {
+                                        throw SqlException.$(lastPos, "ORDER BY not supported for string_distinct_agg");
+                                    }
+                                }
+                            }
+                        }
+                        break;
                     case '*':
                         // special case for tab.*
                         if (prevBranch == BRANCH_DOT) {

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -994,6 +994,8 @@ public class ExpressionParser {
                         break;
                     case 'O':
                     case 'o':
+                        // PostgreSQL supports an optional ORDER BY for string_distinct_agg(), e.g.: string_distinct_agg('a', ',' ORDER BY 'b')
+                        // We do not support it and this branch exists to give a meaningful error message in this case
                         processDefaultBranch = true;
                         if (SqlKeywords.isOrderKeyword(tok) && opStack.size() > 2) {
                             ExpressionNode en = opStack.peek();

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -438,7 +438,7 @@ public class ExpressionParser {
                                     if (!Chars.equals(nextToken, ')')) {
                                         en = opStack.peek(1);
                                         if (en.type == ExpressionNode.LITERAL) {
-                                            if (Chars.equalsIgnoreCase("count", en.token)) {
+                                            if (SqlKeywords.isCountKeyword(en.token)) {
                                                 if (Chars.equals(nextToken, '*')) {
                                                     throw SqlException.$(lastPos, "count(distinct *) is not supported");
                                                 }

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -431,11 +431,12 @@ public class ExpressionParser {
                                 CharSequence tokenStash = GenericLexer.immutableOf(tok);
                                 CharSequence nextToken = SqlUtil.fetchNext(lexer);
                                 if (nextToken != null) {
-                                    // if distinct is the only argument then we treat it as a column name
-                                    // and not a keyword. strictly speaking, keywords used as column names
-                                    // should be quoted, but for now we are not enforcing it here for backwards compatibility reasons.
-                                    // it's something we could/should consider in the future
-                                    if (!Chars.equals(nextToken, ')')) {
+                                    if (Chars.equals(nextToken, ')') || Chars.equals(nextToken, ',') || Chars.equals(nextToken, "::")) {
+                                        // this means 'distinct' is meant to be used as a column name and not as a keyword.
+                                        // at this point we also know 'distinct' is not in double-quotes since otherwise the CASE wouldn't match
+                                        // we call assertTableNameIsQuotedOrNotAKeyword() to ensure a consistent error message
+                                        SqlKeywords.assertTableNameIsQuotedOrNotAKeyword(tokenStash, lastPos);
+                                    } else {
                                         en = opStack.peek(1);
                                         if (en.type == ExpressionNode.LITERAL) {
                                             if (SqlKeywords.isCountKeyword(en.token)) {

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -359,69 +359,6 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCountDistinctRewrites() throws SqlException {
-        x("foo count_distinct", "count_distinct(foo)");
-        x("foo count_distinct", "count(distinct foo)");
-
-        x("1 1 + count_distinct", "count_distinct(1+1)");
-        x("1 1 + count_distinct", "count(distinct 1+1)");
-
-        x("bar foo count_distinct", "count_distinct(foo(bar))");
-        x("bar foo count_distinct", "count(distinct foo(bar))");
-
-        x("bar foo count_distinct varchar cast", "cast (count_distinct(foo(bar)) as varchar)");
-        x("bar foo count_distinct varchar cast", "cast (count(distinct foo(bar)) as varchar)");
-
-        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
-        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
-        x("distinct count varchar cast", "cast (count(distinct) as varchar)");
-        // check it works even if quoted
-        x("distinct count varchar cast", "cast (count(\"distinct\") as varchar)");
-        // it works with multiple arguments too
-        x("distinct foo count", "count(\"distinct\", foo)");
-        // not written when count is not a function
-        x("count distinct foo", "foo(count, distinct)");
-        x("distinctnot count", "count(distinctnot)");
-        x("bar count distinct foo", "foo(bar, count, distinct)");
-        x("count bar distinct foo", "foo(bar(count), distinct)");
-
-        assertFail("count(distinct *)", 6, "count(distinct *) is not supported");
-        assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
-        assertFail("notcount(distinct foo)", 18, "dangling literal");
-    }
-
-    @Test
-    public void testStringAggDistinctRewrites() throws SqlException {
-        x("foo string_distinct_agg", "string_distinct_agg(foo)");
-        x("foo string_distinct_agg", "string_agg(distinct foo)");
-
-        x("1 1 + string_distinct_agg", "string_distinct_agg(1+1)");
-        x("1 1 + string_distinct_agg", "string_agg(distinct 1+1)");
-
-        x("bar foo string_distinct_agg", "string_distinct_agg(foo(bar))");
-        x("bar foo string_distinct_agg", "string_agg(distinct foo(bar))");
-
-        x("bar foo string_distinct_agg varchar cast", "cast (string_distinct_agg(foo(bar)) as varchar)");
-        x("bar foo string_distinct_agg varchar cast", "cast (string_agg(distinct foo(bar)) as varchar)");
-
-        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
-        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
-        x("distinct string_agg varchar cast", "cast (string_agg(distinct) as varchar)");
-        // check it works even if quoted
-        x("distinct string_agg varchar cast", "cast (string_agg(\"distinct\") as varchar)");
-        // it works with multiple arguments too
-        x("distinct foo string_agg", "string_agg(\"distinct\", foo)");
-        // not written when string_agg is not a function
-        x("string_agg distinct foo", "foo(string_agg, distinct)");
-        x("distinctnot string_agg", "string_agg(distinctnot)");
-        x("bar string_agg distinct foo", "foo(bar, string_agg, distinct)");
-        x("string_agg bar distinct foo", "foo(bar(string_agg), distinct)");
-
-        assertFail("string_agg(distinct ", 11, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
-        assertFail("notcount(distinct foo)", 18, "dangling literal");
-    }
-
-    @Test
     public void testCaseWithOuterBraces() throws SqlException {
         x("10  w1 1 + 10 = 'th1' w2 3 * 1 > 'th2' 0 case 1 + *",
                 "10*(case" +
@@ -624,6 +561,38 @@ public class ExpressionParserTest extends AbstractCairoTest {
         x("1 2 | 3 in", "1 | 2 IN 3");
         x("1 1 in not true =", "1 not in (1) = true");
         x("a b ^ c ^", "a^b^c");
+    }
+
+    @Test
+    public void testCountDistinctRewrites() throws SqlException {
+        x("foo count_distinct", "count_distinct(foo)");
+        x("foo count_distinct", "count(distinct foo)");
+
+        x("1 1 + count_distinct", "count_distinct(1+1)");
+        x("1 1 + count_distinct", "count(distinct 1+1)");
+
+        x("bar foo count_distinct", "count_distinct(foo(bar))");
+        x("bar foo count_distinct", "count(distinct foo(bar))");
+
+        x("bar foo count_distinct varchar cast", "cast (count_distinct(foo(bar)) as varchar)");
+        x("bar foo count_distinct varchar cast", "cast (count(distinct foo(bar)) as varchar)");
+
+        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
+        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
+        x("distinct count varchar cast", "cast (count(distinct) as varchar)");
+        // check it works even if quoted
+        x("distinct count varchar cast", "cast (count(\"distinct\") as varchar)");
+        // it works with multiple arguments too
+        x("distinct foo count", "count(\"distinct\", foo)");
+        // not written when count is not a function
+        x("count distinct foo", "foo(count, distinct)");
+        x("distinctnot count", "count(distinctnot)");
+        x("bar count distinct foo", "foo(bar, count, distinct)");
+        x("count bar distinct foo", "foo(bar(count), distinct)");
+
+        assertFail("count(distinct *)", 6, "count(distinct *) is not supported");
+        assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
+        assertFail("notcount(distinct foo)", 18, "dangling literal");
     }
 
     @Test
@@ -1198,6 +1167,42 @@ public class ExpressionParserTest extends AbstractCairoTest {
     @Test
     public void testSimpleLiteralExit() throws Exception {
         x("a", "a lit");
+    }
+
+    @Test
+    public void testStringAggDistinctRewrites() throws SqlException {
+        x("foo string_distinct_agg", "string_distinct_agg(foo)");
+        x("foo string_distinct_agg", "string_agg(distinct foo)");
+
+        x("1 1 + string_distinct_agg", "string_distinct_agg(1+1)");
+        x("1 1 + string_distinct_agg", "string_agg(distinct 1+1)");
+
+        x("bar foo string_distinct_agg", "string_distinct_agg(foo(bar))");
+        x("bar foo string_distinct_agg", "string_agg(distinct foo(bar))");
+
+        x("bar foo string_distinct_agg varchar cast", "cast (string_distinct_agg(foo(bar)) as varchar)");
+        x("bar foo string_distinct_agg varchar cast", "cast (string_agg(distinct foo(bar)) as varchar)");
+
+        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
+        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
+        x("distinct string_agg varchar cast", "cast (string_agg(distinct) as varchar)");
+        // check it works even if quoted
+        x("distinct string_agg varchar cast", "cast (string_agg(\"distinct\") as varchar)");
+        // it works with multiple arguments too
+        x("distinct foo string_agg", "string_agg(\"distinct\", foo)");
+        // not written when string_agg is not a function
+        x("string_agg distinct foo", "foo(string_agg, distinct)");
+        x("distinctnot string_agg", "string_agg(distinctnot)");
+        x("bar string_agg distinct foo", "foo(bar, string_agg, distinct)");
+        x("string_agg bar distinct foo", "foo(bar(string_agg), distinct)");
+
+        assertFail("string_agg(distinct ", 11, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
+        assertFail("notcount(distinct foo)", 18, "dangling literal");
+    }
+
+    @Test
+    public void testStringAggDistinct_orderByNotSupported() throws SqlException {
+        assertFail("string_agg(distinct foo, ',' order by bar)", 29, "ORDER BY not supported for string_distinct_agg");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -591,8 +591,12 @@ public class ExpressionParserTest extends AbstractCairoTest {
         assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
         assertFail("notcount(distinct foo)", 18, "dangling literal");
         assertFail("count(distinct(foo, bar))", 23, "count distinct aggregation supports a single column only");
+        assertFail("count(DISTINCT(foo, bar))", 23, "count distinct aggregation supports a single column only");
+        assertFail("count(distinct (foo, bar))", 24, "count distinct aggregation supports a single column only"); // with an extra space
+        assertFail("count(DiSTiNcT (foo, bar))", 24, "count distinct aggregation supports a single column only"); // with an extra space
         assertFail("count(distinct(foo, bar, foobar))", 31, "count distinct aggregation supports a single column only");
         assertFail("count(distinct(foo, bar, foobar, 1+1))", 36, "count distinct aggregation supports a single column only");
+        assertFail("count(Distinct(foo, bar, foobar, 1+1))", 36, "count distinct aggregation supports a single column only");
         assertFail("count(distinct))", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -359,6 +359,69 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCountDistinctRewrites() throws SqlException {
+        x("foo count_distinct", "count_distinct(foo)");
+        x("foo count_distinct", "count(distinct foo)");
+
+        x("1 1 + count_distinct", "count_distinct(1+1)");
+        x("1 1 + count_distinct", "count(distinct 1+1)");
+
+        x("bar foo count_distinct", "count_distinct(foo(bar))");
+        x("bar foo count_distinct", "count(distinct foo(bar))");
+
+        x("bar foo count_distinct varchar cast", "cast (count_distinct(foo(bar)) as varchar)");
+        x("bar foo count_distinct varchar cast", "cast (count(distinct foo(bar)) as varchar)");
+
+        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
+        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
+        x("distinct count varchar cast", "cast (count(distinct) as varchar)");
+        // check it works even if quoted
+        x("distinct count varchar cast", "cast (count(\"distinct\") as varchar)");
+        // it works with multiple arguments too
+        x("distinct foo count", "count(\"distinct\", foo)");
+        // not written when count is not a function
+        x("count distinct foo", "foo(count, distinct)");
+        x("distinctnot count", "count(distinctnot)");
+        x("bar count distinct foo", "foo(bar, count, distinct)");
+        x("count bar distinct foo", "foo(bar(count), distinct)");
+
+        assertFail("count(distinct *)", 6, "count(distinct *) is not supported");
+        assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
+        assertFail("notcount(distinct foo)", 18, "dangling literal");
+    }
+
+    @Test
+    public void testStringAggDistinctRewrites() throws SqlException {
+        x("foo string_distinct_agg", "string_distinct_agg(foo)");
+        x("foo string_distinct_agg", "string_agg(distinct foo)");
+
+        x("1 1 + string_distinct_agg", "string_distinct_agg(1+1)");
+        x("1 1 + string_distinct_agg", "string_agg(distinct 1+1)");
+
+        x("bar foo string_distinct_agg", "string_distinct_agg(foo(bar))");
+        x("bar foo string_distinct_agg", "string_agg(distinct foo(bar))");
+
+        x("bar foo string_distinct_agg varchar cast", "cast (string_distinct_agg(foo(bar)) as varchar)");
+        x("bar foo string_distinct_agg varchar cast", "cast (string_agg(distinct foo(bar)) as varchar)");
+
+        // 'distinct' on its own is treated as a column name. technically, it should have been in double quotes
+        // since it is a reserved word. but that's a compatibility issue. so let's check it's not rewritten
+        x("distinct string_agg varchar cast", "cast (string_agg(distinct) as varchar)");
+        // check it works even if quoted
+        x("distinct string_agg varchar cast", "cast (string_agg(\"distinct\") as varchar)");
+        // it works with multiple arguments too
+        x("distinct foo string_agg", "string_agg(\"distinct\", foo)");
+        // not written when string_agg is not a function
+        x("string_agg distinct foo", "foo(string_agg, distinct)");
+        x("distinctnot string_agg", "string_agg(distinctnot)");
+        x("bar string_agg distinct foo", "foo(bar, string_agg, distinct)");
+        x("string_agg bar distinct foo", "foo(bar(string_agg), distinct)");
+
+        assertFail("string_agg(distinct ", 11, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
+        assertFail("notcount(distinct foo)", 18, "dangling literal");
+    }
+
+    @Test
     public void testCaseWithOuterBraces() throws SqlException {
         x("10  w1 1 + 10 = 'th1' w2 3 * 1 > 'th2' 0 case 1 + *",
                 "10*(case" +

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -593,6 +593,9 @@ public class ExpressionParserTest extends AbstractCairoTest {
         assertFail("count(distinct *)", 6, "count(distinct *) is not supported");
         assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
         assertFail("notcount(distinct foo)", 18, "dangling literal");
+        assertFail("count(distinct(foo, bar))", 23, "count distinct aggregation supports a single column only");
+        assertFail("count(distinct(foo, bar, foobar))", 31, "count distinct aggregation supports a single column only");
+        assertFail("count(distinct(foo, bar, foobar, 1+1))", 36, "count distinct aggregation supports a single column only");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -2392,17 +2392,18 @@ public class GroupByTest extends AbstractCairoTest {
 
     @Test
     public void testNestedGroupByWithExplicitGroupByClause() throws Exception {
+        String expected = "url\tu_count\tcnt\tavg_m_sum\n" +
+                "RXPEHNRXGZ\t4\t4\t414.25\n" +
+                "DXYSBEOUOJ\t1\t1\t225.0\n" +
+                "SXUXIBBTGP\t2\t2\t379.5\n" +
+                "GWFFYUDEYY\t5\t5\t727.2\n" +
+                "LOFJGETJRS\t2\t2\t524.5\n" +
+                "ZSRYRFBVTM\t2\t2\t337.0\n" +
+                "VTJWCPSWHY\t1\t1\t660.0\n" +
+                "HGOOZZVDZJ\t1\t1\t540.0\n" +
+                "SHRUEDRQQU\t2\t2\t468.0\n";
         assertQuery(
-                "url\tu_count\tcnt\tavg_m_sum\n" +
-                        "RXPEHNRXGZ\t4\t4\t414.25\n" +
-                        "DXYSBEOUOJ\t1\t1\t225.0\n" +
-                        "SXUXIBBTGP\t2\t2\t379.5\n" +
-                        "GWFFYUDEYY\t5\t5\t727.2\n" +
-                        "LOFJGETJRS\t2\t2\t524.5\n" +
-                        "ZSRYRFBVTM\t2\t2\t337.0\n" +
-                        "VTJWCPSWHY\t1\t1\t660.0\n" +
-                        "HGOOZZVDZJ\t1\t1\t540.0\n" +
-                        "SHRUEDRQQU\t2\t2\t468.0\n",
+                expected,
                 "WITH x_sample AS (\n" +
                         "  SELECT id, uuid, url, sum(metric) m_sum\n" +
                         "  FROM x\n" +
@@ -2423,6 +2424,16 @@ public class GroupByTest extends AbstractCairoTest {
                 true,
                 true
         );
+        assertSql(expected,
+                "WITH x_sample AS (\n" +
+                        "  SELECT id, uuid, url, sum(metric) m_sum\n" +
+                        "  FROM x\n" +
+                        "  WHERE ts >= '1023-03-31T00:00:00' and ts <= '2023-04-02T23:59:59'\n" +
+                        "  GROUP BY id, uuid, url\n" +
+                        ")\n" +
+                        "SELECT url, count(distinct uuid) u_count, count() cnt, avg(m_sum) avg_m_sum\n" +
+                        "FROM x_sample\n" +
+                        "GROUP BY url");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -2141,9 +2141,10 @@ public class IPv4Test extends AbstractCairoTest {
 
     @Test
     public void testIPv4CountDistinct() throws Exception {
+        String expected = "count_distinct\n" +
+                "20\n";
         assertQuery(
-                "count_distinct\n" +
-                        "20\n",
+                expected,
                 "select count_distinct(ip) from test",
                 "create table test as " +
                         "(" +
@@ -2157,6 +2158,7 @@ public class IPv4Test extends AbstractCairoTest {
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct ip) from test");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -25,7 +25,11 @@
 package io.questdb.test.griffin;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableReader;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
@@ -7649,9 +7653,15 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                     ") timestamp(ts) partition by DAY");
 
             // we need have more partitions than maxOpenPartitions for this test
+            String expected = "count_distinct\n" +
+                    "6\n";
             assertSql(
-                    "count_distinct\n" +
-                            "6\n", "select count_distinct(timestamp_floor('d', ts)) from x"
+                    expected,
+                    "select count_distinct(timestamp_floor('d', ts)) from x"
+            );
+            assertSql(
+                    expected,
+                    "select count(distinct timestamp_floor('d', ts)) from x"
             );
 
             for (int i = 0; i < 10; i++) {

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -396,32 +396,46 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
         assertMemoryLeak(() -> {
             ddl("create table y (x long, ts timestamp) timestamp(ts);");
             ddl("create table y1 (x long, ts timestamp) timestamp(ts);");
-            final String query = "select * from y \n" +
+            final String queryA = "select * from y \n" +
                     "inner join (select count_distinct(x) c from y1) as y1 \n" +
                     "on y.x = y1.c";
-            final QueryModel model = compileModel(query);
+            final String queryB = "select * from y \n" +
+                    "inner join (select count(distinct x) c from y1) as y1 \n" +
+                    "on y.x = y1.c";
+
+            String expectedModel = "select-choose y.x x, y.ts ts, y1.c c from (select [x, ts] from y timestamp (ts) " +
+                    "join select [c] from (select-group-by [count() c] count() c from (select-group-by x from " +
+                    "(select [x] from y1 timestamp (ts) where null != x))) y1 on y1.c = y.x)";
             assertEquals(
-                    "select-choose y.x x, y.ts ts, y1.c c from (select [x, ts] from y timestamp (ts) " +
-                            "join select [c] from (select-group-by [count() c] count() c from (select-group-by x from " +
-                            "(select [x] from y1 timestamp (ts) where null != x))) y1 on y1.c = y.x)",
-                    model.toString0()
+                    expectedModel,
+                    compileModel(queryA).toString0()
+            );
+            assertEquals(
+                    expectedModel,
+                    compileModel(queryB).toString0()
+            );
+
+            String expectedPlan = "SelectedRecord\n" +
+                    "    Hash Join\n" +
+                    "      condition: y1.c=y.x\n" +
+                    "        PageFrame\n" +
+                    "            Row forward scan\n" +
+                    "            Frame forward scan on: y\n" +
+                    "        Hash\n" +
+                    "            Count\n" +
+                    "                Async JIT Group By workers: 1\n" +
+                    "                  keys: [x]\n" +
+                    "                  filter: x!=null\n" +
+                    "                    PageFrame\n" +
+                    "                        Row forward scan\n" +
+                    "                        Frame forward scan on: y1\n";
+            assertPlanNoLeakCheck(
+                    queryA,
+                    expectedPlan
             );
             assertPlanNoLeakCheck(
-                    query,
-                    "SelectedRecord\n" +
-                            "    Hash Join\n" +
-                            "      condition: y1.c=y.x\n" +
-                            "        PageFrame\n" +
-                            "            Row forward scan\n" +
-                            "            Frame forward scan on: y\n" +
-                            "        Hash\n" +
-                            "            Count\n" +
-                            "                Async JIT Group By workers: 1\n" +
-                            "                  keys: [x]\n" +
-                            "                  filter: x!=null\n" +
-                            "                    PageFrame\n" +
-                            "                        Row forward scan\n" +
-                            "                        Frame forward scan on: y1\n"
+                    queryB,
+                    expectedPlan
             );
         });
     }
@@ -3537,21 +3551,27 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
     public void testSingleCountDistinct() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table y (x int, ts timestamp) timestamp(ts) partition by day;");
-            final String query = "select count_distinct(x) from y;";
-            final QueryModel model = compileModel(query);
+            final String queryA = "select count_distinct(x) from y;";
+            final String queryB = "select count(distinct x) from y;";
+            String expectedModel = "select-group-by count() count_distinct from (select-group-by x from (select [x] from y timestamp (ts) where null != x))";
             assertEquals(
-                    "select-group-by count() count_distinct from (select-group-by x from (select [x] from y timestamp (ts) where null != x))",
-                    model.toString0()
+                    expectedModel,
+                    compileModel(queryA).toString0()
+            );
+            String expectedPlan = "Count\n" +
+                    "    Async JIT Group By workers: 1\n" +
+                    "      keys: [x]\n" +
+                    "      filter: x!=null\n" +
+                    "        PageFrame\n" +
+                    "            Row forward scan\n" +
+                    "            Frame forward scan on: y\n";
+            assertPlanNoLeakCheck(
+                    queryA,
+                    expectedPlan
             );
             assertPlanNoLeakCheck(
-                    query,
-                    "Count\n" +
-                            "    Async JIT Group By workers: 1\n" +
-                            "      keys: [x]\n" +
-                            "      filter: x!=null\n" +
-                            "        PageFrame\n" +
-                            "            Row forward scan\n" +
-                            "            Frame forward scan on: y\n"
+                    queryB,
+                    expectedPlan
             );
         });
     }
@@ -3603,31 +3623,41 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
     public void testUnionQueryOnSingleCountDistinct() throws Exception {
         assertMemoryLeak(() -> {
             ddl("create table y (x int, z int);");
-            final String query = "select count_distinct(x) from y union select count_distinct(z) from y;";
-            final QueryModel model = compileModel(query);
+            final String queryA = "select count_distinct(x) from y union select count_distinct(z) from y;";
+            final String queryB = "select count(distinct x) from y union select count_distinct(z) from y;";
+            String expectedModel = "select-group-by [count() count_distinct] count() count_distinct from (select-group-by x from (select [x] from y where null != x)) " +
+                    "union " +
+                    "select-group-by [count() count_distinct] count() count_distinct from (select-group-by z from (select [z] from y where null != z))";
             assertEquals(
-                    "select-group-by [count() count_distinct] count() count_distinct from (select-group-by x from (select [x] from y where null != x)) " +
-                            "union " +
-                            "select-group-by [count() count_distinct] count() count_distinct from (select-group-by z from (select [z] from y where null != z))",
-                    model.toString0()
+                    expectedModel,
+                    compileModel(queryA).toString0()
+            );
+            assertEquals(
+                    expectedModel,
+                    compileModel(queryB).toString0()
+            );
+            String expectedPlan = "Union\n" +
+                    "    Count\n" +
+                    "        Async JIT Group By workers: 1\n" +
+                    "          keys: [x]\n" +
+                    "          filter: x!=null\n" +
+                    "            PageFrame\n" +
+                    "                Row forward scan\n" +
+                    "                Frame forward scan on: y\n" +
+                    "    Count\n" +
+                    "        Async JIT Group By workers: 1\n" +
+                    "          keys: [z]\n" +
+                    "          filter: z!=null\n" +
+                    "            PageFrame\n" +
+                    "                Row forward scan\n" +
+                    "                Frame forward scan on: y\n";
+            assertPlanNoLeakCheck(
+                    queryA,
+                    expectedPlan
             );
             assertPlanNoLeakCheck(
-                    query,
-                    "Union\n" +
-                            "    Count\n" +
-                            "        Async JIT Group By workers: 1\n" +
-                            "          keys: [x]\n" +
-                            "          filter: x!=null\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: y\n" +
-                            "    Count\n" +
-                            "        Async JIT Group By workers: 1\n" +
-                            "          keys: [z]\n" +
-                            "          filter: z!=null\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: y\n"
+                    queryB,
+                    expectedPlan
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/UuidTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UuidTest.java
@@ -227,12 +227,16 @@ public class UuidTest extends AbstractCairoTest {
             insert("insert into x values (1, cast('33333333-3333-3333-3333-333333333333' as varchar))");
             insert("insert into x values (1, cast('33333333-3333-3333-3333-333333333333' as varchar))");
 
-
+            String expected = "i\tcount_distinct\n" +
+                    "0\t2\n" +
+                    "1\t1\n";
             assertSql(
-                    "i\tcount_distinct\n" +
-                            "0\t2\n" +
-                            "1\t1\n",
+                    expected,
                     "select i, count_distinct(u) from x group by i order by i"
+            );
+            assertSql(
+                    expected,
+                    "select i, count(distinct u) from x group by i order by i"
             );
         });
     }
@@ -266,11 +270,16 @@ public class UuidTest extends AbstractCairoTest {
             insert("insert into x values (1, '33333333-3333-3333-3333-333333333333')");
             insert("insert into x values (1, '33333333-3333-3333-3333-333333333333')");
 
+            String expected = "i\tcount_distinct\n" +
+                    "0\t2\n" +
+                    "1\t1\n";
             assertSql(
-                    "i\tcount_distinct\n" +
-                            "0\t2\n" +
-                            "1\t1\n",
+                    expected,
                     "select i, count_distinct(u) from x group by i order by i"
+            );
+            assertSql(
+                    expected,
+                    "select i, count(distinct u) from x group by i order by i"
             );
         });
     }
@@ -285,10 +294,15 @@ public class UuidTest extends AbstractCairoTest {
             insert("insert into x values (1, '33333333-3333-3333-3333-333333333333')");
             insert("insert into x values (1, '33333333-3333-3333-3333-333333333333')");
 
+            String expected = "count_distinct\n" +
+                    "3\n";
             assertSql(
-                    "count_distinct\n" +
-                            "3\n",
+                    expected,
                     "select count_distinct(u) from x"
+            );
+            assertSql(
+                    expected,
+                    "select count(distinct u) from x"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunctionFactoryTest.java
@@ -49,14 +49,17 @@ public class ApproxCountDistinctIntGroupByFunctionFactoryTest extends AbstractCa
         assertMemoryLeak(() -> {
             compile("create table x as (select * from (select rnd_int(1, 1000000, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(1000000)) timestamp(ts))");
 
+            String expected = "count_distinct\n" +
+                    "631884\n";
             assertQueryNoLeakCheck(
-                    "count_distinct\n" +
-                            "631884\n",
+                    expected,
                     "select count_distinct(s) from x",
                     null,
                     false,
                     true
             );
+
+            assertSql(expected, "select count(  distinct s) from x");
 
             long[] expectedEstimates = new long[]{
                     501129L,

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
@@ -31,30 +31,37 @@ public class CountDistinctIntGroupByFunctionFactoryTest extends AbstractCairoTes
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
+
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(42) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+
+        assertSql(expected, "select a, count(distinct 42) from x order by a");
     }
 
     @Test
     public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        String expected = "count_distinct\n" +
+                "1\n";
         assertQuery(
-                "count_distinct\n" +
-                        "1\n",
+                expected,
                 "select count_distinct(l) from x",
                 "create table x as (select -1::int as l from long_sequence(10))",
                 null,
                 false,
                 true
         );
+
+        assertSql(expected, "select count(distinct l) from x");
     }
 
     @Test
@@ -72,41 +79,53 @@ public class CountDistinctIntGroupByFunctionFactoryTest extends AbstractCairoTes
                     true,
                     true
             );
+            assertSql(expected, "select a, count(distinct s * 42) from x order by a");
+
             // multiplication shouldn't affect the number of distinct values,
             // so the result should stay the same
             assertSql(expected, "select a, count_distinct(s) from x order by a");
+            assertSql(expected, "select a, count(distinct s) from x order by a");
+
         });
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t2\n" +
+                "b\t1\n" +
+                "c\t2\n" +
+                "d\t4\n" +
+                "e\t4\n" +
+                "f\t4\n";
+
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t2\n" +
-                        "b\t1\n" +
-                        "c\t2\n" +
-                        "d\t4\n" +
-                        "e\t4\n" +
-                        "f\t4\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_int(0, 16, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
+
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select rnd_int(1, 6, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
@@ -122,102 +141,122 @@ public class CountDistinctIntGroupByFunctionFactoryTest extends AbstractCairoTes
                     false,
                     true
             );
+            assertSql(expected, "select count(distinct s) from x");
 
             insert("insert into x values(cast(null as INT), '2021-05-21')");
             insert("insert into x values(cast(null as INT), '1970-01-01')");
             assertSql(expected, "select count_distinct(s) from x");
+            assertSql(expected, "select count(distinct s) from x");
         });
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(cast(null as INT)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+
+        assertSql(expected, "select a, count(distinct cast(null as INT)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t8\n" +
+                "1970-01-01T00:00:01.000000Z\t9\n" +
+                "1970-01-01T00:00:02.000000Z\t9\n" +
+                "1970-01-01T00:00:03.000000Z\t9\n" +
+                "1970-01-01T00:00:04.000000Z\t8\n" +
+                "1970-01-01T00:00:05.000000Z\t9\n" +
+                "1970-01-01T00:00:06.000000Z\t10\n" +
+                "1970-01-01T00:00:07.000000Z\t7\n" +
+                "1970-01-01T00:00:08.000000Z\t8\n" +
+                "1970-01-01T00:00:09.000000Z\t7\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t8\n" +
-                        "1970-01-01T00:00:01.000000Z\t9\n" +
-                        "1970-01-01T00:00:02.000000Z\t9\n" +
-                        "1970-01-01T00:00:03.000000Z\t9\n" +
-                        "1970-01-01T00:00:04.000000Z\t8\n" +
-                        "1970-01-01T00:00:05.000000Z\t9\n" +
-                        "1970-01-01T00:00:06.000000Z\t10\n" +
-                        "1970-01-01T00:00:07.000000Z\t7\n" +
-                        "1970-01-01T00:00:08.000000Z\t8\n" +
-                        "1970-01-01T00:00:09.000000Z\t7\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select rnd_int(0, 16, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     @Test
     public void testSampleFillNone() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.050000Z\t8\n" +
-                        "1970-01-01T00:00:02.050000Z\t8\n",
-                "with x as (select * from (select rnd_int(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(150)) timestamp(ts))\n" +
-                        "select ts, count_distinct(s) from x sample by 2s align to first observation"
-        ));
+        assertMemoryLeak(() -> {
+            String expected = "ts\tcount_distinct\n" +
+                    "1970-01-01T00:00:00.050000Z\t8\n" +
+                    "1970-01-01T00:00:02.050000Z\t8\n";
+            assertSql(
+                    expected,
+                    "with x as (select * from (select rnd_int(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(150)) timestamp(ts))\n" +
+                            "select ts, count_distinct(s) from x sample by 2s align to first observation"
+            );
+
+            assertSql(
+                    expected,
+                    "with x as (select * from (select rnd_int(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(150)) timestamp(ts))\n" +
+                            "select ts, count(distinct s) from x sample by 2s align to first observation"
+            );
+        });
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t8\n" +
+                "1970-01-01T00:00:01.000000Z\t6\n" +
+                "1970-01-01T00:00:02.000000Z\t7\n" +
+                "1970-01-01T00:00:03.000000Z\t8\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t7\n" +
+                "1970-01-01T00:00:06.000000Z\t7\n" +
+                "1970-01-01T00:00:07.000000Z\t6\n" +
+                "1970-01-01T00:00:08.000000Z\t7\n" +
+                "1970-01-01T00:00:09.000000Z\t5\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t8\n" +
-                        "1970-01-01T00:00:01.000000Z\t6\n" +
-                        "1970-01-01T00:00:02.000000Z\t7\n" +
-                        "1970-01-01T00:00:03.000000Z\t8\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t7\n" +
-                        "1970-01-01T00:00:06.000000Z\t7\n" +
-                        "1970-01-01T00:00:07.000000Z\t6\n" +
-                        "1970-01-01T00:00:08.000000Z\t7\n" +
-                        "1970-01-01T00:00:09.000000Z\t5\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select rnd_int(0, 8, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "a\t5\t1970-01-01T00:00:00.000000Z\n" +
+                "f\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t9\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t7\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t5\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t5\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "e\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "d\t7\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t4\t1970-01-01T00:00:05.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "a\t5\t1970-01-01T00:00:00.000000Z\n" +
-                        "f\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t9\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t7\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t5\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t5\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "e\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "d\t7\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t4\t1970-01-01T00:00:05.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 5s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_int(0, 12, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 5s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctIntGroupByFunctionFactoryTest.java
@@ -65,6 +65,21 @@ public class CountDistinctIntGroupByFunctionFactoryTest extends AbstractCairoTes
     }
 
     @Test
+    public void testCountDistinctMultipleColNotSupported() throws Exception {
+        assertException(
+                "select count(distinct(x::varchar, x+1::varchar)) from long_sequence(1)",
+                46,
+                "count distinct aggregation supports a single column only"
+        );
+
+        assertException(
+                "select count(distinct(x::varchar, foo(bar))) from long_sequence(1)",
+                42,
+                "count distinct aggregation supports a single column only"
+        );
+    }
+
+    @Test
     public void testExpression() throws Exception {
         assertMemoryLeak(() -> {
             final String expected = "a\tcount_distinct\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunctionFactoryTest.java
@@ -31,30 +31,37 @@ public class CountDistinctLong256GroupByFunctionFactoryTest extends AbstractCair
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
+
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(to_long256(42L, 42L, 42L, 42L)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+
+        assertSql(expected, "select a, count(distinct to_long256(42L, 42L, 42L, 42L)) from x order by a");
     }
 
     @Test
     public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        String expected = "count_distinct\n" +
+                "1\n";
+
         assertQuery(
-                "count_distinct\n" +
-                        "1\n",
+                expected,
                 "select count_distinct(to_long256(l, l, l, l)) from x",
                 "create table x as (select -1::long as l from long_sequence(10))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct to_long256(l, l, l, l)) from x");
     }
 
     @Test
@@ -72,41 +79,48 @@ public class CountDistinctLong256GroupByFunctionFactoryTest extends AbstractCair
                     true,
                     true
             );
+            assertSql(expected, "select a, count(distinct to_long256(s*42, s*42, s*42, s*42)) from x order by a");
+
             // multiplication shouldn't affect the number of distinct values,
             // so the result should stay the same
             assertSql(expected, "select a, count_distinct(s) from x order by a");
+            assertSql(expected, "select a, count(distinct s) from x order by a");
         });
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t2\n" +
+                "b\t1\n" +
+                "c\t1\n" +
+                "d\t4\n" +
+                "e\t4\n" +
+                "f\t3\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t2\n" +
-                        "b\t1\n" +
-                        "c\t1\n" +
-                        "d\t4\n" +
-                        "e\t4\n" +
-                        "f\t3\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, to_long256(rnd_long(0, 16, 0), 0, 0, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select to_long256(rnd_long(1, 6, 0), 0, 0, 0) s, timestamp_sequence(0, 1000) ts from long_sequence(1000)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
@@ -122,10 +136,12 @@ public class CountDistinctLong256GroupByFunctionFactoryTest extends AbstractCair
                     false,
                     true
             );
+            assertSql(expected, "select count(distinct s) from x");
 
             insert("insert into x values(cast(null as long256), '2021-05-21')");
             insert("insert into x values(cast(null as long256), '1970-01-01')");
             assertSql(expected, "select count_distinct(s) from x");
+            assertSql(expected, "select count(distinct s) from x");
         });
     }
 
@@ -144,100 +160,114 @@ public class CountDistinctLong256GroupByFunctionFactoryTest extends AbstractCair
             insert("insert into x values ('a', to_long256(5, 0, 5, 5), '2021-05-21'), ('a', to_long256(5, 0, 5, 5), '2021-05-21'), ('a', to_long256(5, null, 5, 5), '2021-05-21'), ('a', to_long256(0, 5, 5, 5), '2021-05-21'), ('a', to_long256(null, 5, 5, 5), '2021-05-21')"
                     + ", ('a', to_long256(5, 5, 0, 5), '2021-05-21'), ('a', to_long256(5, 5, null, 5), '2021-05-21'), ('a', to_long256(5, 5, 5, 0), '2021-05-21'), ('a', to_long256(5, 5, 5, null), '2021-05-21')" +
                     ", ('a', to_long256(0, 0, 0, 0), '2021-05-21'), ('a', to_long256(null, null, null, null), '2021-05-21')");
-            assertSql("a\ts\n" +
-                    "a\t9\n", "select a, count_distinct(s) as s from x order by a");
+            String expected = "a\ts\n" +
+                    "a\t9\n";
+            assertSql(expected, "select a, count_distinct(s) as s from x order by a");
+            assertSql(expected, "select a, count(distinct s) as s from x order by a");
         });
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(to_long256(null, null, null, null)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct to_long256(null, null, null, null)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t9\n" +
+                "1970-01-01T00:00:01.000000Z\t7\n" +
+                "1970-01-01T00:00:02.000000Z\t7\n" +
+                "1970-01-01T00:00:03.000000Z\t8\n" +
+                "1970-01-01T00:00:04.000000Z\t8\n" +
+                "1970-01-01T00:00:05.000000Z\t8\n" +
+                "1970-01-01T00:00:06.000000Z\t7\n" +
+                "1970-01-01T00:00:07.000000Z\t8\n" +
+                "1970-01-01T00:00:08.000000Z\t7\n" +
+                "1970-01-01T00:00:09.000000Z\t9\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t9\n" +
-                        "1970-01-01T00:00:01.000000Z\t7\n" +
-                        "1970-01-01T00:00:02.000000Z\t7\n" +
-                        "1970-01-01T00:00:03.000000Z\t8\n" +
-                        "1970-01-01T00:00:04.000000Z\t8\n" +
-                        "1970-01-01T00:00:05.000000Z\t8\n" +
-                        "1970-01-01T00:00:06.000000Z\t7\n" +
-                        "1970-01-01T00:00:07.000000Z\t8\n" +
-                        "1970-01-01T00:00:08.000000Z\t7\n" +
-                        "1970-01-01T00:00:09.000000Z\t9\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select to_long256(rnd_long(0, 16, 0), 0, 0, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     @Test
     public void testSampleFillNone() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.050000Z\t8\n" +
-                        "1970-01-01T00:00:02.050000Z\t8\n",
-                "with x as (select * from (select to_long256(rnd_long(1, 8, 0), 0, 0, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
-                        "select ts, count_distinct(s) from x sample by 2s align to first observation"
-        ));
+        assertMemoryLeak(() -> {
+            String expected = "ts\tcount_distinct\n" +
+                    "1970-01-01T00:00:00.050000Z\t8\n" +
+                    "1970-01-01T00:00:02.050000Z\t8\n";
+
+            assertSql(expected, "with x as (select * from (select to_long256(rnd_long(1, 8, 0), 0, 0, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                    "select ts, count_distinct(s) from x sample by 2s align to first observation"
+            );
+            assertSql(expected, "with x as (select * from (select to_long256(rnd_long(1, 8, 0), 0, 0, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                    "select ts, count(distinct s) from x sample by 2s align to first observation");
+        });
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t5\n" +
+                "1970-01-01T00:00:01.000000Z\t8\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t7\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t5\n" +
+                "1970-01-01T00:00:06.000000Z\t6\n" +
+                "1970-01-01T00:00:07.000000Z\t6\n" +
+                "1970-01-01T00:00:08.000000Z\t6\n" +
+                "1970-01-01T00:00:09.000000Z\t7\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t5\n" +
-                        "1970-01-01T00:00:01.000000Z\t8\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t7\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t5\n" +
-                        "1970-01-01T00:00:06.000000Z\t6\n" +
-                        "1970-01-01T00:00:07.000000Z\t6\n" +
-                        "1970-01-01T00:00:08.000000Z\t6\n" +
-                        "1970-01-01T00:00:09.000000Z\t7\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select to_long256(rnd_long(0, 8, 0), 0, 0, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "a\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "f\t9\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t5\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t4\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t7\t1970-01-01T00:00:05.000000Z\n" +
+                "e\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "d\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t5\t1970-01-01T00:00:05.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "a\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "f\t9\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t5\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t4\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t7\t1970-01-01T00:00:05.000000Z\n" +
-                        "e\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "d\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t5\t1970-01-01T00:00:05.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 5s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, to_long256(rnd_long(0, 12, 0), 0, 0, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 5s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLongGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctLongGroupByFunctionFactoryTest.java
@@ -31,30 +31,34 @@ public class CountDistinctLongGroupByFunctionFactoryTest extends AbstractCairoTe
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(42L) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct 42L) from x order by a");
     }
 
     @Test
     public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        String expected = "count_distinct\n" +
+                "1\n";
         assertQuery(
-                "count_distinct\n" +
-                        "1\n",
+                expected,
                 "select count_distinct(l) from x",
                 "create table x as (select -1::long as l from long_sequence(10))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct l) from x");
     }
 
     @Test
@@ -72,41 +76,48 @@ public class CountDistinctLongGroupByFunctionFactoryTest extends AbstractCairoTe
                     true,
                     true
             );
+            assertSql(expected, "select a, count(distinct s * 42) from x order by a");
+
             // multiplication shouldn't affect the number of distinct values,
             // so the result should stay the same
             assertSql(expected, "select a, count_distinct(s) from x order by a");
+            assertSql(expected, "select a, count(distinct s) from x order by a");
         });
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t2\n" +
+                "b\t1\n" +
+                "c\t1\n" +
+                "d\t4\n" +
+                "e\t4\n" +
+                "f\t3\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t2\n" +
-                        "b\t1\n" +
-                        "c\t1\n" +
-                        "d\t4\n" +
-                        "e\t4\n" +
-                        "f\t3\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_long(0, 16, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select rnd_long(1, 6, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
@@ -122,102 +133,117 @@ public class CountDistinctLongGroupByFunctionFactoryTest extends AbstractCairoTe
                     false,
                     true
             );
+            assertSql(expected, "select count(distinct s) from x");
 
             insert("insert into x values(cast(null as LONG), '2021-05-21')");
             insert("insert into x values(cast(null as LONG), '1970-01-01')");
             assertSql(expected, "select count_distinct(s) from x");
+            assertSql(expected, "select count(distinct s) from x");
         });
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(cast(null as LONG)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct cast(null as LONG)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t9\n" +
+                "1970-01-01T00:00:01.000000Z\t7\n" +
+                "1970-01-01T00:00:02.000000Z\t7\n" +
+                "1970-01-01T00:00:03.000000Z\t8\n" +
+                "1970-01-01T00:00:04.000000Z\t8\n" +
+                "1970-01-01T00:00:05.000000Z\t8\n" +
+                "1970-01-01T00:00:06.000000Z\t7\n" +
+                "1970-01-01T00:00:07.000000Z\t8\n" +
+                "1970-01-01T00:00:08.000000Z\t7\n" +
+                "1970-01-01T00:00:09.000000Z\t9\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t9\n" +
-                        "1970-01-01T00:00:01.000000Z\t7\n" +
-                        "1970-01-01T00:00:02.000000Z\t7\n" +
-                        "1970-01-01T00:00:03.000000Z\t8\n" +
-                        "1970-01-01T00:00:04.000000Z\t8\n" +
-                        "1970-01-01T00:00:05.000000Z\t8\n" +
-                        "1970-01-01T00:00:06.000000Z\t7\n" +
-                        "1970-01-01T00:00:07.000000Z\t8\n" +
-                        "1970-01-01T00:00:08.000000Z\t7\n" +
-                        "1970-01-01T00:00:09.000000Z\t9\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select rnd_long(0, 16, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     @Test
     public void testSampleFillNone() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.050000Z\t8\n" +
-                        "1970-01-01T00:00:02.050000Z\t8\n",
-                "with x as (select * from (select rnd_long(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
-                        "select ts, count_distinct(s) from x sample by 2s align to first observation"
-        ));
+        assertMemoryLeak(() -> {
+            String expected = "ts\tcount_distinct\n" +
+                    "1970-01-01T00:00:00.050000Z\t8\n" +
+                    "1970-01-01T00:00:02.050000Z\t8\n";
+            assertSql(
+                    expected,
+                    "with x as (select * from (select rnd_long(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                            "select ts, count_distinct(s) from x sample by 2s align to first observation"
+            );
+            assertSql(expected, "with x as (select * from (select rnd_long(1, 8, 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                    "select ts, count(distinct s) from x sample by 2s align to first observation");
+        });
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t5\n" +
+                "1970-01-01T00:00:01.000000Z\t8\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t7\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t5\n" +
+                "1970-01-01T00:00:06.000000Z\t6\n" +
+                "1970-01-01T00:00:07.000000Z\t6\n" +
+                "1970-01-01T00:00:08.000000Z\t6\n" +
+                "1970-01-01T00:00:09.000000Z\t7\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t5\n" +
-                        "1970-01-01T00:00:01.000000Z\t8\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t7\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t5\n" +
-                        "1970-01-01T00:00:06.000000Z\t6\n" +
-                        "1970-01-01T00:00:07.000000Z\t6\n" +
-                        "1970-01-01T00:00:08.000000Z\t6\n" +
-                        "1970-01-01T00:00:09.000000Z\t7\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select rnd_long(0, 8, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "a\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "f\t9\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t5\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t4\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t7\t1970-01-01T00:00:05.000000Z\n" +
+                "e\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "d\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t5\t1970-01-01T00:00:05.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "a\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "f\t9\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t5\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t4\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t7\t1970-01-01T00:00:05.000000Z\n" +
-                        "e\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "d\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t5\t1970-01-01T00:00:05.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 5s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_long(0, 12, 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 5s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunctionFactoryTest.java
@@ -31,30 +31,34 @@ public class CountDistinctUuidGroupByFunctionFactoryTest extends AbstractCairoTe
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(to_uuid(42L, 42L)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct to_uuid(42L, 42L)) from x order by a");
     }
 
     @Test
     public void testConstantDefaultHashSetNoEntryValue() throws Exception {
+        String expected = "count_distinct\n" +
+                "1\n";
         assertQuery(
-                "count_distinct\n" +
-                        "1\n",
+                expected,
                 "select count_distinct(to_uuid(l, l)) from x",
                 "create table x as (select -1::long as l from long_sequence(10))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct to_uuid(l, l)) from x");
     }
 
     @Test
@@ -72,41 +76,47 @@ public class CountDistinctUuidGroupByFunctionFactoryTest extends AbstractCairoTe
                     true,
                     true
             );
+            assertSql(expected, "select a, count(distinct to_uuid(s * 42, s * 42)) from x order by a");
             // multiplication shouldn't affect the number of distinct values,
             // so the result should stay the same
             assertSql(expected, "select a, count_distinct(s) from x order by a");
+            assertSql(expected, "select a, count(distinct s) from x order by a");
         });
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t2\n" +
+                "b\t1\n" +
+                "c\t1\n" +
+                "d\t4\n" +
+                "e\t4\n" +
+                "f\t3\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t2\n" +
-                        "b\t1\n" +
-                        "c\t1\n" +
-                        "d\t4\n" +
-                        "e\t4\n" +
-                        "f\t3\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, to_uuid(rnd_long(0, 16, 0), 0) s, timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select to_uuid(rnd_long(1, 6, 0), 0) s, timestamp_sequence(0, 1000) ts from long_sequence(1000)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
@@ -122,10 +132,12 @@ public class CountDistinctUuidGroupByFunctionFactoryTest extends AbstractCairoTe
                     false,
                     true
             );
+            assertSql(expected, "select count(distinct s) from x");
 
             insert("insert into x values(cast(null as UUID), '2021-05-21')");
             insert("insert into x values(cast(null as UUID), '1970-01-01')");
             assertSql(expected, "select count_distinct(s) from x");
+            assertSql(expected, "select count(distinct s) from x");
         });
     }
 
@@ -143,100 +155,114 @@ public class CountDistinctUuidGroupByFunctionFactoryTest extends AbstractCairoTe
 
             insert("insert into x values ('a', to_uuid(5, 0), '2021-05-21'), ('a', to_uuid(5, 0), '2021-05-21'), ('a', to_uuid(5, null), '2021-05-21'), ('a', to_uuid(10, 0), '2021-05-21'), ('a', to_uuid(10, null), '2021-05-21')" +
                     ", ('a', to_uuid(0, 5), '2021-05-21'), ('a', to_uuid(0, 5), '2021-05-21'), ('a', to_uuid(null, 5), '2021-05-21'), ('a', to_uuid(0, 10), '2021-05-21'), ('a', to_uuid(null, 10), '2021-05-21'), ('a', to_uuid(0, 0), '2021-05-21'), ('a', to_uuid(null, null), '2021-05-21')");
-            assertSql("a\ts\n" +
-                    "a\t9\n", "select a, count_distinct(s) as s from x order by a");
+            String expected = "a\ts\n" +
+                    "a\t9\n";
+            assertSql(expected, "select a, count_distinct(s) as s from x order by a");
+            assertSql(expected, "select a, count(distinct s) as s from x order by a");
         });
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(to_uuid(null, null)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct to_uuid(null, null)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t9\n" +
+                "1970-01-01T00:00:01.000000Z\t7\n" +
+                "1970-01-01T00:00:02.000000Z\t7\n" +
+                "1970-01-01T00:00:03.000000Z\t8\n" +
+                "1970-01-01T00:00:04.000000Z\t8\n" +
+                "1970-01-01T00:00:05.000000Z\t8\n" +
+                "1970-01-01T00:00:06.000000Z\t7\n" +
+                "1970-01-01T00:00:07.000000Z\t8\n" +
+                "1970-01-01T00:00:08.000000Z\t7\n" +
+                "1970-01-01T00:00:09.000000Z\t9\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t9\n" +
-                        "1970-01-01T00:00:01.000000Z\t7\n" +
-                        "1970-01-01T00:00:02.000000Z\t7\n" +
-                        "1970-01-01T00:00:03.000000Z\t8\n" +
-                        "1970-01-01T00:00:04.000000Z\t8\n" +
-                        "1970-01-01T00:00:05.000000Z\t8\n" +
-                        "1970-01-01T00:00:06.000000Z\t7\n" +
-                        "1970-01-01T00:00:07.000000Z\t8\n" +
-                        "1970-01-01T00:00:08.000000Z\t7\n" +
-                        "1970-01-01T00:00:09.000000Z\t9\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select to_uuid(rnd_long(0, 16, 0), 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     //
     @Test
     public void testSampleFillNone() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.050000Z\t8\n" +
+                "1970-01-01T00:00:02.050000Z\t8\n";
         assertMemoryLeak(() -> assertSql(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.050000Z\t8\n" +
-                        "1970-01-01T00:00:02.050000Z\t8\n", "with x as (select * from (select to_uuid(rnd_long(1, 8, 0), 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                expected,
+                "with x as (select * from (select to_uuid(rnd_long(1, 8, 0), 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
                         "select ts, count_distinct(s) from x sample by 2s align to first observation"
         ));
+        assertSql(expected, "with x as (select * from (select to_uuid(rnd_long(1, 8, 0), 0) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                "select ts, count(distinct s) from x sample by 2s align to first observation");
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t5\n" +
+                "1970-01-01T00:00:01.000000Z\t8\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t7\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t5\n" +
+                "1970-01-01T00:00:06.000000Z\t6\n" +
+                "1970-01-01T00:00:07.000000Z\t6\n" +
+                "1970-01-01T00:00:08.000000Z\t6\n" +
+                "1970-01-01T00:00:09.000000Z\t7\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t5\n" +
-                        "1970-01-01T00:00:01.000000Z\t8\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t7\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t5\n" +
-                        "1970-01-01T00:00:06.000000Z\t6\n" +
-                        "1970-01-01T00:00:07.000000Z\t6\n" +
-                        "1970-01-01T00:00:08.000000Z\t6\n" +
-                        "1970-01-01T00:00:09.000000Z\t7\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select to_uuid(rnd_long(0, 8, 0), 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "a\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "f\t9\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t5\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t4\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t7\t1970-01-01T00:00:05.000000Z\n" +
+                "e\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "d\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t5\t1970-01-01T00:00:05.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "a\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "f\t9\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t5\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t4\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t7\t1970-01-01T00:00:05.000000Z\n" +
-                        "e\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "d\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t5\t1970-01-01T00:00:05.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 5s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, to_uuid(rnd_long(0, 12, 0), 0) s, timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 5s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountLong256GroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountLong256GroupByFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.groupby;
 
+import io.questdb.std.Rnd;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -31,17 +32,19 @@ public class CountLong256GroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(cast('0x42' AS LONG256)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct cast('0x42' AS LONG256)) from x order by a");
     }
 
     @Test
@@ -59,41 +62,47 @@ public class CountLong256GroupByFunctionFactoryTest extends AbstractCairoTest {
                     true,
                     true
             );
+            assertSql(expected, "select a, count(distinct s + s) from x order by a");
             // self-addition shouldn't affect the number of distinct values,
             // so the result should stay the same
             assertSql(expected, "select a, count_distinct(s) from x order by a");
+            assertSql(expected, "select a, count(distinct s) from x order by a");
         });
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t4\n" +
+                "c\t5\n" +
+                "d\t3\n" +
+                "e\t1\n" +
+                "f\t4\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t4\n" +
-                        "c\t5\n" +
-                        "d\t3\n" +
-                        "e\t1\n" +
-                        "f\t4\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_long256(16) s,  timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select rnd_long256(6) s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
@@ -109,102 +118,120 @@ public class CountLong256GroupByFunctionFactoryTest extends AbstractCairoTest {
                     false,
                     true
             );
+            assertSql(expected, "select count(distinct s) from x");
 
             insert("insert into x values(cast(null as LONG256), '2021-05-21')");
             insert("insert into x values(cast(null as LONG256), '1970-01-01')");
             assertSql(expected, "select count_distinct(s) from x");
+            assertSql(expected, "select count(distinct s) from x");
         });
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(cast(null as LONG256)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct cast(null as LONG256)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t6\n" +
+                "1970-01-01T00:00:01.000000Z\t6\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t6\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t7\n" +
+                "1970-01-01T00:00:06.000000Z\t6\n" +
+                "1970-01-01T00:00:07.000000Z\t7\n" +
+                "1970-01-01T00:00:08.000000Z\t5\n" +
+                "1970-01-01T00:00:09.000000Z\t7\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t6\n" +
-                        "1970-01-01T00:00:01.000000Z\t6\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t6\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t7\n" +
-                        "1970-01-01T00:00:06.000000Z\t6\n" +
-                        "1970-01-01T00:00:07.000000Z\t7\n" +
-                        "1970-01-01T00:00:08.000000Z\t5\n" +
-                        "1970-01-01T00:00:09.000000Z\t7\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select rnd_long256(10) s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     @Test
     public void testSampleFillNone() throws Exception {
-        assertMemoryLeak(() -> assertSql(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.050000Z\t8\n" +
-                        "1970-01-01T00:00:02.050000Z\t8\n",
-                "with x as (select * from (select rnd_long256(8) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
-                        "select ts, count_distinct(s) from x sample by 2s align to first observation"
-        ));
+        assertMemoryLeak(() -> {
+            String expected = "ts\tcount_distinct\n" +
+                    "1970-01-01T00:00:00.050000Z\t8\n" +
+                    "1970-01-01T00:00:02.050000Z\t8\n";
+            Rnd rnd = sqlExecutionContext.getRandom();
+            long so = rnd.getSeed0();
+            long s1 = rnd.getSeed1();
+            assertSql(expected,
+                    "with x as (select * from (select rnd_long256(8) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                            "select ts, count_distinct(s) from x sample by 2s align to first observation"
+            );
+            rnd.reset(so, s1);
+            assertSql(expected, "with x as (select * from (select rnd_long256(8) s, timestamp_sequence(50000, 100000L/4) ts from long_sequence(100)) timestamp(ts))\n" +
+                    "select ts, count(distinct s) from x sample by 2s align to first observation");
+        });
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t7\n" +
+                "1970-01-01T00:00:01.000000Z\t7\n" +
+                "1970-01-01T00:00:02.000000Z\t7\n" +
+                "1970-01-01T00:00:03.000000Z\t5\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t6\n" +
+                "1970-01-01T00:00:06.000000Z\t7\n" +
+                "1970-01-01T00:00:07.000000Z\t5\n" +
+                "1970-01-01T00:00:08.000000Z\t7\n" +
+                "1970-01-01T00:00:09.000000Z\t5\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t7\n" +
-                        "1970-01-01T00:00:01.000000Z\t7\n" +
-                        "1970-01-01T00:00:02.000000Z\t7\n" +
-                        "1970-01-01T00:00:03.000000Z\t5\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t6\n" +
-                        "1970-01-01T00:00:06.000000Z\t7\n" +
-                        "1970-01-01T00:00:07.000000Z\t5\n" +
-                        "1970-01-01T00:00:08.000000Z\t7\n" +
-                        "1970-01-01T00:00:09.000000Z\t5\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select rnd_long256(8) s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "f\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t8\t1970-01-01T00:00:00.000000Z\n" +
+                "a\t4\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t5\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t6\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t4\t1970-01-01T00:00:05.000000Z\n" +
+                "d\t8\t1970-01-01T00:00:05.000000Z\n" +
+                "e\t6\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t4\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t6\t1970-01-01T00:00:05.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "f\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t8\t1970-01-01T00:00:00.000000Z\n" +
-                        "a\t4\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t5\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t6\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t4\t1970-01-01T00:00:05.000000Z\n" +
-                        "d\t8\t1970-01-01T00:00:05.000000Z\n" +
-                        "e\t6\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t4\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t6\t1970-01-01T00:00:05.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 5s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_long256(12) s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 5s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountSymbolGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountSymbolGroupByFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.groupby;
 
+import io.questdb.std.Rnd;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -31,202 +32,227 @@ public class CountSymbolGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t1\n" +
+                "b\t1\n" +
+                "c\t1\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t1\n" +
-                        "b\t1\n" +
-                        "c\t1\n",
+                expected,
                 "select a, count_distinct(cast('foobar' as SYMBOL)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct cast('foobar' as SYMBOL)) from x order by a");
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t4\n" +
+                "b\t4\n" +
+                "c\t3\n" +
+                "d\t1\n" +
+                "e\t2\n" +
+                "f\t3\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t4\n" +
-                        "b\t4\n" +
-                        "c\t3\n" +
-                        "d\t1\n" +
-                        "e\t2\n" +
-                        "f\t3\n",
+                expected,
                 "select a, count_distinct(s) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(20)) timestamp(ts))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct s) from x order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "count_distinct\n" +
+                "6\n";
         assertQuery(
-                "count_distinct\n" +
-                        "6\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
     public void testGroupNotKeyedWithNull() throws Exception {
+        String expected = "count_distinct\n" +
+                "2\n";
         assertQuery(
-                "count_distinct\n" +
-                        "2\n",
+                expected,
                 "select count_distinct(s) from x",
                 "create table x as (select * from (select rnd_symbol(null, '344', 'xx2', null) s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select count(distinct s) from x");
     }
 
     @Test
     public void testNullConstant() throws Exception {
+        String expected = "a\tcount_distinct\n" +
+                "a\t0\n" +
+                "b\t0\n" +
+                "c\t0\n";
         assertQuery(
-                "a\tcount_distinct\n" +
-                        "a\t0\n" +
-                        "b\t0\n" +
-                        "c\t0\n",
+                expected,
                 "select a, count_distinct(cast(null as SYMBOL)) from x order by a",
                 "create table x as (select * from (select rnd_symbol('a','b','c') a from long_sequence(20)))",
                 null,
                 true,
                 true
         );
+        assertSql(expected, "select a, count(distinct cast(null as SYMBOL)) from x order by a");
     }
 
     @Test
     public void testSampleFillLinear() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t5\n" +
+                "1970-01-01T00:00:01.000000Z\t5\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t5\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t4\n" +
+                "1970-01-01T00:00:06.000000Z\t4\n" +
+                "1970-01-01T00:00:07.000000Z\t5\n" +
+                "1970-01-01T00:00:08.000000Z\t6\n" +
+                "1970-01-01T00:00:09.000000Z\t5\n";
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t5\n" +
-                        "1970-01-01T00:00:01.000000Z\t5\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t5\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t4\n" +
-                        "1970-01-01T00:00:06.000000Z\t4\n" +
-                        "1970-01-01T00:00:07.000000Z\t5\n" +
-                        "1970-01-01T00:00:08.000000Z\t6\n" +
-                        "1970-01-01T00:00:09.000000Z\t5\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(linear)",
                 "create table x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true,
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(linear)");
     }
 
     @Test
     public void testSampleFillNone() throws Exception {
         assertMemoryLeak(() -> {
-            final String sql = "with x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))\n" +
+            String expected = "ts\tcount_distinct\n" +
+                    "1970-01-01T00:00:00.000000Z\t5\n" +
+                    "1970-01-01T00:00:01.000000Z\t5\n" +
+                    "1970-01-01T00:00:02.000000Z\t6\n" +
+                    "1970-01-01T00:00:03.000000Z\t5\n" +
+                    "1970-01-01T00:00:04.000000Z\t6\n" +
+                    "1970-01-01T00:00:05.000000Z\t4\n" +
+                    "1970-01-01T00:00:06.000000Z\t4\n" +
+                    "1970-01-01T00:00:07.000000Z\t5\n" +
+                    "1970-01-01T00:00:08.000000Z\t6\n" +
+                    "1970-01-01T00:00:09.000000Z\t5\n";
+
+            Rnd rnd = sqlExecutionContext.getRandom();
+            long s0 = rnd.getSeed0();
+            long s1 = rnd.getSeed1();
+            final String sqlA = "with x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))\n" +
                     "select ts, count_distinct(s) from x sample by 1s";
-            assertSql(
-                    "ts\tcount_distinct\n" +
-                            "1970-01-01T00:00:00.000000Z\t5\n" +
-                            "1970-01-01T00:00:01.000000Z\t5\n" +
-                            "1970-01-01T00:00:02.000000Z\t6\n" +
-                            "1970-01-01T00:00:03.000000Z\t5\n" +
-                            "1970-01-01T00:00:04.000000Z\t6\n" +
-                            "1970-01-01T00:00:05.000000Z\t4\n" +
-                            "1970-01-01T00:00:06.000000Z\t4\n" +
-                            "1970-01-01T00:00:07.000000Z\t5\n" +
-                            "1970-01-01T00:00:08.000000Z\t6\n" +
-                            "1970-01-01T00:00:09.000000Z\t5\n", sql
-            );
+            assertSql(expected, sqlA);
+
+            rnd.reset(s0, s1);
+            final String sqlB = "with x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))\n" +
+                    "select ts, count(distinct s) from x sample by 1s";
+            assertSql(expected, sqlB);
         });
     }
 
     @Test
     public void testSampleFillValue() throws Exception {
+        String expected = "ts\tcount_distinct\n" +
+                "1970-01-01T00:00:00.000000Z\t5\n" +
+                "1970-01-01T00:00:01.000000Z\t5\n" +
+                "1970-01-01T00:00:02.000000Z\t6\n" +
+                "1970-01-01T00:00:03.000000Z\t5\n" +
+                "1970-01-01T00:00:04.000000Z\t6\n" +
+                "1970-01-01T00:00:05.000000Z\t4\n" +
+                "1970-01-01T00:00:06.000000Z\t4\n" +
+                "1970-01-01T00:00:07.000000Z\t5\n" +
+                "1970-01-01T00:00:08.000000Z\t6\n" +
+                "1970-01-01T00:00:09.000000Z\t5\n";
+
         assertQuery(
-                "ts\tcount_distinct\n" +
-                        "1970-01-01T00:00:00.000000Z\t5\n" +
-                        "1970-01-01T00:00:01.000000Z\t5\n" +
-                        "1970-01-01T00:00:02.000000Z\t6\n" +
-                        "1970-01-01T00:00:03.000000Z\t5\n" +
-                        "1970-01-01T00:00:04.000000Z\t6\n" +
-                        "1970-01-01T00:00:05.000000Z\t4\n" +
-                        "1970-01-01T00:00:06.000000Z\t4\n" +
-                        "1970-01-01T00:00:07.000000Z\t5\n" +
-                        "1970-01-01T00:00:08.000000Z\t6\n" +
-                        "1970-01-01T00:00:09.000000Z\t5\n",
+                expected,
                 "select ts, count_distinct(s) from x sample by 1s fill(99)",
                 "create table x as (select * from (select rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 true
         );
+        assertSql(expected, "select ts, count(distinct s) from x sample by 1s fill(99)");
     }
 
     @Test
     public void testSampleKeyed() throws Exception {
+        String expected = "a\tcount_distinct\tts\n" +
+                "a\t3\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t2\t1970-01-01T00:00:00.000000Z\n" +
+                "f\t1\t1970-01-01T00:00:00.000000Z\n" +
+                "c\t1\t1970-01-01T00:00:00.000000Z\n" +
+                "e\t2\t1970-01-01T00:00:00.000000Z\n" +
+                "d\t1\t1970-01-01T00:00:00.000000Z\n" +
+                "b\t3\t1970-01-01T00:00:01.000000Z\n" +
+                "a\t2\t1970-01-01T00:00:01.000000Z\n" +
+                "d\t1\t1970-01-01T00:00:01.000000Z\n" +
+                "c\t2\t1970-01-01T00:00:01.000000Z\n" +
+                "f\t2\t1970-01-01T00:00:01.000000Z\n" +
+                "c\t2\t1970-01-01T00:00:02.000000Z\n" +
+                "b\t3\t1970-01-01T00:00:02.000000Z\n" +
+                "f\t3\t1970-01-01T00:00:02.000000Z\n" +
+                "e\t2\t1970-01-01T00:00:02.000000Z\n" +
+                "f\t3\t1970-01-01T00:00:03.000000Z\n" +
+                "a\t1\t1970-01-01T00:00:03.000000Z\n" +
+                "c\t2\t1970-01-01T00:00:03.000000Z\n" +
+                "e\t1\t1970-01-01T00:00:03.000000Z\n" +
+                "d\t1\t1970-01-01T00:00:03.000000Z\n" +
+                "b\t1\t1970-01-01T00:00:03.000000Z\n" +
+                "b\t3\t1970-01-01T00:00:04.000000Z\n" +
+                "a\t1\t1970-01-01T00:00:04.000000Z\n" +
+                "c\t3\t1970-01-01T00:00:04.000000Z\n" +
+                "f\t3\t1970-01-01T00:00:04.000000Z\n" +
+                "d\t3\t1970-01-01T00:00:05.000000Z\n" +
+                "b\t1\t1970-01-01T00:00:05.000000Z\n" +
+                "a\t2\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t1\t1970-01-01T00:00:05.000000Z\n" +
+                "f\t2\t1970-01-01T00:00:05.000000Z\n" +
+                "c\t2\t1970-01-01T00:00:06.000000Z\n" +
+                "f\t4\t1970-01-01T00:00:06.000000Z\n" +
+                "b\t2\t1970-01-01T00:00:06.000000Z\n" +
+                "d\t1\t1970-01-01T00:00:06.000000Z\n" +
+                "a\t1\t1970-01-01T00:00:06.000000Z\n" +
+                "e\t1\t1970-01-01T00:00:07.000000Z\n" +
+                "c\t3\t1970-01-01T00:00:07.000000Z\n" +
+                "f\t1\t1970-01-01T00:00:07.000000Z\n" +
+                "d\t2\t1970-01-01T00:00:07.000000Z\n" +
+                "b\t2\t1970-01-01T00:00:07.000000Z\n" +
+                "d\t2\t1970-01-01T00:00:08.000000Z\n" +
+                "e\t2\t1970-01-01T00:00:08.000000Z\n" +
+                "a\t2\t1970-01-01T00:00:08.000000Z\n" +
+                "b\t1\t1970-01-01T00:00:08.000000Z\n" +
+                "c\t1\t1970-01-01T00:00:08.000000Z\n" +
+                "f\t1\t1970-01-01T00:00:08.000000Z\n" +
+                "c\t2\t1970-01-01T00:00:09.000000Z\n" +
+                "b\t2\t1970-01-01T00:00:09.000000Z\n" +
+                "d\t2\t1970-01-01T00:00:09.000000Z\n" +
+                "e\t1\t1970-01-01T00:00:09.000000Z\n" +
+                "a\t1\t1970-01-01T00:00:09.000000Z\n" +
+                "f\t1\t1970-01-01T00:00:09.000000Z\n";
         assertQuery(
-                "a\tcount_distinct\tts\n" +
-                        "a\t3\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t2\t1970-01-01T00:00:00.000000Z\n" +
-                        "f\t1\t1970-01-01T00:00:00.000000Z\n" +
-                        "c\t1\t1970-01-01T00:00:00.000000Z\n" +
-                        "e\t2\t1970-01-01T00:00:00.000000Z\n" +
-                        "d\t1\t1970-01-01T00:00:00.000000Z\n" +
-                        "b\t3\t1970-01-01T00:00:01.000000Z\n" +
-                        "a\t2\t1970-01-01T00:00:01.000000Z\n" +
-                        "d\t1\t1970-01-01T00:00:01.000000Z\n" +
-                        "c\t2\t1970-01-01T00:00:01.000000Z\n" +
-                        "f\t2\t1970-01-01T00:00:01.000000Z\n" +
-                        "c\t2\t1970-01-01T00:00:02.000000Z\n" +
-                        "b\t3\t1970-01-01T00:00:02.000000Z\n" +
-                        "f\t3\t1970-01-01T00:00:02.000000Z\n" +
-                        "e\t2\t1970-01-01T00:00:02.000000Z\n" +
-                        "f\t3\t1970-01-01T00:00:03.000000Z\n" +
-                        "a\t1\t1970-01-01T00:00:03.000000Z\n" +
-                        "c\t2\t1970-01-01T00:00:03.000000Z\n" +
-                        "e\t1\t1970-01-01T00:00:03.000000Z\n" +
-                        "d\t1\t1970-01-01T00:00:03.000000Z\n" +
-                        "b\t1\t1970-01-01T00:00:03.000000Z\n" +
-                        "b\t3\t1970-01-01T00:00:04.000000Z\n" +
-                        "a\t1\t1970-01-01T00:00:04.000000Z\n" +
-                        "c\t3\t1970-01-01T00:00:04.000000Z\n" +
-                        "f\t3\t1970-01-01T00:00:04.000000Z\n" +
-                        "d\t3\t1970-01-01T00:00:05.000000Z\n" +
-                        "b\t1\t1970-01-01T00:00:05.000000Z\n" +
-                        "a\t2\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t1\t1970-01-01T00:00:05.000000Z\n" +
-                        "f\t2\t1970-01-01T00:00:05.000000Z\n" +
-                        "c\t2\t1970-01-01T00:00:06.000000Z\n" +
-                        "f\t4\t1970-01-01T00:00:06.000000Z\n" +
-                        "b\t2\t1970-01-01T00:00:06.000000Z\n" +
-                        "d\t1\t1970-01-01T00:00:06.000000Z\n" +
-                        "a\t1\t1970-01-01T00:00:06.000000Z\n" +
-                        "e\t1\t1970-01-01T00:00:07.000000Z\n" +
-                        "c\t3\t1970-01-01T00:00:07.000000Z\n" +
-                        "f\t1\t1970-01-01T00:00:07.000000Z\n" +
-                        "d\t2\t1970-01-01T00:00:07.000000Z\n" +
-                        "b\t2\t1970-01-01T00:00:07.000000Z\n" +
-                        "d\t2\t1970-01-01T00:00:08.000000Z\n" +
-                        "e\t2\t1970-01-01T00:00:08.000000Z\n" +
-                        "a\t2\t1970-01-01T00:00:08.000000Z\n" +
-                        "b\t1\t1970-01-01T00:00:08.000000Z\n" +
-                        "c\t1\t1970-01-01T00:00:08.000000Z\n" +
-                        "f\t1\t1970-01-01T00:00:08.000000Z\n" +
-                        "c\t2\t1970-01-01T00:00:09.000000Z\n" +
-                        "b\t2\t1970-01-01T00:00:09.000000Z\n" +
-                        "d\t2\t1970-01-01T00:00:09.000000Z\n" +
-                        "e\t1\t1970-01-01T00:00:09.000000Z\n" +
-                        "a\t1\t1970-01-01T00:00:09.000000Z\n" +
-                        "f\t1\t1970-01-01T00:00:09.000000Z\n",
+                expected,
                 "select a, count_distinct(s), ts from x sample by 1s align to first observation",
                 "create table x as (select * from (select rnd_symbol('a','b','c','d','e','f') a, rnd_symbol('344', 'xx2', '00s', '544', 'rraa', '0llp') s,  timestamp_sequence(0, 100000) ts from long_sequence(100)) timestamp(ts))",
                 "ts",
                 false
         );
+        assertSql(expected, "select a, count(distinct s), ts from x sample by 1s align to first observation");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
@@ -57,6 +57,36 @@ public class StringAggGroupByFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDistinctColumnNameNotQuoted() throws Exception {
+        assertException(
+                "select string_agg(distinct, ',') from x",
+                "create table x as (select * from (select rnd_str('abc', 'aaa', 'bbb', 'ccc') \"distinct\", timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
+                18,
+                "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\""
+        );
+
+        assertException("select string_agg(distinct::varchar, ',') from x", 18, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
+    }
+
+    @Test
+    public void testDistinctColumnNameQuoted() throws Exception {
+        String expected = "string_agg\n" +
+                "abc,bbb,aaa,ccc,aaa\n";
+        assertQuery(
+                "string_agg\n" +
+                        "abc,bbb,aaa,ccc,aaa\n",
+                "select string_agg(\"distinct\", ',') from x",
+                "create table x as (select * from (select rnd_str('abc', 'aaa', 'bbb', 'ccc') \"distinct\", timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
+                null,
+                false,
+                true
+        );
+
+        assertSql(expected, "select string_agg(\"distinct\"::varchar, ',') from x");
+        assertSql(expected, "select string_agg(cast (\"distinct\" as string)::varchar, ',') from x");
+    }
+
+    @Test
     public void testGroupKeyed() throws Exception {
         assertQuery(
                 "a\tstring_agg\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
@@ -27,6 +27,7 @@ package io.questdb.test.griffin.engine.functions.groupby;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
+
 public class StringAggGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunctionFactoryTest.java
@@ -31,40 +31,45 @@ public class StringDistinctAggSymbolGroupByFunctionFactoryTest extends AbstractC
 
     @Test
     public void testConstantNull() throws Exception {
+        String expected = "string_distinct_agg\n" +
+                "\n";
         assertQuery(
-                "string_distinct_agg\n" +
-                        "\n",
+                expected,
                 "select string_distinct_agg(null::symbol, ',') from x",
                 "create table x as (select * from (select timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select string_agg(distinct null, ',') from x");
     }
 
     @Test
     public void testConstantString() throws Exception {
+        String expected = "string_distinct_agg\n" +
+                "aaa\n";
         assertQuery(
-                "string_distinct_agg\n" +
-                        "aaa\n",
+                expected,
                 "select string_distinct_agg('aaa'::symbol, ',') from x",
                 "create table x as (select * from (select timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select string_agg(distinct 'aaa'::symbol, ',') from x");
     }
 
     @Test
     public void testGroupKeyed() throws Exception {
+        String expected = "a\tstring_distinct_agg\n" +
+                "a\tbbb,abc,aaa\n" +
+                "b\tccc,abc,bbb\n" +
+                "c\tccc,abc,aaa\n" +
+                "d\tbbb,abc\n" +
+                "e\tabc,ccc\n" +
+                "f\tccc,abc,bbb\n";
         assertQuery(
-                "a\tstring_distinct_agg\n" +
-                        "a\tbbb,abc,aaa\n" +
-                        "b\tccc,abc,bbb\n" +
-                        "c\tccc,abc,aaa\n" +
-                        "d\tbbb,abc\n" +
-                        "e\tabc,ccc\n" +
-                        "f\tccc,abc,bbb\n",
+                expected,
                 "select a, string_distinct_agg(s, ',') from x order by a",
                 "create table x as (" +
                         "select * from (" +
@@ -78,15 +83,17 @@ public class StringDistinctAggSymbolGroupByFunctionFactoryTest extends AbstractC
                 true,
                 true
         );
+        assertSql(expected, "select a, string_agg(distinct s, ',') from x group by a order by a");
     }
 
     @Test
     public void testGroupKeyedAllNulls() throws Exception {
+        String expected = "a\tstring_distinct_agg\n" +
+                "a\t\n" +
+                "b\t\n" +
+                "c\t\n";
         assertQuery(
-                "a\tstring_distinct_agg\n" +
-                        "a\t\n" +
-                        "b\t\n" +
-                        "c\t\n",
+                expected,
                 "select a, string_distinct_agg(s, ',') from x order by a",
                 "create table x as (" +
                         "select * from (" +
@@ -100,13 +107,15 @@ public class StringDistinctAggSymbolGroupByFunctionFactoryTest extends AbstractC
                 true,
                 true
         );
+        assertSql(expected, "select a, string_agg(distinct s, ',') from x group by a order by a");
     }
 
     @Test
     public void testGroupKeyedManyRows() throws Exception {
+        String expected = "max\n" +
+                "15\n";
         assertQuery(
-                "max\n" +
-                        "15\n",
+                expected,
                 "select max(length(agg)) from (select a, string_distinct_agg(s, ',') agg from x)",
                 "create table x as (" +
                         "select * from (" +
@@ -120,14 +129,16 @@ public class StringDistinctAggSymbolGroupByFunctionFactoryTest extends AbstractC
                 false,
                 true
         );
+        assertSql(expected, "select max(length(agg)) from (select a, string_agg(distinct s, ',') agg from x)");
     }
 
     @Test
     public void testGroupKeyedSomeNulls() throws Exception {
+        String expected = "a\tstring_distinct_agg\n" +
+                "\taaa\n" +
+                "a\taaa\n";
         assertQuery(
-                "a\tstring_distinct_agg\n" +
-                        "\taaa\n" +
-                        "a\taaa\n",
+                expected,
                 "select a, string_distinct_agg(s, ',') from x",
                 "create table x as (" +
                         "select * from (" +
@@ -141,32 +152,54 @@ public class StringDistinctAggSymbolGroupByFunctionFactoryTest extends AbstractC
                 true,
                 true
         );
+        assertSql(expected, "select a, string_agg(distinct s, ',') from x group by a order by a");
     }
 
     @Test
     public void testGroupNotKeyed() throws Exception {
+        String expected = "string_distinct_agg\n" +
+                "abc,bbb,aaa,ccc\n";
         assertQuery(
-                "string_distinct_agg\n" +
-                        "abc,bbb,aaa,ccc\n",
+                expected,
                 "select string_distinct_agg(s, ',') from x",
                 "create table x as (select * from (select rnd_symbol('abc', 'aaa', 'bbb', 'ccc') s, timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
                 null,
                 false,
                 true
         );
+        assertSql(expected, "select string_agg(distinct s, ',') from x");
     }
 
     @Test
     public void testSkipNull() throws Exception {
+        String expected = "string_distinct_agg\n" +
+                "\n";
+        String ddl = "create table x as (select * from (select cast(null as symbol) s from long_sequence(5)))";
+        String ddl2 = "insert into x select 'abc' from long_sequence(1)";
+        String expected2 = "string_distinct_agg\n" +
+                "abc\n";
+
         assertQuery(
-                "string_distinct_agg\n" +
-                        "\n",
+                expected,
                 "select string_distinct_agg(s, ',') from x",
-                "create table x as (select * from (select cast(null as symbol) s from long_sequence(5)))",
+                ddl,
                 null,
-                "insert into x select 'abc' from long_sequence(1)",
-                "string_distinct_agg\n" +
-                        "abc\n",
+                ddl2,
+                expected2,
+                false,
+                true,
+                false
+        );
+
+        drop("drop table x");
+
+        assertQuery(
+                expected,
+                "select string_agg(distinct s, ',') from x",
+                ddl,
+                null,
+                ddl2,
+                expected2,
                 false,
                 true,
                 false

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringDistinctAggVarcharGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringDistinctAggVarcharGroupByFunctionFactoryTest.java
@@ -157,6 +157,13 @@ public class StringDistinctAggVarcharGroupByFunctionFactoryTest extends Abstract
     }
 
     @Test
+    public void testOrderByNotSupported() throws Exception {
+        ddl("create table x as (select * from (select timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))");
+        assertException("select string_distinct_agg(ts, ',' ORDER BY ts) from x", 35, "ORDER BY not supported for string_distinct_agg");
+        assertException("select string_distinct_agg(ts, ',' order by ts) from x", 35, "ORDER BY not supported for string_distinct_agg");
+    }
+
+    @Test
     public void testSkipNull() throws Exception {
         assertQuery(
                 "string_distinct_agg\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/json/JsonExtractVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/json/JsonExtractVarcharFunctionFactoryTest.java
@@ -417,6 +417,11 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
                             "1\n",
                     "select count_distinct(json_extract(text, '.list[2]')) from json_test"
             );
+            assertSql(
+                    "count_distinct\n" +
+                            "1\n",
+                    "select count(distinct json_extract(text, '.list[2]')) from json_test"
+            );
 
             assertSql(
                     "sum\n" +


### PR DESCRIPTION
This change means that instead of using `count_distinct(foo)`, it is now possible to write `count(distinct foo)`. Similarly, instead of `string_distinct_agg(foo)`, you can now use `string_agg(distinct foo)`.

The motivation for this change is to improve compatibility with PostgreSQL.

Internally, the `count()` and `string_agg()` functions are rewritten to their distinct versions when the `distinct` keyword is present.

### Notes for reviewers
#### On backwards compatibility

~`count(distinct)` is still treated as a non-unique count of a column named distinct. Since `distinct` is a keyword, we could (or should?) enforce that it be enclosed in double quotes when used as a column name. This would cause `count(distinct)` to fail. However, this PR is more lenient and does not enforce this, prioritizing backward compatibility.~

~If reviewers feel that we should fail such queries - e.g., for the sake of consistency - I can add that enforcement.~

This is a breaking change: When counting a column named `distinct` (`count("distinct")`) QuestDB now enforces the column name to be in double-quotes. Since `distinct` is a keyword. This is a not a new requirement, but it was not enforced in previous versions. 

#### On tests

I wrote new tests for the `ExpressionParser`, but that's a relatively minor part of this change. I mostly rely on the existing test suite. I identified the relevant tests that exercise `count_distinct(foo)` and added versions using count(distinct foo) as well. This should give us solid coverage across various cases, where `foo` can be a literal, another expression, or part of tests involving CTEs, etc.