### PR TITLE
fix(sql): cap `string_agg()` memory use to the "strFunctionMaxBufferLength" value

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunctionFactory.java
@@ -51,6 +51,11 @@ public class StringAggGroupByFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new StringAggGroupByFunction(args.getQuick(0), args.getQuick(1).getChar(null));
+        return new StringAggGroupByFunction(
+                args.getQuick(0),
+                argPositions.getQuick(0),
+                args.getQuick(1).getChar(null),
+                configuration.getStrFunctionMaxBufferLength()
+        );
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
@@ -24,11 +24,39 @@
 
 package io.questdb.test.griffin.engine.functions.groupby;
 
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlException;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 
 public class StringAggGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testBufferLimitCompliance() throws Exception {
+        assertMemoryLeak(() -> {
+            engine.ddl("create table break as (select rnd_str(25,25,0) a from long_sequence(100000));", sqlExecutionContext);
+            try (SqlCompiler compiler = engine.getSqlCompiler()) {
+                try (RecordCursorFactory fact = compiler.compile("select string_agg(a, ',') from break", sqlExecutionContext).getRecordCursorFactory()) {
+                    // execute factory a couple of times to make sure nothing breaks
+                    testBufferLimitCompliance0(fact);
+                    testBufferLimitCompliance0(fact);
+
+                    engine.ddl("truncate table break", sqlExecutionContext);
+                    engine.insert("insert into break select rnd_str(25,25,0) a from long_sequence(10)", sqlExecutionContext);
+                    // execute factory few times to make sure nothing accumulates
+                    testBufferLimitCompliance1(fact);
+                    testBufferLimitCompliance1(fact);
+                    testBufferLimitCompliance1(fact);
+                }
+            }
+        });
+    }
 
     @Test
     public void testConstantNull() throws Exception {
@@ -202,5 +230,30 @@ public class StringAggGroupByFunctionFactoryTest extends AbstractCairoTest {
                 true,
                 false
         );
+    }
+
+    private static void testBufferLimitCompliance0(RecordCursorFactory fact) throws SqlException {
+        try (RecordCursor cursor = fact.getCursor(sqlExecutionContext)) {
+            try {
+                TestUtils.assertCursor(null, cursor, fact.getMetadata(), true, sink);
+                Assert.fail();
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "string_agg() result exceeds max size of");
+                Assert.assertEquals(18, e.getPosition());
+            }
+        }
+    }
+
+    private static void testBufferLimitCompliance1(RecordCursorFactory fact) throws SqlException {
+        try (RecordCursor cursor = fact.getCursor(sqlExecutionContext)) {
+            TestUtils.assertCursor(
+                    "string_agg\n" +
+                            "FGSLQDYOCTKSCTOHWMRHGLXBI,HWIIOHDDLYDZEUTOQEZOODZRO,NSTFHKVDEKTQJGFGVRMVZVRCO,HRFVCWZYHGIEIEJEIDVRHYFXF,LEZBTJQRMHTRYZEUDDOTUHDOC,IMSSDLJUVTBCCPKOOEYICCHMH,NSBDCJLEPQPOVFLEJCELDSOWJ,TIMPLKXPJEVHPWLCKDUTWKOSZ,HBJLFGZSKNBUVJNXJUUKCSJHM,GDKSKLTEBHKVQXNELZCHSPSYD\n",
+                    cursor,
+                    fact.getMetadata(),
+                    true,
+                    sink
+            );
+        }
     }
 }


### PR DESCRIPTION
`string_agg()` can knockout server if not careful. This PR forces the memory cap per function instance that defaults to 1MiB

Error message to the user in case cap is breached:

![image](https://github.com/user-attachments/assets/b35be46a-18ad-4480-bdd4-409bf5acd9db)

The value is configures via `cairo.sql.string.function.buffer.max.size` and is dynamically reloadable by this function.
