### PR TITLE
perf(sql): use faster hash table in window functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/RankFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/RankFunctionFactory.java
@@ -24,13 +24,20 @@
 
 package io.questdb.griffin.engine.functions.window;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.Reopenable;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.ScalarFunction;
+import io.questdb.cairo.sql.VirtualRecord;
+import io.questdb.cairo.sql.WindowSPI;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
@@ -77,7 +84,7 @@ public class RankFunctionFactory implements FunctionFactory {
             arrayColumnTypes.add(ColumnType.LONG); // max index
             arrayColumnTypes.add(ColumnType.LONG); // current index
             arrayColumnTypes.add(ColumnType.LONG); // offset
-            Map map = MapFactory.createOrderedMap(configuration, windowContext.getPartitionByKeyTypes(), arrayColumnTypes);
+            Map map = MapFactory.createUnorderedMap(configuration, windowContext.getPartitionByKeyTypes(), arrayColumnTypes);
             return new RankFunction(map, windowContext.getPartitionByRecord(), windowContext.getPartitionBySink());
         }
         if (windowContext.isOrdered()) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
@@ -24,13 +24,22 @@
 
 package io.questdb.griffin.engine.functions.window;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.Reopenable;
+import io.questdb.cairo.SingleColumnType;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.ScalarFunction;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.cairo.sql.VirtualRecord;
+import io.questdb.cairo.sql.WindowSPI;
 import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
@@ -73,7 +82,7 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         }
 
         if (windowContext.getPartitionByRecord() != null) {
-            Map map = MapFactory.createOrderedMap(
+            Map map = MapFactory.createUnorderedMap(
                     configuration,
                     windowContext.getPartitionByKeyTypes(),
                     LONG_COLUMN_TYPE

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionUnitTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionUnitTest.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 public class WindowFunctionUnitTest extends AbstractCairoTest {
     private static final Log LOG = LogFactory.getLog(WindowFunctionUnitTest.class);
-    short[] columnTypes = new short[]{ColumnType.TIMESTAMP, ColumnType.INT, ColumnType.LONG};
+    private static final short[] columnTypes = new short[]{ColumnType.TIMESTAMP, ColumnType.INT, ColumnType.LONG};
 
     @Test
     public void testAggOverPartitionRangeFuzz() throws Exception {


### PR DESCRIPTION
For some reason `OrderedMap` was used in `WindowFunction`s while they don't seem to use the iteration order property of the hash table.