### PR TITLE
fix(pgwire): fix a spurios errors after table schema change

### DIFF
--- a/.github/workflows/pgwire_latest.yml
+++ b/.github/workflows/pgwire_latest.yml
@@ -27,52 +27,19 @@ jobs:
         run: tar -xzf core/target/questdb-*-no-jre-bin.tar.gz
       - name: Start QuestDB
         run: ./questdb-*bin/questdb.sh start
-      - name: Setup Python version
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3
-      - name: Create and start virtual environment for psycopg2
-        run: |
-          python3 -m venv venv_psycopg2
-          source venv_psycopg2/bin/activate
-          pip install -r compat/src/test/python/requirements_psycopg2_latest.txt
-      - name: Run tests with psycopg2
-        run: |
-          source venv_psycopg2/bin/activate
-          python compat/src/test/python/runner_psycopg2.py compat/src/test/resources/test_cases.yaml
-      - name: Create and start virtual environment for psycopg3
-        run: |
-          python3 -m venv venv_psycopg3
-          source venv_psycopg3/bin/activate
-          pip install -r compat/src/test/python/requirements_psycopg3_latest.txt
-      - name: Run tests with psycopg3
-        run: |
-          source venv_psycopg3/bin/activate
-          python compat/src/test/python/runner_psycopg3.py compat/src/test/resources/test_cases.yaml
-      - name: Create and start virtual environment for asyncpg
-        run: |
-          python3 -m venv venv_asyncpg
-          source venv_asyncpg/bin/activate
-          pip install -r compat/src/test/python/requirements_asyncpg_latest.txt
-      - name: Run tests with asyncpg
-        run: |
-          source venv_asyncpg/bin/activate
-          python compat/src/test/python/runner_asyncpg.py compat/src/test/resources/test_cases.yaml
       - name: Setup Rust toolchain
         # 4d1965c9142484e48d40c19de54b5cba84953a06 is the same as @v1, except it's guaranteed to be immutable
         # even if the original tag is moved or deleted
         uses: actions-rust-lang/setup-rust-toolchain@4d1965c9142484e48d40c19de54b5cba84953a06
         with:
           toolchain: stable
-          # No cache when testing latest
-          cache: 'false'
-      - name: Compile Rust scenarios runner
+          cache-workspaces: compat/src/test/rust/scenarios
+      - name: Setup Python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3
+      - name: Run all scenarios
         run: |
-          cd compat/src/test/rust/scenarios
-          cargo build --release
-      - name: Run Rust test runner
-        run: |
-          compat/src/test/rust/scenarios/target/release/questrun_rust compat/src/test/resources/test_cases.yaml
+          ./compat/src/test/scenarios_latest.sh
       - name: Stop QuestDB
         run: ./questdb-*bin/questdb.sh stop
-# TODO: Add notification via Slack webhook

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Stop QuestDB
         run: ./questdb-*bin/questdb.sh stop
       - name: Upload logs
+        if: failure() # Only upload logs if the job failed
         uses: actions/upload-artifact@v4
         with:
           path: ~/.questdb/log/*

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -40,6 +40,12 @@ jobs:
           ./compat/src/test/scenarios_stable.sh
       - name: Stop QuestDB
         run: ./questdb-*bin/questdb.sh stop
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        with:
+          path: ~/.questdb/log/*
+          name: logs
+          retention-days: 5
 
         
 

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -24,41 +24,6 @@ jobs:
         run: tar -xzf core/target/questdb-*-no-jre-bin.tar.gz
       - name: Start QuestDB
         run: ./questdb-*bin/questdb.sh start
-      - name: Setup Python version
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Create and start virtual environment for psycopg2
-        run: |
-          python3 -m venv venv_psycopg2
-          source venv_psycopg2/bin/activate
-          pip install -r compat/src/test/python/requirements_psycopg2_stable.txt
-      - name: Run tests with psycopg2
-        run: |
-          source venv_psycopg2/bin/activate
-          python compat/src/test/python/runner_psycopg2.py compat/src/test/resources/test_cases.yaml
-      - name: Create and start virtual environment for psycopg3
-        run: |
-          python3 -m venv venv_psycopg3
-          source venv_psycopg3/bin/activate
-          pip install -r compat/src/test/python/requirements_psycopg3_stable.txt
-      - name: Run tests with psycopg3
-        run: |
-          source venv_psycopg3/bin/activate
-          python compat/src/test/python/runner_psycopg3.py compat/src/test/resources/test_cases.yaml
-      - name: Create and start virtual environment for asyncpg
-        run: |
-          python3 -m venv venv_asyncpg
-          source venv_asyncpg/bin/activate
-          pip install -r compat/src/test/python/requirements_asyncpg_stable.txt
-      - name: Run tests with asyncpg
-        run: |
-          source venv_asyncpg/bin/activate
-          python compat/src/test/python/runner_asyncpg.py compat/src/test/resources/test_cases.yaml
-      - name: Activate Cargo Lock File
-        run: |
-          cd compat/src/test/rust/scenarios
-          cp ./Cargo.unlocked ./Cargo.lock
       - name: Setup Rust toolchain
         # 4d1965c9142484e48d40c19de54b5cba84953a06 is the same as @v1, except it's guaranteed to be immutable
         # even if the original tag is moved or deleted
@@ -66,13 +31,13 @@ jobs:
         with:
           toolchain: 1.79.0
           cache-workspaces: compat/src/test/rust/scenarios
-      - name: Compile Rust scenarios runner
+      - name: Setup Python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Run all scenarios
         run: |
-          cd compat/src/test/rust/scenarios
-          cargo build --release
-      - name: Run Rust test runner
-        run: |
-          compat/src/test/rust/scenarios/target/release/questrun_rust compat/src/test/resources/test_cases.yaml
+          ./compat/src/test/scenarios_stable.sh
       - name: Stop QuestDB
         run: ./questdb-*bin/questdb.sh stop
 

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Stop QuestDB
         run: ./questdb-*bin/questdb.sh stop
       - name: Upload logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ~/.questdb/log/*
           name: logs

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ core/CMakeCache.txt
 .envrc
 .vscode
 core/rust/qdbr/target
+compat/src/test/rust/scenarios/target/
+compat/src/test/rust/scenarios/Cargo.lock

--- a/compat/src/test/python/runner_asyncpg.py
+++ b/compat/src/test/python/runner_asyncpg.py
@@ -22,6 +22,8 @@
 
 
 import asyncio
+import os
+
 import asyncpg
 import re
 import sys
@@ -96,9 +98,11 @@ async def run_test(test, global_variables):
     variables = global_variables.copy()
     variables.update(test.get('variables', {}))
 
+    # port from env. variable of default to 8812
+    port = int(os.getenv('PGPORT', 8812))
     connection = await asyncpg.connect(
         host='localhost',
-        port=8812,
+        port=port,
         user='admin',
         password='quest',
         database='qdb'
@@ -142,6 +146,7 @@ async def main(yaml_file):
     for test in tests:
         iterations = test.get('iterations', 50)
         for _ in range(iterations):
+            print(f"Running test '{test['name']}' (iteration {_ + 1})")
             await run_test(test, global_variables)
 
 

--- a/compat/src/test/python/runner_psycopg2.py
+++ b/compat/src/test/python/runner_psycopg2.py
@@ -19,7 +19,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-
+import os
 
 import psycopg2
 import re
@@ -136,12 +136,14 @@ def main(yaml_file):
     global_variables = data.get('variables', {})
     tests = data.get('tests', [])
 
+    port = int(os.getenv('PGPORT', 8812))
     for test in tests:
         iterations = test.get('iterations', 50)
         for i in range(iterations):
+            print(f"Running test '{test['name']}' iteration {i + 1}...")
             connection = psycopg2.connect(
                 host='localhost',
-                port=8812,
+                port=port,
                 user='admin',
                 password='quest',
                 database='qdb'

--- a/compat/src/test/python/runner_psycopg3.py
+++ b/compat/src/test/python/runner_psycopg3.py
@@ -19,6 +19,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import os
 
 import psycopg
 import re
@@ -136,12 +137,14 @@ def main(yaml_file):
     global_variables = data.get('variables', {})
     tests = data.get('tests', [])
 
+    port = int(os.getenv('PGPORT', 8812))
     for test in tests:
         iterations = test.get('iterations', 50)
         for i in range(iterations):
+            print(f"Running test '{test['name']}' (iteration {i + 1})")
             connection = psycopg.connect(
                 host='localhost',
-                port=8812,
+                port=port,
                 user='admin',
                 password='quest',
                 dbname='qdb'

--- a/compat/src/test/scenarios_latest.sh
+++ b/compat/src/test/scenarios_latest.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+export PGPORT=8812
+
+echo "starting psycopg2 tests"
+python3 -m venv venv/psycopg2_latest
+source venv/psycopg2_latest/bin/activate
+pip install -r compat/src/test/python/requirements_psycopg2_latest.txt
+python compat/src/test/python/runner_psycopg2.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "psycopg2 tests failed"
+    exit 1
+fi
+deactivate
+echo "psycopg2 tests finished"
+
+echo "starting psycopg3 tests"
+python3 -m venv venv/psycopg3_latest
+source venv/psycopg3_latest/bin/activate
+pip install -r compat/src/test/python/requirements_psycopg3_latest.txt
+python compat/src/test/python/runner_psycopg3.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "psycopg3 tests failed"
+    exit 1
+fi
+deactivate
+echo "psycopg3 tests finished"
+
+echo "starting asyncpg tests"
+python3 -m venv venv/asyncpg_latest
+source venv/asyncpg_latest/bin/activate
+pip install -r compat/src/test/python/requirements_asyncpg_latest.txt
+python compat/src/test/python/runner_asyncpg.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "asyncpg tests failed"
+    exit 1
+fi
+deactivate
+echo "asyncpg tests finished"
+
+echo "starting rust tests"
+cd compat/src/test/rust/scenarios
+rm -f ./Cargo.lock
+cargo build --release
+./target/release/questrun_rust ../../resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "rust tests failed"
+    exit 1
+fi
+echo "rust tests finished"

--- a/compat/src/test/scenarios_stable.sh
+++ b/compat/src/test/scenarios_stable.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+export PGPORT=8812
+
+echo "starting psycopg2 tests"
+python3 -m venv venv/psycopg2_stable
+source venv/psycopg2_stable/bin/activate
+pip install -r compat/src/test/python/requirements_psycopg2_stable.txt
+python compat/src/test/python/runner_psycopg2.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "psycopg2 tests failed"
+    exit 1
+fi
+deactivate
+echo "psycopg2 tests finished"
+
+echo "starting psycopg3 tests"
+python3 -m venv venv/psycopg3_stable
+source venv/psycopg3_stable/bin/activate
+pip install -r compat/src/test/python/requirements_psycopg3_stable.txt
+python compat/src/test/python/runner_psycopg3.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "psycopg3 tests failed"
+    exit 1
+fi
+deactivate
+echo "psycopg3 tests finished"
+
+echo "starting asyncpg tests"
+python3 -m venv venv/asyncpg_stable
+source venv/asyncpg_stable/bin/activate
+pip install -r compat/src/test/python/requirements_asyncpg_stable.txt
+python compat/src/test/python/runner_asyncpg.py compat/src/test/resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "asyncpg tests failed"
+    exit 1
+fi
+deactivate
+echo "asyncpg tests finished"
+
+echo "starting rust tests"
+cd compat/src/test/rust/scenarios
+# use well-known versions of dependencies
+cp ./Cargo.unlocked ./Cargo.lock
+cargo build --release
+./target/release/questrun_rust ../../resources/test_cases.yaml
+if [ $? -ne 0 ]; then
+    echo "rust tests failed"
+    exit 1
+fi
+echo "rust tests finished"

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -2480,6 +2480,11 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         CharacterStoreEntry e = characterStore.newEntry();
 
         if (Utf8s.utf8ToUtf16(lo, limit - 1, e)) {
+            // do not cache simple queries, because we don't consult query cache when executing
+            // simple queries anyway. thus caching simple queries would only evict other cached queries
+            // from other clients, but they would not be used.
+            typesAndSelectIsCached = false;
+            typesAndUpdateIsCached = false;
             queryText = characterStore.toImmutable();
             try (SqlCompiler compiler = engine.getSqlCompiler()) {
                 compiler.compileBatch(queryText, sqlExecutionContext, batchCallback);
@@ -2778,9 +2783,16 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
                     if (retries == maxRecompileAttempts) {
                         throw SqlException.$(0, e.getFlyweightMessage());
                     }
-                    LOG.info().$(e.getFlyweightMessage()).$();
+                    LOG.info().$(e.getFlyweightMessage()).$("setupFactoryAndCursor [retries=").$(retries).I$();
                     freeFactory();
-                    compileQuery();
+                    if (!compileQuery()) {
+                        // when we get a query from cache then we don't count it as
+                        // a recompile attempt. since a large cache full of stale queries
+                        // can trigger a lot of recompiles yet it's not an indication of
+                        // a problem with the query itself or a volatile schema.
+                        // it just means the cache had been populated and then the schema changed.
+                        retries--;
+                    }
                     buildSelectColumnTypes();
                     applyLatestBindColumnFormats();
                 } catch (Throwable e) {

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
@@ -92,6 +92,7 @@ public abstract class BasePGTest extends AbstractCairoTest {
     protected int forceSendFragmentationChunkSize = 1024 * 1024;
     protected int recvBufferSize = 1024 * 1024;
     protected int sendBufferSize = 1024 * 1024;
+    protected int selectCacheBlockCount = -1;
 
     public static void assertResultSet(CharSequence expected, StringSink sink, ResultSet rs) throws SQLException, IOException {
         assertResultSet(null, expected, sink, rs);
@@ -459,6 +460,11 @@ public abstract class BasePGTest extends AbstractCairoTest {
         };
 
         final PGWireConfiguration conf = new Port0PGWireConfiguration(connectionLimit) {
+
+            @Override
+            public int getSelectCacheBlockCount() {
+                return selectCacheBlockCount == -1 ? super.getSelectCacheBlockCount() : selectCacheBlockCount;
+            }
 
             @Override
             public SqlExecutionCircuitBreakerConfiguration getCircuitBreakerConfiguration() {


### PR DESCRIPTION
This PR fixes a bug in PGWire query caching.

**Problem:**

1. Simple Protocol Clients: These clients caused cache poisoning by failing to poll the cache during query execution, but still populated it afterward, leading to stale entries.
2. Schema Change: A schema change invalidated all cached plans, which is expected.
3. Extended Protocol Clients: After the schema change, extended protocol clients consulted the cache, found stale query plans, and triggered retries. Each retry failed as the cache continued returning stale plans.

**Fix:**
Simple protocol clients now do not populate the query cache.


Also - added a facility for simple local execution of non-Java tests and Rust runner respects iteration config