### PR TITLE
test(core): partially disabled `Files.testIsDirOrSoftLinkDir` test on Windows

### DIFF
--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -104,6 +104,8 @@ steps:
         -Dsurefire.failIfNoSpecifiedTests=false
          $(MAVEN_RUN_OPTS)"
       jdkVersionOption: $(jdk)
+    env:
+      QDB_TEST_WINDOWS_SYMLINKS: "1"
     timeoutInMinutes: 55
     condition: |
       and(
@@ -127,6 +129,8 @@ steps:
       jdkVersionOption: $(jdk)
       codeCoverageToolOption: "$(CODE_COVERAGE_TOOL_OPTION)"
       codeCoverageClassFilter: "$(COVERAGE_DIFF)"
+    env:
+      QDB_TEST_WINDOWS_SYMLINKS: "1"
     timeoutInMinutes: 55
     condition: |
       and(

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -1597,7 +1597,7 @@ public class FilesTest {
                     file.exists());
         } else {
             final File file = new File(baseDir, scenario);
-            Assert.assertTrue(file.getParentFile().mkdirs());
+            Assert.assertTrue(file.getParentFile().exists() || file.getParentFile().mkdirs());
             touch(file);
             Assert.assertTrue(
                     "Could not set up scenario: " + scenario,

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -541,28 +541,34 @@ public class FilesTest {
 
     @Test
     public void testIsDirOrSoftLinkDir() throws Exception {
-        Assume.assumeFalse(Os.isWindows());
+        // Technically, the code _should_ (and is) supported on Windows too.
+        // That said it requires Admin or Developer mode enabled on Windows. It runs just fine on CI, but fails to run
+        // on most desktop machines. On Windows this is thus hidden behind an environment variable.
+        final boolean testSymlinks = !Os.isWindows() || "1".equals(System.getenv("QDB_TEST_WINDOWS_SYMLINKS"));
         final File baseDir = temporaryFolder.newFolder();
 
         setupPath(baseDir, "empty_dir/");
         setupPath(baseDir, "file");
         setupPath(baseDir, "dir_with_a_file/file");
         setupPath(baseDir, "dir_with_an_empty_dir/dir/");
-        setupPath(baseDir, "link_to_file -> file");
-        setupPath(baseDir, "link_to_empty_dir -> empty_dir/");
-        setupPath(baseDir, "link_to_dir_with_a_file -> dir_with_a_file/");
-        setupPath(baseDir, "link_to_dir_with_an_empty_dir -> dir_with_an_empty_dir/");
-        setupPath(baseDir, "nonexistent"); // deleted later
-        setupPath(baseDir, "link_to_nonexistent -> nonexistent");
-        setupPath(baseDir, "link_to_link_to_file -> link_to_file");
-        setupPath(baseDir, "link_to_link_to_empty_dir -> link_to_empty_dir");
-        setupPath(baseDir, "link_to_link_to_dir_with_a_file -> link_to_dir_with_a_file");
-        setupPath(baseDir, "link_to_link_to_dir_with_an_empty_dir -> link_to_dir_with_an_empty_dir");
-        setupPath(baseDir, "link_to_link_to_nonexistent -> link_to_nonexistent");
 
-        final File nonexistent = new File(baseDir, "nonexistent");
-        Assert.assertTrue(nonexistent.delete());
-        Assert.assertFalse(nonexistent.exists());
+        if (testSymlinks) {
+            setupPath(baseDir, "link_to_file -> file");
+            setupPath(baseDir, "link_to_empty_dir -> empty_dir/");
+            setupPath(baseDir, "link_to_dir_with_a_file -> dir_with_a_file/");
+            setupPath(baseDir, "link_to_dir_with_an_empty_dir -> dir_with_an_empty_dir/");
+            setupPath(baseDir, "nonexistent"); // deleted later
+            setupPath(baseDir, "link_to_nonexistent -> nonexistent");
+            setupPath(baseDir, "link_to_link_to_file -> link_to_file");
+            setupPath(baseDir, "link_to_link_to_empty_dir -> link_to_empty_dir");
+            setupPath(baseDir, "link_to_link_to_dir_with_a_file -> link_to_dir_with_a_file");
+            setupPath(baseDir, "link_to_link_to_dir_with_an_empty_dir -> link_to_dir_with_an_empty_dir");
+            setupPath(baseDir, "link_to_link_to_nonexistent -> link_to_nonexistent");
+
+            final File nonexistent = new File(baseDir, "nonexistent");
+            Assert.assertTrue(nonexistent.delete());
+            Assert.assertFalse(nonexistent.exists());
+        }
 
         assertMemoryLeak(() -> {
             Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "something/that/does/not/exist"));
@@ -572,16 +578,19 @@ public class FilesTest {
             Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "dir_with_a_file/"));
             Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "dir_with_an_empty_dir/"));
             Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "dir_with_an_empty_dir/dir/.."));
-            Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_file"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_empty_dir"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_dir_with_a_file"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_dir_with_an_empty_dir"));
-            Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_nonexistent"));
-            Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_link_to_file"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_empty_dir"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_dir_with_a_file"));
-            Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_dir_with_an_empty_dir"));
-            Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_link_to_nonexistent"));
+
+            if (testSymlinks) {
+                Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_file"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_empty_dir"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_dir_with_a_file"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_dir_with_an_empty_dir"));
+                Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_nonexistent"));
+                Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_link_to_file"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_empty_dir"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_dir_with_a_file"));
+                Assert.assertTrue(isDirOrSoftLinkDir(baseDir, "link_to_link_to_dir_with_an_empty_dir"));
+                Assert.assertFalse(isDirOrSoftLinkDir(baseDir, "link_to_link_to_nonexistent"));
+            }
         });
     }
 
@@ -1578,7 +1587,7 @@ public class FilesTest {
             final String targetPathString = parts[1].replaceAll("/$", "");
             final File target = new File(baseDir, targetPathString);
             final File link = new File(baseDir, parts[0]);
-            Assert.assertTrue(link.getParentFile().mkdirs());
+            Assert.assertTrue(link.getParentFile().exists() || link.getParentFile().mkdirs());
             try (
                     Path targetPath = new Path().of(target.getAbsolutePath());
                     Path linkPath = new Path().of(link.getAbsolutePath())

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -541,6 +541,7 @@ public class FilesTest {
 
     @Test
     public void testIsDirOrSoftLinkDir() throws Exception {
+        Assume.assumeFalse(Os.isWindows());
         final File baseDir = temporaryFolder.newFolder();
 
         setupPath(baseDir, "empty_dir/");
@@ -560,7 +561,7 @@ public class FilesTest {
         setupPath(baseDir, "link_to_link_to_nonexistent -> link_to_nonexistent");
 
         final File nonexistent = new File(baseDir, "nonexistent");
-        nonexistent.delete();
+        Assert.assertTrue(nonexistent.delete());
         Assert.assertFalse(nonexistent.exists());
 
         assertMemoryLeak(() -> {
@@ -636,13 +637,13 @@ public class FilesTest {
     }
 
     @Test
-    public void testLongFd() throws Exception {
+    public void testLongFd() {
         long unuqFd = Numbers.encodeLowHighInts(1000, -1);
         Assert.assertTrue(unuqFd < 0);
     }
 
     @Test
-    public void testLongFd2() throws Exception {
+    public void testLongFd2() {
         long unuqFd = Numbers.encodeLowHighInts(Integer.MAX_VALUE, 1000);
         Assert.assertTrue(unuqFd > 0);
     }
@@ -1374,7 +1375,7 @@ public class FilesTest {
             }
             StringSink sink = Misc.getThreadLocalSink();
             Utf8s.utf8ToUtf16(buffPtr, buffPtr + size, sink);
-            TestUtils.assertEquals(fileContent, sink.toString());
+            TestUtils.assertEquals(fileContent, sink);
         } finally {
             Files.close(fd);
             Unsafe.free(buffPtr, buffSize, MemoryTag.NATIVE_DEFAULT);
@@ -1577,7 +1578,7 @@ public class FilesTest {
             final String targetPathString = parts[1].replaceAll("/$", "");
             final File target = new File(baseDir, targetPathString);
             final File link = new File(baseDir, parts[0]);
-            link.getParentFile().mkdirs();
+            Assert.assertTrue(link.getParentFile().mkdirs());
             try (
                     Path targetPath = new Path().of(target.getAbsolutePath());
                     Path linkPath = new Path().of(link.getAbsolutePath())
@@ -1590,13 +1591,13 @@ public class FilesTest {
 
         } else if (scenario.endsWith("/")) {
             final File file = new File(baseDir, scenario.replaceAll("/$", ""));
-            file.mkdirs();
+            Assert.assertTrue(file.mkdirs());
             Assert.assertTrue(
                     "Could not set up scenario: " + scenario,
                     file.exists());
         } else {
             final File file = new File(baseDir, scenario);
-            file.getParentFile().mkdirs();
+            Assert.assertTrue(file.getParentFile().mkdirs());
             touch(file);
             Assert.assertTrue(
                     "Could not set up scenario: " + scenario,


### PR DESCRIPTION
The `Files.testIsDirOrSoftLinkDir` test requires either Admin or Developer Mode privilidges on Windows.

After this PR, the test will always test the `isDir` logic, but will only execute the symlink checks on CI where the extra privilidges are present.

This change does not affect Linux and MacOS runners.