### PR TITLE
perf(core): optimize StringSink buffer reuse - garbage elimination

### DIFF
--- a/core/src/main/java/io/questdb/std/str/StringSink.java
+++ b/core/src/main/java/io/questdb/std/str/StringSink.java
@@ -175,7 +175,7 @@ public class StringSink implements MutableUtf16Sink, CharSequence, CloneableMuta
 
     private void checkCapacity(int extra) {
         int len = pos + extra;
-        if (buffer.length > len) {
+        if (buffer.length >= len) {
             return;
         }
         len = Math.max(pos * 2, len);


### PR DESCRIPTION
Avoid redundant buffer allocations in StringSink when the existing buffer matches the required size. Previously, repeated insertions of same-sized strings would unnecessarily create new buffers, even when the existing one was adequate.

Spotted this in allocation profiler while working with PGWire data. I was pumping in tons of INSERT rows, and QueryRegistry (which uses StringSink internally) kept recreating buffers for no good reason even after it hit the right size.