### PR TITLE
ci(build): fix ci release pipeline draft url parsing

### DIFF
--- a/ci/github-release-pipeline.yml
+++ b/ci/github-release-pipeline.yml
@@ -84,7 +84,7 @@ stages:
               tag_name=$(echo "$(Build.SourceBranch)" | cut -d'/' -f '3-')
               echo "Checking if release ${tag_name} already exists..."
               
-              release_tag=$(gh release view ${tag_name} | grep "github" | sed 's#.*/##')
+              release_tag=$(gh release view ${tag_name} | | grep -E "url:.*github.*/tag/" | sed 's#.*/##')
               echo "Using release tag ${release_tag}"
               
               gh release upload ${release_tag} $(Build.ArtifactStagingDirectory)/drop/*.gz

--- a/ci/github-release-pipeline.yml
+++ b/ci/github-release-pipeline.yml
@@ -84,7 +84,7 @@ stages:
               tag_name=$(echo "$(Build.SourceBranch)" | cut -d'/' -f '3-')
               echo "Checking if release ${tag_name} already exists..."
               
-              release_tag=$(gh release view ${tag_name} | | grep -E "url:.*github.*/tag/" | sed 's#.*/##')
+              release_tag=$(gh release view ${tag_name} | grep -E "url:.*github.*/tag/" | sed 's#.*/##')
               echo "Using release tag ${release_tag}"
               
               gh release upload ${release_tag} $(Build.ArtifactStagingDirectory)/drop/*.gz


### PR DESCRIPTION
Fix 

https://dev.azure.com/questdb/questdb/_build/results?buildId=114472&view=logs&j=8a903c0a-beec-5c5f-3f8d-9756db27ce86&t=e27b12f5-dddf-508b-19d6-b729a9cbdfc9

Previously `grep` resulted into too many lines, this fixes it to take only the line that contains the draft release url