### PR TITLE
fix(sql): BREAKING 💥 - align common column names across multiple catalogue views  

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/TableStorageRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/TableStorageRecordCursorFactory.java
@@ -219,7 +219,7 @@ public class TableStorageRecordCursorFactory extends AbstractRecordCursorFactory
 
     static {
         final GenericRecordMetadata metadata = new GenericRecordMetadata();
-        metadata.add(new TableColumnMetadata("tableName", ColumnType.STRING));
+        metadata.add(new TableColumnMetadata("table_name", ColumnType.STRING));
         metadata.add(new TableColumnMetadata("walEnabled", ColumnType.BOOLEAN));
         metadata.add(new TableColumnMetadata("partitionBy", ColumnType.STRING));
         metadata.add(new TableColumnMetadata("partitionCount", ColumnType.LONG));

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -857,7 +857,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.catalogue.TablesFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.KeywordsFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.FunctionListFunctionFactory,
-            io.questdb.griffin.engine.functions.catalogue.WalTableListFunctionFactory,
+            io.questdb.griffin.engine.functions.catalogue.WalTablesFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.WalTransactionsFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory,
             io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -808,7 +808,7 @@ io.questdb.griffin.engine.functions.catalogue.FunctionListFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.PrefixedPgGetKeywordsFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.TablesFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.KeywordsFunctionFactory
-io.questdb.griffin.engine.functions.catalogue.WalTableListFunctionFactory
+io.questdb.griffin.engine.functions.catalogue.WalTablesFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.WalTransactionsFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.DumpMemoryUsageFunctionFactory
 io.questdb.griffin.engine.functions.catalogue.DumpThreadStacksFunctionFactory

--- a/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
@@ -87,7 +87,7 @@ public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
                         sqlExecutionContext,
                         "select * from wal_tables order by 1",
                         sink,
-                        "name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+                        "table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                                 "x\tfalse\t0\t0\t0\t\t\t0\n" +
                                 "y\tfalse\t2\t0\t2\t\t\t0\n"
                 );

--- a/core/src/test/java/io/questdb/test/griffin/AbstractAlterTableSetTypeRestartTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AbstractAlterTableSetTypeRestartTest.java
@@ -43,7 +43,11 @@ import org.junit.Assert;
 import org.postgresql.util.PSQLException;
 
 import java.io.IOException;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import static org.junit.Assert.*;
 
@@ -84,7 +88,7 @@ abstract class AbstractAlterTableSetTypeRestartTest extends AbstractBootstrapTes
     static void checkSuspended(String tableName) throws SQLException {
         try (
                 final Connection connection = DriverManager.getConnection(PG_CONNECTION_URI, PG_CONNECTION_PROPERTIES);
-                final PreparedStatement stmt = connection.prepareStatement("select name, suspended from wal_tables()")
+                final PreparedStatement stmt = connection.prepareStatement("select table_name, suspended from wal_tables()")
         ) {
             final ResultSet rs = stmt.executeQuery();
             if (rs.next()) {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
@@ -24,7 +24,11 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.SymbolMapWriter;
+import io.questdb.cairo.TableToken;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
@@ -188,21 +192,21 @@ public class AlterTableConvertPartitionTest extends AbstractCairoTest {
                     "insert into " + tableName + " values(5, '2024-06-15T00:00:00.000000Z')",
                     "insert into " + tableName + " values(6, '2024-06-12T00:00:02.000000Z')");
 
-            assertQuery("index\tname\treadOnly\tisParquet\tparquetFileSize\n"
+            assertQuery("partition_index\tpartition_name\treadOnly\tparquet\tparquetFileSize\n"
                     + "0\t2024-06-10\tfalse\tfalse\t-1\n"
                     + "1\t2024-06-11\tfalse\tfalse\t-1\n"
                     + "2\t2024-06-12\tfalse\tfalse\t-1\n"
-                    + "3\t2024-06-15\tfalse\tfalse\t-1\n", "select index, name, readOnly, isParquet, parquetFileSize from table_partitions('" + tableName + "')", false, true
+                    + "3\t2024-06-15\tfalse\tfalse\t-1\n", "select partition_index, partition_name, readOnly, parquet, parquetFileSize from table_partitions('" + tableName + "')", false, true
             );
 
             ddl("alter table " + tableName + " convert partition to parquet where timestamp = to_timestamp('2024-06-12', 'yyyy-MM-dd')");
 
-            assertQuery("index\tname\treadOnly\tisParquet\tparquetFileSize\tminTimestamp\tmaxTimestamp\n"
+            assertQuery("partition_index\tpartition_name\treadOnly\tparquet\tparquetFileSize\tminTimestamp\tmaxTimestamp\n"
                             + "0\t2024-06-10\tfalse\tfalse\t-1\t2024-06-10T00:00:00.000000Z\t2024-06-10T00:00:00.000000Z\n"
                             + "1\t2024-06-11\tfalse\tfalse\t-1\t2024-06-11T00:00:00.000000Z\t2024-06-11T00:00:00.000000Z\n"
                             + "2\t2024-06-12\tfalse\ttrue\t594\t\t\n" +
                             "3\t2024-06-15\tfalse\tfalse\t-1\t2024-06-15T00:00:00.000000Z\t2024-06-15T00:00:00.000000Z\n",
-                    "select index, name, readOnly, isParquet, parquetFileSize, minTimestamp, maxTimestamp from table_partitions('" + tableName + "')", false, true);
+                    "select partition_index, partition_name, readOnly, parquet, parquetFileSize, minTimestamp, maxTimestamp from table_partitions('" + tableName + "')", false, true);
 
             assertPartitionDoesntExists(tableName, "2024-06-10");
             assertPartitionDoesntExists(tableName, "2024-06-11.0");

--- a/core/src/test/java/io/questdb/test/griffin/O3SquashPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/O3SquashPartitionTest.java
@@ -98,8 +98,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             rowCount = assertRowCount(1010, rowCount);
 
             // Check that the partition is not split
-            assertSql("name\n" +
-                    "2020-02-03\n", "select name from table_partitions('x')");
+            assertSql("partition_name\n" +
+                    "2020-02-03\n", "select partition_name from table_partitions('x')");
 
             // Split at 2020-02-03T01
             insert(
@@ -115,9 +115,9 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             );
 
             // Check that the partition is split
-            assertSql("name\tnumRows\n" +
+            assertSql("partition_name\tnumRows\n" +
                     "2020-02-03\t809\n" +
-                    "2020-02-03T000000-000001\t211\n", "select name,numRows from table_partitions('x')");
+                    "2020-02-03T000000-000001\t211\n", "select partition_name,numRows from table_partitions('x')");
 
             assertRowCount(211, rowCount);
         });
@@ -161,8 +161,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                     sqlExecutionContext
             );
 
-            String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                     "2020-02-04T20:01:00.000000Z\t319\t2020-02-04T200000-000001\n", partitionsSql);
 
@@ -178,7 +178,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 );
 
                 // Partition "2020-02-04" cannot be squashed with the new update because it's locked by the reader
-                assertSql("minTimestamp\tnumRows\tname\n" +
+                assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                         "2020-02-04T00:00:00.000000Z\t1081\t2020-02-04\n" +
                         "2020-02-04T18:01:00.000000Z\t170\t2020-02-04T180000-000001\n" +
                         "2020-02-04T20:01:00.000000Z\t319\t2020-02-04T200000-000001\n", partitionsSql);
@@ -193,7 +193,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                     sqlExecutionContext
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1301\t2020-02-04\n" +
                     "2020-02-04T20:01:00.000000Z\t319\t2020-02-04T200000-000001\n", partitionsSql);
 
@@ -206,7 +206,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                     sqlExecutionContext
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1301\t2020-02-04\n" +
                     "2020-02-04T20:01:00.000000Z\t369\t2020-02-04T200000-000001\n", partitionsSql);
 
@@ -220,7 +220,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                     sqlExecutionContext
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1670\t2020-02-04\n" +
                     "2020-02-05T01:01:15.000000Z\t50\t2020-02-05\n", partitionsSql);
 
@@ -271,8 +271,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
 
             rowCount = assertRowCount(319 * 2, rowCount);
 
-            String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1520\t2020-02-04\n", partitionsSql);
 
             // Append in order to check last partition opened for writing correctly.
@@ -283,7 +283,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                             " from long_sequence(200)"
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1720\t2020-02-04\n", partitionsSql);
 
             assertRowCount(200, rowCount);
@@ -560,8 +560,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 TestUtils.assertContains(ex.getFlyweightMessage(), "Cannot copy data");
             }
 
-            String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                     "2020-02-04T20:01:00.000000Z\t439\t2020-02-04T200000-000001\n" +
                     "2020-02-05T00:00:00.000000Z\t720\t2020-02-05\n", partitionsSql);
@@ -580,7 +580,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 TestUtils.assertContains(ex.getFlyweightMessage(), "Cannot copy data");
             }
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                     "2020-02-04T20:01:00.000000Z\t639\t2020-02-04T200000-000001\n" +
                     "2020-02-05T00:00:00.000000Z\t720\t2020-02-05\n", partitionsSql);
@@ -594,7 +594,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                             " from long_sequence(200)"
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t2040\t2020-02-04\n" +
                     "2020-02-05T00:00:00.000000Z\t720\t2020-02-05\n", partitionsSql);
 
@@ -650,22 +650,22 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                         true
                 );
                 TestUtils.assertSqlCursors(engine, sqlExecutionContext, "y where sym = '5' order by ts", "x where sym = '5'", LOG);
-                assertSql("name\tminTimestamp\n" +
+                assertSql("partition_name\tminTimestamp\n" +
                         "2020-02-03\t2020-02-03T13:00:00.000000Z\n" +
                         "2020-02-04\t2020-02-04T00:00:00.000000Z\n" +
                         "2020-02-04T230000-000001\t2020-02-04T23:01:00.000000Z\n" +
-                        "2020-02-05\t2020-02-05T00:00:00.000000Z\n", "select name, minTimestamp from table_partitions('x')"
+                        "2020-02-05\t2020-02-05T00:00:00.000000Z\n", "select partition_name, minTimestamp from table_partitions('x')"
                 );
             }
 
             // Another reader, should allow to squash partitions
             try (TableReader ignore = getReader("x")) {
                 insert("insert into x(ts) values('2020-02-06')");
-                assertSql("name\tminTimestamp\n" +
+                assertSql("partition_name\tminTimestamp\n" +
                         "2020-02-03\t2020-02-03T13:00:00.000000Z\n" +
                         "2020-02-04\t2020-02-04T00:00:00.000000Z\n" +
                         "2020-02-05\t2020-02-05T00:00:00.000000Z\n" +
-                        "2020-02-06\t2020-02-06T00:00:00.000000Z\n", "select name, minTimestamp from table_partitions('x')");
+                        "2020-02-06\t2020-02-06T00:00:00.000000Z\n", "select partition_name, minTimestamp from table_partitions('x')");
             }
 
             TestUtils.assertIndexBlockCapacity(engine, "x", "sym");
@@ -701,7 +701,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                     " rnd_str(5,16,2) as str," +
                     " rnd_varchar(1,40,5) as varc1," +
                     " rnd_varchar(1, 1,5) as varc2,";
-            String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
+            String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
 
             // Prevent squashing
             try (TableReader ignore = getReader("x")) {
@@ -712,7 +712,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                                 " from long_sequence(200)"
                 );
 
-                assertSql("minTimestamp\tnumRows\tname\n" +
+                assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                         "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                         "2020-02-04T20:01:00.000000Z\t319\t2020-02-04T200000-000001\n", partitionsSql);
             }
@@ -727,7 +727,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                             " from long_sequence(200)"
             );
 
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T00:00:00.000000Z\t1720\t2020-02-04\n", partitionsSql);
 
         });
@@ -817,8 +817,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             compile("alter table x squash partitions");
             drainWalQueue();
 
-            String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
-            assertSql("minTimestamp\tnumRows\tname\n" +
+            String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
+            assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                     "2020-02-04T20:01:00.000000Z\t200\t2020-02-04\n" +
                     "2020-02-05T18:01:00.000000Z\t200\t2020-02-05\n", partitionsSql);
 
@@ -864,8 +864,8 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 );
                 drainWalQueue();
 
-                String partitionsSql = "select minTimestamp, numRows, name from table_partitions('x')";
-                assertSql("minTimestamp\tnumRows\tname\n" +
+                String partitionsSql = "select minTimestamp, numRows, partition_name from table_partitions('x')";
+                assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                         "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                         "2020-02-04T20:01:00.000000Z\t439\t2020-02-04T200000-000001\n" +
                         "2020-02-05T00:00:00.000000Z\t1320\t2020-02-05\n", partitionsSql);
@@ -878,7 +878,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 drainWalQueue();
 
                 // Partition "2020-02-04" cannot be squashed with the new update because it's locked by the reader
-                assertSql("minTimestamp\tnumRows\tname\n" +
+                assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                         "2020-02-04T00:00:00.000000Z\t1201\t2020-02-04\n" +
                         "2020-02-04T20:01:00.000000Z\t439\t2020-02-04T200000-000001\n" +
                         "2020-02-05T00:00:00.000000Z\t1081\t2020-02-05\n" +
@@ -888,7 +888,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
                 compile("alter table x squash partitions");
 
                 drainWalQueue();
-                assertSql("minTimestamp\tnumRows\tname\n" +
+                assertSql("minTimestamp\tnumRows\tpartition_name\n" +
                         "2020-02-04T00:00:00.000000Z\t1640\t2020-02-04\n" +
                         "2020-02-05T00:00:00.000000Z\t1370\t2020-02-05\n", partitionsSql);
 

--- a/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
@@ -129,9 +129,9 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 Assert.assertEquals(0, Files.softLink(srcPath.$(), dstPath.$()));
                 assertShowPartitions(
                         "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
-                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\t114688\t112.0 KiB\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\t114688\t112.0 KiB\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "null\tDAY\t2023-03.attachable\t-1\t\t\t-1\t163840\t160.0 KiB\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "null\tDAY\t2023-03.attachable\t-1\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                         tabName);
             }
         });
@@ -185,9 +185,9 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 Assert.assertEquals(0, Files.softLink(srcPath.$(), dstPath.$()));
                 assertShowPartitions(
                         "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
-                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\t114688\t112.0 KiB\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\t114688\t112.0 KiB\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "null\tDAY\t2023-03-15.attachable\t-1\t\t\t-1\t163840\t160.0 KiB\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "null\tDAY\t2023-03-15.attachable\t-1\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                         tabName);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowPartitionsTest.java
@@ -128,10 +128,10 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 dstPath.of(configuration.getRoot()).concat(engine.verifyTableName(tabName)).concat("2023-03").put(ATTACHABLE_DIR_MARKER);
                 Assert.assertEquals(0, Files.softLink(srcPath.$(), dstPath.$()));
                 assertShowPartitions(
-                        "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                                "0\tDAY\t2023-03-13\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "1\tDAY\t2023-03-14\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "null\tDAY\t2023-03.attachable\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                        "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\t114688\t112.0 KiB\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\t114688\t112.0 KiB\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "null\tDAY\t2023-03.attachable\t-1\t\t\t-1\t163840\t160.0 KiB\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                         tabName);
             }
         });
@@ -184,10 +184,10 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 dstPath.of(configuration.getRoot()).concat(engine.verifyTableName(tabName)).concat("2023-03-15").put(ATTACHABLE_DIR_MARKER);
                 Assert.assertEquals(0, Files.softLink(srcPath.$(), dstPath.$()));
                 assertShowPartitions(
-                        "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                                "0\tDAY\t2023-03-13\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "1\tDAY\t2023-03-14\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                                "null\tDAY\t2023-03-15.attachable\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                        "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                                "0\tDAY\t2023-03-13\t-1\t2023-03-13T04:47:59.900000Z\t2023-03-13T23:59:59.500000Z\t5\t114688\t112.0 KiB\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "1\tDAY\t2023-03-14\t-1\t2023-03-14T04:47:59.400000Z\t2023-03-14T23:59:59.000000Z\t5\t114688\t112.0 KiB\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                                "null\tDAY\t2023-03-15.attachable\t-1\t\t\t-1\t163840\t160.0 KiB\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                         tabName);
             }
         });
@@ -231,32 +231,32 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 }
             }
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.attachable\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.attachable\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.attachable\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.attachable\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.attachable\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.attachable\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                     tableName);
             ddl("ALTER TABLE " + tableName + " ATTACH PARTITION LIST '2023-02', '2023-03'", sqlExecutionContext);
             if (isWal) {
                 drainWalQueue();
             }
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-02\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\ttrue\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "1\tMONTH\t2023-03\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\ttrue\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "2\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.attachable\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-02\t6\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\ttrue\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "1\tMONTH\t2023-03\t7\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\ttrue\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "2\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.attachable\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\ttrue\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -272,13 +272,13 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             }
             deleteFile(tableName, "2023-04" + TableUtils.DETACHED_DIR_MARKER, TableUtils.META_FILE_NAME);
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -294,13 +294,13 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             }
             deleteFile(tableName, "2023-04" + TableUtils.DETACHED_DIR_MARKER, "timestamp.d");
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t\t\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t\t\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -316,13 +316,13 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             }
             deleteFile(tableName, "2023-04" + TableUtils.DETACHED_DIR_MARKER, TableUtils.TXN_FILE_NAME);
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t\t\t-1\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -338,12 +338,12 @@ public class ShowPartitionsTest extends AbstractCairoTest {
                 drainWalQueue();
             }
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "null\tMONTH\t2023-01.detached\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-02.detached\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-03.detached\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-04.detached\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
-                            "null\tMONTH\t2023-05.detached\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "null\tMONTH\t2023-01.detached\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-02.detached\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-03.detached\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-04.detached\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n" +
+                            "null\tMONTH\t2023-05.detached\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\tfalse\ttrue\tfalse\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -355,8 +355,8 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             createTable(tableName);
             assertQueryNoLeakCheck(
                     replaceSizeToMatchOS(
-                            "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                                    "5\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
+                            "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                                    "5\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
                             tableName, configuration, engine, sink),
                     "SELECT * FROM table_partitions('" + tableName + "') WHERE active = true;",
                     null,
@@ -373,8 +373,8 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             createTable(tableName, PartitionBy.WEEK);
             assertQueryNoLeakCheck(
                     replaceSizeToMatchOS(
-                            "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                                    "25\tWEEK\t2023-W25\t2023-06-19T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t25\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
+                            "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                                    "25\tWEEK\t2023-W25\t-1\t2023-06-19T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t25\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
                             tableName, configuration, engine, sink),
                     "SELECT * FROM table_partitions('" + tableName + "') WHERE active = true;",
                     null,
@@ -395,8 +395,8 @@ public class ShowPartitionsTest extends AbstractCairoTest {
             }
             assertQueryNoLeakCheck(
                     replaceSizeToMatchOS(
-                            "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                                    "5\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
+                            "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                                    "5\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
                             tableName, configuration, engine, sink),
                     "SELECT * FROM partitions WHERE active = true;",
                     null,
@@ -420,13 +420,13 @@ public class ShowPartitionsTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             createTable(tableName);
             assertShowPartitions(
-                    "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                            "0\tMONTH\t2023-01\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "1\tMONTH\t2023-02\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "2\tMONTH\t2023-03\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "3\tMONTH\t2023-04\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "4\tMONTH\t2023-05\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                            "5\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
+                    "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                            "0\tMONTH\t2023-01\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "1\tMONTH\t2023-02\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "2\tMONTH\t2023-03\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "3\tMONTH\t2023-04\t-1\t2023-04-01T00:00:00.000000Z\t2023-04-30T18:00:00.000000Z\t120\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "4\tMONTH\t2023-05\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                            "5\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
                     tableName);
         });
     }
@@ -438,13 +438,13 @@ public class ShowPartitionsTest extends AbstractCairoTest {
         deleteFile(tableName, "2023-04", "timestamp.d");
 
         final String finallyExpected = replaceSizeToMatchOS(
-                "index\tpartitionBy\tname\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tisParquet\tparquetFileSize\n" +
-                        "0\tMONTH\t2023-01\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                        "1\tMONTH\t2023-02\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                        "2\tMONTH\t2023-03\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                        "null\tMONTH\t2023-04\t\t\t120\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                        "4\tMONTH\t2023-05\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
-                        "5\tMONTH\t2023-06\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
+                "partition_index\tpartitionBy\tpartition_name\tpartition_name_txn\tminTimestamp\tmaxTimestamp\tnumRows\tdiskSize\tdiskSizeHuman\treadOnly\tactive\tattached\tdetached\tattachable\tparquet\tparquetFileSize\n" +
+                        "0\tMONTH\t2023-01\t-1\t2023-01-01T06:00:00.000000Z\t2023-01-31T18:00:00.000000Z\t123\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                        "1\tMONTH\t2023-02\t-1\t2023-02-01T00:00:00.000000Z\t2023-02-28T18:00:00.000000Z\t112\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                        "2\tMONTH\t2023-03\t-1\t2023-03-01T00:00:00.000000Z\t2023-03-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                        "null\tMONTH\t2023-04\t-1\t\t\t120\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                        "4\tMONTH\t2023-05\t-1\t2023-05-01T00:00:00.000000Z\t2023-05-31T18:00:00.000000Z\t124\tSIZE\tHUMAN\tfalse\tfalse\ttrue\tfalse\tfalse\tfalse\t-1\n" +
+                        "5\tMONTH\t2023-06\t-1\t2023-06-01T00:00:00.000000Z\t2023-06-25T00:00:00.000000Z\t97\tSIZE\tHUMAN\tfalse\ttrue\ttrue\tfalse\tfalse\tfalse\t-1\n",
                 tableName, configuration, engine, sink
         );
 

--- a/core/src/test/java/io/questdb/test/griffin/ShowTableStorageTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowTableStorageTest.java
@@ -60,7 +60,7 @@ public class ShowTableStorageTest extends AbstractCairoTest {
             final CharSequence size1 = Long.toString(getDirSize("trades_1"));
             final CharSequence size2 = Long.toString(getDirSize("trades_2"));
             assertSql(
-                    "tableName\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
+                    "table_name\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
                             "trades_2\tfalse\tHOUR\t4\t4\t" + size1 + "\n" +
                             "trades_1\tfalse\tHOUR\t4\t4\t" + size2 + "\n",
                     "select * from table_storage()"
@@ -96,7 +96,7 @@ public class ShowTableStorageTest extends AbstractCairoTest {
             final CharSequence size1 = Long.toString(getDirSize("trades_1"));
             final CharSequence size2 = Long.toString(getDirSize("trades_2"));
             assertSql(
-                    "tableName\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
+                    "table_name\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
                             "trades_2\tfalse\tNONE\t1\t4\t" + size1 + "\n" +
                             "trades_1\tfalse\tNONE\t1\t4\t" + size2 + "\n",
                     "select * from table_storage()"
@@ -121,7 +121,7 @@ public class ShowTableStorageTest extends AbstractCairoTest {
             engine.releaseAllWriters();
             engine.releaseAllWriters();
             final CharSequence size = Long.toString(getDirSize("trades_1"));
-            assertSql("tableName\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
+            assertSql("table_name\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
                             "trades_1\tfalse\tHOUR\t4\t4\t" + size + "\n",
                     "select * from table_storage()"
             );
@@ -144,7 +144,7 @@ public class ShowTableStorageTest extends AbstractCairoTest {
             drainWalQueue();
             engine.releaseAllWriters();
             final CharSequence size = Long.toString(getDirSize("trades_1"));
-            assertSql("tableName\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
+            assertSql("table_name\twalEnabled\tpartitionBy\tpartitionCount\trowCount\tdiskSize\n" +
                             "trades_1\tfalse\tNONE\t1\t4\t" + size + "\n",
                     "select * from table_storage()"
             );

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTableListFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTableListFunctionFactoryTest.java
@@ -71,7 +71,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
             Assert.assertNotNull(token);
 
             SeqTxnTracker txnTracker = tableSequencerAPI.getTxnTracker(token);
-            assertMemoryPressureLevel("A", 0);
+            assertMemoryPressureLevel(0);
 
             long now = 0;
             int parallelism = txnTracker.getMaxO3MergeParallelism();
@@ -80,7 +80,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
 
             // Memory pressure level should be 1 after the first OOM event - it indicates that the table is under memory pressure
             // and reducing parallelism
-            assertMemoryPressureLevel("A", 1);
+            assertMemoryPressureLevel(1);
 
             do {
                 now += 1000;
@@ -91,7 +91,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
 
             // eventually memory pressure level should be 2 after the second OOM event - it indicates that the table is under memory pressure
             // and is applying backoff
-            assertMemoryPressureLevel("A", 2);
+            assertMemoryPressureLevel(2);
 
 
             // now let's simulate reducing memory pressure
@@ -102,7 +102,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
 
             // after a first successful O3 merge memory pressure level should be 1 - still reducing parallelism
             // but no longer applying backoff
-            assertMemoryPressureLevel("A", 1);
+            assertMemoryPressureLevel(1);
 
             do {
                 now += 1000;
@@ -112,7 +112,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
             } while (txnTracker.getMemoryPressureLevel() == 1);
 
             // eventually the memory pressure should be 0 - no memory pressure at all
-            assertMemoryPressureLevel("A", 0);
+            assertMemoryPressureLevel(0);
         });
     }
 
@@ -208,10 +208,10 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
         testWalTablesSuspendedWithError("alter table B suspend wal", NONE, "");
     }
 
-    private void assertMemoryPressureLevel(CharSequence tableName, int expectedMemoryPressureLevel) throws SqlException {
+    private void assertMemoryPressureLevel(int expectedMemoryPressureLevel) throws SqlException {
         assertQuery("memoryPressure\n" +
-                        +expectedMemoryPressureLevel + "\n",
-                "select memoryPressure from wal_tables() where table_name = '" + tableName + "'", false, false);
+                        expectedMemoryPressureLevel + "\n",
+                "select memoryPressure from wal_tables() where table_name = '" + "A" + "'", false, false);
     }
 
     private void createTable(final String tableName, boolean isWal) throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTableListFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTableListFunctionFactoryTest.java
@@ -129,7 +129,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
                 for (int i = 0; i < 5; i++) {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         println(factory, cursor);
-                        TestUtils.assertEquals("name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+                        TestUtils.assertEquals("table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                                 "B\tfalse\t0\t0\t0\t\t\t0\n" +
                                 "C\tfalse\t0\t0\t0\t\t\t0\n", sink);
                     }
@@ -176,18 +176,18 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("C")));
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("D")));
 
-            assertSql("name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+            assertSql("table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                     "B\ttrue\t1\t0\t3\t\tcould not open read-write [file=" + root + SEPARATOR + "B~2" + SEPARATOR + "2022-12-05" + SEPARATOR + "x.d.1]\t0\n" +
                     "C\tfalse\t2\t0\t2\t\t\t0\n" +
-                    "D\tfalse\t1\t0\t1\t\t\t0\n", "wal_tables() order by name");
+                    "D\tfalse\t1\t0\t1\t\t\t0\n", "wal_tables() order by table_name");
 
-            assertSql("name\tsuspended\twriterTxn\n" +
+            assertSql("table_name\tsuspended\twriterTxn\n" +
                     "B\ttrue\t1\n" +
                     "C\tfalse\t2\n" +
-                    "D\tfalse\t1\n", "select name, suspended, writerTxn from wal_tables() order by name");
+                    "D\tfalse\t1\n", "select table_name, suspended, writerTxn from wal_tables() order by table_name");
 
-            assertSql("name\tsuspended\twriterTxn\n" +
-                    "B\ttrue\t1\n", "select name, suspended, writerTxn from wal_tables() where name = 'B'");
+            assertSql("table_name\tsuspended\twriterTxn\n" +
+                    "B\ttrue\t1\n", "select table_name, suspended, writerTxn from wal_tables() where table_name = 'B'");
         });
     }
 
@@ -211,7 +211,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
     private void assertMemoryPressureLevel(CharSequence tableName, int expectedMemoryPressureLevel) throws SqlException {
         assertQuery("memoryPressure\n" +
                         +expectedMemoryPressureLevel + "\n",
-                "select memoryPressure from wal_tables() where name = '" + tableName + "'", false, false);
+                "select memoryPressure from wal_tables() where table_name = '" + tableName + "'", false, false);
     }
 
     private void createTable(final String tableName, boolean isWal) throws SqlException {
@@ -241,7 +241,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
 
             Assert.assertTrue(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("B")));
 
-            assertSql("name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+            assertSql("table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                     "B\ttrue\t2\t0\t2\t" + expectedErrorTag.text() + "\t" + expectedErrorMessage + "\t0\n", "wal_tables()");
 
             compile("alter table B resume wal");
@@ -250,7 +250,7 @@ public class WalTableListFunctionFactoryTest extends AbstractCairoTest {
 
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("B")));
 
-            assertSql("name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+            assertSql("table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                     "B\tfalse\t2\t0\t2\t\t\t0\n", "wal_tables()");
 
             dropTable("A");

--- a/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/wal/WalTableSqlTest.java
@@ -25,10 +25,23 @@
 package io.questdb.test.griffin.wal;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableConverter;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TxReader;
+import io.questdb.cairo.TxWriter;
 import io.questdb.cairo.sql.InsertMethod;
 import io.questdb.cairo.sql.InsertOperation;
-import io.questdb.cairo.wal.*;
+import io.questdb.cairo.wal.ApplyWal2TableJob;
+import io.questdb.cairo.wal.CheckWalTransactionsJob;
+import io.questdb.cairo.wal.WalPurgeJob;
+import io.questdb.cairo.wal.WalUtils;
+import io.questdb.cairo.wal.WalWriter;
 import io.questdb.griffin.CompiledQuery;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
@@ -37,7 +50,13 @@ import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.mp.Job;
-import io.questdb.std.*;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
+import io.questdb.std.Os;
+import io.questdb.std.Rnd;
+import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -1218,7 +1237,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
 
             drainWalQueue();
 
-            assertSql("name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
+            assertSql("table_name\tsuspended\twriterTxn\twriterLagTxnCount\tsequencerTxn\terrorTag\terrorMessage\tmemoryPressure\n" +
                     "testEmptyTruncate\tfalse\t1\t0\t1\t\t\t0\n", "wal_tables()");
         });
     }

--- a/core/src/test/resources/sqllogictest/test/dedup/dedup_size.test
+++ b/core/src/test/resources/sqllogictest/test/dedup/dedup_size.test
@@ -19,7 +19,7 @@ select wait_wal_table('size_control');
 
 # check dedup data
 query TIT
-select name, numRows, diskSize
+select partition_name, numRows, diskSize
 from table_partitions('size_control');
 ----
 2022-02-24T00   3600    153693
@@ -38,7 +38,7 @@ select wait_wal_table('size_control');
 
 # check dedup data
 query TIT
-select name, numRows, diskSize
+select partition_name, numRows, diskSize
 from table_partitions('size_control');
 ----
 2022-02-24T00   3600    153693


### PR DESCRIPTION
Affected views:

- `wal_tables`
- `table_partitions()`
- `SHOW PARTITIONS`
- `table_storage`

## Details

```
wal_tables.name -> wal_tables.table_name
table_partitions.index -> table_partitions.partition_index
table_partitions.name -> table_partitions.partition_name
table_partitions.isparquet -> table_partitions.parquet
table_storage.tablename -> table_storage.table_name
```

New column:
```
table_partitions.partition_name_txn -> the numeric txn that is used in constructing partition directory name.
```