### PR TITLE
chore(sql): simplify group-by SQL assembly

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -24,38 +24,266 @@
 
 package io.questdb.griffin;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractPartitionFrameCursorFactory;
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.BitmapIndexReader;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnFilter;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.ColumnTypes;
+import io.questdb.cairo.EntityColumnFilter;
+import io.questdb.cairo.FullBwdPartitionFrameCursorFactory;
+import io.questdb.cairo.FullFwdPartitionFrameCursorFactory;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.IntervalBwdPartitionFrameCursorFactory;
+import io.questdb.cairo.IntervalFwdPartitionFrameCursorFactory;
+import io.questdb.cairo.ListColumnFilter;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.RecordSinkFactory;
+import io.questdb.cairo.SqlJitMode;
+import io.questdb.cairo.SymbolMapReader;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableReaderMetadata;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.map.RecordValueSink;
 import io.questdb.cairo.map.RecordValueSinkFactory;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.PageFrameCursor;
+import io.questdb.cairo.sql.PartitionFrameCursorFactory;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.RowCursorFactory;
+import io.questdb.cairo.sql.SingleSymbolFilter;
+import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.sql.TableMetadata;
+import io.questdb.cairo.sql.TableRecordMetadata;
+import io.questdb.cairo.sql.VirtualRecord;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
 import io.questdb.cairo.sql.async.PageFrameReduceTaskFactory;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCARW;
-import io.questdb.griffin.engine.*;
+import io.questdb.griffin.engine.EmptyTableRecordCursorFactory;
+import io.questdb.griffin.engine.ExplainPlanFactory;
+import io.questdb.griffin.engine.LimitOverflowException;
+import io.questdb.griffin.engine.LimitRecordCursorFactory;
+import io.questdb.griffin.engine.RecordComparator;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
-import io.questdb.griffin.engine.functions.cast.*;
-import io.questdb.griffin.engine.functions.columns.*;
-import io.questdb.griffin.engine.functions.constants.*;
-import io.questdb.griffin.engine.groupby.*;
+import io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastByteToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastDateToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastDateToTimestampFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastDateToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastDoubleToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastDoubleToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastFloatToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastFloatToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastGeoHashToGeoHashFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastIntToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastIntToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastIntervalToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastLong256ToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastLong256ToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastLongToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastLongToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastShortToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastShortToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastStrToGeoHashFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastSymbolToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastSymbolToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastTimestampToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastTimestampToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastUuidToStrFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastUuidToVarcharFunctionFactory;
+import io.questdb.griffin.engine.functions.cast.CastVarcharToGeoHashFunctionFactory;
+import io.questdb.griffin.engine.functions.columns.BinColumn;
+import io.questdb.griffin.engine.functions.columns.BooleanColumn;
+import io.questdb.griffin.engine.functions.columns.ByteColumn;
+import io.questdb.griffin.engine.functions.columns.CharColumn;
+import io.questdb.griffin.engine.functions.columns.DateColumn;
+import io.questdb.griffin.engine.functions.columns.DoubleColumn;
+import io.questdb.griffin.engine.functions.columns.FloatColumn;
+import io.questdb.griffin.engine.functions.columns.GeoByteColumn;
+import io.questdb.griffin.engine.functions.columns.GeoIntColumn;
+import io.questdb.griffin.engine.functions.columns.GeoLongColumn;
+import io.questdb.griffin.engine.functions.columns.GeoShortColumn;
+import io.questdb.griffin.engine.functions.columns.IPv4Column;
+import io.questdb.griffin.engine.functions.columns.IntColumn;
+import io.questdb.griffin.engine.functions.columns.IntervalColumn;
+import io.questdb.griffin.engine.functions.columns.Long256Column;
+import io.questdb.griffin.engine.functions.columns.LongColumn;
+import io.questdb.griffin.engine.functions.columns.ShortColumn;
+import io.questdb.griffin.engine.functions.columns.StrColumn;
+import io.questdb.griffin.engine.functions.columns.SymbolColumn;
+import io.questdb.griffin.engine.functions.columns.TimestampColumn;
+import io.questdb.griffin.engine.functions.columns.UuidColumn;
+import io.questdb.griffin.engine.functions.columns.VarcharColumn;
+import io.questdb.griffin.engine.functions.constants.ConstantFunction;
+import io.questdb.griffin.engine.functions.constants.LongConstant;
+import io.questdb.griffin.engine.functions.constants.NullConstant;
+import io.questdb.griffin.engine.functions.constants.StrConstant;
+import io.questdb.griffin.engine.functions.constants.SymbolConstant;
+import io.questdb.griffin.engine.functions.constants.TimestampConstant;
+import io.questdb.griffin.engine.groupby.CountRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.DistinctIntKeyRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.DistinctRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.DistinctSymbolRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.DistinctTimeSeriesRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.FillRangeRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.GroupByNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.GroupByUtils;
+import io.questdb.griffin.engine.groupby.SampleByFillNoneNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillNoneRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillNullNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillNullRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillPrevNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillPrevRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillValueNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFillValueRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByFirstLastRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.SampleByInterpolateRecordCursorFactory;
+import io.questdb.griffin.engine.groupby.TimestampSampler;
+import io.questdb.griffin.engine.groupby.TimestampSamplerFactory;
+import io.questdb.griffin.engine.groupby.vect.AvgDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.AvgIntVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.AvgLongVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.AvgShortVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.CountDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.CountIntVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.CountLongVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.CountVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.GroupByNotKeyedVectorRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.vect.GroupByRecordCursorFactory;
-import io.questdb.griffin.engine.groupby.vect.*;
-import io.questdb.griffin.engine.join.*;
-import io.questdb.griffin.engine.orderby.*;
-import io.questdb.griffin.engine.table.*;
-import io.questdb.griffin.engine.union.*;
+import io.questdb.griffin.engine.groupby.vect.KSumDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxDateVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxIntVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxLongVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxShortVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MaxTimestampVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinDateVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinIntVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinLongVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinShortVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.MinTimestampVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.NSumDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.SumDoubleVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.SumIntVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.SumLong256VectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.SumLongVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.SumShortVectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.VectorAggregateFunction;
+import io.questdb.griffin.engine.groupby.vect.VectorAggregateFunctionConstructor;
+import io.questdb.griffin.engine.join.AsOfJoinFastRecordCursorFactory;
+import io.questdb.griffin.engine.join.AsOfJoinLightRecordCursorFactory;
+import io.questdb.griffin.engine.join.AsOfJoinNoKeyFastRecordCursorFactory;
+import io.questdb.griffin.engine.join.AsOfJoinNoKeyRecordCursorFactory;
+import io.questdb.griffin.engine.join.AsOfJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.CrossJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashJoinLightRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashOuterJoinFilteredLightRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashOuterJoinFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashOuterJoinLightRecordCursorFactory;
+import io.questdb.griffin.engine.join.HashOuterJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.JoinRecordMetadata;
+import io.questdb.griffin.engine.join.LtJoinLightRecordCursorFactory;
+import io.questdb.griffin.engine.join.LtJoinNoKeyFastRecordCursorFactory;
+import io.questdb.griffin.engine.join.LtJoinNoKeyRecordCursorFactory;
+import io.questdb.griffin.engine.join.LtJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.NestedLoopLeftJoinRecordCursorFactory;
+import io.questdb.griffin.engine.join.NullRecordFactory;
+import io.questdb.griffin.engine.join.RecordAsAFieldRecordCursorFactory;
+import io.questdb.griffin.engine.join.SpliceJoinLightRecordCursorFactory;
+import io.questdb.griffin.engine.orderby.LimitedSizeSortedLightRecordCursorFactory;
+import io.questdb.griffin.engine.orderby.LongSortedLightRecordCursorFactory;
+import io.questdb.griffin.engine.orderby.RecordComparatorCompiler;
+import io.questdb.griffin.engine.orderby.SortedLightRecordCursorFactory;
+import io.questdb.griffin.engine.orderby.SortedRecordCursorFactory;
+import io.questdb.griffin.engine.table.AsyncFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.AsyncGroupByNotKeyedRecordCursorFactory;
+import io.questdb.griffin.engine.table.AsyncGroupByRecordCursorFactory;
+import io.questdb.griffin.engine.table.AsyncJitFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.BwdPageFrameRowCursorFactory;
+import io.questdb.griffin.engine.table.DeferredSingleSymbolFilterPageFrameRecordCursorFactory;
+import io.questdb.griffin.engine.table.DeferredSymbolIndexFilteredRowCursorFactory;
+import io.questdb.griffin.engine.table.DeferredSymbolIndexRowCursorFactory;
+import io.questdb.griffin.engine.table.FilterOnExcludedValuesRecordCursorFactory;
+import io.questdb.griffin.engine.table.FilterOnSubQueryRecordCursorFactory;
+import io.questdb.griffin.engine.table.FilterOnValuesRecordCursorFactory;
+import io.questdb.griffin.engine.table.FilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByAllFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByAllIndexedRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByAllSymbolsFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByDeferredListValuesFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByLightRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestBySubQueryRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueDeferredFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueDeferredIndexedFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueDeferredIndexedRowCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueIndexedFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValueIndexedRowCursorFactory;
+import io.questdb.griffin.engine.table.LatestByValuesIndexedFilteredRecordCursorFactory;
+import io.questdb.griffin.engine.table.PageFrameFwdRowCursorFactory;
+import io.questdb.griffin.engine.table.PageFrameRecordCursorFactory;
+import io.questdb.griffin.engine.table.SelectedRecordCursorFactory;
+import io.questdb.griffin.engine.table.SortedSymbolIndexRecordCursorFactory;
+import io.questdb.griffin.engine.table.SymbolIndexFilteredRowCursorFactory;
+import io.questdb.griffin.engine.table.SymbolIndexRowCursorFactory;
+import io.questdb.griffin.engine.table.VirtualRecordCursorFactory;
+import io.questdb.griffin.engine.union.ExceptAllRecordCursorFactory;
+import io.questdb.griffin.engine.union.ExceptRecordCursorFactory;
+import io.questdb.griffin.engine.union.IntersectAllRecordCursorFactory;
+import io.questdb.griffin.engine.union.IntersectRecordCursorFactory;
+import io.questdb.griffin.engine.union.SetRecordCursorFactoryConstructor;
+import io.questdb.griffin.engine.union.UnionAllRecordCursorFactory;
+import io.questdb.griffin.engine.union.UnionRecordCursorFactory;
 import io.questdb.griffin.engine.window.CachedWindowRecordCursorFactory;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.engine.window.WindowRecordCursorFactory;
-import io.questdb.griffin.model.*;
+import io.questdb.griffin.model.ExecutionModel;
+import io.questdb.griffin.model.ExplainModel;
+import io.questdb.griffin.model.ExpressionNode;
+import io.questdb.griffin.model.IntrinsicModel;
+import io.questdb.griffin.model.JoinContext;
+import io.questdb.griffin.model.QueryColumn;
+import io.questdb.griffin.model.QueryModel;
+import io.questdb.griffin.model.RuntimeIntrinsicIntervalModel;
+import io.questdb.griffin.model.WindowColumn;
 import io.questdb.jit.CompiledFilter;
 import io.questdb.jit.CompiledFilterIRSerializer;
 import io.questdb.jit.JitUtil;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.*;
+import io.questdb.std.BitSet;
+import io.questdb.std.BytecodeAssembler;
+import io.questdb.std.Chars;
+import io.questdb.std.GenericLexer;
+import io.questdb.std.IntHashSet;
+import io.questdb.std.IntList;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.LongList;
+import io.questdb.std.LowerCaseCharSequenceIntHashMap;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.Mutable;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+import io.questdb.std.ObjObjHashMap;
+import io.questdb.std.ObjectPool;
+import io.questdb.std.Transient;
 import io.questdb.std.str.StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -136,6 +364,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final CairoEngine engine;
     private final EntityColumnFilter entityColumnFilter = new EntityColumnFilter();
     private final ObjectPool<ExpressionNode> expressionNodePool;
+    private final boolean fastAsOfJoins;
     private final FunctionParser functionParser;
     private final IntList groupByFunctionPositions = new IntList();
     private final ObjObjHashMap<IntList, ObjList<WindowFunction>> groupedWindow = new ObjObjHashMap<>();
@@ -169,7 +398,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final BitSet writeStringAsVarcharB = new BitSet();
     private final BitSet writeSymbolAsString = new BitSet();
     private boolean enableJitNullChecks = true;
-    private boolean fastAsOfJoins = true;
     private boolean fullFatJoins = false;
 
     public SqlCodeGenerator(
@@ -3056,46 +3284,27 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 final int columnCount = metadata.getColumnCount();
                 final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
-                try {
-                    GroupByUtils.prepareGroupByFunctions(
-                            model,
-                            metadata,
-                            functionParser,
-                            executionContext,
-                            groupByFunctions,
-                            groupByFunctionPositions,
-                            null,
-                            null,
-                            valueTypes
-                    );
-                } catch (Throwable e) {
-                    Misc.freeObjList(groupByFunctions);
-                    throw e;
-                }
-
                 final ObjList<Function> recordFunctions = new ObjList<>(columnCount);
                 final GenericRecordMetadata groupByMetadata = new GenericRecordMetadata();
-                try {
-                    GroupByUtils.prepareGroupByRecordFunctions(
-                            sqlNodeStack,
-                            model,
-                            metadata,
-                            listColumnFilterA,
-                            groupByFunctions,
-                            groupByFunctionPositions,
-                            null,
-                            recordFunctions,
-                            recordFunctionPositions,
-                            groupByMetadata,
-                            keyTypes,
-                            valueTypes.getColumnCount(),
-                            false,
-                            timestampIndex
-                    );
-                } catch (Throwable e) {
-                    Misc.freeObjList(recordFunctions); // groupByFunctions are included in recordFunctions
-                    throw e;
-                }
+                GroupByUtils.assembleGroupByFunctions(
+                        functionParser,
+                        sqlNodeStack,
+                        model,
+                        executionContext,
+                        metadata,
+                        timestampIndex,
+                        false,
+                        groupByFunctions,
+                        groupByFunctionPositions,
+                        recordFunctions,
+                        recordFunctionPositions,
+                        groupByMetadata,
+                        null,
+                        null,
+                        valueTypes,
+                        keyTypes,
+                        listColumnFilterA
+                );
 
                 return new SampleByInterpolateRecordCursorFactory(
                         asm,
@@ -3123,46 +3332,27 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
             final int columnCount = model.getColumns().size();
             final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
-            try {
-                GroupByUtils.prepareGroupByFunctions(
-                        model,
-                        metadata,
-                        functionParser,
-                        executionContext,
-                        groupByFunctions,
-                        groupByFunctionPositions,
-                        null,
-                        null,
-                        valueTypes
-                );
-            } catch (Throwable e) {
-                Misc.freeObjList(groupByFunctions);
-                throw e;
-            }
-
             final ObjList<Function> recordFunctions = new ObjList<>(columnCount);
             final GenericRecordMetadata groupByMetadata = new GenericRecordMetadata();
-            try {
-                GroupByUtils.prepareGroupByRecordFunctions(
-                        sqlNodeStack,
-                        model,
-                        metadata,
-                        listColumnFilterA,
-                        groupByFunctions,
-                        groupByFunctionPositions,
-                        null,
-                        recordFunctions,
-                        recordFunctionPositions,
-                        groupByMetadata,
-                        keyTypes,
-                        valueTypes.getColumnCount(),
-                        false,
-                        timestampIndex
-                );
-            } catch (Throwable e) {
-                Misc.freeObjList(recordFunctions); // groupByFunctions are included in recordFunctions
-                throw e;
-            }
+            GroupByUtils.assembleGroupByFunctions(
+                    functionParser,
+                    sqlNodeStack,
+                    model,
+                    executionContext,
+                    metadata,
+                    timestampIndex,
+                    false,
+                    groupByFunctions,
+                    groupByFunctionPositions,
+                    recordFunctions,
+                    recordFunctionPositions,
+                    groupByMetadata,
+                    null,
+                    null,
+                    valueTypes,
+                    keyTypes,
+                    listColumnFilterA
+            );
 
             boolean isFillNone = fillCount == 0 || fillCount == 1 && Chars.equalsLowerCaseAscii(sampleByFill.getQuick(0).token, "none");
             boolean allGroupsFirstLast = isFillNone && allGroupsFirstLastWithSingleSymbolFilter(model, metadata);
@@ -3908,48 +4098,28 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
             final ObjList<Function> keyFunctions = new ObjList<>(columnCount);
             final ObjList<ExpressionNode> keyFunctionNodes = new ObjList<>(columnCount);
-            try {
-                GroupByUtils.prepareGroupByFunctions(
-                        model,
-                        metadata,
-                        functionParser,
-                        executionContext,
-                        groupByFunctions,
-                        groupByFunctionPositions,
-                        keyFunctions,
-                        keyFunctionNodes,
-                        valueTypes
-                );
-            } catch (Throwable e) {
-                Misc.freeObjList(groupByFunctions);
-                Misc.freeObjList(keyFunctions);
-                throw e;
-            }
-
             final ObjList<Function> recordFunctions = new ObjList<>(columnCount);
             final GenericRecordMetadata groupByMetadata = new GenericRecordMetadata();
-            try {
-                GroupByUtils.prepareGroupByRecordFunctions(
-                        sqlNodeStack,
-                        model,
-                        metadata,
-                        listColumnFilterA,
-                        groupByFunctions,
-                        groupByFunctionPositions,
-                        keyFunctions,
-                        recordFunctions,
-                        recordFunctionPositions,
-                        groupByMetadata,
-                        keyTypes,
-                        valueTypes.getColumnCount(),
-                        true,
-                        timestampIndex
-                );
-            } catch (Throwable e) {
-                Misc.freeObjList(recordFunctions); // groupByFunctions are included in recordFunctions
-                Misc.freeObjList(keyFunctions);
-                throw e;
-            }
+
+            GroupByUtils.assembleGroupByFunctions(
+                    functionParser,
+                    sqlNodeStack,
+                    model,
+                    executionContext,
+                    metadata,
+                    timestampIndex,
+                    true,
+                    groupByFunctions,
+                    groupByFunctionPositions,
+                    recordFunctions,
+                    recordFunctionPositions,
+                    groupByMetadata,
+                    keyFunctions,
+                    keyFunctionNodes,
+                    valueTypes,
+                    keyTypes,
+                    listColumnFilterA
+            );
 
             // Check if we have a non-keyed query with all early exit aggregate functions (e.g. count_distinct(symbol))
             // and no filter. In such a case, use single-threaded factories instead of the multithreaded ones.

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -24,7 +24,11 @@
 
 package io.questdb.griffin.engine.groupby;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.ListColumnFilter;
+import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.FunctionParser;
@@ -33,17 +37,305 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.functions.cast.CastStrToSymbolFunctionFactory;
-import io.questdb.griffin.engine.functions.columns.*;
+import io.questdb.griffin.engine.functions.columns.BinColumn;
+import io.questdb.griffin.engine.functions.columns.BooleanColumn;
+import io.questdb.griffin.engine.functions.columns.ByteColumn;
+import io.questdb.griffin.engine.functions.columns.CharColumn;
+import io.questdb.griffin.engine.functions.columns.DateColumn;
+import io.questdb.griffin.engine.functions.columns.DoubleColumn;
+import io.questdb.griffin.engine.functions.columns.FloatColumn;
+import io.questdb.griffin.engine.functions.columns.GeoByteColumn;
+import io.questdb.griffin.engine.functions.columns.GeoIntColumn;
+import io.questdb.griffin.engine.functions.columns.GeoLongColumn;
+import io.questdb.griffin.engine.functions.columns.GeoShortColumn;
+import io.questdb.griffin.engine.functions.columns.IPv4Column;
+import io.questdb.griffin.engine.functions.columns.IntColumn;
+import io.questdb.griffin.engine.functions.columns.IntervalColumn;
+import io.questdb.griffin.engine.functions.columns.Long128Column;
+import io.questdb.griffin.engine.functions.columns.Long256Column;
+import io.questdb.griffin.engine.functions.columns.LongColumn;
+import io.questdb.griffin.engine.functions.columns.ShortColumn;
+import io.questdb.griffin.engine.functions.columns.StrColumn;
+import io.questdb.griffin.engine.functions.columns.TimestampColumn;
+import io.questdb.griffin.engine.functions.columns.UuidColumn;
+import io.questdb.griffin.engine.functions.columns.VarcharColumn;
 import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.QueryColumn;
 import io.questdb.griffin.model.QueryModel;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayDeque;
 
+import static io.questdb.griffin.model.ExpressionNode.LITERAL;
+
 public class GroupByUtils {
+
+    public static void assembleGroupByFunctions(
+            @NotNull FunctionParser functionParser,
+            @NotNull ArrayDeque<ExpressionNode> sqlNodeStack,
+            QueryModel model,
+            SqlExecutionContext executionContext,
+            RecordMetadata baseMetadata,
+            int timestampIndex,
+            boolean timestampUnimportant,
+            ObjList<GroupByFunction> outGroupByFunctions,
+            IntList outGroupByFunctionPositions,
+            ObjList<Function> outRecordFunctions,
+            IntList outRecordFunctionPositions,
+            GenericRecordMetadata outGroupByMetadata,
+            @Nullable ObjList<Function> outKeyFunctions,
+            @Nullable ObjList<ExpressionNode> outKeyFunctionNodes,
+            ArrayColumnTypes outValueTypes,
+            ArrayColumnTypes outKeyTypes,
+            ListColumnFilter outColumnFilter
+    ) throws SqlException {
+        try {
+            outGroupByFunctionPositions.clear();
+            outRecordFunctionPositions.clear();
+
+            int columnKeyCount = 0;
+            int lastIndex = -1;
+            final ObjList<QueryColumn> columns = model.getColumns();
+
+            // There are two iterations over the model's columns. The first iterations creates value
+            // slots for the group-by functions. They are added first because each group-by function is likely
+            // to require several slots. The number of slots for each function is not known upfront and
+            // is effectively evaluates in the first loop.
+            for (int i = 0, n = columns.size(); i < n; i++) {
+                final QueryColumn column = columns.getQuick(i);
+                final ExpressionNode node = column.getAst();
+
+                if (node.type != LITERAL) {
+                    // this can fail
+                    final Function function = functionParser.parseFunction(
+                            node,
+                            baseMetadata,
+                            executionContext
+                    );
+
+                    // record functions will have all model function, including consecutive duplicates
+                    outRecordFunctions.add(function);
+
+                    if (function instanceof GroupByFunction) {
+                        // configure map value columns for group-by functions
+                        // some functions may need more than one column in values,
+                        // so we have them do all the work
+                        GroupByFunction func = (GroupByFunction) function;
+                        func.initValueTypes(outValueTypes);
+                        outGroupByFunctions.add(func);
+                        outGroupByFunctionPositions.add(node.position);
+                    } else {
+                        // it's a key function
+                        assert outKeyFunctions != null && outKeyFunctionNodes != null : "key functions are supported in group by only";
+                        outKeyFunctions.add(function);
+                        outKeyFunctionNodes.add(node);
+                    }
+                } else {
+
+                    // function is unknown at this iteration, because we cannot create function not knowing
+                    // the slot in the map it will occupy.
+                    outRecordFunctions.add(null);
+
+                    int index = baseMetadata.getColumnIndexQuiet(node.token);
+                    if (index == -1) {
+                        throw SqlException.invalidColumn(node.position, node.token);
+                    }
+
+                    if (index != timestampIndex) {
+                        // when we have same column several times in a row
+                        // we only add it once to map keys
+                        if (lastIndex != index) {
+                            columnKeyCount++;
+                            lastIndex = index;
+                        }
+                    }
+                }
+                outRecordFunctionPositions.add(node.position);
+            }
+
+            int valueCount = outValueTypes.getColumnCount();
+            int keyColumnIndex = valueCount;
+            int functionKeyColumnIndex = valueCount + columnKeyCount;
+            int inferredKeyColumnCount = 0;
+
+            lastIndex = -1;
+            for (int i = 0, n = columns.size(); i < n; i++) {
+                final QueryColumn column = columns.getQuick(i);
+                final ExpressionNode node = column.getAst();
+                final int type;
+
+                if (node.type == LITERAL) {
+                    // column index has already been validated
+                    int index = baseMetadata.getColumnIndexQuiet(node.token);
+                    type = baseMetadata.getColumnType(index);
+                    if (index != timestampIndex || timestampUnimportant) {
+                        if (lastIndex != index) {
+                            outColumnFilter.add(index + 1);
+                            outKeyTypes.add(keyColumnIndex - valueCount, type);
+                            keyColumnIndex++;
+                            lastIndex = index;
+                        }
+                        outRecordFunctions.set(i, createColumnFunction(baseMetadata, keyColumnIndex, type, index));
+                    } else {
+                        // set this function to null, cursor will replace it with an instance class
+                        // timestamp function returns value of class member which makes it impossible
+                        // to create these columns in advance of cursor instantiation
+                        if (outGroupByMetadata.getTimestampIndex() == -1) {
+                            outGroupByMetadata.setTimestampIndex(i);
+                        }
+                        assert ColumnType.tagOf(type) == ColumnType.TIMESTAMP;
+                    }
+
+                    // and finish with populating metadata for this factory
+                    if (column.getAlias() == null) {
+                        outGroupByMetadata.add(baseMetadata.getColumnMetadata(index));
+                    } else {
+                        outGroupByMetadata.add(
+                                new TableColumnMetadata(
+                                        Chars.toString(column.getAlias()),
+                                        type,
+                                        baseMetadata.isColumnIndexed(index),
+                                        baseMetadata.getIndexValueBlockCapacity(index),
+                                        baseMetadata.isSymbolTableStatic(index),
+                                        baseMetadata.getMetadata(index)
+                                )
+                        );
+                    }
+                    inferredKeyColumnCount++;
+                } else {
+                    Function func = outRecordFunctions.getQuick(i);
+
+                    if (!(func instanceof GroupByFunction)) {
+                        // leave group-by function alone but re-write non-group-by functions as column references
+                        functionKeyColumnIndex++;
+                        Function columnRefFunc = createColumnFunction(null, functionKeyColumnIndex, func.getType(), -1);
+                        outKeyTypes.add(functionKeyColumnIndex - valueCount - 1, columnRefFunc.getType());
+                        if (func.getType() == ColumnType.SYMBOL && columnRefFunc.getType() == ColumnType.STRING) {
+                            // must be a function key, so we need to cast it to symbol
+                            columnRefFunc = new CastStrToSymbolFunctionFactory.Func(columnRefFunc);
+                        }
+
+                        // override function with column ref function
+                        func = columnRefFunc;
+                        outRecordFunctions.set(i, columnRefFunc);
+                        inferredKeyColumnCount++;
+                    }
+
+                    // and finish with populating metadata for this factory
+                    outGroupByMetadata.add(
+                            new TableColumnMetadata(
+                                    Chars.toString(column.getName()),
+                                    func.getType(),
+                                    false,
+                                    0,
+                                    func instanceof SymbolFunction && (((SymbolFunction) func).isSymbolTableStatic()),
+                                    func.getMetadata()
+                            )
+                    );
+                }
+            }
+            validateGroupByColumns(sqlNodeStack, model, inferredKeyColumnCount);
+        } catch (Throwable e) {
+            Misc.freeObjList(outGroupByFunctions);
+            Misc.freeObjList(outKeyFunctions);
+            throw e;
+        }
+    }
+
+    public static Function createColumnFunction(
+            @Nullable RecordMetadata metadata,
+            int keyColumnIndex,
+            int type,
+            int index
+    ) {
+        final Function func;
+        switch (ColumnType.tagOf(type)) {
+            case ColumnType.BOOLEAN:
+                func = BooleanColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.BYTE:
+                func = ByteColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.SHORT:
+                func = ShortColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.CHAR:
+                func = CharColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.INT:
+                func = IntColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.IPv4:
+                func = IPv4Column.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.LONG:
+                func = LongColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.FLOAT:
+                func = FloatColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.DOUBLE:
+                func = DoubleColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.STRING:
+                func = StrColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.VARCHAR:
+                func = VarcharColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.SYMBOL:
+                if (metadata != null) {
+                    // must be a column key
+                    func = new MapSymbolColumn(keyColumnIndex - 1, index, metadata.isSymbolTableStatic(index));
+                } else {
+                    // must be a function key, so we treat symbols as strings
+                    func = new StrColumn(keyColumnIndex - 1);
+                }
+                break;
+            case ColumnType.DATE:
+                func = DateColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.TIMESTAMP:
+                func = TimestampColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.LONG256:
+                func = Long256Column.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.GEOBYTE:
+                func = GeoByteColumn.newInstance(keyColumnIndex - 1, type);
+                break;
+            case ColumnType.GEOSHORT:
+                func = GeoShortColumn.newInstance(keyColumnIndex - 1, type);
+                break;
+            case ColumnType.GEOINT:
+                func = GeoIntColumn.newInstance(keyColumnIndex - 1, type);
+                break;
+            case ColumnType.GEOLONG:
+                func = GeoLongColumn.newInstance(keyColumnIndex - 1, type);
+                break;
+            case ColumnType.LONG128:
+                func = Long128Column.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.UUID:
+                func = UuidColumn.newInstance(keyColumnIndex - 1);
+                break;
+            case ColumnType.INTERVAL:
+                func = IntervalColumn.newInstance(keyColumnIndex - 1);
+                break;
+            default:
+                func = BinColumn.newInstance(keyColumnIndex - 1);
+                break;
+        }
+        return func;
+    }
+
+    // prepareGroupByFunctions must be called first to get the idea of how many map values
+    // we will have. Map value count is needed to calculate offsets for map key columns.
 
     public static boolean isEarlyExitSupported(ObjList<GroupByFunction> functions) {
         for (int i = 0, n = functions.size(); i < n; i++) {
@@ -61,204 +353,6 @@ public class GroupByUtils {
             }
         }
         return true;
-    }
-
-    public static void prepareGroupByFunctions(
-            @NotNull QueryModel model,
-            @NotNull RecordMetadata metadata,
-            @NotNull FunctionParser functionParser,
-            @NotNull SqlExecutionContext executionContext,
-            @NotNull ObjList<GroupByFunction> groupByFunctions,
-            @Transient @NotNull IntList groupByFunctionPositions,
-            @Nullable ObjList<Function> keyFunctions,
-            @Nullable ObjList<ExpressionNode> keyFunctionNodes,
-            @NotNull ArrayColumnTypes valueTypes
-    ) throws SqlException {
-        groupByFunctionPositions.clear();
-
-        final ObjList<QueryColumn> columns = model.getColumns();
-        for (int i = 0, n = columns.size(); i < n; i++) {
-            final QueryColumn column = columns.getQuick(i);
-            final ExpressionNode node = column.getAst();
-
-            if (node.type != ExpressionNode.LITERAL) {
-                // this can fail
-                final Function function = functionParser.parseFunction(
-                        node,
-                        metadata,
-                        executionContext
-                );
-
-                if (function instanceof GroupByFunction) {
-                    // configure map value columns for group-by functions
-                    // some functions may need more than one column in values,
-                    // so we have them do all the work
-                    GroupByFunction func = (GroupByFunction) function;
-                    func.initValueTypes(valueTypes);
-                    groupByFunctions.add(func);
-                    groupByFunctionPositions.add(node.position);
-                } else {
-                    // it's a key function
-                    assert keyFunctions != null && keyFunctionNodes != null : "key functions are supported in group by only";
-                    keyFunctions.add(function);
-                    keyFunctionNodes.add(node);
-                }
-            }
-        }
-    }
-
-    // prepareGroupByFunctions must be called first to get the idea of how many map values
-    // we will have. Map value count is needed to calculate offsets for map key columns.
-    public static void prepareGroupByRecordFunctions(
-            @NotNull ArrayDeque<ExpressionNode> sqlNodeStack,
-            @NotNull QueryModel model,
-            @NotNull RecordMetadata metadata,
-            @NotNull ListColumnFilter listColumnFilter,
-            @NotNull ObjList<GroupByFunction> groupByFunctions,
-            @Transient @NotNull IntList groupByFunctionPositions,
-            @Nullable ObjList<Function> keyFunctions,
-            @NotNull ObjList<Function> recordFunctions,
-            @Transient @NotNull IntList recordFunctionPositions,
-            GenericRecordMetadata groupByMetadata,
-            ArrayColumnTypes keyTypes,
-            int valueCount,
-            boolean timestampUnimportant,
-            int timestampIndex
-    ) throws SqlException {
-        recordFunctionPositions.clear();
-
-        final ObjList<QueryColumn> columns = model.getColumns();
-
-        // first, calculate the number of column keys;
-        // that's to be able to index function keys in the map
-        // since we place them after the column keys
-        int columnKeyCount = 0;
-        int lastIndex = -1;
-        for (int i = 0, n = columns.size(); i < n; i++) {
-            final QueryColumn column = columns.getQuick(i);
-            final ExpressionNode node = column.getAst();
-
-            if (node.type == ExpressionNode.LITERAL) {
-                int index = metadata.getColumnIndexQuiet(node.token);
-                if (index == -1) {
-                    throw SqlException.invalidColumn(node.position, node.token);
-                }
-
-                if (index != timestampIndex || timestampUnimportant) {
-                    // when we have same column several times in a row
-                    // we only add it once to map keys
-                    if (lastIndex != index) {
-                        columnKeyCount++;
-                        lastIndex = index;
-                    }
-                }
-            }
-        }
-
-        int keyColumnIndex = valueCount;
-        int functionKeyColumnIndex = valueCount + columnKeyCount;
-        int groupByFunctionIndex = 0;
-        int keyFunctionIndex = 0;
-        int inferredKeyColumnCount = 0;
-
-        lastIndex = -1;
-        for (int i = 0, n = columns.size(); i < n; i++) {
-            final QueryColumn column = columns.getQuick(i);
-            final ExpressionNode node = column.getAst();
-            final int type;
-
-            if (node.type == ExpressionNode.LITERAL) {
-                // this is key
-                int index = metadata.getColumnIndexQuiet(node.token);
-                if (index == -1) {
-                    throw SqlException.invalidColumn(node.position, node.token);
-                }
-
-                type = metadata.getColumnType(index);
-                if (index != timestampIndex || timestampUnimportant) {
-                    if (lastIndex != index) {
-                        listColumnFilter.add(index + 1);
-                        keyTypes.add(keyColumnIndex - valueCount, type);
-                        keyColumnIndex++;
-                        lastIndex = index;
-                    }
-
-                    final Function func = createColumnFunction(metadata, keyColumnIndex, type, index);
-                    recordFunctions.add(func);
-                    recordFunctionPositions.add(node.position);
-                } else {
-                    // set this function to null, cursor will replace it with an instance class
-                    // timestamp function returns value of class member which makes it impossible
-                    // to create these columns in advance of cursor instantiation
-                    recordFunctions.add(null);
-                    groupByFunctionPositions.add(0);
-                    if (groupByMetadata.getTimestampIndex() == -1) {
-                        groupByMetadata.setTimestampIndex(i);
-                    }
-                    assert ColumnType.tagOf(type) == ColumnType.TIMESTAMP;
-                }
-
-                // and finish with populating metadata for this factory
-                if (column.getAlias() == null) {
-                    groupByMetadata.add(metadata.getColumnMetadata(index));
-                } else {
-                    groupByMetadata.add(
-                            new TableColumnMetadata(
-                                    Chars.toString(column.getAlias()),
-                                    type,
-                                    metadata.isColumnIndexed(index),
-                                    metadata.getIndexValueBlockCapacity(index),
-                                    metadata.isSymbolTableStatic(index),
-                                    metadata.getMetadata(index)
-                            )
-                    );
-                }
-                inferredKeyColumnCount++;
-            } else {
-                Function func;
-                if (groupByFunctionIndex < groupByFunctionPositions.size()
-                        && node.position == groupByFunctionPositions.getQuick(groupByFunctionIndex)) {
-                    // group-by function
-                    // add group-by function as a record function as well,
-                    // so it can produce column values
-                    func = groupByFunctions.getQuick(groupByFunctionIndex++);
-                    type = func.getType();
-                    recordFunctions.add(func);
-                    recordFunctionPositions.add(node.position);
-                } else {
-                    // key function
-                    assert keyFunctions != null && keyFunctionIndex < keyFunctions.size();
-                    Function keyFunc = keyFunctions.getQuick(keyFunctionIndex++);
-                    type = keyFunc.getType();
-                    // create a function to be used to access Map column
-                    functionKeyColumnIndex++;
-                    func = createColumnFunction(null, functionKeyColumnIndex, type, -1);
-                    keyTypes.add(functionKeyColumnIndex - valueCount - 1, func.getType());
-                    if (type == ColumnType.SYMBOL && func.getType() == ColumnType.STRING) {
-                        // must be a function key, so we need to cast it to symbol
-                        func = new CastStrToSymbolFunctionFactory.Func(func);
-                    }
-
-                    recordFunctions.add(func);
-                    recordFunctionPositions.add(node.position);
-
-                    inferredKeyColumnCount++;
-                }
-
-                // and finish with populating metadata for this factory
-                groupByMetadata.add(
-                        new TableColumnMetadata(
-                                Chars.toString(column.getName()),
-                                type,
-                                false,
-                                0,
-                                func instanceof SymbolFunction && (((SymbolFunction) func).isSymbolTableStatic()),
-                                func.getMetadata()
-                        )
-                );
-            }
-        }
-        validateGroupByColumns(sqlNodeStack, model, inferredKeyColumnCount);
     }
 
     public static void prepareWorkerGroupByFunctions(
@@ -326,7 +420,6 @@ public class GroupByUtils {
             return;
         }
 
-        final QueryModel nested = model.getNestedModel();
         QueryModel chooseModel = model;
         while (chooseModel != null
                 && chooseModel.getSelectModelType() != QueryModel.SELECT_MODEL_CHOOSE
@@ -460,92 +553,5 @@ public class GroupByUtils {
         }
 
         return false;
-    }
-
-    private static Function createColumnFunction(
-            @Nullable RecordMetadata metadata,
-            int keyColumnIndex,
-            int type,
-            int index
-    ) {
-        final Function func;
-        switch (ColumnType.tagOf(type)) {
-            case ColumnType.BOOLEAN:
-                func = BooleanColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.BYTE:
-                func = ByteColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.SHORT:
-                func = ShortColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.CHAR:
-                func = CharColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.INT:
-                func = IntColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.IPv4:
-                func = IPv4Column.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.LONG:
-                func = LongColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.FLOAT:
-                func = FloatColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.DOUBLE:
-                func = DoubleColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.STRING:
-                func = StrColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.VARCHAR:
-                func = VarcharColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.SYMBOL:
-                if (metadata != null) {
-                    // must be a column key
-                    func = new MapSymbolColumn(keyColumnIndex - 1, index, metadata.isSymbolTableStatic(index));
-                } else {
-                    // must be a function key, so we treat symbols as strings
-                    func = new StrColumn(keyColumnIndex - 1);
-                }
-                break;
-            case ColumnType.DATE:
-                func = DateColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.TIMESTAMP:
-                func = TimestampColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.LONG256:
-                func = Long256Column.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.GEOBYTE:
-                func = GeoByteColumn.newInstance(keyColumnIndex - 1, type);
-                break;
-            case ColumnType.GEOSHORT:
-                func = GeoShortColumn.newInstance(keyColumnIndex - 1, type);
-                break;
-            case ColumnType.GEOINT:
-                func = GeoIntColumn.newInstance(keyColumnIndex - 1, type);
-                break;
-            case ColumnType.GEOLONG:
-                func = GeoLongColumn.newInstance(keyColumnIndex - 1, type);
-                break;
-            case ColumnType.LONG128:
-                func = Long128Column.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.UUID:
-                func = UuidColumn.newInstance(keyColumnIndex - 1);
-                break;
-            case ColumnType.INTERVAL:
-                func = IntervalColumn.newInstance(keyColumnIndex - 1);
-                break;
-            default:
-                func = BinColumn.newInstance(keyColumnIndex - 1);
-                break;
-        }
-        return func;
     }
 }


### PR DESCRIPTION
Replace spaghetti-like two-method tandem, which was assembling artefacts for group-by and sample-by queries. This was necessitated by an awkward dependency of code generator on the token position, which is ordinarily display-only value. This makes tricky SQL rewrites that do not have organic position.

There is a single method now, with simpler logic that does the same thing. Hence tests pass (hopefully)