### PR TITLE
fix(ilp): Java ILP client supports timestamps up to 9999-12-31 23:59:59.999999

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -433,7 +433,7 @@ public abstract class AbstractLineSender implements Utf8Sink, Closeable, Sender 
                 return value * 1_000_000;
             default:
                 Duration duration = unit.getDuration();
-                long micros = duration.toSecondsPart() * 1_000_000L;
+                long micros = duration.toSeconds() * 1_000_000L;
                 micros += duration.toNanosPart() / 1_000;
                 return micros * value;
         }

--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 import java.security.*;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 
@@ -417,6 +418,24 @@ public abstract class AbstractLineSender implements Utf8Sink, Closeable, Sender 
                 return 1_000_000_000;
             default:
                 return unit.getDuration().toNanos();
+        }
+    }
+
+    protected static long toMicros(long value, ChronoUnit unit) {
+        switch (unit) {
+            case NANOS:
+                return value / 1_000;
+            case MICROS:
+                return value;
+            case MILLIS:
+                return value * 1_000;
+            case SECONDS:
+                return value * 1_000_000;
+            default:
+                Duration duration = unit.getDuration();
+                long micros = duration.toSecondsPart() * 1_000_000L;
+                micros += duration.toNanosPart() / 1_000;
+                return micros * value;
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/AbstractLineSender.java
@@ -421,24 +421,6 @@ public abstract class AbstractLineSender implements Utf8Sink, Closeable, Sender 
         }
     }
 
-    protected static long toMicros(long value, ChronoUnit unit) {
-        switch (unit) {
-            case NANOS:
-                return value / 1_000;
-            case MICROS:
-                return value;
-            case MILLIS:
-                return value * 1_000;
-            case SECONDS:
-                return value * 1_000_000;
-            default:
-                Duration duration = unit.getDuration();
-                long micros = duration.toSeconds() * 1_000_000L;
-                micros += duration.toNanosPart() / 1_000;
-                return micros * value;
-        }
-    }
-
     protected void send00() {
         validateNotClosed();
         int len = (int) (ptr - lineStart);

--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
@@ -113,7 +113,7 @@ public class LineTcpSender extends AbstractLineSender {
     @Override
     public final AbstractLineSender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
         // micros
-        writeFieldName(name).put(toMicros(value, unit)).put('t');
+        writeFieldName(name).put(Timestamps.toMicros(value, unit)).put('t');
         return this;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSender.java
@@ -113,7 +113,7 @@ public class LineTcpSender extends AbstractLineSender {
     @Override
     public final AbstractLineSender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
         // micros
-        writeFieldName(name).put(value * unitToNanos(unit) / 1000).put('t');
+        writeFieldName(name).put(toMicros(value, unit)).put('t');
         return this;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
@@ -67,7 +67,7 @@ public class LineUdpSender extends AbstractLineSender {
 
     @Override
     public final AbstractLineSender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
-        writeFieldName(name).put(value * unitToNanos(unit) / 1000);
+        writeFieldName(name).put(toMicros(value, unit));
         return this;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineUdpSender.java
@@ -67,7 +67,7 @@ public class LineUdpSender extends AbstractLineSender {
 
     @Override
     public final AbstractLineSender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
-        writeFieldName(name).put(toMicros(value, unit));
+        writeFieldName(name).put(Timestamps.toMicros(value, unit));
         return this;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
@@ -299,7 +299,7 @@ public final class LineHttpSender implements Sender {
                 return value * 1_000_000;
             default:
                 Duration duration = unit.getDuration();
-                long micros = duration.toSecondsPart() * 1_000_000L;
+                long micros = duration.toSeconds() * 1_000_000L;
                 micros += duration.toNanosPart() / 1_000;
                 return micros * value;
         }

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSender.java
@@ -113,7 +113,7 @@ public final class LineHttpSender implements Sender {
 
     @Override
     public void at(long timestamp, ChronoUnit unit) {
-        request.putAscii(' ').put(toMicros(timestamp, unit)).put('t');
+        request.putAscii(' ').put(Timestamps.toMicros(timestamp, unit)).put('t');
         atNow();
     }
 
@@ -256,7 +256,7 @@ public final class LineHttpSender implements Sender {
     @Override
     public Sender timestampColumn(CharSequence name, long value, ChronoUnit unit) {
         // micros
-        writeFieldName(name).put(toMicros(value, unit)).put('t');
+        writeFieldName(name).put(Timestamps.toMicros(value, unit)).put('t');
         return this;
     }
 
@@ -285,24 +285,6 @@ public final class LineHttpSender implements Sender {
     private static boolean keepAliveDisabled(HttpClient.ResponseHeaders response) {
         DirectUtf8Sequence connectionHeader = response.getHeader(HttpConstants.HEADER_CONNECTION);
         return connectionHeader != null && Utf8s.equalsAscii("close", connectionHeader);
-    }
-
-    private static long toMicros(long value, ChronoUnit unit) {
-        switch (unit) {
-            case NANOS:
-                return value / 1_000;
-            case MICROS:
-                return value;
-            case MILLIS:
-                return value * 1_000;
-            case SECONDS:
-                return value * 1_000_000;
-            default:
-                Duration duration = unit.getDuration();
-                long micros = duration.toSeconds() * 1_000_000L;
-                micros += duration.toNanosPart() / 1_000;
-                return micros * value;
-        }
     }
 
     private int backoff(int retryBackoff) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineProtocolException.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineProtocolException.java
@@ -76,6 +76,13 @@ public class LineProtocolException extends CairoException {
                 .put(" does not exist, creating new columns is disabled");
     }
 
+    public static LineProtocolException designatedTimestampMustBePositive(String tableNameUtf16, long timestamp) {
+        return instance()
+                .put("table: ").put(tableNameUtf16)
+                .put(", timestamp: ").put(timestamp)
+                .put("; designated timestamp before 1970-01-01 is not allowed");
+    }
+
     public LineProtocolException put(@Nullable Utf8Sequence us) {
         message.put(us);
         return this;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineWalAppender.java
@@ -114,6 +114,9 @@ public class LineWalAppender {
 
         long timestamp = parser.getTimestamp();
         if (timestamp != LineTcpParser.NULL_TIMESTAMP) {
+            if (timestamp < 0) {
+                throw LineProtocolException.designatedTimestampMustBePositive(tud.getTableNameUtf16(), timestamp);
+            }
             timestamp = timestampAdapter.getMicros(timestamp, parser.getTimestampUnit());
         } else {
             timestamp = microsecondClock.getTicks();

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -150,8 +150,8 @@ public final class Timestamps {
                 return value * 1_000_000;
             default:
                 Duration duration = unit.getDuration();
-                long micros = duration.toSeconds() * 1_000_000L;
-                micros += duration.toNanosPart() / 1_000;
+                long micros = duration.getSeconds() * 1_000_000L;
+                micros += duration.getNano() / 1_000;
                 return micros * value;
         }
     }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -31,6 +31,9 @@ import io.questdb.std.datetime.TimeZoneRules;
 import io.questdb.std.str.Utf16Sink;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
 public final class Timestamps {
@@ -126,6 +129,31 @@ public final class Timestamps {
             _d = maxDay;
         }
         return toMicros(_y, _m, _d) + getTimeMicros(micros) + (micros < 0 ? 1 : 0);
+    }
+
+    /**
+     * Convert a timestamp in arbitrary units to microseconds.
+     *
+     * @param value timestamp value
+     * @param unit  timestamp unit
+     * @return timestamp in microseconds
+     */
+    public static long toMicros(long value, ChronoUnit unit) {
+        switch (unit) {
+            case NANOS:
+                return value / 1_000;
+            case MICROS:
+                return value;
+            case MILLIS:
+                return value * 1_000;
+            case SECONDS:
+                return value * 1_000_000;
+            default:
+                Duration duration = unit.getDuration();
+                long micros = duration.toSeconds() * 1_000_000L;
+                micros += duration.toNanosPart() / 1_000;
+                return micros * value;
+        }
     }
 
     public static long addPeriod(long lo, char type, int period) {

--- a/core/src/test/java/io/questdb/test/std/datetime/microtime/TimestampsTest.java
+++ b/core/src/test/java/io/questdb/test/std/datetime/microtime/TimestampsTest.java
@@ -40,6 +40,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.temporal.ChronoUnit;
+
 import static io.questdb.cairo.PartitionBy.getPartitionDirFormatMethod;
 import static io.questdb.std.datetime.TimeZoneRuleFactory.RESOLUTION_MICROS;
 
@@ -50,6 +52,28 @@ public class TimestampsTest {
     @Before
     public void setUp() {
         sink.clear();
+    }
+
+    @Test
+    public void testToMicros() throws Exception {
+        Assert.assertEquals(1, Timestamps.toMicros(1000, ChronoUnit.NANOS));
+        Assert.assertEquals(1, Timestamps.toMicros(1, ChronoUnit.MICROS));
+        Assert.assertEquals(1000, Timestamps.toMicros(1, ChronoUnit.MILLIS));
+        Assert.assertEquals(1_000_000, Timestamps.toMicros(1, ChronoUnit.SECONDS));
+
+        Assert.assertEquals(60 * 1000 * 1000, Timestamps.toMicros(1, ChronoUnit.MINUTES));
+        Assert.assertEquals(Long.MAX_VALUE, Timestamps.toMicros(Long.MAX_VALUE, ChronoUnit.MICROS));
+
+        Assert.assertEquals(Timestamps.toMicros(1, ChronoUnit.HOURS), Timestamps.toMicros(60, ChronoUnit.MINUTES));
+        Assert.assertEquals(0, Timestamps.toMicros(0, ChronoUnit.NANOS));
+        Assert.assertEquals(0, Timestamps.toMicros(0, ChronoUnit.MICROS));
+        Assert.assertEquals(0, Timestamps.toMicros(0, ChronoUnit.MILLIS));
+        Assert.assertEquals(0, Timestamps.toMicros(0, ChronoUnit.SECONDS));
+        Assert.assertEquals(0, Timestamps.toMicros(0, ChronoUnit.MINUTES));
+
+        // micros values remain unchanged
+        Assert.assertEquals(123456789L, Timestamps.toMicros(123456789L, ChronoUnit.MICROS));
+        Assert.assertEquals(123456789L, Timestamps.toMicros(123456789000L, ChronoUnit.NANOS));
     }
 
     @Test


### PR DESCRIPTION
Client no longer works with nanoseconds internally. Previously, even non-designated timestamps were converted to nanos only to be converted back to microseconds. The highest timestamp which can be represented in nanos in a 64-bit signed integer is 2262-04-11 23:47:16.854. Anything above this would overflow. This change converts timestamps directly to microseconds, preventing the overflow.

It also changes behavior for designated timestamps: they are now sent as microseconds instead of nanos, since the server would store them in microseconds anyway. This means even the designated timestamps now support a higher range.

The max timestamp that works reliably is 9999-12-31 23:59:59.999999 since our timestamp format compiler assumes at most 4-digit years. If we remove this limitation, we could support timestamps up to 294247-01-10T04:00:54.775807Z.

Last but not least: `WalAppender` now checks if the micros value is non-negative and throws an appropriate error when it's not. Without this check, an attempt to store a negative designated timestamp resulted in a CairoException which was propagated as an internal error. Internal errors are represented as HTTP 500 and this makes clients retry, even when it's futile in this case. An explicit check with `LineProtocolException` results in HTTP 400 which is NOT retried by clients.