### PR TITLE
feat(http): make healthcheck endpoint responsive on high CPU load

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -482,6 +482,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private int httpMinWorkerCount;
     private boolean httpMinWorkerHaltOnError;
     private long httpMinWorkerNapThreshold;
+    private int httpMinWorkerPoolPriority;
     private long httpMinWorkerSleepThreshold;
     private long httpMinWorkerSleepTimeout;
     private long httpMinWorkerYieldThreshold;
@@ -802,6 +803,10 @@ public class PropServerConfiguration implements ServerConfiguration {
             if (httpMinServerEnabled) {
                 this.httpMinWorkerHaltOnError = getBoolean(properties, env, PropertyKey.HTTP_MIN_WORKER_HALT_ON_ERROR, false);
                 this.httpMinWorkerCount = getInt(properties, env, PropertyKey.HTTP_MIN_WORKER_COUNT, 1);
+
+                final int httpMinWorkerPoolPriority = getInt(properties, env, PropertyKey.HTTP_MIN_WORKER_POOL_PRIORITY, Thread.MAX_PRIORITY - 2);
+                this.httpMinWorkerPoolPriority = Math.min(Thread.MAX_PRIORITY, Math.max(Thread.MIN_PRIORITY, httpMinWorkerPoolPriority));
+
                 this.httpMinWorkerAffinity = getAffinity(properties, env, PropertyKey.HTTP_MIN_WORKER_AFFINITY, httpMinWorkerCount);
                 this.httpMinWorkerYieldThreshold = getLong(properties, env, PropertyKey.HTTP_MIN_WORKER_YIELD_THRESHOLD, 10);
                 this.httpMinWorkerNapThreshold = getLong(properties, env, PropertyKey.HTTP_MIN_WORKER_NAP_THRESHOLD, 100);
@@ -816,7 +821,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     httpMinBindPort = p;
                 });
 
-                this.httpMinNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_LIMIT, 4);
+                this.httpMinNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_LIMIT, 32);
 
                 // deprecated
                 this.httpMinNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_IDLE_CONNECTION_TIMEOUT, 5 * 60 * 1000L);
@@ -3539,6 +3544,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean preAllocateBuffers() {
             return true;
+        }
+
+        @Override
+        public int workerPoolPriority() {
+            return httpMinWorkerPoolPriority;
         }
     }
 

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -821,7 +821,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     httpMinBindPort = p;
                 });
 
-                this.httpMinNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_LIMIT, 32);
+                this.httpMinNetConnectionLimit = getInt(properties, env, PropertyKey.HTTP_MIN_NET_CONNECTION_LIMIT, 64);
 
                 // deprecated
                 this.httpMinNetConnectionTimeout = getLong(properties, env, PropertyKey.HTTP_MIN_NET_IDLE_CONNECTION_TIMEOUT, 5 * 60 * 1000L);

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -279,6 +279,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     HTTP_BUSY_RETRY_INITIAL_WAIT_QUEUE_SIZE("http.busy.retry.initialWaitQueueSize"),
     HTTP_BUSY_RETRY_MAX_PROCESSING_QUEUE_SIZE("http.busy.retry.maxProcessingQueueSize"),
     HTTP_MIN_WORKER_COUNT("http.min.worker.count"),
+    HTTP_MIN_WORKER_POOL_PRIORITY("http.min.worker.priority"),
     HTTP_MIN_NET_CONNECTION_LIMIT("http.min.net.connection.limit"),
     HTTP_NET_BIND_TO("http.net.bind.to"),
     HTTP_CONNECTION_POOL_INITIAL_CAPACITY("http.connection.pool.initial.capacity"),
@@ -500,8 +501,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     HTTP_MIN_MULTIPART_IDLE_SPIN_COUNT("http.min.multipart.idle.spin.count"),
     HTTP_MIN_ALLOW_DEFLATE_BEFORE_SEND("http.min.allow.deflate.before.send"),
     HTTP_MIN_SERVER_KEEP_ALIVE("http.min.server.keep.alive"),
-    HTTP_MIN_REQUEST_HEADER_BUFFER_SIZE("http.min.request.header.buffer.size"),
-    ;
+    HTTP_MIN_REQUEST_HEADER_BUFFER_SIZE("http.min.request.header.buffer.size");
 
     private static final Map<String, PropertyKey> nameMapping;
     private final boolean debug;

--- a/core/src/main/java/io/questdb/WorkerPoolManager.java
+++ b/core/src/main/java/io/questdb/WorkerPoolManager.java
@@ -72,6 +72,7 @@ public abstract class WorkerPoolManager implements Scrapable {
         LOG.info().$("new DEDICATED pool [name=").$(poolName)
                 .$(", requester=").$(requester)
                 .$(", workers=").$(pool.getWorkerCount())
+                .$(", priority=").$(config.workerPoolPriority())
                 .I$();
         return pool;
     }

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -47,6 +47,7 @@ public class WorkerPool implements Closeable {
     private final Metrics metrics;
     private final long napThreshold;
     private final String poolName;
+    private final int priority;
     private final AtomicBoolean running = new AtomicBoolean();
     private final long sleepMs;
     private final long sleepThreshold;
@@ -79,6 +80,7 @@ public class WorkerPool implements Closeable {
         this.sleepThreshold = configuration.getSleepThreshold();
         this.sleepMs = configuration.getSleepTimeout();
         this.metrics = metrics;
+        this.priority = configuration.workerPoolPriority();
 
         assert this.workerAffinity.length == workerCount;
 
@@ -189,6 +191,7 @@ public class WorkerPool implements Closeable {
                         metrics,
                         log
                 );
+                worker.setPriority(priority);
                 worker.setDaemon(daemons);
                 workers.add(worker);
                 worker.start();

--- a/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
@@ -62,4 +62,8 @@ public interface WorkerPoolConfiguration {
     default boolean isEnabled() {
         return true;
     }
+
+    default int workerPoolPriority() {
+        return Thread.NORM_PRIORITY;
+    }
 }

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -349,7 +349,7 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
                 unregisterListenerFd();
                 listening = false;
                 closeListenFdEpochMs = timestamp + queuedConnectionTimeoutMs;
-                LOG.info().$("max connection limit reached, unregistered listener [serverFd=").$(serverFd).I$();
+                LOG.advisory().$("max connection limit reached, unregistered listener [serverFd=").$(serverFd).I$();
             }
         }
     }
@@ -377,7 +377,7 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
                 }
                 registerListenerFd();
                 listening = true;
-                LOG.info().$("below maximum connection limit, registered listener [serverFd=").$(serverFd).I$();
+                LOG.advisory().$("below maximum connection limit, registered listener [serverFd=").$(serverFd).I$();
             }
         }
     }

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -383,7 +383,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "http.min.enabled\tQDB_HTTP_MIN_ENABLED\ttrue\tconf\tfalse\tfalse\n" +
                                     "http.min.net.bind.to\tQDB_HTTP_MIN_NET_BIND_TO\t0.0.0.0:9011\tconf\tfalse\tfalse\n" +
                                     "http.min.net.connection.hint\tQDB_HTTP_MIN_NET_CONNECTION_HINT\tfalse\tdefault\tfalse\tfalse\n" +
-                                    "http.min.net.connection.limit\tQDB_HTTP_MIN_NET_CONNECTION_LIMIT\t32\tdefault\tfalse\tfalse\n" +
+                                    "http.min.net.connection.limit\tQDB_HTTP_MIN_NET_CONNECTION_LIMIT\t64\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.queue.timeout\tQDB_HTTP_MIN_NET_CONNECTION_QUEUE_TIMEOUT\t5000\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.rcvbuf\tQDB_HTTP_MIN_NET_CONNECTION_RCVBUF\t1024\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.sndbuf\tQDB_HTTP_MIN_NET_CONNECTION_SNDBUF\t1024\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -383,7 +383,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "http.min.enabled\tQDB_HTTP_MIN_ENABLED\ttrue\tconf\tfalse\tfalse\n" +
                                     "http.min.net.bind.to\tQDB_HTTP_MIN_NET_BIND_TO\t0.0.0.0:9011\tconf\tfalse\tfalse\n" +
                                     "http.min.net.connection.hint\tQDB_HTTP_MIN_NET_CONNECTION_HINT\tfalse\tdefault\tfalse\tfalse\n" +
-                                    "http.min.net.connection.limit\tQDB_HTTP_MIN_NET_CONNECTION_LIMIT\t4\tdefault\tfalse\tfalse\n" +
+                                    "http.min.net.connection.limit\tQDB_HTTP_MIN_NET_CONNECTION_LIMIT\t32\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.queue.timeout\tQDB_HTTP_MIN_NET_CONNECTION_QUEUE_TIMEOUT\t5000\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.rcvbuf\tQDB_HTTP_MIN_NET_CONNECTION_RCVBUF\t1024\tdefault\tfalse\tfalse\n" +
                                     "http.min.net.connection.sndbuf\tQDB_HTTP_MIN_NET_CONNECTION_SNDBUF\t1024\tdefault\tfalse\tfalse\n" +
@@ -590,7 +590,8 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "http.min.connection.string.pool.capacity\tQDB_HTTP_MIN_CONNECTION_STRING_POOL_CAPACITY\t2\tdefault\tfalse\tfalse\n" +
                                     "http.min.connection.pool.initial.capacity\tQDB_HTTP_MIN_CONNECTION_POOL_INITIAL_CAPACITY\t2\tdefault\tfalse\tfalse\n" +
                                     "http.min.multipart.idle.spin.count\tQDB_HTTP_MIN_MULTIPART_IDLE_SPIN_COUNT\t0\tdefault\tfalse\tfalse\n" +
-                                    "cairo.o3.partition.overwrite.control.enabled\tQDB_CAIRO_O3_PARTITION_OVERWRITE_CONTROL_ENABLED\tfalse\tdefault\tfalse\tfalse\n"
+                                    "cairo.o3.partition.overwrite.control.enabled\tQDB_CAIRO_O3_PARTITION_OVERWRITE_CONTROL_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
+                                    "http.min.worker.priority\tQDB_HTTP_MIN_WORKER_PRIORITY\t8\tdefault\tfalse\tfalse\n"
                             )
                                     .split("\n");
 


### PR DESCRIPTION
This change makes QuestDB more responsive to the health check endpoint, which is usually used by Kubernetes. What used to happen is that on high CPU load `http-min-server` does not cope with processing disconnects and exceeds connection limit. That closes the listening socket and the server becomes unresponsive. Kubernates then restart the QuestDB pod.

Changes

- Make HTTP server connection limit log message of Advisory level so it's clear that the limit is exceeded.
- Increase default HTTP min server connection limit from 4 to 64.
- Set higher HTTP MIn server worker pool threads priority