### PR TITLE
fix(sql): cross join queries not cancelling when circuit breaker is invoked

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/join/CrossJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/CrossJoinRecordCursorFactory.java
@@ -27,7 +27,10 @@ package io.questdb.griffin.engine.join;
 import io.questdb.cairo.DataUnavailableException;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -180,6 +183,7 @@ public class CrossJoinRecordCursorFactory extends AbstractJoinRecordCursorFactor
                 }
 
                 slaveCursor.toTop();
+                circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
                 isMasterHasNextPending = true;
             }
         }

--- a/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
@@ -41,7 +41,11 @@ import io.questdb.std.datetime.microtime.TimestampFormatCompiler;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.tools.TestUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -302,6 +306,45 @@ public class SecurityTest extends AbstractCairoTest {
                         engine,
                         readOnlyExecutionContext,
                         "tab order by d",
+                        sink
+                );
+                Assert.fail();
+            } catch (Exception ex) {
+                Assert.assertTrue(ex.toString().contains("Interrupting SQL processing"));
+            } finally {
+                circuitBreakerTimeoutDeadline = Long.MAX_VALUE;
+            }
+        });
+    }
+
+    @Test
+    public void testCircuitBreakerTimeoutForCrossJoin() throws Exception {
+        assertMemoryLeak(() -> {
+            sqlExecutionContext.getRandom().reset();
+            ddl(" CREATE TABLE 'bench' (\n" +
+                    "    symbol SYMBOL capacity 256 CACHE,\n" +
+                    "    timestamp TIMESTAMP,\n" +
+                    "    price DOUBLE,\n" +
+                    "    amount DOUBLE\n" +
+                    ") timestamp (timestamp) PARTITION BY DAY WAL;");
+            insert("insert into bench\n" +
+                    "select rnd_symbol('a', 'b', 'c') symbol, \n" +
+                    "rnd_timestamp('2022-03-08T00:00:00Z', '2022-03-08T23:59:59Z', 0) timestamp, \n" +
+                    "rnd_double() price, rnd_double() amount from long_sequence(100000)");
+            drainWalQueue();
+            memoryRestrictedEngine.reloadTableNames();
+
+            try {
+                setMaxCircuitBreakerChecks(Long.MAX_VALUE);
+                circuitBreakerTimeoutDeadline = MicrosecondClockImpl.INSTANCE.getTicks() + 10; // 10ms query timeout
+                TestUtils.printSql(
+                        engine,
+                        readOnlyExecutionContext,
+                        "select t1.*, t2.* from (SELECT * FROM bench LIMIT 100000) t1 \n" +
+                                "join (SELECT * FROM bench LIMIT 100000) t2 \n" +
+                                "on t1.symbol=concat(t2.price, '') and t1.symbol = cast(t2.symbol as varchar)\n" +
+                                "where t1.timestamp between '2022-03-08T00:00:00Z' and '2022-03-08T23:59:59Z'\n" +
+                                "and t2.timestamp between '2022-03-08T00:00:00Z' and '2022-03-08T23:59:59Z'",
                         sink
                 );
                 Assert.fail();

--- a/core/src/test/java/io/questdb/test/griffin/model/IntrinsicModelTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/model/IntrinsicModelTest.java
@@ -151,7 +151,6 @@ public class IntrinsicModelTest {
     public void testDateCeilYYYYMMDDHmsSU() throws NumericException {
         assertDateCeil("2015-02-28T07:21:44.556012Z", "2015-02-28T07:21:44.556011");
     }
-    //////////////////////////////
 
     @Test
     public void testDateCeilYYYYMMDDNonLeap() throws NumericException {


### PR DESCRIPTION
`CrossJoinRecordCursorFactory` was missing a circuit breaker check. We now check it after each iteration through the secondary table.