### PR TITLE
chore(core): increase min WAL apply worker pool size to 2

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -761,12 +761,12 @@ public class PropServerConfiguration implements ServerConfiguration {
         int cpuUsed = 0;
         int cpuSpare = 0;
         int cpuIoWorkers = 0;
-        int cpuWalApplyWorkers = 1;
+        int cpuWalApplyWorkers = 2;
 
         if (cpuAvailable > 8) {
-            cpuWalApplyWorkers = 2;
+            cpuWalApplyWorkers = 3;
         } else if (cpuAvailable > 16) {
-            cpuWalApplyWorkers = 2;
+            cpuWalApplyWorkers = 3;
             cpuSpare = 1;
             // tested on 4/32/48 core servers
             cpuIoWorkers = cpuAvailable / 2;


### PR DESCRIPTION
We need at least two threads to avoid slow transactions on a table leading to starvation for other tables' transactions