### PR TITLE
perf(sql): introduce fast paths for parallel keyed group by

### DIFF
--- a/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered2Map.java
@@ -57,7 +57,7 @@ import org.jetbrains.annotations.Nullable;
  * the declared column types to guarantee memory access safety.
  */
 public class Unordered2Map implements Map, Reopenable {
-    static final long KEY_SIZE = Short.BYTES;
+    public static final long KEY_SIZE = Short.BYTES;
     private static final int TABLE_SIZE = Short.toUnsignedInt((short) -1) + 1;
 
     private final Unordered2MapCursor cursor;

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -79,7 +79,7 @@ import org.jetbrains.annotations.Nullable;
  * </pre>
  */
 public class Unordered8Map implements Map, Reopenable {
-    static final long KEY_SIZE = Long.BYTES;
+    public static final long KEY_SIZE = Long.BYTES;
     private static final long MAX_SAFE_INT_POW_2 = 1L << 31;
     private static final int MIN_KEY_CAPACITY = 16;
 

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8MapValue.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8MapValue.java
@@ -24,7 +24,12 @@
 
 package io.questdb.cairo.map;
 
-import io.questdb.std.*;
+import io.questdb.std.Long256;
+import io.questdb.std.Long256Impl;
+import io.questdb.std.Long256Util;
+import io.questdb.std.Numbers;
+import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
 
 final class Unordered8MapValue implements MapValue {
     private final Long256Impl long256 = new Long256Impl();

--- a/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
@@ -84,9 +84,9 @@ import org.jetbrains.annotations.Nullable;
  * memory. The lower 63 bits are the actual pointer value.
  */
 public class UnorderedVarcharMap implements Map, Reopenable {
+    public static final long KEY_SIZE = 2 * Long.BYTES;
     static final byte FLAG_IS_ASCII = (byte) (1 << 7);
     static final byte FLAG_IS_NULL = (byte) (1 << 6);
-    static final long KEY_SIZE = 2 * Long.BYTES;
     static final int MASK_FLAGS_FROM_SIZE = 0x3FFFFFFF; // clear top 2 bits: ascii and null
     static final long PTR_UNSTABLE_MASK = 0x8000000000000000L; // 63 bits
     static final long PTR_MASK = ~PTR_UNSTABLE_MASK;

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
@@ -103,6 +103,11 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, Closea
         auxPageSizes = null;
     }
 
+    // unsafe as it can be; use at your own risk
+    public long getAuxPageAddress(int columnIndex) {
+        return auxPageAddresses.getQuick(columnIndex);
+    }
+
     @Override
     public BinarySequence getBin(int columnIndex) {
         final long dataPageAddress = pageAddresses.getQuick(columnIndex);
@@ -312,6 +317,11 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, Closea
     @Override
     public long getLongIPv4(int columnIndex) {
         return Numbers.ipv4ToLong(getIPv4(columnIndex));
+    }
+
+    // unsafe as it can be; use at your own risk
+    public long getPageAddress(int columnIndex) {
+        return pageAddresses.getQuick(columnIndex);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -290,6 +290,10 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
         return perWorkerFunctionUpdaters.getQuick(slotId);
     }
 
+    public Class<? extends Map> getMapClass() {
+        return ownerFragment.map.getClass();
+    }
+
     public RecordSink getMapSink(int slotId) {
         if (slotId == -1 || perWorkerMapSinks == null) {
             return ownerMapSink;

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -28,33 +28,36 @@ import io.questdb.MessageBus;
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.ArrayColumnTypes;
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ListColumnFilter;
-import io.questdb.cairo.RecordSink;
-import io.questdb.cairo.map.Map;
-import io.questdb.cairo.map.MapKey;
-import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered2Map;
+import io.questdb.cairo.map.Unordered4Map;
+import io.questdb.cairo.map.Unordered8Map;
+import io.questdb.cairo.map.UnorderedVarcharMap;
 import io.questdb.cairo.sql.Function;
-import io.questdb.cairo.sql.PageFrameMemory;
-import io.questdb.cairo.sql.PageFrameMemoryRecord;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
 import io.questdb.cairo.sql.async.PageFrameReduceTaskFactory;
-import io.questdb.cairo.sql.async.PageFrameReducer;
 import io.questdb.cairo.sql.async.PageFrameSequence;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
-import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.functions.groupby.CountLongConstGroupByFunction;
 import io.questdb.griffin.engine.groupby.GroupByRecordCursorFactory;
+import io.questdb.griffin.engine.table.aggr.Aggregator;
+import io.questdb.griffin.engine.table.aggr.IntKeyAggregator;
+import io.questdb.griffin.engine.table.aggr.LongKeyAggregator;
+import io.questdb.griffin.engine.table.aggr.LongKeyCountAggregator;
+import io.questdb.griffin.engine.table.aggr.ShortKeyAggregator;
+import io.questdb.griffin.engine.table.aggr.VarcharKeyAggregator;
+import io.questdb.griffin.engine.table.aggr.VarcharKeyCountAggregator;
 import io.questdb.jit.CompiledFilter;
 import io.questdb.mp.SCSequence;
 import io.questdb.std.BytecodeAssembler;
-import io.questdb.std.DirectLongList;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
@@ -63,13 +66,8 @@ import org.jetbrains.annotations.Nullable;
 
 import static io.questdb.cairo.sql.PartitionFrameCursorFactory.ORDER_ASC;
 import static io.questdb.cairo.sql.PartitionFrameCursorFactory.ORDER_DESC;
-import static io.questdb.griffin.engine.table.AsyncGroupByNotKeyedRecordCursorFactory.applyCompiledFilter;
-import static io.questdb.griffin.engine.table.AsyncGroupByNotKeyedRecordCursorFactory.applyFilter;
 
 public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory {
-    private static final PageFrameReducer AGGREGATE = AsyncGroupByRecordCursorFactory::aggregate;
-    private static final PageFrameReducer FILTER_AND_AGGREGATE = AsyncGroupByRecordCursorFactory::filterAndAggregate;
-
     private final RecordCursorFactory base;
     private final SCSequence collectSubSeq = new SCSequence();
     private final AsyncGroupByRecordCursor cursor;
@@ -123,12 +121,13 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
                     perWorkerFilters,
                     workerCount
             );
+            final Aggregator aggregator = createAggregator(listColumnFilter, keyTypes, groupByFunctions, atom);
             if (filter != null) {
                 this.frameSequence = new PageFrameSequence<>(
                         configuration,
                         messageBus,
                         atom,
-                        FILTER_AND_AGGREGATE,
+                        aggregator::filterAndAggregate,
                         reduceTaskFactory,
                         workerCount,
                         PageFrameReduceTask.TYPE_GROUP_BY
@@ -138,7 +137,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
                         configuration,
                         messageBus,
                         atom,
-                        AGGREGATE,
+                        aggregator::aggregate,
                         reduceTaskFactory,
                         workerCount,
                         PageFrameReduceTask.TYPE_GROUP_BY
@@ -208,218 +207,56 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         return base.usesIndex();
     }
 
-    private static void aggregate(
-            int workerId,
-            @NotNull PageFrameMemoryRecord record,
-            @NotNull PageFrameReduceTask task,
-            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
-            @Nullable PageFrameSequence<?> stealingFrameSequence
+    private Aggregator createAggregator(
+            ListColumnFilter columnFilter,
+            ArrayColumnTypes keyTypes,
+            ObjList<GroupByFunction> groupByFunctions,
+            AsyncGroupByAtom atom
     ) {
-        final long frameRowCount = task.getFrameRowCount();
-        assert frameRowCount > 0;
-        final AsyncGroupByAtom atom = task.getFrameSequence(AsyncGroupByAtom.class).getAtom();
-
-        final PageFrameMemory frameMemory = task.populateFrameMemory();
-        record.init(frameMemory);
-
-        final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
-        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
-        final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
-        final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
-        final RecordSink mapSink = atom.getMapSink(slotId);
-        try {
-            if (atom.isSharded()) {
-                fragment.shard();
-            }
-
-            record.setRowIndex(0);
-            long baseRowId = record.getRowId();
-
-            if (!fragment.isSharded()) {
-                aggregateNonSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
-            } else {
-                aggregateSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
-            }
-
-            atom.requestSharding(fragment);
-        } finally {
-            atom.release(slotId);
-            task.releaseFrameMemory();
+        if (
+                atom.getMapClass() == Unordered2Map.class
+                        && columnFilter.size() == 1
+                        && keyTypes.getColumnCount() == 1
+                        && keyTypes.getColumnType(0) == ColumnType.SHORT
+        ) {
+            final int index = (columnFilter.getColumnIndex(0) * columnFilter.getIndexFactor(0) - 1);
+            return new ShortKeyAggregator(index);
         }
-    }
-
-    private static void aggregateFilteredNonSharded(
-            PageFrameMemoryRecord record,
-            DirectLongList rows,
-            long baseRowId,
-            GroupByFunctionsUpdater functionUpdater,
-            AsyncGroupByAtom.MapFragment fragment,
-            RecordSink mapSink
-    ) {
-        final Map map = fragment.reopenMap();
-        for (long p = 0, n = rows.size(); p < n; p++) {
-            long r = rows.get(p);
-            record.setRowIndex(r);
-
-            final MapKey key = map.withKey();
-            mapSink.copy(record, key);
-            MapValue value = key.createValue();
-            if (value.isNew()) {
-                functionUpdater.updateNew(value, record, baseRowId + r);
-            } else {
-                functionUpdater.updateExisting(value, record, baseRowId + r);
-            }
+        if (
+                atom.getMapClass() == Unordered4Map.class
+                        && columnFilter.size() == 1
+                        && keyTypes.getColumnCount() == 1
+                        && keyTypes.getColumnType(0) == ColumnType.INT
+        ) {
+            final int index = (columnFilter.getColumnIndex(0) * columnFilter.getIndexFactor(0) - 1);
+            // There is no IntKeyCountAggregator since such combination should be handled by the .vect factory.
+            return new IntKeyAggregator(index);
         }
-    }
-
-    private static void aggregateFilteredSharded(
-            PageFrameMemoryRecord record,
-            DirectLongList rows,
-            long baseRowId,
-            GroupByFunctionsUpdater functionUpdater,
-            AsyncGroupByAtom.MapFragment fragment,
-            RecordSink mapSink
-    ) {
-        // The first map is used to write keys.
-        final Map lookupShard = fragment.getShards().getQuick(0);
-        for (long p = 0, n = rows.size(); p < n; p++) {
-            long r = rows.get(p);
-            record.setRowIndex(r);
-
-            final MapKey lookupKey = lookupShard.withKey();
-            mapSink.copy(record, lookupKey);
-            lookupKey.commit();
-            final long hashCode = lookupKey.hash();
-
-            final Map shard = fragment.getShardMap(hashCode);
-            final MapKey shardKey;
-            if (shard != lookupShard) {
-                shardKey = shard.withKey();
-                shardKey.copyFrom(lookupKey);
-            } else {
-                shardKey = lookupKey;
+        if (
+                atom.getMapClass() == Unordered8Map.class
+                        && columnFilter.size() == 1
+                        && keyTypes.getColumnCount() == 1
+                        && keyTypes.getColumnType(0) == ColumnType.LONG
+        ) {
+            final int index = (columnFilter.getColumnIndex(0) * columnFilter.getIndexFactor(0) - 1);
+            if (groupByFunctions.size() == 1 && groupByFunctions.getQuick(0) instanceof CountLongConstGroupByFunction) {
+                return new LongKeyCountAggregator(index);
             }
-
-            MapValue shardValue = shardKey.createValue(hashCode);
-            if (shardValue.isNew()) {
-                functionUpdater.updateNew(shardValue, record, baseRowId + r);
-            } else {
-                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
-            }
+            return new LongKeyAggregator(index);
         }
-    }
-
-    private static void aggregateNonSharded(
-            PageFrameMemoryRecord record,
-            long frameRowCount,
-            long baseRowId,
-            GroupByFunctionsUpdater functionUpdater,
-            AsyncGroupByAtom.MapFragment fragment,
-            RecordSink mapSink
-    ) {
-        final Map map = fragment.reopenMap();
-        for (long r = 0; r < frameRowCount; r++) {
-            record.setRowIndex(r);
-
-            final MapKey key = map.withKey();
-            mapSink.copy(record, key);
-            MapValue value = key.createValue();
-            if (value.isNew()) {
-                functionUpdater.updateNew(value, record, baseRowId + r);
-            } else {
-                functionUpdater.updateExisting(value, record, baseRowId + r);
+        if (
+                atom.getMapClass() == UnorderedVarcharMap.class
+                        && columnFilter.size() == 1
+                        && keyTypes.getColumnCount() == 1
+                        && keyTypes.getColumnType(0) == ColumnType.VARCHAR
+        ) {
+            final int index = (columnFilter.getColumnIndex(0) * columnFilter.getIndexFactor(0) - 1);
+            if (groupByFunctions.size() == 1 && groupByFunctions.getQuick(0) instanceof CountLongConstGroupByFunction) {
+                return new VarcharKeyCountAggregator(index);
             }
+            return new VarcharKeyAggregator(index);
         }
-    }
-
-    private static void aggregateSharded(
-            PageFrameMemoryRecord record,
-            long frameRowCount,
-            long baseRowId,
-            GroupByFunctionsUpdater functionUpdater,
-            AsyncGroupByAtom.MapFragment fragment,
-            RecordSink mapSink
-    ) {
-        // The first map is used to write keys.
-        final Map lookupShard = fragment.getShards().getQuick(0);
-        for (long r = 0; r < frameRowCount; r++) {
-            record.setRowIndex(r);
-
-            final MapKey lookupKey = lookupShard.withKey();
-            mapSink.copy(record, lookupKey);
-            lookupKey.commit();
-            final long hashCode = lookupKey.hash();
-
-            final Map shard = fragment.getShardMap(hashCode);
-            final MapKey shardKey;
-            if (shard != lookupShard) {
-                shardKey = shard.withKey();
-                shardKey.copyFrom(lookupKey);
-            } else {
-                shardKey = lookupKey;
-            }
-
-            MapValue shardValue = shardKey.createValue(hashCode);
-            if (shardValue.isNew()) {
-                functionUpdater.updateNew(shardValue, record, baseRowId + r);
-            } else {
-                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
-            }
-        }
-    }
-
-    private static void filterAndAggregate(
-            int workerId,
-            @NotNull PageFrameMemoryRecord record,
-            @NotNull PageFrameReduceTask task,
-            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
-            @Nullable PageFrameSequence<?> stealingFrameSequence
-    ) {
-        final DirectLongList rows = task.getFilteredRows();
-        final PageFrameSequence<AsyncGroupByAtom> frameSequence = task.getFrameSequence(AsyncGroupByAtom.class);
-
-        final PageFrameMemory frameMemory = task.populateFrameMemory();
-        record.init(frameMemory);
-
-        rows.clear();
-
-        final long frameRowCount = task.getFrameRowCount();
-        assert frameRowCount > 0;
-        final AsyncGroupByAtom atom = frameSequence.getAtom();
-
-        final boolean owner = stealingFrameSequence != null && stealingFrameSequence == frameSequence;
-        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
-        final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
-        final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
-        final CompiledFilter compiledFilter = atom.getCompiledFilter();
-        final Function filter = atom.getFilter(slotId);
-        final RecordSink mapSink = atom.getMapSink(slotId);
-        try {
-            if (compiledFilter == null || frameSequence.getPageFrameAddressCache().hasColumnTops(task.getFrameIndex())) {
-                // Use Java-based filter when there is no compiled filter or in case of a page frame with column tops.
-                applyFilter(filter, rows, record, frameRowCount);
-            } else {
-                applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
-            }
-
-            if (atom.isSharded()) {
-                fragment.shard();
-            }
-
-            record.setRowIndex(0);
-            long baseRowId = record.getRowId();
-
-            if (!fragment.isSharded()) {
-                aggregateFilteredNonSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
-            } else {
-                aggregateFilteredSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
-            }
-
-            atom.requestSharding(fragment);
-        } finally {
-            atom.release(slotId);
-            task.releaseFrameMemory();
-        }
+        return GenericAggregator.INSTANCE;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/GenericAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/GenericAggregator.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.Map;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.aggr.AbstractAggregator;
+import io.questdb.std.DirectLongList;
+
+/**
+ * Generic aggregator that handles any keys and map combination.
+ */
+public class GenericAggregator extends AbstractAggregator {
+    public static final GenericAggregator INSTANCE = new GenericAggregator();
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Map map = fragment.reopenMap();
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            long r = rows.get(p);
+            record.setRowIndex(r);
+
+            final MapKey key = map.withKey();
+            mapSink.copy(record, key);
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        // The first map is used to write keys.
+        final Map lookupShard = fragment.getShards().getQuick(0);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            long r = rows.get(p);
+            record.setRowIndex(r);
+
+            final MapKey lookupKey = lookupShard.withKey();
+            mapSink.copy(record, lookupKey);
+            lookupKey.commit();
+            final long hashCode = lookupKey.hash();
+
+            final Map shard = fragment.getShardMap(hashCode);
+            final MapKey shardKey;
+            if (shard != lookupShard) {
+                shardKey = shard.withKey();
+                shardKey.copyFrom(lookupKey);
+            } else {
+                shardKey = lookupKey;
+            }
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Map map = fragment.reopenMap();
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+
+            final MapKey key = map.withKey();
+            mapSink.copy(record, key);
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        // The first map is used to write keys.
+        final Map lookupShard = fragment.getShards().getQuick(0);
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+
+            final MapKey lookupKey = lookupShard.withKey();
+            mapSink.copy(record, lookupKey);
+            lookupKey.commit();
+            final long hashCode = lookupKey.hash();
+
+            final Map shard = fragment.getShardMap(hashCode);
+            final MapKey shardKey;
+            if (shard != lookupShard) {
+                shardKey = shard.withKey();
+                shardKey.copyFrom(lookupKey);
+            } else {
+                shardKey = lookupKey;
+            }
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/AbstractAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/AbstractAggregator.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.PageFrameMemory;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.async.PageFrameReduceTask;
+import io.questdb.cairo.sql.async.PageFrameSequence;
+import io.questdb.cairo.vm.api.MemoryCARW;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.jit.CompiledFilter;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class AbstractAggregator implements Aggregator {
+
+    public static void applyCompiledFilter(
+            CompiledFilter compiledFilter,
+            MemoryCARW bindVarMemory,
+            ObjList<Function> bindVarFunctions,
+            PageFrameReduceTask task
+    ) {
+        task.populateJitData();
+        final DirectLongList data = task.getDataAddresses();
+        final DirectLongList varSizeAux = task.getAuxAddresses();
+        final DirectLongList rows = task.getFilteredRows();
+        long hi = compiledFilter.call(
+                data.getAddress(),
+                data.size(),
+                varSizeAux.getAddress(),
+                bindVarMemory.getAddress(),
+                bindVarFunctions.size(),
+                rows.getAddress(),
+                task.getFrameRowCount(),
+                0
+        );
+        rows.setPos(hi);
+    }
+
+    public static void applyFilter(Function filter, DirectLongList rows, PageFrameMemoryRecord record, long frameRowCount) {
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+            if (filter.getBool(record)) {
+                rows.add(r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregate(
+            int workerId,
+            @NotNull PageFrameMemoryRecord record,
+            @NotNull PageFrameReduceTask task,
+            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
+            @Nullable PageFrameSequence<?> stealingFrameSequence
+    ) {
+        final long frameRowCount = task.getFrameRowCount();
+        assert frameRowCount > 0;
+        final AsyncGroupByAtom atom = task.getFrameSequence(AsyncGroupByAtom.class).getAtom();
+
+        final PageFrameMemory frameMemory = task.populateFrameMemory();
+        record.init(frameMemory);
+
+        final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
+        final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
+        final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
+        final RecordSink mapSink = atom.getMapSink(slotId);
+        try {
+            if (atom.isSharded()) {
+                fragment.shard();
+            }
+
+            record.setRowIndex(0);
+            long baseRowId = record.getRowId();
+
+            if (!fragment.isSharded()) {
+                aggregateNonSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
+            } else {
+                aggregateSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
+            }
+
+            atom.requestSharding(fragment);
+        } finally {
+            atom.release(slotId);
+            task.releaseFrameMemory();
+        }
+    }
+
+    @Override
+    public void filterAndAggregate(
+            int workerId,
+            @NotNull PageFrameMemoryRecord record,
+            @NotNull PageFrameReduceTask task,
+            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
+            @Nullable PageFrameSequence<?> stealingFrameSequence
+    ) {
+        final DirectLongList rows = task.getFilteredRows();
+        final PageFrameSequence<AsyncGroupByAtom> frameSequence = task.getFrameSequence(AsyncGroupByAtom.class);
+
+        final PageFrameMemory frameMemory = task.populateFrameMemory();
+        record.init(frameMemory);
+
+        rows.clear();
+
+        final long frameRowCount = task.getFrameRowCount();
+        assert frameRowCount > 0;
+        final AsyncGroupByAtom atom = frameSequence.getAtom();
+
+        final boolean owner = stealingFrameSequence != null && stealingFrameSequence == frameSequence;
+        final int slotId = atom.maybeAcquire(workerId, owner, circuitBreaker);
+        final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
+        final AsyncGroupByAtom.MapFragment fragment = atom.getFragment(slotId);
+        final CompiledFilter compiledFilter = atom.getCompiledFilter();
+        final Function filter = atom.getFilter(slotId);
+        final RecordSink mapSink = atom.getMapSink(slotId);
+        try {
+            if (compiledFilter == null || frameSequence.getPageFrameAddressCache().hasColumnTops(task.getFrameIndex())) {
+                // Use Java-based filter when there is no compiled filter or in case of a page frame with column tops.
+                applyFilter(filter, rows, record, frameRowCount);
+            } else {
+                applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
+            }
+
+            if (atom.isSharded()) {
+                fragment.shard();
+            }
+
+            record.setRowIndex(0);
+            long baseRowId = record.getRowId();
+
+            if (!fragment.isSharded()) {
+                aggregateFilteredNonSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
+            } else {
+                aggregateFilteredSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
+            }
+
+            atom.requestSharding(fragment);
+        } finally {
+            atom.release(slotId);
+            task.releaseFrameMemory();
+        }
+    }
+
+    protected abstract void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    );
+
+    protected abstract void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    );
+
+    protected abstract void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    );
+
+    protected abstract void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    );
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/Aggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/Aggregator.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.async.PageFrameReduceTask;
+import io.questdb.cairo.sql.async.PageFrameSequence;
+import io.questdb.griffin.engine.table.AsyncGroupByRecordCursorFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles keyed aggregations issued by {@link AsyncGroupByRecordCursorFactory}.
+ */
+public interface Aggregator {
+
+    void aggregate(
+            int workerId,
+            @NotNull PageFrameMemoryRecord record,
+            @NotNull PageFrameReduceTask task,
+            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
+            @Nullable PageFrameSequence<?> stealingFrameSequence
+    );
+
+    void filterAndAggregate(
+            int workerId,
+            @NotNull PageFrameMemoryRecord record,
+            @NotNull PageFrameReduceTask task,
+            @NotNull SqlExecutionCircuitBreaker circuitBreaker,
+            @Nullable PageFrameSequence<?> stealingFrameSequence
+    );
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/IntKeyAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/IntKeyAggregator.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered4Map;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Hash;
+import io.questdb.std.Unsafe;
+
+public class IntKeyAggregator extends AbstractAggregator {
+    private final int columnIndex;
+
+    public IntKeyAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered4Map map = (Unordered4Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 2);
+            final int v = Unsafe.getUnsafe().getInt(addr);
+
+            final MapKey key = map.withKey();
+            key.putInt(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 2);
+            final int v = Unsafe.getUnsafe().getInt(addr);
+
+            final long hashCode = Hash.hashInt64(v);
+
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putInt(v);
+
+            record.setRowIndex(r);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered4Map map = (Unordered4Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 4) {
+            final int v = Unsafe.getUnsafe().getInt(addr);
+
+            final MapKey key = map.withKey();
+            key.putInt(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 4) {
+            final int v = Unsafe.getUnsafe().getInt(addr);
+
+            final long hashCode = Hash.hashInt64(v);
+
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putInt(v);
+
+            record.setRowIndex(r);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/LongKeyAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/LongKeyAggregator.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered8Map;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Hash;
+import io.questdb.std.Unsafe;
+
+public class LongKeyAggregator extends AbstractAggregator {
+    private final int columnIndex;
+
+    public LongKeyAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered8Map map = (Unordered8Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 3);
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final MapKey key = map.withKey();
+            key.putLong(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 3);
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final long hashCode = Hash.hashLong64(v);
+
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putLong(v);
+
+            record.setRowIndex(r);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered8Map map = (Unordered8Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 8) {
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final MapKey key = map.withKey();
+            key.putLong(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 8) {
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final long hashCode = Hash.hashLong64(v);
+
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putLong(v);
+
+            record.setRowIndex(r);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/LongKeyCountAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/LongKeyCountAggregator.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered8Map;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Hash;
+import io.questdb.std.Unsafe;
+
+public class LongKeyCountAggregator extends AbstractAggregator {
+    private final int columnIndex;
+
+    public LongKeyCountAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered8Map map = (Unordered8Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 3);
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final MapKey key = map.withKey();
+            key.putLong(v);
+
+            MapValue value = key.createValue();
+            // Unordered8Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + Unordered8Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 3);
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final long hashCode = Hash.hashLong64(v);
+
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putLong(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            // Unordered8Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = shardValue.getStartAddress() + Unordered8Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered8Map map = (Unordered8Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        final long lim = startAddr + 8 * frameRowCount;
+        for (long addr = startAddr; addr < lim; addr += 8) {
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final MapKey key = map.withKey();
+            key.putLong(v);
+
+            MapValue value = key.createValue();
+            // Unordered8Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + Unordered8Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final long startAddr = record.getPageAddress(columnIndex);
+        final long lim = startAddr + 8 * frameRowCount;
+        for (long addr = startAddr; addr < lim; addr += 8) {
+            final long v = Unsafe.getUnsafe().getLong(addr);
+
+            final long hashCode = Hash.hashLong64(v);
+
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putLong(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            // Unordered8Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = shardValue.getStartAddress() + Unordered8Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/ShortKeyAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/ShortKeyAggregator.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered2Map;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Unsafe;
+
+public class ShortKeyAggregator extends AbstractAggregator {
+    private final int columnIndex;
+
+    public ShortKeyAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered2Map map = (Unordered2Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 1);
+            final short v = Unsafe.getUnsafe().getShort(addr);
+
+            final MapKey key = map.withKey();
+            key.putShort(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        throw new UnsupportedOperationException("Unordered2Map does not support sharding");
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered2Map map = (Unordered2Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 2) {
+            final short v = Unsafe.getUnsafe().getShort(addr);
+
+            final MapKey key = map.withKey();
+            key.putShort(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        throw new UnsupportedOperationException("Unordered2Map does not support sharding");
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/ShortKeyCountAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/ShortKeyCountAggregator.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.Unordered2Map;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Unsafe;
+
+public class ShortKeyCountAggregator extends AbstractAggregator {
+    private final int columnIndex;
+
+    public ShortKeyCountAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered2Map map = (Unordered2Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            final long addr = startAddr + (r << 1);
+            final short v = Unsafe.getUnsafe().getShort(addr);
+
+            final MapKey key = map.withKey();
+            key.putShort(v);
+
+            MapValue value = key.createValue();
+            // Unordered2Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + Unordered2Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        throw new UnsupportedOperationException("Unordered2Map does not support sharding");
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final Unordered2Map map = (Unordered2Map) fragment.reopenMap();
+        final long startAddr = record.getPageAddress(columnIndex);
+        for (long r = 0, addr = startAddr; r < frameRowCount; r++, addr += 2) {
+            final short v = Unsafe.getUnsafe().getShort(addr);
+
+            final MapKey key = map.withKey();
+            key.putShort(v);
+
+            record.setRowIndex(r);
+
+            MapValue value = key.createValue();
+            // Unordered2Map zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + Unordered2Map.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        throw new UnsupportedOperationException("Unordered2Map does not support sharding");
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/VarcharKeyAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/VarcharKeyAggregator.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.UnorderedVarcharMap;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Hash;
+import io.questdb.std.str.Utf8Sequence;
+
+public class VarcharKeyAggregator extends AbstractAggregator {
+    private static final long NULL_HASH_CODE = Hash.hashMem64(0, 0);
+
+    private final int columnIndex;
+
+    public VarcharKeyAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final UnorderedVarcharMap map = (UnorderedVarcharMap) fragment.reopenMap();
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final MapKey key = map.withKey();
+            key.putVarchar(v);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final long hashCode = v != null ? Hash.hashMem64(v.ptr(), v.size()) : NULL_HASH_CODE;
+
+            final UnorderedVarcharMap shard = (UnorderedVarcharMap) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putVarchar(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final UnorderedVarcharMap map = (UnorderedVarcharMap) fragment.reopenMap();
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final MapKey key = map.withKey();
+            key.putVarchar(v);
+
+            MapValue value = key.createValue();
+            if (value.isNew()) {
+                functionUpdater.updateNew(value, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(value, record, baseRowId + r);
+            }
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final long hashCode = v != null ? Hash.hashMem64(v.ptr(), v.size()) : NULL_HASH_CODE;
+
+            final UnorderedVarcharMap shard = (UnorderedVarcharMap) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putVarchar(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            if (shardValue.isNew()) {
+                functionUpdater.updateNew(shardValue, record, baseRowId + r);
+            } else {
+                functionUpdater.updateExisting(shardValue, record, baseRowId + r);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/aggr/VarcharKeyCountAggregator.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/aggr/VarcharKeyCountAggregator.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table.aggr;
+
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.UnorderedVarcharMap;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
+import io.questdb.griffin.engine.table.AsyncGroupByAtom;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Hash;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.Utf8Sequence;
+
+public class VarcharKeyCountAggregator extends AbstractAggregator {
+    private static final long NULL_HASH_CODE = Hash.hashMem64(0, 0);
+
+    private final int columnIndex;
+
+    public VarcharKeyCountAggregator(int columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public void aggregateFilteredNonSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final UnorderedVarcharMap map = (UnorderedVarcharMap) fragment.reopenMap();
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final MapKey key = map.withKey();
+            key.putVarchar(v);
+
+            MapValue value = key.createValue();
+            // UnorderedVarcharMap zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + UnorderedVarcharMap.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    public void aggregateFilteredSharded(
+            PageFrameMemoryRecord record,
+            DirectLongList rows,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        for (long p = 0, n = rows.size(); p < n; p++) {
+            final long r = rows.get(p);
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final long hashCode = v != null ? Hash.hashMem64(v.ptr(), v.size()) : NULL_HASH_CODE;
+
+            final UnorderedVarcharMap shard = (UnorderedVarcharMap) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putVarchar(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            // UnorderedVarcharMap zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = shardValue.getStartAddress() + UnorderedVarcharMap.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    protected void aggregateNonSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        final UnorderedVarcharMap map = (UnorderedVarcharMap) fragment.reopenMap();
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final MapKey key = map.withKey();
+            key.putVarchar(v);
+
+            MapValue value = key.createValue();
+            // UnorderedVarcharMap zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = value.getStartAddress() + UnorderedVarcharMap.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+
+    @Override
+    protected void aggregateSharded(
+            PageFrameMemoryRecord record,
+            long frameRowCount,
+            long baseRowId,
+            GroupByFunctionsUpdater functionUpdater,
+            AsyncGroupByAtom.MapFragment fragment,
+            RecordSink mapSink
+    ) {
+        for (long r = 0; r < frameRowCount; r++) {
+            record.setRowIndex(r);
+            final Utf8Sequence v = record.getVarcharA(columnIndex);
+
+            final long hashCode = v != null ? Hash.hashMem64(v.ptr(), v.size()) : NULL_HASH_CODE;
+
+            final UnorderedVarcharMap shard = (UnorderedVarcharMap) fragment.getShardMap(hashCode);
+            final MapKey shardKey = shard.withKey();
+            shardKey.putVarchar(v);
+
+            MapValue shardValue = shardKey.createValue(hashCode);
+            // UnorderedVarcharMap zeroes all keys and values, so we can add 1 even in case of a new value.
+            long valueAddr = shardValue.getStartAddress() + UnorderedVarcharMap.KEY_SIZE;
+            Unsafe.getUnsafe().putLong(valueAddr, Unsafe.getUnsafe().getLong(valueAddr) + 1);
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/std/Hash.java
+++ b/core/src/main/java/io/questdb/std/Hash.java
@@ -74,6 +74,11 @@ public final class Hash {
         return fmix64(k);
     }
 
+    // unrolled version of hashMem64() for <long, int> input
+    public static long hashLongInt64(long lv, int iv) {
+        return fmix64(lv * M2 + iv);
+    }
+
     /**
      * Calculates integer hash for the given chunk of native memory using a polynomial hash function.
      * Suitable for potentially large sequences of bytes.

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -118,6 +118,7 @@ open module io.questdb {
     exports io.questdb.griffin.engine.functions.json;
     exports io.questdb.std.filewatch;
     exports io.questdb.griffin.engine.table.parquet;
+    exports io.questdb.griffin.engine.table.aggr;
 
     provides io.questdb.griffin.FunctionFactory with
 


### PR DESCRIPTION
Depends on #5152 (it's simply easier to measure improvements this way)

Introduces fast path implementations for certain key and value type combinations in parallel keyed group by. This is done by the new `Aggregator` interface which has generic and specialized implementations, e.g. for long key + count() aggregate function combination.