### PR TITLE
Added ToTimezoneIntervalFunction to handle Intervals in to_timezone

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactory.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.IntervalFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.microtime.TimestampFormatUtils;
+import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.Interval;
+
+import static io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory.getTimestampFunction;
+
+public class ToTimezoneIntervalFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_timezone(ΔS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        Function interval = args.getQuick(0);
+        Function timezone = args.getQuick(1);
+
+        if (timezone.isConstant()) {
+            //Incomplete return getIntervalFunction(argPositions, interval, timezone, 1);
+        } else {
+            return new ToTimezoneIntervalFunctionVar(interval, timezone);
+        }
+    }
+
+    private static class ToTimezoneIntervalFunctionVar extends IntervalFunction implements BinaryFunction {
+        private final Function interval;
+        private final Function timezone;
+
+        public ToTimezoneIntervalFunctionVar(Function interval, Function timezone) {
+            this.interval = interval;
+            this.timezone = timezone;
+        }
+
+        @Override
+        public Interval getInterval(Record rec) {
+            final long timestampLo = interval.getInterval(rec).getLo();
+            final long timestampHi = interval.getInterval(rec).getHi();
+            try {
+                final CharSequence tz = timezone.getStrA(rec);
+                if (tz != null) {
+                    return new Interval(
+                            Timestamps.toTimezone(timestampLo, TimestampFormatUtils.EN_LOCALE, tz),
+                            Timestamps.toTimezone(timestampHi, TimestampFormatUtils.EN_LOCALE, tz)
+                    );
+                } else {
+                    return new Interval(timestampLo, timestampHi);
+                }
+            } catch (NumericException e) {
+                return new Interval(timestampLo, timestampHi);
+            }
+        }
+
+        @Override
+        public Function getLeft() {
+            return interval;
+        }
+
+        @Override
+        public String getName() {
+            return "to_timezone";
+        }
+
+        @Override
+        public Function getRight() {
+            return timezone;
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1036,6 +1036,7 @@ open module io.questdb {
 
             io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory,
             io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory,
+            io.questdb.griffin.engine.functions.date.ToTimezoneIntervalFunctionFactory,
 
             // long128 functions
             io.questdb.griffin.engine.functions.long128.LongsToLong128FunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -1019,6 +1019,7 @@ io.questdb.griffin.engine.functions.math.IPv4VarcharNetmaskFunctionFactory
 # timezone conversion
 io.questdb.griffin.engine.functions.date.ToTimezoneTimestampFunctionFactory
 io.questdb.griffin.engine.functions.date.ToUTCTimestampFunctionFactory
+io.questdb.griffin.engine.functions.date.ToTimezoneIntervalFunctionFactory
 
 # geohash functions
 io.questdb.griffin.engine.functions.geohash.GeoHashFromCoordinatesFunctionFactory


### PR DESCRIPTION
This draft aims to add support for the interval type for the to_timezone function. Currently the case for (timezone.isConstant()) is incomplete and I'd appreciate some clarification regarding the same. 
- From what I gathered from the slack channel, I need to implement a getIntervalFunction with parameters similar to the getTimestampFunction present in ToUTCTimestampFunctionFactory, and handle both the low and high timestamps independently.
- How Can I get the Lo and Hi values of the interval since the interval is of type Function and I do not have a Record to pass as an argument. Also do I add this function to the same file? 

Please do let me know if there are any other changes that need to be made. Thank you!