### PR TITLE
fix(sql): improve Parquet partition format support in TableReader/TableWriter

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6920,8 +6920,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         long parquetFileFd = -1L;
         try (
                 PartitionDecoder partitionDecoder = new PartitionDecoder();
-                RowGroupStatBuffers rowGroupStatBuffers = new RowGroupStatBuffers();
-                DirectIntList columnIdsAndTypes = new DirectIntList(2, MemoryTag.NATIVE_O3)
+                RowGroupStatBuffers rowGroupStatBuffers = new RowGroupStatBuffers(MemoryTag.NATIVE_TABLE_WRITER);
+                DirectIntList columnIdsAndTypes = new DirectIntList(2, MemoryTag.NATIVE_TABLE_WRITER)
         ) {
             parquetFileFd = TableUtils.openRO(ff, partitionPath.concat(PARQUET_PARTITION_NAME).$(), LOG);
             partitionDecoder.of(parquetFileFd);
@@ -6980,8 +6980,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         long parquetFileFd = -1L;
         try (
                 PartitionDecoder partitionDecoder = new PartitionDecoder();
-                RowGroupStatBuffers rowGroupStatBuffers = new RowGroupStatBuffers();
-                DirectIntList columnIdsAndTypes = new DirectIntList(2, MemoryTag.NATIVE_O3)
+                RowGroupStatBuffers rowGroupStatBuffers = new RowGroupStatBuffers(MemoryTag.NATIVE_TABLE_WRITER);
+                DirectIntList columnIdsAndTypes = new DirectIntList(2, MemoryTag.NATIVE_TABLE_WRITER)
         ) {
             parquetFileFd = TableUtils.openRO(ff, filePath.$(), LOG);
             partitionDecoder.of(parquetFileFd);

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
@@ -40,6 +40,8 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static io.questdb.cairo.TableUtils.PARQUET_PARTITION_NAME;
+
 public class AlterTableConvertPartitionTest extends AbstractCairoTest {
 
     @Test
@@ -422,7 +424,7 @@ public class AlterTableConvertPartitionTest extends AbstractCairoTest {
         int tablePathLen = path.size();
 
         path.trimTo(tablePathLen);
-        path.concat(partition).concat("data.parquet");
+        path.concat(partition).concat(PARQUET_PARTITION_NAME);
 
         if (rev) {
             Assert.assertFalse(ff.exists(path.$()));

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -911,7 +911,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
                     renameDetachedToAttachable(tableName, "2022-06-01");
                     ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
 
-                    assertContent(expected, tableName); //FIXME: mixed partition format query
+                    assertContent(expected, tableName);
                 });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -2090,7 +2090,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
 
             assertFailure(
                     "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampDay + "'",
-                    "cannot read min, max timestamp from the column"
+                    "cannot read min, max timestamp from the"
             );
         });
     }
@@ -2134,7 +2134,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
 
             assertFailure(
                     "ALTER TABLE " + tableName + " ATTACH PARTITION LIST '" + timestampWrongDay2 + "'",
-                    "invalid timestamp column data in detached partition, data does not match partition directory name"
+                    "invalid timestamp data in detached partition, data does not match partition directory name"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -867,6 +867,55 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
     }
 
     @Test
+    public void testDetachAttachParquetPartition() throws Exception {
+        assertMemoryLeak(
+                () -> {
+                    String tableName = testName.getMethodName();
+                    TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
+                    createPopulateTable(
+                            1,
+                            tab.timestamp("ts")
+                                    .col("si", ColumnType.SYMBOL).indexed(true, 250)
+                                    .col("i", ColumnType.INT)
+                                    .col("l", ColumnType.LONG)
+                                    .col("s", ColumnType.SYMBOL)
+                                    .col("vch", ColumnType.VARCHAR),
+                            10,
+                            "2022-06-01",
+                            2
+                    );
+
+
+                    String expected = "ts\tsi\ti\tl\ts\tvch\n" +
+                            "2022-06-01T04:47:59.900000Z\tPEHN\t1\t1\tSXUX\t擉q\uDAE2\uDC5E͛\n" +
+                            "2022-06-01T09:35:59.800000Z\t\t2\t2\t\t蝰L➤~2\uDAC6\uDED3ڎBH\n" +
+                            "2022-06-01T14:23:59.700000Z\tVTJW\t3\t3\tRXGZ\t\n" +
+                            "2022-06-01T19:11:59.600000Z\tVTJW\t4\t4\tGPGW\t:}w?5J8A.mS+F~W\n" +
+                            "2022-06-01T23:59:59.500000Z\tCPSW\t5\t5\tGPGW\td^Z\n" +
+                            "2022-06-02T04:47:59.400000Z\tPEHN\t6\t6\tGPGW\t篸{\uD9D7\uDFE5\uDAE9\uDF46OF\n" +
+                            "2022-06-02T09:35:59.300000Z\tVTJW\t7\t7\t\t\n" +
+                            "2022-06-02T14:23:59.200000Z\tVTJW\t8\t8\t\t䒭ܲ\u0379軦۽㒾\uD99D\uDEA7K裷\uD9CC\uDE73+\u0093ً\n" +
+                            "2022-06-02T19:11:59.100000Z\t\t9\t9\tGPGW\tK\uD8E2\uDE25ӽ-\uDBED\uDC98\n" +
+                            "2022-06-02T23:59:59.000000Z\t\t10\t10\t\ty\u0086W\n";
+
+                    assertContent(expected, tableName);
+
+                    engine.clear();
+                    ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    renameDetachedToAttachable(tableName, "2022-06-01");
+                    ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+
+                    engine.clear();
+                    ddl("ALTER TABLE " + tableName + " CONVERT PARTITION TO PARQUET LIST '2022-06-01'", sqlExecutionContext);
+                    ddl("ALTER TABLE " + tableName + " DETACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+                    renameDetachedToAttachable(tableName, "2022-06-01");
+                    ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2022-06-01'", sqlExecutionContext);
+
+                    assertContent(expected, tableName); //FIXME: mixed partition format query
+                });
+    }
+
+    @Test
     public void testDetachAttachPartitionBrokenMetadataColumnType() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = "tabBrokenColType";

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/PartitionDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/PartitionDecoderTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin.engine.table.parquet;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableReaderMetadata;
 import io.questdb.cairo.TableUtils;
@@ -35,12 +36,12 @@ import io.questdb.griffin.engine.table.parquet.PartitionEncoder;
 import io.questdb.griffin.engine.table.parquet.RowGroupBuffers;
 import io.questdb.griffin.engine.table.parquet.RowGroupStatBuffers;
 import io.questdb.std.DirectIntList;
-import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.TableModel;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -184,15 +185,19 @@ public class PartitionDecoderTest extends AbstractCairoTest {
      */
     @Test
     public void testUpdateInvalidRowGroup() throws Exception {
-        final long rows = 10;
+        final long rows = 1000;
         final FilesFacade ff = configuration.getFilesFacade();
 
         // We first set up the table without memory limits.
         assertMemoryLeak(() -> {
-            ddl("create table x as (select" +
-                    " x id," +
-                    " timestamp_sequence(400000000000, 500) designated_ts" +
-                    " from long_sequence(" + rows + ")) timestamp(designated_ts) partition by day");
+            TableModel src = new TableModel(configuration, "x", PartitionBy.DAY);
+            createPopulateTable(
+                    1,
+                    src.timestamp("designated_ts")
+                            .col("id", ColumnType.LONG),
+                    100,
+                    "1970-01-05",
+                    2); // generate 2 partitions
 
             // Convert the partition to parquet via SQL.
             ddl("alter table x convert partition to parquet where designated_ts >= 0");

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ReadParquetFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ReadParquetFunctionTest.java
@@ -34,6 +34,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.engine.table.parquet.PartitionDescriptor;
 import io.questdb.griffin.engine.table.parquet.PartitionEncoder;
 import io.questdb.std.Files;
+import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
@@ -76,30 +77,23 @@ public class ReadParquetFunctionTest extends AbstractCairoTest {
                     " rnd_geohash(16) a_geo_int," +
                     " rnd_geohash(32) a_geo_long," +
                     " rnd_bin(10, 20, 2) a_bin," +
-                    " timestamp_sequence('2015',2) as a_ts," +
+                    " timestamp_sequence('2015', " + (Timestamps.AVG_YEAR_MICROS / 4) + ") as a_ts," +
                     " from long_sequence(" + rows + ")) timestamp (a_ts) partition by YEAR");
 
             ddl("alter table x convert partition to parquet where a_ts > 0");
 
             engine.releaseInactive();
             try (Path path = new Path()) {
-                path.concat(engine.verifyTableName("x")).concat("2015.1").concat(PARQUET_PARTITION_NAME);
+                path.concat(engine.verifyTableName("x")).concat("2015.2").concat(PARQUET_PARTITION_NAME);
 
                 sink.clear();
                 sink.put("select * from read_parquet('").put(path).put("')");
                 assertQuery("id\ta_long\ta_str\ta_varchar\ta_boolean\ta_short\ta_byte\ta_char\ta_uuid\ta_double\ta_float\ta_sym\ta_date\ta_long256\ta_ip\ta_geo_byte\ta_geo_short\ta_geo_int\ta_geo_long\ta_bin\ta_ts\n" +
-                                "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-11-24T20:19:13.843Z\t0x2705e02c613acfc405374f5fbcef4819523eb59d99c647af9840ad8800156d26\t138.69.22.149\t0000\t11001010\t0000101000111011\t10100111010101011100000010101100\t\t2015-01-01T00:00:00.000000Z\n" +
-                                "2\t-461611463\tHYRX\t0L#YS\\%~\\2o#/ZUAI6Q,]K+BuHiX\tfalse\t3428\t25\tO\t71660a9b-0890-42f0-aa0a-ccd425e948d4\t0.38642336707855873\t0.9205\tGPGW\t2015-02-04T13:09:51.166Z\t0x51686790e59377ca68653a6cd896f81ed4e0ddcd6eb2cff1c736a8b67656c4f1\t250.26.136.156\t1001\t10001000\t1110111101101001\t01010111101100101101110010010001\t00000000 e5 61 2f 64 0e 2c 7f d7 6f b8 c9 ae 28 c7 84 47\t2015-01-01T00:00:00.000002Z\n" +
-                                "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-08-16T07:46:57.313Z\t0xc6dfacdd3f3c52b88b4e4831499fc2a526567f4430b46b7f78c594c496995885\t107.3.2.123\t1110\t00110010\t0010010010010011\t01110010110101010111111110111011\t00000000 64 d2 ad 49 1c f2 3c ed 39 ac a8 3b a6\t2015-01-01T00:00:00.000004Z\n" +
-                                "4\t-283321892\tCPSW\t\tfalse\t-22894\t70\tZ\tdb217d41-156b-4ee1-a90c-04663c808638\t0.3679848625908545\t0.8231\tGPGW\t2015-05-24T01:10:00.026Z\t0x0ec6c3651b1c029f825c96def9f2fcc2b942438168662cb7aa21f9d816335363\t241.72.62.41\t1110\t00100111\t1111001111111000\t11100111010111100111111001011011\t00000000 43 1d 57 34 04 23 8d d8 57 91 88 28 a5 18 93 bd\n" +
-                                "00000010 0b 61 f5\t2015-01-01T00:00:00.000006Z\n" +
-                                "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-04-15T00:02:37.661Z\t0x70061ac6a4115ca72121bcf90e43824476ffd1a81bf39767b92d0771d78263eb\t142.167.96.106\t0100\t11111111\t1000111111011111\t00001000010100101111101101110000\t\t2015-01-01T00:00:00.000008Z\n" +
-                                "6\t-1726426588\t\t\uDB42\uDC86W씌䒙\uD8F2\uDE8E>\uDAE6\uDEE3gX夺\uDA02\uDE66\uDA29\uDE0E⋜\uD9DC\uDEB3\uD90B\uDDC5cᣮաf@ץ;윦\u0382宏\ttrue\t29923\t36\tH\t89f3ac11-65aa-40b1-a61a-2e7ca9350807\t0.95820305972778\t0.7707\t\t\t0x7ab72c8ee7c4dea1c54dc9aa8e01394b65464a26629d85cb508ce19ec75e8088\t245.42.76.207\t1001\t10000010\t1111010101000000\t10101101010100011001100001111001\t00000000 2b b3 71 a7 d5 af 11 96 37 08\t2015-01-01T00:00:00.000010Z\n" +
-                                "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-03-25T09:21:52.776Z\t0x6a44a113d18bd82a6784e4a783247d88546c26b247358a5497a77df30ee95def\t202.243.69.162\t0111\t11010111\t0110101110000011\t11100001001100101011101100010111\t\t2015-01-01T00:00:00.000012Z\n" +
-                                "8\t-158323100\tVTJW\tU,MF|yrXB,=B)iRv59Q,?/qbOku|U#EHD\tfalse\t7583\t105\tS\tc04ba3c4-3305-482a-8174-454ba2921cbb\t0.798471808479839\t0.2942\t\t2015-10-06T15:07:04.728Z\t0xb23ff8774a5db433b19ddb7ff5abcafec82c35a389f834dababcd0482f05618f\t53.137.68.152\t1101\t00100011\t0001111000101110\t11010100111101010000100010001011\t\t2015-01-01T00:00:00.000014Z\n" +
-                                "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-08-19T07:45:23.196Z\t0x0ceb6d48cda39eb24f38804270a4a64349b5760a687d8cf838cbb9ae96e9ecdc\t10.101.5.227\t0011\t01001000\t1111111101011000\t11001010001000000100111000111110\t00000000 c4 4a c9 cf fb 9d 63 ca 94 00 6b dd 18 fe 71 76\n" +
-                                "00000010 bc\t2015-01-01T00:00:00.000016Z\n" +
-                                "10\t835713605\t\tt0&{b4BKKUL\\'k1X^{DaU%\ttrue\t19244\t66\tC\t4cedbc17-2f67-4fb6-a4d3-28f097940cde\t0.16698121316984016\t0.3383\tGPGW\t2015-03-18T21:31:57.871Z\t0xdb679af7e4282aa3d7a37bf63a1a9a89b88b0261a4770cf3bd27bad88085f716\t154.162.204.131\t0001\t11010000\t0001101100100110\t01010100100010110010010100101000\t\t2015-01-01T00:00:00.000018Z\n",
+                        "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-11-24T20:19:13.843Z\t0x2705e02c613acfc405374f5fbcef4819523eb59d99c647af9840ad8800156d26\t138.69.22.149\t0000\t11001010\t0000101000111011\t10100111010101011100000010101100\t\t2015-01-01T00:00:00.000000Z\n" +
+                        "2\t-461611463\tHYRX\t0L#YS\\%~\\2o#/ZUAI6Q,]K+BuHiX\tfalse\t3428\t25\tO\t71660a9b-0890-42f0-aa0a-ccd425e948d4\t0.38642336707855873\t0.9205\tGPGW\t2015-02-04T13:09:51.166Z\t0x51686790e59377ca68653a6cd896f81ed4e0ddcd6eb2cff1c736a8b67656c4f1\t250.26.136.156\t1001\t10001000\t1110111101101001\t01010111101100101101110010010001\t00000000 e5 61 2f 64 0e 2c 7f d7 6f b8 c9 ae 28 c7 84 47\t2015-04-02T07:27:18.000000Z\n" +
+                        "null\tnull\t\t\tfalse\t0\t0\t\t\tnull\tnull\t\t2015-08-16T07:46:57.313Z\t0xc6dfacdd3f3c52b88b4e4831499fc2a526567f4430b46b7f78c594c496995885\t107.3.2.123\t1110\t00110010\t0010010010010011\t01110010110101010111111110111011\t00000000 64 d2 ad 49 1c f2 3c ed 39 ac a8 3b a6\t2015-07-02T14:54:36.000000Z\n" +
+                        "4\t-283321892\tCPSW\t\tfalse\t-22894\t70\tZ\tdb217d41-156b-4ee1-a90c-04663c808638\t0.3679848625908545\t0.8231\tGPGW\t2015-05-24T01:10:00.026Z\t0x0ec6c3651b1c029f825c96def9f2fcc2b942438168662cb7aa21f9d816335363\t241.72.62.41\t1110\t00100111\t1111001111111000\t11100111010111100111111001011011\t00000000 43 1d 57 34 04 23 8d d8 57 91 88 28 a5 18 93 bd\n" +
+                        "00000010 0b 61 f5\t2015-10-01T22:21:54.000000Z\n",
                         sink, null, null, false, true);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ReadParquetFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ReadParquetFunctionTest.java
@@ -41,6 +41,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.questdb.cairo.TableUtils.PARQUET_PARTITION_NAME;
+
 public class ReadParquetFunctionTest extends AbstractCairoTest {
 
     @Before
@@ -81,7 +83,7 @@ public class ReadParquetFunctionTest extends AbstractCairoTest {
 
             engine.releaseInactive();
             try (Path path = new Path()) {
-                path.concat(engine.verifyTableName("x")).concat("2015.1").concat("data.parquet");
+                path.concat(engine.verifyTableName("x")).concat("2015.1").concat(PARQUET_PARTITION_NAME);
 
                 sink.clear();
                 sink.put("select * from read_parquet('").put(path).put("')");


### PR DESCRIPTION
- Added support for Parquet partition format in TableReader partition reload logic.
- Fixed issues with removing Parquet partitions.
- Attach/detach sql now works with Parquet partitions.
- Modified partition format conversion logic to ignore active partitions.
- Updated tests to account for changes, particularly for converting the last (active) partition to Parquet.