### PR TITLE
perf(sql): implement interface of `deepClone` for functions.

### DIFF
--- a/benchmarks/src/main/java/org/questdb/FunctionDeepCloneBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/FunctionDeepCloneBenchmark.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.FunctionFactoryCache;
+import io.questdb.griffin.FunctionParser;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.griffin.engine.functions.FunctionCloneFactory;
+import io.questdb.griffin.engine.functions.date.ToStrDateFunctionFactory;
+import io.questdb.griffin.engine.functions.groupby.CountDistinctStringGroupByFunctionFactory;
+import io.questdb.griffin.model.ExpressionNode;
+import io.questdb.griffin.model.QueryModel;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FunctionDeepCloneBenchmark {
+    private static final CairoConfiguration configuration =
+            new DefaultCairoConfiguration(System.getProperty("java.io.tmpdir"));
+    private static final ArrayList<FunctionFactory> functions = new ArrayList<>(Arrays.asList(new ToStrDateFunctionFactory(), new CountDistinctStringGroupByFunctionFactory()));
+    private static final FunctionParser functionParser = new FunctionParser(configuration, new FunctionFactoryCache(configuration, functions));
+    private static SqlExecutionContextImpl ctx;
+    private static final GenericRecordMetadata metadata = new GenericRecordMetadata();
+    private static ExpressionNode node;
+    private static Function function;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(FunctionDeepCloneBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(2)
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Setup(Level.Trial)
+    public void setup() throws SqlException {
+        CairoEngine engine = new CairoEngine(configuration);
+        ctx = new SqlExecutionContextImpl(engine, 1);
+        QueryModel queryModel = QueryModel.FACTORY.newInstance();
+        metadata.add(new TableColumnMetadata("a", ColumnType.DATE));
+
+        try (SqlCompiler compiler = engine.getSqlCompiler()) {
+            node = compiler.testParseExpression("count_distinct(to_str(a, 'EE, dd-MMM-yyyy hh:mm:ss'))", queryModel);
+            function = functionParser.parseFunction(node, metadata, ctx);
+        }
+    }
+
+    @Benchmark
+    public Function deepClone() {
+        return FunctionCloneFactory.deepCloneFunction(function);
+    }
+
+    @Benchmark
+    public Function functionParser() throws SqlException {
+        return functionParser.parseFunction(node, metadata, ctx);
+    }
+}

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -376,6 +376,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlPageFrameMinRows;
     private final boolean sqlParallelFilterEnabled;
     private final boolean sqlParallelFilterPreTouchEnabled;
+    private final boolean sqlParallelFunctionDeepCloneEnabled;
     private final boolean sqlParallelGroupByEnabled;
     private final int sqlParallelWorkStealingThreshold;
     private final int sqlQueryRegistryPoolSize;
@@ -1461,6 +1462,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             final int defaultReduceShardCount = Math.min(sharedWorkerCount, 4);
             this.cairoPageFrameReduceShardCount = getInt(properties, env, PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, defaultReduceShardCount);
             this.sqlParallelFilterPreTouchEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED, true);
+            this.sqlParallelFunctionDeepCloneEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FUNCTION_DEEP_CLONE_ENABLED, true);
             this.sqlCopyModelPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_SQL_COPY_MODEL_POOL_CAPACITY, 32);
 
             boolean defaultParallelSqlEnabled = sharedWorkerCount >= 4;
@@ -3257,6 +3259,12 @@ public class PropServerConfiguration implements ServerConfiguration {
         public boolean isSqlParallelFilterPreTouchEnabled() {
             return sqlParallelFilterPreTouchEnabled;
         }
+
+        @Override
+        public boolean isSqlParallelFunctionDeepCloneEnabled() {
+            return sqlParallelFunctionDeepCloneEnabled;
+        }
+
 
         @Override
         public boolean isSqlParallelGroupByEnabled() {

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -94,6 +94,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY("cairo.page.frame.rowid.list.capacity"),
     CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY("cairo.page.frame.column.list.capacity"),
     CAIRO_SQL_PARALLEL_FILTER_ENABLED("cairo.sql.parallel.filter.enabled"),
+    CAIRO_SQL_PARALLEL_FUNCTION_DEEP_CLONE_ENABLED("cairo.sql.parallel.function.deep.clone.enabled"),
     CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED("cairo.sql.parallel.filter.pretouch.enabled"),
     CAIRO_SQL_PARALLEL_GROUPBY_ENABLED("cairo.sql.parallel.groupby.enabled"),
     CAIRO_SQL_PARALLEL_GROUPBY_MERGE_QUEUE_CAPACITY("cairo.sql.parallel.groupby.merge.shard.queue.capacity"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -618,6 +618,8 @@ public interface CairoConfiguration {
 
     boolean isSqlParallelFilterPreTouchEnabled();
 
+    boolean isSqlParallelFunctionDeepCloneEnabled();
+
     boolean isSqlParallelGroupByEnabled();
 
     boolean isTableTypeConversionEnabled();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1161,6 +1161,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public boolean isSqlParallelFunctionDeepCloneEnabled() {
+        return getDelegate().isSqlParallelFunctionDeepCloneEnabled();
+    }
+
+    @Override
     public boolean isSqlParallelGroupByEnabled() {
         return getDelegate().isSqlParallelGroupByEnabled();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -1179,6 +1179,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean isSqlParallelFunctionDeepCloneEnabled() {
+        return true;
+    }
+
+    @Override
     public boolean isSqlParallelGroupByEnabled() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cairo/sql/Function.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Function.java
@@ -270,7 +270,7 @@ public interface Function extends Closeable, StatefulAtom, Plannable {
 
     /**
      * Return true if the function support clone itself init states for parallel execution,
-     * which would call by ({@link io.questdb.griffin.engine.functions.FunctionCloneFactory}).
+     * Cloning is done by {@link io.questdb.griffin.engine.functions.FunctionCloneFactory}.
      *
      * @return true if the function and all of its children functions are support deepClone.
      */

--- a/core/src/main/java/io/questdb/cairo/sql/Function.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Function.java
@@ -268,6 +268,10 @@ public interface Function extends Closeable, StatefulAtom, Plannable {
         return true;
     }
 
+    default boolean supportDeepClone() {
+        return true;
+    }
+
     default boolean supportsRandomAccess() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cairo/sql/Function.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Function.java
@@ -268,6 +268,12 @@ public interface Function extends Closeable, StatefulAtom, Plannable {
         return true;
     }
 
+    /**
+     * Return true if the function support clone itself init states for parallel execution,
+     * which would call by ({@link io.questdb.griffin.engine.functions.FunctionCloneFactory}).
+     *
+     * @return true if the function and all of its children functions are support deepClone.
+     */
     default boolean supportDeepClone() {
         return true;
     }

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -820,8 +820,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 for (int i = 0; i < workerCount; i++) {
                     workerFilters.extendAndSet(i, FunctionCloneFactory.deepCloneFunction(filter));
                 }
-            } catch (UnsupportedOperationException e) {
-                LOG.debug().$("Failed to deepClone filter function for parallel worker").I$();
+            } catch (Throwable e) {
+                LOG.debug().$("Failed to deepClone filter function for parallel worker").$();
                 supportDeepClone = false;
             }
             if (!supportDeepClone) {
@@ -896,8 +896,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         workerKeyFunctions.add(FunctionCloneFactory.deepCloneFunction(keyFunctions.getQuick(j)));
                     }
                 }
-            } catch (UnsupportedOperationException e) {
-                LOG.debug().$("Failed to deepClone keyFunctions for parallel worker").I$();
+            } catch (Throwable e) {
+                LOG.debug().$("Failed to deepClone keyFunctions for parallel worker").$();
                 supportDeepClone = false;
             }
             if (!supportDeepClone) {

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -893,7 +893,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     ObjList<Function> workerKeyFunctions = new ObjList<>(keyFunctions.size());
                     allWorkerKeyFunctions.extendAndSet(i, workerKeyFunctions);
                     for(int j = 0, n = keyFunctions.size(); j < n; j++) {
-                        workerKeyFunctions.add(keyFunctions.getQuick(j));
+                        workerKeyFunctions.add(FunctionCloneFactory.deepCloneFunction(keyFunctions.getQuick(j)));
                     }
                 }
             } catch (UnsupportedOperationException e) {
@@ -918,8 +918,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         workerKeyFunctions.add(func);
                     }
                 }
-                return allWorkerKeyFunctions;
             }
+            return allWorkerKeyFunctions;
         }
         return null;
     }

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -892,7 +892,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 for (int i = 0; i < workerCount; i++) {
                     ObjList<Function> workerKeyFunctions = new ObjList<>(keyFunctions.size());
                     allWorkerKeyFunctions.extendAndSet(i, workerKeyFunctions);
-                    for(int j = 0, n = keyFunctions.size(); j < n; j++) {
+                    for (int j = 0, n = keyFunctions.size(); j < n; j++) {
                         workerKeyFunctions.add(FunctionCloneFactory.deepCloneFunction(keyFunctions.getQuick(j)));
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/BinaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/BinaryFunction.java
@@ -88,6 +88,11 @@ public interface BinaryFunction extends Function {
     }
 
     @Override
+    default boolean supportDeepClone() {
+        return getLeft().supportDeepClone() && getRight().supportDeepClone();
+    }
+
+    @Override
     default void toPlan(PlanSink sink) {
         if (isOperator()) {
             sink.val(getLeft()).val(getName()).val(getRight());

--- a/core/src/main/java/io/questdb/griffin/engine/functions/CursorFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/CursorFunction.java
@@ -210,4 +210,9 @@ public class CursorFunction implements ScalarFunction {
     public void toPlan(PlanSink sink) {
         sink.val("cursor ").child(factory);
     }
+
+    @Override
+    public boolean supportDeepClone() {
+        return false;
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.functions;
 import io.questdb.cairo.sql.Function;
 import io.questdb.griffin.engine.functions.bind.IndexedParameterLinkFunction;
 import io.questdb.griffin.engine.functions.bind.NamedParameterLinkFunction;
+import io.questdb.griffin.engine.functions.columns.SymbolColumn;
 import io.questdb.std.DeepCloneable;
 import io.questdb.std.ObjList;
 
@@ -50,6 +51,8 @@ public class FunctionCloneFactory {
         DEFAULT_CLAZZ_VALUES.put(CharSequence.class, "{}");
         DEFAULT_CLAZZ_VALUES.put(double[].class, new double[]{});
         DEFAULT_CLAZZ_VALUES.put(ObjList.class, new ObjList<>());
+        DEFAULT_CLAZZ_VALUES.put(SymbolFunction.class, new SymbolColumn(0, false));
+        DEFAULT_CLAZZ_VALUES.put(Function.class, new SymbolColumn(0, false));
     }
 
     /**
@@ -74,11 +77,7 @@ public class FunctionCloneFactory {
             Object[] pArgs = new Object[parameterCount];
             Class<?>[] pTypes = funcCons.getParameterTypes();
             for (int i = 0; i < parameterCount; i++) {
-                if (pTypes[i] == Function.class) {
-                    pArgs[i] = function;
-                } else {
-                    pArgs[i] = DEFAULT_CLAZZ_VALUES.get(funcCons.getParameterTypes()[i]);
-                }
+                pArgs[i] = DEFAULT_CLAZZ_VALUES.get(pTypes[i]);
             }
             cloneFunc = (Function) funcCons.newInstance(pArgs);
 
@@ -100,7 +99,7 @@ public class FunctionCloneFactory {
                         field.set(cloneFunc, ((DeepCloneable<?>) fValue).deepClone());
                     } else if (fValue instanceof ObjList) {
                         field.set(cloneFunc, cloneObjList((ObjList<?>) fValue));
-                    } else if (field.getType().isPrimitive() || field.get(cloneFunc) == null) {
+                    } else if (field.getType().isPrimitive() || field.get(cloneFunc) == null || field.getType() == CharSequence.class) {
                         field.set(cloneFunc, fValue);
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions;
+
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.engine.functions.bind.IndexedParameterLinkFunction;
+import io.questdb.griffin.engine.functions.bind.NamedParameterLinkFunction;
+import io.questdb.std.DeepCloneable;
+import io.questdb.std.ObjList;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+public class FunctionCloneFactory {
+
+    static Map<Class<?>, Object> DEFAULT_CLAZZ_VALUES = Stream
+            .of(boolean.class, byte.class, char.class, double.class, float.class, int.class, long.class, short.class)
+            .collect(toMap(clazz -> clazz, clazz -> Array.get(Array.newInstance(clazz, 1), 0)));
+
+    static {
+        DEFAULT_CLAZZ_VALUES.put(CharSequence.class, "{}");
+        DEFAULT_CLAZZ_VALUES.put(double[].class, new double[]{});
+        DEFAULT_CLAZZ_VALUES.put(ObjList.class, new ObjList<>());
+    }
+
+    /**
+     * DeepClone does not clone the running-states, only the init states of the function,
+     * must be called before Function::init.
+     * Used for parallel filter/groupBy execution, so that avoid Function::parser for every worker.
+     * Note: CursorFunction and WindowFunction are not supported now.
+     *
+     * @return deep clones of the function
+     */
+    public static Function deepCloneFunction(Function function) {
+        if (!function.supportDeepClone()) {
+            throw new UnsupportedOperationException();
+        }
+
+        Function cloneFunc = null;
+        try {
+            Class<?> cls = function.getClass();
+            Constructor<?> funcCons = cls.getDeclaredConstructors()[0];
+            funcCons.setAccessible(true);
+            int parameterCount = funcCons.getParameterCount();
+            Object[] pArgs = new Object[parameterCount];
+            Class<?>[] pTypes = funcCons.getParameterTypes();
+            for (int i = 0; i < parameterCount; i++) {
+                if (pTypes[i] == Function.class) {
+                    pArgs[i] = function;
+                } else {
+                    pArgs[i] = DEFAULT_CLAZZ_VALUES.get(funcCons.getParameterTypes()[i]);
+                }
+            }
+            cloneFunc = (Function) funcCons.newInstance(pArgs);
+
+            while (cls != null) {
+                for (Field field : cls.getDeclaredFields()) {
+                    field.setAccessible(true);
+                    Object fValue = field.get(function);
+                    if (fValue == null || Modifier.isStatic(field.getModifiers())) {
+                        continue;
+                    }
+
+                    if (fValue instanceof Function) {
+                        if (fValue instanceof IndexedParameterLinkFunction || fValue instanceof NamedParameterLinkFunction) {
+                            field.set(cloneFunc, fValue);
+                        } else {
+                            field.set(cloneFunc, deepCloneFunction((Function) fValue));
+                        }
+                    } else if (fValue instanceof DeepCloneable<?>) {
+                        field.set(cloneFunc, ((DeepCloneable<?>) fValue).deepClone());
+                    } else if (fValue instanceof ObjList) {
+                        field.set(cloneFunc, cloneObjList((ObjList<?>) fValue));
+                    } else if (field.getType().isPrimitive() || field.get(cloneFunc) == null) {
+                        field.set(cloneFunc, fValue);
+                    }
+                }
+                cls = cls.getSuperclass();
+            }
+            return cloneFunc;
+        } catch (Throwable e) {
+            if (cloneFunc != null) {
+                cloneFunc.close();
+            }
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    private static ObjList<?> cloneObjList(ObjList<?> fValue) {
+        if (fValue.size() == 0) {
+            return new ObjList<>(fValue);
+        }
+        ObjList nList = new ObjList<>(fValue.size());
+        for (int i = 0, size = fValue.size(); i < size; i++) {
+            nList.add(cloneElem(fValue));
+        }
+        return nList;
+    }
+
+    private static Object cloneElem(Object fValue) {
+        if (fValue instanceof Function) {
+            if (fValue instanceof IndexedParameterLinkFunction || fValue instanceof NamedParameterLinkFunction) {
+                return fValue;
+            } else {
+                return deepCloneFunction((Function) fValue);
+            }
+        } else if (fValue instanceof DeepCloneable<?>) {
+            return ((DeepCloneable<?>) fValue).deepClone();
+        } else {
+            return fValue;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
@@ -117,11 +117,11 @@ public class FunctionCloneFactory {
 
     private static ObjList<?> cloneObjList(ObjList<?> fValue) {
         if (fValue.size() == 0) {
-            return new ObjList<>(fValue);
+            return new ObjList<>();
         }
         ObjList nList = new ObjList<>(fValue.size());
         for (int i = 0, size = fValue.size(); i < size; i++) {
-            nList.add(cloneElem(fValue));
+            nList.add(cloneElem(fValue.getQuick(i)));
         }
         return nList;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/FunctionCloneFactory.java
@@ -99,7 +99,8 @@ public class FunctionCloneFactory {
                         field.set(cloneFunc, ((DeepCloneable<?>) fValue).deepClone());
                     } else if (fValue instanceof ObjList) {
                         field.set(cloneFunc, cloneObjList((ObjList<?>) fValue));
-                    } else if (field.getType().isPrimitive() || field.get(cloneFunc) == null || field.getType() == CharSequence.class) {
+                    } else if (field.getType().isPrimitive() || field.get(cloneFunc) == null || field.getType() == CharSequence.class
+                            || field.getType() == String.class) {
                         field.set(cloneFunc, fValue);
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/MultiArgFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/MultiArgFunction.java
@@ -100,6 +100,18 @@ public interface MultiArgFunction extends Function {
     }
 
     @Override
+    default boolean supportDeepClone() {
+        final ObjList<Function> args = getArgs();
+        for (int i = 0, n = args.size(); i < n; i++) {
+            final Function function = args.getQuick(i);
+            if (!function.supportDeepClone()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     default void toPlan(PlanSink sink) {
         sink.val(getName()).val('(').val(getArgs()).val(')');
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/QuaternaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/QuaternaryFunction.java
@@ -112,6 +112,14 @@ public interface QuaternaryFunction extends Function {
     }
 
     @Override
+    default boolean supportDeepClone() {
+        return getFunc0().supportDeepClone()
+                && getFunc1().supportDeepClone()
+                && getFunc2().supportDeepClone()
+                && getFunc3().supportDeepClone();
+    }
+
+    @Override
     default void toPlan(PlanSink sink) {
         sink.val(getName()).val('(')
                 .val(getFunc0()).val(',')

--- a/core/src/main/java/io/questdb/griffin/engine/functions/TernaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/TernaryFunction.java
@@ -95,6 +95,11 @@ public interface TernaryFunction extends Function {
     }
 
     @Override
+    default boolean supportDeepClone() {
+        return getLeft().supportDeepClone() && getCenter().supportDeepClone() && getRight().supportDeepClone();
+    }
+
+    @Override
     default void toPlan(PlanSink sink) {
         sink.val(getName()).val('(').val(getLeft()).val(',').val(getCenter()).val(',').val(getRight()).val(')');
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/UnaryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/UnaryFunction.java
@@ -75,6 +75,11 @@ public interface UnaryFunction extends Function {
     }
 
     @Override
+    default boolean supportDeepClone() {
+        return getArg().supportDeepClone();
+    }
+
+    @Override
     default void toPlan(PlanSink sink) {
         if (isOperator()) {
             sink.val(getName()).val(getArg());

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
@@ -147,12 +147,17 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
      * Unrolled loop for 1 pair.
      */
     private static class L2PriceFunction1 extends L2PriceBaseFunction {
-        private final Function size0Func;
-        private final Function targetFunc;
-        private final Function value0Func;
+        private Function size0Func;
+        private Function targetFunc;
+        private Function value0Func;
 
         public L2PriceFunction1(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            super.init(symbolTableSource, executionContext);
             targetFunc = args.getQuick(0);
             size0Func = args.getQuick(1);
             value0Func = args.getQuick(2);
@@ -175,14 +180,19 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
      * Unrolled loop for 2 pairs.
      */
     private static class L2PriceFunction2 extends L2PriceBaseFunction {
-        private final Function size0Func;
-        private final Function size1Func;
-        private final Function targetFunc;
-        private final Function value0Func;
-        private final Function value1Func;
+        private Function size0Func;
+        private Function size1Func;
+        private Function targetFunc;
+        private Function value0Func;
+        private Function value1Func;
 
         public L2PriceFunction2(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            super.init(symbolTableSource, executionContext);
             targetFunc = args.getQuick(0);
             size0Func = args.getQuick(1);
             value0Func = args.getQuick(2);
@@ -214,16 +224,21 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
      * Unrolled loop for 3 pairs.
      */
     private static class L2PriceFunction3 extends L2PriceBaseFunction {
-        private final Function size0Func;
-        private final Function size1Func;
-        private final Function size2Func;
-        private final Function targetFunc;
-        private final Function value0Func;
-        private final Function value1Func;
-        private final Function value2Func;
+        private Function size0Func;
+        private Function size1Func;
+        private Function size2Func;
+        private Function targetFunc;
+        private Function value0Func;
+        private Function value1Func;
+        private Function value2Func;
 
         public L2PriceFunction3(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            super.init(symbolTableSource, executionContext);
             targetFunc = args.getQuick(0);
             size0Func = args.getQuick(1);
             value0Func = args.getQuick(2);
@@ -264,18 +279,23 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
      * Unrolled loop for 4 pairs.
      */
     private static class L2PriceFunction4 extends L2PriceBaseFunction {
-        private final Function size0Func;
-        private final Function size1Func;
-        private final Function size2Func;
-        private final Function size3Func;
-        private final Function targetFunc;
-        private final Function value0Func;
-        private final Function value1Func;
-        private final Function value2Func;
-        private final Function value3Func;
+        private Function size0Func;
+        private Function size1Func;
+        private Function size2Func;
+        private Function size3Func;
+        private Function targetFunc;
+        private Function value0Func;
+        private Function value1Func;
+        private Function value2Func;
+        private Function value3Func;
 
         public L2PriceFunction4(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            super.init(symbolTableSource, executionContext);
             targetFunc = args.getQuick(0);
             size0Func = args.getQuick(1);
             value0Func = args.getQuick(2);
@@ -325,20 +345,25 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
      * Unrolled loop for 5 pairs.
      */
     private static class L2PriceFunction5 extends L2PriceBaseFunction {
-        private final Function size0Func;
-        private final Function size1Func;
-        private final Function size2Func;
-        private final Function size3Func;
-        private final Function size4Func;
-        private final Function targetFunc;
-        private final Function value0Func;
-        private final Function value1Func;
-        private final Function value2Func;
-        private final Function value3Func;
-        private final Function value4Func;
+        private Function size0Func;
+        private Function size1Func;
+        private Function size2Func;
+        private Function size3Func;
+        private Function size4Func;
+        private Function targetFunc;
+        private Function value0Func;
+        private Function value1Func;
+        private Function value2Func;
+        private Function value3Func;
+        private Function value4Func;
 
         public L2PriceFunction5(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            super.init(symbolTableSource, executionContext);
             targetFunc = args.getQuick(0);
             size0Func = args.getQuick(1);
             value0Func = args.getQuick(2);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/LevelTwoPriceFunctionFactory.java
@@ -153,14 +153,11 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
 
         public L2PriceFunction1(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            super.init(symbolTableSource, executionContext);
-            targetFunc = args.getQuick(0);
-            size0Func = args.getQuick(1);
-            value0Func = args.getQuick(2);
+            if (args.size() != 0) {
+                targetFunc = args.getQuick(0);
+                size0Func = args.getQuick(1);
+                value0Func = args.getQuick(2);
+            }
         }
 
         @Override
@@ -188,16 +185,13 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
 
         public L2PriceFunction2(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            super.init(symbolTableSource, executionContext);
-            targetFunc = args.getQuick(0);
-            size0Func = args.getQuick(1);
-            value0Func = args.getQuick(2);
-            size1Func = args.getQuick(3);
-            value1Func = args.getQuick(4);
+            if (args.size() != 0) {
+                targetFunc = args.getQuick(0);
+                size0Func = args.getQuick(1);
+                value0Func = args.getQuick(2);
+                size1Func = args.getQuick(3);
+                value1Func = args.getQuick(4);
+            }
         }
 
         @Override
@@ -234,18 +228,15 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
 
         public L2PriceFunction3(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            super.init(symbolTableSource, executionContext);
-            targetFunc = args.getQuick(0);
-            size0Func = args.getQuick(1);
-            value0Func = args.getQuick(2);
-            size1Func = args.getQuick(3);
-            value1Func = args.getQuick(4);
-            size2Func = args.getQuick(5);
-            value2Func = args.getQuick(6);
+            if (args.size() != 0) {
+                targetFunc = args.getQuick(0);
+                size0Func = args.getQuick(1);
+                value0Func = args.getQuick(2);
+                size1Func = args.getQuick(3);
+                value1Func = args.getQuick(4);
+                size2Func = args.getQuick(5);
+                value2Func = args.getQuick(6);
+            }
         }
 
         @Override
@@ -291,20 +282,17 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
 
         public L2PriceFunction4(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            super.init(symbolTableSource, executionContext);
-            targetFunc = args.getQuick(0);
-            size0Func = args.getQuick(1);
-            value0Func = args.getQuick(2);
-            size1Func = args.getQuick(3);
-            value1Func = args.getQuick(4);
-            size2Func = args.getQuick(5);
-            value2Func = args.getQuick(6);
-            size3Func = args.getQuick(7);
-            value3Func = args.getQuick(8);
+            if (args.size() != 0) {
+                targetFunc = args.getQuick(0);
+                size0Func = args.getQuick(1);
+                value0Func = args.getQuick(2);
+                size1Func = args.getQuick(3);
+                value1Func = args.getQuick(4);
+                size2Func = args.getQuick(5);
+                value2Func = args.getQuick(6);
+                size3Func = args.getQuick(7);
+                value3Func = args.getQuick(8);
+            }
         }
 
         @Override
@@ -359,22 +347,19 @@ public class LevelTwoPriceFunctionFactory implements FunctionFactory {
 
         public L2PriceFunction5(ObjList<Function> args, IntList argPositions) {
             super(args, argPositions);
-        }
-
-        @Override
-        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-            super.init(symbolTableSource, executionContext);
-            targetFunc = args.getQuick(0);
-            size0Func = args.getQuick(1);
-            value0Func = args.getQuick(2);
-            size1Func = args.getQuick(3);
-            value1Func = args.getQuick(4);
-            size2Func = args.getQuick(5);
-            value2Func = args.getQuick(6);
-            size3Func = args.getQuick(7);
-            value3Func = args.getQuick(8);
-            size4Func = args.getQuick(9);
-            value4Func = args.getQuick(10);
+            if (args.size() != 0) {
+                targetFunc = args.getQuick(0);
+                size0Func = args.getQuick(1);
+                value0Func = args.getQuick(2);
+                size1Func = args.getQuick(3);
+                value1Func = args.getQuick(4);
+                size2Func = args.getQuick(5);
+                value2Func = args.getQuick(6);
+                size3Func = args.getQuick(7);
+                value3Func = args.getQuick(8);
+                size4Func = args.getQuick(9);
+                value4Func = args.getQuick(10);
+            }
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -59,8 +59,12 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
 
     @Override
     public void clear() {
-        hllA.resetPtr();
-        hllB.resetPtr();
+        if (hllA != null) {
+            hllA.resetPtr();
+        }
+        if (hllB != null) {
+            hllB.resetPtr();
+        }
     }
 
     @Override
@@ -198,8 +202,12 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        hllA = new HyperLogLog(precision);
-        hllB = new HyperLogLog(precision);
+        if (hllA == null) {
+            hllA = new HyperLogLog(precision);
+        }
+        if (hllB == null) {
+            hllB = new HyperLogLog(precision);
+        }
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -51,6 +51,10 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     public ApproxCountDistinctIPv4GroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (this.precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctIPv4GroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -41,16 +41,16 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private final HyperLogLog hllA;
-    private final HyperLogLog hllB;
+    private HyperLogLog hllA;
+    private HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;
+    private final int precision;
 
     public ApproxCountDistinctIPv4GroupByFunction(Function arg, int precision) {
         this.arg = arg;
-        this.hllA = new HyperLogLog(precision);
-        this.hllB = new HyperLogLog(precision);
+        this.precision = precision;
     }
 
     public ApproxCountDistinctIPv4GroupByFunction(Function arg) {
@@ -198,6 +198,8 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        hllA = new HyperLogLog(precision);
+        hllB = new HyperLogLog(precision);
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -34,6 +34,7 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.hyperloglog.HyperLogLog;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 
@@ -41,8 +42,8 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private HyperLogLog hllA;
-    private HyperLogLog hllB;
+    private @DelayInitialize HyperLogLog hllA;
+    private @DelayInitialize HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -52,6 +52,10 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     public ApproxCountDistinctIPv4GroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctIPv4GroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIPv4GroupByFunction.java
@@ -51,10 +51,6 @@ public class ApproxCountDistinctIPv4GroupByFunction extends LongFunction impleme
     public ApproxCountDistinctIPv4GroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
-        if (this.precision != 0) {
-            this.hllA = new HyperLogLog(precision);
-            this.hllB = new HyperLogLog(precision);
-        }
     }
 
     public ApproxCountDistinctIPv4GroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -52,6 +52,10 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     public ApproxCountDistinctIntGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctIntGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -41,16 +41,16 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private final HyperLogLog hllA;
-    private final HyperLogLog hllB;
+    private HyperLogLog hllA;
+    private HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;
+    private final int precision;
 
     public ApproxCountDistinctIntGroupByFunction(Function arg, int precision) {
         this.arg = arg;
-        this.hllA = new HyperLogLog(precision);
-        this.hllB = new HyperLogLog(precision);
+        this.precision = precision;
     }
 
     public ApproxCountDistinctIntGroupByFunction(Function arg) {
@@ -197,6 +197,8 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        this.hllA = new HyperLogLog(precision);
+        this.hllB = new HyperLogLog(precision);
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -51,6 +51,10 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     public ApproxCountDistinctIntGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (this.precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctIntGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -59,8 +59,12 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
 
     @Override
     public void clear() {
-        hllA.resetPtr();
-        hllB.resetPtr();
+        if (hllA != null) {
+            hllA.resetPtr();
+        }
+        if (hllB != null) {
+            hllB.resetPtr();
+        }
     }
 
     @Override
@@ -197,8 +201,12 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        this.hllA = new HyperLogLog(precision);
-        this.hllB = new HyperLogLog(precision);
+        if (hllA == null) {
+            hllA = new HyperLogLog(precision);
+        }
+        if (hllB == null) {
+            hllB = new HyperLogLog(precision);
+        }
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -51,10 +51,6 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     public ApproxCountDistinctIntGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
-        if (this.precision != 0) {
-            this.hllA = new HyperLogLog(precision);
-            this.hllB = new HyperLogLog(precision);
-        }
     }
 
     public ApproxCountDistinctIntGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctIntGroupByFunction.java
@@ -34,6 +34,7 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.hyperloglog.HyperLogLog;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 
@@ -41,8 +42,8 @@ public class ApproxCountDistinctIntGroupByFunction extends LongFunction implemen
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private HyperLogLog hllA;
-    private HyperLogLog hllB;
+    private @DelayInitialize HyperLogLog hllA;
+    private @DelayInitialize HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -34,6 +34,7 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.hyperloglog.HyperLogLog;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 
@@ -41,8 +42,8 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private HyperLogLog hllA;
-    private HyperLogLog hllB;
+    private @DelayInitialize HyperLogLog hllA;
+    private @DelayInitialize HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -59,8 +59,12 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
 
     @Override
     public void clear() {
-        hllA.resetPtr();
-        hllB.resetPtr();
+        if (hllA != null) {
+            hllA.resetPtr();
+        }
+        if (hllB != null) {
+            hllB.resetPtr();
+        }
     }
 
     @Override
@@ -198,8 +202,12 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        this.hllA = new HyperLogLog(precision);
-        this.hllB = new HyperLogLog(precision);
+        if (hllA == null) {
+            hllA = new HyperLogLog(precision);
+        }
+        if (hllB == null) {
+            hllB = new HyperLogLog(precision);
+        }
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -51,10 +51,6 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     public ApproxCountDistinctLongGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
-        if (this.precision != 0) {
-            this.hllA = new HyperLogLog(precision);
-            this.hllB = new HyperLogLog(precision);
-        }
     }
 
     public ApproxCountDistinctLongGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -51,6 +51,10 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     public ApproxCountDistinctLongGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (this.precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctLongGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -41,16 +41,16 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     private static final long NULL_VALUE = -1;
 
     private final Function arg;
-    private final HyperLogLog hllA;
-    private final HyperLogLog hllB;
+    private HyperLogLog hllA;
+    private HyperLogLog hllB;
     private int hllPtrIndex;
     private int overwrittenFlagIndex;
     private int valueIndex;
+    private final int precision;
 
     public ApproxCountDistinctLongGroupByFunction(Function arg, int precision) {
         this.arg = arg;
-        this.hllA = new HyperLogLog(precision);
-        this.hllB = new HyperLogLog(precision);
+        this.precision = precision;
     }
 
     public ApproxCountDistinctLongGroupByFunction(Function arg) {
@@ -198,6 +198,8 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        this.hllA = new HyperLogLog(precision);
+        this.hllB = new HyperLogLog(precision);
         hllA.setAllocator(allocator);
         hllB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ApproxCountDistinctLongGroupByFunction.java
@@ -52,6 +52,10 @@ public class ApproxCountDistinctLongGroupByFunction extends LongFunction impleme
     public ApproxCountDistinctLongGroupByFunction(Function arg, int precision) {
         this.arg = arg;
         this.precision = precision;
+        if (precision != 0) {
+            this.hllA = new HyperLogLog(precision);
+            this.hllB = new HyperLogLog(precision);
+        }
     }
 
     public ApproxCountDistinctLongGroupByFunction(Function arg) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -48,10 +48,6 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
-            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -38,15 +38,16 @@ import io.questdb.std.Numbers;
 
 public class CountDistinctIPv4GroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByIntHashSet setA;
-    private final GroupByIntHashSet setB;
+    private GroupByIntHashSet setA;
+    private GroupByIntHashSet setB;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctIPv4GroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        // Numbers.IPv4_NULL is zero which is nice for faster zeroing on rehash.
-        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
-        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -157,6 +158,8 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -34,12 +34,13 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
 
 public class CountDistinctIPv4GroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByIntHashSet setA;
-    private GroupByIntHashSet setB;
+    private @DelayInitialize GroupByIntHashSet setA;
+    private @DelayInitialize GroupByIntHashSet setB;
     private int valueIndex;
     private final int setInitialCapacity;
     private final double setLoadFactor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -48,6 +48,10 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -49,6 +49,10 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -52,8 +52,12 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
     }
 
     @Override
@@ -158,8 +162,12 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
-        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        if (setA == null) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -49,6 +49,10 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -34,12 +34,13 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
 
 public class CountDistinctIntGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByIntHashSet setA;
-    private GroupByIntHashSet setB;
+    private @DelayInitialize GroupByIntHashSet setA;
+    private @DelayInitialize GroupByIntHashSet setB;
     private int valueIndex;
     private final int setInitialCapacity;
     private final double setLoadFactor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -52,8 +52,12 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
     }
 
     @Override
@@ -158,8 +162,12 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
-        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+        if (setA == null) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -48,6 +48,10 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -38,14 +38,16 @@ import io.questdb.std.Numbers;
 
 public class CountDistinctIntGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByIntHashSet setA;
-    private final GroupByIntHashSet setB;
+    private GroupByIntHashSet setA;
+    private GroupByIntHashSet setB;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctIntGroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
-        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -156,6 +158,8 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
+        setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -48,10 +48,6 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
-            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIntGroupByFunction.java
@@ -163,10 +163,10 @@ public class CountDistinctIntGroupByFunction extends LongFunction implements Una
     @Override
     public void setAllocator(GroupByAllocator allocator) {
         if (setA == null) {
-            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
         }
         if (setB == null) {
-            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, Numbers.INT_NULL);
         }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
 import io.questdb.griffin.engine.groupby.GroupByLong256HashSet;
 import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
@@ -54,8 +55,12 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
     }
 
     @Override
@@ -169,8 +174,12 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        if (setA == null) {
+            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -40,14 +40,16 @@ import io.questdb.std.Numbers;
 
 public class CountDistinctLong256GroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByLong256HashSet setA;
-    private final GroupByLong256HashSet setB;
+    private GroupByLong256HashSet setA;
+    private GroupByLong256HashSet setB;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctLong256GroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -167,6 +169,8 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -175,10 +175,10 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
     @Override
     public void setAllocator(GroupByAllocator allocator) {
         if (setA == null) {
-            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         }
         if (setB == null) {
-            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.IPv4_NULL);
+            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -51,10 +51,6 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -35,14 +35,15 @@ import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
 import io.questdb.griffin.engine.groupby.GroupByLong256HashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.Numbers;
 
 public class CountDistinctLong256GroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByLong256HashSet setA;
-    private GroupByLong256HashSet setB;
+    private @DelayInitialize GroupByLong256HashSet setA;
+    private @DelayInitialize GroupByLong256HashSet setB;
     private int valueIndex;
     private final int setInitialCapacity;
     private final double setLoadFactor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -52,6 +52,10 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLong256GroupByFunction.java
@@ -51,6 +51,10 @@ public class CountDistinctLong256GroupByFunction extends LongFunction implements
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLong256HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -34,12 +34,13 @@ import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByLongHashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
 
 public class CountDistinctLongGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByLongHashSet setA;
-    private GroupByLongHashSet setB;
+    private @DelayInitialize GroupByLongHashSet setA;
+    private @DelayInitialize GroupByLongHashSet setB;
     private int valueIndex;
     private final int setInitialCapacity;
     private final double setLoadFactor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.griffin.engine.groupby.GroupByLong256HashSet;
 import io.questdb.griffin.engine.groupby.GroupByLongHashSet;
 import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
@@ -49,6 +50,10 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -38,14 +38,16 @@ import io.questdb.std.Numbers;
 
 public class CountDistinctLongGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByLongHashSet setA;
-    private final GroupByLongHashSet setB;
+    private GroupByLongHashSet setA;
+    private GroupByLongHashSet setB;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctLongGroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -156,6 +158,8 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -48,10 +48,6 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-            setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -48,6 +48,10 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctLongGroupByFunction.java
@@ -52,8 +52,12 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
     }
 
     @Override
@@ -158,8 +162,12 @@ public class CountDistinctLongGroupByFunction extends LongFunction implements Un
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        if (setA == null) {
+            setA = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByLongHashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -57,10 +57,6 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            this.setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
-            this.setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -45,15 +45,17 @@ import static io.questdb.cairo.sql.SymbolTable.VALUE_IS_NULL;
 
 public class CountDistinctSymbolGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByIntHashSet setA;
-    private final GroupByIntHashSet setB;
+    private GroupByIntHashSet setA;
+    private GroupByIntHashSet setB;
     private int knownSymbolCount = -1;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctSymbolGroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        this.setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
-        this.setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -189,6 +191,8 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        this.setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        this.setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -39,6 +39,7 @@ import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.columns.SymbolColumn;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
+import io.questdb.griffin.engine.groupby.GroupByLongHashSet;
 import io.questdb.std.Numbers;
 
 import static io.questdb.cairo.sql.SymbolTable.VALUE_IS_NULL;
@@ -60,8 +61,12 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
         knownSymbolCount = -1;
     }
 
@@ -191,8 +196,12 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        this.setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
-        this.setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        if (setA == null) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -58,6 +58,10 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+            setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -40,14 +40,15 @@ import io.questdb.griffin.engine.functions.columns.SymbolColumn;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
 import io.questdb.griffin.engine.groupby.GroupByLongHashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
 
 import static io.questdb.cairo.sql.SymbolTable.VALUE_IS_NULL;
 
 public class CountDistinctSymbolGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByIntHashSet setA;
-    private GroupByIntHashSet setB;
+    private @DelayInitialize GroupByIntHashSet setA;
+    private @DelayInitialize GroupByIntHashSet setB;
     private int knownSymbolCount = -1;
     private int valueIndex;
     private final int setInitialCapacity;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctSymbolGroupByFunction.java
@@ -57,6 +57,10 @@ public class CountDistinctSymbolGroupByFunction extends LongFunction implements 
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            this.setA = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+            this.setB = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -53,6 +53,10 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -35,6 +35,7 @@ import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
 import io.questdb.griffin.engine.groupby.GroupByLong128HashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Numbers;
 import io.questdb.std.Uuid;
 
@@ -42,8 +43,8 @@ import static io.questdb.cairo.sql.SymbolTable.VALUE_IS_NULL;
 
 public final class CountDistinctUuidGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private GroupByLong128HashSet setA;
-    private GroupByLong128HashSet setB;
+    private @DelayInitialize GroupByLong128HashSet setA;
+    private @DelayInitialize GroupByLong128HashSet setB;
     private int valueIndex;
     private final int setInitialCapacity;
     private final double setLoadFactor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -169,10 +169,10 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
     @Override
     public void setAllocator(GroupByAllocator allocator) {
         if (setA == null) {
-            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor,  Numbers.LONG_NULL);
+            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         }
         if (setB == null) {
-            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor,  Numbers.LONG_NULL);
+            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -39,14 +39,16 @@ import io.questdb.std.Uuid;
 
 public final class CountDistinctUuidGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
-    private final GroupByLong128HashSet setA;
-    private final GroupByLong128HashSet setB;
+    private GroupByLong128HashSet setA;
+    private GroupByLong128HashSet setB;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public CountDistinctUuidGroupByFunction(Function arg, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
-        setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -159,6 +161,8 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -52,6 +52,10 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -52,10 +52,6 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
         this.arg = arg;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctUuidGroupByFunction.java
@@ -33,9 +33,12 @@ import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.LongFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
 import io.questdb.griffin.engine.groupby.GroupByLong128HashSet;
 import io.questdb.std.Numbers;
 import io.questdb.std.Uuid;
+
+import static io.questdb.cairo.sql.SymbolTable.VALUE_IS_NULL;
 
 public final class CountDistinctUuidGroupByFunction extends LongFunction implements UnaryFunction, GroupByFunction {
     private final Function arg;
@@ -53,8 +56,12 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
 
     @Override
     public void clear() {
-        setA.resetPtr();
-        setB.resetPtr();
+        if (setA != null) {
+            setA.resetPtr();
+        }
+        if (setB != null) {
+            setB.resetPtr();
+        }
     }
 
     @Override
@@ -161,8 +168,12 @@ public final class CountDistinctUuidGroupByFunction extends LongFunction impleme
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
-        setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor, Numbers.LONG_NULL);
+        if (setA == null) {
+            setA = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor,  Numbers.LONG_NULL);
+        }
+        if (setB == null) {
+            setB = new GroupByLong128HashSet(setInitialCapacity, setLoadFactor,  Numbers.LONG_NULL);
+        }
         setA.setAllocator(allocator);
         setB.setAllocator(allocator);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -58,9 +58,6 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
         this.delimiter = delimiter;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
-        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
-            this.set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
-        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -46,15 +46,18 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
     private static final int INITIAL_SINK_CAPACITY = 128;
     private final Function arg;
     private final char delimiter;
-    private final GroupByIntHashSet set;
+    private GroupByIntHashSet set;
     private final ObjList<DirectUtf16Sink> sinks = new ObjList<>();
     private int sinkIndex = 0;
     private int valueIndex;
+    private final int setInitialCapacity;
+    private final double setLoadFactor;
 
     public StringDistinctAggSymbolGroupByFunction(Function arg, char delimiter, int setInitialCapacity, double setLoadFactor) {
         this.arg = arg;
         this.delimiter = delimiter;
-        this.set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        this.setInitialCapacity = setInitialCapacity;
+        this.setLoadFactor = setLoadFactor;
     }
 
     @Override
@@ -155,6 +158,7 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
+        this.set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
         set.setAllocator(allocator);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -36,8 +36,10 @@ import io.questdb.griffin.engine.functions.StrFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
+import io.questdb.griffin.engine.groupby.GroupByLong128HashSet;
 import io.questdb.std.DelayInitialize;
 import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.str.DirectUtf16Sink;
 
@@ -59,6 +61,9 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
         this.delimiter = delimiter;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -58,6 +58,9 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
         this.delimiter = delimiter;
         this.setInitialCapacity = setInitialCapacity;
         this.setLoadFactor = setLoadFactor;
+        if (setInitialCapacity != 0 || setLoadFactor != 0d) {
+            this.set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -158,7 +158,9 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
 
     @Override
     public void setAllocator(GroupByAllocator allocator) {
-        this.set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        if (set == null) {
+            set = new GroupByIntHashSet(setInitialCapacity, setLoadFactor, VALUE_IS_NULL);
+        }
         set.setAllocator(allocator);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringDistinctAggSymbolGroupByFunction.java
@@ -36,6 +36,7 @@ import io.questdb.griffin.engine.functions.StrFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByIntHashSet;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
 import io.questdb.std.str.DirectUtf16Sink;
@@ -46,7 +47,7 @@ class StringDistinctAggSymbolGroupByFunction extends StrFunction implements Unar
     private static final int INITIAL_SINK_CAPACITY = 128;
     private final Function arg;
     private final char delimiter;
-    private GroupByIntHashSet set;
+    private @DelayInitialize GroupByIntHashSet set;
     private final ObjList<DirectUtf16Sink> sinks = new ObjList<>();
     private int sinkIndex = 0;
     private int valueIndex;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
@@ -366,8 +366,8 @@ public class JsonExtractFunction implements ScalarFunction {
 
     @Override
     public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
-        ScalarFunction.super.init(symbolTableSource, executionContext);
         if (stateA == null) {
+            assert stateB == null;
             switch (targetType) {
                 case ColumnType.IPv4:
                 case ColumnType.DATE:

--- a/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
@@ -46,9 +46,9 @@ public class JsonExtractFunction implements ScalarFunction {
     private final Function json;
     private final int maxSize;
     private final Function path;
-    private JsonExtractSupportingState stateA;
+    private @DelayInitialize JsonExtractSupportingState stateA;
     // Only set for VARCHAR
-    private @Nullable JsonExtractSupportingState stateB;
+    private @DelayInitialize @Nullable JsonExtractSupportingState stateB;
     private final int targetType;
     private DirectUtf8Sink pointer;
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
@@ -48,7 +48,8 @@ public class JsonExtractFunction implements ScalarFunction {
     private final Function path;
     private @DelayInitialize JsonExtractSupportingState stateA;
     // Only set for VARCHAR
-    private @DelayInitialize @Nullable JsonExtractSupportingState stateB;
+    private @DelayInitialize
+    @Nullable JsonExtractSupportingState stateB;
     private final int targetType;
     private DirectUtf8Sink pointer;
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/json/JsonExtractFunction.java
@@ -367,22 +367,24 @@ public class JsonExtractFunction implements ScalarFunction {
     @Override
     public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
         ScalarFunction.super.init(symbolTableSource, executionContext);
-        switch (targetType) {
-            case ColumnType.IPv4:
-            case ColumnType.DATE:
-            case ColumnType.TIMESTAMP:
-                // cxx json code will not resize the utf8 sink, so the initial size is its max size
-                stateA = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), false);
-                stateB = null;
-                break;
-            case ColumnType.VARCHAR:
-                stateA = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), true);
-                stateB = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), true);
-                break;
-            default:
-                stateA = new JsonExtractSupportingState(null, false);
-                stateB = null;
-                break;
+        if (stateA == null) {
+            switch (targetType) {
+                case ColumnType.IPv4:
+                case ColumnType.DATE:
+                case ColumnType.TIMESTAMP:
+                    // cxx json code will not resize the utf8 sink, so the initial size is its max size
+                    stateA = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), false);
+                    stateB = null;
+                    break;
+                case ColumnType.VARCHAR:
+                    stateA = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), true);
+                    stateB = new JsonExtractSupportingState(new DirectUtf8Sink(maxSize, false), true);
+                    break;
+                default:
+                    stateA = new JsonExtractSupportingState(null, false);
+                    stateB = null;
+                    break;
+            }
         }
         stateA.reopen();
         if (stateB != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchStrFunctionFactory.java
@@ -75,22 +75,18 @@ public class MatchStrFunctionFactory implements FunctionFactory {
         private @DelayInitialize Matcher matcher;
         private final Function value;
         private final Function pattern;
-        private boolean initialized;
 
         public MatchStrConstPatternFunction(Function value, Matcher matcher, Function pattern) {
             this.value = value;
             this.matcher = matcher;
             this.pattern = pattern;
-            initialized = matcher != null;
         }
 
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             UnaryFunction.super.init(symbolTableSource, executionContext);
-            if (!initialized) {
-                UnaryFunction.super.init(symbolTableSource, executionContext);
+            if (matcher == null) {
                 matcher = RegexUtils.createMatcher(pattern, 0);
-                initialized = true;
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchStrFunctionFactory.java
@@ -35,6 +35,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import org.jetbrains.annotations.NotNull;
@@ -71,7 +72,7 @@ public class MatchStrFunctionFactory implements FunctionFactory {
     }
 
     static class MatchStrConstPatternFunction extends BooleanFunction implements UnaryFunction {
-        private Matcher matcher;
+        private @DelayInitialize Matcher matcher;
         private final Function value;
         private final Function pattern;
         private boolean initialized;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
@@ -110,13 +110,11 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
         private final IntList symbolKeys = new IntList();
         private boolean initialized;
         private final Function pattern;
-        private boolean matcherInitialized;
 
         public MatchStaticSymbolTableConstPatternFunction(SymbolFunction symbolFun, Matcher matcher, Function pattern) {
             this.symbolFun = symbolFun;
             this.matcher = matcher;
             this.pattern = pattern;
-            this.matcherInitialized = matcher != null;
         }
 
         @Override
@@ -137,9 +135,8 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             UnaryFunction.super.init(symbolTableSource, executionContext);
             initialized = false;
-            if (!matcherInitialized) {
+            if (matcher == null) {
                 matcher = RegexUtils.createMatcher(pattern, 0);
-                matcherInitialized = true;
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
@@ -35,6 +35,7 @@ import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
@@ -104,7 +105,7 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
     }
 
     private static class MatchStaticSymbolTableConstPatternFunction extends BooleanFunction implements UnaryFunction {
-        private Matcher matcher;
+        private @DelayInitialize Matcher matcher;
         private final SymbolFunction symbolFun;
         private final IntList symbolKeys = new IntList();
         private boolean initialized;
@@ -159,7 +160,7 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
         private final SymbolFunction symbolFun;
         private final IntList symbolKeys = new IntList();
         private boolean initialized;
-        private Matcher matcher;
+        private @DelayInitialize Matcher matcher;
 
         public MatchStaticSymbolTableRuntimeConstPatternFunction(SymbolFunction symbolFun, Function pattern, int patternPosition) {
             this.symbolFun = symbolFun;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchSymbolFunctionFactory.java
@@ -72,7 +72,7 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
                 if (matcher == null) {
                     return BooleanConstant.FALSE;
                 }
-                return new MatchStaticSymbolTableConstPatternFunction(func, matcher);
+                return new MatchStaticSymbolTableConstPatternFunction(func, matcher, pattern);
             } else if (pattern.isRuntimeConstant()) {
                 return new MatchStaticSymbolTableRuntimeConstPatternFunction(func, pattern, patternPosition);
             }
@@ -82,7 +82,7 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
                 if (matcher == null) {
                     return BooleanConstant.FALSE;
                 }
-                return new MatchStrFunctionFactory.MatchStrConstPatternFunction(func, matcher);
+                return new MatchStrFunctionFactory.MatchStrConstPatternFunction(func, matcher, pattern);
             } else if (pattern.isRuntimeConstant()) {
                 return new MatchStrFunctionFactory.MatchStrRuntimeConstPatternFunction(func, pattern, patternPosition);
             }
@@ -104,14 +104,18 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
     }
 
     private static class MatchStaticSymbolTableConstPatternFunction extends BooleanFunction implements UnaryFunction {
-        private final Matcher matcher;
+        private Matcher matcher;
         private final SymbolFunction symbolFun;
         private final IntList symbolKeys = new IntList();
         private boolean initialized;
+        private final Function pattern;
+        private boolean matcherInitialized;
 
-        public MatchStaticSymbolTableConstPatternFunction(SymbolFunction symbolFun, Matcher matcher) {
+        public MatchStaticSymbolTableConstPatternFunction(SymbolFunction symbolFun, Matcher matcher, Function pattern) {
             this.symbolFun = symbolFun;
             this.matcher = matcher;
+            this.pattern = pattern;
+            this.matcherInitialized = matcher != null;
         }
 
         @Override
@@ -132,6 +136,10 @@ public class MatchSymbolFunctionFactory implements FunctionFactory {
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             UnaryFunction.super.init(symbolTableSource, executionContext);
             initialized = false;
+            if (!matcherInitialized) {
+                matcher = RegexUtils.createMatcher(pattern, 0);
+                matcherInitialized = true;
+            }
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/NotMatchStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/NotMatchStrFunctionFactory.java
@@ -36,6 +36,7 @@ import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.constants.BooleanConstant;
 import io.questdb.std.Chars;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
@@ -74,7 +75,7 @@ public class NotMatchStrFunctionFactory implements FunctionFactory {
 
     private static class NoMatchStrFunction extends BooleanFunction implements UnaryFunction {
         private final Function arg;
-        private Matcher matcher;
+        private @DelayInitialize Matcher matcher;
         private final CharSequence regex;
         private boolean initialized;
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/NotMatchStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/NotMatchStrFunctionFactory.java
@@ -77,21 +77,18 @@ public class NotMatchStrFunctionFactory implements FunctionFactory {
         private final Function arg;
         private @DelayInitialize Matcher matcher;
         private final CharSequence regex;
-        private boolean initialized;
 
         public NoMatchStrFunction(Function arg, Matcher matcher, CharSequence regex) {
             this.arg = arg;
             this.matcher = matcher;
             this.regex = regex;
-            this.initialized = matcher != null;
         }
 
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             UnaryFunction.super.init(symbolTableSource, executionContext);
-            if (!initialized) {
+            if (matcher == null) {
                 matcher = Pattern.compile(Chars.toString(regex)).matcher("");
-                initialized = true;
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
@@ -226,7 +226,7 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
     private static class SingleGroupAsciiFunc extends VarcharFunction implements UnaryFunction {
         private final int functionPos;
         private final int group;
-        private Matcher matcher;
+        private @DelayInitialize Matcher matcher;
         private final String replacement;
         private final DirectUtf8Sink utf8SinkA;
         private final DirectUtf8Sink utf8SinkB;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
@@ -234,7 +234,6 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
         private final DirectAsciiStringView viewA = new DirectAsciiStringView();
         private final DirectAsciiStringView viewB = new DirectAsciiStringView();
         private final Function pattern;
-        private boolean initialized;
 
         public SingleGroupAsciiFunc(Function value, Matcher matcher, Function pattern, String replacement, int group, int functionPos) {
             try {
@@ -246,7 +245,6 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
                 this.pattern = pattern;
                 this.utf8SinkA = new DirectUtf8Sink(INITIAL_SINK_CAPACITY);
                 this.utf8SinkB = new DirectUtf8Sink(INITIAL_SINK_CAPACITY);
-                this.initialized = matcher != null;
             } catch (Throwable th) {
                 close();
                 throw th;
@@ -263,9 +261,8 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
         @Override
         public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
             UnaryFunction.super.init(symbolTableSource, executionContext);
-            if (!initialized) {
+            if (matcher == null) {
                 matcher = RegexUtils.createMatcher(pattern, 0);
-                initialized = true;
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/RegexpReplaceVarcharFunctionFactory.java
@@ -133,7 +133,7 @@ public class RegexpReplaceVarcharFunctionFactory extends RegexpReplaceStrFunctio
                         throw SqlException.$(replacementPos, "no group ").put(group);
                     }
                     if (canSkipUtf8Decoding(patternStr)) {
-                        return new SingleGroupAsciiFunc(value, matcher, pattern, Chars.toString(replacementStr), group , position);
+                        return new SingleGroupAsciiFunc(value, matcher, pattern, Chars.toString(replacementStr), group, position);
                     } else {
                         return new SingleGroupFunc(value, matcher, pattern, Chars.toString(replacementStr), group, position);
                     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringMemory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringMemory.java
@@ -28,18 +28,22 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryAR;
 import io.questdb.griffin.SqlException;
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
 
 import java.io.Closeable;
 
-class RndStringMemory implements Closeable {
+class RndStringMemory implements Closeable, DeepCloneable<RndStringMemory> {
     private final int count;
     private final int hi;
     private final MemoryAR idxMem;
     private final int lo;
     private final MemoryAR strMem;
+    private final String signature;
+    private final int pageSize;
+    private final int maxPages;
 
     RndStringMemory(String signature, int count, int lo, int hi, int position, CairoConfiguration configuration) throws SqlException {
         try {
@@ -47,8 +51,9 @@ class RndStringMemory implements Closeable {
             this.lo = lo;
             this.hi = hi;
 
-            final int pageSize = configuration.getRndFunctionMemoryPageSize();
-            final int maxPages = configuration.getRndFunctionMemoryMaxPages();
+            this.signature = signature;
+            this.pageSize = configuration.getRndFunctionMemoryPageSize();
+            this.maxPages = configuration.getRndFunctionMemoryMaxPages();
             final long memLimit = (long) maxPages * pageSize;
             // check against worst case, the highest possible mem usage
             final long requiredMem = count * (Vm.getStorageLength(hi) + Long.BYTES);
@@ -77,12 +82,29 @@ class RndStringMemory implements Closeable {
         Misc.free(idxMem);
     }
 
+    @Override
+    public RndStringMemory deepClone() {
+        return new RndStringMemory(this);
+    }
+
     public int getHi() {
         return hi;
     }
 
     public int getLo() {
         return lo;
+    }
+
+    private RndStringMemory(RndStringMemory other) {
+        this.count = other.count;
+        this.lo = other.lo;
+        this.hi = other.hi;
+        this.signature = other.signature;
+        this.pageSize = other.pageSize;
+        this.maxPages = other.maxPages;
+        final int idxPages = count * 8 / pageSize + 1;
+        this.strMem = Vm.getARInstance(pageSize, maxPages - idxPages, MemoryTag.NATIVE_FUNC_RSS);
+        this.idxMem = Vm.getARInstance(pageSize, idxPages, MemoryTag.NATIVE_FUNC_RSS);
     }
 
     private long getStrAddress(long index) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SubStringFunctionFactory.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -75,7 +76,7 @@ public class SubStringFunctionFactory implements FunctionFactory {
     }
 
     private static class SubStringFunc extends StrFunction implements TernaryFunction {
-        private final boolean isSimplifiable;
+        private boolean isSimplifiable;
         private final Function lenFunc;
         private final StringSink sinkA = new StringSink();
         private final StringSink sinkB = new StringSink();
@@ -86,7 +87,11 @@ public class SubStringFunctionFactory implements FunctionFactory {
             this.strFunc = strFunc;
             this.startFunc = startFunc;
             this.lenFunc = lenFunc;
+        }
 
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            TernaryFunction.super.init(symbolTableSource, executionContext);
             this.isSimplifiable = startFunc.isConstant() && lenFunc.isConstant()
                     && startFunc.getInt(null) + lenFunc.getInt(null) < 1;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimStrConstFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimStrConstFunction.java
@@ -40,8 +40,10 @@ public class TrimStrConstFunction extends StrFunction implements UnaryFunction {
 
     public TrimStrConstFunction(Function arg, TrimType type) {
         this.arg = arg;
-        trim(type, getArg().getStrA(null), sinkA);
-        trim(type, getArg().getStrA(null), sinkB);
+        if (type != null) {
+            trim(type, getArg().getStrA(null), sinkA);
+            trim(type, getArg().getStrA(null), sinkB);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TrimVarcharFunctionFactory.java
@@ -35,6 +35,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.griffin.engine.functions.VarcharFunction;
 import io.questdb.griffin.engine.functions.constants.VarcharConstant;
+import io.questdb.std.DelayInitialize;
 import io.questdb.std.IntList;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
@@ -74,7 +75,7 @@ public class TrimVarcharFunctionFactory implements FunctionFactory {
 
     private static class ConstFunc extends VarcharFunction implements UnaryFunction {
         private final Function arg;
-        private DirectUtf8Sink sink;
+        private @DelayInitialize DirectUtf8Sink sink;
         private boolean initialized = false;
         private final TrimType type;
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByIntHashSet.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
@@ -43,7 +44,7 @@ import io.questdb.std.Vect;
  * +--------------------+----------------+----------------------+-----------+
  * </pre>
  */
-public class GroupByIntHashSet {
+public class GroupByIntHashSet implements DeepCloneable<GroupByIntHashSet> {
     private static final long HEADER_SIZE = 3 * Integer.BYTES;
     private static final int MIN_INITIAL_CAPACITY = 2;
     private static final long SIZE_LIMIT_OFFSET = 2 * Integer.BYTES;
@@ -91,6 +92,11 @@ public class GroupByIntHashSet {
 
     public int capacity() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
+    }
+
+    @Override
+    public GroupByIntHashSet deepClone() {
+        return new GroupByIntHashSet(this);
     }
 
     public int keyAt(long index) {
@@ -155,6 +161,12 @@ public class GroupByIntHashSet {
 
     public int sizeLimit() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
+    }
+
+    private GroupByIntHashSet(GroupByIntHashSet other) {
+        this.noKeyValue = other.noKeyValue;
+        this.initialCapacity = other.initialCapacity;
+        this.loadFactor = other.loadFactor;
     }
 
     private long probe(int key, long index) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong128HashSet.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
@@ -43,7 +44,7 @@ import io.questdb.std.Vect;
  * +------------------------+--------------------+--------------------------+---------+---------------+
  * </pre>
  */
-public class GroupByLong128HashSet {
+public class GroupByLong128HashSet implements DeepCloneable<GroupByLong128HashSet> {
     private static final long HEADER_SIZE = 4 * Integer.BYTES;
     private static final int MIN_INITIAL_CAPACITY = 2;
     private static final long SIZE_LIMIT_OFFSET = 2 * Integer.BYTES;
@@ -92,6 +93,11 @@ public class GroupByLong128HashSet {
 
     public int capacity() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
+    }
+
+    @Override
+    public GroupByLong128HashSet deepClone() {
+        return new GroupByLong128HashSet(this);
     }
 
     public long keyAddrAt(long index) {
@@ -159,6 +165,12 @@ public class GroupByLong128HashSet {
 
     public int sizeLimit() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
+    }
+
+    private GroupByLong128HashSet(GroupByLong128HashSet other) {
+        this.initialCapacity = other.initialCapacity;
+        this.loadFactor = other.loadFactor;
+        this.noKeyValue = other.noKeyValue;
     }
 
     private long probe(long lo, long hi, long index) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLong256HashSet.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
@@ -43,7 +44,7 @@ import io.questdb.std.Vect;
  * +------------------------+--------------------+--------------------------+---------+---------------+
  * </pre>
  */
-public class GroupByLong256HashSet {
+public class GroupByLong256HashSet implements DeepCloneable<GroupByLong256HashSet> {
     private static final long HEADER_SIZE = 4 * Integer.BYTES;
     private static final int MIN_INITIAL_CAPACITY = 2;
     private static final long SIZE_LIMIT_OFFSET = 2 * Integer.BYTES;
@@ -94,6 +95,11 @@ public class GroupByLong256HashSet {
 
     public int capacity() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
+    }
+
+    @Override
+    public GroupByLong256HashSet deepClone() {
+        return new GroupByLong256HashSet(this);
     }
 
     public long keyAddrAt(long index) {
@@ -165,6 +171,12 @@ public class GroupByLong256HashSet {
 
     public int sizeLimit() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
+    }
+
+    private GroupByLong256HashSet(GroupByLong256HashSet other) {
+        this.initialCapacity = other.initialCapacity;
+        this.loadFactor = other.loadFactor;
+        this.noKeyValue = other.noKeyValue;
     }
 
     private long probe(long k0, long k1, long k2, long k3, long index) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongHashSet.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.Hash;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
@@ -43,7 +44,7 @@ import io.questdb.std.Vect;
  * +---------------------+-----------------+-----------------------+---------+------------+
  * </pre>
  */
-public class GroupByLongHashSet {
+public class GroupByLongHashSet implements DeepCloneable<GroupByLongHashSet> {
     private static final long HEADER_SIZE = 4 * Integer.BYTES;
     private static final int MIN_INITIAL_CAPACITY = 2;
     private static final long SIZE_LIMIT_OFFSET = 2 * Integer.BYTES;
@@ -91,6 +92,11 @@ public class GroupByLongHashSet {
 
     public int capacity() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr) : 0;
+    }
+
+    @Override
+    public GroupByLongHashSet deepClone() {
+        return new GroupByLongHashSet(this);
     }
 
     public long keyAt(long index) {
@@ -155,6 +161,12 @@ public class GroupByLongHashSet {
 
     public int sizeLimit() {
         return ptr != 0 ? Unsafe.getUnsafe().getInt(ptr + SIZE_LIMIT_OFFSET) : 0;
+    }
+
+    private GroupByLongHashSet(GroupByLongHashSet other) {
+        this.initialCapacity = other.initialCapacity;
+        this.loadFactor = other.loadFactor;
+        this.noKeyValue = other.noKeyValue;
     }
 
     private long probe(long key, long index) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -369,7 +369,7 @@ public class GroupByUtils {
             for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
                 workerGroupByFunctions.add((GroupByFunction) FunctionCloneFactory.deepCloneFunction(groupByFunctions.getQuick(i)));
             }
-        } catch (UnsupportedOperationException e) {
+        } catch (Throwable e) {
             supportDeepClone = false;
         }
         if (!supportDeepClone) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -373,7 +373,7 @@ public class GroupByUtils {
             supportDeepClone = false;
         }
         if (!supportDeepClone) {
-            Misc.freeObjList(groupByFunctions);
+            Misc.freeObjList(workerGroupByFunctions);
             final ObjList<QueryColumn> columns = model.getColumns();
             for (int i = 0, n = columns.size(); i < n; i++) {
                 final QueryColumn column = columns.getQuick(i);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -359,18 +359,20 @@ public class GroupByUtils {
     public static void prepareWorkerGroupByFunctions(
             @NotNull QueryModel model,
             @NotNull RecordMetadata metadata,
+            boolean supportDeepClone,
             @NotNull FunctionParser functionParser,
             @NotNull SqlExecutionContext executionContext,
             @NotNull ObjList<GroupByFunction> groupByFunctions,
             @NotNull ObjList<GroupByFunction> workerGroupByFunctions
     ) throws SqlException {
-        boolean supportDeepClone = true;
-        try {
-            for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
-                workerGroupByFunctions.add((GroupByFunction) FunctionCloneFactory.deepCloneFunction(groupByFunctions.getQuick(i)));
+        if (supportDeepClone) {
+            try {
+                for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
+                    workerGroupByFunctions.add((GroupByFunction) FunctionCloneFactory.deepCloneFunction(groupByFunctions.getQuick(i)));
+                }
+            } catch (Throwable e) {
+                supportDeepClone = false;
             }
-        } catch (Throwable e) {
-            supportDeepClone = false;
         }
         if (!supportDeepClone) {
             Misc.freeObjList(workerGroupByFunctions);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/VectorAggregateFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/VectorAggregateFunction.java
@@ -90,4 +90,8 @@ public interface VectorAggregateFunction extends Function, Mutable {
      * @return true if wrapUp was fine and false if it failed on memory allocation
      */
     boolean wrapUp(long pRosti);
+
+    default boolean supportDeepClone() {
+        return false;
+    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
@@ -68,4 +68,8 @@ public interface WindowFunction extends Function {
       Set index of record chain column used to store window function result.
      */
     void setColumnIndex(int columnIndex);
+
+    default boolean supportDeepClone() {
+        return false;
+    }
 }

--- a/core/src/main/java/io/questdb/std/CharSequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/CharSequenceHashSet.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
-public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements Sinkable {
+public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements Sinkable, DeepCloneable<CharSequenceHashSet> {
 
     private static final int MIN_INITIAL_CAPACITY = 16;
     private final ObjList<CharSequence> list;
@@ -113,6 +113,11 @@ public class CharSequenceHashSet extends AbstractCharSequenceHashSet implements 
     @Override
     public boolean contains(@Nullable CharSequence key) {
         return key == null ? hasNull : keyIndex(key) < 0;
+    }
+
+    @Override
+    public CharSequenceHashSet deepClone() {
+        return new CharSequenceHashSet(this);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/DeepCloneable.java
+++ b/core/src/main/java/io/questdb/std/DeepCloneable.java
@@ -27,8 +27,8 @@ package io.questdb.std;
 /**
  * Return itself deepClone instance.
  * <p>
- * Fields in {@link io.questdb.cairo.sql.Function} that not thread safe in parallel
- * execution need to implement this interface.
+ * Fields in {@link io.questdb.cairo.sql.Function} that are not immutable (hence, not thread safe) need to implement this interface.
+ * Filter and group by functions used in parallel SQL are cloned for each worker thread.
  * Cloning is done by {@link io.questdb.griffin.engine.functions.FunctionCloneFactory}.
  */
 public interface DeepCloneable<T> {

--- a/core/src/main/java/io/questdb/std/DeepCloneable.java
+++ b/core/src/main/java/io/questdb/std/DeepCloneable.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+public interface DeepCloneable<T> {
+    T deepClone();
+}

--- a/core/src/main/java/io/questdb/std/DeepCloneable.java
+++ b/core/src/main/java/io/questdb/std/DeepCloneable.java
@@ -27,9 +27,9 @@ package io.questdb.std;
 /**
  * Return itself deepClone instance.
  * <p>
- * Fields in ({@link io.questdb.cairo.sql.Function}) that not thread safe in parallel
+ * Fields in {@link io.questdb.cairo.sql.Function} that not thread safe in parallel
  * execution need to implement this interface.
- * Would be used in ({@link io.questdb.griffin.engine.functions.FunctionCloneFactory}).
+ * Cloning is done by {@link io.questdb.griffin.engine.functions.FunctionCloneFactory}.
  */
 public interface DeepCloneable<T> {
     T deepClone();

--- a/core/src/main/java/io/questdb/std/DelayInitialize.java
+++ b/core/src/main/java/io/questdb/std/DelayInitialize.java
@@ -24,13 +24,13 @@
 
 package io.questdb.std;
 
-/**
- * Return itself deepClone instance.
- * <p>
- * Fields in ({@link io.questdb.cairo.sql.Function}) that not thread safe in parallel
- * execution need to implement this interface.
- * Would be used in ({@link io.questdb.griffin.engine.functions.FunctionCloneFactory}).
- */
-public interface DeepCloneable<T> {
-    T deepClone();
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface DelayInitialize {
+    String value() default "";
 }

--- a/core/src/main/java/io/questdb/std/DoubleList.java
+++ b/core/src/main/java/io/questdb/std/DoubleList.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class DoubleList implements Mutable, Sinkable {
+public class DoubleList implements Mutable, Sinkable, DeepCloneable<DoubleList> {
     public static final double DEFAULT_NO_ENTRY_VALUE = -1L;
     private static final int DEFAULT_ARRAY_SIZE = 16;
     private final double noEntryValue;
@@ -123,6 +123,11 @@ public class DoubleList implements Mutable, Sinkable {
             System.arraycopy(data, 0, buf, 0, l);
             this.data = buf;
         }
+    }
+
+    @Override
+    public DoubleList deepClone() {
+        return new DoubleList(this);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/IntHashSet.java
+++ b/core/src/main/java/io/questdb/std/IntHashSet.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 
 
-public class IntHashSet extends AbstractIntHashSet implements Sinkable {
+public class IntHashSet extends AbstractIntHashSet implements Sinkable, DeepCloneable<IntHashSet> {
 
     private static final int MIN_INITIAL_CAPACITY = 16;
     private final IntList list;
@@ -93,6 +93,11 @@ public class IntHashSet extends AbstractIntHashSet implements Sinkable {
 
     public boolean contains(int key) {
         return keyIndex(key) < 0;
+    }
+
+    @Override
+    public IntHashSet deepClone() {
+        return new IntHashSet(this);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/IntList.java
+++ b/core/src/main/java/io/questdb/std/IntList.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
-public class IntList implements Mutable, Sinkable {
+public class IntList implements Mutable, Sinkable, DeepCloneable<IntList> {
     private static final int DEFAULT_ARRAY_SIZE = 16;
     private static final int NO_ENTRY_VALUE = -1;
     private final int initialCapacity;
@@ -97,6 +97,11 @@ public class IntList implements Mutable, Sinkable {
 
     public boolean contains(int value) {
         return indexOf(value, 0, pos) > -1;
+    }
+
+    @Override
+    public IntList deepClone() {
+        return new IntList(this);
     }
 
     /**
@@ -282,6 +287,13 @@ public class IntList implements Mutable, Sinkable {
 
     public void zero(int value) {
         Arrays.fill(data, 0, pos, value);
+    }
+
+    private IntList(final IntList other) {
+        this.initialCapacity = Math.max(other.size(), DEFAULT_ARRAY_SIZE);
+        this.data = new int[initialCapacity];
+        setPos(other.size());
+        System.arraycopy(other.data, 0, this.data, 0, pos);
     }
 
     private void checkCapacity(int capacity) {

--- a/core/src/main/java/io/questdb/std/LongList.java
+++ b/core/src/main/java/io/questdb/std/LongList.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.util.Arrays;
 
-public class LongList implements Mutable, LongVec, Sinkable {
+public class LongList implements Mutable, LongVec, Sinkable, DeepCloneable<LongList> {
     private static final int DEFAULT_ARRAY_SIZE = 16;
     private static final long DEFAULT_NO_ENTRY_VALUE = -1L;
     private final int initialCapacity;
@@ -220,6 +220,11 @@ public class LongList implements Mutable, LongVec, Sinkable {
 
     public void clear() {
         pos = 0;
+    }
+
+    @Override
+    public LongList deepClone() {
+        return new LongList(this);
     }
 
     /**

--- a/core/src/main/java/io/questdb/std/LongLongHashSet.java
+++ b/core/src/main/java/io/questdb/std/LongLongHashSet.java
@@ -48,7 +48,7 @@ import java.util.Arrays;
  * <p>
  * This class is not thread safe.
  */
-public final class LongLongHashSet implements Mutable, Sinkable {
+public final class LongLongHashSet implements Mutable, Sinkable, DeepCloneable<LongLongHashSet> {
     public static final SinkStrategy LONG_LONG_STRATEGY = (key1, key2, sink) -> {
         sink.putAscii('[');
         Numbers.append(sink, key1, false);
@@ -139,6 +139,11 @@ public final class LongLongHashSet implements Mutable, Sinkable {
         hasNull = false;
     }
 
+    @Override
+    public LongLongHashSet deepClone() {
+        return new LongLongHashSet(this);
+    }
+
     public boolean hasNull() {
         return hasNull;
     }
@@ -197,6 +202,18 @@ public final class LongLongHashSet implements Mutable, Sinkable {
             }
         }
         sink.putAscii(']');
+    }
+
+    private LongLongHashSet(LongLongHashSet other) {
+        this.noEntryKeyValue = other.noEntryKeyValue;
+        this.loadFactor = other.loadFactor;
+        this.capacity = other.capacity;
+        this.mask = other.mask;
+        this.sinkStrategy = other.sinkStrategy;
+        this.size = other.size;
+        this.hasNull = other.hasNull;
+        this.values = new long[other.values.length];
+        System.arraycopy(other.values, 0, this.values, 0, other.values.length);
     }
 
     private static long firstValue(long[] val, int slot) {

--- a/core/src/main/java/io/questdb/std/Utf8SequenceHashSet.java
+++ b/core/src/main/java/io/questdb/std/Utf8SequenceHashSet.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
-public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements Sinkable {
+public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements Sinkable, DeepCloneable<Utf8SequenceHashSet> {
     private static final int MIN_INITIAL_CAPACITY = 16;
     private final ObjList<Utf8Sequence> list;
     private boolean hasNull = false;
@@ -112,6 +112,11 @@ public class Utf8SequenceHashSet extends AbstractUtf8SequenceHashSet implements 
     @Override
     public boolean contains(@Nullable Utf8Sequence key) {
         return key == null ? hasNull : keyIndex(key) < 0;
+    }
+
+    @Override
+    public Utf8SequenceHashSet deepClone() {
+        return new Utf8SequenceHashSet(this);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/str/StringSink.java
+++ b/core/src/main/java/io/questdb/std/str/StringSink.java
@@ -25,10 +25,11 @@
 package io.questdb.std.str;
 
 import io.questdb.std.Chars;
+import io.questdb.std.DeepCloneable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class StringSink implements MutableUtf16Sink, CharSequence, CloneableMutable, Utf16Sink {
+public class StringSink implements MutableUtf16Sink, CharSequence, CloneableMutable, Utf16Sink, DeepCloneable<StringSink> {
 
     private char[] buffer;
     private int pos;
@@ -60,6 +61,11 @@ public class StringSink implements MutableUtf16Sink, CharSequence, CloneableMuta
     @SuppressWarnings("unchecked")
     public <T> T copy() {
         return (T) new String(buffer, 0, pos);
+    }
+
+    @Override
+    public StringSink deepClone() {
+        return new StringSink(this);
     }
 
     @Override
@@ -171,6 +177,12 @@ public class StringSink implements MutableUtf16Sink, CharSequence, CloneableMuta
 
     public void trimTo(int pos) {
         clear(pos);
+    }
+
+    private StringSink(StringSink other) {
+        this.pos = other.pos;
+        this.buffer = new char[other.buffer.length];
+        System.arraycopy(other.buffer, 0, this.buffer, 0, other.buffer.length);
     }
 
     private void checkCapacity(int extra) {

--- a/core/src/main/java/io/questdb/std/str/Utf8String.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8String.java
@@ -33,7 +33,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * An immutable on-heap sequence of UTF-8 bytes.
  */
-public class Utf8String implements Utf8Sequence , DeepCloneable<Utf8String> {
+public class Utf8String implements Utf8Sequence, DeepCloneable<Utf8String> {
     public static final Utf8String EMPTY = new Utf8String("");
     private final boolean ascii;
     private final AsciiCharSequence asciiCharSequence = new AsciiCharSequence();

--- a/core/src/main/java/io/questdb/std/str/Utf8String.java
+++ b/core/src/main/java/io/questdb/std/str/Utf8String.java
@@ -24,6 +24,7 @@
 
 package io.questdb.std.str;
 
+import io.questdb.std.DeepCloneable;
 import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +33,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * An immutable on-heap sequence of UTF-8 bytes.
  */
-public class Utf8String implements Utf8Sequence {
+public class Utf8String implements Utf8Sequence , DeepCloneable<Utf8String> {
     public static final Utf8String EMPTY = new Utf8String("");
     private final boolean ascii;
     private final AsciiCharSequence asciiCharSequence = new AsciiCharSequence();
@@ -79,6 +80,11 @@ public class Utf8String implements Utf8Sequence {
     @Override
     public byte byteAt(int index) {
         return bytes[index];
+    }
+
+    @Override
+    public Utf8String deepClone() {
+        return newInstance(this);
     }
 
     public int intAt(int index) {

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -282,6 +282,7 @@ public class PropServerConfigurationTest {
         Assert.assertFalse(configuration.getLineUdpReceiverConfiguration().ownThread());
 
         Assert.assertTrue(configuration.getCairoConfiguration().isSqlParallelFilterPreTouchEnabled());
+        Assert.assertTrue(configuration.getCairoConfiguration().isSqlParallelFunctionDeepCloneEnabled());
         Assert.assertEquals(16, configuration.getCairoConfiguration().getSqlParallelWorkStealingThreshold());
         Assert.assertEquals(1_000_000, configuration.getCairoConfiguration().getSqlPageFrameMaxRows());
         Assert.assertEquals(100_000, configuration.getCairoConfiguration().getSqlPageFrameMinRows());
@@ -1462,6 +1463,7 @@ public class PropServerConfigurationTest {
 
         Assert.assertFalse(configuration.isSqlParallelFilterEnabled());
         Assert.assertFalse(configuration.isSqlParallelFilterPreTouchEnabled());
+        Assert.assertFalse(configuration.isSqlParallelFunctionDeepCloneEnabled());
         Assert.assertFalse(configuration.isSqlParallelGroupByEnabled());
         Assert.assertFalse(configuration.isSqlOrderBySortEnabled());
         Assert.assertEquals(100, configuration.getSqlOrderByRadixSortThreshold());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -287,6 +287,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.sql.page.frame.min.rows\tQDB_CAIRO_SQL_PAGE_FRAME_MIN_ROWS\t100000\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.filter.enabled\tQDB_CAIRO_SQL_PARALLEL_FILTER_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.filter.pretouch.enabled\tQDB_CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +
+                                    "cairo.sql.parallel.function.deep.clone.enabled\tQDB_CAIRO_SQL_PARALLEL_FUNCTION_DEEP_CLONE_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.groupby.enabled\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.groupby.merge.shard.queue.capacity\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_MERGE_SHARD_QUEUE_CAPACITY\t4\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.parallel.groupby.sharding.threshold\tQDB_CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD\t100000\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -137,6 +137,7 @@ cairo.sql.page.frame.max.rows=1000
 cairo.sql.page.frame.min.rows=100
 cairo.sql.parallel.filter.enabled=false
 cairo.sql.parallel.filter.pretouch.enabled=false
+cairo.sql.parallel.function.deep.clone.enabled=false
 cairo.sql.parallel.groupby.enabled=false
 cairo.sql.parallel.groupby.merge.shard.queue.capacity=2048
 cairo.sql.parallel.groupby.sharding.threshold=100

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -340,6 +340,9 @@ query.timeout.sec=60
 # maximum allowed heap size for parallel GROUP BY hash table pre-sizing
 #cairo.sql.parallel.groupby.presize.max.heap.size=1G
 
+# enables function deepClone in parallel GROUP BY and FILTER function execution
+#cairo.sql.parallel.function.deep.clone.enabled=true
+
 # threshold for in-flight tasks for disabling work stealing during parallel SQL execution
 # when the number of shared workers is less than 4x of this setting, work stealing is always enabled
 #cairo.sql.parallel.work.stealing.threshold=16


### PR DESCRIPTION
Implement interface of `deepClone` for functions.

Used for parallel filter/groupBy execution to avoid Function::parser for every worker. #5025 

This PR is still under WIP and need to add more tests.

@puzpuzpuz Coluld you please take a brief look this draft firstly to identify whther I am in the right direction ?