### PR TITLE
test(http): flaky TextLoaderTest.testBrokenUtf8Header()

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
@@ -2836,7 +2836,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                     "\tpyh&Nlz{\n" +
                     "\t?\uDBB7\uDE72*\uD93B\uDF2D\uD917\uDDB2\n" +
                     "\uD9F2\uDF17\uDBE8\uDCCF\uF168\u19ADE%۔+@\uDBC6\uDF53B/W\tYx~Eg8S]\n" +
-                    "YpcxLP0u=jR#B9xn*f\t\uDBFE\uDF83Ϊ\u1AC8饋旮5폥V뷓\n" +
+                    "YpcxLP0u=jR#B9xn*f\t\uDBFE\uDF83Ϊ᫈饋旮5폥V뷓\n" +
                     "Z<CF\t\n" +
                     "76{#dfd_[B}&@wtN\t\n" +
                     "\tpݟ\uDB49\uDE58|͆\uD95E\uDC6B\uDA38\uDF16ƈ\n" +
@@ -2868,7 +2868,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                     ",pyh&Nlz{\n" +
                     ",?\uDBB7\uDE72*\uD93B\uDF2D\uD917\uDDB2\n" +
                     "\uD9F2\uDF17\uDBE8\uDCCF\uF168\u19ADE%۔+@\uDBC6\uDF53B/W,Yx~Eg8S]\n" +
-                    "YpcxLP0u=jR#B9xn*f,\uDBFE\uDF83Ϊ\u1AC8饋旮5폥V뷓\n" +
+                    "YpcxLP0u=jR#B9xn*f,\uDBFE\uDF83Ϊ᫈饋旮5폥V뷓\n" +
                     "Z<CF,\n" +
                     "76{#dfd_[B}&@wtN,\n" +
                     ",pݟ\uDB49\uDE58|͆\uD95E\uDC6B\uDA38\uDF16ƈ\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/TextLoaderTest.java
@@ -25,14 +25,30 @@
 package io.questdb.test.cutlass.text;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cutlass.http.ex.NotEnoughLinesException;
 import io.questdb.cutlass.json.JsonLexer;
-import io.questdb.cutlass.text.*;
+import io.questdb.cutlass.text.Atomicity;
+import io.questdb.cutlass.text.DefaultTextConfiguration;
+import io.questdb.cutlass.text.TextConfiguration;
+import io.questdb.cutlass.text.TextException;
+import io.questdb.cutlass.text.TextLoadWarning;
+import io.questdb.cutlass.text.TextLoader;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
-import io.questdb.std.*;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.millitime.DateFormatUtils;
 import io.questdb.std.str.Path;
@@ -43,7 +59,11 @@ import io.questdb.test.cairo.TestFilesFacade;
 import io.questdb.test.cairo.TestTableReaderRecordCursor;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -55,7 +75,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 @RunWith(Parameterized.class)
 public class TextLoaderTest extends AbstractCairoTest {
 
-    private static final ByteManipulator ENTITY_MANIPULATOR = (index, len, b) -> b;
+    private static final ByteArrayTransformer NOOP_TRANSFORMER = (arr) -> {
+    };
     private static final String PATH_SEP_REGEX = Os.isWindows() ?
             String.format("[%c%c]", Files.SEPARATOR, Files.SEPARATOR) : String.valueOf(Files.SEPARATOR);
     private static final Utf8String TEST_TABLE_NAME = new Utf8String("test");
@@ -116,12 +137,12 @@ public class TextLoaderTest extends AbstractCairoTest {
                     "1\t0\t0\t2022-01-04T09:58:58.225032Z";
 
             configureLoaderDefaults(textLoader);
-            playText0(textLoader, csv1, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv1, 1024, NOOP_TRANSFORMER);
             assertTable(expected1);
             textLoader.clear();
 
             configureLoaderDefaults(textLoader);
-            playText0(textLoader, csv2, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv2, 1024, NOOP_TRANSFORMER);
             assertTable(expected2);
             textLoader.clear();
         });
@@ -177,15 +198,10 @@ public class TextLoaderTest extends AbstractCairoTest {
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
             try {
-                playText0(textLoader, csv, 1024, (index, len, b) -> {
-                    switch (index) {
-                        case 1560:
-                        case 1561:
-                        case 1562:
-                            return (byte) 160;
-                        default:
-                            return b;
-                    }
+                playText0(textLoader, csv, 1024, (arr) -> {
+                    arr[1560] = (byte) 160;
+                    arr[1561] = (byte) 160;
+                    arr[1562] = (byte) 160;
                 });
                 Assert.fail();
             } catch (CairoException e) {
@@ -281,15 +297,10 @@ public class TextLoaderTest extends AbstractCairoTest {
             configureLoaderDefaults(textLoader, (byte) ',', Atomicity.SKIP_COL);
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText(engine, textLoader, csv, 1024, expected, (index, len, b) -> {
-                        switch (index) {
-                            case 1560:
-                            case 1561:
-                            case 1562:
-                                return (byte) 160;
-                            default:
-                                return b;
-                        }
+            playText(engine, textLoader, csv, 1024, expected, (arr) -> {
+                        arr[1560] = (byte) 160;
+                        arr[1561] = (byte) 160;
+                        arr[1562] = (byte) 160;
                     },
                     "{\"columnCount\":9,\"columns\":[{\"index\":0,\"name\":\"№ПП\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"ОбъектыКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":2,\"name\":\"ВидКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":3,\"name\":\"ТемаКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":4,\"name\":\"ПроверяемыйПериод\",\"type\":\"" + stringTypeName + "\"},{\"index\":5,\"name\":\"НачалоПроверки\",\"type\":\"" + stringTypeName + "\"},{\"index\":6,\"name\":\"ОкончаниеПроверки\",\"type\":\"" + stringTypeName + "\"},{\"index\":7,\"name\":\"ВыявленныеНарушенияНедостатки\",\"type\":\"" + stringTypeName + "\"},{\"index\":8,\"name\":\"РезультатыПроверки\",\"type\":\"" + stringTypeName + "\"}],\"timestampIndex\":-1}",
                     36,
@@ -385,15 +396,10 @@ public class TextLoaderTest extends AbstractCairoTest {
             configureLoaderDefaults(textLoader);
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText(engine, textLoader, csv, 2048, expected, (index, len, b) -> {
-                        switch (index) {
-                            case 256:
-                            case 257:
-                            case 258:
-                                return (byte) 160;
-                            default:
-                                return b;
-                        }
+            playText(engine, textLoader, csv, 2048, expected, (arr) -> {
+                        arr[256] = (byte) 160;
+                        arr[257] = (byte) 160;
+                        arr[258] = (byte) 160;
                     },
                     "{\"columnCount\":9,\"columns\":[{\"index\":0,\"name\":\"№ПП\",\"type\":\"INT\"},{\"index\":1,\"name\":\"ОбъектыКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":2,\"name\":\"ВидКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":3,\"name\":\"ТемаКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":4,\"name\":\"ПроверяемыйПериод\",\"type\":\"" + stringTypeName + "\"},{\"index\":5,\"name\":\"f5\",\"type\":\"" + stringTypeName + "\"},{\"index\":6,\"name\":\"ОкончаниеПроверки\",\"type\":\"" + stringTypeName + "\"},{\"index\":7,\"name\":\"ВыявленныеНарушенияНедостатки\",\"type\":\"" + stringTypeName + "\"},{\"index\":8,\"name\":\"РезультатыПроверки\",\"type\":\"" + stringTypeName + "\"}],\"timestampIndex\":-1}",
                     36L,
@@ -487,15 +493,10 @@ public class TextLoaderTest extends AbstractCairoTest {
             configureLoaderDefaults(textLoader, (byte) ',', Atomicity.SKIP_ROW);
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText(engine, textLoader, csv, 1024, expected, (index, len, b) -> {
-                        switch (index) {
-                            case 1560:
-                            case 1561:
-                            case 1562:
-                                return (byte) 160;
-                            default:
-                                return b;
-                        }
+            playText(engine, textLoader, csv, 1024, expected, (arr) -> {
+                        arr[1560] = (byte) 160;
+                        arr[1561] = (byte) 160;
+                        arr[1562] = (byte) 160;
                     },
                     "{\"columnCount\":9,\"columns\":[{\"index\":0,\"name\":\"№ПП\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"ОбъектыКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":2,\"name\":\"ВидКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":3,\"name\":\"ТемаКонтрольногоМероприятия\",\"type\":\"" + stringTypeName + "\"},{\"index\":4,\"name\":\"ПроверяемыйПериод\",\"type\":\"" + stringTypeName + "\"},{\"index\":5,\"name\":\"НачалоПроверки\",\"type\":\"" + stringTypeName + "\"},{\"index\":6,\"name\":\"ОкончаниеПроверки\",\"type\":\"" + stringTypeName + "\"},{\"index\":7,\"name\":\"ВыявленныеНарушенияНедостатки\",\"type\":\"" + stringTypeName + "\"},{\"index\":8,\"name\":\"РезультатыПроверки\",\"type\":\"" + stringTypeName + "\"}],\"timestampIndex\":-1}",
                     36,
@@ -565,7 +566,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             configureLoaderDefaults(textLoader, (byte) -1, Atomicity.SKIP_ROW, true);
             try (TableWriter ignore = getWriter("test")) {
                 try {
-                    playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+                    playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
                     Assert.fail();
                 } catch (CairoException e) {
                     TestUtils.assertContains(e.getFlyweightMessage(), "could not lock");
@@ -602,7 +603,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                             "ts,int\n" +
                                     "2021-01-02T00:00:30.000000Z,1\n",
                             512,
-                            ENTITY_MANIPULATOR
+                            NOOP_TRANSFORMER
                     );
                 }
         );
@@ -623,7 +624,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                             "ts,int\n" +
                                     "2021-01-02T00:00:30.000000Z,1\n",
                             512,
-                            ENTITY_MANIPULATOR
+                            NOOP_TRANSFORMER
                     );
 
                     assertTable("ts\tint\n" +
@@ -765,7 +766,7 @@ public class TextLoaderTest extends AbstractCairoTest {
 
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
             sink.clear();
             textLoader.getMetadata().toJson(sink);
             TestUtils.assertEquals("{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"name\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"date\",\"type\":\"DATE\"}],\"timestampIndex\":-1}", sink);
@@ -800,7 +801,7 @@ public class TextLoaderTest extends AbstractCairoTest {
 
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
             sink.clear();
             textLoader.getMetadata().toJson(sink);
             TestUtils.assertEquals("{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"name\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"date\",\"type\":\"DATE\"}],\"timestampIndex\":-1}", sink);
@@ -1815,7 +1816,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                     "eu nisl volutpat viverra. Fusce eget fermentum massa, ut vulputate urna. Etiam in tristique nunc.";
             configureLoaderDefaults(textLoader);
             try {
-                playText0(textLoader, text, 512, ENTITY_MANIPULATOR);
+                playText0(textLoader, text, 512, NOOP_TRANSFORMER);
             } catch (TextException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "min deviation is too high");
             }
@@ -1828,7 +1829,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             String text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae justo mollis, placerat massa vel, ultricies dui.Donec nibh orci, vulputate finibus imperdiet vel, hendrerit ultrices libero. Nulla tristique ipsum ex, efficitur gravida massacondimentum a. Quisque id tellus in enim tempor fermentum. Nunc eu odio vel felis consectetur aliquet eget et nulla. Praesentsit amet sapien magna. Phasellus ut tortor diam. Vestibulum tristique urna ipsum. Maecenas tempor lectus ac ligula dictum,eu semper ante malesuada. Quisque bibendum egestas malesuada. Mauris suscipit orci tempor feugiat finibus. Quisque aliquamelit ut nulla tincidunt, vel cursus diam commodo. Sed id nunc sollicitudin, ornare nisi eu, ultrices nunc. Phasellus ac liberoeu nisl volutpat viverra. Fusce eget fermentum massa, ut vulputate urna. Etiam in tristique nunc.";
             configureLoaderDefaults(textLoader);
             try {
-                playText0(textLoader, text, 512, ENTITY_MANIPULATOR);
+                playText0(textLoader, text, 512, NOOP_TRANSFORMER);
             } catch (NotEnoughLinesException e) {
                 return;
             }
@@ -2260,7 +2261,7 @@ public class TextLoaderTest extends AbstractCairoTest {
 
             configureLoaderDefaults(textLoader, (byte) -1, Atomicity.SKIP_ROW, true);
             try {
-                playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+                playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
                 Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "name is reserved");
@@ -2482,7 +2483,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             String text = "value1,value2,value3\n";
             configureLoaderDefaults(textLoader);
             try {
-                playText0(textLoader, text, 512, ENTITY_MANIPULATOR);
+                playText0(textLoader, text, 512, NOOP_TRANSFORMER);
             } catch (NotEnoughLinesException e) {
                 return;
             }
@@ -2495,7 +2496,7 @@ public class TextLoaderTest extends AbstractCairoTest {
         assertNoLeak(textLoader -> {
             String text = "value1,value2,value3\n";
             configureLoaderDefaults(textLoader, (byte) ',');
-            playText0(textLoader, text, 512, ENTITY_MANIPULATOR);
+            playText0(textLoader, text, 512, NOOP_TRANSFORMER);
         });
     }
 
@@ -2515,7 +2516,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             configureLoaderDefaults(textLoader, (byte) '\t');
             textLoader.setForceHeaders(false);
             try {
-                playText0(textLoader, csv, 1, ENTITY_MANIPULATOR);
+                playText0(textLoader, csv, 1, NOOP_TRANSFORMER);
                 Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "cannot determine text structure");
@@ -2548,7 +2549,7 @@ public class TextLoaderTest extends AbstractCairoTest {
 
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
             sink.clear();
             textLoader.getMetadata().toJson(sink);
             TestUtils.assertEquals("{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"name\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"date\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":-1}", sink);
@@ -2584,7 +2585,7 @@ public class TextLoaderTest extends AbstractCairoTest {
 
             textLoader.setForceHeaders(true);
             textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-            playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
             sink.clear();
             textLoader.getMetadata().toJson(sink);
             TestUtils.assertEquals("{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"name\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"date\",\"type\":\"TIMESTAMP\"}],\"timestampIndex\":-1}", sink);
@@ -2888,7 +2889,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             engine.ddl("create table test(a varchar, b varchar)", sqlExecutionContext);
 
             configureLoaderDefaults(textLoader);
-            playText0(textLoader, csv1, 1024, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv1, 1024, NOOP_TRANSFORMER);
             assertTable(expected1);
             textLoader.clear();
         });
@@ -2976,7 +2977,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                     "CMP1,5,4938,4.42754498450086,2015-02-09T19:15:09.000Z,2015-02-09 19:15:09,02/09/2015,7817,FALSE,61983099\n";
 
             configureLoaderDefaults(textLoader);
-            playText0(textLoader, csv, 350, ENTITY_MANIPULATOR);
+            playText0(textLoader, csv, 350, NOOP_TRANSFORMER);
             sink.clear();
             textLoader.getMetadata().toJson(sink);
             TestUtils.assertEquals("{\"columnCount\":10,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"" + stringTypeName + "\"},{\"index\":1,\"name\":\"f1\",\"type\":\"INT\"},{\"index\":2,\"name\":\"f2\",\"type\":\"INT\"},{\"index\":3,\"name\":\"f3\",\"type\":\"DOUBLE\"},{\"index\":4,\"name\":\"f4\",\"type\":\"DATE\"},{\"index\":5,\"name\":\"f5\",\"type\":\"DATE\"},{\"index\":6,\"name\":\"f6\",\"type\":\"DATE\"},{\"index\":7,\"name\":\"f7\",\"type\":\"INT\"},{\"index\":8,\"name\":\"f8\",\"type\":\"BOOLEAN\"},{\"index\":9,\"name\":\"f9\",\"type\":\"INT\"}],\"timestampIndex\":-1}", sink);
@@ -3176,7 +3177,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             ddl("create table test(a int, b int)");
             configureLoaderDefaults(textLoader);
             try {
-                playText0(textLoader, csv, 1024, ENTITY_MANIPULATOR);
+                playText0(textLoader, csv, 1024, NOOP_TRANSFORMER);
                 Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "column count mismatch [textColumnCount=10, tableColumnCount=2, table=test]");
@@ -3293,14 +3294,15 @@ public class TextLoaderTest extends AbstractCairoTest {
         return pathElements[pathElements.length - 1];
     }
 
-    private static void playText0(TextLoader textLoader, String text, int firstBufSize, ByteManipulator manipulator) throws TextException {
+    private static void playText0(TextLoader textLoader, String text, int firstBufSize, ByteArrayTransformer transformer) throws TextException {
         byte[] bytes = text.getBytes(Files.UTF_8);
+        transformer.transform(bytes);
         int len = bytes.length;
         long buf = Unsafe.malloc(len, MemoryTag.NATIVE_TEXT_PARSER_RSS);
         long smallBuf = Unsafe.malloc(1, MemoryTag.NATIVE_TEXT_PARSER_RSS);
         try {
             for (int i = 0; i < len; i++) {
-                Unsafe.getUnsafe().putByte(buf + i, manipulator.translate(i, len, bytes[i]));
+                Unsafe.getUnsafe().putByte(buf + i, bytes[i]);
             }
 
             if (firstBufSize < len) {
@@ -3662,7 +3664,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             String text,
             final int firstBufSize,
             String expected,
-            ByteManipulator manipulator,
+            ByteArrayTransformer transformer,
             CharSequence expectedMetadata,
             long expectedParsedLineCount,
             long expectedWrittenLineCount,
@@ -3673,7 +3675,7 @@ public class TextLoaderTest extends AbstractCairoTest {
         byte delimiter = textLoader.getColumnDelimiter();
         int maxUncommittedRows = textLoader.getMaxUncommittedRows();
         long o3MaxLag = textLoader.getO3MaxLag();
-        playText0(textLoader, text, firstBufSize, manipulator);
+        playText0(textLoader, text, firstBufSize, transformer);
         sink.clear();
         textLoader.getMetadata().toJson(sink);
         TestUtils.assertEquals(expectedMetadata, sink);
@@ -3694,7 +3696,7 @@ public class TextLoaderTest extends AbstractCairoTest {
             textLoader.configureColumnDelimiter(delimiter);
         }
         textLoader.setState(TextLoader.ANALYZE_STRUCTURE);
-        playText0(textLoader, text, firstBufSize, manipulator);
+        playText0(textLoader, text, firstBufSize, transformer);
         assertTable(expected);
         textLoader.clear();
     }
@@ -3761,7 +3763,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                 text,
                 firstBufSize,
                 expected,
-                ENTITY_MANIPULATOR,
+                NOOP_TRANSFORMER,
                 expectedMetadata,
                 expectedParsedLineCount,
                 expectedWrittenLineCount,
@@ -3792,7 +3794,7 @@ public class TextLoaderTest extends AbstractCairoTest {
                             "ts,int\n" +
                                     "2021-01-02T00:00:30.000000Z,1\n",
                             512,
-                            ENTITY_MANIPULATOR
+                            NOOP_TRANSFORMER
                     );
 
                     assertTable("ts\tint\n" +
@@ -3812,8 +3814,8 @@ public class TextLoaderTest extends AbstractCairoTest {
     }
 
     @FunctionalInterface
-    private interface ByteManipulator {
-        byte translate(int index, int len, byte b);
+    private interface ByteArrayTransformer {
+        void transform(byte[] array);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Fixes https://github.com/questdb/questdb/issues/4823

It looks like a JVM bug! It’s quite interesting:
The test converts a Java string with valid CSV content into a UTF-8 byte array, then copies the array
content into a native buffer.

During copying, it corrupts three specific bytes. These bytes happen to be part of the CSV header.
It literally overrides the three bytes with an invalid UTF-8 sequence: A0 A0 A0.

From that point on, the test exclusively uses the native buffer with the corrupted field name.
When TextMetadataDetector encounters an invalid UTF-8 sequence in the field name, it creates
a synthetic field/column name: f_<index>.

The test asserts that this synthetic field is present. Yet, in failing runs, there is
no synthetic column at all! Magically, the field name is correct—as if the parser wasn’t
reading from a damaged buffer.

I can occasionally reproduce this issue when using JDK 11, running the whole test
class in a loop, and forking a new JVM for each iteration.

This change keeps the test semantics, but corrupts the UTF8 bytes in the original
on-heap byte array, before copying it to the native buffer.

With this change I am no longer able to reproduce the failure. My only explanation is that it is
a JVM bug - program order is violated around Unsafe operations - parser see the original
UTF8 sequence, without any corruption.