### PR TITLE
ci(build): disable ci auto triggers on draft PRs

### DIFF
--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
       - master
+    drafts: false
 
 variables:
   QDB_LOG_W_FILE_LOCATION: "$(Build.BinariesDirectory)/tests.log"


### PR DESCRIPTION
Azure CI is quite expensive to run nowadays and it's often clogged with the draft PRs nowhere near the end.
This change disables triggering CI builds on draft PRs