### PR TITLE
perf(core): replace unconditional txn sync with a conditional one. 10x improvement of ingress perf for small transactions

### DIFF
--- a/benchmarks/src/main/java/org/questdb/UnorderedVarcharMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/UnorderedVarcharMapBenchmark.java
@@ -56,8 +56,8 @@ public class UnorderedVarcharMapBenchmark {
     private MemoryCMR auxReadMem;
     private MemoryCMR dataReadMem;
     private OrderedMap orderedMap;
-    private Utf8SplitString stableUtf8String = new Utf8SplitString(() -> true);
-    private Utf8SplitString unstableUtf8String = new Utf8SplitString(() -> false);
+    private final Utf8SplitString stableUtf8String = new Utf8SplitString(() -> true);
+    private final Utf8SplitString unstableUtf8String = new Utf8SplitString(() -> false);
     private UnorderedVarcharMap varcharMap;
 
     public static void main(String[] args) throws RunnerException {
@@ -152,8 +152,8 @@ public class UnorderedVarcharMapBenchmark {
     public void createMem() {
         FilesFacade ff = FilesFacadeImpl.INSTANCE;
         try (
-                MemoryMA auxAppendMem = Vm.getMAInstance(CommitMode.NOSYNC);
-                MemoryMA dataAppendMem = Vm.getMAInstance(CommitMode.NOSYNC)
+                MemoryMA auxAppendMem = Vm.getMAInstance(null);
+                MemoryMA dataAppendMem = Vm.getMAInstance(null)
         ) {
             try (Path path = new Path()) {
                 path.of(AUX_MEM_FILENAME);

--- a/core/src/main/java/io/questdb/cairo/IndexBuilder.java
+++ b/core/src/main/java/io/questdb/cairo/IndexBuilder.java
@@ -45,7 +45,7 @@ public class IndexBuilder extends RebuildColumnBase {
 
     public IndexBuilder(CairoConfiguration configuration) {
         super(configuration);
-        ddlMem = Vm.getMARInstance(configuration.getCommitMode());
+        ddlMem = Vm.getMARInstance(configuration);
         indexer = new SymbolColumnIndexer(configuration);
         unsupportedColumnMessage = "Column is not indexed";
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -360,7 +360,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             if (todo == TODO_RESTORE_META) {
                 repairMetaRename((int) todoMem.getLong(48));
             }
-            this.ddlMem = Vm.getMARInstance(configuration.getCommitMode());
+            this.ddlMem = Vm.getMARInstance(configuration);
             this.metaMem = Vm.getCMRInstance();
             openMetaFile(ff, path, pathSize, metaMem);
             this.metadata = new TableWriterMetadata(this.tableToken, metaMem);
@@ -3734,12 +3734,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final MemoryCARW o3AuxMem2;
 
         if (type > 0) {
-            dataMem = Vm.getMAInstance(configuration.getCommitMode());
+            dataMem = Vm.getMAInstance(configuration);
             o3DataMem1 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
             o3DataMem2 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
 
             if (ColumnType.isVarSize(type)) {
-                auxMem = Vm.getMAInstance(configuration.getCommitMode());
+                auxMem = Vm.getMAInstance(configuration);
                 o3AuxMem1 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
                 o3AuxMem2 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
             } else {

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryPMARImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryPMARImpl.java
@@ -33,12 +33,13 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.str.LPSZ;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 // paged mapped appendable readable 
 public class MemoryPMARImpl extends MemoryPARWImpl implements MemoryMAR {
     private static final Log LOG = LogFactory.getLog(MemoryPMARImpl.class);
-    private final int commitMode;
+    private final CairoConfiguration configuration;
     private long fd = -1;
     private FilesFacade ff;
     private int madviseOpts = -1;
@@ -47,12 +48,12 @@ public class MemoryPMARImpl extends MemoryPARWImpl implements MemoryMAR {
 
     @TestOnly
     public MemoryPMARImpl(FilesFacade ff, LPSZ name, long pageSize, int memoryTag, long opts) {
-        this(CommitMode.NOSYNC);
+        this(null);
         of(ff, name, pageSize, 0, memoryTag, opts, -1);
     }
 
-    public MemoryPMARImpl(int commitMode) {
-        this.commitMode = commitMode;
+    public MemoryPMARImpl(@Nullable CairoConfiguration configuration) {
+        this.configuration = configuration;
     }
 
     public final void close(boolean truncate, byte truncateMode) {
@@ -138,8 +139,8 @@ public class MemoryPMARImpl extends MemoryPARWImpl implements MemoryMAR {
     }
 
     public void sync(boolean async) {
-        if (pageAddress != 0 && commitMode != CommitMode.NOSYNC) {
-            ff.msync(pageAddress, getPageSize(), commitMode == CommitMode.ASYNC);
+        if (pageAddress != 0) {
+            ff.msync(pageAddress, getPageSize(), async);
         }
     }
 
@@ -169,6 +170,7 @@ public class MemoryPMARImpl extends MemoryPARWImpl implements MemoryMAR {
 
     @Override
     protected void release(long address) {
+        int commitMode = configuration != null ? configuration.getCommitMode() : CommitMode.NOSYNC;
         if (commitMode != CommitMode.NOSYNC) {
             ff.msync(address, getPageSize(), commitMode == CommitMode.ASYNC);
         }

--- a/core/src/main/java/io/questdb/cairo/vm/Vm.java
+++ b/core/src/main/java/io/questdb/cairo/vm/Vm.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.vm;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.vm.api.*;
 import io.questdb.log.Log;
 import io.questdb.std.Files;
@@ -98,12 +99,12 @@ public class Vm {
         return new MemoryCMRImpl(ff, name, size, memoryTag);
     }
 
-    public static MemoryMA getMAInstance(int commitMode) {
-        return new MemoryPMARImpl(commitMode);
+    public static MemoryMA getMAInstance(CairoConfiguration configuration) {
+        return new MemoryPMARImpl(configuration);
     }
 
-    public static MemoryMAR getMARInstance(int commitMode) {
-        return new MemoryPMARImpl(commitMode);
+    public static MemoryMAR getMARInstance(CairoConfiguration configuration) {
+        return new MemoryPMARImpl(configuration);
     }
 
     public static MemoryMARW getMARWInstance() {
@@ -112,10 +113,6 @@ public class Vm {
 
     public static MemoryMARW getMARWInstance(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag, long opts) {
         return new MemoryCMARWImpl(ff, name, extendSegmentSize, size, memoryTag, opts);
-    }
-
-    public static MemoryMR getMRInstance() {
-        return new MemoryCMRImpl();
     }
 
     public static MemoryCMOR getMemoryCMOR() {

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -26,6 +26,7 @@ package io.questdb.cairo.wal;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.VarcharTypeDriver;
 import io.questdb.cairo.sql.BindVariableService;
 import io.questdb.cairo.sql.Function;
@@ -294,8 +295,11 @@ class WalEventWriter implements Closeable {
     }
 
     void sync() {
-        eventMem.sync(false);
-        ff.fsync(indexFd);
+        int commitMode = configuration.getCommitMode();
+        if (commitMode != CommitMode.NOSYNC) {
+            eventMem.sync(commitMode == CommitMode.ASYNC);
+            ff.fsync(indexFd);
+        }
     }
 
     int truncate() {

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -137,7 +137,7 @@ public class WalWriter implements TableWriterAPI {
         this.pathSize = path.size();
         this.metrics = metrics;
         this.open = true;
-        this.symbolMapMem = Vm.getMARInstance(configuration.getCommitMode());
+        this.symbolMapMem = Vm.getMARInstance(configuration);
 
         try {
             lockWal();
@@ -890,7 +890,7 @@ public class WalWriter implements TableWriterAPI {
     private void configureColumn(int columnIndex, int columnType) {
         final int dataColumnOffset = getDataColumnOffset(columnIndex);
         if (columnType > 0) {
-            final MemoryMA dataMem = Vm.getMAInstance(configuration.getCommitMode());
+            final MemoryMA dataMem = Vm.getMAInstance(configuration);
             final MemoryMA auxMem = createAuxColumnMem(columnType);
             columns.extendAndSet(dataColumnOffset, dataMem);
             columns.extendAndSet(dataColumnOffset + 1, auxMem);
@@ -1083,7 +1083,7 @@ public class WalWriter implements TableWriterAPI {
     }
 
     private MemoryMA createAuxColumnMem(int columnType) {
-        return ColumnType.isVarSize(columnType) ? Vm.getMAInstance(configuration.getCommitMode()) : null;
+        return ColumnType.isVarSize(columnType) ? Vm.getMAInstance(configuration) : null;
     }
 
     private SegmentColumnRollSink createSegmentColumnRollSink() {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
@@ -24,13 +24,23 @@
 
 package io.questdb.cairo.wal.seq;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractRecordMetadata;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.TableDescriptor;
+import io.questdb.cairo.TableStructure;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cairo.vm.api.MemoryMR;
 import io.questdb.cairo.wal.WalUtils;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.IntList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
 import io.questdb.std.str.Path;
 
 import java.io.Closeable;
@@ -42,13 +52,13 @@ import static io.questdb.cairo.wal.WalUtils.*;
 public class SequencerMetadata extends AbstractRecordMetadata implements TableRecordMetadata, Closeable, TableDescriptor {
     private final FilesFacade ff;
     private final MemoryMARW metaMem;
+    private final IntList readColumnOrder = new IntList();
     private final boolean readonly;
     private final MemoryMR roMetaMem;
     private final AtomicLong structureVersion = new AtomicLong(-1);
     private volatile boolean suspended;
     private int tableId;
     private TableToken tableToken;
-    private final IntList readColumnOrder = new IntList();
 
     public SequencerMetadata(FilesFacade ff) {
         this(ff, false);
@@ -116,13 +126,13 @@ public class SequencerMetadata extends AbstractRecordMetadata implements TableRe
         structureVersion.incrementAndGet();
     }
 
-    public IntList getReadColumnOrder() {
-        return readColumnOrder;
-    }
-
     @Override
     public long getMetadataVersion() {
         return structureVersion.get();
+    }
+
+    public IntList getReadColumnOrder() {
+        return readColumnOrder;
     }
 
     public int getRealColumnCount() {
@@ -194,7 +204,7 @@ public class SequencerMetadata extends AbstractRecordMetadata implements TableRe
         structureVersion.incrementAndGet();
     }
 
-    public void syncToDisk() {
+    public void sync() {
         metaMem.sync(false);
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -298,6 +298,10 @@ public class TableSequencerImpl implements TableSequencer {
         return tableTransactionLog.lastTxn();
     }
 
+    public boolean metadataMatches(long structureVersion) {
+        return metadata.getMetadataVersion() == structureVersion;
+    }
+
     @Override
     public long nextStructureTxn(long expectedStructureVersion, TableMetadataChange change) {
         // Writing to TableSequencer can happen from multiple threads, so we need to protect against concurrent writes.
@@ -399,11 +403,8 @@ public class TableSequencerImpl implements TableSequencer {
             return null;
         }
 
-        try (
-                TableMetadataChangeLog metaChangeCursor = tableTransactionLog.getTableMetadataChangeLog(
-                        metadata.getMetadataVersion(),
-                        alterCommandWalFormatter
-                )
+        try (TableMetadataChangeLog metaChangeCursor = tableTransactionLog.getTableMetadataChangeLog(
+                metadata.getMetadataVersion(), alterCommandWalFormatter)
         ) {
             boolean updated = false;
             while (metaChangeCursor.hasNext()) {
@@ -484,8 +485,15 @@ public class TableSequencerImpl implements TableSequencer {
             long txnRowCount
     ) {
         return tableTransactionLog.addEntry(
-                getStructureVersion(), walId, segmentId, segmentTxn, timestamp,
-                txnMinTimestamp, txnMaxTimestamp, txnRowCount);
+                getStructureVersion(),
+                walId,
+                segmentId,
+                segmentTxn,
+                timestamp,
+                txnMinTimestamp,
+                txnMaxTimestamp,
+                txnRowCount
+        );
     }
 
     private void notifyTxnCommitted(long txn) {

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogFile.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogFile.java
@@ -123,6 +123,11 @@ public interface TableTransactionLogFile extends Closeable {
     long endMetadataChangeEntry();
 
     /**
+     * Syncs/flushes the log files to the disk unconditionally.
+     */
+    void fullSync();
+
+    /**
      * Returns the cursor to read transactions from the log
      *
      * @param txnLo transaction id to start reading from
@@ -148,9 +153,4 @@ public interface TableTransactionLogFile extends Closeable {
      * @return transaction id of the last committed transaction
      */
     long open(Path path);
-
-    /**
-     * Syncs/flushes the log files to the disk
-     */
-    void sync();
 }

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV1.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableTransactionLogV1.java
@@ -24,7 +24,9 @@
 
 package io.questdb.cairo.wal.seq;
 
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.MemorySerializer;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.vm.Vm;
@@ -32,11 +34,14 @@ import io.questdb.cairo.vm.api.MemoryCMARW;
 import io.questdb.cairo.wal.WalUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.*;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Transient;
+import io.questdb.std.Unsafe;
 import io.questdb.std.str.Path;
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.ThreadLocal;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.questdb.cairo.TableUtils.openSmallFile;
@@ -45,7 +50,7 @@ import static io.questdb.cairo.wal.WalUtils.WAL_SEQUENCER_FORMAT_VERSION_V1;
 
 /**
  * This class is used to read/write transactions to the disk.
- * This is V1 implementation of the sequencer transaction log storage and it will be used
+ * This is V1 implementation of the sequencer transaction log storage, and it will be used
  * in parallel with the new V2 for backward compatibility.
  * <p>
  * All transactions are stored in the single file table_dir\\txn_seq\\_txnlog, the file structure is
@@ -56,15 +61,17 @@ import static io.questdb.cairo.wal.WalUtils.WAL_SEQUENCER_FORMAT_VERSION_V1;
  * See the format of the header and transaction record in @link TableTransactionLogFile
  */
 public class TableTransactionLogV1 implements TableTransactionLogFile {
-    public static long RECORD_SIZE = TX_LOG_COMMIT_TIMESTAMP_OFFSET + Long.BYTES;
     private static final Log LOG = LogFactory.getLog(TableTransactionLogV1.class);
     private static final ThreadLocal<TransactionLogCursorImpl> tlTransactionLogCursor = new ThreadLocal<>();
+    public static long RECORD_SIZE = TX_LOG_COMMIT_TIMESTAMP_OFFSET + Long.BYTES;
+    private final CairoConfiguration configuration;
     private final FilesFacade ff;
     private final AtomicLong maxTxn = new AtomicLong();
     private final MemoryCMARW txnMem = Vm.getCMARWInstance();
 
-    public TableTransactionLogV1(FilesFacade ff) {
-        this.ff = ff;
+    public TableTransactionLogV1(CairoConfiguration configuration) {
+        this.configuration = configuration;
+        this.ff = configuration.getFilesFacade();
     }
 
     public static long readMaxStructureVersion(long logFileFd, FilesFacade ff) {
@@ -77,7 +84,16 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
     }
 
     @Override
-    public long addEntry(long structureVersion, int walId, int segmentId, int segmentTxn, long timestamp, long txnMinTimestamp, long txnMaxTimestamp, long txnRowCount) {
+    public long addEntry(
+            long structureVersion,
+            int walId,
+            int segmentId,
+            int segmentTxn,
+            long timestamp,
+            long txnMinTimestamp,
+            long txnMaxTimestamp,
+            long txnRowCount
+    ) {
         txnMem.putLong(structureVersion);
         txnMem.putInt(walId);
         txnMem.putInt(segmentId);
@@ -87,7 +103,10 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         Unsafe.getUnsafe().storeFence();
         long maxTxn = this.maxTxn.incrementAndGet();
         txnMem.putLong(MAX_TXN_OFFSET_64, maxTxn);
-        txnMem.sync(false);
+        int commitMode = configuration.getCommitMode();
+        if (commitMode != CommitMode.NOSYNC) {
+            txnMem.sync(commitMode == CommitMode.ASYNC);
+        }
         // Transactions are 1 based here
         return maxTxn;
     }
@@ -136,6 +155,11 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
     }
 
     @Override
+    public void fullSync() {
+        txnMem.sync(false);
+    }
+
+    @Override
     public TransactionLogCursor getCursor(long txnLo, @Transient Path path) {
         TransactionLogCursorImpl cursor = tlTransactionLogCursor.get();
         if (cursor == null) {
@@ -178,11 +202,6 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         long maxStructureVersion = txnMem.getLong(HEADER_SIZE + (lastTxn - 1) * RECORD_SIZE + TX_LOG_STRUCTURE_VERSION_OFFSET);
         txnMem.jumpTo(HEADER_SIZE + lastTxn * RECORD_SIZE);
         return maxStructureVersion;
-    }
-
-    @Override
-    public void sync() {
-        txnMem.sync(false);
     }
 
     private static class TransactionLogCursorImpl implements TransactionLogCursor {
@@ -236,6 +255,11 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         @Override
         public long getMaxTxn() {
             return txnCount - 1;
+        }
+
+        @Override
+        public int getPartitionSize() {
+            return 0;
         }
 
         @Override
@@ -309,11 +333,6 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         }
 
         @Override
-        public int getPartitionSize() {
-            return 0;
-        }
-
-        @Override
         public void toTop() {
             if (txnCount > -1L) {
                 this.txnOffset = HEADER_SIZE + (txnLo - 1) * RECORD_SIZE;
@@ -321,8 +340,8 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
             }
         }
 
-        private static long openFileRO(final FilesFacade ff, final Path path, final String fileName) {
-            return TableUtils.openRO(ff, path, fileName, LOG);
+        private static long openFileRO(final FilesFacade ff, final Path path) {
+            return TableUtils.openRO(ff, path, WalUtils.TXNLOG_FILE_NAME, LOG);
         }
 
         private long getMappedLen() {
@@ -341,7 +360,7 @@ public class TableTransactionLogV1 implements TableTransactionLogFile {
         @NotNull
         private TransactionLogCursorImpl of(FilesFacade ff, long txnLo, Path path) {
             this.ff = ff;
-            this.fd = openFileRO(ff, path, TXNLOG_FILE_NAME);
+            this.fd = openFileRO(ff, path);
             long newTxnCount = ff.readNonNegativeLong(fd, MAX_TXN_OFFSET_64);
             if (newTxnCount > -1L) {
                 this.txnCount = newTxnCount;

--- a/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CsvFileIndexer.java
@@ -686,8 +686,7 @@ public class CsvFileIndexer implements Closeable, Mutable {
             this.indexChunkSize = 0;
             this.chunkNumber = 0;
             this.dataSize = 0;
-            this.memory = new MemoryPMARImpl(configuration.getCommitMode());
-
+            this.memory = new MemoryPMARImpl(configuration);
             nextChunk(ff, path);
         }
 

--- a/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
+++ b/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
@@ -35,7 +35,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 
 /**
  * This lock is not reentrant.
- * If a thread holds a write lock and it tries to grab a lock again it will deadlock.
+ * If a thread holds a write lock, and it tries to grab a lock again it will deadlock.
  * If a thread holding a read lock tries to upgrade its lock to a write lock it must first release its read lock or it will deadlock.
  * Threads waiting on a write lock have priority over threads waiting on a read lock.
  * Threads waiting on a write lock are not resumed fairly.
@@ -51,12 +51,12 @@ public class SimpleReadWriteLock implements ReadWriteLock {
     private final WriteLock writeLock = new WriteLock();
 
     @Override
-    public Lock readLock() {
+    public @NotNull Lock readLock() {
         return readLock;
     }
 
     @Override
-    public Lock writeLock() {
+    public @NotNull Lock writeLock() {
         return writeLock;
     }
 
@@ -65,7 +65,6 @@ public class SimpleReadWriteLock implements ReadWriteLock {
         public void lock() {
             while (nReaders.incrementAndGet() >= MAX_READERS) {
                 nReaders.decrementAndGet();
-                Os.pause();
             }
         }
 
@@ -75,7 +74,7 @@ public class SimpleReadWriteLock implements ReadWriteLock {
         }
 
         @Override
-        public Condition newCondition() {
+        public @NotNull Condition newCondition() {
             throw new UnsupportedOperationException();
         }
 
@@ -113,7 +112,7 @@ public class SimpleReadWriteLock implements ReadWriteLock {
         }
 
         @Override
-        public Condition newCondition() {
+        public @NotNull Condition newCondition() {
             throw new UnsupportedOperationException();
         }
 

--- a/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
+++ b/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
@@ -65,6 +65,7 @@ public class SimpleReadWriteLock implements ReadWriteLock {
         public void lock() {
             while (nReaders.incrementAndGet() >= MAX_READERS) {
                 nReaders.decrementAndGet();
+                Thread.yield();
             }
         }
 
@@ -98,7 +99,7 @@ public class SimpleReadWriteLock implements ReadWriteLock {
         @Override
         public void lock() {
             while (!lock.compareAndSet(false, true)) {
-                Os.pause();
+                Thread.yield();
             }
             int n = nReaders.addAndGet(MAX_READERS);
             while (n != MAX_READERS) {
@@ -140,6 +141,5 @@ public class SimpleReadWriteLock implements ReadWriteLock {
             nReaders.addAndGet(-MAX_READERS);
             lock.set(false);
         }
-
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/CairoMemoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoMemoryTest.java
@@ -26,7 +26,6 @@ package io.questdb.test.cairo;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
-import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.vm.MemoryCMORImpl;
 import io.questdb.cairo.vm.MemoryCMRImpl;
 import io.questdb.cairo.vm.MemoryPMARImpl;
@@ -35,7 +34,12 @@ import io.questdb.cairo.vm.api.MemoryARW;
 import io.questdb.cairo.vm.api.MemoryCMARW;
 import io.questdb.cairo.vm.api.MemoryMA;
 import io.questdb.cairo.vm.api.MemoryMR;
-import io.questdb.std.*;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Rnd;
+import io.questdb.std.Unsafe;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
@@ -74,7 +78,7 @@ public class CairoMemoryTest extends AbstractTest {
         int failureCount = 0;
         try (Path path = new Path()) {
             path.of(temp.newFile().getAbsolutePath());
-            try (MemoryMA mem = Vm.getMAInstance(CommitMode.NOSYNC)) {
+            try (MemoryMA mem = Vm.getMAInstance(null)) {
                 mem.of(ff, path.$(), ff.getPageSize() * 2, MemoryTag.MMAP_DEFAULT, CairoConfiguration.O_NONE);
                 int i = 0;
                 while (i < N) {
@@ -155,7 +159,7 @@ public class CairoMemoryTest extends AbstractTest {
         try (Path path = new Path()) {
             path.of(temp.getRoot().getAbsolutePath());
             int prefixLen = path.size();
-            try (MemoryMA mem = Vm.getMAInstance(CommitMode.NOSYNC)) {
+            try (MemoryMA mem = Vm.getMAInstance(null)) {
                 Rnd rnd = new Rnd();
                 for (int k = 0; k < 10; k++) {
                     path.trimTo(prefixLen).concat(rnd.nextString(10));

--- a/core/src/test/java/io/questdb/test/cairo/MemRemappedFileTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MemRemappedFileTest.java
@@ -25,7 +25,6 @@
 package io.questdb.test.cairo;
 
 import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.vm.MemoryCMRImpl;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMA;
@@ -79,7 +78,7 @@ public class MemRemappedFileTest extends AbstractTest {
 
     private double test(MemoryMR readMem) {
         long nanos = 0;
-        try (MemoryMA appMem = Vm.getMAInstance(CommitMode.NOSYNC)) {
+        try (MemoryMA appMem = Vm.getMAInstance(null)) {
             for (int cycle = 0; cycle < NCYCLES; cycle++) {
                 path.trimTo(0).concat(root).concat("file" + nFile).$();
                 nFile++;

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataCorruptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataCorruptionTest.java
@@ -252,7 +252,7 @@ public class TableReaderMetadataCorruptionTest extends AbstractCairoTest {
                     throw CairoException.critical(TestFilesFacadeImpl.INSTANCE.errno()).put("Cannot create dir: ").put(path);
                 }
 
-                try (MemoryMA mem = Vm.getMAInstance(CommitMode.NOSYNC)) {
+                try (MemoryMA mem = Vm.getMAInstance(null)) {
                     mem.of(
                             TestFilesFacadeImpl.INSTANCE,
                             path.trimTo(rootLen).concat(TableUtils.META_FILE_NAME).$(),

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -931,7 +931,7 @@ public class WalWriterTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testConcurrentAddRemoveColumn_DifferentColNamePerThread() throws Exception {
+    public void testConcurrentAddRemoveColumnDifferentColNamePerThread() throws Exception {
         assertMemoryLeak(() -> {
             final String tableName = testName.getMethodName();
             TableToken tableToken = createTable(testName.getMethodName());

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1466,14 +1466,14 @@ public class WalWriterTest extends AbstractCairoTest {
 
     @Test
     public void testOverlappingStructureChangeFails() throws Exception {
+        AtomicInteger errorCounter = new AtomicInteger();
         final FilesFacade ff = new TestFilesFacadeImpl() {
             @Override
             public long openRO(LPSZ name) {
                 try {
                     throw new RuntimeException("Test failure");
                 } catch (Exception e) {
-                    final StackTraceElement[] stackTrace = e.getStackTrace();
-                    if (stackTrace[2].getClassName().endsWith("TableTransactionLog") && stackTrace[2].getMethodName().equals("openFileRO")) {
+                    if (errorCounter.incrementAndGet() == 2) {
                         return -1;
                     }
                 }

--- a/core/src/test/java/io/questdb/test/wal/TableTransactionLogFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/wal/TableTransactionLogFuzzTest.java
@@ -73,13 +73,13 @@ public class TableTransactionLogFuzzTest extends AbstractCairoTest {
 
                 path.of(root).concat("v1");
                 ff.mkdir(path.$(), configuration.getMkDirMode());
-                TableTransactionLogV1 v1 = new TableTransactionLogV1(ff);
+                TableTransactionLogV1 v1 = new TableTransactionLogV1(configuration);
                 v1.create(path.of(root).concat("v1"), 65897);
                 v1.open(path);
 
                 path.of(root).concat("v2");
                 ff.mkdir(path.$(), configuration.getMkDirMode());
-                TableTransactionLogV2 v2 = new TableTransactionLogV2(ff, chunkTransactionCount, configuration.getMkDirMode());
+                TableTransactionLogV2 v2 = new TableTransactionLogV2(configuration, chunkTransactionCount);
                 v2.create(path, 65897);
                 v2.open(path);
 


### PR DESCRIPTION
- remove hard "msync" from critical path (e.g. commit). "msync" is conditional on database being in SYNC mode
- remove read-lock when WAL writer is activated. When metadata version doesn't change WAL activation follows fast path
- refactor out caching of `cairo.commit.mode` value, so it can be reloaded without server restart

PG Wire 2.0 bench before and after. 10 second run of inserts, two fields, commit every row (batch size = 1).

Before:

```
    2,196 inserts    14,042 selects
    4,496 inserts    43,795 selects
    6,760 inserts    75,253 selects
    9,022 inserts   107,121 selects
   11,044 inserts   137,401 selects
   13,246 inserts   170,169 selects
   15,388 inserts   201,575 selects
   17,636 inserts   234,439 selects
   19,868 inserts   266,073 selects
   22,090 inserts   295,647 selects

12 JDBC inserters, 1 selectors combined performance:
2,207 inserts per second, 29,545 selects per second
Per-thread performance:
183 inserts per second, 29,545 selects per second
```

After:
```
  166,154 inserts    19,153 selects
  363,517 inserts    49,326 selects
  535,017 inserts    78,953 selects
  689,515 inserts   109,986 selects
  827,700 inserts   140,584 selects
  957,144 inserts   172,022 selects
1,073,416 inserts   204,529 selects
1,184,451 inserts   237,443 selects
1,287,076 inserts   271,185 selects
1,380,068 inserts   301,670 selects

12 JDBC inserters, 1 selectors combined performance:
137,958 inserts per second, 30,156 selects per second
Per-thread performance:
11,496 inserts per second, 30,156 selects per second
```