### PR TITLE
test(core): fix fuzz drop partition test to not fail when running with drop/recreate fuzz step in parallel

### DIFF
--- a/core/src/test/java/io/questdb/test/fuzz/FuzzDropCreateTableOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzDropCreateTableOperation.java
@@ -59,6 +59,8 @@ public class FuzzDropCreateTableOperation implements FuzzTransactionOperation {
                     if (!isWal) {
                         engine.releaseInactive();
                         Os.sleep(50);
+                    } else {
+                        Os.pause();
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://dev.azure.com/questdb/questdb/_build/results?buildId=118054&view=results

```
2024-11-12T13:06:46.9734992Z 2024-11-12T13:06:46.972336Z I i.q.t.f.FuzzDropCreateTableOperation dropping table testWalWriteFullRandom_wal_parallel~2
2024-11-12T13:06:46.9801186Z 2024-11-12T13:06:46.979883Z I i.q.c.p.WriterPool open [table=`testWalWriteFullRandom_wal_parallel~2`, thread=2955]
2024-11-12T13:06:46.9805414Z 2024-11-12T13:06:46.979955Z I i.q.c.TableWriter open 'testWalWriteFullRandom_wal_parallel'
2024-11-12T13:06:46.9822395Z 2024-11-12T13:06:46.982037Z I i.q.c.TableWriter switched partition [path=/testWalWriteFullRandom_wal_parallel~2/2022-03-06]
2024-11-12T13:06:46.9832094Z 2024-11-12T13:06:46.982942Z I i.q.c.p.WriterPool >> [table=`testWalWriteFullRandom_wal_parallel~2`, thread=2955]
2024-11-12T13:06:46.9836992Z 2024-11-12T13:06:46.983449Z E i.q.g.e.QueryProgress err [id=-1, sql=`ALTER TABLE testWalWriteFullRandom_wal_parallel DROP PARTITION WHERE ts < 1645635600000000 AND ts > 1645635600000000 - 86400000000`, principal=admin, cache=false, jit=false, time=95000, msg=table does not exist [table=testWalWriteFullRandom_wal_parallel], errno=0, pos=12]
2024-11-12T13:06:46.9841648Z 2024-11-12T13:06:46.983635Z I i.q.c.p.WriterPool << [table=`testWalWriteFullRandom_wal_parallel~2`, thread=2955]
2024-11-12T13:06:46.9843062Z 2024-11-12T13:06:46.983674Z C i.q.c.w.ApplyWal2TableJob job failed, table suspended [table=testWalWriteFullRandom_wal_parallel~2, seqTxn=7, error=error applying SQL to wal table [table=testWalWriteFullRandom_wal_parallel, sql=ALTER TABLE testWalWriteFullRandom_wal_parallel DROP PARTITION WHERE ts < 1645635600000000 AND ts > 1645635600000000 - 86400000000, position=12, error=table does not exist [table=testWalWriteFullRandom_wal_parallel], errno=-1]

```