### PR TITLE
test(core): speed up tests by 30s

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
@@ -25,7 +25,13 @@
 package io.questdb.test.cairo;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCMARW;
@@ -137,6 +143,7 @@ public class TableReadFailTest extends AbstractCairoTest {
 
                 // this should time out
                 try {
+                    spinLockTimeout = 100;
                     reader.reload();
                     Assert.fail();
                 } catch (CairoException e) {
@@ -213,17 +220,19 @@ public class TableReadFailTest extends AbstractCairoTest {
         CreateTableTestUtils.createAllTable(engine, PartitionBy.DAY);
         TestUtils.assertMemoryLeak(() -> {
             try {
-                newOffPoolReader(new DefaultTestCairoConfiguration(root) {
-                    @Override
-                    public @NotNull FilesFacade getFilesFacade() {
-                        return ff;
-                    }
+                newOffPoolReader(
+                        new DefaultTestCairoConfiguration(root) {
+                            @Override
+                            public @NotNull FilesFacade getFilesFacade() {
+                                return ff;
+                            }
 
-                    @Override
-                    public long getSpinLockTimeout() {
-                        return 1;
-                    }
-                }, "all").close();
+                            @Override
+                            public long getSpinLockTimeout() {
+                                return 1;
+                            }
+                        }, "all"
+                ).close();
                 Assert.fail();
             } catch (CairoException ignore) {
             }

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableFailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableFailureTest.java
@@ -1836,6 +1836,8 @@ public class WalTableFailureTest extends AbstractCairoTest {
             // Table should be suspended
             execute("update " + tableName + " set x = 1111");
 
+            // minimize time spent opening metadata that cannot be opened
+            spinLockTimeout = 100;
             drainWalQueue();
 
             Assert.assertTrue(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName(tableName)));

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableO3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableO3MaxLagTest.java
@@ -255,6 +255,8 @@ public class AlterTableO3MaxLagTest extends AbstractCairoTest {
             }
 
             engine.releaseAllReaders();
+            // change spin timeout for the test to fail faster
+            spinLockTimeout = 100;
             try (TableReader ignored = getReader("X")) {
                 Assert.fail();
             } catch (CairoException ignored) {


### PR DESCRIPTION
Tests that expect metadata reload to fail wait too long. The default spinLockTimeout is 5s, which is what those test would end up needlessly spending. While in spin lock they also hammer FS, which can take longer on slower disks.