### PR TITLE
chore(core): fix partition drop failures found by fuzz tests

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnVersionWriter.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnVersionWriter.java
@@ -149,7 +149,12 @@ public class ColumnVersionWriter extends ColumnVersionReader {
                     cachedColumnVersionList.set(i + TIMESTAMP_ADDED_PARTITION_OFFSET, lastPartitionTimestamp);
                     // Because column we not really added there, put the column top to the value
                     // of the last partition row count (e.g. transientRowCount)
-                    upsert(lastPartitionTimestamp, columnIndex, columnNameTxn, transientRowCount);
+                    // Add the column top if there is no explicit record for this column, if there is one
+                    // keep the existing value.
+                    int recordIndex = getRecordIndex(lastPartitionTimestamp, columnIndex);
+                    if (recordIndex < 0) {
+                        upsert(lastPartitionTimestamp, columnIndex, columnNameTxn, transientRowCount);
+                    }
                 }
             } else {
                 break;


### PR DESCRIPTION
Fix failures found by multiple fuzz tests during the last few days.

The problem with the recent fix in `ColumnVersionWriter` that handles partition drop, it introduced an artificial column top to the partition before the dropped one if it is the latest partition. The fix is to not overwrite the existing column top for this partition if it exists.