### PR TITLE
chore(core): pickup web console 0.6.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.6.4</web.console.version>
+        <web.console.version>0.6.5</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 


### PR DESCRIPTION
Changed:

- use a new information_schema.questdb_columns() instead of information_schema.columns()