### PR TITLE
fix(core): fix rare crash on read binary and other var length column types

### DIFF
--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMARWImpl.java
@@ -76,6 +76,11 @@ public class MemoryCMARWImpl extends AbstractMemoryCR implements MemoryCMARW, Me
     }
 
     @Override
+    public void changeSize(long dataSize) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void close(boolean truncate, byte truncateMode) {
         if (pageAddress != 0) {
             final long truncateSize;

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -58,6 +58,12 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
     }
 
     @Override
+    public void changeSize(long dataSize) {
+        assert dataSize >= 0;
+        setSize0(dataSize);
+    }
+
+    @Override
     public void close() {
         clear();
         if (pageAddress != 0) {

--- a/core/src/main/java/io/questdb/cairo/vm/NullMemoryCMR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/NullMemoryCMR.java
@@ -47,6 +47,10 @@ public class NullMemoryCMR implements MemoryCMR {
     }
 
     @Override
+    public void changeSize(long dataSize) {
+    }
+
+    @Override
     public void close() {
     }
 

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryCMR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryCMR.java
@@ -30,4 +30,6 @@ public interface MemoryCMR extends MemoryCR, MemoryMR, MemoryCM {
     default boolean isFileBased() {
         return true;
     }
+
+    void changeSize(long dataSize);
 }

--- a/core/src/test/java/io/questdb/test/griffin/O3SplitPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3SplitPartitionTest.java
@@ -37,6 +37,7 @@ import io.questdb.std.Os;
 import io.questdb.std.Vect;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
+import io.questdb.std.str.StringSink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.*;
 import org.junit.rules.TestName;
@@ -48,6 +49,8 @@ import java.util.Collection;
 
 import static io.questdb.cairo.TableUtils.dFile;
 import static io.questdb.cairo.TableUtils.iFile;
+import static io.questdb.test.tools.TestUtils.assertSql;
+import static io.questdb.test.tools.TestUtils.drainWalQueue;
 
 @RunWith(Parameterized.class)
 public class O3SplitPartitionTest extends AbstractO3Test {
@@ -235,7 +238,7 @@ public class O3SplitPartitionTest extends AbstractO3Test {
                     sqlExecutionContext);
 
 
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select ts, metric, loggerChannel from monthly_col_top", sink,
+            assertSql(compiler, sqlExecutionContext, "select ts, metric, loggerChannel from monthly_col_top", sink,
                     "ts\tmetric\tloggerChannel\n" +
                             "2022-06-08T01:40:00.000000Z\t1\t\n" +
                             "2022-06-08T02:41:00.000000Z\t2\t\n" +
@@ -254,7 +257,7 @@ public class O3SplitPartitionTest extends AbstractO3Test {
                             "2022-06-08T04:50:00.000000Z\t13\t2\n" +
                             "2022-06-08T04:50:00.000000Z\t14\t2\n");
 
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '2'", sink,
+            assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '2'", sink,
                     "ts\tmetric\tdiagnostic\tsensorChannel\tloggerChannel\n" +
                             "2022-06-08T02:50:00.000000Z\t9\t\t\t2\n" +
                             "2022-06-08T02:50:00.000000Z\t10\t\t\t2\n" +
@@ -269,7 +272,7 @@ public class O3SplitPartitionTest extends AbstractO3Test {
                             "('2022-06-08T04:50:00.000000Z', '18', '4', '3')",
                     sqlExecutionContext);
 
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '3'", sink,
+            assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '3'", sink,
                     "ts\tmetric\tdiagnostic\tsensorChannel\tloggerChannel\n" +
                             "2022-06-08T02:50:00.000000Z\t5\t\t\t3\n" +
                             "2022-06-08T02:50:00.000000Z\t6\t\t\t3\n" +
@@ -285,7 +288,7 @@ public class O3SplitPartitionTest extends AbstractO3Test {
                             "('2022-06-08T02:50:00.000000Z', '21', '4', '3')",
                     sqlExecutionContext);
 
-            TestUtils.assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '3'", sink,
+            assertSql(compiler, sqlExecutionContext, "select * from monthly_col_top where loggerChannel = '3'", sink,
                     "ts\tmetric\tdiagnostic\tsensorChannel\tloggerChannel\n" +
                             "2022-06-08T02:50:00.000000Z\t5\t\t\t3\n" +
                             "2022-06-08T02:50:00.000000Z\t6\t\t\t3\n" +
@@ -832,6 +835,58 @@ public class O3SplitPartitionTest extends AbstractO3Test {
                     compiler.compile("insert into x select * from z", executionContext);
 
                     assertX(compiler, executionContext, "zz");
+                });
+    }
+
+    @Test
+    public void testSplitSquashMidPartitionWithDedupSameRowCount() throws Exception {
+        executeWithPool(workerCount,
+                (engine, compiler, executionContext) -> {
+                    compiler.compile(
+                            "create table x as (" +
+                                    "select" +
+                                    " cast(x as int) i," +
+                                    " -x j," +
+                                    " rnd_str(5,16,2) as str," +
+                                    " rnd_varchar(5,16,2) as v1," +
+                                    " rnd_varchar(1,1,1) as v2," +
+                                    " cast(null as string) str2," +
+                                    " timestamp_sequence('2020-02-03T13', 60*1000000L) ts" +
+                                    " from long_sequence(60*24*2)" +
+                                    ") timestamp (ts) partition by DAY WAL dedup upsert keys(ts)",
+                            executionContext
+                    );
+
+                    drainWalQueue(engine);
+
+                    // Open reader
+                    TestUtils.assertSql(engine, executionContext, "select sum(j), ts, last(str2) from x sample by 1d", new StringSink(), "sum\tts\tlast\n" +
+                            "-218130\t2020-02-03T00:00:00.000000Z\t\n" +
+                            "-1987920\t2020-02-04T00:00:00.000000Z\t\n" +
+                            "-1942590\t2020-02-05T00:00:00.000000Z\t\n");
+
+                    compiler.compile(
+                            "create table z as (" +
+                                    "select" +
+                                    " cast(x as int) * 1000000 i," +
+                                    " -x - 1000000L as j," +
+                                    " rnd_str(5,16,2) as str," +
+                                    " rnd_varchar(5,16,2) as v1," +
+                                    " rnd_varchar(1,1,1) as v2," +
+                                    " rnd_str(1000, 1000, 0) as str2, " +
+                                    " timestamp_sequence('2020-02-04T23:01', 60*1000000L) ts" +
+                                    " from long_sequence(50))",
+                            executionContext
+                    );
+
+                    compiler.compile("insert into x select * from z", executionContext);
+
+                    drainWalQueue(engine);
+
+                    TestUtils.assertSql(engine, executionContext, "select sum(j), ts, last(str2) from x sample by 1d", new StringSink(), "sum\tts\tlast\n" +
+                            "-218130\t2020-02-03T00:00:00.000000Z\t\n" +
+                            "-51885870\t2020-02-04T00:00:00.000000Z\t\n" +
+                            "-1942590\t2020-02-05T00:00:00.000000Z\t\n");
                 });
     }
 


### PR DESCRIPTION
The problem manifested as a random db crash on reading binary column.

```
Stack: [0x00007fc02c1b5000,0x00007fc02c2b5000],  sp=0x00007fc02c2b36d0,  free space=1017k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
J 6557 c2 io.questdb.cutlass.pgwire.PGConnectionContext$ResponseUtf8Sink.put(Lio/questdb/std/BinarySequence;)V io.questdb@8.1.3-SNAPSHOT (122 bytes) @ 0x00007fc0b88e8044 [0x00007fc0b88e7e20+0x0000000000000224]
J 8050 c2 io.questdb.cutlass.pgwire.PGConnectionContext.appendRecord(Lio/questdb/cairo/sql/Record;I)V io.questdb@8.1.3-SNAPSHOT (825 bytes) @ 0x00007fc0b8d99f9c [0x00007fc0b8d997e0+0x00000000000007bc]
J 7631 c2 io.questdb.cutlass.pgwire.PGConnectionContext.sendCursor(Lio/questdb/cutlass/pgwire/PGConnectionContext$PGResumeProcessor;Lio/questdb/cutlass/pgwire/PGConnectionContext$PGResumeProcessor;Lio/questdb/cutlass/pgwire/PGConnectionContext$PGResumeProcessor;)V io.questdb@8.1.3-SNAPSHOT (55 bytes) @ 0x00007fc0b8c97a24 [0x00007fc0b8c97760+0x00000000000002c4]
J 30715 c2 io.questdb.cutlass.pgwire.PGConnectionContext.processExecute()V io.questdb@8.1.3-SNAPSHOT (131 bytes) @ 0x00007fc0b93a7e20 [0x00007fc0b93a7800+0x0000000000000620]
```

This appeared to be after a reading partition that went through splitting and squashing resulting in a line being updated in the resulting partition. Because of the dedup the resulting partition had the same number of rows as it was before the squash rewrite. It also had the same name (up to the transaction number). The problem is that in such cases TableReader cannot see any changes in the partition and does not open the column files.


