### PR TITLE
fix(core): fix table dissappear after restart if created with the naming collisions

### DIFF
--- a/core/src/main/java/io/questdb/cairo/AbstractTableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractTableNameRegistry.java
@@ -103,7 +103,7 @@ public abstract class AbstractTableNameRegistry implements TableNameRegistry {
         for (Map.Entry<CharSequence, TableToken> e : tableNameToTableTokenMap.entrySet()) {
             TableToken tableNameTableToken = e.getValue();
 
-            if (tableNameTableToken == LOCKED_TOKEN) {
+            if (TableNameRegistry.isLocked(tableNameTableToken)) {
                 continue;
             }
 

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -327,10 +327,6 @@ public class CairoEngine implements Closeable, WriterSource {
         checkpointAgent.checkpointCreate(executionContext, false);
     }
 
-    public void snapshotCreate(SqlExecutionContext executionContext) throws SqlException {
-        checkpointAgent.checkpointCreate(executionContext, true);
-    }
-
     /**
      * Recovers database from checkpoint after restoring data from a snapshot.
      */
@@ -732,6 +728,9 @@ public class CairoEngine implements Closeable, WriterSource {
         if (tableToken == TableNameRegistry.LOCKED_TOKEN) {
             return TableUtils.TABLE_RESERVED;
         }
+        if (tableToken == TableNameRegistry.LOCKED_DROP_TOKEN) {
+            return TableUtils.TABLE_DOES_NOT_EXIST;
+        }
         if (tableToken == null || !tableToken.equals(tableNameRegistry.getTableToken(tableToken.getTableName()))) {
             return TableUtils.TABLE_DOES_NOT_EXIST;
         }
@@ -1062,16 +1061,17 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     @TestOnly
-    public void reloadTableNames() {
-        reloadTableNames(null);
+    public boolean reloadTableNames() {
+        return reloadTableNames(null);
     }
 
     @TestOnly
-    public void reloadTableNames(@Nullable ObjList<TableToken> convertedTables) {
-        tableNameRegistry.reload(convertedTables);
+    public boolean reloadTableNames(@Nullable ObjList<TableToken> convertedTables) {
+        boolean consistent = tableNameRegistry.reload(convertedTables);
         try (MetadataCacheWriter metadataRW = getMetadataCache().writeLock()) {
             metadataRW.hydrateAllTables();
         }
+        return consistent;
     }
 
     public void removeTableToken(TableToken tableToken) {
@@ -1228,6 +1228,10 @@ public class CairoEngine implements Closeable, WriterSource {
         this.checkpointAgent.setWalPurgeJobRunLock(walPurgeJobRunLock);
     }
 
+    public void snapshotCreate(SqlExecutionContext executionContext) throws SqlException {
+        checkpointAgent.checkpointCreate(executionContext, true);
+    }
+
     public void unlock(
             @SuppressWarnings("unused") SecurityContext securityContext,
             TableToken tableToken,
@@ -1304,6 +1308,9 @@ public class CairoEngine implements Closeable, WriterSource {
         if (tableToken == TableNameRegistry.LOCKED_TOKEN) {
             throw CairoException.nonCritical().put("table name is reserved [table=").put(tableName).put("]");
         }
+        if (tableToken == TableNameRegistry.LOCKED_DROP_TOKEN) {
+            throw CairoException.tableDoesNotExist(tableName);
+        }
         return tableToken;
     }
 
@@ -1315,7 +1322,7 @@ public class CairoEngine implements Closeable, WriterSource {
 
     public void verifyTableToken(TableToken tableToken) {
         TableToken tt = tableNameRegistry.getTableToken(tableToken.getTableName());
-        if (tt == null || tt == TableNameRegistry.LOCKED_TOKEN) {
+        if (tt == null || TableNameRegistry.isLocked(tt)) {
             throw CairoException.tableDoesNotExist(tableToken.getTableName());
         }
         if (!tt.equals(tableToken)) {
@@ -1548,7 +1555,7 @@ public class CairoEngine implements Closeable, WriterSource {
     @NotNull
     private TableToken verifyTableNameForRead(CharSequence tableName) {
         TableToken token = getTableTokenIfExists(tableName);
-        if (token == null || token == TableNameRegistry.LOCKED_TOKEN) {
+        if (token == null || TableNameRegistry.isLocked(token)) {
             throw CairoException.tableDoesNotExist(tableName);
         }
         return token;

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
@@ -32,7 +32,12 @@ import org.jetbrains.annotations.TestOnly;
 import java.io.Closeable;
 
 public interface TableNameRegistry extends Closeable {
+    TableToken LOCKED_DROP_TOKEN = new TableToken("__locked_drop__", "__locked_drop__", Integer.MAX_VALUE - 1, false, false, false);
     TableToken LOCKED_TOKEN = new TableToken("__locked__", "__locked__", Integer.MAX_VALUE, false, false, false);
+
+    static boolean isLocked(TableToken tableToken) {
+        return tableToken == LOCKED_TOKEN || tableToken == LOCKED_DROP_TOKEN;
+    }
 
     TableToken addTableAlias(String newName, TableToken tableToken);
 
@@ -143,8 +148,9 @@ public interface TableNameRegistry extends Closeable {
      *
      * @param convertedTables - list of table tokens for tables that have just been converted from WAL to non-WAL or
      *                        other way around. This list can be null or empty if no tables have changes the layout.
+     * @return true if reload did not find any inconsistencies, useful for tests
      */
-    void reload(@Nullable ObjList<TableToken> convertedTables);
+    boolean reload(@Nullable ObjList<TableToken> convertedTables);
 
     void removeAlias(TableToken tableToken);
 

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryRO.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryRO.java
@@ -82,10 +82,10 @@ public class TableNameRegistryRO extends AbstractTableNameRegistry {
     }
 
     @Override
-    public synchronized void reload(@Nullable ObjList<TableToken> convertedTables) {
+    public synchronized boolean reload(@Nullable ObjList<TableToken> convertedTables) {
         tableNameToTableTokenMap2.clear();
         dirNameToTableTokenMap2.clear();
-        nameStore.reload(tableNameToTableTokenMap2, dirNameToTableTokenMap2, convertedTables);
+        boolean consistent = nameStore.reload(tableNameToTableTokenMap2, dirNameToTableTokenMap2, convertedTables);
 
         // Swap the maps
         setNameMaps(tableNameToTableTokenMap2, dirNameToTableTokenMap2);
@@ -99,6 +99,7 @@ public class TableNameRegistryRO extends AbstractTableNameRegistry {
         dirNameToTableTokenMap1 = tmp2;
 
         lastReloadTimestampMs = clockMs.getTicks();
+        return consistent;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -263,27 +263,7 @@ public class WriterPool extends AbstractPool {
                 throw CairoException.critical(0).put("Writer ").put(tableToken.getDirName()).put(" is not locked");
             }
 
-            if (newTable) {
-                // Note that the TableUtils.createTable method will create files, but on some OS's these files
-                // will not immediately become visible on all threads, only in this thread will they definitely
-                // be visible. To prevent spurious file system errors (or even allowing the same table to be
-                // created twice), we cache the writer in the WriterPool whose access via the engine is thread safe.
-                assert writer == null && e.lockFd != -1;
-                LOG.info().$("created [table=`").utf8(tableToken.getDirName()).$("`, thread=").$(thread).$(']').$();
-                writer = new TableWriter(
-                        configuration,
-                        tableToken,
-                        engine.getMessageBus(),
-                        null,
-                        false,
-                        e,
-                        root,
-                        engine.getDdlListener(tableToken),
-                        engine.getCheckpointStatus(),
-                        engine.getMetrics(),
-                        engine
-                );
-            }
+            assert !newTable || writer == null && e.lockFd != -1;
 
             if (writer == null) {
                 // unlock must remove entry because pool does not deal with null writer

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -46,6 +46,7 @@ import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.cairo.SymbolMapReader;
 import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.TableNameRegistry;
 import io.questdb.cairo.TableNameRegistryStore;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableReaderMetadata;
@@ -3124,7 +3125,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             boolean hasIfExists
     ) throws SqlException {
         final TableToken tableToken = executionContext.getTableTokenIfExists(tableName);
-        if (tableToken == null) {
+        if (tableToken == null || TableNameRegistry.isLocked(tableToken)) {
             if (hasIfExists) {
                 compiledQuery.ofDrop();
                 return false;

--- a/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainCleanStartupTest.java
@@ -99,7 +99,6 @@ public class ServerMainCleanStartupTest extends AbstractBootstrapTest {
                         "select table_name, ownership_reason from writer_pool where table_name in ('x','y') order by 1",
                         sink,
                         "table_name\townership_reason\n" +
-                                "x\t\n" +
                                 "y\t\n"
                 );
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpErrorHandlingTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpErrorHandlingTest.java
@@ -88,8 +88,8 @@ public class HttpErrorHandlingTest extends BootstrapTest {
                 serverMain.start();
 
                 try (HttpClient httpClient = HttpClientFactory.newPlainTextInstance(new DefaultHttpClientConfiguration())) {
-                    assertExecRequest(httpClient, "create table x(y long)", HttpURLConnection.HTTP_INTERNAL_ERROR,
-                            "{\"query\":\"create table x(y long)\",\"error\":\"Test error\",\"position\":0}"
+                    assertExecRequest(httpClient, "create table x as (select 1L y)", HttpURLConnection.HTTP_INTERNAL_ERROR,
+                            "{\"query\":\"create table x as (select 1L y)\",\"error\":\"Test error\",\"position\":0}"
                     );
                 }
             }

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGErrorHandlingTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGErrorHandlingTest.java
@@ -89,7 +89,7 @@ public class PGErrorHandlingTest extends BootstrapTest {
                 serverMain.start();
 
                 try (Connection conn = getConnection()) {
-                    conn.createStatement().execute("create table x(y long)");
+                    conn.createStatement().execute("create table x as (select 1L y)");
                     Assert.fail("Expected exception is missing");
                 } catch (PSQLException e) {
                     TestUtils.assertContains(e.getMessage(), "ERROR: Test error");

--- a/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WriterPoolTableFunctionTest.java
@@ -148,10 +148,10 @@ public class WriterPoolTableFunctionTest extends AbstractCairoTest {
     @Test
     public void testWriterList() throws Exception {
         assertMemoryLeak(() -> {
-            ddl("create table a(u int)");
-            ddl("create table b(u int)");
-            ddl("create table c(u int)");
-            ddl("create table d(u int)");
+            ddl("create table a as (select 1 as u)");
+            ddl("create table b as (select 1 as u)");
+            ddl("create table c as (select 1 as u)");
+            ddl("create table d as (select 1 as u)");
 
             assertSql(
                     "table_name\townership_reason\n" +


### PR DESCRIPTION
When the table is dropped/renamed and created with the same name concurrently it may create invalid `tables.d` file where the remove record is not saved before the second create record.

``` 
2024-10-31T15:04:15.300267Z I i.q.c.TableNameRegistryStore reloading tables file [path=/tmp/junit10391119043095694185/dbRoot2/db/tables.d.0, threadId=817]
 2024-10-31T15:04:15.300619Z C i.q.c.TableNameRegistryStore duplicate table dir to name mapping found [tableName=testFuzzReplicationManyTableWithImminentDrop_0, dirName1=testFuzzReplicationManyTableWithImminentDrop_0~10, dirName2=testFuzzReplicationManyTableWithImminentDrop_0~15]
 2024-10-31T15:04:15.300640Z A i.q.c.TableNameRegistryStore dumping table registry [file=tables.d.0, size=6446]
 2024-10-31T15:04:15.300676Z A i.q.c.TableNameRegistryStore operation=add (0), tableName=testFuzzReplicationManyTableWithImminentDrop_0, dirName=testFuzzReplicationManyTableWithImminentDrop_0~10, tableId=10, tableType=1]
 2024-10-31T15:04:15.300698Z A i.q.c.TableNameRegistryStore operation=add (0), tableName=temp_5822f658-31f6-11ee-be56-0242ac120002_testFuzzReplicationManyTableWithImminentDrop_0_1000, dirName=testFuzzReplicationManyTableWithImminentDrop_0~15, tableId=15, tableType=1]
 2024-10-31T15:04:15.300721Z A i.q.c.TableNameRegistryStore operation=remove (-1), tableName=temp_5822f658-31f6-11ee-be56-0242ac120002_testFuzzReplicationManyTableWithImminentDrop_0_1000, dirName=testFuzzReplicationManyTableWithImminentDrop_0~15, tableId=15, tableType=1]
 2024-10-31T15:04:15.300724Z A i.q.c.TableNameRegistryStore operation=add (0), tableName=testFuzzReplicationManyTableWithImminentDrop_0, dirName=testFuzzReplicationManyTableWithImminentDrop_0~15, tableId=15, tableType=1]
 2024-10-31T15:04:15.300727Z A i.q.c.TableNameRegistryStore operation=remove (-1), tableName=testFuzzReplicationManyTableWithImminentDrop_0, dirName=testFuzzReplicationManyTableWithImminentDrop_0~10, tableId=10, tableType=1]
```

the last remove line of `testFuzzReplicationManyTableWithImminentDrop_0~10` should be 2 lines up, before `TableNameRegistryStore operation=add (0), tableName=testFuzzReplicationManyTableWithImminentDrop_0, dirName=testFuzzReplicationManyTableWithImminentDrop_0~15`


