### PR TITLE
Fix for OOM logging is badly formatted #4806

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -768,5 +768,15 @@
             <version>42.5.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version> <!-- Check for the latest version -->
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.6</version> <!-- Check for the latest version -->
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/io/questdb/std/Unsafe.java
+++ b/core/src/main/java/io/questdb/std/Unsafe.java
@@ -35,6 +35,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import static io.questdb.std.MemoryTag.NATIVE_DEFAULT;
 
@@ -63,6 +65,8 @@ public final class Unsafe {
     private static final Method implAddExports;
     //#endif
     private static long RSS_MEM_LIMIT = 0;
+
+    private static final Logger logger = LoggerFactory.getLogger(Unsafe.class);
 
     private Unsafe() {
     }
@@ -250,12 +254,15 @@ public final class Unsafe {
             CairoException e = CairoException.nonCritical().setOutOfMemory(true)
                     .put("sun.misc.Unsafe.allocateMemory() OutOfMemoryError [RSS_MEM_USED=")
                     .put(RSS_MEM_USED.get())
+                    .put(", RSS_MEM_LIMIT=")
+                    .put(RSS_MEM_LIMIT)
                     .put(", size=")
                     .put(size)
                     .put(", memoryTag=").put(memoryTag)
                     .put("], original message: ")
                     .put(oom.getMessage());
-            System.err.println(e.getFlyweightMessage());
+            String errorMssg = e.getFlyweightMessage().toString();
+            logger.error(errorMssg);
             throw e;
         }
     }
@@ -272,6 +279,8 @@ public final class Unsafe {
             CairoException e = CairoException.nonCritical().setOutOfMemory(true)
                     .put("sun.misc.Unsafe.reallocateMemory() OutOfMemoryError [RSS_MEM_USED=")
                     .put(RSS_MEM_USED.get())
+                    .put(", RSS_MEM_LIMIT=")
+                    .put(RSS_MEM_LIMIT)
                     .put(", oldSize=")
                     .put(oldSize)
                     .put(", newSize=")
@@ -279,7 +288,8 @@ public final class Unsafe {
                     .put(", memoryTag=").put(memoryTag)
                     .put("], original message: ")
                     .put(oom.getMessage());
-            System.err.println(e.getFlyweightMessage());
+            String errorMssg = e.getFlyweightMessage().toString();
+            logger.error(errorMssg);
             throw e;
         }
     }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -27,6 +27,8 @@ open module io.questdb {
     requires static org.jetbrains.annotations;
     requires static java.management;
     requires jdk.management;
+    requires org.slf4j;
+    requires logback.classic;
 
     uses io.questdb.griffin.FunctionFactory;
     exports io.questdb;


### PR DESCRIPTION
Hi @ideoma

I have made the changes according to the points which u had mentioned in the issue. 

1) OOM exception is logged using println, not using loggers - now using logger for logging the error message.
2) RSS limit is not logged, only used memory and (allocation?) size - Added the RSS_MEM_LIMIT value in the message.
3) The logging is 2 times nested, OOM inside OOM - For this while setting the original message one of the fields in that is having the OOM message again that's why it's coming up. Please suggest if anything needs to be done here.

Thanks!