### PR TITLE
test(core): fix fuzz test setup / by zero exception

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/DedupInsertFuzzTest.java
@@ -833,7 +833,7 @@ public class DedupInsertFuzzTest extends AbstractFuzzTest {
                 ? symbols
                 : Arrays.copyOf(symbols, 1 + rnd.nextInt(symbols.length - 1));
 
-        long fromTops = startTimestamp + rnd.nextLong(startCount) * initialDelta;
+        long fromTops = startTimestamp + (startCount > 0 ? rnd.nextLong(startCount) : 0) * initialDelta;
         generateInsertsTransactions(
                 transactions,
                 1,


### PR DESCRIPTION
fix 

```
java.lang.ArithmeticException: / by zero
	at io.questdb.std.Rnd.nextLong(Rnd.java:162)
	at io.questdb.test.griffin.wal.DedupInsertFuzzTest.testDedupWithRandomShiftAndStepAndColumnTops(DedupInsertFuzzTest.java:836)
	at io.questdb.test.griffin.wal.DedupInsertFuzzTest.lambda$testDedupWithRandomShiftAndStepAndVarcharKeyAndColumnTops$4(DedupInsertFuzzTest.java:168)
```