### PR TITLE
chore(sql): relocate `regr_slope()`

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionSlopeFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionSlopeFunctionFactory.java
@@ -22,7 +22,7 @@
  *
  ******************************************************************************/
 
-package io.questdb.griffin.engine.functions.finance;
+package io.questdb.griffin.engine.functions.groupby;
 
 import io.questdb.cairo.ArrayColumnTypes;
 import io.questdb.cairo.CairoConfiguration;
@@ -108,6 +108,21 @@ public class RegressionSlopeFunctionFactory implements FunctionFactory {
         }
 
         @Override
+        public Function getLeft() {
+            return xFunction;
+        }
+
+        @Override
+        public String getName() {
+            return "regr_slope";
+        }
+
+        @Override
+        public Function getRight() {
+            return yFunction;
+        }
+
+        @Override
         public int getValueIndex() {
             return valueIndex;
         }
@@ -128,13 +143,13 @@ public class RegressionSlopeFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public boolean isThreadSafe() {
-            return BinaryFunction.super.isThreadSafe();
+        public boolean isConstant() {
+            return false;
         }
 
         @Override
-        public boolean supportsParallelism() {
-            return true;
+        public boolean isThreadSafe() {
+            return BinaryFunction.super.isThreadSafe();
         }
 
         @Override
@@ -159,32 +174,17 @@ public class RegressionSlopeFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public Function getLeft() {
-            return xFunction;
-        }
-
-        @Override
-        public Function getRight() {
-            return yFunction;
-        }
-
-        @Override
-        public boolean isConstant() {
-            return false;
-        }
-
-        @Override
-        public String getName() {
-            return "regr_slope";
-        }
-
-        @Override
         public void setNull(MapValue mapValue) {
             mapValue.putDouble(valueIndex, Double.NaN);
             mapValue.putDouble(valueIndex + 1, Double.NaN);
             mapValue.putDouble(valueIndex + 2, Double.NaN);
             mapValue.putDouble(valueIndex + 3, Double.NaN);
             mapValue.putLong(valueIndex + 4, 0);
+        }
+
+        @Override
+        public boolean supportsParallelism() {
+            return true;
         }
 
         protected void aggregate(MapValue mapValue, double y, double x) {

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,5 +1,3 @@
-import io.questdb.griffin.engine.functions.groupby.RegressionSlopeFunctionFactory;
-
 /*******************************************************************************
  *     ___                  _   ____  ____
  *    / _ \ _   _  ___  ___| |_|  _ \| __ )
@@ -129,7 +127,6 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.finance.MidPriceFunctionFactory,
             io.questdb.griffin.engine.functions.finance.WeightedMidPriceFunctionFactory,
             io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory,
-            RegressionSlopeFunctionFactory,
 
 
             // query activity functions
@@ -776,6 +773,9 @@ open module io.questdb {
 //                  'isOrdered'
             io.questdb.griffin.engine.functions.groupby.IsIPv4OrderedGroupByFunctionFactory,
             io.questdb.griffin.engine.functions.groupby.IsLongOrderedGroupByFunctionFactory,
+
+            io.questdb.griffin.engine.functions.groupby.RegressionSlopeFunctionFactory,
+
 //                  round()
             io.questdb.griffin.engine.functions.math.RoundDoubleZeroScaleFunctionFactory,
             io.questdb.griffin.engine.functions.math.RoundDoubleFunctionFactory,

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import io.questdb.griffin.engine.functions.groupby.RegressionSlopeFunctionFactory;
+
 /*******************************************************************************
  *     ___                  _   ____  ____
  *    / _ \ _   _  ___  ___| |_|  _ \| __ )
@@ -127,7 +129,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.finance.MidPriceFunctionFactory,
             io.questdb.griffin.engine.functions.finance.WeightedMidPriceFunctionFactory,
             io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory,
-            io.questdb.griffin.engine.functions.finance.RegressionSlopeFunctionFactory,
+            RegressionSlopeFunctionFactory,
 
 
             // query activity functions

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -27,7 +27,6 @@ io.questdb.griffin.engine.functions.finance.SpreadFunctionFactory
 io.questdb.griffin.engine.functions.finance.MidPriceFunctionFactory
 io.questdb.griffin.engine.functions.finance.WeightedMidPriceFunctionFactory
 io.questdb.griffin.engine.functions.finance.SpreadBpsFunctionFactory
-io.questdb.griffin.engine.functions.finance.RegressionSlopeFunctionFactory
 
 io.questdb.griffin.engine.functions.activity.CancelQueryFunctionFactory
 io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory
@@ -716,6 +715,8 @@ io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByDefaul
 io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctLongGroupByFunctionFactory
 io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByDefaultFunctionFactory
 io.questdb.griffin.engine.functions.groupby.ApproxCountDistinctIPv4GroupByFunctionFactory
+
+io.questdb.griffin.engine.functions.groupby.RegressionSlopeFunctionFactory
 
 # 'isOrdered'
 io.questdb.griffin.engine.functions.groupby.IsIPv4OrderedGroupByFunctionFactory


### PR DESCRIPTION
`regr_slope` was listed under a finance-related functions issue, but is actually a more generic statistical function, and should be colocated with the others (variance, stddev etc.).