### PR TITLE
feat(ilp): introduce config property to disable logging problematic ILP messages

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -497,6 +497,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private int jsonQueryConnectionCheckFrequency;
     private int jsonQueryDoubleScale;
     private int jsonQueryFloatScale;
+    private boolean lineLogMessageOnError;
     private long lineTcpCommitIntervalDefault;
     private double lineTcpCommitIntervalFraction;
     private int lineTcpConnectionPoolInitialCapacity;
@@ -1389,6 +1390,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     this.lineTcpCommitIntervalDefault = COMMIT_INTERVAL_DEFAULT;
                 }
                 this.lineTcpAuthDB = getString(properties, env, PropertyKey.LINE_TCP_AUTH_DB_PATH, null);
+                this.lineLogMessageOnError = getBoolean(properties, env, PropertyKey.LINE_LOG_MESSAGE_ON_ERROR, true);
                 // deprecated
                 String defaultTcpPartitionByProperty = getString(properties, env, PropertyKey.LINE_TCP_DEFAULT_PARTITION_BY, "DAY");
                 defaultTcpPartitionByProperty = getString(properties, env, PropertyKey.LINE_DEFAULT_PARTITION_BY, defaultTcpPartitionByProperty);
@@ -3769,6 +3771,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropLineHttpProcessorConfiguration implements LineHttpProcessorConfiguration {
+
         @Override
         public boolean autoCreateNewColumns() {
             return ilpAutoCreateNewColumns;
@@ -3828,9 +3831,15 @@ public class PropServerConfiguration implements ServerConfiguration {
         public boolean isUseLegacyStringDefault() {
             return useLegacyStringDefault;
         }
+
+        @Override
+        public boolean logMessageOnError() {
+            return lineLogMessageOnError;
+        }
     }
 
     private class PropLineTcpIOWorkerPoolConfiguration implements WorkerPoolConfiguration {
+
         @Override
         public long getNapThreshold() {
             return lineTcpIOWorkerNapThreshold;
@@ -3868,6 +3877,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropLineTcpReceiverConfiguration implements LineTcpReceiverConfiguration {
+
         @Override
         public String getAuthDB() {
             return lineTcpAuthDB;
@@ -4019,6 +4029,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isUseLegacyStringDefault() {
             return useLegacyStringDefault;
+        }
+
+        @Override
+        public boolean logMessageOnError() {
+            return lineLogMessageOnError;
         }
     }
 

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -363,6 +363,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     LINE_TCP_NET_IO_QUEUE_CAPACITY("line.tcp.net.io.queue.capacity"),
     LINE_TCP_IO_AGGRESSIVE_RECV("line.tcp.io.aggressive.recv"),
     LINE_HTTP_HEADER_MAX_SIZE("line.http.header.max.size"),
+    LINE_LOG_MESSAGE_ON_ERROR("line.log.message.on.error"),
     METRICS_ENABLED("metrics.enabled"),
     NET_TEST_CONNECTION_BUFFER_SIZE("net.test.connection.buffer.size"),
     PG_ENABLED("pg.enabled"),

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
-
     protected final MimeTypesCache mimeTypesCache;
     private final IODispatcherConfiguration dispatcherConfiguration;
     private final HttpContextConfiguration httpContextConfiguration;
@@ -206,16 +205,17 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     @Override
-    public boolean preAllocateBuffers() {
-        return false;
-    }
-
-    @Override
     public boolean isQueryCacheEnabled() {
         return true;
     }
 
+    @Override
+    public boolean preAllocateBuffers() {
+        return false;
+    }
+
     public class DefaultJsonQueryProcessorConfiguration implements JsonQueryProcessorConfiguration {
+
         @Override
         public int getConnectionCheckFrequency() {
             return 1_000_000;
@@ -263,6 +263,7 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
     }
 
     public class DefaultLineHttpProcessorConfiguration implements LineHttpProcessorConfiguration {
+
         @Override
         public boolean autoCreateNewColumns() {
             return lineHttpProcessorConfiguration.autoCreateNewColumns();
@@ -320,6 +321,11 @@ public class DefaultHttpServerConfiguration implements HttpServerConfiguration {
 
         @Override
         public boolean isUseLegacyStringDefault() {
+            return true;
+        }
+
+        @Override
+        public boolean logMessageOnError() {
             return true;
         }
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorConfiguration.java
@@ -28,6 +28,7 @@ import io.questdb.cutlass.line.LineTcpTimestampAdapter;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 
 public interface LineHttpProcessorConfiguration {
+
     boolean autoCreateNewColumns();
 
     boolean autoCreateNewTables();
@@ -51,4 +52,6 @@ public interface LineHttpProcessorConfiguration {
     boolean isStringToCharCastAllowed();
 
     boolean isUseLegacyStringDefault();
+
+    boolean logMessageOnError();
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -207,4 +207,9 @@ public class DefaultLineTcpReceiverConfiguration implements LineTcpReceiverConfi
     public boolean isUseLegacyStringDefault() {
         return false;
     }
+
+    @Override
+    public boolean logMessageOnError() {
+        return true;
+    }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
@@ -100,4 +100,6 @@ public interface LineTcpReceiverConfiguration {
     boolean isStringToCharCastAllowed();
 
     boolean isUseLegacyStringDefault();
+
+    boolean logMessageOnError();
 }

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -587,11 +587,14 @@ cairo.sql.copy.root=import
 
 #line.default.partition.by=DAY
 
-# Enable / Disable  automatic creation of new columns in existing tables via ILP. When set to false overrides value of line.auto.create.new.tables to false
+# Enable / Disable automatic creation of new columns in existing tables via ILP. When set to false overrides value of line.auto.create.new.tables to false
 #line.auto.create.new.columns=true
 
 # Enable / Disable automatic creation of new tables via ILP.
 #line.auto.create.new.tables=true
+
+# Enable / Disable printing problematic ILP messages in case of errors.
+#line.log.message.on.error=true
 
 ################ LINE UDP settings ##################
 
@@ -683,7 +686,7 @@ cairo.sql.copy.root=import
 
 #line.http.enabled=true
 
-#line.http.ping.version=v2.2.2
+#line.http.ping.version=v2.7.4
 
 ################ PG Wire settings ##################
 

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -339,6 +339,7 @@ public class PropServerConfigurationTest {
 
         // influxdb line TCP protocol
         Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().isEnabled());
+        Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().logMessageOnError());
         Assert.assertEquals(256, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getLimit());
         Assert.assertEquals(0, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getBindIPv4Address());
         Assert.assertEquals(9009, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getBindPort());
@@ -381,6 +382,8 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(ColumnType.LONG, configuration.getLineTcpReceiverConfiguration().getDefaultColumnTypeForInteger());
         Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().isUseLegacyStringDefault());
         Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().getDisconnectOnError());
+
+        Assert.assertTrue(configuration.getHttpServerConfiguration().getLineHttpProcessorConfiguration().logMessageOnError());
 
         Assert.assertTrue(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
         Assert.assertEquals("HTTP/1.1 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());
@@ -1072,7 +1075,6 @@ public class PropServerConfigurationTest {
             Assert.assertSame(FilesFacadeImpl.INSTANCE, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getFilesFacade());
             Assert.assertEquals("Keep-Alive: timeout=10, max=50000" + Misc.EOL, configuration.getHttpServerConfiguration().getJsonQueryProcessorConfiguration().getKeepAliveHeader());
 
-
             Assert.assertEquals(167903521, configuration.getLineUdpReceiverConfiguration().getBindIPv4Address());
             Assert.assertEquals(9915, configuration.getLineUdpReceiverConfiguration().getPort());
             Assert.assertEquals(-536805119, configuration.getLineUdpReceiverConfiguration().getGroupIPv4Address());
@@ -1087,6 +1089,7 @@ public class PropServerConfigurationTest {
 
             // influxdb line TCP protocol
             Assert.assertTrue(configuration.getLineTcpReceiverConfiguration().isEnabled());
+            Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().logMessageOnError());
             Assert.assertEquals(11, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getLimit());
             Assert.assertEquals(167903521, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getBindIPv4Address());
             Assert.assertEquals(9916, configuration.getLineTcpReceiverConfiguration().getDispatcherConfiguration().getBindPort());
@@ -1121,6 +1124,8 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(ColumnType.FLOAT, configuration.getLineTcpReceiverConfiguration().getDefaultColumnTypeForFloat());
             Assert.assertEquals(ColumnType.INT, configuration.getLineTcpReceiverConfiguration().getDefaultColumnTypeForInteger());
             Assert.assertFalse(configuration.getLineTcpReceiverConfiguration().getDisconnectOnError());
+
+            Assert.assertFalse(configuration.getHttpServerConfiguration().getLineHttpProcessorConfiguration().logMessageOnError());
 
             Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getServerKeepAlive());
             Assert.assertEquals("HTTP/1.0 ", configuration.getHttpServerConfiguration().getHttpContextConfiguration().getHttpVersion());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -443,6 +443,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "http.worker.sleep.timeout\tQDB_HTTP_WORKER_SLEEP_TIMEOUT\t10\tdefault\tfalse\tfalse\n" +
                                     "http.worker.nap.threshold\tQDB_HTTP_WORKER_NAP_THRESHOLD\t7000\tdefault\tfalse\tfalse\n" +
                                     "http.worker.yield.threshold\tQDB_HTTP_WORKER_YIELD_THRESHOLD\t10\tdefault\tfalse\tfalse\n" +
+                                    "line.log.message.on.error\tQDB_LINE_LOG_MESSAGE_ON_ERROR\ttrue\tdefault\tfalse\tfalse\n" +
                                     "line.auto.create.new.columns\tQDB_LINE_AUTO_CREATE_NEW_COLUMNS\ttrue\tdefault\tfalse\tfalse\n" +
                                     "line.auto.create.new.tables\tQDB_LINE_AUTO_CREATE_NEW_TABLES\ttrue\tdefault\tfalse\tfalse\n" +
                                     "line.default.partition.by\tQDB_LINE_DEFAULT_PARTITION_BY\tDAY\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -218,6 +218,8 @@ line.udp.own.thread=true
 line.udp.own.thread.affinity=2
 line.udp.haltOnError=true
 
+line.log.message.on.error=false
+
 line.tcp.enabled=true
 line.tcp.net.active.connection.limit=11
 line.tcp.net.bind.to=10.2.1.33:9916

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -531,6 +531,15 @@ cairo.sql.copy.root=import
 
 #line.default.partition.by=DAY
 
+# Enable / Disable automatic creation of new columns in existing tables via ILP. When set to false overrides value of line.auto.create.new.tables to false
+#line.auto.create.new.columns=true
+
+# Enable / Disable automatic creation of new tables via ILP.
+#line.auto.create.new.tables=true
+
+# Enable / Disable printing problematic ILP messages in case of errors.
+#line.log.message.on.error=true
+
 ################ LINE UDP settings ##################
 
 #line.udp.bind.to=0.0.0.0:9009
@@ -615,7 +624,7 @@ line.tcp.enabled=false
 
 #line.http.enabled=true
 
-#line.http.ping.version=v2.2.2
+#line.http.ping.version=v2.7.4
 
 ################ PG Wire settings ##################
 


### PR DESCRIPTION
Introduces new `line.log.message.on.error` prop to control whether mangled ILP messages are printed to the server log (`true` by default).