### PR TITLE
fix(pgwire): memory leak with pipelined UPDATEs

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1278,15 +1278,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             }
         }
 
-        if (typesAndUpdate != null) {
-            if (typesAndUpdateIsCached) {
-                assert queryText != null;
-                typesAndUpdateCache.put(queryText, typesAndUpdate);
-                this.typesAndUpdate = null;
-            } else {
-                typesAndUpdate = Misc.free(typesAndUpdate);
-            }
-        }
+        freeOrCacheTypesAndUpdate();
     }
 
     private <T extends Mutable> void clearPool(
@@ -1677,6 +1669,18 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
     private void freeFactory() {
         currentFactory = null;
         typesAndSelect = Misc.free(typesAndSelect);
+    }
+
+    private void freeOrCacheTypesAndUpdate() {
+        if (typesAndUpdate != null) {
+            if (typesAndUpdateIsCached) {
+                assert queryText != null;
+                typesAndUpdateCache.put(queryText, typesAndUpdate);
+                this.typesAndUpdate = null;
+            } else {
+                typesAndUpdate = Misc.free(typesAndUpdate);
+            }
+        }
     }
 
     private void freeUpdateCommand(UpdateOperation op) {
@@ -2430,6 +2434,8 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         if (currentCursor != null) {
             clearCursorAndFactory();
         }
+        // and clear TypesAndUpdate too
+        freeOrCacheTypesAndUpdate();
 
         //TODO: parsePhaseBindVariableCount have to be checked before parseQueryText and fed into it to serve as type hints !
         parseQueryText(lo, hi);


### PR DESCRIPTION
when a client sends multiple UPDATE statements then - depending on the protocol mode - only the last statement is closed on the server side.

the current pgwire implementation does not support pipelined execution very well, but a memory leak justifies the fix.

**Note for reviewers**
GitHub web diff does not cope well with the test change. The new test is taken from the `vi_pg_pipeline` where the new pgwire implementation is being cooked. It's the same test, except it runs in in all pgwire modes: simple, extended, text, binary, different thresholds for prepared statements, etc. 