### PR TITLE
fix(sql): support filtering and sampling dot-prefixed tables

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -284,7 +284,7 @@ public class ExpressionParser {
                                 ExpressionNode en = opStack.pop();
                                 // table prefix cannot be unquoted keywords
                                 CharacterStoreEntry cse = characterStore.newEntry();
-                                cse.put(GenericLexer.unquote(en.token)).put('.');
+                                cse.put(GenericLexer.unquoteIfNoDots(en.token)).put('.');
                                 opStack.push(expressionNodePool.next().of(ExpressionNode.LITERAL, cse.toImmutable(), Integer.MIN_VALUE, en.position));
                             } else {
                                 // attach dot to existing literal or constant
@@ -1295,7 +1295,7 @@ public class ExpressionParser {
                                 // this was more analogous to 'a."b"'
                                 CharacterStoreEntry cse = characterStore.newEntry();
                                 SqlKeywords.assertTableNameIsQuotedOrNotAKeyword(tok, en.position);
-                                cse.put(en.token).put(GenericLexer.unquote(tok));
+                                cse.put(en.token).put(GenericLexer.unquoteIfNoDots(tok));
                                 opStack.push(expressionNodePool.next().of(ExpressionNode.LITERAL, cse.toImmutable(), Integer.MIN_VALUE, en.position));
                             } else {
                                 final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -309,7 +309,7 @@ public class SqlOptimiser implements Mutable {
     ) throws SqlException {
         if (validatingModel != null) {
             CharSequence refColumn = column.getAst().token;
-            final int dot = Chars.indexOf(refColumn, '.');
+            final int dot = Chars.indexOfUnquoted(refColumn, '.');
             validateColumnAndGetModelIndex(validatingModel, refColumn, dot, column.getAst().position);
             // when we have only one model, e.g. this is not a join
             // and there is table alias to lookup column
@@ -569,7 +569,7 @@ public class SqlOptimiser implements Mutable {
     private void addTopDownColumn(@Transient ExpressionNode node, QueryModel model) {
         if (node != null && node.type == LITERAL) {
             final CharSequence columnName = node.token;
-            final int dotIndex = Chars.indexOf(columnName, '.');
+            final int dotIndex = Chars.indexOfUnquoted(columnName, '.');
             if (dotIndex == -1) {
                 // When there is no dot in column name it is still possible that column comes from
                 // one of the join models. What we need to do here is to assign column to that model
@@ -1058,7 +1058,7 @@ public class SqlOptimiser implements Mutable {
         CharSequence prefix = "";
         for (int i = 0, n = orderByAdvice.size(); i < n; i++) {
             CharSequence token = orderByAdvice.getQuick(i).token;
-            int loc = Chars.indexOf(token, '.');
+            int loc = Chars.indexOfUnquoted(token, '.');
             if (loc > -1) {
                 if (prefix.length() == 0) {
                     prefix = token.subSequence(0, loc);
@@ -1078,7 +1078,7 @@ public class SqlOptimiser implements Mutable {
      */
     private boolean checkForDot(ObjList<ExpressionNode> orderByAdvice) {
         for (int i = 0, n = orderByAdvice.size(); i < n; i++) {
-            if (Chars.indexOf(orderByAdvice.getQuick(i).token, '.') > -1) {
+            if (Chars.indexOfUnquoted(orderByAdvice.getQuick(i).token, '.') > -1) {
                 return true;
             }
         }
@@ -1124,7 +1124,7 @@ public class SqlOptimiser implements Mutable {
         }
 
         CharSequence tok = column.token;
-        final int dot = Chars.indexOf(tok, '.');
+        final int dot = Chars.indexOfUnquoted(tok, '.');
         QueryColumn qc = getQueryColumn(model, tok, dot);
 
         if (qc != null &&
@@ -1257,7 +1257,7 @@ public class SqlOptimiser implements Mutable {
     }
 
     private CharSequence createColumnAlias(ExpressionNode node, QueryModel model) {
-        return SqlUtil.createColumnAlias(characterStore, node.token, Chars.indexOf(node.token, '.'), model.getAliasToColumnMap());
+        return SqlUtil.createColumnAlias(characterStore, node.token, Chars.indexOfUnquoted(node.token, '.'), model.getAliasToColumnMap());
     }
 
     // use only if input is a column literal!
@@ -1519,7 +1519,7 @@ public class SqlOptimiser implements Mutable {
             QueryModel distinctModel
     ) throws SqlException {
         // this could be a wildcard, such as '*' or 'a.*'
-        int dot = Chars.indexOf(qc.getAst().token, '.');
+        int dot = Chars.indexOfUnquoted(qc.getAst().token, '.');
         if (dot > -1) {
             int index = baseModel.getModelAliasIndex(qc.getAst().token, 0, dot);
             if (index == -1) {
@@ -1805,7 +1805,7 @@ public class SqlOptimiser implements Mutable {
         for (int j = 0, m = orderByAdvice.size(); j < m; j++) {
             node = orderByAdvice.getQuick(j);
             token = node.token;
-            d = Chars.indexOf(token, '.');
+            d = Chars.indexOfUnquoted(token, '.');
             advice.add(expressionNodePool.next().of(node.type, token.subSequence(d + 1, token.length()), node.precedence, node.position));
         }
         return advice;
@@ -2433,7 +2433,7 @@ public class SqlOptimiser implements Mutable {
         if (target == null) {
             return false;
         }
-        final int dotIndex = Chars.indexOf(name, '.');
+        final int dotIndex = Chars.indexOfUnquoted(name, '.');
         return dotIndex > 0
                 ? Chars.equalsIgnoreCase(table, name, 0, dotIndex) && Chars.equalsIgnoreCase(target, name, dotIndex + 1, name.length())
                 : Chars.equalsIgnoreCase(name, target);
@@ -2606,7 +2606,7 @@ public class SqlOptimiser implements Mutable {
                     CharSequence alias = findQueryColumnByAst(model.getBottomUpColumns(), node);
                     if (alias == null) {
                         // add this function to bottom-up columns and replace this expression with index
-                        alias = SqlUtil.createColumnAlias(characterStore, node.token, Chars.indexOf(node.token, '.'), model.getAliasToColumnMap(), true);
+                        alias = SqlUtil.createColumnAlias(characterStore, node.token, Chars.indexOfUnquoted(node.token, '.'), model.getAliasToColumnMap(), true);
                         QueryColumn qc = queryColumnPool.next().of(
                                 alias,
                                 node,
@@ -3546,7 +3546,7 @@ public class SqlOptimiser implements Mutable {
         }
         // if the orderByAdvice prefixes do not match the primary table name, don't propagate it
         final CharSequence adviceToken = orderByAdvice.getQuick(0).token;
-        final int dotLoc = Chars.indexOf(adviceToken, '.');
+        final int dotLoc = Chars.indexOfUnquoted(adviceToken, '.');
         if (!(Chars.equalsNc(jm1.getTableName(), adviceToken, 0, dotLoc)
                 || (jm1.getAlias() != null && Chars.equals(jm1.getAlias().token, adviceToken, 0, dotLoc)))) {
             optimiseOrderBy(jm1, orderByMnemonic);
@@ -3810,7 +3810,7 @@ public class SqlOptimiser implements Mutable {
     private ExpressionNode replaceIfUnaliasedLiteral(ExpressionNode node, QueryModel baseModel) throws SqlException {
         if (node != null && node.type == LITERAL) {
             CharSequence col = node.token;
-            final int dot = Chars.indexOf(col, '.');
+            final int dot = Chars.indexOfUnquoted(col, '.');
             int modelIndex = validateColumnAndGetModelIndex(baseModel, col, dot, node.position);
 
             boolean addAlias = dot == -1 && baseModel.getJoinModels().size() > 1;
@@ -4379,7 +4379,7 @@ public class SqlOptimiser implements Mutable {
             for (int i = 0; i < sz; i++) {
                 final ExpressionNode orderBy = orderByNodes.getQuick(i);
                 CharSequence column = orderBy.token;
-                int dot = Chars.indexOf(column, '.');
+                int dot = Chars.indexOfUnquoted(column, '.');
                 // is this a table reference?
                 if (dot > -1 || model.getAliasToColumnMap().excludes(column)) {
                     // validate column
@@ -5053,9 +5053,17 @@ public class SqlOptimiser implements Mutable {
             assert timestamp != null;
 
             if (Chars.indexOf(timestamp.token, '.') < 0) {
-                // prefix the timestamp column name
+                // prefix the timestamp column name only if the table is not dotted
+                // this is to handle cases where we use system tables, which are prefixed
+                // downstream code cannot handle `"sys.telemetry.wal".created`
+                // it will break in `where` optimisation, and later metadata lookups
                 CharacterStoreEntry e = characterStore.newEntry();
-                e.put(toAddWhereClause.getTableName()).putAscii('.').put(timestamp.token);
+                if (Chars.indexOf(toAddWhereClause.getTableName(), '.') != -1) {
+                    // Table name has . in the name, quote it
+                    e.putAscii('\"').put(toAddWhereClause.getTableName()).putAscii("\".").put(timestamp.token);
+                } else {
+                    e.put(toAddWhereClause.getTableName()).put('.').put(timestamp.token);
+                }
                 CharSequence prefixedTimestamp = e.toImmutable();
                 timestamp = expressionNodePool.next().of(LITERAL, prefixedTimestamp, timestamp.precedence, timestamp.position);
             }
@@ -6442,7 +6450,7 @@ public class SqlOptimiser implements Mutable {
 
         private ExpressionNode rewrite(ExpressionNode node) {
             if (node != null && node.type == LITERAL) {
-                final int dot = Chars.indexOf(node.token, '.');
+                final int dot = Chars.indexOfUnquoted(node.token, '.');
                 if (dot != -1) {
                     return nextLiteral(node.token.subSequence(dot + 1, node.token.length()));
                 }
@@ -6462,7 +6470,7 @@ public class SqlOptimiser implements Mutable {
         public void visit(ExpressionNode node) throws SqlException {
             switch (node.type) {
                 case LITERAL:
-                    int dot = Chars.indexOf(node.token, '.');
+                    int dot = Chars.indexOfUnquoted(node.token, '.');
                     CharSequence name = dot == -1 ? node.token : node.token.subSequence(dot + 1, node.token.length());
                     indexes.add(validateColumnAndGetModelIndex(model, node.token, dot, node.position));
                     if (names != null) {

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -236,7 +236,7 @@ public class SqlParser {
     }
 
     private void assertNotDot(GenericLexer lexer, CharSequence tok) throws SqlException {
-        if (Chars.indexOf(tok, '.') != -1) {
+        if (Chars.indexOfUnquoted(tok, '.') != -1) {
             throw SqlException.$(lexer.lastTokenPosition(), "'.' is not allowed here");
         }
     }
@@ -255,7 +255,7 @@ public class SqlParser {
         return SqlUtil.createColumnAlias(
                 characterStore,
                 unquote(node.token),
-                Chars.indexOf(node.token, '.'),
+                Chars.indexOfUnquoted(node.token, '.'),
                 aliasToColumnMap,
                 node.type != ExpressionNode.LITERAL
         );
@@ -2420,7 +2420,7 @@ public class SqlParser {
                         throw err(lexer, null, "'from' expected");
                     }
                     CharSequence alias;
-                    if (qc.getAst().type == ExpressionNode.CONSTANT && Chars.indexOf(token, '.') != -1) {
+                    if (qc.getAst().type == ExpressionNode.CONSTANT && Chars.indexOfUnquoted(token, '.') != -1) {
                         alias = createConstColumnAlias(aliasMap);
                     } else {
                         alias = createColumnAlias(qc.getAst(), aliasMap);
@@ -2456,7 +2456,7 @@ public class SqlParser {
                     model.setNestedModel(parseWith(lexer, withClause, sqlParserCallback));
                     model.setAlias(literal(tableName, expr.position));
                 } else {
-                    int dot = Chars.indexOf(tableName, '.');
+                    int dot = Chars.indexOfUnquoted(tableName, '.');
                     if (dot == -1) {
                         model.setTableNameExpr(literal(tableName, expr.position));
                     } else {

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -802,8 +802,12 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         return metadataVersion;
     }
 
-    public int getModelAliasIndex(CharSequence column, int start, int end) {
-        int index = modelAliasIndexes.keyIndex(column, start, end);
+    public int getModelAliasIndex(CharSequence modelAlias, int start, int end) {
+        if (modelAlias.charAt(start) == '"' && modelAlias.charAt(end - 1) == '"') {
+            start++;
+            end--;
+        }
+        int index = modelAliasIndexes.keyIndex(modelAlias, start, end);
         if (index < 0) {
             return modelAliasIndexes.valueAt(index);
         }

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -679,6 +679,46 @@ public final class Chars {
         return -1;
     }
 
+    public static int indexOfUnquoted(@NotNull CharSequence seq, char ch) {
+        return indexOfUnquoted(seq, ch, 0, seq.length(), 1);
+    }
+
+    public static int indexOfUnquoted(@NotNull CharSequence seq, char ch, int seqLo, int seqHi, int occurrence) {
+        if (occurrence == 0) {
+            return -1;
+        }
+
+        int count = 0;
+        boolean inQuotes = false;
+        if (occurrence > 0) {
+            for (int i = seqLo; i < seqHi; i++) {
+                if (seq.charAt(i) == '\"') {
+                    inQuotes = !inQuotes;
+                }
+                if (seq.charAt(i) == ch && !inQuotes) {
+                    count++;
+                    if (count == occurrence) {
+                        return i;
+                    }
+                }
+            }
+        } else {    // if occurrence is negative, search in reverse
+            for (int i = seqHi - 1; i >= seqLo; i--) {
+                if (seq.charAt(i) == '\"') {
+                    inQuotes = !inQuotes;
+                }
+                if (seq.charAt(i) == ch && !inQuotes) {
+                    count--;
+                    if (count == occurrence) {
+                        return i;
+                    }
+                }
+            }
+        }
+
+        return -1;
+    }
+
     public static boolean isAscii(@NotNull CharSequence cs) {
         for (int i = 0, n = cs.length(); i < n; i++) {
             if (cs.charAt(i) > 127) {
@@ -734,7 +774,7 @@ public final class Chars {
         return isQuote(open) && open == s.charAt(s.length() - 1);
     }
 
-    public static int lastIndexOf(CharSequence sequence, int sequenceLo, int sequenceHi, CharSequence term) {
+    public static int lastIndexOf(@NotNull CharSequence sequence, int sequenceLo, int sequenceHi, @NotNull CharSequence term) {
         return indexOf(sequence, sequenceLo, sequenceHi, term, -1);
     }
 

--- a/core/src/main/java/io/questdb/std/GenericLexer.java
+++ b/core/src/main/java/io/questdb/std/GenericLexer.java
@@ -111,6 +111,13 @@ public class GenericLexer implements ImmutableIterator<CharSequence> {
         return immutableOf(value);
     }
 
+    public static CharSequence unquoteIfNoDots(CharSequence value) {
+        if (Chars.isQuoted(value) && Chars.indexOf(value, '.') == -1) {
+            return value.subSequence(1, value.length() - 1);
+        }
+        return immutableOf(value);
+    }
+
     public void backTo(int position, CharSequence lastSeen) {
         if (position < 0 || position > _len) {
             throw new IndexOutOfBoundsException();
@@ -496,19 +503,19 @@ public class GenericLexer implements ImmutableIterator<CharSequence> {
         }
 
         @Override
+        public void shiftLo(int positiveOffset) {
+            assert positiveOffset > -1;
+            this.lo += positiveOffset;
+            assert lo < hi;
+        }
+
+        @Override
         protected final CharSequence _subSequence(int start, int end) {
             FloatingSequence that = csPool.next();
             that.lo = lo + start;
             that.hi = lo + end;
             assert that.lo <= that.hi;
             return that;
-        }
-
-        @Override
-        public void shiftLo(int positiveOffset) {
-            assert positiveOffset > -1;
-            this.lo += positiveOffset;
-            assert lo < hi;
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -50,7 +50,11 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
@@ -92,8 +96,19 @@ public class SampleByTest extends AbstractCairoTest {
             "x::timestamp as n," +
             "FROM long_sequence(480)\n" +
             ") timestamp(ts)";
-
     private static final Log LOG = LogFactory.getLog(SampleByTest.class);
+    final String sysTelemetryWalDdl = "CREATE TABLE IF NOT EXISTS 'sys.telemetry_wal' ( " +
+            "created TIMESTAMP, " +
+            "event SHORT, " +
+            "tableId INT, " +
+            "walId INT, " +
+            "seqTxn LONG, " +
+            "rowCount LONG, " +
+            "physicalRowCount LONG, " +
+            "latency FLOAT " +
+            ") timestamp(created) " +
+            "PARTITION BY MONTH BYPASS WAL " +
+            "WITH maxUncommittedRows=500000, o3MaxLag=600000000us;";
 
     @Test
     public void testBadFunction() throws Exception {
@@ -2853,6 +2868,82 @@ public class SampleByTest extends AbstractCairoTest {
                     "from xx " +
                     "where s in ('a')"
             );
+        });
+    }
+
+    @Test
+    public void testPrefixedTableNames() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(sysTelemetryWalDdl);
+            assertSql("created\tcommit_rate\n" +
+                    "2024-12-08T00:00:00.000000Z\t0\n" +
+                    "2024-12-08T08:00:00.000000Z\t0\n" +
+                    "2024-12-08T16:00:00.000000Z\t0\n", "select created, count() commit_rate\n" +
+                    "from sys.telemetry_wal\n" +
+                    "where tableId = 1017 and event = 103\n" +
+                    "and created >= '2024-12-08' and created < '2024-12-09'\n" +
+                    "sample by 8h from\n" +
+                    "'2024-12-08' to '2024-12-09'\n" +
+                    "fill(0)");
+            assertSql(
+                    "created\tcommit_rate\n" +
+                            "2024-12-08T00:00:00.000000Z\t0\n" +
+                            "2024-12-08T08:00:00.000000Z\t0\n" +
+                            "2024-12-08T16:00:00.000000Z\t0\n",
+                    "select created, count() commit_rate\n" +
+                            "from \"sys.telemetry_wal\"\n" +
+                            "where tableId = 1017 and event = 103\n" +
+                            "and \"sys.telemetry_wal\".created >= '2024-12-08' and created < '2024-12-09'\n" +
+                            "sample by 8h from\n" +
+                            "'2024-12-08' to '2024-12-09'\n" +
+                            "fill(0)"
+            );
+        });
+    }
+
+    @Test
+    public void testQueryCorrectlyFillsSides() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(sysTelemetryWalDdl);
+            drainWalQueue();
+            assertSql("created\twriteAmplification\n" +
+                            "2024-12-10T23:31:02.000000Z\tnull\n" +
+                            "2024-12-11T00:31:02.000000Z\tnull\n" +
+                            "2024-12-11T01:31:02.000000Z\tnull\n" +
+                            "2024-12-11T02:31:02.000000Z\tnull\n" +
+                            "2024-12-11T03:31:02.000000Z\tnull\n" +
+                            "2024-12-11T04:31:02.000000Z\tnull\n" +
+                            "2024-12-11T05:31:02.000000Z\tnull\n" +
+                            "2024-12-11T06:31:02.000000Z\tnull\n" +
+                            "2024-12-11T07:31:02.000000Z\tnull\n" +
+                            "2024-12-11T08:31:02.000000Z\tnull\n" +
+                            "2024-12-11T09:31:02.000000Z\tnull\n" +
+                            "2024-12-11T10:31:02.000000Z\tnull\n",
+                    "select \n" +
+                            "  created,\n" +
+                            "  -- coars, actual write amplification bucketed in 1s buckets\n" +
+                            "  phy_row_count/row_count writeAmplification\n" +
+                            "from (  \n" +
+                            "  select \n" +
+                            "    created, \n" +
+                            "    sum(phy_row_count) over (order by created rows between 59 PRECEDING and CURRENT row) phy_row_count,\n" +
+                            "    sum(row_count) over (order by created rows between 59 PRECEDING and CURRENT row) row_count\n" +
+                            "    from (\n" +
+                            "      select \n" +
+                            "        created, \n" +
+                            "        sum(rowcount) row_count,\n" +
+                            "        sum(physicalRowCount) phy_row_count,\n" +
+                            "      from sys.telemetry_wal\n" +
+                            "      where tableId = 10 and \n" +
+                            "         event = 105\n" +
+                            "         and rowCount > 0 -- this is fixed clause, we have rows with - rowCount logged\n" +
+                            "      sample by 1h\n" +
+                            "      FROM '2024-12-11T00:31:02+01:00' TO '2024-12-11T12:31:02+01:00'\n" +
+                            "      -- fill with null to avoid spurious values and division by 0\n" +
+                            "      fill(null)\n" +
+                            "      \n" +
+                            "  )\n" +
+                            ");");
         });
     }
 


### PR DESCRIPTION
The query engine has inconsistent support for table names with dots in them i.e `sys.telemetry_wal`. There is a general assumption that column names take the form of `table_name.column_name`, and the `table_name` prefix does not itself contain a dot `.`.

This caused incompatibilities when using `SAMPLE BY FROM-TO` in a query, due to an optimisation step that adds the designated timestamp to the `WHERE` clause, and prefixes this timestamp with the table name. 

Now, `sys.telemetry_wal` can be safely reference in `WHERE` filters.

Fixes https://github.com/questdb/questdb/issues/5262
