### PR TITLE
fix(core): bug in network services where service may not recover from connection limit hit

### DIFF
--- a/benchmarks/src/main/java/org/questdb/PongMain.java
+++ b/benchmarks/src/main/java/org/questdb/PongMain.java
@@ -24,10 +24,12 @@
 
 package org.questdb;
 
+import io.questdb.Metrics;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.metrics.NullLongGauge;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IOContext;
 import io.questdb.network.IOContextFactoryImpl;
@@ -59,7 +61,17 @@ public class PongMain {
         // configuration defines bind address and port
         final IODispatcherConfiguration dispatcherConf = new DefaultIODispatcherConfiguration();
         // worker pool, which would handle jobs
-        final WorkerPool workerPool = new WorkerPool(() -> 1);
+        final WorkerPool workerPool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return Metrics.DISABLED;
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 1;
+            }
+        });
         // event loop that accepts connections and publishes network events to event queue
         final IODispatcher<PongConnectionContext> dispatcher = IODispatchers.create(
                 dispatcherConf,

--- a/benchmarks/src/main/java/org/questdb/PongMain.java
+++ b/benchmarks/src/main/java/org/questdb/PongMain.java
@@ -27,7 +27,6 @@ package org.questdb;
 import io.questdb.Metrics;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.NullLongGauge;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
@@ -75,8 +74,7 @@ public class PongMain {
         // event loop that accepts connections and publishes network events to event queue
         final IODispatcher<PongConnectionContext> dispatcher = IODispatchers.create(
                 dispatcherConf,
-                new IOContextFactoryImpl<>(() -> new PongConnectionContext(PlainSocketFactory.INSTANCE, dispatcherConf.getNetworkFacade(), LOG), 8),
-                NullLongGauge.INSTANCE
+                new IOContextFactoryImpl<>(() -> new PongConnectionContext(PlainSocketFactory.INSTANCE, dispatcherConf.getNetworkFacade(), LOG), 8)
         );
         // event queue processor
         final PongRequestProcessor processor = new PongRequestProcessor();

--- a/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
@@ -25,8 +25,14 @@
 package org.questdb;
 
 import io.questdb.MessageBusImpl;
-import io.questdb.Metrics;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.DefaultDdlListener;
+import io.questdb.cairo.DefaultLifecycleManager;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriter;
 import io.questdb.griffin.SqlCompilerImpl;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -35,7 +41,15 @@ import io.questdb.log.LogFactory;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -96,7 +110,6 @@ public class TableReaderReloadBenchmark {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                Metrics.disabled(),
                 cairoEngine
         );
         writer.truncate();

--- a/benchmarks/src/main/java/org/questdb/TableWriterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableWriterBenchmark.java
@@ -25,8 +25,14 @@
 package org.questdb;
 
 import io.questdb.MessageBusImpl;
-import io.questdb.Metrics;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CommitMode;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.DefaultDdlListener;
+import io.questdb.cairo.DefaultLifecycleManager;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriter;
 import io.questdb.griffin.SqlCompilerImpl;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -34,7 +40,16 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.log.LogFactory;
 import io.questdb.std.Numbers;
 import io.questdb.std.Rnd;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -96,7 +111,6 @@ public class TableWriterBenchmark {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                Metrics.disabled(),
                 cairoEngine
         );
         writer2 = new TableWriter(
@@ -109,7 +123,6 @@ public class TableWriterBenchmark {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                Metrics.disabled(),
                 cairoEngine
         );
         writer3 = new TableWriter(
@@ -122,7 +135,6 @@ public class TableWriterBenchmark {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                Metrics.disabled(),
                 cairoEngine
         );
         rnd.reset();

--- a/core/rust/qdbr/src/parquet_write/varchar.rs
+++ b/core/rust/qdbr/src/parquet_write/varchar.rs
@@ -78,7 +78,7 @@ pub fn varchar_to_page(
                 let entry: &AuxEntrySplit = unsafe { mem::transmute(entry) };
                 let header = entry.header;
                 let size = (header >> HEADER_FLAGS_WIDTH) as usize;
-                let offset = entry.offset_lo as usize | (entry.offset_hi as usize) << 16;
+                let offset = entry.offset_lo as usize | ((entry.offset_hi as usize) << 16);
                 assert!(
                     offset + size <= data.len(),
                     "Data corruption in VARCHAR column"

--- a/core/rust/qdbr/src/parquet_write/varchar.rs
+++ b/core/rust/qdbr/src/parquet_write/varchar.rs
@@ -183,7 +183,7 @@ pub fn append_varchar(
         append_offset(aux_mem, data_mem.len())
     } else {
         assert!(value_size <= LENGTH_LIMIT_BYTES);
-        let header = (value_size as u32) << HEADER_FLAGS_WIDTH | is_ascii(value);
+        let header = ((value_size as u32) << HEADER_FLAGS_WIDTH) | is_ascii(value);
         aux_mem.extend_from_slice(&header.to_le_bytes())?;
         aux_mem.extend_from_slice(&value[0..VARCHAR_INLINED_PREFIX_BYTES])?;
         data_mem.extend_from_slice(value)?;

--- a/core/src/main/java/io/questdb/Bootstrap.java
+++ b/core/src/main/java/io/questdb/Bootstrap.java
@@ -90,7 +90,6 @@ public class Bootstrap {
     private final BuildInformation buildInformation;
     private final ServerConfiguration config;
     private final Log log;
-    private final Metrics metrics;
     private final MicrosecondClock microsecondClock;
     private final String rootDirectory;
 
@@ -225,10 +224,7 @@ public class Bootstrap {
             log.errorW().$(e).$();
             throw new BootstrapException(e);
         }
-        if (config.getMetricsConfiguration().isEnabled()) {
-            metrics = Metrics.enabled();
-        } else {
-            metrics = Metrics.disabled();
+        if (!config.getMetricsConfiguration().isEnabled()) {
             log.advisoryW().$("Metrics are disabled, health check endpoint will not consider unhandled errors").$();
         }
         Unsafe.setRssMemLimit(config.getMemoryConfiguration().getResolvedRamUsageLimitBytes());
@@ -367,10 +363,6 @@ public class Bootstrap {
         return log;
     }
 
-    public Metrics getMetrics() {
-        return metrics;
-    }
-
     public MicrosecondClock getMicrosecondClock() {
         return microsecondClock;
     }
@@ -397,7 +389,7 @@ public class Bootstrap {
     }
 
     public CairoEngine newCairoEngine() {
-        return new CairoEngine(getConfiguration().getCairoConfiguration(), getMetrics());
+        return new CairoEngine(getConfiguration().getCairoConfiguration());
     }
 
     private static void copyInputStream(boolean force, byte[] buffer, File out, InputStream is, Log log) throws IOException {

--- a/core/src/main/java/io/questdb/DefaultServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultServerConfiguration.java
@@ -91,6 +91,11 @@ public class DefaultServerConfiguration implements ServerConfiguration {
     }
 
     @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
+    }
+
+    @Override
     public MetricsConfiguration getMetricsConfiguration() {
         return metricsConfiguration;
     }

--- a/core/src/main/java/io/questdb/DefaultServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DefaultServerConfiguration.java
@@ -28,7 +28,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.wal.DefaultWalApplyWorkerPoolConfiguration;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.line.tcp.DefaultLineTcpReceiverConfiguration;
 import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
@@ -66,12 +66,12 @@ public class DefaultServerConfiguration implements ServerConfiguration {
     }
 
     @Override
-    public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+    public HttpServerConfiguration getHttpMinServerConfiguration() {
         return null;
     }
 
     @Override
-    public HttpServerConfiguration getHttpServerConfiguration() {
+    public HttpFullFatServerConfiguration getHttpServerConfiguration() {
         return httpServerConfiguration;
     }
 

--- a/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
@@ -27,7 +27,7 @@ package io.questdb;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoConfigurationWrapper;
 import io.questdb.cairo.CairoEngine;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpMinServerConfigurationWrapper;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfigurationWrapper;
@@ -276,12 +276,12 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
     }
 
     @Override
-    public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+    public HttpServerConfiguration getHttpMinServerConfiguration() {
         return minHttpServerConfig;
     }
 
     @Override
-    public HttpServerConfiguration getHttpServerConfiguration() {
+    public HttpFullFatServerConfiguration getHttpServerConfiguration() {
         return httpServerConfig;
     }
 

--- a/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
@@ -97,7 +97,7 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
     private final LineTcpReceiverConfigurationWrapper lineTcpConfig;
     private final boolean loadAdditionalConfigurations;
     private final Log log;
-    private final MemoryConfigurationImpl memoryConfig;
+    private final MemoryConfigurationWrapper memoryConfig;
     private final Metrics metrics;
     private final MicrosecondClock microsecondClock;
     private final HttpMinServerConfigurationWrapper minHttpServerConfig;
@@ -146,7 +146,7 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
         this.minHttpServerConfig = new HttpMinServerConfigurationWrapper(this.metrics);
         this.httpServerConfig = new HttpServerConfigurationWrapper(this.metrics);
         this.lineTcpConfig = new LineTcpReceiverConfigurationWrapper(this.metrics);
-        this.memoryConfig = new MemoryConfigurationImpl();
+        this.memoryConfig = new MemoryConfigurationWrapper();
         this.pgWireConfig = new PGWireConfigurationWrapper(this.metrics);
         reloadNestedConfigurations(serverConfig);
         this.version = 0;
@@ -417,18 +417,5 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
         lineTcpConfig.setDelegate(serverConfig.getLineTcpReceiverConfiguration());
         memoryConfig.setDelegate(serverConfig.getMemoryConfiguration());
         pgWireConfig.setDelegate(serverConfig.getPGWireConfiguration());
-    }
-
-    private static class MemoryConfigurationImpl extends MemoryConfigurationWrapper {
-        private final AtomicReference<MemoryConfiguration> delegate = new AtomicReference<>();
-
-        @Override
-        public MemoryConfiguration getDelegate() {
-            return delegate.get();
-        }
-
-        public void setDelegate(MemoryConfiguration delegate) {
-            this.delegate.set(delegate);
-        }
     }
 }

--- a/core/src/main/java/io/questdb/MemoryConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/MemoryConfigurationWrapper.java
@@ -24,11 +24,13 @@
 
 package io.questdb;
 
-public class MemoryConfigurationWrapper implements MemoryConfiguration {
-    private final MemoryConfiguration delegate;
+import java.util.concurrent.atomic.AtomicReference;
 
-    protected MemoryConfigurationWrapper() {
-        delegate = null;
+public class MemoryConfigurationWrapper implements MemoryConfiguration {
+    private final AtomicReference<MemoryConfiguration> delegate = new AtomicReference<>();
+
+    public MemoryConfigurationWrapper() {
+        delegate.set(null);
     }
 
     @Override
@@ -51,7 +53,11 @@ public class MemoryConfigurationWrapper implements MemoryConfiguration {
         return getDelegate().getTotalSystemMemory();
     }
 
+    public void setDelegate(MemoryConfiguration delegate) {
+        this.delegate.set(delegate);
+    }
+
     protected MemoryConfiguration getDelegate() {
-        return delegate;
+        return delegate.get();
     }
 }

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -35,7 +35,7 @@ import io.questdb.metrics.HealthMetricsImpl;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.metrics.MetricsRegistryImpl;
 import io.questdb.metrics.NullMetricsRegistry;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.metrics.VirtualLongGauge;
 import io.questdb.metrics.WorkerMetrics;
 import io.questdb.std.MemoryTag;
@@ -45,7 +45,7 @@ import io.questdb.std.Unsafe;
 import io.questdb.std.str.BorrowableUtf8Sink;
 import org.jetbrains.annotations.NotNull;
 
-public class Metrics implements Scrapable, Mutable {
+public class Metrics implements Target, Mutable {
     public static final Metrics DISABLED = new Metrics(false, new NullMetricsRegistry());
     public static final Metrics ENABLED = new Metrics(true, new MetricsRegistryImpl());
     private final GCMetrics gcMetrics;
@@ -160,7 +160,7 @@ public class Metrics implements Scrapable, Mutable {
         metricsRegistry.newVirtualGauge("memory_jvm_max", jvmMaxMemRef);
     }
 
-    void addScrapable(Scrapable scrapable) {
-        metricsRegistry.addScrapable(scrapable);
+    void addScrapable(Target target) {
+        metricsRegistry.addTarget(target);
     }
 }

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -45,8 +45,8 @@ import io.questdb.std.str.BorrowableUtf8Sink;
 import org.jetbrains.annotations.NotNull;
 
 public class Metrics implements Scrapable, Mutable {
-    public static final Metrics DISABLED = Metrics.disabled();
-    public static final Metrics ENABLED = Metrics.enabled();
+    public static final Metrics DISABLED = new Metrics(false, new NullMetricsRegistry());
+    public static final Metrics ENABLED = new Metrics(true, new MetricsRegistryImpl());
     private final GCMetrics gcMetrics;
     private final HealthMetricsImpl healthCheck;
     private final JsonQueryMetrics jsonQuery;
@@ -74,14 +74,6 @@ public class Metrics implements Scrapable, Mutable {
         createMemoryGauges(metricsRegistry);
         this.metricsRegistry = metricsRegistry;
         this.workerMetrics = new WorkerMetrics(metricsRegistry);
-    }
-
-    public static Metrics disabled() {
-        return new Metrics(false, new NullMetricsRegistry());
-    }
-
-    public static Metrics enabled() {
-        return new Metrics(true, new MetricsRegistryImpl());
     }
 
     @Override

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -38,13 +38,15 @@ import io.questdb.metrics.Scrapable;
 import io.questdb.metrics.VirtualLongGauge;
 import io.questdb.metrics.WorkerMetrics;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Mutable;
 import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.BorrowableUtf8Sink;
 import org.jetbrains.annotations.NotNull;
 
-public class Metrics implements Scrapable {
-    private final boolean enabled;
+public class Metrics implements Scrapable, Mutable {
+    public static final Metrics DISABLED = Metrics.disabled();
+    public static final Metrics ENABLED = Metrics.enabled();
     private final GCMetrics gcMetrics;
     private final HealthMetricsImpl healthCheck;
     private final JsonQueryMetrics jsonQuery;
@@ -58,6 +60,7 @@ public class Metrics implements Scrapable {
     private final TableWriterMetrics tableWriter;
     private final WalMetrics walMetrics;
     private final WorkerMetrics workerMetrics;
+    private boolean enabled;
 
     public Metrics(boolean enabled, MetricsRegistry metricsRegistry) {
         this.enabled = enabled;
@@ -79,6 +82,23 @@ public class Metrics implements Scrapable {
 
     public static Metrics enabled() {
         return new Metrics(true, new MetricsRegistryImpl());
+    }
+
+    @Override
+    public void clear() {
+        gcMetrics.clear();
+        jsonQuery.clear();
+        pgWire.clear();
+        line.clear();
+        healthCheck.clear();
+        tableWriter.clear();
+        walMetrics.clear();
+        workerMetrics.clear();
+        enabled = true;
+    }
+
+    public void disable() {
+        enabled = false;
     }
 
     public MetricsRegistry getRegistry() {

--- a/core/src/main/java/io/questdb/Metrics.java
+++ b/core/src/main/java/io/questdb/Metrics.java
@@ -26,6 +26,7 @@ package io.questdb;
 
 import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cairo.wal.WalMetrics;
+import io.questdb.cutlass.http.processors.HttpMetrics;
 import io.questdb.cutlass.http.processors.JsonQueryMetrics;
 import io.questdb.cutlass.line.LineMetrics;
 import io.questdb.cutlass.pgwire.PGWireMetrics;
@@ -49,10 +50,11 @@ public class Metrics implements Scrapable, Mutable {
     public static final Metrics ENABLED = new Metrics(true, new MetricsRegistryImpl());
     private final GCMetrics gcMetrics;
     private final HealthMetricsImpl healthCheck;
-    private final JsonQueryMetrics jsonQuery;
-    private final LineMetrics line;
+    private final HttpMetrics httpMetrics;
+    private final JsonQueryMetrics jsonQueryMetrics;
+    private final LineMetrics lineMetrics;
     private final MetricsRegistry metricsRegistry;
-    private final PGWireMetrics pgWire;
+    private final PGWireMetrics pgWireMetrics;
     private final Runtime runtime = Runtime.getRuntime();
     private final VirtualLongGauge.StatProvider jvmFreeMemRef = runtime::freeMemory;
     private final VirtualLongGauge.StatProvider jvmMaxMemRef = runtime::maxMemory;
@@ -65,9 +67,10 @@ public class Metrics implements Scrapable, Mutable {
     public Metrics(boolean enabled, MetricsRegistry metricsRegistry) {
         this.enabled = enabled;
         this.gcMetrics = new GCMetrics();
-        this.jsonQuery = new JsonQueryMetrics(metricsRegistry);
-        this.pgWire = new PGWireMetrics(metricsRegistry);
-        this.line = new LineMetrics(metricsRegistry);
+        this.jsonQueryMetrics = new JsonQueryMetrics(metricsRegistry);
+        this.httpMetrics = new HttpMetrics(metricsRegistry);
+        this.pgWireMetrics = new PGWireMetrics(metricsRegistry);
+        this.lineMetrics = new LineMetrics(metricsRegistry);
         this.healthCheck = new HealthMetricsImpl(metricsRegistry);
         this.tableWriter = new TableWriterMetrics(metricsRegistry);
         this.walMetrics = new WalMetrics(metricsRegistry);
@@ -79,13 +82,14 @@ public class Metrics implements Scrapable, Mutable {
     @Override
     public void clear() {
         gcMetrics.clear();
-        jsonQuery.clear();
-        pgWire.clear();
-        line.clear();
+        jsonQueryMetrics.clear();
+        pgWireMetrics.clear();
+        lineMetrics.clear();
         healthCheck.clear();
         tableWriter.clear();
         walMetrics.clear();
         workerMetrics.clear();
+        httpMetrics.clear();
         enabled = true;
     }
 
@@ -97,24 +101,28 @@ public class Metrics implements Scrapable, Mutable {
         return metricsRegistry;
     }
 
-    public HealthMetricsImpl health() {
+    public HealthMetricsImpl healthMetrics() {
         return healthCheck;
+    }
+
+    public HttpMetrics httpMetrics() {
+        return httpMetrics;
     }
 
     public boolean isEnabled() {
         return enabled;
     }
 
-    public JsonQueryMetrics jsonQuery() {
-        return jsonQuery;
+    public JsonQueryMetrics jsonQueryMetrics() {
+        return jsonQueryMetrics;
     }
 
-    public LineMetrics line() {
-        return line;
+    public LineMetrics lineMetrics() {
+        return lineMetrics;
     }
 
-    public PGWireMetrics pgWire() {
-        return pgWire;
+    public PGWireMetrics pgWireMetrics() {
+        return pgWireMetrics;
     }
 
     @Override
@@ -125,15 +133,15 @@ public class Metrics implements Scrapable, Mutable {
         }
     }
 
-    public TableWriterMetrics tableWriter() {
+    public TableWriterMetrics tableWriterMetrics() {
         return tableWriter;
     }
 
-    public WalMetrics wal() {
+    public WalMetrics walMetrics() {
         return walMetrics;
     }
 
-    public WorkerMetrics worker() {
+    public WorkerMetrics workerMetrics() {
         return workerMetrics;
     }
 

--- a/core/src/main/java/io/questdb/PropHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropHttpServerConfiguration.java
@@ -132,6 +132,11 @@ class PropHttpContextConfiguration implements HttpContextConfiguration {
     }
 
     @Override
+    public Metrics getMetrics() {
+        return serverConfiguration.getMetrics();
+    }
+
+    @Override
     public MillisecondClock getMillisecondClock() {
         return httpFrozenClock ? StationaryMillisClock.INSTANCE : MillisecondClockImpl.INSTANCE;
     }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3431,17 +3431,17 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getCachedGauge() {
-            return metrics.jsonQuery().cachedQueriesGauge();
+            return metrics.jsonQueryMetrics().cachedQueriesGauge();
         }
 
         @Override
         public Counter getHiCounter() {
-            return metrics.jsonQuery().cacheHitCounter();
+            return metrics.jsonQueryMetrics().cacheHitCounter();
         }
 
         @Override
         public Counter getMissCounter() {
-            return metrics.jsonQuery().cacheMissCounter();
+            return metrics.jsonQueryMetrics().cacheMissCounter();
         }
 
         @Override
@@ -3451,6 +3451,16 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpMinServerConfiguration implements HttpServerConfiguration {
+        @Override
+        public Counter getAboveMaxConnectionCountCounter() {
+            return metrics.httpMetrics().aboveMaxConnectionCountCounter();
+        }
+
+        @Override
+        public Counter getBelowMaxConnectionCountCounter() {
+            return metrics.httpMetrics().belowMaxConnectionCountCounter();
+        }
+
         @Override
         public int getBindIPv4Address() {
             return httpMinBindIPv4Address;
@@ -3468,7 +3478,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getConnectionCountGauge() {
-            return metrics.jsonQuery().connectionCountGauge();
+            return metrics.httpMetrics().connectionCountGauge();
         }
 
         @Override
@@ -3633,6 +3643,15 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpServerConfiguration implements HttpFullFatServerConfiguration {
+        @Override
+        public Counter getAboveMaxConnectionCountCounter() {
+            return metrics.httpMetrics().aboveMaxConnectionCountCounter();
+        }
+
+        @Override
+        public Counter getBelowMaxConnectionCountCounter() {
+            return metrics.httpMetrics().belowMaxConnectionCountCounter();
+        }
 
         @Override
         public int getBindIPv4Address() {
@@ -3656,7 +3675,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getConnectionCountGauge() {
-            return metrics.jsonQuery().connectionCountGauge();
+            return metrics.httpMetrics().connectionCountGauge();
         }
 
         @Override
@@ -4006,6 +4025,11 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     private class PropLineTcpReceiverConfiguration implements LineTcpReceiverConfiguration {
         @Override
+        public Counter getAboveMaxConnectionCountCounter() {
+            return metrics.lineMetrics().aboveMaxConnectionCountCounter();
+        }
+
+        @Override
         public String getAuthDB() {
             return lineTcpAuthDB;
         }
@@ -4018,6 +4042,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean getAutoCreateNewTables() {
             return ilpAutoCreateNewTables;
+        }
+
+        @Override
+        public Counter getBelowMaxConnectionCountCounter() {
+            return metrics.lineMetrics().belowMaxConnectionCountCounter();
         }
 
         @Override
@@ -4055,7 +4084,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getConnectionCountGauge() {
-            return metrics.line().connectionCountGauge();
+            return metrics.lineMetrics().connectionCountGauge();
         }
 
         @Override
@@ -4414,17 +4443,17 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getCachedGauge() {
-            return metrics.pgWire().cachedSelectsGauge();
+            return metrics.pgWireMetrics().cachedSelectsGauge();
         }
 
         @Override
         public Counter getHiCounter() {
-            return metrics.pgWire().selectCacheHitCounter();
+            return metrics.pgWireMetrics().selectCacheHitCounter();
         }
 
         @Override
         public Counter getMissCounter() {
-            return metrics.pgWire().selectCacheMissCounter();
+            return metrics.pgWireMetrics().selectCacheMissCounter();
         }
 
         @Override
@@ -4434,6 +4463,16 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropPGWireConfiguration implements PGWireConfiguration {
+        @Override
+        public Counter getAboveMaxConnectionCountCounter() {
+            return metrics.pgWireMetrics().getAboveMaxConnectionCountCounter();
+        }
+
+        @Override
+        public Counter getBelowMaxConnectionCountCounter() {
+            return metrics.pgWireMetrics().getBelowMaxConnectionCountCounter();
+        }
+
         @Override
         public int getBinParamCountCapacity() {
             return pgBinaryParamsCapacity;
@@ -4476,7 +4515,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         @Override
         public LongGauge getConnectionCountGauge() {
-            return metrics.pgWire().connectionCountGauge();
+            return metrics.pgWireMetrics().connectionCountGauge();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -35,7 +35,7 @@ import io.questdb.cairo.SqlJitMode;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.cutlass.http.HttpContextConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.MimeTypesCache;
 import io.questdb.cutlass.http.WaitProcessorConfiguration;
@@ -464,8 +464,8 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long writerMiscAppendPageSize;
     private final boolean writerMixedIOEnabled;
     private final int writerTickRowsCountMod;
-    protected HttpMinServerConfiguration httpMinServerConfiguration = new PropHttpMinServerConfiguration();
-    protected HttpServerConfiguration httpServerConfiguration = new PropHttpServerConfiguration();
+    protected HttpServerConfiguration httpMinServerConfiguration = new PropHttpMinServerConfiguration();
+    protected HttpFullFatServerConfiguration httpServerConfiguration = new PropHttpServerConfiguration();
     protected JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new PropJsonQueryProcessorConfiguration();
     protected StaticContentProcessorConfiguration staticContentProcessorConfiguration;
     protected long walSegmentRolloverSize;
@@ -643,11 +643,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     ) throws ServerConfigurationException, JsonException {
         this.log = log;
         this.metricsEnabled = getBoolean(properties, env, PropertyKey.METRICS_ENABLED, false);
-        if (metricsEnabled) {
-            this.metrics = Metrics.enabled();
-        } else {
-            this.metrics = Metrics.DISABLED;
-        }
+        this.metrics = metricsEnabled ? Metrics.ENABLED : Metrics.DISABLED;
         this.logSqlQueryProgressExe = getBoolean(properties, env, PropertyKey.LOG_SQL_QUERY_PROGRESS_EXE, true);
         this.logLevelVerbose = getBoolean(properties, env, PropertyKey.LOG_LEVEL_VERBOSE, false);
         this.logTimestampTimezone = getString(properties, env, PropertyKey.LOG_TIMESTAMP_TIMEZONE, "UTC");
@@ -1561,12 +1557,12 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     @Override
-    public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+    public HttpServerConfiguration getHttpMinServerConfiguration() {
         return httpMinServerConfiguration;
     }
 
     @Override
-    public HttpServerConfiguration getHttpServerConfiguration() {
+    public HttpFullFatServerConfiguration getHttpServerConfiguration() {
         return httpServerConfiguration;
     }
 
@@ -3422,7 +3418,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    public class PropHttpMinServerConfiguration implements HttpMinServerConfiguration {
+    public class PropHttpMinServerConfiguration implements HttpServerConfiguration {
         @Override
         public int getBindIPv4Address() {
             return httpMinBindIPv4Address;
@@ -3599,7 +3595,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
     }
 
-    public class PropHttpServerConfiguration implements HttpServerConfiguration {
+    public class PropHttpServerConfiguration implements HttpFullFatServerConfiguration {
         @Override
         public int getBindIPv4Address() {
             return httpNetBindIPv4Address;

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3452,16 +3452,6 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     public class PropHttpMinServerConfiguration implements HttpServerConfiguration {
         @Override
-        public Counter getAboveMaxConnectionCountCounter() {
-            return metrics.httpMetrics().aboveMaxConnectionCountCounter();
-        }
-
-        @Override
-        public Counter getBelowMaxConnectionCountCounter() {
-            return metrics.httpMetrics().belowMaxConnectionCountCounter();
-        }
-
-        @Override
         public int getBindIPv4Address() {
             return httpMinBindIPv4Address;
         }
@@ -3632,6 +3622,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public Counter listenerStateChangeCounter() {
+            return metrics.httpMetrics().listenerStateChangeCounter();
+        }
+
+        @Override
         public boolean preAllocateBuffers() {
             return true;
         }
@@ -3643,15 +3638,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpServerConfiguration implements HttpFullFatServerConfiguration {
-        @Override
-        public Counter getAboveMaxConnectionCountCounter() {
-            return metrics.httpMetrics().aboveMaxConnectionCountCounter();
-        }
-
-        @Override
-        public Counter getBelowMaxConnectionCountCounter() {
-            return metrics.httpMetrics().belowMaxConnectionCountCounter();
-        }
 
         @Override
         public int getBindIPv4Address() {
@@ -3859,6 +3845,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public Counter listenerStateChangeCounter() {
+            return metrics.httpMetrics().listenerStateChangeCounter();
+        }
+
+        @Override
         public boolean preAllocateBuffers() {
             return false;
         }
@@ -4025,11 +4016,6 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     private class PropLineTcpReceiverConfiguration implements LineTcpReceiverConfiguration {
         @Override
-        public Counter getAboveMaxConnectionCountCounter() {
-            return metrics.lineMetrics().aboveMaxConnectionCountCounter();
-        }
-
-        @Override
         public String getAuthDB() {
             return lineTcpAuthDB;
         }
@@ -4042,11 +4028,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean getAutoCreateNewTables() {
             return ilpAutoCreateNewTables;
-        }
-
-        @Override
-        public Counter getBelowMaxConnectionCountCounter() {
-            return metrics.lineMetrics().belowMaxConnectionCountCounter();
         }
 
         @Override
@@ -4273,6 +4254,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public Counter listenerStateChangeCounter() {
+            return metrics.lineMetrics().aboveMaxConnectionCountCounter();
+        }
+
+        @Override
         public boolean logMessageOnError() {
             return lineLogMessageOnError;
         }
@@ -4463,15 +4449,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropPGWireConfiguration implements PGWireConfiguration {
-        @Override
-        public Counter getAboveMaxConnectionCountCounter() {
-            return metrics.pgWireMetrics().getAboveMaxConnectionCountCounter();
-        }
-
-        @Override
-        public Counter getBelowMaxConnectionCountCounter() {
-            return metrics.pgWireMetrics().getBelowMaxConnectionCountCounter();
-        }
 
         @Override
         public int getBinParamCountCapacity() {
@@ -4761,6 +4738,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isUpdateCacheEnabled() {
             return pgUpdateCacheEnabled;
+        }
+
+        @Override
+        public Counter listenerStateChangeCounter() {
+            return metrics.pgWireMetrics().listenerStateChangeCounter();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -65,6 +65,7 @@ import io.questdb.log.Log;
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsConfiguration;
+import io.questdb.metrics.MetricsRegistryImpl;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.EpollFacadeImpl;
@@ -648,7 +649,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     ) throws ServerConfigurationException, JsonException {
         this.log = log;
         this.metricsEnabled = getBoolean(properties, env, PropertyKey.METRICS_ENABLED, false);
-        this.metrics = metricsEnabled ? Metrics.ENABLED : Metrics.DISABLED;
+        this.metrics = metricsEnabled ? new Metrics(true, new MetricsRegistryImpl()) : Metrics.DISABLED;
         this.logSqlQueryProgressExe = getBoolean(properties, env, PropertyKey.LOG_SQL_QUERY_PROGRESS_EXE, true);
         this.logLevelVerbose = getBoolean(properties, env, PropertyKey.LOG_LEVEL_VERBOSE, false);
         this.logTimestampTimezone = getString(properties, env, PropertyKey.LOG_TIMESTAMP_TIMEZONE, "UTC");

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3745,16 +3745,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getQueryCacheBlockCount() {
-            return httpSqlCacheBlockCount;
-        }
-
-        @Override
-        public int getQueryCacheRowCount() {
-            return httpSqlCacheRowCount;
-        }
-
-        @Override
         public long getQueueTimeout() {
             return httpNetConnectionQueueTimeout;
         }
@@ -4637,16 +4627,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getRecvBufferSize() {
             return pgRecvBufferSize;
-        }
-
-        @Override
-        public int getSelectCacheBlockCount() {
-            return pgSelectCacheBlockCount;
-        }
-
-        @Override
-        public int getSelectCacheRowCount() {
-            return pgSelectCacheRowCount;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -269,6 +269,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int maxUncommittedRows;
     private final MemoryConfiguration memoryConfiguration;
     private final int metadataStringPoolCapacity;
+    private final Metrics metrics;
     private final MetricsConfiguration metricsConfiguration = new PropMetricsConfiguration();
     private final boolean metricsEnabled;
     private final MicrosecondClock microsecondClock;
@@ -641,6 +642,12 @@ public class PropServerConfiguration implements ServerConfiguration {
             boolean loadAdditionalConfigurations
     ) throws ServerConfigurationException, JsonException {
         this.log = log;
+        this.metricsEnabled = getBoolean(properties, env, PropertyKey.METRICS_ENABLED, false);
+        if (metricsEnabled) {
+            this.metrics = Metrics.enabled();
+        } else {
+            this.metrics = Metrics.DISABLED;
+        }
         this.logSqlQueryProgressExe = getBoolean(properties, env, PropertyKey.LOG_SQL_QUERY_PROGRESS_EXE, true);
         this.logLevelVerbose = getBoolean(properties, env, PropertyKey.LOG_LEVEL_VERBOSE, false);
         this.logTimestampTimezone = getString(properties, env, PropertyKey.LOG_TIMESTAMP_TIMEZONE, "UTC");
@@ -756,6 +763,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.cairoSqlCopyRoot = null;
             this.cairoSqlCopyWorkRoot = null;
         }
+
 
         this.cairoAttachPartitionSuffix = getString(properties, env, PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, TableUtils.ATTACHABLE_DIR_MARKER);
         this.cairoAttachPartitionCopy = getBoolean(properties, env, PropertyKey.CAIRO_ATTACH_PARTITION_COPY, false);
@@ -1490,7 +1498,6 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.sqlParquetFrameCacheCapacity = Math.max(getInt(properties, env, PropertyKey.CAIRO_SQL_PARQUET_FRAME_CACHE_CAPACITY, 3), 3);
             this.sqlOrderBySortEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_ORDER_BY_SORT_ENABLED, true);
             this.sqlOrderByRadixSortThreshold = getInt(properties, env, PropertyKey.CAIRO_SQL_ORDER_BY_RADIX_SORT_THRESHOLD, 600);
-            this.metricsEnabled = getBoolean(properties, env, PropertyKey.METRICS_ENABLED, false);
             this.writerAsyncCommandBusyWaitTimeout = getMillis(properties, env, PropertyKey.CAIRO_WRITER_ALTER_BUSY_WAIT_TIMEOUT, 500);
             this.writerAsyncCommandMaxWaitTimeout = getMillis(properties, env, PropertyKey.CAIRO_WRITER_ALTER_MAX_WAIT_TIMEOUT, 30_000);
             this.writerTickRowsCountMod = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_WRITER_TICK_ROWS_COUNT, 1024)) - 1;
@@ -1576,6 +1583,11 @@ public class PropServerConfiguration implements ServerConfiguration {
     @Override
     public MemoryConfiguration getMemoryConfiguration() {
         return memoryConfiguration;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return metrics;
     }
 
     @Override
@@ -2625,6 +2637,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
+        @Override
         public @NotNull MicrosecondClock getMicrosecondClock() {
             return microsecondClock;
         }
@@ -3406,7 +3423,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpMinServerConfiguration implements HttpMinServerConfiguration {
-
         @Override
         public int getBindIPv4Address() {
             return httpMinBindIPv4Address;
@@ -3460,6 +3476,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getLimit() {
             return httpMinNetConnectionLimit;
+        }
+
+        @Override
+        public Metrics getMetrics() {
+            return metrics;
         }
 
         @Override
@@ -3579,7 +3600,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpServerConfiguration implements HttpServerConfiguration {
-
         @Override
         public int getBindIPv4Address() {
             return httpNetBindIPv4Address;
@@ -3643,6 +3663,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public LineHttpProcessorConfiguration getLineHttpProcessorConfiguration() {
             return lineHttpProcessorConfiguration;
+        }
+
+        @Override
+        public Metrics getMetrics() {
+            return metrics;
         }
 
         @Override
@@ -3905,6 +3930,11 @@ public class PropServerConfiguration implements ServerConfiguration {
     private class PropLineTcpIOWorkerPoolConfiguration implements WorkerPoolConfiguration {
 
         @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
+        @Override
         public long getNapThreshold() {
             return lineTcpIOWorkerNapThreshold;
         }
@@ -3941,7 +3971,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropLineTcpReceiverConfiguration implements LineTcpReceiverConfiguration {
-
         @Override
         public String getAuthDB() {
             return lineTcpAuthDB;
@@ -4076,6 +4105,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
+        @Override
         public MicrosecondClock getMicrosecondClock() {
             return MicrosecondClockImpl.INSTANCE;
         }
@@ -4177,6 +4211,11 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropLineTcpWriterWorkerPoolConfiguration implements WorkerPoolConfiguration {
+        @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
         @Override
         public long getNapThreshold() {
             return lineTcpWriterWorkerNapThreshold;
@@ -4443,6 +4482,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getMaxBlobSizeOnQuery() {
             return pgMaxBlobSizeOnQuery;
+        }
+
+        @Override
+        public Metrics getMetrics() {
+            return metrics;
         }
 
         @Override
@@ -4847,6 +4891,11 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     private class PropWalApplyPoolConfiguration implements WorkerPoolConfiguration {
         @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
+        @Override
         public long getNapThreshold() {
             return walApplyWorkerNapThreshold;
         }
@@ -4893,6 +4942,11 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropWorkerPoolConfiguration implements WorkerPoolConfiguration {
+        @Override
+        public Metrics getMetrics() {
+            return metrics;
+        }
+
         @Override
         public long getNapThreshold() {
             return sharedWorkerNapThreshold;

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -62,6 +62,7 @@ import io.questdb.cutlass.text.types.InputFormatConfiguration;
 import io.questdb.griffin.engine.table.parquet.ParquetCompression;
 import io.questdb.griffin.engine.table.parquet.ParquetVersion;
 import io.questdb.log.Log;
+import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsConfiguration;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.EpollFacade;
@@ -3435,6 +3436,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public LongGauge getConnectionCountGauge() {
+            return metrics.jsonQuery().connectionCountGauge();
+        }
+
+        @Override
         public String getDispatcherLogName() {
             return "http-min-server";
         }
@@ -3596,6 +3602,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public class PropHttpServerConfiguration implements HttpFullFatServerConfiguration {
+
         @Override
         public int getBindIPv4Address() {
             return httpNetBindIPv4Address;
@@ -3609,6 +3616,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public MillisecondClock getClock() {
             return MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public LongGauge getConnectionCountGauge() {
+            return metrics.jsonQuery().connectionCountGauge();
         }
 
         @Override
@@ -4016,6 +4028,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public LongGauge getConnectionCountGauge() {
+            return metrics.line().connectionCountGauge();
+        }
+
+        @Override
         public int getConnectionPoolInitialCapacity() {
             return lineTcpConnectionPoolInitialCapacity;
         }
@@ -4364,7 +4381,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     private class PropPGWireConfiguration implements PGWireConfiguration {
-
         @Override
         public int getBinParamCountCapacity() {
             return pgBinaryParamsCapacity;
@@ -4398,6 +4414,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public MillisecondClock getClock() {
             return MillisecondClockImpl.INSTANCE;
+        }
+
+        @Override
+        public LongGauge getConnectionCountGauge() {
+            return metrics.pgWire().connectionCountGauge();
         }
 
         @Override

--- a/core/src/main/java/io/questdb/ServerConfiguration.java
+++ b/core/src/main/java/io/questdb/ServerConfiguration.java
@@ -26,7 +26,7 @@ package io.questdb;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
 import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
@@ -41,9 +41,9 @@ public interface ServerConfiguration {
 
     FactoryProvider getFactoryProvider();
 
-    HttpMinServerConfiguration getHttpMinServerConfiguration();
+    HttpServerConfiguration getHttpMinServerConfiguration();
 
-    HttpServerConfiguration getHttpServerConfiguration();
+    HttpFullFatServerConfiguration getHttpServerConfiguration();
 
     LineTcpReceiverConfiguration getLineTcpReceiverConfiguration();
 

--- a/core/src/main/java/io/questdb/ServerConfiguration.java
+++ b/core/src/main/java/io/questdb/ServerConfiguration.java
@@ -72,4 +72,6 @@ public interface ServerConfiguration {
 
     default void init(CairoEngine engine, FreeOnExit freeOnExit) {
     }
+
+    Metrics getMetrics();
 }

--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -40,8 +40,8 @@ import io.questdb.cutlass.auth.LineAuthenticatorFactory;
 import io.questdb.cutlass.http.DefaultHttpAuthenticatorFactory;
 import io.questdb.cutlass.http.HttpAuthenticatorFactory;
 import io.questdb.cutlass.http.HttpContextConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpServer;
-import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.StaticHttpAuthenticatorFactory;
 import io.questdb.cutlass.line.tcp.StaticChallengeResponseMatcher;
 import io.questdb.cutlass.pgwire.IPGWireServer;
@@ -134,7 +134,7 @@ public class ServerMain implements Closeable {
     }
 
     public static HttpAuthenticatorFactory getHttpAuthenticatorFactory(ServerConfiguration configuration) {
-        HttpServerConfiguration httpConfig = configuration.getHttpServerConfiguration();
+        HttpFullFatServerConfiguration httpConfig = configuration.getHttpServerConfiguration();
         String username = httpConfig.getUsername();
         if (Chars.empty(username)) {
             return DefaultHttpAuthenticatorFactory.INSTANCE;

--- a/core/src/main/java/io/questdb/WorkerPoolManager.java
+++ b/core/src/main/java/io/questdb/WorkerPoolManager.java
@@ -26,7 +26,7 @@ package io.questdb;
 
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.mp.Worker;
 import io.questdb.mp.WorkerPool;
 import io.questdb.mp.WorkerPoolConfiguration;
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public abstract class WorkerPoolManager implements Scrapable {
+public abstract class WorkerPoolManager implements Target {
 
     private static final Log LOG = LogFactory.getLog(WorkerPoolManager.class);
     protected final WorkerPool sharedPool;

--- a/core/src/main/java/io/questdb/WorkerPoolManager.java
+++ b/core/src/main/java/io/questdb/WorkerPoolManager.java
@@ -45,13 +45,13 @@ public abstract class WorkerPoolManager implements Scrapable {
     private final CharSequenceObjHashMap<WorkerPool> dedicatedPools = new CharSequenceObjHashMap<>(4);
     private final AtomicBoolean running = new AtomicBoolean();
 
-    public WorkerPoolManager(ServerConfiguration config, Metrics metrics) {
-        sharedPool = new WorkerPool(config.getWorkerPoolConfiguration(), metrics);
+    public WorkerPoolManager(ServerConfiguration config) {
+        sharedPool = new WorkerPool(config.getWorkerPoolConfiguration());
         configureSharedPool(sharedPool); // abstract method giving callers the chance to assign jobs
-        metrics.addScrapable(this);
+        config.getMetrics().addScrapable(this);
     }
 
-    public WorkerPool getInstance(@NotNull WorkerPoolConfiguration config, @NotNull Metrics metrics, @NotNull Requester requester) {
+    public WorkerPool getInstance(@NotNull WorkerPoolConfiguration config, @NotNull Requester requester) {
         if (running.get() || closed.get()) {
             throw new IllegalStateException("can only get instance before start");
         }
@@ -66,7 +66,7 @@ public abstract class WorkerPoolManager implements Scrapable {
         String poolName = config.getPoolName();
         WorkerPool pool = dedicatedPools.get(poolName);
         if (pool == null) {
-            pool = new WorkerPool(config, metrics);
+            pool = new WorkerPool(config);
             dedicatedPools.put(poolName, pool);
         }
         LOG.info().$("new DEDICATED pool [name=").$(poolName)

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -28,6 +28,7 @@ import io.questdb.BuildInformation;
 import io.questdb.ConfigPropertyKey;
 import io.questdb.ConfigPropertyValue;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.TelemetryConfiguration;
 import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
@@ -670,4 +671,6 @@ public interface CairoConfiguration {
     }
 
     boolean useFastAsOfJoin();
+
+    Metrics getMetrics();
 }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -449,7 +449,6 @@ public class CairoEngine implements Closeable, WriterSource {
                 backupDirName,
                 getDdlListener(tableToken),
                 checkpointAgent,
-                Metrics.disabled(),
                 this
         );
     }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -56,8 +56,8 @@ import io.questdb.cairo.wal.WalDirectoryPolicy;
 import io.questdb.cairo.wal.WalListener;
 import io.questdb.cairo.wal.WalReader;
 import io.questdb.cairo.wal.WalWriter;
-import io.questdb.cairo.wal.seq.SequencerMetadata;
 import io.questdb.cairo.wal.seq.SeqTxnTracker;
+import io.questdb.cairo.wal.seq.SequencerMetadata;
 import io.questdb.cairo.wal.seq.TableSequencerAPI;
 import io.questdb.cutlass.text.CopyContext;
 import io.questdb.griffin.CompiledQuery;
@@ -146,13 +146,7 @@ public class CairoEngine implements Closeable, WriterSource {
     private @NotNull WalDirectoryPolicy walDirectoryPolicy = DefaultWalDirectoryPolicy.INSTANCE;
     private @NotNull WalListener walListener = DefaultWalListener.INSTANCE;
 
-    // Kept for embedded API purposes. The second constructor (the one with metrics)
-    // should be preferred for internal use.
     public CairoEngine(CairoConfiguration configuration) {
-        this(configuration, Metrics.disabled());
-    }
-
-    public CairoEngine(CairoConfiguration configuration, Metrics metrics) {
         try {
             ffCache = new FunctionFactoryCache(
                     configuration,
@@ -163,7 +157,7 @@ public class CairoEngine implements Closeable, WriterSource {
             this.copyContext = new CopyContext(configuration);
             this.tableSequencerAPI = new TableSequencerAPI(this, configuration);
             this.messageBus = new MessageBusImpl(configuration);
-            this.metrics = metrics;
+            this.metrics = configuration.getMetrics();
             // Message bus and metrics must be initialized before the pools.
             this.writerPool = new WriterPool(configuration, this);
             this.readerPool = new ReaderPool(configuration, messageBus, partitionOverwriteControl);

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -29,6 +29,7 @@ import io.questdb.BuildInformationHolder;
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.DefaultTelemetryConfiguration;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.PropServerConfiguration;
 import io.questdb.TelemetryConfiguration;
 import io.questdb.VolumeDefinitions;
@@ -466,6 +467,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getMetadataPoolCapacity() {
         return getSqlModelPoolCapacity();
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
@@ -26,8 +26,9 @@ package io.questdb.cairo;
 
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.MetricsRegistry;
+import io.questdb.std.Mutable;
 
-public class TableWriterMetrics {
+public class TableWriterMetrics implements Mutable {
 
     // Includes all types of commits (in-order and o3)
     private final Counter commitCounter;
@@ -51,6 +52,15 @@ public class TableWriterMetrics {
 
     public void addPhysicallyWrittenRows(long rows) {
         physicallyWrittenRowCounter.add(rows);
+    }
+
+    @Override
+    public void clear() {
+        commitCounter.reset();
+        committedRowCounter.reset();
+        o3CommitCounter.reset();
+        physicallyWrittenRowCounter.reset();
+        rollbackCounter.reset();
     }
 
     public long getCommitCount() {

--- a/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WalWriterPool.java
@@ -76,7 +76,7 @@ public class WalWriterPool extends AbstractMultiTenantPool<WalWriterPool.WalWrit
                 WalDirectoryPolicy walDirectoryPolicy,
                 Metrics metrics
         ) {
-            super(pool.getConfiguration(), tableToken, tableSequencerAPI, ddlListener, walDirectoryPolicy, metrics);
+            super(pool.getConfiguration(), tableToken, tableSequencerAPI, ddlListener, walDirectoryPolicy);
             this.pool = pool;
             this.entry = entry;
             this.index = index;

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -24,7 +24,16 @@
 
 package io.questdb.cairo.pool;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoError;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.DefaultLifecycleManager;
+import io.questdb.cairo.EntryUnavailableException;
+import io.questdb.cairo.LifecycleManager;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.pool.ex.EntryLockedException;
 import io.questdb.cairo.pool.ex.PoolClosedException;
 import io.questdb.cairo.sql.AsyncWriterCommand;
@@ -380,7 +389,6 @@ public class WriterPool extends AbstractPool {
                     root,
                     engine.getDdlListener(tableToken),
                     engine.getCheckpointStatus(),
-                    engine.getMetrics(),
                     engine
             );
             e.ownershipReason = lockReason;

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -105,7 +105,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
         CairoConfiguration configuration = engine.getConfiguration();
         microClock = configuration.getMicrosecondClock();
         walEventReader = new WalEventReader(configuration.getFilesFacade());
-        metrics = engine.getMetrics().wal();
+        metrics = engine.getMetrics().walMetrics();
         lookAheadTransactionCount = configuration.getWalApplyLookAheadTransactionCount();
         tableTimeQuotaMicros = configuration.getWalApplyTableTimeQuota() >= 0 ? configuration.getWalApplyTableTimeQuota() * 1000L : Timestamps.DAY_MICROS;
     }

--- a/core/src/main/java/io/questdb/cairo/wal/DefaultWalApplyWorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/wal/DefaultWalApplyWorkerPoolConfiguration.java
@@ -24,17 +24,11 @@
 
 package io.questdb.cairo.wal;
 
-import io.questdb.Metrics;
 import io.questdb.mp.WorkerPoolConfiguration;
 
 public class DefaultWalApplyWorkerPoolConfiguration implements WorkerPoolConfiguration {
     @Override
     public int getWorkerCount() {
         return 2;
-    }
-
-    @Override
-    public Metrics getMetrics() {
-        return Metrics.ENABLED;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/DefaultWalApplyWorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/wal/DefaultWalApplyWorkerPoolConfiguration.java
@@ -24,11 +24,17 @@
 
 package io.questdb.cairo.wal;
 
+import io.questdb.Metrics;
 import io.questdb.mp.WorkerPoolConfiguration;
 
 public class DefaultWalApplyWorkerPoolConfiguration implements WorkerPoolConfiguration {
     @Override
     public int getWorkerCount() {
         return 2;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalMetrics.java
@@ -27,10 +27,11 @@ package io.questdb.cairo.wal;
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
+import io.questdb.std.Mutable;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-public class WalMetrics {
+public class WalMetrics implements Mutable {
     private final Counter applyPhysicallyWrittenRowsCounter;
     private final LongGauge applyRowsWriteRateGauge;
     private final Counter applyRowsWrittenCounter;
@@ -56,5 +57,15 @@ public class WalMetrics {
 
     public void addRowsWritten(long rows) {
         rowsWrittenCounter.add(rows);
+    }
+
+    @Override
+    public void clear() {
+        applyPhysicallyWrittenRowsCounter.reset();
+        applyRowsWriteRateGauge.setValue(0);
+        applyRowsWrittenCounter.reset();
+        rowsWrittenCounter.reset();
+        totalRowsWritten.set(0);
+        totalRowsWrittenTotalTime.set(0);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -319,7 +319,7 @@ public class WalWriter implements TableWriterAPI {
                         .$(", minTs=").$ts(txnMinTimestamp).$(", maxTs=").$ts(txnMaxTimestamp).I$();
                 resetDataTxnProperties();
                 mayRollSegmentOnNextRow();
-                metrics.wal().addRowsWritten(rowsToCommit);
+                metrics.walMetrics().addRowsWritten(rowsToCommit);
                 return seqTxn;
             }
         } catch (CairoException ex) {

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -161,8 +161,7 @@ public class WalWriter implements TableWriterAPI {
             TableToken tableToken,
             TableSequencerAPI tableSequencerAPI,
             DdlListener ddlListener,
-            WalDirectoryPolicy walDirectoryPolicy,
-            Metrics metrics
+            WalDirectoryPolicy walDirectoryPolicy
     ) {
         LOG.info().$("open '").utf8(tableToken.getDirName()).$('\'').$();
         this.sequencer = tableSequencerAPI;
@@ -179,7 +178,7 @@ public class WalWriter implements TableWriterAPI {
         this.pathRootSize = path.size();
         this.path.concat(tableToken).concat(walName);
         this.pathSize = path.size();
-        this.metrics = metrics;
+        this.metrics = configuration.getMetrics();
         this.open = true;
         this.symbolMapMem = Vm.getMARInstance(configuration);
 

--- a/core/src/main/java/io/questdb/cutlass/Services.java
+++ b/core/src/main/java/io/questdb/cutlass/Services.java
@@ -30,8 +30,8 @@ import io.questdb.WorkerPoolManager;
 import io.questdb.WorkerPoolManager.Requester;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cutlass.http.HttpCookieHandler;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpHeaderParserFactory;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.HttpRequestProcessorFactory;
 import io.questdb.cutlass.http.HttpServer;
@@ -68,7 +68,7 @@ public class Services {
             CairoEngine cairoEngine,
             WorkerPoolManager workerPoolManager
     ) {
-        HttpServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
+        HttpFullFatServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
         if (!httpServerConfiguration.isEnabled()) {
             return null;
         }
@@ -91,7 +91,7 @@ public class Services {
             WorkerPool workerPool,
             int sharedWorkerCount
     ) {
-        final HttpServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
+        final HttpFullFatServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
         if (!httpServerConfiguration.isEnabled()) {
             return null;
         }
@@ -182,7 +182,7 @@ public class Services {
 
     @Nullable
     public HttpServer createMinHttpServer(
-            HttpMinServerConfiguration configuration,
+            HttpServerConfiguration configuration,
             WorkerPoolManager workerPoolManager
     ) {
         if (!configuration.isEnabled()) {
@@ -200,7 +200,7 @@ public class Services {
     }
 
     @Nullable
-    public HttpServer createMinHttpServer(HttpMinServerConfiguration configuration, WorkerPool workerPool) {
+    public HttpServer createMinHttpServer(HttpServerConfiguration configuration, WorkerPool workerPool) {
         if (!configuration.isEnabled()) {
             return null;
         }

--- a/core/src/main/java/io/questdb/cutlass/Services.java
+++ b/core/src/main/java/io/questdb/cutlass/Services.java
@@ -66,8 +66,7 @@ public class Services {
     public HttpServer createHttpServer(
             ServerConfiguration serverConfiguration,
             CairoEngine cairoEngine,
-            WorkerPoolManager workerPoolManager,
-            Metrics metrics
+            WorkerPoolManager workerPoolManager
     ) {
         HttpServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
         if (!httpServerConfiguration.isEnabled()) {
@@ -80,9 +79,8 @@ public class Services {
         return createHttpServer(
                 serverConfiguration,
                 cairoEngine,
-                workerPoolManager.getInstance(httpServerConfiguration, metrics, Requester.HTTP_SERVER),
-                workerPoolManager.getSharedWorkerCount(),
-                metrics
+                workerPoolManager.getInstance(httpServerConfiguration, Requester.HTTP_SERVER),
+                workerPoolManager.getSharedWorkerCount()
         );
     }
 
@@ -91,8 +89,7 @@ public class Services {
             ServerConfiguration serverConfiguration,
             CairoEngine cairoEngine,
             WorkerPool workerPool,
-            int sharedWorkerCount,
-            Metrics metrics
+            int sharedWorkerCount
     ) {
         final HttpServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
         if (!httpServerConfiguration.isEnabled()) {
@@ -103,7 +100,6 @@ public class Services {
         final HttpHeaderParserFactory headerParserFactory = serverConfiguration.getFactoryProvider().getHttpHeaderParserFactory();
         final HttpServer server = new HttpServer(
                 httpServerConfiguration,
-                metrics,
                 workerPool,
                 serverConfiguration.getFactoryProvider().getHttpSocketFactory(),
                 cookieHandler,
@@ -139,8 +135,7 @@ public class Services {
     public LineTcpReceiver createLineTcpReceiver(
             LineTcpReceiverConfiguration config,
             CairoEngine cairoEngine,
-            WorkerPoolManager workerPoolManager,
-            Metrics metrics
+            WorkerPoolManager workerPoolManager
     ) {
         if (!config.isEnabled()) {
             return null;
@@ -159,12 +154,10 @@ public class Services {
 
         final WorkerPool ioPool = workerPoolManager.getInstance(
                 config.getIOWorkerPoolConfiguration(),
-                metrics,
                 Requester.LINE_TCP_IO
         );
         final WorkerPool writerPool = workerPoolManager.getInstance(
                 config.getWriterWorkerPoolConfiguration(),
-                metrics,
                 Requester.LINE_TCP_WRITER
         );
         return new LineTcpReceiver(config, cairoEngine, ioPool, writerPool);
@@ -190,8 +183,7 @@ public class Services {
     @Nullable
     public HttpServer createMinHttpServer(
             HttpMinServerConfiguration configuration,
-            WorkerPoolManager workerPoolManager,
-            Metrics metrics
+            WorkerPoolManager workerPoolManager
     ) {
         if (!configuration.isEnabled()) {
             return null;
@@ -202,19 +194,19 @@ public class Services {
         // - DEDICATED (1 worker) otherwise
         final WorkerPool workerPool = workerPoolManager.getInstance(
                 configuration,
-                metrics,
                 Requester.HTTP_MIN_SERVER
         );
-        return createMinHttpServer(configuration, workerPool, metrics);
+        return createMinHttpServer(configuration, workerPool);
     }
 
     @Nullable
-    public HttpServer createMinHttpServer(HttpMinServerConfiguration configuration, WorkerPool workerPool, Metrics metrics) {
+    public HttpServer createMinHttpServer(HttpMinServerConfiguration configuration, WorkerPool workerPool) {
         if (!configuration.isEnabled()) {
             return null;
         }
 
-        final HttpServer server = new HttpServer(configuration, metrics, workerPool, configuration.getFactoryProvider().getHttpMinSocketFactory());
+        final HttpServer server = new HttpServer(configuration, workerPool, configuration.getFactoryProvider().getHttpMinSocketFactory());
+        Metrics metrics = configuration.getHttpContextConfiguration().getMetrics();
         server.bind(new HttpRequestProcessorFactory() {
             @Override
             public String getUrl() {
@@ -250,8 +242,7 @@ public class Services {
     public IPGWireServer createPGWireServer(
             PGWireConfiguration configuration,
             CairoEngine cairoEngine,
-            WorkerPoolManager workerPoolManager,
-            Metrics metrics
+            WorkerPoolManager workerPoolManager
     ) {
         if (!configuration.isEnabled()) {
             return null;
@@ -262,7 +253,6 @@ public class Services {
         // - SHARED otherwise
         final WorkerPool workerPool = workerPoolManager.getInstance(
                 configuration,
-                metrics,
                 Requester.PG_WIRE_SERVER
         );
 

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpContextConfiguration.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.http;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.NanosecondClock;
@@ -119,5 +120,10 @@ public class DefaultHttpContextConfiguration implements HttpContextConfiguration
     @Override
     public boolean readOnlySecurityContext() {
         return false;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.http;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
@@ -112,6 +113,11 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
     @Override
     public LineHttpProcessorConfiguration getLineHttpProcessorConfiguration() {
         return lineHttpProcessorConfiguration;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -132,16 +132,6 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
     }
 
     @Override
-    public int getQueryCacheBlockCount() {
-        return 2;
-    }
-
-    @Override
-    public int getQueryCacheRowCount() {
-        return 8;
-    }
-
-    @Override
     public byte getRequiredAuthType() {
         return SecurityContext.AUTH_TYPE_NONE;
     }

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -44,7 +44,7 @@ import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfiguration implements HttpServerConfiguration {
+public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfiguration implements HttpFullFatServerConfiguration {
     protected final MimeTypesCache mimeTypesCache;
     private final HttpContextConfiguration httpContextConfiguration;
     private final JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new DefaultJsonQueryProcessorConfiguration() {

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -26,7 +26,6 @@ package io.questdb.cutlass.http;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
-import io.questdb.Metrics;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
@@ -120,11 +119,6 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
     @Override
     public LineHttpProcessorConfiguration getLineHttpProcessorConfiguration() {
         return lineHttpProcessorConfiguration;
-    }
-
-    @Override
-    public Metrics getMetrics() {
-        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -33,6 +33,8 @@ import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
 import io.questdb.cutlass.line.LineTcpTimestampAdapter;
 import io.questdb.network.DefaultIODispatcherConfiguration;
+import io.questdb.std.ConcurrentCacheConfiguration;
+import io.questdb.std.DefaultConcurrentCacheConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.NanosecondClock;
@@ -93,6 +95,11 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
             throw new RuntimeException(e);
         }
         this.httpContextConfiguration = httpContextConfiguration;
+    }
+
+    @Override
+    public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+        return DefaultConcurrentCacheConfiguration.DEFAULT;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -115,12 +115,10 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
     @TestOnly
     public HttpConnectionContext(
             HttpMinServerConfiguration configuration,
-            Metrics metrics,
             SocketFactory socketFactory
     ) {
         this(
                 configuration,
-                metrics,
                 socketFactory,
                 DefaultHttpCookieHandler.INSTANCE,
                 DefaultHttpHeaderParserFactory.INSTANCE,
@@ -130,7 +128,6 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
 
     public HttpConnectionContext(
             HttpMinServerConfiguration configuration,
-            Metrics metrics,
             SocketFactory socketFactory,
             HttpCookieHandler cookieHandler,
             HttpHeaderParserFactory headerParserFactory,
@@ -160,7 +157,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         this.dumpNetworkTraffic = contextConfiguration.getDumpNetworkTraffic();
         // This is default behaviour until the security context is overridden with correct principal.
         this.securityContext = DenyAllSecurityContext.INSTANCE;
-        this.metrics = metrics;
+        this.metrics = contextConfiguration.getMetrics();
         this.authenticator = contextConfiguration.getFactoryProvider().getHttpAuthenticatorFactory().getHttpAuthenticator();
         this.rejectProcessor = contextConfiguration.getFactoryProvider().getRejectProcessorFactory().getRejectProcessor(this);
         this.forceFragmentationReceiveChunkSize = contextConfiguration.getForceRecvFragmentationChunkSize();

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -77,7 +77,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
     private static final Log LOG = LogFactory.getLog(HttpConnectionContext.class);
     private final HttpAuthenticator authenticator;
     private final ChunkedContentParser chunkedContentParser = new ChunkedContentParser();
-    private final HttpMinServerConfiguration configuration;
+    private final HttpServerConfiguration configuration;
     private final HttpCookieHandler cookieHandler;
     private final ObjectPool<DirectUtf8String> csPool;
     private final boolean dumpNetworkTraffic;
@@ -114,7 +114,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
 
     @TestOnly
     public HttpConnectionContext(
-            HttpMinServerConfiguration configuration,
+            HttpServerConfiguration configuration,
             SocketFactory socketFactory
     ) {
         this(
@@ -127,7 +127,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
     }
 
     public HttpConnectionContext(
-            HttpMinServerConfiguration configuration,
+            HttpServerConfiguration configuration,
             SocketFactory socketFactory,
             HttpCookieHandler cookieHandler,
             HttpHeaderParserFactory headerParserFactory,

--- a/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpContextConfiguration.java
@@ -25,6 +25,7 @@
 package io.questdb.cutlass.http;
 
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.network.NetworkFacade;
 import io.questdb.std.NanosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
@@ -64,4 +65,6 @@ public interface HttpContextConfiguration {
     boolean getServerKeepAlive();
 
     boolean readOnlySecurityContext();
+
+    Metrics getMetrics();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
@@ -24,21 +24,26 @@
 
 package io.questdb.cutlass.http;
 
-import io.questdb.FactoryProvider;
-import io.questdb.mp.WorkerPoolConfiguration;
-import io.questdb.network.IODispatcherConfiguration;
+import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
+import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
+import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
 
-public interface HttpMinServerConfiguration extends IODispatcherConfiguration, WorkerPoolConfiguration {
+public interface HttpFullFatServerConfiguration extends HttpServerConfiguration {
+    String DEFAULT_PROCESSOR_URL = "*";
 
-    FactoryProvider getFactoryProvider();
+    JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration();
 
-    HttpContextConfiguration getHttpContextConfiguration();
+    LineHttpProcessorConfiguration getLineHttpProcessorConfiguration();
 
-    byte getRequiredAuthType();
+    String getPassword();
 
-    WaitProcessorConfiguration getWaitProcessorConfiguration();
+    int getQueryCacheBlockCount();
 
-    boolean isPessimisticHealthCheckEnabled();
+    int getQueryCacheRowCount();
 
-    boolean preAllocateBuffers();
+    StaticContentProcessorConfiguration getStaticContentProcessorConfiguration();
+
+    String getUsername();
+
+    boolean isQueryCacheEnabled();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
@@ -27,9 +27,12 @@ package io.questdb.cutlass.http;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
+import io.questdb.std.ConcurrentCacheConfiguration;
 
 public interface HttpFullFatServerConfiguration extends HttpServerConfiguration {
     String DEFAULT_PROCESSOR_URL = "*";
+
+    ConcurrentCacheConfiguration getConcurrentCacheConfiguration();
 
     JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration();
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpFullFatServerConfiguration.java
@@ -40,10 +40,6 @@ public interface HttpFullFatServerConfiguration extends HttpServerConfiguration 
 
     String getPassword();
 
-    int getQueryCacheBlockCount();
-
-    int getQueryCacheRowCount();
-
     StaticContentProcessorConfiguration getStaticContentProcessorConfiguration();
 
     String getUsername();

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
@@ -46,16 +46,6 @@ public class HttpMinServerConfigurationWrapper implements HttpServerConfiguratio
     }
 
     @Override
-    public Counter getAboveMaxConnectionCountCounter() {
-        return getDelegate().getAboveMaxConnectionCountCounter();
-    }
-
-    @Override
-    public Counter getBelowMaxConnectionCountCounter() {
-        return getDelegate().getBelowMaxConnectionCountCounter();
-    }
-
-    @Override
     public int getBindIPv4Address() {
         return getDelegate().getBindIPv4Address();
     }
@@ -258,6 +248,11 @@ public class HttpMinServerConfigurationWrapper implements HttpServerConfiguratio
     @Override
     public boolean isPessimisticHealthCheckEnabled() {
         return getDelegate().isPessimisticHealthCheckEnabled();
+    }
+
+    @Override
+    public Counter listenerStateChangeCounter() {
+        return getDelegate().listenerStateChangeCounter();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.http;
 
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
@@ -45,6 +46,16 @@ public class HttpMinServerConfigurationWrapper implements HttpServerConfiguratio
     }
 
     @Override
+    public Counter getAboveMaxConnectionCountCounter() {
+        return getDelegate().getAboveMaxConnectionCountCounter();
+    }
+
+    @Override
+    public Counter getBelowMaxConnectionCountCounter() {
+        return getDelegate().getBelowMaxConnectionCountCounter();
+    }
+
+    @Override
     public int getBindIPv4Address() {
         return getDelegate().getBindIPv4Address();
     }
@@ -61,7 +72,7 @@ public class HttpMinServerConfigurationWrapper implements HttpServerConfiguratio
 
     @Override
     public LongGauge getConnectionCountGauge() {
-        return metrics.jsonQuery().connectionCountGauge();
+        return metrics.httpMetrics().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
@@ -34,8 +34,8 @@ import io.questdb.std.datetime.millitime.MillisecondClock;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-public class HttpMinServerConfigurationWrapper implements HttpMinServerConfiguration {
-    private final AtomicReference<HttpMinServerConfiguration> delegate = new AtomicReference<>();
+public class HttpMinServerConfigurationWrapper implements HttpServerConfiguration {
+    private final AtomicReference<HttpServerConfiguration> delegate = new AtomicReference<>();
     private final Metrics metrics;
 
     public HttpMinServerConfigurationWrapper(Metrics metrics) {
@@ -248,7 +248,7 @@ public class HttpMinServerConfigurationWrapper implements HttpMinServerConfigura
         return getDelegate().preAllocateBuffers();
     }
 
-    public void setDelegate(HttpMinServerConfiguration delegate) {
+    public void setDelegate(HttpServerConfiguration delegate) {
         this.delegate.set(delegate);
     }
 
@@ -257,7 +257,7 @@ public class HttpMinServerConfigurationWrapper implements HttpMinServerConfigura
         return getDelegate().workerPoolPriority();
     }
 
-    protected HttpMinServerConfiguration getDelegate() {
+    protected HttpServerConfiguration getDelegate() {
         return delegate.get();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMinServerConfigurationWrapper.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.http;
 
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
+import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
 import io.questdb.network.NetworkFacade;
@@ -56,6 +57,11 @@ public class HttpMinServerConfigurationWrapper implements HttpServerConfiguratio
     @Override
     public MillisecondClock getClock() {
         return getDelegate().getClock();
+    }
+
+    @Override
+    public LongGauge getConnectionCountGauge() {
+        return metrics.jsonQuery().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -89,7 +89,7 @@ public class HttpResponseSink implements Closeable, Mutable {
     private long totalBytesSent = 0;
     private long zStreamPtr = 0;
 
-    public HttpResponseSink(HttpMinServerConfiguration configuration) {
+    public HttpResponseSink(HttpServerConfiguration configuration) {
         final int responseBufferSize = configuration.getSendBufferSize();
         this.nf = configuration.getNetworkFacade();
         this.buffer = new ChunkUtf8Sink(responseBufferSize);

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -119,11 +119,7 @@ public class HttpServer implements Closeable {
         }
 
         this.httpContextFactory = new HttpContextFactory(configuration, socketFactory, cookieHandler, headerParserFactory, selectCache);
-        this.dispatcher = IODispatchers.create(
-                configuration,
-                httpContextFactory,
-                configuration.getHttpContextConfiguration().getMetrics().jsonQuery().connectionCountGauge()
-        );
+        this.dispatcher = IODispatchers.create(configuration, httpContextFactory);
         pool.assign(dispatcher);
         this.rescheduleContext = new WaitProcessor(configuration.getWaitProcessorConfiguration(), dispatcher);
         pool.assign(rescheduleContext);

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -72,7 +72,7 @@ public class HttpServer implements Closeable {
 
     // used for min http server only
     public HttpServer(
-            HttpMinServerConfiguration configuration,
+            HttpServerConfiguration configuration,
             WorkerPool pool,
             SocketFactory socketFactory
     ) {
@@ -86,7 +86,7 @@ public class HttpServer implements Closeable {
     }
 
     public HttpServer(
-            HttpMinServerConfiguration configuration,
+            HttpServerConfiguration configuration,
             WorkerPool pool,
             SocketFactory socketFactory,
             HttpCookieHandler cookieHandler,
@@ -99,8 +99,8 @@ public class HttpServer implements Closeable {
             selectors.add(new HttpRequestProcessorSelectorImpl());
         }
 
-        if (configuration instanceof HttpServerConfiguration) {
-            final HttpServerConfiguration serverConfiguration = (HttpServerConfiguration) configuration;
+        if (configuration instanceof HttpFullFatServerConfiguration) {
+            final HttpFullFatServerConfiguration serverConfiguration = (HttpFullFatServerConfiguration) configuration;
             Metrics metrics = serverConfiguration.getHttpContextConfiguration().getMetrics();
             if (serverConfiguration.isQueryCacheEnabled()) {
                 this.selectCache = new ConcurrentAssociativeCache<>(
@@ -160,7 +160,7 @@ public class HttpServer implements Closeable {
             HttpRequestProcessorBuilder jsonQueryProcessorBuilder,
             HttpRequestProcessorBuilder ilpWriteProcessorBuilderV2
     ) {
-        final HttpServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
+        final HttpFullFatServerConfiguration httpServerConfiguration = serverConfiguration.getHttpServerConfiguration();
         final LineHttpProcessorConfiguration lineHttpProcessorConfiguration = httpServerConfiguration.getLineHttpProcessorConfiguration();
         // Disable ILP HTTP if the instance configured to be read-only for HTTP requests
         if (httpServerConfiguration.isEnabled() && lineHttpProcessorConfiguration.isEnabled() && !httpServerConfiguration.getHttpContextConfiguration().readOnlySecurityContext()) {
@@ -286,7 +286,7 @@ public class HttpServer implements Closeable {
         server.bind(new HttpRequestProcessorFactory() {
             @Override
             public String getUrl() {
-                return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
             }
 
             @Override
@@ -305,7 +305,7 @@ public class HttpServer implements Closeable {
         assert url != null;
         for (int i = 0; i < workerCount; i++) {
             HttpRequestProcessorSelectorImpl selector = selectors.getQuick(i);
-            if (HttpServerConfiguration.DEFAULT_PROCESSOR_URL.equals(url)) {
+            if (HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL.equals(url)) {
                 selector.defaultRequestProcessor = factory.newInstance();
             } else {
                 final HttpRequestProcessor processor = factory.newInstance();
@@ -362,7 +362,7 @@ public class HttpServer implements Closeable {
     private static class HttpContextFactory extends IOContextFactoryImpl<HttpConnectionContext> {
 
         public HttpContextFactory(
-                HttpMinServerConfiguration configuration,
+                HttpServerConfiguration configuration,
                 SocketFactory socketFactory,
                 HttpCookieHandler cookieHandler,
                 HttpHeaderParserFactory headerParserFactory,

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServer.java
@@ -24,7 +24,6 @@
 
 package io.questdb.cutlass.http;
 
-import io.questdb.Metrics;
 import io.questdb.ServerConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.sql.RecordCursorFactory;
@@ -101,15 +100,8 @@ public class HttpServer implements Closeable {
 
         if (configuration instanceof HttpFullFatServerConfiguration) {
             final HttpFullFatServerConfiguration serverConfiguration = (HttpFullFatServerConfiguration) configuration;
-            Metrics metrics = serverConfiguration.getHttpContextConfiguration().getMetrics();
             if (serverConfiguration.isQueryCacheEnabled()) {
-                this.selectCache = new ConcurrentAssociativeCache<>(
-                        serverConfiguration.getQueryCacheBlockCount(),
-                        serverConfiguration.getQueryCacheRowCount(),
-                        metrics.jsonQuery().cachedQueriesGauge(),
-                        metrics.jsonQuery().cacheHitCounter(),
-                        metrics.jsonQuery().cacheMissCounter()
-                );
+                this.selectCache = new ConcurrentAssociativeCache<>(serverConfiguration.getConcurrentCacheConfiguration());
             } else {
                 this.selectCache = NO_OP_CACHE;
             }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfiguration.java
@@ -24,27 +24,21 @@
 
 package io.questdb.cutlass.http;
 
-import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
-import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
-import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
+import io.questdb.FactoryProvider;
+import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.network.IODispatcherConfiguration;
 
-public interface HttpServerConfiguration extends HttpMinServerConfiguration {
-    String DEFAULT_PROCESSOR_URL = "*";
-    int MIN_SEND_BUFFER_SIZE = 128;
+public interface HttpServerConfiguration extends IODispatcherConfiguration, WorkerPoolConfiguration {
 
-    JsonQueryProcessorConfiguration getJsonQueryProcessorConfiguration();
+    FactoryProvider getFactoryProvider();
 
-    LineHttpProcessorConfiguration getLineHttpProcessorConfiguration();
+    HttpContextConfiguration getHttpContextConfiguration();
 
-    String getPassword();
+    byte getRequiredAuthType();
 
-    int getQueryCacheBlockCount();
+    WaitProcessorConfiguration getWaitProcessorConfiguration();
 
-    int getQueryCacheRowCount();
+    boolean isPessimisticHealthCheckEnabled();
 
-    StaticContentProcessorConfiguration getStaticContentProcessorConfiguration();
-
-    String getUsername();
-
-    boolean isQueryCacheEnabled();
+    boolean preAllocateBuffers();
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -189,16 +189,6 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     }
 
     @Override
-    public int getQueryCacheBlockCount() {
-        return getDelegate().getQueryCacheBlockCount();
-    }
-
-    @Override
-    public int getQueryCacheRowCount() {
-        return getDelegate().getQueryCacheRowCount();
-    }
-
-    @Override
     public long getQueueTimeout() {
         return getDelegate().getQueueTimeout();
     }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -34,6 +34,7 @@ import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.SelectFacade;
+import io.questdb.std.ConcurrentCacheConfiguration;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -60,6 +61,11 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     @Override
     public MillisecondClock getClock() {
         return getDelegate().getClock();
+    }
+
+    @Override
+    public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+        return getDelegate().getConcurrentCacheConfiguration();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -29,6 +29,7 @@ import io.questdb.Metrics;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
@@ -46,6 +47,16 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     public HttpServerConfigurationWrapper(Metrics metrics) {
         this.metrics = metrics;
         delegate.set(null);
+    }
+
+    @Override
+    public Counter getAboveMaxConnectionCountCounter() {
+        return getDelegate().getAboveMaxConnectionCountCounter();
+    }
+
+    @Override
+    public Counter getBelowMaxConnectionCountCounter() {
+        return getDelegate().getBelowMaxConnectionCountCounter();
     }
 
     @Override
@@ -70,7 +81,7 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
 
     @Override
     public LongGauge getConnectionCountGauge() {
-        return metrics.jsonQuery().connectionCountGauge();
+        return metrics.httpMetrics().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -37,8 +37,8 @@ import io.questdb.std.datetime.millitime.MillisecondClock;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-public class HttpServerConfigurationWrapper implements HttpServerConfiguration {
-    private final AtomicReference<HttpServerConfiguration> delegate = new AtomicReference<>();
+public class HttpServerConfigurationWrapper implements HttpFullFatServerConfiguration {
+    private final AtomicReference<HttpFullFatServerConfiguration> delegate = new AtomicReference<>();
     private final Metrics metrics;
 
     public HttpServerConfigurationWrapper(Metrics metrics) {
@@ -291,7 +291,7 @@ public class HttpServerConfigurationWrapper implements HttpServerConfiguration {
         return getDelegate().preAllocateBuffers();
     }
 
-    public void setDelegate(HttpServerConfiguration delegate) {
+    public void setDelegate(HttpFullFatServerConfiguration delegate) {
         this.delegate.set(delegate);
     }
 
@@ -300,7 +300,7 @@ public class HttpServerConfigurationWrapper implements HttpServerConfiguration {
         return getDelegate().workerPoolPriority();
     }
 
-    protected HttpServerConfiguration getDelegate() {
+    protected HttpFullFatServerConfiguration getDelegate() {
         return delegate.get();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -29,6 +29,7 @@ import io.questdb.Metrics;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
 import io.questdb.cutlass.http.processors.StaticContentProcessorConfiguration;
+import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
 import io.questdb.network.NetworkFacade;
@@ -59,6 +60,11 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     @Override
     public MillisecondClock getClock() {
         return getDelegate().getClock();
+    }
+
+    @Override
+    public LongGauge getConnectionCountGauge() {
+        return metrics.jsonQuery().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpServerConfigurationWrapper.java
@@ -50,16 +50,6 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     }
 
     @Override
-    public Counter getAboveMaxConnectionCountCounter() {
-        return getDelegate().getAboveMaxConnectionCountCounter();
-    }
-
-    @Override
-    public Counter getBelowMaxConnectionCountCounter() {
-        return getDelegate().getBelowMaxConnectionCountCounter();
-    }
-
-    @Override
     public int getBindIPv4Address() {
         return getDelegate().getBindIPv4Address();
     }
@@ -297,6 +287,11 @@ public class HttpServerConfigurationWrapper implements HttpFullFatServerConfigur
     @Override
     public boolean isQueryCacheEnabled() {
         return getDelegate().isQueryCacheEnabled();
+    }
+
+    @Override
+    public Counter listenerStateChangeCounter() {
+        return getDelegate().listenerStateChangeCounter();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
@@ -26,8 +26,8 @@ package io.questdb.cutlass.http.processors;
 
 import io.questdb.cutlass.http.HttpChunkedResponse;
 import io.questdb.cutlass.http.HttpConnectionContext;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestProcessor;
+import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.metrics.HealthMetricsImpl;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
@@ -37,7 +37,7 @@ public class HealthCheckProcessor implements HttpRequestProcessor {
     private final boolean pessimisticMode;
     private final byte requiredAuthType;
 
-    public HealthCheckProcessor(HttpMinServerConfiguration configuration) {
+    public HealthCheckProcessor(HttpServerConfiguration configuration) {
         this.pessimisticMode = configuration.isPessimisticHealthCheckEnabled();
         this.requiredAuthType = configuration.getRequiredAuthType();
     }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HealthCheckProcessor.java
@@ -52,7 +52,7 @@ public class HealthCheckProcessor implements HttpRequestProcessor {
         HttpChunkedResponse response = context.getChunkedResponse();
 
         if (pessimisticMode) {
-            final HealthMetricsImpl metrics = context.getMetrics().health();
+            final HealthMetricsImpl metrics = context.getMetrics().healthMetrics();
             final long unhandledErrors = metrics.unhandledErrorsCount();
             if (unhandledErrors > 0) {
                 response.status(500, "text/plain");

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HttpMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HttpMetrics.java
@@ -22,27 +22,22 @@
  *
  ******************************************************************************/
 
-package io.questdb.cutlass.line;
+package io.questdb.cutlass.http.processors;
 
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.std.Mutable;
 
-public class LineMetrics implements Mutable {
-
+public class HttpMetrics implements Mutable {
     private final Counter aboveMaxConnectionCountCounter;
     private final Counter belowMaxConnectionCountCounter;
     private final LongGauge connectionCountGauge;
-    private final LongGauge totalIlpHttpBytesGauge;
-    private final LongGauge totalIlpTcpBytesGauge;
 
-    public LineMetrics(MetricsRegistry metricsRegistry) {
-        this.connectionCountGauge = metricsRegistry.newLongGauge("line_tcp_connections");
-        this.totalIlpTcpBytesGauge = metricsRegistry.newLongGauge("line_tcp_recv_bytes");
-        this.totalIlpHttpBytesGauge = metricsRegistry.newLongGauge("line_http_recv_bytes");
-        this.aboveMaxConnectionCountCounter = metricsRegistry.newCounter("line_tcp_above_max_connection_count");
-        this.belowMaxConnectionCountCounter = metricsRegistry.newCounter("line_tcp_below_max_connection_count");
+    public HttpMetrics(MetricsRegistry metricsRegistry) {
+        this.connectionCountGauge = metricsRegistry.newLongGauge("http_connections");
+        this.aboveMaxConnectionCountCounter = metricsRegistry.newCounter("http_above_max_connection_count");
+        this.belowMaxConnectionCountCounter = metricsRegistry.newCounter("http_below_max_connection_count");
     }
 
     public Counter aboveMaxConnectionCountCounter() {
@@ -56,21 +51,11 @@ public class LineMetrics implements Mutable {
     @Override
     public void clear() {
         connectionCountGauge.setValue(0);
-        totalIlpTcpBytesGauge.setValue(0);
-        totalIlpHttpBytesGauge.setValue(0);
         aboveMaxConnectionCountCounter.reset();
         belowMaxConnectionCountCounter.reset();
     }
 
     public LongGauge connectionCountGauge() {
         return connectionCountGauge;
-    }
-
-    public LongGauge totalIlpHttpBytesGauge() {
-        return totalIlpHttpBytesGauge;
-    }
-
-    public LongGauge totalIlpTcpBytesGauge() {
-        return totalIlpTcpBytesGauge;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/HttpMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/HttpMetrics.java
@@ -30,29 +30,22 @@ import io.questdb.metrics.MetricsRegistry;
 import io.questdb.std.Mutable;
 
 public class HttpMetrics implements Mutable {
-    private final Counter aboveMaxConnectionCountCounter;
-    private final Counter belowMaxConnectionCountCounter;
+    private final Counter listenerStateChangeCounter;
     private final LongGauge connectionCountGauge;
 
     public HttpMetrics(MetricsRegistry metricsRegistry) {
         this.connectionCountGauge = metricsRegistry.newLongGauge("http_connections");
-        this.aboveMaxConnectionCountCounter = metricsRegistry.newCounter("http_above_max_connection_count");
-        this.belowMaxConnectionCountCounter = metricsRegistry.newCounter("http_below_max_connection_count");
-    }
-
-    public Counter aboveMaxConnectionCountCounter() {
-        return aboveMaxConnectionCountCounter;
-    }
-
-    public Counter belowMaxConnectionCountCounter() {
-        return belowMaxConnectionCountCounter;
+        this.listenerStateChangeCounter = metricsRegistry.newCounter("http_listener_state_change_count");
     }
 
     @Override
     public void clear() {
         connectionCountGauge.setValue(0);
-        aboveMaxConnectionCountCounter.reset();
-        belowMaxConnectionCountCounter.reset();
+        listenerStateChangeCounter.reset();
+    }
+
+    public Counter listenerStateChangeCounter() {
+        return listenerStateChangeCounter;
     }
 
     public LongGauge connectionCountGauge() {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
@@ -35,27 +35,14 @@ public class JsonQueryMetrics implements Mutable {
     private final Counter cacheMissCounter;
     private final LongGauge cachedQueriesGauge;
     private final Counter completedQueriesCounter;
-    private final LongGauge connectionCountGauge;
     private final Counter startedQueriesCounter;
 
     public JsonQueryMetrics(MetricsRegistry metricsRegistry) {
-        this.connectionCountGauge = metricsRegistry.newLongGauge("http_connections");
         this.startedQueriesCounter = metricsRegistry.newCounter("json_queries");
         this.completedQueriesCounter = metricsRegistry.newCounter("json_queries_completed");
         this.cachedQueriesGauge = metricsRegistry.newLongGauge("json_queries_cached");
         this.cacheHitCounter = metricsRegistry.newCounter("json_queries_cache_hits");
         this.cacheMissCounter = metricsRegistry.newCounter("json_queries_cache_misses");
-    }
-
-    @Override
-    public void clear() {
-        cacheHitCounter.reset();
-        cacheHitCounter.reset();
-        cacheMissCounter.reset();
-        cachedQueriesGauge.setValue(0);
-        completedQueriesCounter.reset();
-        connectionCountGauge.setValue(0);
-        startedQueriesCounter.reset();
     }
 
     public Counter cacheHitCounter() {
@@ -70,13 +57,19 @@ public class JsonQueryMetrics implements Mutable {
         return cachedQueriesGauge;
     }
 
+    @Override
+    public void clear() {
+        cacheHitCounter.reset();
+        cacheHitCounter.reset();
+        cacheMissCounter.reset();
+        cachedQueriesGauge.setValue(0);
+        completedQueriesCounter.reset();
+        startedQueriesCounter.reset();
+    }
+
     @TestOnly
     public long completedQueriesCount() {
         return completedQueriesCounter.getValue();
-    }
-
-    public LongGauge connectionCountGauge() {
-        return connectionCountGauge;
     }
 
     public void markComplete() {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryMetrics.java
@@ -27,9 +27,10 @@ package io.questdb.cutlass.http.processors;
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
+import io.questdb.std.Mutable;
 import org.jetbrains.annotations.TestOnly;
 
-public class JsonQueryMetrics {
+public class JsonQueryMetrics implements Mutable {
     private final Counter cacheHitCounter;
     private final Counter cacheMissCounter;
     private final LongGauge cachedQueriesGauge;
@@ -44,6 +45,17 @@ public class JsonQueryMetrics {
         this.cachedQueriesGauge = metricsRegistry.newLongGauge("json_queries_cached");
         this.cacheHitCounter = metricsRegistry.newCounter("json_queries_cache_hits");
         this.cacheMissCounter = metricsRegistry.newCounter("json_queries_cache_misses");
+    }
+
+    @Override
+    public void clear() {
+        cacheHitCounter.reset();
+        cacheHitCounter.reset();
+        cacheMissCounter.reset();
+        cachedQueriesGauge.setValue(0);
+        completedQueriesCounter.reset();
+        connectionCountGauge.setValue(0);
+        startedQueriesCounter.reset();
     }
 
     public Counter cacheHitCounter() {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -187,7 +187,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         circuitBreaker.resetTimer();
 
         if (fut == null) {
-            metrics.jsonQuery().markStart();
+            metrics.jsonQueryMetrics().markStart();
             state.startExecutionTimer();
             // do not set random for new request to avoid copying random from previous request into next one
             // the only time we need to copy random from state is when we resume request execution
@@ -429,7 +429,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
                     .$(", q=`").utf8(state.getQueryOrHidden())
                     .$("`]").$();
             // This is a critical error, so we treat it as an unhandled one.
-            metrics.health().incrementUnhandledErrors();
+            metrics.healthMetrics().incrementUnhandledErrors();
         }
     }
 
@@ -575,7 +575,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
                 fut.close();
             }
         }
-        metrics.jsonQuery().markComplete();
+        metrics.jsonQueryMetrics().markComplete();
         sendConfirmation(state, keepAliveHeader);
     }
 
@@ -596,7 +596,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         } finally {
             Misc.free(op);
         }
-        metrics.jsonQuery().markComplete();
+        metrics.jsonQueryMetrics().markComplete();
         sendConfirmation(state, keepAliveHeader);
     }
 
@@ -618,7 +618,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         try {
             if (state.of(factory, false, sqlExecutionContext)) {
                 doResumeSend(state, context, sqlExecutionContext);
-                metrics.jsonQuery().markComplete();
+                metrics.jsonQueryMetrics().markComplete();
             } else {
                 readyForNextRequest(context);
             }
@@ -634,7 +634,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             CharSequence keepAliveHeader
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, SqlException {
         cq.getInsertOperation().execute(sqlExecutionContext).await();
-        metrics.jsonQuery().markComplete();
+        metrics.jsonQueryMetrics().markComplete();
         sendInsertConfirmation(state, keepAliveHeader);
     }
 
@@ -665,7 +665,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         // Make sure to mark the query as non-cacheable.
         if (state.of(factory, false, sqlExecutionContext)) {
             doResumeSend(state, context, sqlExecutionContext);
-            metrics.jsonQuery().markComplete();
+            metrics.jsonQueryMetrics().markComplete();
         } else {
             readyForNextRequest(context);
         }
@@ -676,7 +676,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         try {
             if (state.of(factory, sqlExecutionContext)) {
                 doResumeSend(state, context, sqlExecutionContext);
-                metrics.jsonQuery().markComplete();
+                metrics.jsonQueryMetrics().markComplete();
             } else {
                 readyForNextRequest(context);
             }
@@ -705,7 +705,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             }
             // All good, finished update
             final long updatedCount = fut.getAffectedRowsCount();
-            metrics.jsonQuery().markComplete();
+            metrics.jsonQueryMetrics().markComplete();
             sendUpdateConfirmation(state, keepAliveHeader, updatedCount);
         } catch (CairoException e) {
             // close e.g. when query has been cancelled, or we got an OOM
@@ -851,7 +851,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             CompiledQuery cq,
             CharSequence keepAliveHeader
     ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        metrics.jsonQuery().markComplete();
+        metrics.jsonQueryMetrics().markComplete();
         sendConfirmation(state, keepAliveHeader);
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessor.java
@@ -156,7 +156,7 @@ public class LineHttpProcessor implements HttpRequestProcessor, HttpMultipartCon
             state.setSendStatus(SendStatus.CONTENT);
             sendErrorContent(context);
         }
-        engine.getMetrics().line().totalIlpHttpBytesGauge().add(context.getTotalReceived());
+        engine.getMetrics().lineMetrics().totalIlpHttpBytesGauge().add(context.getTotalReceived());
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
@@ -24,7 +24,11 @@
 
 package io.questdb.cutlass.http.processors;
 
-import io.questdb.cutlass.http.*;
+import io.questdb.cutlass.http.HttpChunkedResponse;
+import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpRequestProcessor;
+import io.questdb.cutlass.http.HttpServerConfiguration;
+import io.questdb.cutlass.http.LocalValue;
 import io.questdb.metrics.Scrapable;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
@@ -43,7 +47,7 @@ public class PrometheusMetricsProcessor implements HttpRequestProcessor {
     private final RequestStatePool pool;
     private final byte requiredAuthType;
 
-    public PrometheusMetricsProcessor(Scrapable metrics, HttpMinServerConfiguration configuration, RequestStatePool pool) {
+    public PrometheusMetricsProcessor(Scrapable metrics, HttpServerConfiguration configuration, RequestStatePool pool) {
         this.metrics = metrics;
         this.requiredAuthType = configuration.getRequiredAuthType();
         this.pool = pool;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/PrometheusMetricsProcessor.java
@@ -29,7 +29,7 @@ import io.questdb.cutlass.http.HttpConnectionContext;
 import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.LocalValue;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.std.Files;
@@ -43,11 +43,11 @@ import org.jetbrains.annotations.TestOnly;
 public class PrometheusMetricsProcessor implements HttpRequestProcessor {
     private static final CharSequence CONTENT_TYPE_TEXT = "text/plain; version=0.0.4; charset=utf-8";
     private static final LocalValue<RequestState> LV = new LocalValue<>();
-    private final Scrapable metrics;
+    private final Target metrics;
     private final RequestStatePool pool;
     private final byte requiredAuthType;
 
-    public PrometheusMetricsProcessor(Scrapable metrics, HttpServerConfiguration configuration, RequestStatePool pool) {
+    public PrometheusMetricsProcessor(Target metrics, HttpServerConfiguration configuration, RequestStatePool pool) {
         this.metrics = metrics;
         this.requiredAuthType = configuration.getRequiredAuthType();
         this.pool = pool;

--- a/core/src/main/java/io/questdb/cutlass/http/processors/StaticContentProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/StaticContentProcessor.java
@@ -25,7 +25,15 @@
 package io.questdb.cutlass.http.processors;
 
 import io.questdb.cairo.SecurityContext;
-import io.questdb.cutlass.http.*;
+import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
+import io.questdb.cutlass.http.HttpRangeParser;
+import io.questdb.cutlass.http.HttpRawSocket;
+import io.questdb.cutlass.http.HttpRequestHeader;
+import io.questdb.cutlass.http.HttpRequestProcessor;
+import io.questdb.cutlass.http.HttpResponseHeader;
+import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.http.MimeTypesCache;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.log.LogRecord;
@@ -35,7 +43,12 @@ import io.questdb.std.FilesFacade;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
-import io.questdb.std.str.*;
+import io.questdb.std.str.DirectUtf8Sequence;
+import io.questdb.std.str.FileNameExtractorUtf8Sequence;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.PrefixedPath;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8s;
 
 import java.io.Closeable;
 
@@ -53,7 +66,7 @@ public class StaticContentProcessor implements HttpRequestProcessor, Closeable {
     private final HttpRangeParser rangeParser = new HttpRangeParser();
     private final byte requiredAuthType;
 
-    public StaticContentProcessor(HttpServerConfiguration configuration) {
+    public StaticContentProcessor(HttpFullFatServerConfiguration configuration) {
         this.mimeTypes = configuration.getStaticContentProcessorConfiguration().getMimeTypesCache();
         this.prefixedPath = new PrefixedPath(configuration.getStaticContentProcessorConfiguration().getPublicDirectory());
         this.indexFileName = configuration.getStaticContentProcessorConfiguration().getIndexFileName();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/TextQueryProcessor.java
@@ -496,7 +496,7 @@ public class TextQueryProcessor implements HttpRequestProcessor, Closeable {
                     .$(", q=`").utf8(state.query)
                     .$("`]").$();
             // This is a critical error, so we treat it as an unhandled one.
-            metrics.health().incrementUnhandledErrors();
+            metrics.healthMetrics().incrementUnhandledErrors();
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineMetrics.java
@@ -26,12 +26,13 @@ package io.questdb.cutlass.line;
 
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
+import io.questdb.std.Mutable;
 
-public class LineMetrics {
+public class LineMetrics implements Mutable {
 
     private final LongGauge connectionCountGauge;
-    private final LongGauge totalIlpTcpBytesGauge;
     private final LongGauge totalIlpHttpBytesGauge;
+    private final LongGauge totalIlpTcpBytesGauge;
 
     public LineMetrics(MetricsRegistry metricsRegistry) {
         this.connectionCountGauge = metricsRegistry.newLongGauge("line_tcp_connections");
@@ -39,15 +40,22 @@ public class LineMetrics {
         this.totalIlpHttpBytesGauge = metricsRegistry.newLongGauge("line_http_recv_bytes");
     }
 
+    @Override
+    public void clear() {
+        connectionCountGauge.setValue(0);
+        totalIlpTcpBytesGauge.setValue(0);
+        totalIlpHttpBytesGauge.setValue(0);
+    }
+
     public LongGauge connectionCountGauge() {
         return connectionCountGauge;
     }
 
-    public LongGauge totalIlpTcpBytesGauge() {
-        return totalIlpTcpBytesGauge;
-    }
-
     public LongGauge totalIlpHttpBytesGauge() {
         return totalIlpHttpBytesGauge;
+    }
+
+    public LongGauge totalIlpTcpBytesGauge() {
+        return totalIlpTcpBytesGauge;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -43,10 +43,6 @@ import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
 public class DefaultLineTcpReceiverConfiguration extends DefaultIODispatcherConfiguration implements LineTcpReceiverConfiguration {
     private static final WorkerPoolConfiguration SHARED_CONFIGURATION = new WorkerPoolConfiguration() {
-        @Override
-        public Metrics getMetrics() {
-            return Metrics.ENABLED;
-        }
 
         @Override
         public String getPoolName() {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/DefaultLineTcpReceiverConfiguration.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.line.tcp;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cutlass.line.LineTcpTimestampAdapter;
@@ -42,6 +43,11 @@ import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
 public class DefaultLineTcpReceiverConfiguration extends DefaultIODispatcherConfiguration implements LineTcpReceiverConfiguration {
     private static final WorkerPoolConfiguration SHARED_CONFIGURATION = new WorkerPoolConfiguration() {
+        @Override
+        public Metrics getMetrics() {
+            return Metrics.ENABLED;
+        }
+
         @Override
         public String getPoolName() {
             return "ilptcp";
@@ -140,6 +146,11 @@ public class DefaultLineTcpReceiverConfiguration extends DefaultIODispatcherConf
     @Override
     public int getMaxMeasurementSize() {
         return 512;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -432,7 +432,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
                         .$(", ex=").$(ex)
                         .I$();
                 // This is a critical error, so we treat it as an unhandled one.
-                metrics.health().incrementUnhandledErrors();
+                metrics.healthMetrics().incrementUnhandledErrors();
                 return IOContextResult.NEEDS_DISCONNECT;
             }
         }
@@ -443,7 +443,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
         final int orig = bufferRemaining;
         if (bufferRemaining > 0 && !peerDisconnected) {
             int bytesRead = socket.recv(recvBufPos, bufferRemaining);
-            metrics.line().totalIlpTcpBytesGauge().add(bytesRead);
+            metrics.lineMetrics().totalIlpTcpBytesGauge().add(bytesRead);
             if (bytesRead > 0) {
                 recvBufPos += bytesRead;
                 bufferRemaining -= bytesRead;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -79,7 +79,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
     private long nextCheckIdleTime;
     private long nextCommitTime;
 
-    public LineTcpConnectionContext(LineTcpReceiverConfiguration configuration, LineTcpMeasurementScheduler scheduler, Metrics metrics) {
+    public LineTcpConnectionContext(LineTcpReceiverConfiguration configuration, LineTcpMeasurementScheduler scheduler) {
         super(
                 configuration.getFactoryProvider().getLineSocketFactory(),
                 configuration.getNetworkFacade(),
@@ -92,7 +92,7 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
             this.disconnectOnError = configuration.getDisconnectOnError();
             this.logMessageOnError = configuration.logMessageOnError();
             this.scheduler = scheduler;
-            this.metrics = metrics;
+            this.metrics = configuration.getMetrics();
             this.milliClock = configuration.getMillisecondClock();
             parser = new LineTcpParser();
             this.authenticator = configuration.getFactoryProvider().getLineAuthenticatorFactory().getLineTCPAuthenticator();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
@@ -24,7 +24,6 @@
 
 package io.questdb.cutlass.line.tcp;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.IOContextFactoryImpl;
@@ -38,7 +37,6 @@ import java.io.Closeable;
 
 public class LineTcpReceiver implements Closeable {
     private final IODispatcher<LineTcpConnectionContext> dispatcher;
-    private final Metrics metrics;
     private LineTcpMeasurementScheduler scheduler;
 
     public LineTcpReceiver(
@@ -49,7 +47,6 @@ public class LineTcpReceiver implements Closeable {
     ) {
         try {
             this.scheduler = null;
-            this.metrics = engine.getMetrics();
             ObjectFactory<LineTcpConnectionContext> factory;
             factory = () -> new LineTcpConnectionContext(configuration, scheduler);
 
@@ -57,7 +54,7 @@ public class LineTcpReceiver implements Closeable {
                     factory,
                     configuration.getConnectionPoolInitialCapacity()
             );
-            this.dispatcher = IODispatchers.create(configuration, contextFactory, metrics.line().connectionCountGauge());
+            this.dispatcher = IODispatchers.create(configuration, contextFactory);
             ioWorkerPool.assign(dispatcher);
             this.scheduler = new LineTcpMeasurementScheduler(configuration, engine, ioWorkerPool, dispatcher, writerWorkerPool);
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiver.java
@@ -51,7 +51,7 @@ public class LineTcpReceiver implements Closeable {
             this.scheduler = null;
             this.metrics = engine.getMetrics();
             ObjectFactory<LineTcpConnectionContext> factory;
-            factory = () -> new LineTcpConnectionContext(configuration, scheduler, metrics);
+            factory = () -> new LineTcpConnectionContext(configuration, scheduler);
 
             IOContextFactoryImpl<LineTcpConnectionContext> contextFactory = new IOContextFactoryImpl<>(
                     factory,

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfiguration.java
@@ -25,6 +25,7 @@
 package io.questdb.cutlass.line.tcp;
 
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.cutlass.line.LineTcpTimestampAdapter;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
@@ -74,6 +75,8 @@ public interface LineTcpReceiverConfiguration extends IODispatcherConfiguration 
     int getMaxFileNameLength();
 
     int getMaxMeasurementSize();
+
+    Metrics getMetrics();
 
     MicrosecondClock getMicrosecondClock();
 

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
@@ -50,11 +50,6 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     }
 
     @Override
-    public Counter getAboveMaxConnectionCountCounter() {
-        return getDelegate().getAboveMaxConnectionCountCounter();
-    }
-
-    @Override
     public String getAuthDB() {
         return getDelegate().getAuthDB();
     }
@@ -67,11 +62,6 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     @Override
     public boolean getAutoCreateNewTables() {
         return getDelegate().getAutoCreateNewTables();
-    }
-
-    @Override
-    public Counter getBelowMaxConnectionCountCounter() {
-        return getDelegate().getBelowMaxConnectionCountCounter();
     }
 
     @Override
@@ -322,6 +312,11 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     @Override
     public boolean isUseLegacyStringDefault() {
         return getDelegate().isUseLegacyStringDefault();
+    }
+
+    @Override
+    public Counter listenerStateChangeCounter() {
+        return getDelegate().listenerStateChangeCounter();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.line.tcp;
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
 import io.questdb.cutlass.line.LineTcpTimestampAdapter;
+import io.questdb.metrics.LongGauge;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
@@ -90,6 +91,11 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     @Override
     public double getCommitIntervalFraction() {
         return getDelegate().getCommitIntervalFraction();
+    }
+
+    @Override
+    public LongGauge getConnectionCountGauge() {
+        return metrics.line().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpReceiverConfigurationWrapper.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.line.tcp;
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
 import io.questdb.cutlass.line.LineTcpTimestampAdapter;
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.EpollFacade;
@@ -49,6 +50,11 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     }
 
     @Override
+    public Counter getAboveMaxConnectionCountCounter() {
+        return getDelegate().getAboveMaxConnectionCountCounter();
+    }
+
+    @Override
     public String getAuthDB() {
         return getDelegate().getAuthDB();
     }
@@ -61,6 +67,11 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
     @Override
     public boolean getAutoCreateNewTables() {
         return getDelegate().getAutoCreateNewTables();
+    }
+
+    @Override
+    public Counter getBelowMaxConnectionCountCounter() {
+        return getDelegate().getBelowMaxConnectionCountCounter();
     }
 
     @Override
@@ -95,7 +106,7 @@ public class LineTcpReceiverConfigurationWrapper implements LineTcpReceiverConfi
 
     @Override
     public LongGauge getConnectionCountGauge() {
-        return metrics.line().connectionCountGauge();
+        return metrics.lineMetrics().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpWriterJob.java
@@ -118,7 +118,7 @@ class LineTcpWriterJob implements Job, Closeable {
                             .$("commit failed [table=").$(assignedTables.getQuick(n).getTableToken())
                             .$(",ex=").$(ex)
                             .I$();
-                    metrics.health().incrementUnhandledErrors();
+                    metrics.healthMetrics().incrementUnhandledErrors();
                 }
             }
             // if no tables, just use the default commit interval
@@ -167,7 +167,7 @@ class LineTcpWriterJob implements Job, Closeable {
                                 .$("closing writer because of error [table=").$(tud.getTableToken())
                                 .$(", ex=").$(ex)
                                 .I$();
-                        metrics.health().incrementUnhandledErrors();
+                        metrics.healthMetrics().incrementUnhandledErrors();
                         closeWriter = true;
                         event.createWriterReleaseEvent(tud, false);
                         // This is a critical error, so we treat it as an unhandled one.

--- a/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.pgwire;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
@@ -114,6 +115,11 @@ public class DefaultPGWireConfiguration extends DefaultIODispatcherConfiguration
     public int getMaxBlobSizeOnQuery() {
         // BLOBs must fit inside send buffer together with other column values
         return 512 * 1024;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
@@ -30,6 +30,8 @@ import io.questdb.Metrics;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
+import io.questdb.std.ConcurrentCacheConfiguration;
+import io.questdb.std.DefaultConcurrentCacheConfiguration;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.millitime.DateFormatUtils;
 
@@ -59,6 +61,11 @@ public class DefaultPGWireConfiguration extends DefaultIODispatcherConfiguration
     @Override
     public SqlExecutionCircuitBreakerConfiguration getCircuitBreakerConfiguration() {
         return circuitBreakerConfiguration;
+    }
+
+    @Override
+    public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+        return DefaultConcurrentCacheConfiguration.DEFAULT;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
@@ -26,7 +26,6 @@ package io.questdb.cutlass.pgwire;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
-import io.questdb.Metrics;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.network.DefaultIODispatcherConfiguration;
@@ -122,11 +121,6 @@ public class DefaultPGWireConfiguration extends DefaultIODispatcherConfiguration
     public int getMaxBlobSizeOnQuery() {
         // BLOBs must fit inside send buffer together with other column values
         return 512 * 1024;
-    }
-
-    @Override
-    public Metrics getMetrics() {
-        return Metrics.ENABLED;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/DefaultPGWireConfiguration.java
@@ -164,16 +164,6 @@ public class DefaultPGWireConfiguration extends DefaultIODispatcherConfiguration
     }
 
     @Override
-    public int getSelectCacheBlockCount() {
-        return 2;
-    }
-
-    @Override
-    public int getSelectCacheRowCount() {
-        return 8;
-    }
-
-    @Override
     public int getSendBufferSize() {
         return 1024 * 1024;
     }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -314,7 +314,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             final boolean enabledUpdateCache = configuration.isUpdateCacheEnabled();
             final int updateBlockCount = enabledUpdateCache ? configuration.getUpdateCacheBlockCount() : 1;
             final int updateRowCount = enabledUpdateCache ? configuration.getUpdateCacheRowCount() : 1;
-            this.typesAndUpdateCache = new SimpleAssociativeCache<>(updateBlockCount, updateRowCount, metrics.pgWire().cachedUpdatesGauge());
+            this.typesAndUpdateCache = new SimpleAssociativeCache<>(updateBlockCount, updateRowCount, metrics.pgWireMetrics().cachedUpdatesGauge());
             this.typesAndUpdatePool = new WeakSelfReturningObjectPool<>(parent -> new TypesAndUpdate(parent, engine), updateBlockCount * updateRowCount);
 
             final boolean enableInsertCache = configuration.isInsertCacheEnabled();
@@ -518,7 +518,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             // BAU, not error metric
             throw e;
         } catch (Throwable th) {
-            metrics.pgWire().getErrorCounter().inc();
+            metrics.pgWireMetrics().getErrorCounter().inc();
             throw th;
         }
 
@@ -1825,7 +1825,7 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
     }
 
     private void handleException(int position, CharSequence message, boolean critical, int errno, boolean interruption) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        metrics.pgWire().getErrorCounter().inc();
+        metrics.pgWireMetrics().getErrorCounter().inc();
         clearCursorAndFactory();
         if (interruption) {
             prepareErrorResponse(position, message);

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfiguration.java
@@ -83,10 +83,6 @@ public interface PGWireConfiguration extends IODispatcherConfiguration, WorkerPo
 
     String getReadOnlyUsername();
 
-    int getSelectCacheBlockCount();
-
-    int getSelectCacheRowCount();
-
     String getServerVersion();
 
     int getUpdateCacheBlockCount();

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfiguration.java
@@ -28,6 +28,7 @@ import io.questdb.FactoryProvider;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.network.IODispatcherConfiguration;
+import io.questdb.std.ConcurrentCacheConfiguration;
 import io.questdb.std.Rnd;
 import io.questdb.std.datetime.DateLocale;
 
@@ -103,4 +104,6 @@ public interface PGWireConfiguration extends IODispatcherConfiguration, WorkerPo
     boolean isUpdateCacheEnabled();
 
     boolean readOnlySecurityContext();
+
+    ConcurrentCacheConfiguration getConcurrentCacheConfiguration();
 }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
@@ -50,16 +50,6 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     }
 
     @Override
-    public Counter getAboveMaxConnectionCountCounter() {
-        return getDelegate().getAboveMaxConnectionCountCounter();
-    }
-
-    @Override
-    public Counter getBelowMaxConnectionCountCounter() {
-        return getDelegate().getBelowMaxConnectionCountCounter();
-    }
-
-    @Override
     public int getBinParamCountCapacity() {
         return getDelegate().getBinParamCountCapacity();
     }
@@ -392,6 +382,11 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     @Override
     public boolean isUpdateCacheEnabled() {
         return getDelegate().isUpdateCacheEnabled();
+    }
+
+    @Override
+    public Counter listenerStateChangeCounter() {
+        return getDelegate().listenerStateChangeCounter();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
@@ -32,6 +32,7 @@ import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.SelectFacade;
+import io.questdb.std.ConcurrentCacheConfiguration;
 import io.questdb.std.Rnd;
 import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.millitime.MillisecondClock;
@@ -80,6 +81,11 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     @Override
     public MillisecondClock getClock() {
         return getDelegate().getClock();
+    }
+
+    @Override
+    public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+        return getDelegate().getConcurrentCacheConfiguration();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
@@ -284,16 +284,6 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     }
 
     @Override
-    public int getSelectCacheBlockCount() {
-        return getDelegate().getSelectCacheBlockCount();
-    }
-
-    @Override
-    public int getSelectCacheRowCount() {
-        return getDelegate().getSelectCacheRowCount();
-    }
-
-    @Override
     public SelectFacade getSelectFacade() {
         return getDelegate().getSelectFacade();
     }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.pgwire;
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
@@ -46,6 +47,16 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     public PGWireConfigurationWrapper(Metrics metrics) {
         this.metrics = metrics;
         delegate.set(null);
+    }
+
+    @Override
+    public Counter getAboveMaxConnectionCountCounter() {
+        return getDelegate().getAboveMaxConnectionCountCounter();
+    }
+
+    @Override
+    public Counter getBelowMaxConnectionCountCounter() {
+        return getDelegate().getBelowMaxConnectionCountCounter();
     }
 
     @Override
@@ -90,7 +101,7 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
 
     @Override
     public LongGauge getConnectionCountGauge() {
-        return metrics.pgWire().connectionCountGauge();
+        return metrics.pgWireMetrics().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireConfigurationWrapper.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.pgwire;
 import io.questdb.FactoryProvider;
 import io.questdb.Metrics;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
+import io.questdb.metrics.LongGauge;
 import io.questdb.network.EpollFacade;
 import io.questdb.network.KqueueFacade;
 import io.questdb.network.NetworkFacade;
@@ -79,6 +80,11 @@ public class PGWireConfigurationWrapper implements PGWireConfiguration {
     @Override
     public MillisecondClock getClock() {
         return getDelegate().getClock();
+    }
+
+    @Override
+    public LongGauge getConnectionCountGauge() {
+        return metrics.pgWire().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
@@ -31,13 +31,12 @@ import io.questdb.std.Mutable;
 import org.jetbrains.annotations.TestOnly;
 
 public class PGWireMetrics implements Mutable {
-    private final Counter aboveMaxConnectionCountCounter;
-    private final Counter belowMaxConnectionCountCounter;
     private final LongGauge cachedSelectsGauge;
     private final LongGauge cachedUpdatesGauge;
     private final Counter completedQueriesCounter;
     private final LongGauge connectionCountGauge;
     private final Counter errorCounter;
+    private final Counter listenerStateChangeCounter;
     private final Counter selectCacheHitCounter;
     private final Counter selectCacheMissCounter;
     private final Counter startedQueriesCounter;
@@ -51,8 +50,7 @@ public class PGWireMetrics implements Mutable {
         this.selectCacheHitCounter = metricsRegistry.newCounter("pg_wire_select_cache_hits");
         this.selectCacheMissCounter = metricsRegistry.newCounter("pg_wire_select_cache_misses");
         this.errorCounter = metricsRegistry.newCounter("pg_wire_errors");
-        this.aboveMaxConnectionCountCounter = metricsRegistry.newCounter("pg_wire_above_max_connection_count");
-        this.belowMaxConnectionCountCounter = metricsRegistry.newCounter("pg_wire_below_max_connection_count");
+        this.listenerStateChangeCounter = metricsRegistry.newCounter("pg_wire_listener_state_change_count");
     }
 
     public LongGauge cachedSelectsGauge() {
@@ -73,8 +71,7 @@ public class PGWireMetrics implements Mutable {
         selectCacheHitCounter.reset();
         selectCacheMissCounter.reset();
         startedQueriesCounter.reset();
-        aboveMaxConnectionCountCounter.reset();
-        belowMaxConnectionCountCounter.reset();
+        listenerStateChangeCounter.reset();
     }
 
     @TestOnly
@@ -86,16 +83,12 @@ public class PGWireMetrics implements Mutable {
         return connectionCountGauge;
     }
 
-    public Counter getAboveMaxConnectionCountCounter() {
-        return aboveMaxConnectionCountCounter;
-    }
-
-    public Counter getBelowMaxConnectionCountCounter() {
-        return belowMaxConnectionCountCounter;
-    }
-
     public Counter getErrorCounter() {
         return errorCounter;
+    }
+
+    public Counter listenerStateChangeCounter() {
+        return listenerStateChangeCounter;
     }
 
     public void markComplete() {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
@@ -31,6 +31,8 @@ import io.questdb.std.Mutable;
 import org.jetbrains.annotations.TestOnly;
 
 public class PGWireMetrics implements Mutable {
+    private final Counter aboveMaxConnectionCountCounter;
+    private final Counter belowMaxConnectionCountCounter;
     private final LongGauge cachedSelectsGauge;
     private final LongGauge cachedUpdatesGauge;
     private final Counter completedQueriesCounter;
@@ -49,6 +51,8 @@ public class PGWireMetrics implements Mutable {
         this.selectCacheHitCounter = metricsRegistry.newCounter("pg_wire_select_cache_hits");
         this.selectCacheMissCounter = metricsRegistry.newCounter("pg_wire_select_cache_misses");
         this.errorCounter = metricsRegistry.newCounter("pg_wire_errors");
+        this.aboveMaxConnectionCountCounter = metricsRegistry.newCounter("pg_wire_above_max_connection_count");
+        this.belowMaxConnectionCountCounter = metricsRegistry.newCounter("pg_wire_below_max_connection_count");
     }
 
     public LongGauge cachedSelectsGauge() {
@@ -69,6 +73,8 @@ public class PGWireMetrics implements Mutable {
         selectCacheHitCounter.reset();
         selectCacheMissCounter.reset();
         startedQueriesCounter.reset();
+        aboveMaxConnectionCountCounter.reset();
+        belowMaxConnectionCountCounter.reset();
     }
 
     @TestOnly
@@ -78,6 +84,14 @@ public class PGWireMetrics implements Mutable {
 
     public LongGauge connectionCountGauge() {
         return connectionCountGauge;
+    }
+
+    public Counter getAboveMaxConnectionCountCounter() {
+        return aboveMaxConnectionCountCounter;
+    }
+
+    public Counter getBelowMaxConnectionCountCounter() {
+        return belowMaxConnectionCountCounter;
     }
 
     public Counter getErrorCounter() {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireMetrics.java
@@ -27,9 +27,10 @@ package io.questdb.cutlass.pgwire;
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
+import io.questdb.std.Mutable;
 import org.jetbrains.annotations.TestOnly;
 
-public class PGWireMetrics {
+public class PGWireMetrics implements Mutable {
     private final LongGauge cachedSelectsGauge;
     private final LongGauge cachedUpdatesGauge;
     private final Counter completedQueriesCounter;
@@ -56,6 +57,18 @@ public class PGWireMetrics {
 
     public LongGauge cachedUpdatesGauge() {
         return cachedUpdatesGauge;
+    }
+
+    @Override
+    public void clear() {
+        cachedSelectsGauge.setValue(0);
+        cachedUpdatesGauge.setValue(0);
+        completedQueriesCounter.reset();
+        connectionCountGauge.setValue(0);
+        errorCounter.reset();
+        selectCacheHitCounter.reset();
+        selectCacheMissCounter.reset();
+        startedQueriesCounter.reset();
     }
 
     @TestOnly

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -73,13 +73,7 @@ public class PGWireServer implements IPGWireServer {
     ) {
         this.metrics = engine.getMetrics();
         if (configuration.isSelectCacheEnabled()) {
-            this.typesAndSelectCache = new ConcurrentAssociativeCache<>(
-                    configuration.getSelectCacheBlockCount(),
-                    configuration.getSelectCacheRowCount(),
-                    metrics.pgWire().cachedSelectsGauge(),
-                    metrics.pgWire().selectCacheHitCounter(),
-                    metrics.pgWire().selectCacheMissCounter()
-            );
+            this.typesAndSelectCache = new ConcurrentAssociativeCache<>(configuration.getConcurrentCacheConfiguration());
         } else {
             this.typesAndSelectCache = NO_OP_CACHE;
         }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -90,7 +90,7 @@ public class PGWireServer implements IPGWireServer {
                 executionContextObjectFactory,
                 typesAndSelectCache
         );
-        this.dispatcher = IODispatchers.create(configuration, contextFactory, metrics.pgWire().connectionCountGauge());
+        this.dispatcher = IODispatchers.create(configuration, contextFactory);
         this.workerPool = workerPool;
         this.registry = registry;
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGWireServer.java
@@ -120,7 +120,7 @@ public class PGWireServer implements IPGWireServer {
                     } catch (Throwable e) { // must remain last in catch list!
                         LOG.critical().$("internal error [ex=").$(e).$(']').$();
                         // This is a critical error, so we treat it as an unhandled one.
-                        metrics.health().incrementUnhandledErrors();
+                        metrics.healthMetrics().incrementUnhandledErrors();
                         dispatcher.disconnect(context, DISCONNECT_REASON_SERVER_ERROR);
                     }
                     return false;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGConnectionContextModern.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGConnectionContextModern.java
@@ -409,7 +409,7 @@ public class PGConnectionContextModern extends IOContext<PGConnectionContextMode
             shutdownSocketGracefully();
             throw bpe; // request disconnection
         } catch (Throwable th) {
-            metrics.pgWire().getErrorCounter().inc();
+            metrics.pgWireMetrics().getErrorCounter().inc();
             throw th;
         }
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
@@ -616,33 +616,33 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                     rollback(pendingWriters);
                     return IMPLICIT_TRANSACTION;
                 case CompiledQuery.CREATE_TABLE_AS_SELECT:
-                    engine.getMetrics().pgWire().markStart();
+                    engine.getMetrics().pgWireMetrics().markStart();
                     try (OperationFuture fut = operation.execute(sqlExecutionContext, tempSequence)) {
                         fut.await();
                         sqlAffectedRowCount = fut.getAffectedRowsCount();
                     } finally {
-                        engine.getMetrics().pgWire().markComplete();
+                        engine.getMetrics().pgWireMetrics().markComplete();
                     }
                     break;
                 case CompiledQuery.CREATE_TABLE:
                     // fall-through
                 case CompiledQuery.DROP:
-                    engine.getMetrics().pgWire().markStart();
+                    engine.getMetrics().pgWireMetrics().markStart();
                     try (OperationFuture fut = operation.execute(sqlExecutionContext, tempSequence)) {
                         fut.await();
                     } finally {
-                        engine.getMetrics().pgWire().markComplete();
+                        engine.getMetrics().pgWireMetrics().markComplete();
                     }
                     break;
                 default:
                     // execute statements that either have not been parse-executed
                     // or we are re-executing it from a prepared statement
                     if (!empty) {
-                        engine.getMetrics().pgWire().markStart();
+                        engine.getMetrics().pgWireMetrics().markStart();
                         try {
                             engine.execute(sqlText, sqlExecutionContext);
                         } finally {
-                            engine.getMetrics().pgWire().markComplete();
+                            engine.getMetrics().pgWireMetrics().markComplete();
                         }
                     }
                     break;
@@ -1391,7 +1391,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             WeakSelfReturningObjectPool<TypesAndInsertModern> taiPool
     ) throws SqlException, BadProtocolException {
         if (transactionState != ERROR_TRANSACTION) {
-            engine.getMetrics().pgWire().markStart();
+            engine.getMetrics().pgWireMetrics().markStart();
             // execute against writer from the engine, synchronously (null sequence)
             try {
                 for (int attempt = 1; ; attempt++) {
@@ -1415,7 +1415,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                     }
                 }
             } finally {
-                engine.getMetrics().pgWire().markComplete();
+                engine.getMetrics().pgWireMetrics().markComplete();
             }
         }
     }
@@ -1437,7 +1437,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             case IMPLICIT_TRANSACTION:
                 // fall through, there is no difference between implicit and explicit transaction at this stage
             case IN_TRANSACTION: {
-                engine.getMetrics().pgWire().markStart();
+                engine.getMetrics().pgWireMetrics().markStart();
                 try {
                     for (int attempt = 1; ; attempt++) {
                         copyParameterValuesToBindVariableService(
@@ -1469,7 +1469,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                         }
                     }
                 } finally {
-                    engine.getMetrics().pgWire().markComplete();
+                    engine.getMetrics().pgWireMetrics().markComplete();
                 }
             }
             break;
@@ -1492,7 +1492,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             int maxRecompileAttempts
     ) throws SqlException, BadProtocolException {
         if (cursor == null) {
-            engine.getMetrics().pgWire().markStart();
+            engine.getMetrics().pgWireMetrics().markStart();
 
             // commit implicitly if we are not in a transaction
             // this makes data inserted in the same pipeline visible to the select
@@ -1561,7 +1561,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             WeakSelfReturningObjectPool<TypesAndInsertModern> taiPool
     ) throws SqlException, BadProtocolException {
         if (transactionState != ERROR_TRANSACTION) {
-            engine.getMetrics().pgWire().markStart();
+            engine.getMetrics().pgWireMetrics().markStart();
             // execute against writer from the engine, synchronously (null sequence)
             try {
                 for (int attempt = 1; ; attempt++) {
@@ -1599,7 +1599,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                     }
                 }
             } finally {
-                engine.getMetrics().pgWire().markComplete();
+                engine.getMetrics().pgWireMetrics().markComplete();
             }
         }
     }
@@ -2067,7 +2067,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             stateSync = SYNC_DATA_SUSPENDED;
         }
 
-        engine.getMetrics().pgWire().markComplete();
+        engine.getMetrics().pgWireMetrics().markComplete();
     }
 
     private void outError(PGResponseSink utf8Sink, ObjObjHashMap<TableToken, TableWriterAPI> pendingWriters) {

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
@@ -77,13 +77,7 @@ public class PGWireServerModern implements IPGWireServer {
     ) {
         this.metrics = engine.getMetrics();
         if (configuration.isSelectCacheEnabled()) {
-            this.typesAndSelectCache = new ConcurrentAssociativeCache<>(
-                    configuration.getSelectCacheBlockCount(),
-                    configuration.getSelectCacheRowCount(),
-                    metrics.pgWire().cachedSelectsGauge(),
-                    metrics.pgWire().selectCacheHitCounter(),
-                    metrics.pgWire().selectCacheMissCounter()
-            );
+            this.typesAndSelectCache = new ConcurrentAssociativeCache<>(configuration.getConcurrentCacheConfiguration());
         } else {
             this.typesAndSelectCache = NO_OP_CACHE;
         }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
@@ -94,11 +94,7 @@ public class PGWireServerModern implements IPGWireServer {
                 executionContextObjectFactory,
                 typesAndSelectCache
         );
-        this.dispatcher = IODispatchers.create(
-                configuration,
-                contextFactory,
-                metrics.pgWire().connectionCountGauge()
-        );
+        this.dispatcher = IODispatchers.create(configuration, contextFactory);
         this.workerPool = workerPool;
         this.registry = registry;
 

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGWireServerModern.java
@@ -124,7 +124,7 @@ public class PGWireServerModern implements IPGWireServer {
                     } catch (Throwable e) { // must remain last in catch list!
                         LOG.critical().$("internal error [ex=").$(e).$(']').$();
                         // This is a critical error, so we treat it as an unhandled one.
-                        metrics.health().incrementUnhandledErrors();
+                        metrics.healthMetrics().incrementUnhandledErrors();
                         dispatcher.disconnect(context, DISCONNECT_REASON_SERVER_ERROR);
                     }
                     return false;

--- a/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
@@ -24,7 +24,19 @@
 
 package io.questdb.cutlass.text;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.DefaultLifecycleManager;
+import io.questdb.cairo.ImplicitCastException;
+import io.questdb.cairo.SymbolMapReaderImpl;
+import io.questdb.cairo.SymbolMapWriter;
+import io.questdb.cairo.TableStructure;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TxReader;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.sql.ExecutionCircuitBreaker;
 import io.questdb.cairo.sql.RecordMetadata;
@@ -35,8 +47,26 @@ import io.questdb.cutlass.text.types.TypeAdapter;
 import io.questdb.griffin.engine.functions.columns.ColumnUtils;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.*;
-import io.questdb.std.str.*;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.IOURing;
+import io.questdb.std.IOURingFacade;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.LongList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.Os;
+import io.questdb.std.SwarUtils;
+import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
+import io.questdb.std.str.DirectUtf16Sink;
+import io.questdb.std.str.DirectUtf8Sequence;
+import io.questdb.std.str.DirectUtf8Sink;
+import io.questdb.std.str.DirectUtf8String;
+import io.questdb.std.str.Path;
+import io.questdb.std.str.StringSink;
 import org.jetbrains.annotations.Nullable;
 
 import static io.questdb.cairo.TableUtils.TXN_FILE_NAME;
@@ -505,7 +535,6 @@ public class CopyTask {
                             root,
                             cairoEngine.getDdlListener(tableToken),
                             cairoEngine.getCheckpointStatus(),
-                            cairoEngine.getMetrics(),
                             cairoEngine
                     )
             ) {
@@ -891,7 +920,6 @@ public class CopyTask {
                             importRoot,
                             engine.getDdlListener(tableToken),
                             engine.getCheckpointStatus(),
-                            engine.getMetrics(),
                             engine
                     )
             ) {

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -2375,7 +2375,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                         engine.getConfiguration().getRoot(),
                         engine.getDdlListener(tableToken),
                         engine.getCheckpointStatus(),
-                        engine.getMetrics(),
                         engine
                 );
             } else {

--- a/core/src/main/java/io/questdb/griffin/engine/table/TableWriterMetricsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/TableWriterMetricsRecordCursorFactory.java
@@ -25,7 +25,11 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.Metrics;
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.TableWriterMetrics;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.griffin.PlanSink;
@@ -52,7 +56,7 @@ public final class TableWriterMetricsRecordCursorFactory extends AbstractRecordC
     public RecordCursor getCursor(SqlExecutionContext executionContext) {
         Metrics metrics = executionContext.getCairoEngine().getMetrics();
         if (metrics.isEnabled()) {
-            TableWriterMetrics tableWriterMetrics = metrics.tableWriter();
+            TableWriterMetrics tableWriterMetrics = metrics.tableWriterMetrics();
             values[TOTAL_COMMITS_COLUMN_INDEX] = tableWriterMetrics.getCommitCount();
             values[O3_COMMITS_COLUMN_INDEX] = tableWriterMetrics.getO3CommitCount();
             values[ROLLBACKS_COLUMN_INDEX] = tableWriterMetrics.getRollbackCount();

--- a/core/src/main/java/io/questdb/log/LogFactory.java
+++ b/core/src/main/java/io/questdb/log/LogFactory.java
@@ -110,6 +110,11 @@ public class LogFactory implements Closeable {
         this.clock = clock;
         workerPool = new WorkerPool(new WorkerPoolConfiguration() {
             @Override
+            public Metrics getMetrics() {
+                return Metrics.DISABLED;
+            }
+
+            @Override
             public String getPoolName() {
                 return "logging";
             }
@@ -123,7 +128,7 @@ public class LogFactory implements Closeable {
             public boolean isDaemonPool() {
                 return true;
             }
-        }, Metrics.disabled());
+        });
     }
 
     public static synchronized void closeInstance() {

--- a/core/src/main/java/io/questdb/metrics/Counter.java
+++ b/core/src/main/java/io/questdb/metrics/Counter.java
@@ -26,7 +26,7 @@ package io.questdb.metrics;
 
 import org.jetbrains.annotations.TestOnly;
 
-public interface Counter extends Scrapable {
+public interface Counter extends Target {
 
     void add(long value);
 

--- a/core/src/main/java/io/questdb/metrics/CounterWithOneLabel.java
+++ b/core/src/main/java/io/questdb/metrics/CounterWithOneLabel.java
@@ -24,7 +24,7 @@
 
 package io.questdb.metrics;
 
-public interface CounterWithOneLabel extends Scrapable {
+public interface CounterWithOneLabel extends Target {
 
     void inc(short label0);
 }

--- a/core/src/main/java/io/questdb/metrics/CounterWithTwoLabels.java
+++ b/core/src/main/java/io/questdb/metrics/CounterWithTwoLabels.java
@@ -24,7 +24,7 @@
 
 package io.questdb.metrics;
 
-public interface CounterWithTwoLabels extends Scrapable {
+public interface CounterWithTwoLabels extends Target {
 
     void inc(short label0, short label1);
 }

--- a/core/src/main/java/io/questdb/metrics/DoubleGaugeImpl.java
+++ b/core/src/main/java/io/questdb/metrics/DoubleGaugeImpl.java
@@ -28,7 +28,7 @@ import io.questdb.std.str.BorrowableUtf8Sink;
 import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 
-public class DoubleGaugeImpl implements Scrapable, DoubleGauge {
+public class DoubleGaugeImpl implements Target, DoubleGauge {
     private final CharSequence name;
     private volatile double value;
 

--- a/core/src/main/java/io/questdb/metrics/GCMetrics.java
+++ b/core/src/main/java/io/questdb/metrics/GCMetrics.java
@@ -37,7 +37,7 @@ import java.lang.management.ManagementFactory;
  * GC metrics don't rely on MetricsRegistry to be able to obtain and write all metrics
  * to the sink in one go.
  */
-public class GCMetrics implements Scrapable, Mutable {
+public class GCMetrics implements Target, Mutable {
 
     private static final CharSequenceHashSet majorGCNames = new CharSequenceHashSet();
     private static final CharSequenceHashSet minorGCNames = new CharSequenceHashSet();

--- a/core/src/main/java/io/questdb/metrics/GCMetrics.java
+++ b/core/src/main/java/io/questdb/metrics/GCMetrics.java
@@ -25,6 +25,7 @@
 package io.questdb.metrics;
 
 import io.questdb.std.CharSequenceHashSet;
+import io.questdb.std.Mutable;
 import io.questdb.std.str.BorrowableUtf8Sink;
 import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
@@ -36,7 +37,7 @@ import java.lang.management.ManagementFactory;
  * GC metrics don't rely on MetricsRegistry to be able to obtain and write all metrics
  * to the sink in one go.
  */
-public class GCMetrics implements Scrapable {
+public class GCMetrics implements Scrapable, Mutable {
 
     private static final CharSequenceHashSet majorGCNames = new CharSequenceHashSet();
     private static final CharSequenceHashSet minorGCNames = new CharSequenceHashSet();
@@ -72,6 +73,10 @@ public class GCMetrics implements Scrapable {
         appendCounter(sink, minorTime, "jvm_minor_gc_time");
         appendCounter(sink, unknownCount, "jvm_unknown_gc_count");
         appendCounter(sink, unknownTime, "jvm_unknown_gc_time");
+    }
+
+    @Override
+    public void clear() {
     }
 
     private void appendCounter(CharSink<?> sink, long value, String name) {

--- a/core/src/main/java/io/questdb/metrics/HealthMetricsImpl.java
+++ b/core/src/main/java/io/questdb/metrics/HealthMetricsImpl.java
@@ -25,12 +25,19 @@
 package io.questdb.metrics;
 
 
-public class HealthMetricsImpl implements HealthMetrics {
+import io.questdb.std.Mutable;
+
+public class HealthMetricsImpl implements HealthMetrics, Mutable {
 
     private final Counter unhandledErrorCounter;
 
     public HealthMetricsImpl(MetricsRegistry metricsRegistry) {
         this.unhandledErrorCounter = metricsRegistry.newCounter("unhandled_errors");
+    }
+
+    @Override
+    public void clear() {
+        unhandledErrorCounter.reset();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/metrics/LongGauge.java
+++ b/core/src/main/java/io/questdb/metrics/LongGauge.java
@@ -24,7 +24,7 @@
 
 package io.questdb.metrics;
 
-public interface LongGauge extends Scrapable {
+public interface LongGauge extends Target {
 
     void add(long value);
 

--- a/core/src/main/java/io/questdb/metrics/MetricsRegistry.java
+++ b/core/src/main/java/io/questdb/metrics/MetricsRegistry.java
@@ -24,9 +24,9 @@
 
 package io.questdb.metrics;
 
-public interface MetricsRegistry extends Scrapable {
+public interface MetricsRegistry extends Target {
 
-    void addScrapable(Scrapable scrapable);
+    void addTarget(Target target);
 
     Counter newCounter(CharSequence name);
 

--- a/core/src/main/java/io/questdb/metrics/MetricsRegistryImpl.java
+++ b/core/src/main/java/io/questdb/metrics/MetricsRegistryImpl.java
@@ -29,11 +29,11 @@ import io.questdb.std.str.BorrowableUtf8Sink;
 import org.jetbrains.annotations.NotNull;
 
 public class MetricsRegistryImpl implements MetricsRegistry {
-    private final ObjList<Scrapable> metrics = new ObjList<>();
+    private final ObjList<Target> metrics = new ObjList<>();
 
     @Override
-    public void addScrapable(Scrapable scrapable) {
-        metrics.add(scrapable);
+    public void addTarget(Target target) {
+        metrics.add(target);
     }
 
     @Override
@@ -90,7 +90,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     @Override
     public void scrapeIntoPrometheus(@NotNull BorrowableUtf8Sink sink) {
         for (int i = 0, n = metrics.size(); i < n; i++) {
-            Scrapable metric = metrics.getQuick(i);
+            Target metric = metrics.getQuick(i);
             metric.scrapeIntoPrometheus(sink);
         }
     }

--- a/core/src/main/java/io/questdb/metrics/NullMetricsRegistry.java
+++ b/core/src/main/java/io/questdb/metrics/NullMetricsRegistry.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
 public class NullMetricsRegistry implements MetricsRegistry {
 
     @Override
-    public void addScrapable(Scrapable scrapable) {
+    public void addTarget(Target target) {
     }
 
     @Override

--- a/core/src/main/java/io/questdb/metrics/Target.java
+++ b/core/src/main/java/io/questdb/metrics/Target.java
@@ -29,7 +29,7 @@ import io.questdb.std.str.BorrowableUtf8Sink;
 /**
  * Anything that can be scraped for Prometheus metrics.
  */
-public interface Scrapable {
+public interface Target {
 
     // We need a sink that we can borrow from and append to in native code.
     void scrapeIntoPrometheus(BorrowableUtf8Sink sink);

--- a/core/src/main/java/io/questdb/metrics/WorkerMetrics.java
+++ b/core/src/main/java/io/questdb/metrics/WorkerMetrics.java
@@ -24,7 +24,9 @@
 
 package io.questdb.metrics;
 
-public class WorkerMetrics {
+import io.questdb.std.Mutable;
+
+public class WorkerMetrics implements Mutable {
 
     private final LongGauge max;
     private final LongGauge min;
@@ -34,6 +36,12 @@ public class WorkerMetrics {
         max = metricsRegistry.newLongGauge("workers_job_start_micros_max");
         min.setValue(Long.MAX_VALUE);
         max.setValue(Long.MIN_VALUE);
+    }
+
+    @Override
+    public void clear() {
+        min.setValue(0);
+        max.setValue(0);
     }
 
     public long getMaxElapsedMicros() {

--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -151,10 +151,12 @@ public class Worker extends Thread {
                         try {
                             runAsap |= jobs.get(i).run(workerId, runStatus);
                         } catch (Throwable e) {
-                            try {
-                                metrics.health().incrementUnhandledErrors();
-                            } catch (Throwable t) {
-                                stdErrCritical(t);
+                            if (metrics.isEnabled()) {
+                                try {
+                                    metrics.health().incrementUnhandledErrors();
+                                } catch (Throwable t) {
+                                    stdErrCritical(t);
+                                }
                             }
                             if (log != null) {
                                 log.critical().$("unhandled error [job=").$(jobs.get(i).toString()).$(", ex=").$(e).I$();

--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -153,7 +153,7 @@ public class Worker extends Thread {
                         } catch (Throwable e) {
                             if (metrics.isEnabled()) {
                                 try {
-                                    metrics.health().incrementUnhandledErrors();
+                                    metrics.healthMetrics().incrementUnhandledErrors();
                                 } catch (Throwable t) {
                                     stdErrCritical(t);
                                 }

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -38,7 +38,6 @@ import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class WorkerPool implements Closeable {
-    private static final Metrics DISABLED = Metrics.disabled();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final boolean daemons;
     private final ObjList<Closeable> freeOnExit = new ObjList<>();
@@ -60,10 +59,6 @@ public class WorkerPool implements Closeable {
     private final long yieldThreshold;
 
     public WorkerPool(WorkerPoolConfiguration configuration) {
-        this(configuration, DISABLED);
-    }
-
-    public WorkerPool(WorkerPoolConfiguration configuration, Metrics metrics) {
         this.workerCount = configuration.getWorkerCount();
         int[] workerAffinity = configuration.getWorkerAffinity();
         if (workerAffinity != null && workerAffinity.length > 0) {
@@ -79,7 +74,7 @@ public class WorkerPool implements Closeable {
         this.napThreshold = configuration.getNapThreshold();
         this.sleepThreshold = configuration.getSleepThreshold();
         this.sleepMs = configuration.getSleepTimeout();
-        this.metrics = metrics;
+        this.metrics = configuration.getMetrics();
         this.priority = configuration.workerPoolPriority();
 
         assert this.workerAffinity.length == workerCount;

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -199,7 +199,7 @@ public class WorkerPool implements Closeable {
     }
 
     public void updateWorkerMetrics(long now) {
-        WorkerMetrics workerMetrics = metrics.worker();
+        WorkerMetrics workerMetrics = metrics.workerMetrics();
         long min = workerMetrics.getMinElapsedMicros();
         long max = workerMetrics.getMaxElapsedMicros();
         for (int i = 0, n = workers.size(); i < n; i++) {

--- a/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
@@ -24,6 +24,8 @@
 
 package io.questdb.mp;
 
+import io.questdb.Metrics;
+
 public interface WorkerPoolConfiguration {
 
     default long getNapThreshold() {
@@ -67,4 +69,6 @@ public interface WorkerPoolConfiguration {
     default int workerPoolPriority() {
         return Thread.NORM_PRIORITY;
     }
+
+    Metrics getMetrics();
 }

--- a/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
@@ -70,5 +70,7 @@ public interface WorkerPoolConfiguration {
         return Thread.NORM_PRIORITY;
     }
 
-    Metrics getMetrics();
+    default Metrics getMetrics() {
+        return Metrics.ENABLED;
+    }
 }

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -256,6 +256,8 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
         if (connectionCount.get() < activeConnectionLimit) {
             if (serverFd < 0) {
                 createListenerFd();
+                // Make sure to always register for listening if server fd was recreated.
+                listening = false;
             }
 
             if (!listening) {

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -100,12 +100,11 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
 
     public AbstractIODispatcher(
             IODispatcherConfiguration configuration,
-            IOContextFactory<C> ioContextFactory,
-            LongGauge connectionCountGauge
+            IOContextFactory<C> ioContextFactory
     ) {
         this.LOG = LogFactory.getLog(configuration.getDispatcherLogName());
         this.configuration = configuration;
-        this.connectionCountGauge = connectionCountGauge;
+        this.connectionCountGauge = configuration.getConnectionCountGauge();
         this.nf = configuration.getNetworkFacade();
 
         this.testConnectionBufSize = configuration.getTestConnectionBufferSize();

--- a/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
@@ -34,16 +34,6 @@ public class DefaultIODispatcherConfiguration implements IODispatcherConfigurati
     public static final IODispatcherConfiguration INSTANCE = new DefaultIODispatcherConfiguration();
 
     @Override
-    public Counter getAboveMaxConnectionCountCounter() {
-        return Metrics.DISABLED.httpMetrics().aboveMaxConnectionCountCounter();
-    }
-
-    @Override
-    public Counter getBelowMaxConnectionCountCounter() {
-        return Metrics.DISABLED.httpMetrics().belowMaxConnectionCountCounter();
-    }
-
-    @Override
     public int getBindIPv4Address() {
         return 0;
     }
@@ -127,5 +117,10 @@ public class DefaultIODispatcherConfiguration implements IODispatcherConfigurati
     @Override
     public long getTimeout() {
         return 5 * 60 * 1000L;
+    }
+
+    @Override
+    public Counter listenerStateChangeCounter() {
+        return Metrics.DISABLED.httpMetrics().listenerStateChangeCounter();
     }
 }

--- a/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
@@ -25,12 +25,23 @@
 package io.questdb.network;
 
 import io.questdb.Metrics;
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
 public class DefaultIODispatcherConfiguration implements IODispatcherConfiguration {
     public static final IODispatcherConfiguration INSTANCE = new DefaultIODispatcherConfiguration();
+
+    @Override
+    public Counter getAboveMaxConnectionCountCounter() {
+        return Metrics.DISABLED.httpMetrics().aboveMaxConnectionCountCounter();
+    }
+
+    @Override
+    public Counter getBelowMaxConnectionCountCounter() {
+        return Metrics.DISABLED.httpMetrics().belowMaxConnectionCountCounter();
+    }
 
     @Override
     public int getBindIPv4Address() {
@@ -49,7 +60,7 @@ public class DefaultIODispatcherConfiguration implements IODispatcherConfigurati
 
     @Override
     public LongGauge getConnectionCountGauge() {
-        return Metrics.DISABLED.jsonQuery().connectionCountGauge();
+        return Metrics.DISABLED.httpMetrics().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/DefaultIODispatcherConfiguration.java
@@ -24,6 +24,8 @@
 
 package io.questdb.network;
 
+import io.questdb.Metrics;
+import io.questdb.metrics.LongGauge;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
@@ -43,6 +45,11 @@ public class DefaultIODispatcherConfiguration implements IODispatcherConfigurati
     @Override
     public MillisecondClock getClock() {
         return MillisecondClockImpl.INSTANCE;
+    }
+
+    @Override
+    public LongGauge getConnectionCountGauge() {
+        return Metrics.DISABLED.jsonQuery().connectionCountGauge();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/network/IODispatcher.java
+++ b/core/src/main/java/io/questdb/network/IODispatcher.java
@@ -53,6 +53,11 @@ public interface IODispatcher<C extends IOContext<C>> extends Closeable, Job {
 
     void disconnect(C context, int reason);
 
+    default void drainIOQueue(IORequestProcessor<C> processor) {
+        //noinspection StatementWithEmptyBody
+        while (processIOQueue(processor)) ;
+    }
+
     int getConnectionCount();
 
     int getPort();

--- a/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
@@ -24,6 +24,7 @@
 
 package io.questdb.network;
 
+import io.questdb.metrics.LongGauge;
 import io.questdb.std.Numbers;
 import io.questdb.std.Os;
 import io.questdb.std.datetime.millitime.MillisecondClock;
@@ -106,4 +107,6 @@ public interface IODispatcherConfiguration {
     int getTestConnectionBufferSize();
 
     long getTimeout();
+
+    LongGauge getConnectionCountGauge();
 }

--- a/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
@@ -24,6 +24,7 @@
 
 package io.questdb.network;
 
+import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
 import io.questdb.std.Numbers;
 import io.questdb.std.Os;
@@ -33,11 +34,17 @@ public interface IODispatcherConfiguration {
     int BIAS_READ = 1;
     int BIAS_WRITE = 2;
 
+    Counter getAboveMaxConnectionCountCounter();
+
+    Counter getBelowMaxConnectionCountCounter();
+
     int getBindIPv4Address();
 
     int getBindPort();
 
     MillisecondClock getClock();
+
+    LongGauge getConnectionCountGauge();
 
     default String getDispatcherLogName() {
         return "IODispatcher";
@@ -107,6 +114,4 @@ public interface IODispatcherConfiguration {
     int getTestConnectionBufferSize();
 
     long getTimeout();
-
-    LongGauge getConnectionCountGauge();
 }

--- a/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherConfiguration.java
@@ -34,9 +34,7 @@ public interface IODispatcherConfiguration {
     int BIAS_READ = 1;
     int BIAS_WRITE = 2;
 
-    Counter getAboveMaxConnectionCountCounter();
-
-    Counter getBelowMaxConnectionCountCounter();
+    Counter listenerStateChangeCounter();
 
     int getBindIPv4Address();
 

--- a/core/src/main/java/io/questdb/network/IODispatcherLinux.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherLinux.java
@@ -24,7 +24,6 @@
 
 package io.questdb.network;
 
-import io.questdb.metrics.LongGauge;
 import io.questdb.std.LongMatrix;
 
 public class IODispatcherLinux<C extends IOContext<C>> extends AbstractIODispatcher<C> {
@@ -39,10 +38,9 @@ public class IODispatcherLinux<C extends IOContext<C>> extends AbstractIODispatc
 
     public IODispatcherLinux(
             IODispatcherConfiguration configuration,
-            IOContextFactory<C> ioContextFactory,
-            LongGauge connectionCountGauge
+            IOContextFactory<C> ioContextFactory
     ) {
-        super(configuration, ioContextFactory, connectionCountGauge);
+        super(configuration, ioContextFactory);
         this.epoll = new Epoll(configuration.getEpollFacade(), configuration.getEventCapacity());
         registerListenerFd();
     }

--- a/core/src/main/java/io/questdb/network/IODispatcherLinux.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherLinux.java
@@ -377,7 +377,7 @@ public class IODispatcherLinux<C extends IOContext<C>> extends AbstractIODispatc
 
     @Override
     protected void registerListenerFd() {
-        this.epoll.listen(serverFd);
+        epoll.listen(serverFd);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/network/IODispatcherOsx.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherOsx.java
@@ -53,9 +53,9 @@ public class IODispatcherOsx<C extends IOContext<C>> extends AbstractIODispatche
         try {
             this.kqueue = new Kqueue(configuration.getKqueueFacade(), capacity);
             registerListenerFd();
-        } catch (Throwable t) {
+        } catch (Throwable th) {
             close();
-            throw t;
+            throw th;
         }
     }
 

--- a/core/src/main/java/io/questdb/network/IODispatcherOsx.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherOsx.java
@@ -25,7 +25,6 @@
 package io.questdb.network;
 
 import io.questdb.KqueueAccessor;
-import io.questdb.metrics.LongGauge;
 import io.questdb.std.LongHashSet;
 import io.questdb.std.LongMatrix;
 import io.questdb.std.Misc;
@@ -46,10 +45,9 @@ public class IODispatcherOsx<C extends IOContext<C>> extends AbstractIODispatche
 
     public IODispatcherOsx(
             IODispatcherConfiguration configuration,
-            IOContextFactory<C> ioContextFactory,
-            LongGauge connectionCountGauge
+            IOContextFactory<C> ioContextFactory
     ) {
-        super(configuration, ioContextFactory, connectionCountGauge);
+        super(configuration, ioContextFactory);
         this.capacity = configuration.getEventCapacity();
         // bind socket
         try {

--- a/core/src/main/java/io/questdb/network/IODispatcherWindows.java
+++ b/core/src/main/java/io/questdb/network/IODispatcherWindows.java
@@ -24,7 +24,6 @@
 
 package io.questdb.network;
 
-import io.questdb.metrics.LongGauge;
 import io.questdb.std.LongIntHashMap;
 
 public class IODispatcherWindows<C extends IOContext<C>> extends AbstractIODispatcher<C> {
@@ -38,10 +37,9 @@ public class IODispatcherWindows<C extends IOContext<C>> extends AbstractIODispa
 
     public IODispatcherWindows(
             IODispatcherConfiguration configuration,
-            IOContextFactory<C> ioContextFactory,
-            LongGauge connectionCountGauge
+            IOContextFactory<C> ioContextFactory
     ) {
-        super(configuration, ioContextFactory, connectionCountGauge);
+        super(configuration, ioContextFactory);
         this.sf = configuration.getSelectFacade();
         this.readFdSet = new FDSet(configuration.getEventCapacity());
         this.writeFdSet = new FDSet(configuration.getEventCapacity());

--- a/core/src/main/java/io/questdb/network/IODispatchers.java
+++ b/core/src/main/java/io/questdb/network/IODispatchers.java
@@ -24,7 +24,6 @@
 
 package io.questdb.network;
 
-import io.questdb.metrics.LongGauge;
 import io.questdb.std.Os;
 
 public class IODispatchers {
@@ -34,17 +33,16 @@ public class IODispatchers {
 
     public static <C extends IOContext<C>> IODispatcher<C> create(
             IODispatcherConfiguration configuration,
-            IOContextFactory<C> ioContextFactory,
-            LongGauge connectionCountGauge
+            IOContextFactory<C> ioContextFactory
     ) {
         switch (Os.type) {
             case Os.LINUX:
-                return new IODispatcherLinux<>(configuration, ioContextFactory, connectionCountGauge);
+                return new IODispatcherLinux<>(configuration, ioContextFactory);
             case Os.DARWIN:
             case Os.FREEBSD:
-                return new IODispatcherOsx<>(configuration, ioContextFactory, connectionCountGauge);
+                return new IODispatcherOsx<>(configuration, ioContextFactory);
             case Os.WINDOWS:
-                return new IODispatcherWindows<>(configuration, ioContextFactory, connectionCountGauge);
+                return new IODispatcherWindows<>(configuration, ioContextFactory);
             default:
                 throw new RuntimeException();
         }

--- a/core/src/main/java/io/questdb/std/ConcurrentAssociativeCache.java
+++ b/core/src/main/java/io/questdb/std/ConcurrentAssociativeCache.java
@@ -26,8 +26,6 @@ package io.questdb.std;
 
 import io.questdb.metrics.Counter;
 import io.questdb.metrics.LongGauge;
-import io.questdb.metrics.NullCounter;
-import io.questdb.metrics.NullLongGauge;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,14 +58,10 @@ public class ConcurrentAssociativeCache<V> implements AssociativeCache<V> {
     // Each row has its own array of values.
     private final ObjList<V[]> values;
 
-    public ConcurrentAssociativeCache(int blocks, int rows) {
-        this(blocks, rows, NullLongGauge.INSTANCE, NullCounter.INSTANCE, NullCounter.INSTANCE);
-    }
-
     @SuppressWarnings("unchecked")
-    public ConcurrentAssociativeCache(int blocks, int rows, LongGauge cachedGauge, Counter hitCounter, Counter missCounter) {
-        this.blocks = Math.max(MIN_BLOCKS, Numbers.ceilPow2(blocks));
-        this.rows = Math.max(MIN_ROWS, Numbers.ceilPow2(rows));
+    public ConcurrentAssociativeCache(ConcurrentCacheConfiguration configuration) {
+        this.blocks = Math.max(MIN_BLOCKS, Numbers.ceilPow2(configuration.getBlocks()));
+        this.rows = Math.max(MIN_ROWS, Numbers.ceilPow2(configuration.getRows()));
 
         int capacity = this.rows * this.blocks;
         if (capacity < 0) {
@@ -80,9 +74,9 @@ public class ConcurrentAssociativeCache<V> implements AssociativeCache<V> {
             values.add((V[]) new Object[this.blocks]);
         }
         this.rowMask = this.rows - 1;
-        this.cachedGauge = cachedGauge;
-        this.hitCounter = hitCounter;
-        this.missCounter = missCounter;
+        this.cachedGauge = configuration.getCachedGauge();
+        this.hitCounter = configuration.getHiCounter();
+        this.missCounter = configuration.getMissCounter();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/std/ConcurrentCacheConfiguration.java
+++ b/core/src/main/java/io/questdb/std/ConcurrentCacheConfiguration.java
@@ -22,42 +22,19 @@
  *
  ******************************************************************************/
 
-package io.questdb.metrics;
+package io.questdb.std;
 
-import io.questdb.std.Mutable;
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.LongGauge;
 
-public class WorkerMetrics implements Mutable {
+public interface ConcurrentCacheConfiguration {
+    int getBlocks();
 
-    private final LongGauge max;
-    private final LongGauge min;
+    LongGauge getCachedGauge();
 
-    public WorkerMetrics(MetricsRegistry metricsRegistry) {
-        min = metricsRegistry.newLongGauge("workers_job_start_micros_min");
-        max = metricsRegistry.newLongGauge("workers_job_start_micros_max");
-        min.setValue(Long.MAX_VALUE);
-        max.setValue(Long.MIN_VALUE);
-    }
+    Counter getHiCounter();
 
-    @Override
-    public void clear() {
-        min.setValue(Long.MAX_VALUE);
-        max.setValue(Long.MIN_VALUE);
-    }
+    Counter getMissCounter();
 
-    public long getMaxElapsedMicros() {
-        return max.getValue();
-    }
-
-    public long getMinElapsedMicros() {
-        return min.getValue();
-    }
-
-    public void update(long candidateMin, long candidateMax) {
-        if (candidateMin < min.getValue()) {
-            min.setValue(candidateMin);
-        }
-        if (candidateMax > max.getValue()) {
-            max.setValue(candidateMax);
-        }
-    }
+    int getRows();
 }

--- a/core/src/main/java/io/questdb/std/DefaultConcurrentCacheConfiguration.java
+++ b/core/src/main/java/io/questdb/std/DefaultConcurrentCacheConfiguration.java
@@ -22,42 +22,38 @@
  *
  ******************************************************************************/
 
-package io.questdb.metrics;
+package io.questdb.std;
 
-import io.questdb.std.Mutable;
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.LongGauge;
+import io.questdb.metrics.NullCounter;
+import io.questdb.metrics.NullLongGauge;
 
-public class WorkerMetrics implements Mutable {
+public class DefaultConcurrentCacheConfiguration implements ConcurrentCacheConfiguration {
+    public static final ConcurrentCacheConfiguration DEFAULT = new DefaultConcurrentCacheConfiguration();
 
-    private final LongGauge max;
-    private final LongGauge min;
-
-    public WorkerMetrics(MetricsRegistry metricsRegistry) {
-        min = metricsRegistry.newLongGauge("workers_job_start_micros_min");
-        max = metricsRegistry.newLongGauge("workers_job_start_micros_max");
-        min.setValue(Long.MAX_VALUE);
-        max.setValue(Long.MIN_VALUE);
+    @Override
+    public int getBlocks() {
+        return 2;
     }
 
     @Override
-    public void clear() {
-        min.setValue(Long.MAX_VALUE);
-        max.setValue(Long.MIN_VALUE);
+    public LongGauge getCachedGauge() {
+        return NullLongGauge.INSTANCE;
     }
 
-    public long getMaxElapsedMicros() {
-        return max.getValue();
+    @Override
+    public Counter getHiCounter() {
+        return NullCounter.INSTANCE;
     }
 
-    public long getMinElapsedMicros() {
-        return min.getValue();
+    @Override
+    public Counter getMissCounter() {
+        return NullCounter.INSTANCE;
     }
 
-    public void update(long candidateMin, long candidateMax) {
-        if (candidateMin < min.getValue()) {
-            min.setValue(candidateMin);
-        }
-        if (candidateMax > max.getValue()) {
-            max.setValue(candidateMax);
-        }
+    @Override
+    public int getRows() {
+        return 8;
     }
 }

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -26,8 +26,6 @@ package io.questdb.test;
 
 import io.questdb.FactoryProvider;
 import io.questdb.MessageBus;
-import io.questdb.MessageBusImpl;
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -160,7 +158,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
     protected static String inputWorkRoot = null;
     protected static IOURingFacade ioURingFacade = IOURingFacadeImpl.INSTANCE;
     protected static MessageBus messageBus;
-    protected static Metrics metrics;
     protected static QuestDBTestNode node1;
     protected static ObjList<QuestDBTestNode> nodes = new ObjList<>();
     protected static SecurityContext securityContext;
@@ -476,7 +473,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
         node1 = newNode(Chars.toString(root), false, 1, staticOverrides, getEngineFactory(), getConfigurationFactory());
         configuration = node1.getConfiguration();
         securityContext = configuration.getFactoryProvider().getSecurityContextFactory().getRootContext();
-        metrics = node1.getMetrics();
         engine = node1.getEngine();
         try (MetadataCacheWriter metadataRW = engine.getMetadataCache().writeLock()) {
             metadataRW.clearCache();
@@ -1441,10 +1437,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
         return new TableReader(configuration, engine.verifyTableName(tableName));
     }
 
-    protected static TableWriter newOffPoolWriter(CairoConfiguration configuration, CharSequence tableName, Metrics metrics) {
-        return TestUtils.newOffPoolWriter(configuration, engine.verifyTableName(tableName), metrics, new MessageBusImpl(configuration), engine);
-    }
-
     protected static TableWriter newOffPoolWriter(CairoConfiguration configuration, CharSequence tableName) {
         return TestUtils.newOffPoolWriter(configuration, engine.verifyTableName(tableName), engine);
     }
@@ -2016,8 +2008,8 @@ public abstract class AbstractCairoTest extends AbstractTest {
         return engine.isWalTable(engine.verifyTableName(tableName));
     }
 
-    protected TableWriter newOffPoolWriter(CairoConfiguration configuration, CharSequence tableName, Metrics metrics, MessageBus messageBus) {
-        return TestUtils.newOffPoolWriter(configuration, engine.verifyTableName(tableName), metrics, messageBus, engine);
+    protected TableWriter newOffPoolWriter(CairoConfiguration configuration, CharSequence tableName, MessageBus messageBus) {
+        return TestUtils.newOffPoolWriter(configuration, engine.verifyTableName(tableName), messageBus, engine);
     }
 
     protected long update(CharSequence updateSql) throws SqlException {

--- a/core/src/test/java/io/questdb/test/AbstractTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractTest.java
@@ -25,10 +25,16 @@
 package io.questdb.test;
 
 import io.questdb.Bootstrap;
+import io.questdb.Metrics;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.test.tools.TestUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.runner.OrderWith;
@@ -62,6 +68,7 @@ public class AbstractTest {
     public void setUp() {
         LOG.info().$("Starting test ").$(getClass().getSimpleName()).$('#').$(testName.getMethodName()).$();
         TestUtils.createTestPath(root);
+        Metrics.ENABLED.clear();
     }
 
     @After

--- a/core/src/test/java/io/questdb/test/BootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/BootstrapTest.java
@@ -26,8 +26,17 @@ package io.questdb.test;
 
 import io.questdb.Bootstrap;
 import io.questdb.cairo.CairoConfiguration;
-import io.questdb.log.*;
-import io.questdb.std.*;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.log.LogFileWriter;
+import io.questdb.log.LogLevel;
+import io.questdb.log.LogWriterConfig;
+import io.questdb.log.Logger;
+import io.questdb.std.CharSequenceObjHashMap;
+import io.questdb.std.Files;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
 import io.questdb.std.str.DirectUtf8StringZ;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Utf8s;
@@ -59,7 +68,7 @@ public class BootstrapTest extends AbstractBootstrapTest {
         Bootstrap bootstrap = new Bootstrap(getServerMainArgs());
         Assert.assertNotNull(bootstrap.getLog());
         Assert.assertNotNull(bootstrap.getConfiguration());
-        Assert.assertNotNull(bootstrap.getMetrics());
+        Assert.assertNotNull(bootstrap.getConfiguration().getMetrics());
         bootstrap.extractSite();
         Assert.assertTrue(Files.exists(auxPath.trimTo(pathLen).concat("conf").concat(LogFactory.DEFAULT_CONFIG_NAME).$()));
     }

--- a/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
@@ -128,7 +128,8 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                     w.write("http.net.connection.limit=10\n");
                 }
 
-                TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.jsonQuery().connectionCountGauge().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.httpMetrics().connectionCountGauge().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertEquals(2, metrics.httpMetrics().belowMaxConnectionCountCounter().getValue()));
 
                 assertReloadConfig(true);
 
@@ -295,7 +296,8 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                     w.write("pg.net.connection.limit=10\n");
                 }
 
-                TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.pgWire().connectionCountGauge().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.pgWireMetrics().connectionCountGauge().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertEquals(2, metrics.pgWireMetrics().getBelowMaxConnectionCountCounter().getValue()));
 
                 // call the reload method directly instead of using the reload_config() SQL function
                 // to avoid opening a PGWire connection;

--- a/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
@@ -197,6 +197,9 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
 
                 assertReloadConfig(true);
 
+                // second reload should not reload (no changes)
+                assertReloadConfig(false);
+
                 try (TestHttpClient testHttpClient = new TestHttpClient()) {
                     testHttpClient.assertGet(
                             "/exec",
@@ -303,6 +306,9 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                 // to avoid opening a PGWire connection;
                 // there is no reliable way to wait until the server listener is re-registered
                 serverMain.getEngine().getConfigReloader().reload();
+
+                // while configuration was reloaded, metrics must not be reset
+                Assert.assertEquals(2, metrics.pgWireMetrics().getBelowMaxConnectionCountCounter().getValue());
 
                 // we should be able to open two connections eventually
                 TestUtils.assertEventually(() -> {

--- a/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
@@ -129,7 +129,7 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                 }
 
                 TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.httpMetrics().connectionCountGauge().getValue()));
-                TestUtils.assertEventually(() -> Assert.assertEquals(2, metrics.httpMetrics().belowMaxConnectionCountCounter().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertTrue(3 < metrics.httpMetrics().listenerStateChangeCounter().getValue()));
 
                 assertReloadConfig(true);
 
@@ -300,7 +300,7 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                 }
 
                 TestUtils.assertEventually(() -> Assert.assertEquals(0, metrics.pgWireMetrics().connectionCountGauge().getValue()));
-                TestUtils.assertEventually(() -> Assert.assertEquals(2, metrics.pgWireMetrics().getBelowMaxConnectionCountCounter().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertTrue(3 < metrics.pgWireMetrics().listenerStateChangeCounter().getValue()));
 
                 // call the reload method directly instead of using the reload_config() SQL function
                 // to avoid opening a PGWire connection;
@@ -308,7 +308,7 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                 serverMain.getEngine().getConfigReloader().reload();
 
                 // while configuration was reloaded, metrics must not be reset
-                Assert.assertEquals(2, metrics.pgWireMetrics().getBelowMaxConnectionCountCounter().getValue());
+                TestUtils.assertEventually(() -> Assert.assertTrue(3 < metrics.pgWireMetrics().listenerStateChangeCounter().getValue()));
 
                 // we should be able to open two connections eventually
                 TestUtils.assertEventually(() -> {

--- a/core/src/test/java/io/questdb/test/MetricsTest.java
+++ b/core/src/test/java/io/questdb/test/MetricsTest.java
@@ -25,7 +25,15 @@
 package io.questdb.test;
 
 import io.questdb.Metrics;
-import io.questdb.metrics.*;
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.CounterWithOneLabel;
+import io.questdb.metrics.CounterWithTwoLabels;
+import io.questdb.metrics.DoubleGauge;
+import io.questdb.metrics.LongGauge;
+import io.questdb.metrics.MetricsRegistry;
+import io.questdb.metrics.NullMetricsRegistry;
+import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.VirtualLongGauge;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.str.BorrowableUtf8Sink;
 import io.questdb.std.str.DirectUtf8Sink;
@@ -34,7 +42,11 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -97,7 +109,7 @@ public class MetricsTest {
 
     @Test
     public void testMetricNamesContainGCMetrics() {
-        final Metrics metrics = Metrics.enabled();
+        final Metrics metrics = Metrics.ENABLED;
 
         final DirectUtf8Sink sink = new DirectUtf8Sink(32);
         metrics.scrapeIntoPrometheus(sink);

--- a/core/src/test/java/io/questdb/test/MetricsTest.java
+++ b/core/src/test/java/io/questdb/test/MetricsTest.java
@@ -32,7 +32,7 @@ import io.questdb.metrics.DoubleGauge;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.metrics.NullMetricsRegistry;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.metrics.VirtualLongGauge;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.str.BorrowableUtf8Sink;
@@ -139,8 +139,8 @@ public class MetricsTest {
         private final Set<CharSequence> notUniqueMetrics = new HashSet<>();
 
         @Override
-        public void addScrapable(Scrapable scrapable) {
-            delegate.addScrapable(scrapable);
+        public void addTarget(Target target) {
+            delegate.addTarget(target);
         }
 
         public Set<CharSequence> getLabelNames() {

--- a/core/src/test/java/io/questdb/test/PerformanceTest.java
+++ b/core/src/test/java/io/questdb/test/PerformanceTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
@@ -80,7 +79,7 @@ public class PerformanceTest extends AbstractCairoTest {
                     .col("ex", ColumnType.SYMBOL).symbolCapacity(2);
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "quote", Metrics.disabled())) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "quote")) {
                 for (int i = -count; i < count; i++) {
                     if (i == 0) {
                         t = System.nanoTime();
@@ -170,7 +169,7 @@ public class PerformanceTest extends AbstractCairoTest {
         SOCountDownLatch stopLatch = new SOCountDownLatch(2);
         SOCountDownLatch startLatch = new SOCountDownLatch(2);
         try (
-                TableWriter writer = newOffPoolWriter(configuration, "quote", Metrics.disabled());
+                TableWriter writer = newOffPoolWriter(configuration, "quote");
                 TableReader reader = newOffPoolReader(configuration, "quote")
         ) {
             // Writing

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -128,8 +128,8 @@ public class PropServerConfigurationTest {
         Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().getDumpNetworkTraffic());
         Assert.assertFalse(configuration.getHttpServerConfiguration().getHttpContextConfiguration().allowDeflateBeforeSend());
         Assert.assertTrue(configuration.getHttpServerConfiguration().isQueryCacheEnabled());
-        Assert.assertEquals(8 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getHttpServerConfiguration().getQueryCacheBlockCount());
-        Assert.assertEquals(2 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getHttpServerConfiguration().getQueryCacheRowCount());
+        Assert.assertEquals(8 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getHttpServerConfiguration().getConcurrentCacheConfiguration().getBlocks());
+        Assert.assertEquals(2 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getHttpServerConfiguration().getConcurrentCacheConfiguration().getRows());
 
         Assert.assertEquals(10, configuration.getWorkerPoolConfiguration().getYieldThreshold());
         Assert.assertEquals(10000, configuration.getWorkerPoolConfiguration().getSleepThreshold());
@@ -419,8 +419,8 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(64, configuration.getPGWireConfiguration().getTestConnectionBufferSize());
         Assert.assertEquals(2, configuration.getPGWireConfiguration().getBinParamCountCapacity());
         Assert.assertTrue(configuration.getPGWireConfiguration().isSelectCacheEnabled());
-        Assert.assertEquals(8 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getPGWireConfiguration().getSelectCacheBlockCount());
-        Assert.assertEquals(2 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getPGWireConfiguration().getSelectCacheRowCount());
+        Assert.assertEquals(8 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getPGWireConfiguration().getConcurrentCacheConfiguration().getBlocks());
+        Assert.assertEquals(2 * configuration.getWorkerPoolConfiguration().getWorkerCount(), configuration.getPGWireConfiguration().getConcurrentCacheConfiguration().getRows());
         Assert.assertTrue(configuration.getPGWireConfiguration().isInsertCacheEnabled());
         Assert.assertEquals(4, configuration.getPGWireConfiguration().getInsertCacheBlockCount());
         Assert.assertEquals(4, configuration.getPGWireConfiguration().getInsertCacheRowCount());
@@ -1089,8 +1089,8 @@ public class PropServerConfigurationTest {
             Assert.assertEquals("index2.html", configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getIndexFileName());
             Assert.assertEquals(SecurityContext.AUTH_TYPE_NONE, configuration.getHttpServerConfiguration().getStaticContentProcessorConfiguration().getRequiredAuthType());
             Assert.assertFalse(configuration.getHttpServerConfiguration().isQueryCacheEnabled());
-            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getQueryCacheBlockCount());
-            Assert.assertEquals(16, configuration.getHttpServerConfiguration().getQueryCacheRowCount());
+            Assert.assertEquals(32, configuration.getHttpServerConfiguration().getConcurrentCacheConfiguration().getBlocks());
+            Assert.assertEquals(16, configuration.getHttpServerConfiguration().getConcurrentCacheConfiguration().getRows());
 
             Assert.assertTrue(configuration.getHttpServerConfiguration().isPessimisticHealthCheckEnabled());
             Assert.assertEquals(SecurityContext.AUTH_TYPE_NONE, configuration.getHttpServerConfiguration().getRequiredAuthType());
@@ -1207,8 +1207,8 @@ public class PropServerConfigurationTest {
             // PG wire
             Assert.assertEquals(9, configuration.getPGWireConfiguration().getBinParamCountCapacity());
             Assert.assertFalse(configuration.getPGWireConfiguration().isSelectCacheEnabled());
-            Assert.assertEquals(1, configuration.getPGWireConfiguration().getSelectCacheBlockCount());
-            Assert.assertEquals(2, configuration.getPGWireConfiguration().getSelectCacheRowCount());
+            Assert.assertEquals(1, configuration.getPGWireConfiguration().getConcurrentCacheConfiguration().getBlocks());
+            Assert.assertEquals(2, configuration.getPGWireConfiguration().getConcurrentCacheConfiguration().getRows());
             Assert.assertFalse(configuration.getPGWireConfiguration().isInsertCacheEnabled());
             Assert.assertEquals(128, configuration.getPGWireConfiguration().getInsertCacheBlockCount());
             Assert.assertEquals(256, configuration.getPGWireConfiguration().getInsertCacheRowCount());

--- a/core/src/test/java/io/questdb/test/QuestDBTestNode.java
+++ b/core/src/test/java/io/questdb/test/QuestDBTestNode.java
@@ -24,7 +24,11 @@
 
 package io.questdb.test;
 
-import io.questdb.*;
+import io.questdb.DefaultTelemetryConfiguration;
+import io.questdb.MessageBus;
+import io.questdb.Metrics;
+import io.questdb.PropertyKey;
+import io.questdb.TelemetryConfiguration;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.sql.BindVariableService;
@@ -75,7 +79,7 @@ public class QuestDBTestNode {
     }
 
     public Metrics getMetrics() {
-        return cairo.metrics;
+        return cairo.configuration.getMetrics();
     }
 
     public CharSequence getRoot() {
@@ -146,7 +150,6 @@ public class QuestDBTestNode {
     private static class Cairo {
         private final CairoConfiguration configuration;
         private final MessageBus messageBus;
-        private final Metrics metrics;
         private final Overrides overrides;
         private final boolean ownRoot;
         private final CharSequence root;
@@ -170,8 +173,7 @@ public class QuestDBTestNode {
             };
 
             configuration = configurationFactory.getInstance(root, telemetryConfiguration, overrides);
-            metrics = Metrics.enabled();
-            engine = engineFactory.getInstance(configuration, metrics);
+            engine = engineFactory.getInstance(configuration);
             messageBus = engine.getMessageBus();
         }
 

--- a/core/src/test/java/io/questdb/test/ServerMainFlushQueryCacheTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainFlushQueryCacheTest.java
@@ -75,14 +75,14 @@ public class ServerMainFlushQueryCacheTest extends AbstractBootstrapTest {
                 }
 
                 final Metrics metrics = serverMain.getEngine().getMetrics();
-                TestUtils.assertEventually(() -> Assert.assertEquals(nQueries, metrics.pgWire().cachedSelectsGauge().getValue()));
+                TestUtils.assertEventually(() -> Assert.assertEquals(nQueries, metrics.pgWireMetrics().cachedSelectsGauge().getValue()));
 
                 try (Statement statement = conn.createStatement()) {
                     statement.execute("select flush_query_cache();");
                 }
 
                 // Only the select flush_query_cache(); query may remain in the cache.
-                TestUtils.assertEventually(() -> Assert.assertTrue(metrics.pgWire().cachedSelectsGauge().getValue() <= 1));
+                TestUtils.assertEventually(() -> Assert.assertTrue(metrics.pgWireMetrics().cachedSelectsGauge().getValue() <= 1));
             }
         }
     }

--- a/core/src/test/java/io/questdb/test/TestCairoEngineFactory.java
+++ b/core/src/test/java/io/questdb/test/TestCairoEngineFactory.java
@@ -24,10 +24,9 @@
 
 package io.questdb.test;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 
 public interface TestCairoEngineFactory {
-    CairoEngine getInstance(CairoConfiguration configuration, Metrics metrics);
+    CairoEngine getInstance(CairoConfiguration configuration);
 }

--- a/core/src/test/java/io/questdb/test/TestServerConfiguration.java
+++ b/core/src/test/java/io/questdb/test/TestServerConfiguration.java
@@ -26,7 +26,6 @@ package io.questdb.test;
 
 import io.questdb.DefaultServerConfiguration;
 import io.questdb.FactoryProvider;
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
@@ -194,52 +193,10 @@ public class TestServerConfiguration extends DefaultServerConfiguration {
                 return TestUtils.getCsvRoot();
             }
         };
-        this.confWalApplyPool = new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return cairoConfiguration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 0;
-            }
-        };
-        this.confSharedPool = new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return cairoConfiguration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCountShared;
-            }
-        };
-
-        this.confLineTcpIOPool = new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return cairoConfiguration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCountLineTcpIO;
-            }
-        };
-
-        this.confLineTcpWriterPool = new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return cairoConfiguration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCountLineTcpWriter;
-            }
-        };
+        this.confWalApplyPool = () -> 0;
+        this.confSharedPool = () -> workerCountShared;
+        this.confLineTcpIOPool = () -> workerCountLineTcpIO;
+        this.confLineTcpWriterPool = () -> workerCountLineTcpWriter;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
+++ b/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
@@ -46,6 +46,7 @@ import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,11 @@ public class WorkerPoolManagerTest {
 
     private static final String END_MESSAGE = "run is over";
     private static final Metrics METRICS = Metrics.ENABLED;
+
+    @Before
+    public void setUp() throws Exception {
+        METRICS.clear();
+    }
 
     @Test
     public void testConstructor() {

--- a/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
+++ b/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
@@ -57,11 +57,10 @@ import java.util.function.Consumer;
 public class WorkerPoolManagerTest {
 
     private static final String END_MESSAGE = "run is over";
-    private static final Metrics METRICS = Metrics.ENABLED;
 
     @Before
     public void setUp() throws Exception {
-        METRICS.clear();
+        Metrics.ENABLED.clear();
     }
 
     @Test
@@ -80,11 +79,6 @@ public class WorkerPoolManagerTest {
         final String poolName = "pool";
         final WorkerPoolManager workerPoolManager = createWorkerPoolManager(workerCount);
         WorkerPool workerPool = workerPoolManager.getInstance(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return METRICS;
-            }
-
             @Override
             public String getPoolName() {
                 return poolName;
@@ -106,11 +100,6 @@ public class WorkerPoolManagerTest {
         final String poolName = "pool";
         final WorkerPoolManager workerPoolManager = createWorkerPoolManager(workerCount);
         final WorkerPoolConfiguration workerPoolConfiguration = new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return METRICS;
-            }
-
             @Override
             public String getPoolName() {
                 return poolName;
@@ -137,11 +126,6 @@ public class WorkerPoolManagerTest {
         final WorkerPoolManager workerPoolManager = createWorkerPoolManager(workerCount);
         WorkerPool workerPool = workerPoolManager.getInstance(new WorkerPoolConfiguration() {
             @Override
-            public Metrics getMetrics() {
-                return METRICS;
-            }
-
-            @Override
             public String getPoolName() {
                 return "pool";
             }
@@ -162,11 +146,6 @@ public class WorkerPoolManagerTest {
         workerPoolManager.start(null);
         try {
             workerPoolManager.getInstance(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return METRICS;
-                }
-
                 @Override
                 public String getPoolName() {
                     return null;
@@ -216,7 +195,7 @@ public class WorkerPoolManagerTest {
         workerPoolManager.halt();
 
         Assert.assertEquals(0, endLatch.getCount());
-        WorkerMetrics metrics = METRICS.worker();
+        WorkerMetrics metrics = Metrics.ENABLED.worker();
         long min = metrics.getMinElapsedMicros();
         long max = metrics.getMaxElapsedMicros();
         Assert.assertTrue(min > 0L);
@@ -274,7 +253,7 @@ public class WorkerPoolManagerTest {
 
             @Override
             public Metrics getMetrics() {
-                return METRICS;
+                return Metrics.ENABLED;
             }
 
             @Override
@@ -299,17 +278,7 @@ public class WorkerPoolManagerTest {
 
             @Override
             public WorkerPoolConfiguration getWorkerPoolConfiguration() {
-                return new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return METRICS;
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount;
-                    }
-                };
+                return () -> workerCount;
             }
         };
     }
@@ -343,7 +312,7 @@ public class WorkerPoolManagerTest {
         return (workerId, runStatus) -> {
             final DirectUtf8Sink s = sink.get();
             s.clear();
-            METRICS.scrapeIntoPrometheus(s);
+            Metrics.ENABLED.scrapeIntoPrometheus(s);
             return false; // not eager
         };
     }
@@ -357,11 +326,6 @@ public class WorkerPoolManagerTest {
 
     private static WorkerPoolConfiguration workerPoolConfiguration(String poolName, long sleepMillis) {
         return new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return METRICS;
-            }
-
             @Override
             public String getPoolName() {
                 return poolName;

--- a/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
+++ b/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
@@ -32,7 +32,7 @@ import io.questdb.PublicPassthroughConfiguration;
 import io.questdb.ServerConfiguration;
 import io.questdb.WorkerPoolManager;
 import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.line.tcp.LineTcpReceiverConfiguration;
 import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
@@ -56,7 +56,7 @@ import java.util.function.Consumer;
 public class WorkerPoolManagerTest {
 
     private static final String END_MESSAGE = "run is over";
-    private static final Metrics METRICS = Metrics.enabled();
+    private static final Metrics METRICS = Metrics.ENABLED;
 
     @Test
     public void testConstructor() {
@@ -242,12 +242,12 @@ public class WorkerPoolManagerTest {
             }
 
             @Override
-            public HttpMinServerConfiguration getHttpMinServerConfiguration() {
+            public HttpServerConfiguration getHttpMinServerConfiguration() {
                 return null;
             }
 
             @Override
-            public HttpServerConfiguration getHttpServerConfiguration() {
+            public HttpFullFatServerConfiguration getHttpServerConfiguration() {
                 return null;
             }
 

--- a/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
+++ b/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
@@ -195,7 +195,7 @@ public class WorkerPoolManagerTest {
         workerPoolManager.halt();
 
         Assert.assertEquals(0, endLatch.getCount());
-        WorkerMetrics metrics = Metrics.ENABLED.worker();
+        WorkerMetrics metrics = Metrics.ENABLED.workerMetrics();
         long min = metrics.getMinElapsedMicros();
         long max = metrics.getMaxElapsedMicros();
         Assert.assertTrue(min > 0L);

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -24,7 +24,21 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractIndexReader;
+import io.questdb.cairo.BitmapIndexBwdReader;
+import io.questdb.cairo.BitmapIndexFwdReader;
+import io.questdb.cairo.BitmapIndexReader;
+import io.questdb.cairo.BitmapIndexUtils;
+import io.questdb.cairo.BitmapIndexWriter;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.ConcurrentBitmapIndexFwdReader;
+import io.questdb.cairo.EmptyRowCursor;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.RowCursor;
 import io.questdb.cairo.vm.NullMemoryCMR;
 import io.questdb.cairo.vm.Vm;
@@ -34,7 +48,20 @@ import io.questdb.cairo.vm.api.MemoryMA;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.griffin.engine.functions.geohash.GeoHashNative;
 import io.questdb.griffin.engine.table.LatestByArguments;
-import io.questdb.std.*;
+import io.questdb.std.BitmapIndexUtilsNative;
+import io.questdb.std.Chars;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.IntList;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.LongList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.Rnd;
+import io.questdb.std.Rows;
+import io.questdb.std.Vect;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
@@ -724,7 +751,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += timestampIncrement);
                     row.putStr(0, rnd.nextChars(20));

--- a/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
@@ -25,7 +25,15 @@
 package io.questdb.test.cairo;
 
 import io.questdb.PropertyKey;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.vm.Vm;
@@ -408,7 +416,7 @@ public class CairoEngineTest extends AbstractCairoTest {
     public void testRenameExternallyLockedTable() throws Exception {
         assertMemoryLeak(() -> {
             TableToken x = createX(engine);
-            try (TableWriter ignored1 = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter ignored1 = newOffPoolWriter(configuration, "x")) {
 
                 try (CairoEngine engine = new CairoEngine(configuration)) {
                     try {
@@ -519,7 +527,7 @@ public class CairoEngineTest extends AbstractCairoTest {
             // the test relies on negative inactive writer TTL - we want the maintenance job to always close idle writers
             assert engine.getConfiguration().getInactiveWriterTTL() < 0;
 
-            try (WorkerPool workerPool = new TestWorkerPool(1, metrics)) {
+            try (WorkerPool workerPool = new TestWorkerPool(1, configuration.getMetrics())) {
                 TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
                         .col("a", ColumnType.BYTE)
                         .col("b", ColumnType.STRING)

--- a/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoTestConfiguration.java
@@ -25,6 +25,7 @@
 package io.questdb.test.cairo;
 
 import io.questdb.FactoryProvider;
+import io.questdb.Metrics;
 import io.questdb.TelemetryConfiguration;
 import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.CairoConfiguration;
@@ -51,6 +52,7 @@ public class CairoTestConfiguration extends CairoConfigurationWrapper {
     private final VolumeDefinitions volumeDefinitions = new VolumeDefinitions();
 
     public CairoTestConfiguration(CharSequence root, TelemetryConfiguration telemetryConfiguration, Overrides overrides) {
+        super(Metrics.ENABLED);
         this.root = Chars.toString(root);
         this.snapshotRoot = Chars.toString(root) + Files.SEPARATOR + TableUtils.CHECKPOINT_DIRECTORY;
         this.telemetryConfiguration = telemetryConfiguration;

--- a/core/src/test/java/io/questdb/test/cairo/DefaultTestCairoConfiguration.java
+++ b/core/src/test/java/io/questdb/test/cairo/DefaultTestCairoConfiguration.java
@@ -24,12 +24,15 @@
 
 package io.questdb.test.cairo;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import org.jetbrains.annotations.NotNull;
 
 public class DefaultTestCairoConfiguration extends DefaultCairoConfiguration {
+    private final Metrics metrics = Metrics.ENABLED;
+
     public DefaultTestCairoConfiguration(CharSequence root) {
         super(root);
     }
@@ -47,6 +50,11 @@ public class DefaultTestCairoConfiguration extends DefaultCairoConfiguration {
     @Override
     public @NotNull FilesFacade getFilesFacade() {
         return TestFilesFacadeImpl.INSTANCE;
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return metrics;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/DoubleReloadTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/DoubleReloadTest.java
@@ -44,7 +44,7 @@ public class DoubleReloadTest extends AbstractCairoTest {
 
         try (
                 TableReader reader = newOffPoolReader(configuration, "int_test");
-                TableWriter writer = newOffPoolWriter(configuration, "int_test", metrics)
+                TableWriter writer = newOffPoolWriter(configuration, "int_test")
         ) {
             reader.reload();
 

--- a/core/src/test/java/io/questdb/test/cairo/FullBwdPartitionFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/FullBwdPartitionFrameCursorTest.java
@@ -24,7 +24,11 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.FullBwdPartitionFrameCursorFactory;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.PartitionFrame;
 import io.questdb.cairo.sql.PartitionFrameCursor;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
@@ -75,7 +79,7 @@ public class FullBwdPartitionFrameCursorTest extends AbstractCairoTest {
             long increment = 3600000000L * 8;
             int N = 10;
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow(timestamp);
                     row.putInt(0, rnd.nextInt());

--- a/core/src/test/java/io/questdb/test/cairo/FullFwdPartitionFrameCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/FullFwdPartitionFrameCursorFactoryTest.java
@@ -89,7 +89,7 @@ public class FullFwdPartitionFrameCursorFactoryTest extends AbstractCairoTest {
             GenericRecordMetadata metadata;
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));

--- a/core/src/test/java/io/questdb/test/cairo/IntervalBwdPartitionFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IntervalBwdPartitionFrameCursorTest.java
@@ -427,7 +427,7 @@ public class IntervalBwdPartitionFrameCursorTest extends AbstractCairoTest {
 
                 assertEqualTimestamps("", record, cursor);
 
-                try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                     for (int i = 0; i < rowCount; i++) {
                         TableWriter.Row row = writer.newRow(timestamp);
                         row.putSym(0, rnd.nextChars(4));
@@ -664,7 +664,7 @@ public class IntervalBwdPartitionFrameCursorTest extends AbstractCairoTest {
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < rowCount; i++) {
                     TableWriter.Row row = writer.newRow(timestamp);
                     row.putSym(0, rnd.nextChars(4));

--- a/core/src/test/java/io/questdb/test/cairo/IntervalFwdPartitionFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IntervalFwdPartitionFrameCursorTest.java
@@ -454,7 +454,7 @@ public class IntervalFwdPartitionFrameCursorTest extends AbstractCairoTest {
 
                 assertEqualTimestamps("", record, cursor);
 
-                try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                     for (int i = 0; i < rowCount; i++) {
                         TableWriter.Row row = writer.newRow(timestamp);
                         row.putSym(0, rnd.nextChars(4));
@@ -691,7 +691,7 @@ public class IntervalFwdPartitionFrameCursorTest extends AbstractCairoTest {
 
             final Rnd rnd = new Rnd();
             long timestamp = TimestampFormatUtils.parseTimestamp("1980-01-01T00:00:00.000Z");
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < rowCount; i++) {
                     TableWriter.Row row = writer.newRow(timestamp);
                     row.putSym(0, rnd.nextChars(4));

--- a/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReadFailTest.java
@@ -107,7 +107,7 @@ public class TableReadFailTest extends AbstractCairoTest {
                 TableToken tableToken = engine.verifyTableName(x);
                 path.of(configuration.getRoot()).concat(tableToken).concat(TableUtils.TXN_FILE_NAME).$();
 
-                try (TableWriter writer = newOffPoolWriter(configuration, x, metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, x)) {
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = writer.newRow();
                         r.putInt(0, rnd.nextInt());
@@ -165,7 +165,7 @@ public class TableReadFailTest extends AbstractCairoTest {
                 // make sure reload functions correctly. Txn changed from 1 to 3, reload should return true
                 Assert.assertTrue(reader.reload());
 
-                try (TableWriter writer = newOffPoolWriter(configuration, x, metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, x)) {
                     // add more data
                     for (int i = 0; i < N; i++) {
                         TableWriter.Row r = writer.newRow();

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
@@ -24,7 +24,13 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableReaderMetadata;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.std.ObjIntHashMap;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
@@ -478,7 +484,7 @@ public class TableReaderMetadataTest extends AbstractCairoTest {
                 tableId = metadata.getTableId();
                 for (ColumnManipulator manipulator : manipulators) {
                     long structVersion;
-                    try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+                    try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                         manipulator.restructure(writer);
                         structVersion = writer.getMetadataVersion();
                     }

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTimestampTest.java
@@ -173,7 +173,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 Assert.assertEquals(13, metadata.getColumnCount());
                 Assert.assertEquals(expectedInitialTimestampIndex, metadata.getTimestampIndex());
                 long structureVersion;
-                try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                     writer.removeColumn("timestamp");
                     structureVersion = writer.getMetadataVersion();
                 }
@@ -217,7 +217,7 @@ public class TableReaderMetadataTimestampTest extends AbstractCairoTest {
                 Assert.assertEquals(13, metadata.getColumnCount());
                 Assert.assertEquals(expectedInitialTimestampIndex, metadata.getTimestampIndex());
                 long structVersion;
-                try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                     manipulator.restructure(writer);
                     structVersion = writer.getMetadataVersion();
                 }

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderReloadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderReloadFuzzTest.java
@@ -91,7 +91,7 @@ public class TableReaderReloadFuzzTest extends AbstractCairoTest {
         TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY).timestamp();
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
             TableWriter.Row row = writer.newRow(0L);
             row.append();
             writer.commit();
@@ -254,7 +254,7 @@ public class TableReaderReloadFuzzTest extends AbstractCairoTest {
 
     private void testFuzzReload(int numOfReloads, int addFactor, int removeFactor, int renameFactor, int convertFactor) {
         createTable();
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             try (TableReader reader = newOffPoolReader(configuration, "all")) {
                 for (int i = 0; i < numOfReloads; i++) {
                     ingest(writer);

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
@@ -153,7 +153,7 @@ public class TableReaderReloadTest extends AbstractCairoTest {
         AbstractCairoTest.create(model);
 
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
 
             try (TableReader reader = newOffPoolReader(configuration, "all")) {
                 Assert.assertFalse(reader.reload());
@@ -206,7 +206,7 @@ public class TableReaderReloadTest extends AbstractCairoTest {
         AbstractCairoTest.create(model);
 
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             try (TableReader reader = newOffPoolReader(configuration, "all")) {
                 Assert.assertFalse(reader.reload());
             }

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -1497,7 +1497,7 @@ public class TableReaderTest extends AbstractCairoTest {
         CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
 
         assertMemoryLeak(() -> {
-            try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
                 TableWriter.Row r = writer.newRow(Numbers.LONG_NULL);
                 r.putInt(0, 100);
                 r.append();
@@ -1690,7 +1690,7 @@ public class TableReaderTest extends AbstractCairoTest {
             ).col("cc", ColumnType.STRING);
             AbstractCairoTest.create(model);
             char[] data = {'a', 'b', 'f', 'g'};
-            try (TableWriter writer = newOffPoolWriter(configuration, "char_test", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "char_test")) {
 
                 for (int i = 0, n = data.length; i < n; i++) {
                     TableWriter.Row r = writer.newRow();
@@ -1772,7 +1772,7 @@ public class TableReaderTest extends AbstractCairoTest {
             new Thread(() -> {
                 try {
                     startBarrier.await();
-                    try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+                    try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                         for (int i = 0; i < N * scale; i++) {
                             TableWriter.Row row = writer.newRow();
                             row.putLong(0, list.getQuick(i % N));
@@ -1836,14 +1836,14 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "x", PartitionBy.NONE).col("a", ColumnType.LONG256);
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 TableWriter.Row r = writer.newRow();
                 r.putLong256(0, 1, 2, 3, 4);
                 r.append();
                 writer.commit();
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 TableWriter.Row r = writer.newRow();
                 r.putLong256(0, 5, 6, 7, 8);
                 r.append();
@@ -2038,7 +2038,7 @@ public class TableReaderTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             CreateTableTestUtils.createAllTable(engine, PartitionBy.NONE);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
                 TableWriter.Row r = writer.newRow(1000000); // <-- higher timestamp
                 r.putInt(0, 10);
                 r.putByte(1, (byte) 56);
@@ -2073,7 +2073,7 @@ public class TableReaderTest extends AbstractCairoTest {
 
             long N = 280000000;
             Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow();
                     r.putLong(0, rnd.nextLong());
@@ -2103,7 +2103,7 @@ public class TableReaderTest extends AbstractCairoTest {
         CreateTableTestUtils.createAllTable(engine, PartitionBy.NONE);
         int N = 10000;
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             int col = writer.getMetadata().getColumnIndex("str");
             for (int i = 0; i < N; i++) {
                 TableWriter.Row r = writer.newRow();
@@ -2172,11 +2172,11 @@ public class TableReaderTest extends AbstractCairoTest {
     public void testReadEmptyTable() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             CreateTableTestUtils.createAllTable(engine, PartitionBy.NONE);
-            try (TableWriter ignored1 = newOffPoolWriter(configuration, "all", metrics)) {
+            try (TableWriter ignored1 = newOffPoolWriter(configuration, "all")) {
 
                 // open another writer, which should fail
                 try {
-                    try (TableWriter ignore = newOffPoolWriter(configuration, "all", metrics)) {
+                    try (TableWriter ignore = newOffPoolWriter(configuration, "all")) {
                         Assert.fail();
                     }
                 } catch (CairoException ignored) {
@@ -2201,7 +2201,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2236,7 +2236,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()));
@@ -2271,7 +2271,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2306,7 +2306,7 @@ public class TableReaderTest extends AbstractCairoTest {
         final int N = 1_000_000;
         final Rnd rnd = new Rnd();
         long timestamp = 0;
-        try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow(timestamp);
                 row.putLong256(0, "0x" + padHexLong(rnd.nextLong()) + padHexLong(rnd.nextLong()));
@@ -2352,7 +2352,7 @@ public class TableReaderTest extends AbstractCairoTest {
             AtomicInteger errorCount = new AtomicInteger(0);
 
             try (
-                    TableWriter writer = newOffPoolWriter(configuration, "x", metrics);
+                    TableWriter writer = newOffPoolWriter(configuration, "x");
                     TableReader reader = newOffPoolReader(configuration, "x")
             ) {
                 new Thread(() -> {
@@ -2415,7 +2415,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableToken tableToken = AbstractCairoTest.create(model);
 
             int rowCount = 10;
-            try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                 try (TableReader ignore = getReader(tableToken)) {
                     for (int i = 0; i < rowCount; i++) {
                         TableWriter.Row row = writer.newRow();
@@ -2444,7 +2444,7 @@ public class TableReaderTest extends AbstractCairoTest {
         TableModel model = new TableModel(configuration, "x", PartitionBy.HOUR).col("i", ColumnType.INT).timestamp();
         TestUtils.createTable(engine, model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
             for (int i = 0; i < rows; i++) {
                 TableWriter.Row row = writer.newRow(i * tsStep);
                 row.putInt(0, i);
@@ -2497,7 +2497,7 @@ public class TableReaderTest extends AbstractCairoTest {
             AbstractCairoTest.create(model);
 
             try (
-                    TableWriter writer = newOffPoolWriter(configuration, "w", metrics);
+                    TableWriter writer = newOffPoolWriter(configuration, "w");
                     TableReader reader = newOffPoolReader(configuration, "w");
                     TestTableReaderRecordCursor cursor = new TestTableReaderRecordCursor().of(reader)
             ) {
@@ -2590,7 +2590,7 @@ public class TableReaderTest extends AbstractCairoTest {
             final int M = 1_000_000;
             final Rnd rnd = new Rnd();
 
-            try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                 long timestamp = TimestampFormatUtils.parseUTCTimestamp("2019-01-31T10:00:00.000001Z");
                 long timestampStep = 500;
 
@@ -2655,7 +2655,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "tab", PartitionBy.DAY).col("x", ColumnType.SYMBOL).col("y", ColumnType.LONG);
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "tab", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "tab")) {
                 TableWriter.Row r = writer.newRow();
                 r.putSym(0, "hello");
                 r.append();
@@ -2706,7 +2706,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "w", PartitionBy.NONE).col("l", ColumnType.LONG).timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
                     for (int i = 0; i < N; i++) {
@@ -2858,7 +2858,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "w", PartitionBy.DAY).col("l", ColumnType.LONG).timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
                     for (int i = 0; i < N; i++) {
@@ -2958,7 +2958,7 @@ public class TableReaderTest extends AbstractCairoTest {
         CreateTableTestUtils.createTableWithVersionAndId(model, engine, ColumnType.VERSION, 1);
         assertMemoryLeak(() -> {
             try (TableReader ignore = getReader("all")) {
-                try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
                     for (int i = 0; i < configuration.getTxnScoreboardEntryCount() + 1; i++) {
                         TableWriter.Row r = writer.newRow(1000);
                         r.putInt(0, 100);
@@ -2973,7 +2973,7 @@ public class TableReaderTest extends AbstractCairoTest {
                     TestUtils.assertContains(ex.getFlyweightMessage(), "max txn-inflight limit reached");
                 }
 
-                try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
                     TableWriter.Row r = writer.newRow(0);
                     r.putInt(0, 100);
                     r.append();
@@ -3065,7 +3065,7 @@ public class TableReaderTest extends AbstractCairoTest {
             int N = 1000;
             long ts = TimestampFormatUtils.parseTimestamp("2018-01-06T10:00:00.000Z");
             final Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 sink.clear();
                 writer.getMetadata().toJson(sink);
                 TestUtils.assertEquals(expected, sink);
@@ -3843,7 +3843,7 @@ public class TableReaderTest extends AbstractCairoTest {
     }
 
     private long testAppend(Rnd rnd, CairoConfiguration configuration, long ts, int count, long inc, long blob, int testPartitionSwitch) {
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             return testAppend(writer, rnd, ts, count, inc, blob, testPartitionSwitch, TableReaderTest.BATCH1_GENERATOR);
         }
     }
@@ -3932,7 +3932,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 try {
                     startBarrier.await();
                     long timestampUs = TimestampFormatUtils.parseTimestamp("2017-12-11T00:00:00.000Z");
-                    try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+                    try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                         for (int i = 0; i < N; i++) {
                             TableWriter.Row row = writer.newRow(timestampUs);
                             row.putLong(0, i);
@@ -4075,7 +4075,7 @@ public class TableReaderTest extends AbstractCairoTest {
 
                     // writer will inflate last partition in order to optimise appends
                     // reader must be able to cope with that
-                    try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+                    try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
                         // this is a bit of paranoid check, but make sure our reader doesn't flinch when new writer is open
                         assertCursor(cursor, ts, increment, blob, 2L * count, BATCH1_ASSERTER);
 
@@ -4220,7 +4220,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, tableName, partitionBy).col("l", ColumnType.LONG).timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
                     for (int i = 0; i < N; i++) {
@@ -4288,7 +4288,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
                     for (int i = 0; i < N; i++) {
@@ -4357,7 +4357,7 @@ public class TableReaderTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "w", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "w")) {
                 for (int k = 0; k < N_PARTITIONS; k++) {
                     long band = k * bandStride;
                     for (int i = 0; i < N; i++) {

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTxnScoreboardInteractionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTxnScoreboardInteractionTest.java
@@ -24,7 +24,12 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TxnScoreboard;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -120,7 +125,7 @@ public class TableReaderTxnScoreboardInteractionTest extends AbstractCairoTest {
                 Assert.assertEquals(0, reader.getTxn());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 addRow(writer);
 
                 final TxnScoreboard txnScoreboard = writer.getTxnScoreboard();

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
@@ -206,7 +205,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long interval = 60000L * 1000L;
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             ts = populateProducts(writer, rnd, ts, count, interval);
             Assert.assertEquals(count, writer.size());
             writer.addColumn("abc", ColumnType.STRING);
@@ -217,7 +216,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             populateTable2(writer, rnd, count, ts, interval);
             writer.commit();
             Assert.assertEquals(2 * count, writer.size());
@@ -318,7 +317,7 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testAddColumnDuplicate() throws Exception {
         long ts = populateTable(FF, PartitionBy.MONTH);
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             try {
                 writer.addColumn("supplier", ColumnType.BOOLEAN);
                 Assert.fail();
@@ -461,7 +460,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT, metrics)) {
+        }, PRODUCT)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -495,7 +494,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testAddColumnNonPartitioned() throws Exception {
         int N = 100000;
         create(FF, PartitionBy.NONE, N);
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -510,7 +509,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testAddColumnPartitioned() throws Exception {
         int N = 10000;
         create(FF, PartitionBy.DAY, N);
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             writer.addColumn("xyz", ColumnType.STRING);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -601,7 +600,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 Assert.assertEquals(20, writer.getColumnCount());
                 writer.addColumn("abc", ColumnType.STRING);
                 Assert.assertEquals(22, writer.getColumnCount());
@@ -700,7 +699,7 @@ public class TableWriterTest extends AbstractCairoTest {
             AbstractCairoTest.create(model);
 
             final int N = 1000;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 final Rnd rnd = new Rnd();
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow();
@@ -741,7 +740,7 @@ public class TableWriterTest extends AbstractCairoTest {
             AbstractCairoTest.create(model);
 
             final int N = 1000;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 final Rnd rnd = new Rnd();
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow();
@@ -791,7 +790,7 @@ public class TableWriterTest extends AbstractCairoTest {
         int N = 10000;
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 TableWriter.Row r = writer.newRow(ts);
@@ -827,7 +826,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 ts = populateProducts(writer, rnd, ts, N, 60 * 60000 * 1000L);
                 writer.commit();
@@ -842,7 +841,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -870,7 +869,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 // add 48 hours
                 ts = populateProducts(writer, rnd, ts, N / 2, increment);
@@ -913,7 +912,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 TableWriter.Row r = writer.newRow(ts);
@@ -950,7 +949,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.DAY, 4);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 TableWriter.Row r = writer.newRow(ts);
                 r.cancel();
@@ -968,7 +967,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
             int N = 94;
             create(FF, PartitionBy.DAY, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 // add 48 hours
                 ts = populateProducts(writer, rnd, ts, N / 2, increment);
@@ -997,7 +996,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testCancelFirstRowSecondPartition() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.DAY, 4);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 writer.newRow(TimestampFormatUtils.parseTimestamp("2013-03-01T00:00:00.000Z")).append();
                 writer.newRow(TimestampFormatUtils.parseTimestamp("2013-03-01T00:00:00.000Z")).append();
 
@@ -1016,7 +1015,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             // Last 2 rows are not committed, expect size to revert to 2
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(2, writer.size());
             }
         });
@@ -1032,7 +1031,7 @@ public class TableWriterTest extends AbstractCairoTest {
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
             try (MemoryARW vmem = Vm.getARWInstance(FF.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
-                try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;
 
@@ -1069,7 +1068,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             final int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 int cancelCount = 0;
@@ -1107,7 +1106,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long interval = 60000 * 1000L;
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             ts = populateProducts(writer, rnd, ts, N, interval);
 
             Assert.assertEquals(N, writer.size());
@@ -1128,7 +1127,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             populateTable2(writer, rnd, N, ts, interval);
             writer.commit();
             Assert.assertEquals(2 * N, writer.size());
@@ -1143,7 +1142,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             DefaultCairoConfiguration configuration = new DefaultTestCairoConfiguration(root);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 populateProducts(writer, rnd, ts, 1, 0);
                 writer.commit();
@@ -1170,7 +1169,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(2, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(AbstractCairoTest.configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(AbstractCairoTest.configuration, PRODUCT)) {
                 Assert.assertEquals(2, writer.size());
             }
 
@@ -1216,7 +1215,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public @NotNull FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT, metrics)) {
+                }, PRODUCT)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;
 
@@ -1264,7 +1263,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 10000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -1283,7 +1282,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(N + 1, writer.size());
             }
         });
@@ -1331,7 +1330,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public @NotNull FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT, metrics).close();
+                }, PRODUCT).close();
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -1615,7 +1614,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testCloseActivePartitionAndRollback() throws Exception {
         int N = 10000;
         create(FF, PartitionBy.DAY, N);
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
             populateProducts(writer, rnd, ts, N, 6 * 60000 * 1000L);
@@ -1655,13 +1654,13 @@ public class TableWriterTest extends AbstractCairoTest {
             int N = 10000;
             create(FF, PartitionBy.DAY, N);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 populateProducts(writer, new Rnd(), TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z"), N, 60000 * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -1680,7 +1679,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return 1024 * 1024; // 1MB
                 }
             };
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 for (int k = 0; k < 3; k++) {
@@ -1691,7 +1690,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2014-03-04T00:00:00.000Z");
                 Assert.assertEquals(0, writer.size());
                 populateProducts(writer, rnd, ts, N, increment);
@@ -1714,7 +1713,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return 1024 * 1024; // 1MB
                 }
             };
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 for (int k = 0; k < 3; k++) {
@@ -1725,7 +1724,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2014-03-04T00:00:00.000Z");
                 Assert.assertEquals(0, writer.size());
                 populateProducts(writer, rnd, ts, N, increment);
@@ -1745,7 +1744,7 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             int N = 100000;
             create(FF, PartitionBy.NONE, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -1853,7 +1852,7 @@ public class TableWriterTest extends AbstractCairoTest {
     @Test
     public void testGetColumnIndex() {
         CreateTableTestUtils.createAllTable(engine, PartitionBy.NONE);
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             Assert.assertEquals(1, writer.getColumnIndex("short"));
             try {
                 writer.getColumnIndex("bad");
@@ -1878,12 +1877,12 @@ public class TableWriterTest extends AbstractCairoTest {
                 mem.putLong(40, 9990001L);
                 mem.jumpTo(48);
             }
-            try (TableWriter writer = newOffPoolWriter(configuration, all, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, all)) {
                 Assert.assertNotNull(writer);
                 Assert.assertTrue(writer.isOpen());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, all, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, all)) {
                 Assert.assertNotNull(writer);
                 Assert.assertTrue(writer.isOpen());
             }
@@ -2014,7 +2013,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     .timestamp();
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "weather", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "weather")) {
                 TableWriter.Row r;
                 r = writer.newRow(IntervalUtils.parseFloorPartialTimestamp("2021-01-31"));
                 r.putDouble(0, 1.0);
@@ -2063,7 +2062,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 .timestamp();
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), Metrics.disabled())) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
             // Add 46 rows in partition 2020-07-13T00
             long ts = IntervalUtils.parseFloorPartialTimestamp("2020-07-13");
             long increment = Timestamps.SECOND_MICROS;
@@ -2125,7 +2124,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     631152000000000L,
                     631160000000000L
             };
-            try (TableWriter writer = newOffPoolWriter(configuration, "weather", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "weather")) {
                 TableWriter.Row r = writer.newRow(tss[1]);
                 r.putDouble(0, 1.0);
                 r.append();
@@ -2176,7 +2175,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
             try {
                 AbstractCairoTest.create(model);
-                newOffPoolWriter(configuration, "x", metrics).close();
+                newOffPoolWriter(configuration, "x").close();
                 Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "only supported");
@@ -2193,7 +2192,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 TableToken tableToken = engine.verifyTableName(all);
                 Assert.assertTrue(FF.removeQuiet(path.of(root).concat(tableToken).concat(TableUtils.TXN_FILE_NAME).$()));
                 try {
-                    newOffPoolWriter(configuration, all, metrics).close();
+                    newOffPoolWriter(configuration, all).close();
                     Assert.fail();
                 } catch (CairoException ignore) {
                 }
@@ -2408,7 +2407,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
 
             append10KProducts(ts, rnd, writer);
 
@@ -2421,7 +2420,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Assert.assertEquals(20000, writer.size());
         }
 
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
             append10KNoTimestamp(rnd, writer);
             writer.commit();
             Assert.assertEquals(30000, writer.size());
@@ -2439,7 +2438,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 .col("supplier", ColumnType.SYMBOL);
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "ABC", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "ABC")) {
             try {
                 writer.removeColumn("timestamp");
                 Assert.fail();
@@ -2643,7 +2642,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
 
             append10KProducts(ts, rnd, writer);
 
@@ -2656,7 +2655,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Assert.assertEquals(20000, writer.size());
         }
 
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
             append10KProducts(writer.getMaxTimestamp(), rnd, writer);
             writer.commit();
             Assert.assertEquals(30000, writer.size());
@@ -2676,7 +2675,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
 
             append10KProducts(ts, rnd, writer);
 
@@ -2689,7 +2688,7 @@ public class TableWriterTest extends AbstractCairoTest {
             Assert.assertEquals(20000, writer.size());
         }
 
-        try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
             append10KProducts(writer.getMaxTimestamp(), rnd, writer);
             writer.commit();
             Assert.assertEquals(30000, writer.size());
@@ -2731,7 +2730,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT, metrics)) {
+        }, PRODUCT)) {
 
             ts = populateProducts(writer, rnd, ts, N, increment);
             writer.commit();
@@ -2782,7 +2781,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT, metrics)) {
+        }, PRODUCT)) {
 
             ts = populateProducts(writer, rnd, ts, N, increment);
             writer.commit();
@@ -2819,7 +2818,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
             final long increment = 60000L * 1000L;
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = populateProducts(writer, rnd, ts, 5, increment);
                 writer.commit();
 
@@ -2871,12 +2870,12 @@ public class TableWriterTest extends AbstractCairoTest {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.YEAR, 4);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 writer.truncate();
                 Assert.assertEquals(0, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(0, writer.size());
             }
         });
@@ -2906,7 +2905,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 path.of(configuration.getRoot()).concat(PRODUCT).concat(WalUtils.SEQ_DIR_DEPRECATED).slash$();
                 Assert.assertEquals(0, ff.mkdirs(path, configuration.getMkDirMode()));
 
-                newOffPoolWriter(configuration, PRODUCT, metrics).close();
+                newOffPoolWriter(configuration, PRODUCT).close();
 
                 path.of(configuration.getRoot()).concat(PRODUCT_FS).concat("default").slash$();
                 Assert.assertTrue(ff.exists(path.$()));
@@ -2950,7 +2949,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 path.of(configuration.getRoot()).concat(PRODUCT).concat(WalUtils.SEQ_DIR_DEPRECATED).slash$();
                 Assert.assertEquals(0, ff.mkdirs(path, configuration.getMkDirMode()));
 
-                newOffPoolWriter(configuration, PRODUCT, metrics).close();
+                newOffPoolWriter(configuration, PRODUCT).close();
 
                 path.of(configuration.getRoot()).concat(PRODUCT).concat("default").slash$();
                 Assert.assertTrue(ff.exists(path.$()));
@@ -2974,7 +2973,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testTableDoesNotExist() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try {
-                newOffPoolWriter(configuration, PRODUCT, metrics).close();
+                newOffPoolWriter(configuration, PRODUCT).close();
                 Assert.fail();
             } catch (CairoException e) {
                 LOG.info().$((Sinkable) e).$();
@@ -3043,9 +3042,9 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testTableLock() {
         CreateTableTestUtils.createAllTable(engine, PartitionBy.NONE);
 
-        try (TableWriter ignored = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter ignored = newOffPoolWriter(configuration, "all")) {
             try {
-                newOffPoolWriter(configuration, "all", metrics).close();
+                newOffPoolWriter(configuration, "all").close();
                 Assert.fail();
             } catch (CairoException ignored2) {
             }
@@ -3062,7 +3061,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return getFilesFacade().getPageSize();
                 }
             };
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
                 Rnd rnd = new Rnd();
@@ -3085,7 +3084,7 @@ public class TableWriterTest extends AbstractCairoTest {
     public void testToString() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             create(FF, PartitionBy.NONE, 4);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals("TableWriter{name=product}", writer.toString());
             }
         });
@@ -3115,7 +3114,7 @@ public class TableWriterTest extends AbstractCairoTest {
         AbstractCairoTest.create(model);
 
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, name)) {
             for (int i = 0; i < 1000000; i++) {
                 TableWriter.Row r = writer.newRow();
                 r.putStr(0, rnd.nextChars(5));
@@ -3161,7 +3160,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public @NotNull FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT, metrics).close();
+                }, PRODUCT).close();
                 Assert.fail();
             } catch (CairoException ignore) {
             }
@@ -3193,7 +3192,7 @@ public class TableWriterTest extends AbstractCairoTest {
         AbstractCairoTest.create(model);
         String something = "Щось";
         String boring = "Таке-Сяке";
-        try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, name)) {
             TableWriter.Row r = writer.newRow();
             TestUtils.putUtf8(r, something, 0, false);
             try {
@@ -3349,7 +3348,7 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     private void appendAndAssert10K(long ts, Rnd rnd) {
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             Assert.assertEquals(20, writer.getColumnCount());
             populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
             writer.commit();
@@ -3367,7 +3366,7 @@ public class TableWriterTest extends AbstractCairoTest {
         model.col("g", ColumnType.getGeoHashTypeWithBits(tableBits));
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, tableName, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
             TableWriter.Row r = writer.newRow();
             if (isStr) {
                 r.putGeoStr(0, hash);
@@ -3464,7 +3463,7 @@ public class TableWriterTest extends AbstractCairoTest {
         Rnd rnd = new Rnd();
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
         long interval = 60000L * 1000L;
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             ts = populateProducts(writer, rnd, ts, n, interval);
             writer.commit();
 
@@ -3481,7 +3480,7 @@ public class TableWriterTest extends AbstractCairoTest {
         }
 
         // append more
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             populateTable2(writer, rnd, n, ts, interval);
             Assert.assertEquals(3 * n, writer.size());
             writer.commit();
@@ -3502,7 +3501,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public @NotNull FilesFacade getFilesFacade() {
                 return ff;
             }
-        }, PRODUCT, metrics)) {
+        }, PRODUCT)) {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             ts = populateProducts(writer, new Rnd(), ts, N, 60000L * 1000L);
             writer.commit();
@@ -3539,7 +3538,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, name, metrics)) {
+            }, name)) {
 
                 ts = append10KProducts(ts, rnd, writer);
 
@@ -3555,7 +3554,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, name)) {
                 append10KNoSupplier(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3584,7 +3583,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, name, metrics)) {
+            }, name)) {
 
                 ts = append10KProducts(ts, rnd, writer);
 
@@ -3600,7 +3599,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, name, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, name)) {
                 append10KWithNewName(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -3614,17 +3613,17 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             create(FF, partitionBy, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = populateProducts(writer, rnd, ts, N, 60L * 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 writer.addColumn("xyz", ColumnType.STRING);
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 for (int i = 0; i < N; i++) {
                     ts = populateRow(writer, rnd, ts, 60L * 60000 * 1000L);
                 }
@@ -3644,7 +3643,7 @@ public class TableWriterTest extends AbstractCairoTest {
             };
             long ts = populateTable();
             Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(20000, writer.size());
@@ -3658,52 +3657,9 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            newOffPoolWriter(configuration, PRODUCT, metrics).close();
+            newOffPoolWriter(configuration, PRODUCT).close();
 
             appendAndAssert10K(ts, rnd);
-        });
-    }
-
-    private void testAddColumnUnrecoverableFault(FilesFacade ff) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            long ts = populateTable();
-            Rnd rnd = new Rnd();
-            CairoConfiguration configuration = new DefaultTestCairoConfiguration(root) {
-                @Override
-                public @NotNull FilesFacade getFilesFacade() {
-                    return ff;
-                }
-            };
-            TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics);
-            try {
-                Assert.assertEquals(20, writer.getColumnCount());
-                ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
-                writer.commit();
-                try {
-                    writer.addColumn("abc", ColumnType.SYMBOL);
-                    Assert.fail();
-                } catch (CairoException ignore) {
-                }
-
-                if (writer.isDistressed()) {
-                    // Column add exception maybe recoverable but not always
-                    Misc.free(writer);
-                    writer = newOffPoolWriter(configuration, PRODUCT, metrics);
-                }
-
-                // ignore error and add more rows
-                ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
-                writer.commit();
-                Assert.assertEquals(30000, writer.size());
-            } finally {
-                writer.close();
-            }
-
-            try (TableWriter writer2 = newOffPoolWriter(configuration, PRODUCT, metrics)) {
-                populateProducts(writer2, rnd, ts, 10000, 60000L * 1000L);
-                writer2.commit();
-                Assert.assertEquals(40000, writer2.size());
-            }
         });
     }
 
@@ -3717,7 +3673,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     return ff;
                 }
             };
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(20, writer.getColumnCount());
                 ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
@@ -3729,10 +3685,53 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(30000, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(40000, writer.size());
+            }
+        });
+    }
+
+    private void testAddColumnUnrecoverableFault(FilesFacade ff) throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long ts = populateTable();
+            Rnd rnd = new Rnd();
+            CairoConfiguration configuration = new DefaultTestCairoConfiguration(root) {
+                @Override
+                public @NotNull FilesFacade getFilesFacade() {
+                    return ff;
+                }
+            };
+            TableWriter writer = newOffPoolWriter(configuration, PRODUCT);
+            try {
+                Assert.assertEquals(20, writer.getColumnCount());
+                ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
+                writer.commit();
+                try {
+                    writer.addColumn("abc", ColumnType.SYMBOL);
+                    Assert.fail();
+                } catch (CairoException ignore) {
+                }
+
+                if (writer.isDistressed()) {
+                    // Column add exception maybe recoverable but not always
+                    Misc.free(writer);
+                    writer = newOffPoolWriter(configuration, PRODUCT);
+                }
+
+                // ignore error and add more rows
+                ts = populateProducts(writer, rnd, ts, 10000, 60000L * 1000L);
+                writer.commit();
+                Assert.assertEquals(30000, writer.size());
+            } finally {
+                writer.close();
+            }
+
+            try (TableWriter writer2 = newOffPoolWriter(configuration, PRODUCT)) {
+                populateProducts(writer2, rnd, ts, 10000, 60000L * 1000L);
+                writer2.commit();
+                Assert.assertEquals(40000, writer2.size());
             }
         });
     }
@@ -3743,19 +3742,19 @@ public class TableWriterTest extends AbstractCairoTest {
             Rnd rnd = new Rnd();
 
             create(FF, partitionBy, N);
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = populateProducts(writer, rnd, ts, N, 60L * 60000L * 1000L);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 writer.addIndex("supplier", configuration.getIndexValueBlockSize());
                 Assert.fail();
             } catch (CairoException ignored) {
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row r = writer.newRow(ts += 60L * 60000 * 1000L);
                     r.putInt(0, rnd.nextPositiveInt());
@@ -3770,7 +3769,7 @@ public class TableWriterTest extends AbstractCairoTest {
             }
 
             // another attempt to create index
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 writer.addIndex("supplier", configuration.getIndexValueBlockSize());
             }
         });
@@ -3784,7 +3783,7 @@ public class TableWriterTest extends AbstractCairoTest {
             public @NotNull FilesFacade getFilesFacade() {
                 return TableWriterTest.FF;
             }
-        }, "all", metrics)) {
+        }, "all")) {
             long size = writer.size();
             for (int i = 0; i < 10000; i++) {
                 TableWriter.Row r = writer.newRow(ts += 60L * 60000L * 1000L);
@@ -3852,7 +3851,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public @NotNull FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, PRODUCT, metrics).close();
+                }, PRODUCT).close();
                 Assert.fail();
             } catch (CairoException e) {
                 LOG.info().$((Sinkable) e).$();
@@ -3875,7 +3874,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testO3RecordsFail(int N) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
 
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
@@ -3913,7 +3912,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertTrue(failureCount > 0);
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -3921,7 +3920,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
     private void testO3RecordsNewerThanOlder(int N, CairoConfiguration configuration) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
 
                 long ts;
                 long ts1 = TimestampFormatUtils.parseTimestamp("2013-03-04T04:00:00.000Z");
@@ -3951,7 +3950,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(N, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 Assert.assertEquals(N, writer.size());
             }
         });
@@ -3963,7 +3962,7 @@ public class TableWriterTest extends AbstractCairoTest {
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
 
             Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
 
                 // optional
                 writer.warmUp();
@@ -3992,7 +3991,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 Assert.assertEquals(20000, writer.size());
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, model.getName(), metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, model.getName())) {
                 append10KNoSupplier(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -4010,7 +4009,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4026,7 +4025,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -4122,7 +4121,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4138,7 +4137,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(30000, writer.size());
@@ -4150,7 +4149,7 @@ public class TableWriterTest extends AbstractCairoTest {
         long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
         Rnd rnd = new Rnd();
         final long increment = 60000L * 1000L;
-        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
             ts = populateProducts(writer, rnd, ts, N / 2, increment);
             writer.commit();
 
@@ -4204,7 +4203,7 @@ public class TableWriterTest extends AbstractCairoTest {
                     public @NotNull FilesFacade getFilesFacade() {
                         return ff;
                     }
-                }, "all", metrics).close();
+                }, "all").close();
                 Assert.fail();
             } catch (CairoException | CairoError ignore) {
             }
@@ -4221,7 +4220,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
         int N = 1000;
         Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
             Assert.assertEquals(cacheFlag, writer.isSymbolMapWriterCached(0));
             Assert.assertNotEquals(cacheFlag, writer.isSymbolMapWriterCached(2));
             for (int i = 0; i < N; i++) {
@@ -4369,7 +4368,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                 Rnd rnd = new Rnd();
                 populateProducts(writer, rnd, ts, N, 60 * 60000L * 1000L);
@@ -4389,7 +4388,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 public @NotNull FilesFacade getFilesFacade() {
                     return ff;
                 }
-            }, PRODUCT, metrics)) {
+            }, PRODUCT)) {
                 ts = populateProducts(writer, rnd, ts, 10000, 60000 * 1000L);
                 writer.commit();
 
@@ -4417,7 +4416,7 @@ public class TableWriterTest extends AbstractCairoTest {
             create(FF, PartitionBy.DAY, N);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4428,7 +4427,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());
@@ -4448,7 +4447,7 @@ public class TableWriterTest extends AbstractCairoTest {
             create(FF, PartitionBy.DAY, N);
             long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
             Rnd rnd = new Rnd();
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 ts = append10KProducts(ts, rnd, writer);
                 writer.commit();
 
@@ -4459,7 +4458,7 @@ public class TableWriterTest extends AbstractCairoTest {
                 }
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT, metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                 append10KProducts(ts, rnd, writer);
                 writer.commit();
                 Assert.assertEquals(N, writer.size());

--- a/core/src/test/java/io/questdb/test/cairo/TimestampFinderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TimestampFinderTest.java
@@ -74,8 +74,8 @@ public class TimestampFinderTest extends AbstractCairoTest {
             long maxTimestamp = minTimestamp;
             long timestamp = minTimestamp;
             try (
-                    TableWriter oracleWriter = newOffPoolWriter(configuration, "oracle", metrics);
-                    TableWriter writer = newOffPoolWriter(configuration, "x", metrics)
+                    TableWriter oracleWriter = newOffPoolWriter(configuration, "oracle");
+                    TableWriter writer = newOffPoolWriter(configuration, "x")
             ) {
                 int ticks = duplicatesPerTick;
                 for (int i = 0; i < rowCount; i++) {

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/AbstractFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/AbstractFuzzTest.java
@@ -53,7 +53,7 @@ public class AbstractFuzzTest extends AbstractCairoTest {
     public final static int MAX_WAL_APPLY_O3_SPLIT_PARTITION_CEIL = 20000;
     public final static int MAX_WAL_APPLY_O3_SPLIT_PARTITION_MIN = 200;
     protected final FuzzRunner fuzzer = new FuzzRunner();
-    protected final WorkerPool sharedWorkerPool = new TestWorkerPool(4, metrics);
+    protected final WorkerPool sharedWorkerPool = new TestWorkerPool(4, node1.getMetrics());
 
     public static int getRndO3PartitionSplit(Rnd rnd) {
         return MAX_WAL_APPLY_O3_SPLIT_PARTITION_MIN + rnd.nextInt(MAX_WAL_APPLY_O3_SPLIT_PARTITION_CEIL - MAX_WAL_APPLY_O3_SPLIT_PARTITION_MIN);

--- a/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
@@ -907,7 +907,7 @@ public class OrderedMapTest extends AbstractCairoTest {
             model.col("a", ColumnType.LONG).col("b", geohashType);
             AbstractCairoTest.create(model);
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < N; i++) {
                     TableWriter.Row row = writer.newRow();
                     long rndGeohash = GeoHashes.fromCoordinatesDeg(rnd.nextDouble() * 180 - 90, rnd.nextDouble() * 360 - 180, precisionBits);
@@ -2212,7 +2212,7 @@ public class OrderedMapTest extends AbstractCairoTest {
                 .col("m", ColumnType.UUID);
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
             for (int i = 0; i < n; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putByte(0, rnd.nextByte());

--- a/core/src/test/java/io/questdb/test/cairo/map/RecordValueSinkFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/RecordValueSinkFactoryTest.java
@@ -24,8 +24,21 @@
 
 package io.questdb.test.cairo.map;
 
-import io.questdb.cairo.*;
-import io.questdb.cairo.map.*;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.EntityColumnFilter;
+import io.questdb.cairo.ListColumnFilter;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.SingleColumnType;
+import io.questdb.cairo.SymbolAsIntTypes;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.map.Map;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.map.OrderedMap;
+import io.questdb.cairo.map.RecordValueSink;
+import io.questdb.cairo.map.RecordValueSinkFactory;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.std.BytecodeAssembler;
@@ -58,7 +71,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
 
         final int N = 1024;
         final Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putInt(0, rnd.nextInt());
@@ -143,7 +156,7 @@ public class RecordValueSinkFactoryTest extends AbstractCairoTest {
 
         final int N = 1024;
         final Rnd rnd = new Rnd();
-        try (TableWriter writer = newOffPoolWriter(configuration, "all", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
             for (int i = 0; i < N; i++) {
                 TableWriter.Row row = writer.newRow();
                 row.putInt(0, rnd.nextInt());

--- a/core/src/test/java/io/questdb/test/cairo/o3/AbstractO3Test.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/AbstractO3Test.java
@@ -43,7 +43,6 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.rnd.SharedRandom;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.BytecodeAssembler;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.Rnd;
@@ -359,17 +358,7 @@ public class AbstractO3Test extends AbstractTest {
                         return mixedIOEnabledFFDefault && mixedIOEnabled;
                     }
                 };
-                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return configuration.getMetrics();
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount;
-                    }
-                });
+                WorkerPool pool = new WorkerPool(() -> workerCount);
                 TestUtils.execute(pool, runnable, configuration, LOG);
             } else {
                 // we need to create entire engine

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cairo.o3;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
@@ -42,7 +41,6 @@ import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
@@ -3289,17 +3287,7 @@ public class O3FailureTest extends AbstractO3Test {
             final AtomicInteger errorCount = new AtomicInteger();
 
             // we have two pairs of tables (x,y) and (x1,y1)
-            try (WorkerPool pool1 = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return engine.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-            })) {
+            try (WorkerPool pool1 = new WorkerPool(() -> 1)) {
                 pool1.assign(new Job() {
                     private boolean toRun = true;
 

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cairo.o3;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
@@ -41,6 +42,7 @@ import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
@@ -3287,7 +3289,17 @@ public class O3FailureTest extends AbstractO3Test {
             final AtomicInteger errorCount = new AtomicInteger();
 
             // we have two pairs of tables (x,y) and (x1,y1)
-            try (WorkerPool pool1 = new WorkerPool(() -> 1)) {
+            try (WorkerPool pool1 = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return engine.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+            })) {
                 pool1.assign(new Job() {
                     private boolean toRun = true;
 

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3MetricsTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3MetricsTest.java
@@ -70,8 +70,8 @@ public class O3MetricsTest extends AbstractO3Test {
             TestUtils.assertEquals(expected, sink);
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getCommittedRows());
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getCommittedRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -102,10 +102,10 @@ public class O3MetricsTest extends AbstractO3Test {
             }
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getCommittedRows());
 
             // Appended to new partition.
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
 
             try (TableWriter w = TestUtils.getWriter(engine, "x")) {
                 TableWriter.Row r;
@@ -128,10 +128,10 @@ public class O3MetricsTest extends AbstractO3Test {
                 TestUtils.assertEquals(expected, sink);
             }
 
-            Assert.assertEquals(initRowCount + 2, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 2, metrics.tableWriterMetrics().getCommittedRows());
 
             // Created new partition that didn't previously exist in between the other two.
-            Assert.assertEquals(initRowCount + 2, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount + 2, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -166,10 +166,10 @@ public class O3MetricsTest extends AbstractO3Test {
             TestUtils.assertEquals(expected, sink);
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getCommittedRows());
 
             // There was a single partition which had to be re-written, along with the additional record.
-            Assert.assertEquals(initRowCount * 2 + 1, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount * 2 + 1, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -204,10 +204,10 @@ public class O3MetricsTest extends AbstractO3Test {
             TestUtils.assertEquals(expected, sink);
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getCommittedRows());
 
             // There was a single partition which had to be re-written, along with the additional record.
-            Assert.assertEquals(initRowCount * 2 + 1, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount * 2 + 1, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -283,10 +283,10 @@ public class O3MetricsTest extends AbstractO3Test {
             TestUtils.assertEquals(expected, sink);
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 6, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 6, metrics.tableWriterMetrics().getCommittedRows());
 
             // No partitions had to be re-written: New records appended at the end of each.
-            Assert.assertEquals(initRowCount + 6, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount + 6, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -315,10 +315,10 @@ public class O3MetricsTest extends AbstractO3Test {
             TestUtils.assertEquals(expected, sink);
 
             Metrics metrics = engine.getMetrics();
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getCommittedRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getCommittedRows());
 
             // Appended to earlier partition.
-            Assert.assertEquals(initRowCount + 1, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(initRowCount + 1, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
         });
     }
 
@@ -331,7 +331,7 @@ public class O3MetricsTest extends AbstractO3Test {
             Metrics metrics = engine.getMetrics();
 
             long rowCount = initRowCount;
-            Assert.assertEquals(rowCount, metrics.tableWriter().getPhysicallyWrittenRows());
+            Assert.assertEquals(rowCount, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
 
             try (TableWriter w = TestUtils.getWriter(engine, "x")) {
                 TableWriter.Row r = w.newRow(millenniumTimestamp(0));
@@ -359,8 +359,8 @@ public class O3MetricsTest extends AbstractO3Test {
                 w.ic();
 
                 w.commit();
-                Assert.assertEquals(rowCount, metrics.tableWriter().getCommittedRows());
-                Assert.assertEquals(rowCount + 2, metrics.tableWriter().getPhysicallyWrittenRows());
+                Assert.assertEquals(rowCount, metrics.tableWriterMetrics().getCommittedRows());
+                Assert.assertEquals(rowCount + 2, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
 
             }
         });
@@ -405,7 +405,7 @@ public class O3MetricsTest extends AbstractO3Test {
         engine.execute(createTableSql, sqlExecutionContext);
 
         Metrics metrics = engine.getMetrics();
-        Assert.assertEquals(rowCount, metrics.tableWriter().getCommittedRows());
-        Assert.assertEquals(rowCount, metrics.tableWriter().getPhysicallyWrittenRows());
+        Assert.assertEquals(rowCount, metrics.tableWriterMetrics().getCommittedRows());
+        Assert.assertEquals(rowCount, metrics.tableWriterMetrics().getPhysicallyWrittenRows());
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
@@ -63,7 +63,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             long start = TimestampFormatUtils.parseTimestamp("2020-02-03");
 
             Metrics metrics = engine.getMetrics();
-            int rowCount = (int) metrics.tableWriter().getPhysicallyWrittenRows();
+            int rowCount = (int) metrics.tableWriterMetrics().getPhysicallyWrittenRows();
 
             // create table with 800 points at 2020-02-03 sharp
             // and 200 points in at 2020-02-03T01
@@ -129,7 +129,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             // 4kb prefix split threshold
             node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 4 * (1 << 10));
             node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 2);
-            int rowCount = (int) node1.getMetrics().tableWriter().getPhysicallyWrittenRows();
+            int rowCount = (int) node1.getMetrics().tableWriterMetrics().getPhysicallyWrittenRows();
 
             execute(
                     "create table x as (" +
@@ -238,7 +238,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             Overrides overrides = node1.getConfigurationOverrides();
             overrides.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 1);
 
-            int rowCount = (int) node1.getMetrics().tableWriter().getPhysicallyWrittenRows();
+            int rowCount = (int) node1.getMetrics().tableWriterMetrics().getPhysicallyWrittenRows();
             execute(
                     "create table x as (" +
                             "select" +
@@ -756,7 +756,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
     private int assertRowCount(int delta, int rowCount) {
         Assert.assertEquals(delta, getPhysicalRowsSinceLastCommit());
         rowCount += delta;
-        Assert.assertEquals(rowCount, node1.getMetrics().tableWriter().getPhysicallyWrittenRows());
+        Assert.assertEquals(rowCount, node1.getMetrics().tableWriterMetrics().getPhysicallyWrittenRows());
         return rowCount;
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
@@ -129,7 +129,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             // 4kb prefix split threshold
             node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 4 * (1 << 10));
             node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 2);
-            int rowCount = (int) metrics.tableWriter().getPhysicallyWrittenRows();
+            int rowCount = (int) node1.getMetrics().tableWriter().getPhysicallyWrittenRows();
 
             execute(
                     "create table x as (" +
@@ -238,7 +238,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
             Overrides overrides = node1.getConfigurationOverrides();
             overrides.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 1);
 
-            int rowCount = (int) metrics.tableWriter().getPhysicallyWrittenRows();
+            int rowCount = (int) node1.getMetrics().tableWriter().getPhysicallyWrittenRows();
             execute(
                     "create table x as (" +
                             "select" +
@@ -756,7 +756,7 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
     private int assertRowCount(int delta, int rowCount) {
         Assert.assertEquals(delta, getPhysicalRowsSinceLastCommit());
         rowCount += delta;
-        Assert.assertEquals(rowCount, metrics.tableWriter().getPhysicallyWrittenRows());
+        Assert.assertEquals(rowCount, node1.getMetrics().tableWriter().getPhysicallyWrittenRows());
         return rowCount;
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cairo.o3;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.ColumnType;
@@ -42,6 +43,7 @@ import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
@@ -7961,7 +7963,17 @@ public class O3Test extends AbstractO3Test {
             final AtomicInteger errorCount = new AtomicInteger();
 
             // we have two pairs of tables (x,y) and (x1,y1)
-            try (WorkerPool pool1 = new WorkerPool(() -> 1)) {
+            try (WorkerPool pool1 = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return engine.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+            })) {
 
                 pool1.assign(new Job() {
                     private boolean toRun = true;

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cairo.o3;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.ColumnType;
@@ -43,7 +42,6 @@ import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.mp.Job;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
@@ -7963,17 +7961,7 @@ public class O3Test extends AbstractO3Test {
             final AtomicInteger errorCount = new AtomicInteger();
 
             // we have two pairs of tables (x,y) and (x1,y1)
-            try (WorkerPool pool1 = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return engine.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 1;
-                }
-            })) {
+            try (WorkerPool pool1 = new WorkerPool(() -> 1)) {
 
                 pool1.assign(new Job() {
                     private boolean toRun = true;

--- a/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
@@ -24,7 +24,15 @@
 
 package io.questdb.test.cairo.pool;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.DefaultLifecycleManager;
+import io.questdb.cairo.EntryUnavailableException;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cairo.pool.WriterPool;
 import io.questdb.cairo.pool.ex.EntryLockedException;
@@ -195,7 +203,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             // check that we can't create standalone writer either
             try {
-                newOffPoolWriter(configuration, "z", metrics).close();
+                newOffPoolWriter(configuration, "z").close();
                 Assert.fail();
             } catch (CairoException ignored) {
             }
@@ -203,7 +211,7 @@ public class WriterPoolTest extends AbstractCairoTest {
             pool.unlock(zTableToken);
 
             // check if we can create standalone writer after pool unlocked it
-            writer = newOffPoolWriter(configuration, "z", metrics);
+            writer = newOffPoolWriter(configuration, "z");
             Assert.assertNotNull(writer);
             writer.close();
 
@@ -847,7 +855,7 @@ public class WriterPoolTest extends AbstractCairoTest {
 
             pool.close();
 
-            TableWriter writer = newOffPoolWriter(configuration, "z", metrics);
+            TableWriter writer = newOffPoolWriter(configuration, "z");
             Assert.assertNotNull(writer);
             writer.close();
         });

--- a/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
@@ -668,7 +668,6 @@ public class WriterPoolTest extends AbstractCairoTest {
                     engine.getConfiguration().getRoot(),
                     engine.getDdlListener(tableToken),
                     engine.getCheckpointStatus(),
-                    engine.getMetrics(),
                     engine
             );
             for (int i = 0; i < 100; i++) {

--- a/core/src/test/java/io/questdb/test/cutlass/IODispatcherHeartbeatTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/IODispatcherHeartbeatTest.java
@@ -26,7 +26,6 @@ package io.questdb.test.cutlass;
 
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.NullLongGauge;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.IOContext;
 import io.questdb.network.IODispatcher;
@@ -93,8 +92,7 @@ public class IODispatcherHeartbeatTest {
                     (fd, d) -> {
                         connected.incrementAndGet();
                         return new TestContext(fd, d, heartbeatInterval);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 IORequestProcessor<TestContext> processor = new TestProcessor(clock);
                 Rnd rnd = new Rnd();
@@ -126,7 +124,7 @@ public class IODispatcherHeartbeatTest {
                             Assert.assertEquals(1, Net.send(fds[idx], buf, 1));
                         }
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                     }
                 } finally {
                     Unsafe.free(buf, 1, MemoryTag.NATIVE_DEFAULT);
@@ -173,8 +171,7 @@ public class IODispatcherHeartbeatTest {
                     (fd, d) -> {
                         connected.incrementAndGet();
                         return new TestContext(fd, d, heartbeatInterval);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 IORequestProcessor<TestContext> processor = new TestProcessor(clock);
                 long buf = Unsafe.malloc(1, MemoryTag.NATIVE_DEFAULT);
@@ -199,7 +196,7 @@ public class IODispatcherHeartbeatTest {
                     for (int i = 0; i < tickCount; i++) {
                         clock.setCurrent(i);
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                     }
 
                     TestUtils.assertEventually(() -> {
@@ -248,8 +245,7 @@ public class IODispatcherHeartbeatTest {
                     (fd, d) -> {
                         connected.incrementAndGet();
                         return new TestContext(fd, d, heartbeatInterval);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 SuspendEvent suspendEvent = SuspendEventFactory.newInstance(ioDispatcherConfig);
                 suspendEvent.setDeadline(suspendEventDeadline);
@@ -276,7 +272,7 @@ public class IODispatcherHeartbeatTest {
                     for (int i = 0; i < tickCount; i++) {
                         clock.setCurrent(i);
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                     }
 
                     TestUtils.assertEventually(() -> {
@@ -319,8 +315,7 @@ public class IODispatcherHeartbeatTest {
                     (fd, d) -> {
                         connected.incrementAndGet();
                         return new TestContext(fd, d, heartbeatInterval);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 SuspendEvent suspendEvent = SuspendEventFactory.newInstance(ioDispatcherConfig);
                 IORequestProcessor<TestContext> processor = new SuspendingTestProcessor(clock, suspendEvent);
@@ -347,7 +342,7 @@ public class IODispatcherHeartbeatTest {
                     for (; tick.get() < tickCount; tick.incrementAndGet()) {
                         clock.setCurrent(tick.get());
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                     }
 
                     // Trigger the event and wait until the dispatcher handles it.
@@ -355,7 +350,7 @@ public class IODispatcherHeartbeatTest {
                     TestUtils.assertEventually(() -> {
                         clock.setCurrent(tick.incrementAndGet());
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                         Assert.assertTrue(suspendEvent.isClosedByAtLeastOneSide());
                     }, 10);
                 } finally {
@@ -401,8 +396,7 @@ public class IODispatcherHeartbeatTest {
                     (fd, d) -> {
                         connected.incrementAndGet();
                         return new TestContext(fd, d, heartbeatInterval);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 SuspendEvent suspendEvent = SuspendEventFactory.newInstance(ioDispatcherConfig);
                 IORequestProcessor<TestContext> processor = new SuspendingTestProcessor(clock, suspendEvent);
@@ -428,7 +422,7 @@ public class IODispatcherHeartbeatTest {
                     for (int i = 0; i < tickCount; i++) {
                         clock.setCurrent(i);
                         dispatcher.run(0);
-                        while (dispatcher.processIOQueue(processor)) ;
+                        dispatcher.drainIOQueue(processor);
                     }
 
                     TestUtils.assertEventually(() -> {

--- a/core/src/test/java/io/questdb/test/cutlass/http/HealthCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HealthCheckTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.cutlass.http;
 
 import io.questdb.Metrics;
 import io.questdb.network.NetworkFacadeImpl;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -55,30 +56,34 @@ public class HealthCheckTest {
             .withLookingForStuckThread(true)
             .build();
 
+    @Before
+    public void setUp() throws Exception {
+        Metrics.ENABLED.clear();
+    }
+
     @Test
     public void testHealthyViaRootPathWhenMetricsDisabled() throws Exception {
-        testHealthy(Metrics.disabled(), healthCheckOnRootRequest);
+        testHealthy(healthCheckOnRootRequest);
     }
 
     @Test
     public void testHealthyViaRootPathWhenMetricsEnabled() throws Exception {
-        testHealthy(Metrics.enabled(), healthCheckOnRootRequest);
+        testHealthy(healthCheckOnRootRequest);
     }
 
     @Test
     public void testHealthyViaStatusPathWhenMetricsDisabled() throws Exception {
-        testHealthy(Metrics.disabled(), healthCheckRequest);
+        testHealthy(healthCheckRequest);
     }
 
     @Test
     public void testHealthyViaStatusPathWhenMetricsEnabled() throws Exception {
-        testHealthy(Metrics.enabled(), healthCheckRequest);
+        testHealthy(healthCheckRequest);
     }
 
-    public void testUnhealthy(Metrics metrics, boolean pessimisticHealthCheck, String expectedResponse) throws Exception {
+    public void testUnhealthy(boolean pessimisticHealthCheck, String expectedResponse) throws Exception {
         new HttpHealthCheckTestBuilder()
                 .withTempFolder(temp)
-                .withMetrics(metrics)
                 .withPessimisticHealthCheck(pessimisticHealthCheck)
                 .withInjectedUnhandledError()
                 .run(engine -> new SendAndReceiveRequestBuilder()
@@ -99,11 +104,12 @@ public class HealthCheckTest {
                 "Unhandled errors: 1\r\n" +
                 "00\r\n" +
                 "\r\n";
-        testUnhealthy(Metrics.enabled(), true, expectedResponse);
+        testUnhealthy(true, expectedResponse);
     }
 
     @Test
     public void testUnhealthyWhenMetricsDisabled() throws Exception {
+        Metrics.ENABLED.disable();
         // Unhandled error detection is based on metrics, so we expect the health check to return HTTP 200.
         final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
                 "Server: questDB/1.0\r\n" +
@@ -115,7 +121,7 @@ public class HealthCheckTest {
                 "Status: Healthy\r\n" +
                 "00\r\n" +
                 "\r\n";
-        testUnhealthy(Metrics.disabled(), true, expectedResponse);
+        testUnhealthy(true, expectedResponse);
     }
 
     @Test
@@ -131,13 +137,12 @@ public class HealthCheckTest {
                 "Status: Healthy\r\n" +
                 "00\r\n" +
                 "\r\n";
-        testUnhealthy(Metrics.enabled(), false, expectedResponse);
+        testUnhealthy(false, expectedResponse);
     }
 
-    private void testHealthy(Metrics metrics, String request) throws Exception {
+    private void testHealthy(String request) throws Exception {
         new HttpHealthCheckTestBuilder()
                 .withTempFolder(temp)
-                .withMetrics(metrics)
                 .run(engine -> {
                     final String expectedResponse = "HTTP/1.1 200 OK\r\n" +
                             "Server: questDB/1.0\r\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpAlterTableTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpAlterTableTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cutlass.http;
 
-import io.questdb.Metrics;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.test.AbstractTest;
 import org.junit.Rule;
@@ -49,8 +48,7 @@ public class HttpAlterTableTest extends AbstractTest {
 
     @Test
     public void testAlterTableSetType() throws Exception {
-        Metrics metrics = Metrics.enabled();
-        testJsonQuery(metrics, (engine, sqlExecutionContext) -> {
+        testJsonQuery((engine, sqlExecutionContext) -> {
             // create table
             sendAndReceiveDdl("CREATE TABLE test\n" +
                     "AS(\n" +
@@ -75,8 +73,7 @@ public class HttpAlterTableTest extends AbstractTest {
 
     @Test
     public void testAlterTableSquashPartition() throws Exception {
-        Metrics metrics = Metrics.enabled();
-        testJsonQuery(metrics, (engine, sqlExecutionContext) -> {
+        testJsonQuery((engine, sqlExecutionContext) -> {
             // create table
             sendAndReceiveDdl("CREATE TABLE test\n" +
                     "AS(\n" +
@@ -93,8 +90,7 @@ public class HttpAlterTableTest extends AbstractTest {
 
     @Test
     public void testAlterTableSuspendResume() throws Exception {
-        Metrics metrics = Metrics.enabled();
-        testJsonQuery(metrics, (engine, sqlExecutionContext) -> {
+        testJsonQuery((engine, sqlExecutionContext) -> {
             // create table
             sendAndReceiveDdl("CREATE TABLE test\n" +
                     "AS(\n" +
@@ -104,6 +100,7 @@ public class HttpAlterTableTest extends AbstractTest {
                     "    FROM long_sequence(1000) x)\n" +
                     "TIMESTAMP(ts)\n" +
                     "PARTITION BY DAY WAL");
+
             drainWalQueue(engine);
 
             // execute a SELECT query
@@ -180,12 +177,11 @@ public class HttpAlterTableTest extends AbstractTest {
         );
     }
 
-    private void testJsonQuery(Metrics metrics, HttpQueryTestBuilder.HttpClientCode code) throws Exception {
+    private void testJsonQuery(HttpQueryTestBuilder.HttpClientCode code) throws Exception {
         new HttpQueryTestBuilder()
                 .withWorkerCount(2)
                 .withTempFolder(root)
                 .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
-                .withMetrics(metrics)
                 .run(code);
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -77,7 +77,7 @@ public class HttpHealthCheckTestBuilder {
                 final Metrics metrics = cairoConfiguration.getMetrics();
                 if (injectUnhandledError && metrics.isEnabled()) {
                     for (int i = 0; i < 40; i++) {
-                        if (metrics.health().unhandledErrorsCount() > 0) {
+                        if (metrics.healthMetrics().unhandledErrorsCount() > 0) {
                             break;
                         }
                         Os.sleep(50);

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpHealthCheckTestBuilder.java
@@ -45,7 +45,6 @@ public class HttpHealthCheckTestBuilder {
 
     private static final Log LOG = LogFactory.getLog(HttpHealthCheckTestBuilder.class);
     private boolean injectUnhandledError;
-    private Metrics metrics;
     private boolean pessimisticHealthCheck = false;
     private TemporaryFolder temp;
 
@@ -56,11 +55,7 @@ public class HttpHealthCheckTestBuilder {
                     .withBaseDir(baseDir)
                     .withPessimisticHealthCheck(pessimisticHealthCheck)
                     .build();
-            if (metrics == null) {
-                metrics = Metrics.enabled();
-            }
-
-            WorkerPool workerPool = new TestWorkerPool(1, metrics);
+            WorkerPool workerPool = new TestWorkerPool(1, httpConfiguration.getMetrics());
 
             if (injectUnhandledError) {
                 final AtomicBoolean alreadyErrored = new AtomicBoolean();
@@ -74,11 +69,12 @@ public class HttpHealthCheckTestBuilder {
 
             DefaultTestCairoConfiguration cairoConfiguration = new DefaultTestCairoConfiguration(baseDir);
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration, metrics);
-                    HttpServer ignored = Services.INSTANCE.createMinHttpServer(httpConfiguration, workerPool, metrics)
+                    CairoEngine engine = new CairoEngine(cairoConfiguration);
+                    HttpServer ignored = Services.INSTANCE.createMinHttpServer(httpConfiguration, workerPool)
             ) {
                 workerPool.start(LOG);
 
+                final Metrics metrics = cairoConfiguration.getMetrics();
                 if (injectUnhandledError && metrics.isEnabled()) {
                     for (int i = 0; i < 40; i++) {
                         if (metrics.health().unhandledErrorsCount() > 0) {
@@ -99,11 +95,6 @@ public class HttpHealthCheckTestBuilder {
 
     public HttpHealthCheckTestBuilder withInjectedUnhandledError() {
         this.injectUnhandledError = true;
-        return this;
-    }
-
-    public HttpHealthCheckTestBuilder withMetrics(Metrics metrics) {
-        this.metrics = metrics;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTest.java
@@ -28,7 +28,7 @@ import io.questdb.DefaultHttpClientConfiguration;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoException;
 import io.questdb.cutlass.http.HttpContextConfiguration;
-import io.questdb.cutlass.http.HttpMinServerConfiguration;
+import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.client.Fragment;
 import io.questdb.cutlass.http.client.HttpClient;
 import io.questdb.cutlass.http.client.HttpClientFactory;
@@ -72,7 +72,7 @@ public class HttpMinTest extends AbstractBootstrapTest {
                     PropertyKey.HTTP_ENABLED.getEnvVarName(), "false"
             )) {
                 serverMain.start();
-                HttpMinServerConfiguration httpMinConfig = serverMain.getConfiguration().getHttpMinServerConfiguration();
+                HttpServerConfiguration httpMinConfig = serverMain.getConfiguration().getHttpMinServerConfiguration();
                 HttpContextConfiguration httpMinContextConfig = httpMinConfig.getHttpContextConfiguration();
                 long expectedAllocation = httpMinConfig.getSendBufferSize() + 20
                         + httpMinConfig.getRecvBufferSize()

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cutlass.http;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.security.AllowAllSecurityContext;
@@ -72,8 +71,8 @@ public class HttpMinTestBuilder {
             CairoConfiguration cairoConfiguration = new DefaultTestCairoConfiguration(baseDir);
 
             try (
-                    CairoEngine engine = new CairoEngine(cairoConfiguration, Metrics.disabled());
-                    HttpServer httpServer = new HttpServer(httpConfiguration, Metrics.disabled(), workerPool, PlainSocketFactory.INSTANCE);
+                    CairoEngine engine = new CairoEngine(cairoConfiguration);
+                    HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, PlainSocketFactory.INSTANCE);
                     SqlExecutionContext sqlExecutionContext = new SqlExecutionContextImpl(engine, 1).with(AllowAllSecurityContext.INSTANCE)
             ) {
                 final PrometheusMetricsProcessor.RequestStatePool requestStatePool = prometheusRequestStatePool != null

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMinTestBuilder.java
@@ -37,7 +37,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.PlainSocketFactory;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
@@ -50,7 +50,7 @@ public class HttpMinTestBuilder {
 
     private static final Log LOG = LogFactory.getLog(HttpMinTestBuilder.class);
     private PrometheusMetricsProcessor.RequestStatePool prometheusRequestStatePool;
-    private Scrapable scrapable;
+    private Target target;
     private int sendBufferSize;
     private int tcpSndBufSize;
     private TemporaryFolder temp;
@@ -87,7 +87,7 @@ public class HttpMinTestBuilder {
 
                     @Override
                     public HttpRequestProcessor newInstance() {
-                        return new PrometheusMetricsProcessor(scrapable, httpConfiguration, requestStatePool);
+                        return new PrometheusMetricsProcessor(target, httpConfiguration, requestStatePool);
                     }
                 });
 
@@ -122,8 +122,8 @@ public class HttpMinTestBuilder {
         return this;
     }
 
-    public HttpMinTestBuilder withScrapable(Scrapable scrapable) {
-        this.scrapable = scrapable;
+    public HttpMinTestBuilder withScrapable(Target target) {
+        this.target = target;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
@@ -34,10 +34,10 @@ import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.HttpRequestProcessorFactory;
 import io.questdb.cutlass.http.HttpServer;
-import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.processors.HealthCheckProcessor;
 import io.questdb.cutlass.http.processors.JsonQueryProcessor;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
@@ -191,7 +191,7 @@ public class HttpQueryTestBuilder {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -74,7 +74,6 @@ import io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactor
 import io.questdb.jit.JitUtil;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.metrics.NullLongGauge;
 import io.questdb.mp.MPSequence;
 import io.questdb.mp.RingQueue;
 import io.questdb.mp.SCSequence;
@@ -270,8 +269,7 @@ public class IODispatcherTest extends AbstractTest {
                     (fd, dispatcher1) -> {
                         connectLatch.countDown();
                         return new HelloContext(fd, contextClosedLatch, dispatcher1);
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 AtomicBoolean serverRunning = new AtomicBoolean(true);
                 SOCountDownLatch serverHaltLatch = new SOCountDownLatch(1);
@@ -389,8 +387,7 @@ public class IODispatcherTest extends AbstractTest {
                             return nf;
                         }
                     },
-                    (fd, dispatcher1) -> new HttpConnectionContext(serverConfiguration, PlainSocketFactory.INSTANCE).of(fd, dispatcher1),
-                    NullLongGauge.INSTANCE
+                    (fd, dispatcher1) -> new HttpConnectionContext(serverConfiguration, PlainSocketFactory.INSTANCE).of(fd, dispatcher1)
             )) {
                 // spin up dispatcher thread
                 AtomicBoolean dispatcherRunning = new AtomicBoolean(true);
@@ -474,8 +471,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             }.of(fd, dispatcher1);
                         }
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 HttpRequestProcessorSelector selector = new HttpRequestProcessorSelector() {
                     @Override
@@ -5813,8 +5809,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             }.of(fd, dispatcher1);
                         }
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 try (HttpRequestProcessorSelector selector = new HttpRequestProcessorSelector() {
                     @Override
@@ -6706,8 +6701,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             }.of(fd, dispatcher1);
                         }
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 StringSink sink = new StringSink();
 
@@ -6879,8 +6873,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             }.of(fd, dispatcher1);
                         }
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 StringSink sink = new StringSink();
 
@@ -7040,8 +7033,7 @@ public class IODispatcherTest extends AbstractTest {
                                 }
                             }.of(fd, dispatcher1);
                         }
-                    },
-                    NullLongGauge.INSTANCE
+                    }
             )) {
                 StringSink sink = new StringSink();
 
@@ -8121,8 +8113,7 @@ public class IODispatcherTest extends AbstractTest {
                                     return true;
                                 }
                             },
-                            (fd, dispatcher1) -> new HttpConnectionContext(httpServerConfiguration, PlainSocketFactory.INSTANCE).of(fd, dispatcher1),
-                            NullLongGauge.INSTANCE
+                            (fd, dispatcher1) -> new HttpConnectionContext(httpServerConfiguration, PlainSocketFactory.INSTANCE).of(fd, dispatcher1)
                     );
                     final RingQueue<Status> queue = new RingQueue<>(Status::new, 1024)
             ) {
@@ -9636,7 +9627,7 @@ public class IODispatcherTest extends AbstractTest {
             Thread serverThread;
             long sockAddr = 0;
             final CountDownLatch serverLatch = new CountDownLatch(1);
-            try (IODispatcher<TestIOContext> dispatcher = IODispatchers.create(configuration, contextFactory, NullLongGauge.INSTANCE)) {
+            try (IODispatcher<TestIOContext> dispatcher = IODispatchers.create(configuration, contextFactory)) {
                 final int resolvedPort = dispatcher.getPort();
                 sockAddr = Net.sockaddr("127.0.0.1", resolvedPort);
                 serverThread = new Thread("test-io-dispatcher") {

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -681,7 +681,7 @@ public class IODispatcherTest extends AbstractTest {
                             "}",
                     "select simulate_crash('A') from long_sequence(5)"
             );
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount());
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount());
         });
     }
 
@@ -8027,7 +8027,7 @@ public class IODispatcherTest extends AbstractTest {
                             "}",
                     "select simulate_crash('E')"
             );
-            Assert.assertEquals(1, engine.getMetrics().health().unhandledErrorsCount());
+            Assert.assertEquals(1, engine.getMetrics().healthMetrics().unhandledErrorsCount());
         });
     }
 
@@ -8045,7 +8045,7 @@ public class IODispatcherTest extends AbstractTest {
                             "}",
                     "select simulate_crash('0')"
             );
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount());
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount());
         });
     }
 
@@ -8063,7 +8063,7 @@ public class IODispatcherTest extends AbstractTest {
                             "}",
                     "select npe()"
             );
-            Assert.assertEquals(1, engine.getMetrics().health().unhandledErrorsCount());
+            Assert.assertEquals(1, engine.getMetrics().healthMetrics().unhandledErrorsCount());
         });
     }
 
@@ -9183,7 +9183,7 @@ public class IODispatcherTest extends AbstractTest {
                             "}",
                     "select simulate_crash('" + numOfRows + "') from long_sequence(5)"
             );
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount());
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount());
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -51,12 +51,12 @@ import io.questdb.cutlass.Services;
 import io.questdb.cutlass.http.DefaultHttpContextConfiguration;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
 import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestHeader;
 import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.HttpRequestProcessorFactory;
 import io.questdb.cutlass.http.HttpRequestProcessorSelector;
 import io.questdb.cutlass.http.HttpServer;
-import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.RescheduleContext;
 import io.questdb.cutlass.http.processors.HealthCheckProcessor;
 import io.questdb.cutlass.http.processors.JsonQueryProcessor;
@@ -362,7 +362,7 @@ public class IODispatcherTest extends AbstractTest {
     @Test
     public void testCannotSetNonBlocking() throws Exception {
         assertMemoryLeak(() -> {
-            final HttpServerConfiguration serverConfiguration = new DefaultHttpServerConfiguration();
+            final HttpFullFatServerConfiguration serverConfiguration = new DefaultHttpServerConfiguration();
             final NetworkFacade nf = new NetworkFacadeImpl() {
                 long theFd;
 
@@ -449,7 +449,7 @@ public class IODispatcherTest extends AbstractTest {
         LOG.info().$("started testConnectDisconnect").$();
 
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
 
             SOCountDownLatch connectLatch = new SOCountDownLatch(1);
             SOCountDownLatch contextClosedLatch = new SOCountDownLatch(1);
@@ -1141,7 +1141,7 @@ public class IODispatcherTest extends AbstractTest {
         final String expectedTableMetadata = "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"LONG256\"},{\"index\":1,\"name\":\"f1\",\"type\":\"CHAR\"}],\"timestampIndex\":-1}";
 
         final String baseDir = root;
-        final HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
+        final HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
             @Override
             public MillisecondClock getMillisecondClock() {
                 return StationaryMillisClock.INSTANCE;
@@ -1155,7 +1155,7 @@ public class IODispatcherTest extends AbstractTest {
 
         final ServerConfiguration serverConfiguration = new DefaultServerConfiguration(baseDir) {
             @Override
-            public HttpServerConfiguration getHttpServerConfiguration() {
+            public HttpFullFatServerConfiguration getHttpServerConfiguration() {
                 return httpServerConfiguration;
             }
         };
@@ -1221,7 +1221,7 @@ public class IODispatcherTest extends AbstractTest {
         final String expectedTableMetadata = "{\"columnCount\":2,\"columns\":[{\"index\":0,\"name\":\"f0\",\"type\":\"LONG256\"},{\"index\":1,\"name\":\"f1\",\"type\":\"CHAR\"}],\"timestampIndex\":-1}";
 
         final String baseDir = root;
-        final HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
+        final HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(new DefaultHttpContextConfiguration() {
             @Override
             public MillisecondClock getMillisecondClock() {
                 return StationaryMillisClock.INSTANCE;
@@ -1234,7 +1234,7 @@ public class IODispatcherTest extends AbstractTest {
         });
         final ServerConfiguration serverConfiguration = new DefaultServerConfiguration(baseDir) {
             @Override
-            public HttpServerConfiguration getHttpServerConfiguration() {
+            public HttpFullFatServerConfiguration getHttpServerConfiguration() {
                 return httpServerConfiguration;
             }
         };
@@ -2554,7 +2554,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -3167,7 +3167,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -5109,7 +5109,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -5346,7 +5346,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -5420,7 +5420,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -5511,7 +5511,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -5776,7 +5776,7 @@ public class IODispatcherTest extends AbstractTest {
     public void testMaxConnections() throws Exception {
         LOG.info().$("started maxConnections").$();
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
 
             // change to 400 to trigger lockup
             // excess connection take a while to return (because it's N TCP retransmissions + timeout under the hood
@@ -6251,7 +6251,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -6379,7 +6379,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -6529,7 +6529,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override
@@ -6680,7 +6680,7 @@ public class IODispatcherTest extends AbstractTest {
                 "\r\n";
 
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
 
             SOCountDownLatch connectLatch = new SOCountDownLatch(1);
             SOCountDownLatch contextClosedLatch = new SOCountDownLatch(1);
@@ -6842,7 +6842,7 @@ public class IODispatcherTest extends AbstractTest {
                 "\r\n";
 
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration(
                     new DefaultHttpContextConfiguration() {
                         @Override
                         public MillisecondClock getMillisecondClock() {
@@ -7009,7 +7009,7 @@ public class IODispatcherTest extends AbstractTest {
                 "\r\n";
 
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
 
             SOCountDownLatch connectLatch = new SOCountDownLatch(1);
             SOCountDownLatch contextClosedLatch = new SOCountDownLatch(1);
@@ -8107,7 +8107,7 @@ public class IODispatcherTest extends AbstractTest {
         final int senderCount = 2;
 
         assertMemoryLeak(() -> {
-            HttpServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
+            HttpFullFatServerConfiguration httpServerConfiguration = new DefaultHttpServerConfiguration();
 
             final NetworkFacade nf = NetworkFacadeImpl.INSTANCE;
             final AtomicInteger requestsReceived = new AtomicInteger();
@@ -8432,7 +8432,7 @@ public class IODispatcherTest extends AbstractTest {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {
-                        return HttpServerConfiguration.DEFAULT_PROCESSOR_URL;
+                        return HttpFullFatServerConfiguration.DEFAULT_PROCESSOR_URL;
                     }
 
                     @Override

--- a/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/MetricsIODispatcherTest.java
@@ -35,7 +35,7 @@ import io.questdb.metrics.CounterWithTwoLabels;
 import io.questdb.metrics.LongGauge;
 import io.questdb.metrics.MetricsRegistry;
 import io.questdb.metrics.MetricsRegistryImpl;
-import io.questdb.metrics.Scrapable;
+import io.questdb.metrics.Target;
 import io.questdb.network.DefaultIODispatcherConfiguration;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.std.ObjList;
@@ -241,7 +241,7 @@ public class MetricsIODispatcherTest {
         final int workerCount = Math.max(2, Math.min(parallelRequestBatches, 6));
         final PrometheusMetricsProcessor.RequestStatePool pool = new PrometheusMetricsProcessor.RequestStatePool(workerCount);
 
-        Assert.assertEquals(pool.size(), 0);
+        Assert.assertEquals(0, pool.size());
 
         MetricsRegistry metrics = new MetricsRegistryImpl();
         for (int i = 0; i < metricCount; i++) {
@@ -256,7 +256,7 @@ public class MetricsIODispatcherTest {
         final HttpQueryTestBuilder.HttpClientCode makeRequest = (engine, sqlExecutionContext) -> {
             try (HttpClient client = HttpClientFactory.newPlainTextInstance()) {
                 if (parallelRequestBatches == 1) {
-                    Assert.assertEquals(pool.size(), 0);
+                    Assert.assertEquals(0, pool.size());
                 }
 
                 final StringSink utf16Sink = new StringSink();
@@ -308,10 +308,10 @@ public class MetricsIODispatcherTest {
                 .withPrometheusPool(pool)
                 .run(clientCode);
 
-        Assert.assertEquals(pool.size(), 0);
+        Assert.assertEquals(0, pool.size());
     }
 
-    private static class TestMetrics implements Scrapable {
+    private static class TestMetrics implements Target {
         private static final short INSERT = 0;
         private static final short QUERY_CANCELLED = 0;
         private static final CharSequence[] QUERY_TYPE_ID_TO_NAME = new CharSequence[2];

--- a/core/src/test/java/io/questdb/test/cutlass/http/RetryIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/RetryIODispatcherTest.java
@@ -484,6 +484,7 @@ public class RetryIODispatcherTest extends AbstractTest {
             assertInsertsIsPerformedWhenWriterLockedAndDisconnected();
             TestUtils.removeTestPath(root);
             TestUtils.createTestPath(root);
+            Metrics.ENABLED.clear();
         }
     }
 
@@ -577,7 +578,7 @@ public class RetryIODispatcherTest extends AbstractTest {
                     assertNRowsInserted(validRequestRecordCount);
 
                     for (long fd : fds) {
-                        Assert.assertNotEquals(fd, -1);
+                        Assert.assertNotEquals(-1, fd);
                         NetworkFacadeImpl.INSTANCE.close(fd);
                     }
 
@@ -730,12 +731,10 @@ public class RetryIODispatcherTest extends AbstractTest {
 
     private void assertInsertsIsPerformedWhenWriterLockedAndDisconnected() throws Exception {
         final int parallelCount = 4;
-        final Metrics metrics = Metrics.enabled();
         new HttpQueryTestBuilder()
                 .withTempFolder(root)
                 .withWorkerCount(parallelCount)
                 .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
-                .withMetrics(metrics)
                 .withTelemetry(false)
                 .run((engine, sqlExecutionContext) -> {
                     long nonInsertQueries = 0;
@@ -790,6 +789,7 @@ public class RetryIODispatcherTest extends AbstractTest {
                     final int maxWaitTimeMillis = 3000;
                     final int sleepMillis = 10;
 
+                    final Metrics metrics = engine.getMetrics();
                     // wait for all insert queries to be initially handled
                     long startedInserts;
                     for (int i = 0; i < maxWaitTimeMillis / sleepMillis; i++) {
@@ -806,7 +806,7 @@ public class RetryIODispatcherTest extends AbstractTest {
                     );
 
                     for (int n = 0; n < fds.length; n++) {
-                        Assert.assertNotEquals(fds[n], -1);
+                        Assert.assertNotEquals(-1, fds[n]);
                         NetworkFacadeImpl.INSTANCE.close(fds[n]);
                     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/RetryIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/RetryIODispatcherTest.java
@@ -793,13 +793,13 @@ public class RetryIODispatcherTest extends AbstractTest {
                     // wait for all insert queries to be initially handled
                     long startedInserts;
                     for (int i = 0; i < maxWaitTimeMillis / sleepMillis; i++) {
-                        startedInserts = metrics.jsonQuery().startedQueriesCount() - nonInsertQueries;
+                        startedInserts = metrics.jsonQueryMetrics().startedQueriesCount() - nonInsertQueries;
                         if (startedInserts >= parallelCount) {
                             break;
                         }
                         Os.sleep(sleepMillis);
                     }
-                    startedInserts = metrics.jsonQuery().startedQueriesCount() - nonInsertQueries;
+                    startedInserts = metrics.jsonQueryMetrics().startedQueriesCount() - nonInsertQueries;
                     Assert.assertTrue(
                             "expected at least " + parallelCount + "insert attempts, but got: " + startedInserts,
                             startedInserts >= parallelCount
@@ -815,13 +815,13 @@ public class RetryIODispatcherTest extends AbstractTest {
                     // wait for all insert queries to be executed
                     long completeInserts;
                     for (int i = 0; i < maxWaitTimeMillis / sleepMillis; i++) {
-                        completeInserts = metrics.jsonQuery().completedQueriesCount() - nonInsertQueries;
+                        completeInserts = metrics.jsonQueryMetrics().completedQueriesCount() - nonInsertQueries;
                         if (completeInserts == parallelCount) {
                             break;
                         }
                         Os.sleep(sleepMillis);
                     }
-                    completeInserts = metrics.jsonQuery().completedQueriesCount() - nonInsertQueries;
+                    completeInserts = metrics.jsonQueryMetrics().completedQueriesCount() - nonInsertQueries;
                     Assert.assertEquals("expected all inserts to succeed", parallelCount, completeInserts);
 
                     // check that we have all the records inserted

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderMockServerTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderMockServerTest.java
@@ -25,7 +25,6 @@
 package io.questdb.test.cutlass.http.line;
 
 import io.questdb.BuildInformationHolder;
-import io.questdb.Metrics;
 import io.questdb.client.Sender;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
 import io.questdb.cutlass.http.HttpConstants;
@@ -55,7 +54,6 @@ public class LineHttpSenderMockServerTest extends AbstractTest {
     public static final Function<Integer, Sender.LineSenderBuilder> DEFAULT_FACTORY = port -> Sender.builder(Sender.Transport.HTTP).address("localhost:" + port);
 
     private static final CharSequence QUESTDB_VERSION = new BuildInformationHolder().getSwVersion();
-    private static final Metrics metrics = Metrics.enabled();
 
     @Test
     public void testAutoFlushInterval() throws Exception {
@@ -527,7 +525,7 @@ public class LineHttpSenderMockServerTest extends AbstractTest {
             final DefaultHttpServerConfiguration httpConfiguration = createHttpServerConfiguration();
 
             try (WorkerPool workerPool = new TestWorkerPool(1);
-                 HttpServer httpServer = new HttpServer(httpConfiguration, metrics, workerPool, PlainSocketFactory.INSTANCE)) {
+                 HttpServer httpServer = new HttpServer(httpConfiguration, workerPool, PlainSocketFactory.INSTANCE)) {
                 httpServer.bind(new HttpRequestProcessorFactory() {
                     @Override
                     public String getUrl() {

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -88,7 +88,6 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
     protected static final int WAIT_NO_WAIT = 0x0;
     private final static Log LOG = LogFactory.getLog(AbstractLineTcpReceiverTest.class);
     protected final int bindPort = 9002; // Don't clash with other tests since they may run in parallel
-    protected final WorkerPool sharedWorkerPool = new TestWorkerPool(getWorkerCount(), metrics);
     private final ThreadLocal<Socket> tlSocket = new ThreadLocal<>();
     protected String authKeyId = null;
     private final FactoryProvider factoryProvider = new DefaultFactoryProvider() {
@@ -205,6 +204,8 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
             return useLegacyStringDefault;
         }
     };
+
+    protected final WorkerPool sharedWorkerPool = new TestWorkerPool(getWorkerCount(), lineConfiguration.getMetrics());
 
     public static void assertTableExists(CairoEngine engine, CharSequence tableName) {
         try (Path path = new Path()) {

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpO3Test.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpO3Test.java
@@ -25,7 +25,6 @@
 package io.questdb.test.cutlass.line.tcp;
 
 import io.questdb.FreeOnExit;
-import io.questdb.Metrics;
 import io.questdb.PropServerConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.pool.PoolListener;
@@ -127,8 +126,7 @@ public class LineTcpO3Test extends AbstractCairoTest {
         configuration = serverConf.getCairoConfiguration();
         lineConfiguration = serverConf.getLineTcpReceiverConfiguration();
         sharedWorkerPoolConfiguration = serverConf.getWorkerPoolConfiguration();
-        metrics = Metrics.enabled();
-        engine = new CairoEngine(configuration, metrics);
+        engine = new CairoEngine(configuration);
         serverConf.init(engine, freeOnExit);
         messageBus = engine.getMessageBus();
         LOG.info().$("setup engine completed").$();
@@ -201,7 +199,7 @@ public class LineTcpO3Test extends AbstractCairoTest {
             Assert.assertTrue(clientFd >= 0);
 
             long ilpSockAddr = Net.sockaddr(Net.parseIPv4("127.0.0.1"), lineConfiguration.getBindPort());
-            WorkerPool sharedWorkerPool = new WorkerPool(sharedWorkerPoolConfiguration, metrics);
+            WorkerPool sharedWorkerPool = new WorkerPool(sharedWorkerPoolConfiguration);
             try (
                     LineTcpReceiver ignored = new LineTcpReceiver(lineConfiguration, engine, sharedWorkerPool, sharedWorkerPool);
                     SqlExecutionContext sqlExecutionContext = TestUtils.createSqlExecutionCtx(engine)

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -814,39 +814,39 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
 
     @Test
     public void testShutdownWithDedicatedPoolsCloseIoPoolFirst() throws Exception {
-        long preTestErrors = engine.getMetrics().health().unhandledErrorsCount();
+        long preTestErrors = engine.getMetrics().healthMetrics().unhandledErrorsCount();
 
         assertMemoryLeak(() -> {
             WorkerPool writerPool = new TestWorkerPool("writer", 2, engine.getMetrics());
             WorkerPool ioPool = new TestWorkerPool("io", 2, engine.getMetrics());
             shutdownReceiverWhileSenderIsSendingData(ioPool, writerPool);
 
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount() - preTestErrors);
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount() - preTestErrors);
         });
     }
 
     @Test
     public void testShutdownWithDedicatedPoolsCloseWriterPoolFirst() throws Exception {
-        long preTestErrors = engine.getMetrics().health().unhandledErrorsCount();
+        long preTestErrors = engine.getMetrics().healthMetrics().unhandledErrorsCount();
 
         assertMemoryLeak(() -> {
             WorkerPool writerPool = new TestWorkerPool("writer", 2, engine.getMetrics());
             WorkerPool ioPool = new TestWorkerPool("io", 2, engine.getMetrics());
             shutdownReceiverWhileSenderIsSendingData(ioPool, writerPool);
 
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount() - preTestErrors);
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount() - preTestErrors);
         });
     }
 
     @Test
     public void testShutdownWithSharedPool() throws Exception {
-        long preTestErrors = engine.getMetrics().health().unhandledErrorsCount();
+        long preTestErrors = engine.getMetrics().healthMetrics().unhandledErrorsCount();
 
         assertMemoryLeak(() -> {
             WorkerPool sharedPool = new TestWorkerPool("shared", 2, engine.getMetrics());
             shutdownReceiverWhileSenderIsSendingData(sharedPool, sharedPool);
 
-            Assert.assertEquals(0, engine.getMetrics().health().unhandledErrorsCount() - preTestErrors);
+            Assert.assertEquals(0, engine.getMetrics().healthMetrics().unhandledErrorsCount() - preTestErrors);
         });
     }
 
@@ -1907,7 +1907,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
                     ioPool.halt();
 
                     long start = System.currentTimeMillis();
-                    while (engine.getMetrics().health().unhandledErrorsCount() == 0) {
+                    while (engine.getMetrics().healthMetrics().unhandledErrorsCount() == 0) {
                         Os.sleep(10);
                         if (System.currentTimeMillis() - start > 1000) {
                             break;

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
@@ -24,7 +24,16 @@
 
 package io.questdb.test.cutlass.line.tcp;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AlterTableContextException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.SecurityContext;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TableWriterAPI;
+import io.questdb.cairo.TxReader;
 import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.Vm;
@@ -37,7 +46,14 @@ import io.questdb.mp.RingQueue;
 import io.questdb.mp.SCSequence;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.SPSequence;
-import io.questdb.std.*;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.Mutable;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.DirectUtf8String;
@@ -201,7 +217,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 TableToken tableToken = engine.verifyTableName(tableName);
                 try (
-                        TableWriter writer = newOffPoolWriter(configuration, tableName, metrics);
+                        TableWriter writer = newOffPoolWriter(configuration, tableName);
                         TxReader txReader = new TxReader(ff).ofRO(
                                 path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$(),
                                 PartitionBy.DAY
@@ -382,7 +398,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                 long mem = Unsafe.malloc(DBCS_MAX_SIZE, MemoryTag.NATIVE_DEFAULT);
                 TableToken tableToken = engine.verifyTableName(tableName);
                 try (
-                        TableWriter writer = TestUtils.newOffPoolWriter(configuration, tableToken, metrics, engine);
+                        TableWriter writer = TestUtils.newOffPoolWriter(configuration, tableToken, engine);
                         TxReader txReader = new TxReader(ff).ofRO(
                                 path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$(),
                                 PartitionBy.DAY
@@ -446,7 +462,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
                 try (
-                        TableWriter writer = newOffPoolWriter(configuration, tableName, metrics);
+                        TableWriter writer = newOffPoolWriter(configuration, tableName);
                         MemoryMR txMem = Vm.getCMRInstance();
                         TxReader txReader = new TxReader(ff).ofRO(
                                 path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$(),
@@ -605,7 +621,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
                 try (
-                        TableWriter writer = newOffPoolWriter(configuration, tableName, metrics);
+                        TableWriter writer = newOffPoolWriter(configuration, tableName);
                         MemoryMR txMem = Vm.getCMRInstance();
                         TxReader txReader = new TxReader(ff).ofRO(
                                 path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$(),
@@ -688,7 +704,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
                 DirectUtf8String dus = new DirectUtf8String();
                 TableToken tableToken = engine.verifyTableName(tableName);
                 try (
-                        TableWriter writer = newOffPoolWriter(configuration, tableName, metrics);
+                        TableWriter writer = newOffPoolWriter(configuration, tableName);
                         MemoryMR txMem = Vm.getCMRInstance();
                         TxReader txReader = new TxReader(ff).ofRO(
                                 path.of(configuration.getRoot()).concat(tableToken).concat(TXN_FILE_NAME).$(),

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpInsertTest.java
@@ -24,11 +24,19 @@
 
 package io.questdb.test.cutlass.line.udp;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableReaderMetadata;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cutlass.line.AbstractLineSender;
 import io.questdb.cutlass.line.LineUdpSender;
-import io.questdb.cutlass.line.udp.*;
+import io.questdb.cutlass.line.udp.AbstractLineProtoUdpReceiver;
+import io.questdb.cutlass.line.udp.DefaultLineUdpReceiverConfiguration;
+import io.questdb.cutlass.line.udp.LineUdpReceiver;
+import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
+import io.questdb.cutlass.line.udp.LinuxMMLineUdpReceiver;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.network.Net;
 import io.questdb.network.NetworkFacadeImpl;
@@ -81,7 +89,7 @@ public abstract class LineUdpInsertTest extends AbstractCairoTest {
                                      Consumer<AbstractLineSender> senderConsumer,
                                      String... expectedExtraStringColumns) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 final SOCountDownLatch waitForData = new SOCountDownLatch(1);
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                     if (event == PoolListener.EV_RETURN && name.getTableName().equals(tableName)

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserImplTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserImplTest.java
@@ -24,12 +24,24 @@
 
 package io.questdb.test.cutlass.line.udp;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cutlass.line.udp.DefaultLineUdpReceiverConfiguration;
 import io.questdb.cutlass.line.udp.LineUdpLexer;
 import io.questdb.cutlass.line.udp.LineUdpParserImpl;
 import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.NumericException;
+import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.str.Path;
@@ -317,7 +329,7 @@ public class LineUdpParserImplTest extends AbstractCairoTest {
         };
 
         // open writer so that pool cannot have it
-        try (TableWriter ignored = newOffPoolWriter(configuration, "x", metrics)) {
+        try (TableWriter ignored = newOffPoolWriter(configuration, "x")) {
             assertThat(expected, lines, "x", configuration);
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserSupportTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LineUdpParserSupportTest.java
@@ -320,7 +320,7 @@ public class LineUdpParserSupportTest extends LineUdpInsertTest {
             Consumer<AbstractLineSender> senderConsumer
     ) throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 final SOCountDownLatch waitForData = new SOCountDownLatch(1);
                 engine.setPoolListener((factoryType, thread, name, event, segment, position) -> {
                     if (event == PoolListener.EV_RETURN && name.getTableName().equals(tableName)

--- a/core/src/test/java/io/questdb/test/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/udp/LinuxLineUdpProtoReceiverTest.java
@@ -24,10 +24,18 @@
 
 package io.questdb.test.cutlass.line.udp;
 
-import io.questdb.Metrics;
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.DatabaseCheckpointStatus;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cutlass.line.LineUdpSender;
-import io.questdb.cutlass.line.udp.*;
+import io.questdb.cutlass.line.udp.AbstractLineProtoUdpReceiver;
+import io.questdb.cutlass.line.udp.DefaultLineUdpReceiverConfiguration;
+import io.questdb.cutlass.line.udp.LineUdpReceiver;
+import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
+import io.questdb.cutlass.line.udp.LinuxMMLineUdpReceiver;
 import io.questdb.griffin.FunctionFactoryCache;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.Net;
@@ -46,9 +54,9 @@ import org.junit.Test;
 public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
 
     private final static ReceiverFactory GENERIC_FACTORY =
-            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent, metrics) -> new LineUdpReceiver(configuration, engine, workerPool);
+            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent) -> new LineUdpReceiver(configuration, engine, workerPool);
     private final static ReceiverFactory LINUX_FACTORY =
-            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent, metrics) -> new LinuxMMLineUdpReceiver(configuration, engine, workerPool);
+            (configuration, engine, workerPool, localPool, sharedWorkerCount, functionFactoryCache, snapshotAgent) -> new LinuxMMLineUdpReceiver(configuration, engine, workerPool);
 
     @Test
     public void testGenericCannotBindSocket() throws Exception {
@@ -196,7 +204,7 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
     private void assertConstructorFail(LineUdpReceiverConfiguration receiverCfg, ReceiverFactory factory) {
         try (CairoEngine engine = new CairoEngine(configuration)) {
             try {
-                factory.create(receiverCfg, engine, null, true, 0, null, null, metrics);
+                factory.create(receiverCfg, engine, null, true, 0, null, null);
                 Assert.fail();
             } catch (NetworkError ignore) {
             }
@@ -228,7 +236,7 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
                     "blue\tx square\t3.4\t1970-01-01T00:01:40.000000Z\n";
 
             try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, 0, null, null, metrics)) {
+                try (AbstractLineProtoUdpReceiver receiver = factory.create(receiverCfg, engine, null, false, 0, null, null)) {
                     // create table
                     String tableName = "tab";
                     TableModel model = new TableModel(configuration, tableName, PartitionBy.NONE)
@@ -282,8 +290,7 @@ public class LinuxLineUdpProtoReceiverTest extends AbstractCairoTest {
                 boolean isWorkerPoolLocal,
                 int sharedWorkerCount,
                 @Nullable FunctionFactoryCache functionFactoryCache,
-                @Nullable DatabaseCheckpointStatus snapshotAgent,
-                Metrics metrics
+                @Nullable DatabaseCheckpointStatus snapshotAgent
         );
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
@@ -456,7 +456,7 @@ public abstract class BasePGTest extends AbstractCairoTest {
         if (configuration.isLegacyModeEnabled() != legacyMode) {
             ((Port0PGWireConfiguration) configuration).isLegacyMode = legacyMode;
         }
-        TestWorkerPool workerPool = new TestWorkerPool(configuration.getWorkerCount(), metrics);
+        TestWorkerPool workerPool = new TestWorkerPool(configuration);
         copyRequestJob = new CopyRequestJob(engine, configuration.getWorkerCount());
 
         workerPool.assign(copyRequestJob);

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
@@ -41,6 +41,8 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.WorkerPool;
 import io.questdb.network.NetworkFacade;
 import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.std.ConcurrentCacheConfiguration;
+import io.questdb.std.DefaultConcurrentCacheConfiguration;
 import io.questdb.std.IntIntHashMap;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjectFactory;
@@ -493,6 +495,13 @@ public abstract class BasePGTest extends AbstractCairoTest {
             }
         };
 
+        final ConcurrentCacheConfiguration concurrentCacheConfiguration = new DefaultConcurrentCacheConfiguration() {
+            @Override
+            public int getBlocks() {
+                return selectCacheBlockCount == -1 ? super.getBlocks() : selectCacheBlockCount;
+            }
+        };
+        
         final PGWireConfiguration conf = new Port0PGWireConfiguration(-1, legacyMode) {
 
             @Override
@@ -516,8 +525,8 @@ public abstract class BasePGTest extends AbstractCairoTest {
             }
 
             @Override
-            public int getSelectCacheBlockCount() {
-                return selectCacheBlockCount == -1 ? super.getSelectCacheBlockCount() : selectCacheBlockCount;
+            public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+                return concurrentCacheConfiguration;
             }
 
             @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/BasePGTest.java
@@ -501,12 +501,17 @@ public abstract class BasePGTest extends AbstractCairoTest {
                 return selectCacheBlockCount == -1 ? super.getBlocks() : selectCacheBlockCount;
             }
         };
-        
+
         final PGWireConfiguration conf = new Port0PGWireConfiguration(-1, legacyMode) {
 
             @Override
             public SqlExecutionCircuitBreakerConfiguration getCircuitBreakerConfiguration() {
                 return circuitBreakerConfiguration;
+            }
+
+            @Override
+            public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
+                return concurrentCacheConfiguration;
             }
 
             @Override
@@ -522,11 +527,6 @@ public abstract class BasePGTest extends AbstractCairoTest {
             @Override
             public int getRecvBufferSize() {
                 return recvBufferSize;
-            }
-
-            @Override
-            public ConcurrentCacheConfiguration getConcurrentCacheConfiguration() {
-                return concurrentCacheConfiguration;
             }
 
             @Override

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -7816,7 +7816,7 @@ nodejs code:
                 }
             };
 
-            final WorkerPool workerPool = new TestWorkerPool(4, metrics);
+            final WorkerPool workerPool = new TestWorkerPool(4, conf.getMetrics());
             try (final IPGWireServer server = createPGWireServer(
                     conf,
                     engine,
@@ -8442,26 +8442,26 @@ nodejs code:
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             execute("create table x as (select x id from long_sequence(10))");
             // table
-            metrics.pgWire().resetQueryCounters();
+            configuration.getMetrics().pgWire().resetQueryCounters();
             try (
                     PreparedStatement stmt = connection.prepareStatement("select count() from x;");
                     ResultSet rs = stmt.executeQuery()
             ) {
                 rs.next();
                 Assert.assertEquals(10, rs.getLong(1));
-                Assert.assertEquals(1, metrics.pgWire().startedQueriesCount());
-                Assert.assertEquals(1, metrics.pgWire().completedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWire().startedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWire().completedQueriesCount());
             }
             // virtual
-            metrics.pgWire().resetQueryCounters();
+            configuration.getMetrics().pgWire().resetQueryCounters();
             try (
                     PreparedStatement stmt = connection.prepareStatement("select 1;");
                     ResultSet rs = stmt.executeQuery()
             ) {
                 rs.next();
                 Assert.assertEquals(1, rs.getLong(1));
-                Assert.assertEquals(1, metrics.pgWire().startedQueriesCount());
-                Assert.assertEquals(1, metrics.pgWire().completedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWire().startedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWire().completedQueriesCount());
             }
         });
     }
@@ -11930,7 +11930,7 @@ create table tab as (
             }
         };
 
-        WorkerPool workerPool = new TestWorkerPool(2, metrics);
+        WorkerPool workerPool = new TestWorkerPool(2, conf.getMetrics());
         DefaultCircuitBreakerRegistry registry = new DefaultCircuitBreakerRegistry(conf, engine.getConfiguration());
         try {
             return createPGWireServer(
@@ -12040,7 +12040,7 @@ create table tab as (
 
         try (
                 DefaultCircuitBreakerRegistry registry = new DefaultCircuitBreakerRegistry(conf, engine.getConfiguration());
-                WorkerPool pool = new WorkerPool(conf, metrics)
+                WorkerPool pool = new WorkerPool(conf)
         ) {
             pool.assign(engine.getEngineMaintenanceJob());
             try (

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -8442,26 +8442,26 @@ nodejs code:
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             execute("create table x as (select x id from long_sequence(10))");
             // table
-            configuration.getMetrics().pgWire().resetQueryCounters();
+            configuration.getMetrics().pgWireMetrics().resetQueryCounters();
             try (
                     PreparedStatement stmt = connection.prepareStatement("select count() from x;");
                     ResultSet rs = stmt.executeQuery()
             ) {
                 rs.next();
                 Assert.assertEquals(10, rs.getLong(1));
-                Assert.assertEquals(1, configuration.getMetrics().pgWire().startedQueriesCount());
-                Assert.assertEquals(1, configuration.getMetrics().pgWire().completedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWireMetrics().startedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWireMetrics().completedQueriesCount());
             }
             // virtual
-            configuration.getMetrics().pgWire().resetQueryCounters();
+            configuration.getMetrics().pgWireMetrics().resetQueryCounters();
             try (
                     PreparedStatement stmt = connection.prepareStatement("select 1;");
                     ResultSet rs = stmt.executeQuery()
             ) {
                 rs.next();
                 Assert.assertEquals(1, rs.getLong(1));
-                Assert.assertEquals(1, configuration.getMetrics().pgWire().startedQueriesCount());
-                Assert.assertEquals(1, configuration.getMetrics().pgWire().completedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWireMetrics().startedQueriesCount());
+                Assert.assertEquals(1, configuration.getMetrics().pgWireMetrics().completedQueriesCount());
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGTlsCompatTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGTlsCompatTest.java
@@ -80,7 +80,7 @@ public class PGTlsCompatTest extends BasePGTest {
                 }
             };
 
-            final WorkerPool workerPool = new TestWorkerPool(1, metrics);
+            final WorkerPool workerPool = new TestWorkerPool(1, conf.getMetrics());
             try (final IPGWireServer server = createPGWireServer(conf, engine, workerPool)) {
                 Assert.assertNotNull(server);
 
@@ -121,7 +121,7 @@ public class PGTlsCompatTest extends BasePGTest {
                 }
             };
 
-            final WorkerPool workerPool = new TestWorkerPool(1, metrics);
+            final WorkerPool workerPool = new TestWorkerPool(1, conf.getMetrics());
             try (final IPGWireServer server = createPGWireServer(conf, engine, workerPool)) {
                 Assert.assertNotNull(server);
 
@@ -168,7 +168,7 @@ public class PGTlsCompatTest extends BasePGTest {
             };
 
             final int N = 10;
-            final WorkerPool workerPool = new TestWorkerPool(1, metrics);
+            final WorkerPool workerPool = new TestWorkerPool(1, conf.getMetrics());
             try (final IPGWireServer server = createPGWireServer(conf, engine, workerPool)) {
                 Assert.assertNotNull(server);
                 final String url = String.format("jdbc:postgresql://127.0.0.1:%d/qdb", server.getPort());

--- a/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.cutlass.text;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
@@ -51,7 +50,6 @@ import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FilesFacadeImpl;
@@ -3253,17 +3251,7 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
                         return queueCapacity;
                     }
                 };
-                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return configuration1.getMetrics();
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount;
-                    }
-                });
+                WorkerPool pool = new WorkerPool(() -> workerCount);
                 execute(pool, runnable, configuration1);
             } else {
                 // we need to create entire engine

--- a/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -2011,11 +2010,6 @@ public class AggregateTest extends AbstractCairoTest {
                 };
 
                 WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return configuration1.getMetrics();
-                    }
-
                     @Override
                     public long getSleepTimeout() {
                         return 1;

--- a/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -1992,18 +1993,6 @@ public class AggregateTest extends AbstractCairoTest {
         // we need to create entire engine
         assertMemoryLeak(() -> {
             if (workerCount > 0) {
-                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public long getSleepTimeout() {
-                        return 1;
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount - 1;
-                    }
-                });
-
                 final CairoConfiguration configuration1 = new DefaultTestCairoConfiguration(root) {
                     @Override
                     public @NotNull RostiAllocFacade getRostiAllocFacade() {
@@ -2020,6 +2009,23 @@ public class AggregateTest extends AbstractCairoTest {
                         return queueSize;
                     }
                 };
+
+                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                    @Override
+                    public Metrics getMetrics() {
+                        return configuration1.getMetrics();
+                    }
+
+                    @Override
+                    public long getSleepTimeout() {
+                        return 1;
+                    }
+
+                    @Override
+                    public int getWorkerCount() {
+                        return workerCount - 1;
+                    }
+                });
 
                 execute(pool, runnable, configuration1);
             } else {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAddColumnTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAddColumnTest.java
@@ -24,7 +24,13 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AlterTableUtils;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.EntryUnavailableException;
+import io.questdb.cairo.SymbolMapReader;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.test.AbstractCairoTest;
@@ -366,7 +372,7 @@ public class AlterTableAddColumnTest extends AbstractCairoTest {
                         }
                     };
 
-                    try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+                    try (CairoEngine engine = new CairoEngine(configuration)) {
                         try (SqlCompiler compiler = engine.getSqlCompiler()) {
                             execute(compiler, "alter table x add column meh symbol cache");
 
@@ -543,7 +549,7 @@ public class AlterTableAddColumnTest extends AbstractCairoTest {
                         }
                     };
 
-                    try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+                    try (CairoEngine engine = new CairoEngine(configuration)) {
                         try (SqlCompiler compiler = engine.getSqlCompiler()) {
                             execute(compiler, "alter table x add column meh symbol", sqlExecutionContext);
                             try (TableReader reader = getReader("x")) {

--- a/core/src/test/java/io/questdb/test/griffin/IntervalIntrinsicTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/IntervalIntrinsicTest.java
@@ -154,8 +154,8 @@ public class IntervalIntrinsicTest extends AbstractCairoTest {
             long maxTimestamp = minTimestamp;
             long timestamp = minTimestamp;
             try (
-                    TableWriter oracleWriter = newOffPoolWriter(configuration, "oracle", metrics);
-                    TableWriter writer = newOffPoolWriter(configuration, "x", metrics)
+                    TableWriter oracleWriter = newOffPoolWriter(configuration, "oracle");
+                    TableWriter writer = newOffPoolWriter(configuration, "x")
             ) {
                 int ticks = duplicatesPerTick;
                 for (int i = 0; i < rowCount; i++) {

--- a/core/src/test/java/io/questdb/test/griffin/ParallelFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelFilterTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.SqlJitMode;
@@ -40,7 +39,6 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.jit.JitUtil;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
@@ -228,17 +226,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     @Test
     public void testEarlyCursorClose() throws Exception {
         // This scenario used to lead to an NPE on `circuitBreaker.cancelledFlag` access in PageFrameReduceJob.
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -275,17 +263,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
         final int threadCount = 4;
         final int workerCount = 4;
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCount;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> workerCount);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -718,17 +696,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     }
 
     private void testAsyncSubQueryWithFilter(String query) throws Exception {
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -765,17 +733,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     }
 
     private void testAsyncTimestampSubQueryWithFilter(String query, String expected) throws Exception {
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -805,17 +763,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testIn(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -855,17 +803,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testInAndInTimestamp(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -912,17 +850,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testInTimestamp(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -965,17 +893,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCount;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> workerCount);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -1031,17 +949,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCount;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> workerCount);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -1096,17 +1004,7 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testStrBindVariable(String columnType, int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {

--- a/core/src/test/java/io/questdb/test/griffin/ParallelFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelFilterTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.SqlJitMode;
@@ -39,6 +40,7 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.jit.JitUtil;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
@@ -226,9 +228,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     @Test
     public void testEarlyCursorClose() throws Exception {
         // This scenario used to lead to an NPE on `circuitBreaker.cancelledFlag` access in PageFrameReduceJob.
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE x (" +
                                     "  ts TIMESTAMP," +
@@ -262,9 +275,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
         final int threadCount = 4;
         final int workerCount = 4;
 
-        WorkerPool pool = new WorkerPool((() -> workerCount));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return workerCount;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE 'test1' " +
                                     "(column1 SYMBOL capacity 256 CACHE index capacity 256, timestamp TIMESTAMP) " +
@@ -694,9 +718,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     }
 
     private void testAsyncSubQueryWithFilter(String query) throws Exception {
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE price (" +
                                     "  ts TIMESTAMP," +
@@ -730,7 +765,17 @@ public class ParallelFilterTest extends AbstractCairoTest {
     }
 
     private void testAsyncTimestampSubQueryWithFilter(String query, String expected) throws Exception {
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -760,9 +805,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testIn(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (\n" +
                                     "  ts TIMESTAMP," +
@@ -799,9 +855,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testInAndInTimestamp(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (\n" +
                                     "  ts TIMESTAMP," +
@@ -845,9 +912,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testInTimestamp(int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (\n" +
                                     "  ts TIMESTAMP," +
@@ -887,9 +965,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(() -> workerCount);
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return workerCount;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "create table x ( " +
                                     " v long, " +
@@ -942,9 +1031,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool(() -> workerCount);
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return workerCount;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "create table x ( " +
                                     " l long, " +
@@ -996,9 +1096,20 @@ public class ParallelFilterTest extends AbstractCairoTest {
     private void testStrBindVariable(String columnType, int jitMode) throws Exception {
         node1.setProperty(PropertyKey.CAIRO_SQL_JIT_MODE, SqlJitMode.toString(jitMode));
 
-        WorkerPool pool = new WorkerPool((() -> 4));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE price (\n" +
                                     "  ts TIMESTAMP," +

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
@@ -41,7 +40,6 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.griffin.engine.groupby.vect.GroupByRecordCursorFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
@@ -233,17 +231,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // The table is empty.
         Assume.assumeFalse(convertToParquet);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -702,17 +690,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // This query shouldn't be executed in parallel,
         // so this test verifies that nothing breaks.
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -1194,17 +1172,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "2025.5\t8202000.0\n";
 
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        final WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -1697,17 +1665,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
 
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -2072,17 +2030,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "k4\t1643226.5\n";
 
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        final WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -2153,17 +2101,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         final int numOfThreads = 8;
         final int numOfIterations = 50;
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return 4;
-            }
-        });
+        final WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {
@@ -2897,17 +2835,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // The table is empty, so there is nothing to convert.
         Assume.assumeFalse(convertToParquet);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -2972,17 +2900,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeTrue(enableParallelGroupBy);
         assertMemoryLeak(() -> {
             final Rnd rnd = TestUtils.generateRandom(LOG);
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3048,17 +2966,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelGroupByAllTypes(BindVariablesInitializer initializer, String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3111,17 +3019,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeTrue(enableParallelGroupBy);
         node1.setProperty(PropertyKey.DEV_MODE_ENABLED, true);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3222,17 +3120,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelJsonKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3263,17 +3151,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelMultiSymbolKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3312,17 +3190,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelNonKeyedGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3361,17 +3229,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // Rosti doesn't support filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3425,17 +3283,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelStringAndVarcharKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3498,17 +3346,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelSymbolKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 4;
-                }
-            });
+            final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByFuzzTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
@@ -40,6 +41,7 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.griffin.engine.groupby.vect.GroupByRecordCursorFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
@@ -231,9 +233,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // The table is empty.
         Assume.assumeFalse(convertToParquet);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
-                    pool, (engine, compiler, sqlExecutionContext) -> {
+                    pool,
+                    (engine, compiler, sqlExecutionContext) -> {
                         execute(
                                 compiler,
                                 "CREATE TABLE tab (" +
@@ -689,9 +702,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // This query shouldn't be executed in parallel,
         // so this test verifies that nothing breaks.
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
-                    pool, (engine, compiler, sqlExecutionContext) -> {
+                    pool,
+                    (engine, compiler, sqlExecutionContext) -> {
                         execute(
                                 compiler,
                                 "create table x as (select * from (select rnd_symbol('a','b','c') a, 'x' || x b from long_sequence(" + ROW_COUNT + ")))",
@@ -1170,9 +1194,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "2025.5\t8202000.0\n";
 
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool((() -> 4));
+        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (" +
                                     "  ts TIMESTAMP," +
@@ -1662,7 +1697,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeFalse(convertToParquet);
 
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -2027,9 +2072,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "k4\t1643226.5\n";
 
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool((() -> 4));
+        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (" +
                                     "  ts TIMESTAMP," +
@@ -2097,9 +2153,20 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         final int numOfThreads = 8;
         final int numOfIterations = 50;
         final ConcurrentHashMap<Integer, Throwable> errors = new ConcurrentHashMap<>();
-        final WorkerPool pool = new WorkerPool((() -> 4));
+        final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 4;
+            }
+        });
         TestUtils.execute(
-                pool, (engine, compiler, sqlExecutionContext) -> {
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
                     engine.execute(
                             "CREATE TABLE tab (" +
                                     "  ts TIMESTAMP," +
@@ -2830,7 +2897,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // The table is empty, so there is nothing to convert.
         Assume.assumeFalse(convertToParquet);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -2895,7 +2972,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeTrue(enableParallelGroupBy);
         assertMemoryLeak(() -> {
             final Rnd rnd = TestUtils.generateRandom(LOG);
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -2961,7 +3048,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelGroupByAllTypes(BindVariablesInitializer initializer, String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3014,7 +3111,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         Assume.assumeTrue(enableParallelGroupBy);
         node1.setProperty(PropertyKey.DEV_MODE_ENABLED, true);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3115,7 +3222,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelJsonKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3146,7 +3263,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelMultiSymbolKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3185,7 +3312,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelNonKeyedGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3224,7 +3361,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         // Rosti doesn't support filter, so we don't care about JIT.
         Assume.assumeTrue(enableJitCompiler);
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3278,7 +3425,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelStringAndVarcharKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
@@ -3341,7 +3498,17 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     private void testParallelSymbolKeyGroupBy(String... queriesAndExpectedResults) throws Exception {
         assertMemoryLeak(() -> {
-            final WorkerPool pool = new WorkerPool((() -> 4));
+            final WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public Metrics getMetrics() {
+                    return configuration.getMetrics();
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 4;
+                }
+            });
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {

--- a/core/src/test/java/io/questdb/test/griffin/ParallelLatestByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelLatestByTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.sql.RecordCursor;
@@ -36,7 +35,6 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.rnd.SharedRandom;
 import io.questdb.griffin.engine.table.LatestByAllIndexedJob;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
@@ -200,17 +198,7 @@ public class ParallelLatestByTest extends AbstractTest {
                 final CairoConfiguration configuration = new DefaultTestCairoConfiguration(root) {
                 };
 
-                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return configuration.getMetrics();
-                    }
-
-                    @Override
-                    public int getWorkerCount() {
-                        return workerCount;
-                    }
-                });
+                WorkerPool pool = new WorkerPool(() -> workerCount);
                 execute(pool, runnable, configuration);
             } else {
                 // we need to create entire engine

--- a/core/src/test/java/io/questdb/test/griffin/ParallelLatestByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelLatestByTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.sql.RecordCursor;
@@ -35,6 +36,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.rnd.SharedRandom;
 import io.questdb.griffin.engine.table.LatestByAllIndexedJob;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Misc;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
@@ -195,11 +197,20 @@ public class ParallelLatestByTest extends AbstractTest {
     ) throws Exception {
         executeVanilla(() -> {
             if (workerCount > 0) {
-                WorkerPool pool = new WorkerPool(() -> workerCount);
-
                 final CairoConfiguration configuration = new DefaultTestCairoConfiguration(root) {
                 };
 
+                WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+                    @Override
+                    public Metrics getMetrics() {
+                        return configuration.getMetrics();
+                    }
+
+                    @Override
+                    public int getWorkerCount() {
+                        return workerCount;
+                    }
+                });
                 execute(pool, runnable, configuration);
             } else {
                 // we need to create entire engine

--- a/core/src/test/java/io/questdb/test/griffin/PartitionDeleteTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/PartitionDeleteTest.java
@@ -42,7 +42,7 @@ public class PartitionDeleteTest extends AbstractCairoTest {
         execute("create table events (sequence long, event binary, timestamp timestamp) timestamp(timestamp) partition by DAY");
         engine.releaseAllWriters();
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "events", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "events")) {
             long ts = TimestampFormatUtils.parseTimestamp("2020-06-30T00:00:00.000000Z");
             for (int i = 0; i < 10; i++) {
                 TableWriter.Row r = writer.newRow(ts);
@@ -73,7 +73,7 @@ public class PartitionDeleteTest extends AbstractCairoTest {
             while (cursor.hasNext()) {
             }
 
-            try (TableWriter writer = newOffPoolWriter(configuration, "events", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "events")) {
                 long ts = TimestampFormatUtils.parseTimestamp("2020-07-02T00:00:00.000000Z");
                 for (int i = 0; i < 10; i++) {
                     TableWriter.Row row = writer.newRow(ts);

--- a/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableRepairTest.java
@@ -57,7 +57,7 @@ public class TableRepairTest extends AbstractCairoTest {
 
                 // repair by opening and closing writer
 
-                try (TableWriter writer = newOffPoolWriter(configuration, "tst", metrics)) {
+                try (TableWriter writer = newOffPoolWriter(configuration, "tst")) {
                     Assert.assertTrue(reader.reload());
                     Assert.assertEquals(95040, reader.size());
                     Assert.assertEquals(950390000000L, writer.getMaxTimestamp());
@@ -96,7 +96,7 @@ public class TableRepairTest extends AbstractCairoTest {
 
                 // repair by opening and closing writer
 
-                newOffPoolWriter(configuration, "tst", metrics).close();
+                newOffPoolWriter(configuration, "tst").close();
 
                 Assert.assertTrue(reader.reload());
                 Assert.assertEquals(91360, reader.size());

--- a/core/src/test/java/io/questdb/test/griffin/TimeFrameRecordCursorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimeFrameRecordCursorTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.sql.Record;
@@ -32,7 +31,6 @@ import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.TimeFrame;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Rows;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
@@ -483,17 +481,7 @@ public class TimeFrameRecordCursorTest extends AbstractCairoTest {
                     return 1000;
                 }
             };
-            WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                @Override
-                public Metrics getMetrics() {
-                    return configuration.getMetrics();
-                }
-
-                @Override
-                public int getWorkerCount() {
-                    return 2;
-                }
-            });
+            WorkerPool pool = new WorkerPool(() -> 2);
             TestUtils.execute(pool, runnable, configuration, LOG);
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.Metrics;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
@@ -32,9 +31,21 @@ import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.BindVariableService;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.griffin.*;
-import io.questdb.griffin.model.*;
-import io.questdb.std.*;
+import io.questdb.griffin.FunctionParser;
+import io.questdb.griffin.PostOrderTreeTraversalAlgo;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.WhereClauseParser;
+import io.questdb.griffin.model.ExpressionNode;
+import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.griffin.model.IntrinsicModel;
+import io.questdb.griffin.model.QueryModel;
+import io.questdb.griffin.model.RuntimeIntrinsicIntervalModel;
+import io.questdb.std.LongList;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8StringSink;
@@ -127,7 +138,7 @@ public class WhereClauseParserTest extends AbstractCairoTest {
                 .timestamp();
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "v", Metrics.disabled())) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "v")) {
             TableWriter.Row row = writer.newRow(0);
             row.putSym(0, "sym1");
             row.putSym(5, "mode1");

--- a/core/src/test/java/io/questdb/test/griffin/engine/QueryExecutionTimeoutTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/QueryExecutionTimeoutTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin.engine;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -618,11 +617,6 @@ public class QueryExecutionTimeoutTest extends AbstractCairoTest {
                 };
 
                 WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-                    @Override
-                    public Metrics getMetrics() {
-                        return configuration1.getMetrics();
-                    }
-
                     @Override
                     public long getSleepTimeout() {
                         return 1;

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTablesInitialisationTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/WalTablesInitialisationTest.java
@@ -44,7 +44,6 @@ public class WalTablesInitialisationTest extends AbstractBootstrapTest {
     @Test
     public void testWalTablesFunctionBeforeSeqTrackerInitialized() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            long httpConnMem = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_HTTP_CONN);
             assert Unsafe.getMemUsedByTag(MemoryTag.NATIVE_HTTP_CONN) == 0;
 
             // Need many table, single table will be initialized way too quickly on a background thread

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin.engine.groupby;
 
-import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -51,7 +50,6 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
-import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.Misc;
@@ -13132,17 +13130,7 @@ public class SampleByTest extends AbstractCairoTest {
         final int threadCount = 4;
         final int workerCount = 2;
 
-        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
-            @Override
-            public Metrics getMetrics() {
-                return configuration.getMetrics();
-            }
-
-            @Override
-            public int getWorkerCount() {
-                return workerCount;
-            }
-        });
+        WorkerPool pool = new WorkerPool(() -> workerCount);
         assertMemoryLeak(() -> TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.groupby;
 
+import io.questdb.Metrics;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
@@ -50,6 +51,7 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.std.Chars;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.Misc;
@@ -13130,7 +13132,17 @@ public class SampleByTest extends AbstractCairoTest {
         final int threadCount = 4;
         final int workerCount = 2;
 
-        WorkerPool pool = new WorkerPool((() -> workerCount));
+        WorkerPool pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return configuration.getMetrics();
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return workerCount;
+            }
+        });
         assertMemoryLeak(() -> TestUtils.execute(
                 pool,
                 (engine, compiler, sqlExecutionContext) -> {

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/PageFrameRecordCursorImplFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/PageFrameRecordCursorImplFactoryTest.java
@@ -87,7 +87,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 for (int i = 0; i < M; i++) {
                     TableWriter.Row row = writer.newRow(timestamp += increment);
                     row.putStr(0, rnd.nextChars(20));
@@ -99,7 +99,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 String value = symbols[N - 10];
                 int columnIndex;
                 int symbolKey;
@@ -220,7 +220,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
 
             // prepare the data, writing rows in the backward direction
             long timestamp = 0;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 int iIndex = writer.getColumnIndex("i");
                 int jIndex = -1;
                 int sIndex = -1;
@@ -246,7 +246,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 GenericRecordMetadata metadata;
                 try (TableReader reader = engine.getReader("x")) {
                     metadata = GenericRecordMetadata.copyOf(reader.getMetadata());
@@ -332,7 +332,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
 
             // prepare the data
             long timestamp = 0;
-            try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+            try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
                 int iIndex = writer.getColumnIndex("i");
                 int jIndex = -1;
                 int sIndex = -1;
@@ -355,7 +355,7 @@ public class PageFrameRecordCursorImplFactoryTest extends AbstractCairoTest {
                 writer.commit();
             }
 
-            try (CairoEngine engine = new CairoEngine(configuration, metrics)) {
+            try (CairoEngine engine = new CairoEngine(configuration)) {
                 GenericRecordMetadata metadata;
                 try (TableReader reader = engine.getReader("x")) {
                     metadata = GenericRecordMetadata.copyOf(reader.getMetadata());

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
@@ -64,9 +64,10 @@ public class TableWriterMetricsRecordCursorFactoryTest extends AbstractCairoTest
 
     @Test
     public void testDisabled() throws Exception {
+        Metrics.ENABLED.disable();
         assertMemoryLeak(() -> {
             try (
-                    CairoEngine localEngine = new CairoEngine(configuration, Metrics.disabled());
+                    CairoEngine localEngine = new CairoEngine(configuration);
                     SqlCompiler localCompiler = localEngine.getSqlCompiler();
                     SqlExecutionContext localSqlExecutionContext = TestUtils.createSqlExecutionCtx(localEngine)
             ) {
@@ -114,7 +115,6 @@ public class TableWriterMetricsRecordCursorFactoryTest extends AbstractCairoTest
     @Test
     public void testSanity() {
         // we want to make sure metrics in tests are enabled by default
-        assertTrue(metrics.isEnabled());
         assertTrue(engine.getMetrics().isEnabled());
 
         MetricsSnapshot metricsSnapshot = snapshotMetrics();

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/TableWriterMetricsRecordCursorFactoryTest.java
@@ -127,7 +127,7 @@ public class TableWriterMetricsRecordCursorFactoryTest extends AbstractCairoTest
     }
 
     private static MetricsSnapshot snapshotMetrics() {
-        TableWriterMetrics writerMetrics = engine.getMetrics().tableWriter();
+        TableWriterMetrics writerMetrics = engine.getMetrics().tableWriterMetrics();
         return new MetricsSnapshot(writerMetrics.getCommitCount(),
                 writerMetrics.getCommittedRows(),
                 writerMetrics.getO3CommitCount(),

--- a/core/src/test/java/io/questdb/test/jit/CompiledFilterIRSerializerTest.java
+++ b/core/src/test/java/io/questdb/test/jit/CompiledFilterIRSerializerTest.java
@@ -43,7 +43,12 @@ import io.questdb.std.ObjList;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.TableModel;
 import io.questdb.test.griffin.BaseFunctionFactoryTest;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -106,7 +111,7 @@ public class CompiledFilterIRSerializerTest extends BaseFunctionFactoryTest {
                 .timestamp();
         AbstractCairoTest.create(model);
 
-        try (TableWriter writer = newOffPoolWriter(configuration, "x", metrics)) {
+        try (TableWriter writer = newOffPoolWriter(configuration, "x")) {
             TableWriter.Row row = writer.newRow();
             row.putSym(writer.getColumnIndex("asymbol"), KNOWN_SYMBOL_1);
             row.putSym(writer.getColumnIndex("anothersymbol"), KNOWN_SYMBOL_2);

--- a/core/src/test/java/io/questdb/test/metrics/MetricsRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/metrics/MetricsRegistryTest.java
@@ -24,7 +24,14 @@
 
 package io.questdb.test.metrics;
 
-import io.questdb.metrics.*;
+import io.questdb.metrics.Counter;
+import io.questdb.metrics.CounterWithOneLabel;
+import io.questdb.metrics.CounterWithTwoLabels;
+import io.questdb.metrics.LongGauge;
+import io.questdb.metrics.MetricsRegistry;
+import io.questdb.metrics.MetricsRegistryImpl;
+import io.questdb.metrics.NullMetricsRegistry;
+import io.questdb.metrics.Target;
 import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
@@ -130,16 +137,16 @@ public class MetricsRegistryTest {
         assetNull(gauge);
     }
 
-    private static void assertScrapable(Scrapable scrapable, CharSequence expected) {
+    private static void assertScrapable(Target target, CharSequence expected) {
         try (DirectUtf8Sink sink = new DirectUtf8Sink(32)) {
-            scrapable.scrapeIntoPrometheus(sink);
+            target.scrapeIntoPrometheus(sink);
             TestUtils.assertEquals(expected, sink.toString());
         }
     }
 
-    private static void assetNull(Scrapable scrapable) {
+    private static void assetNull(Target target) {
         try (DirectUtf8Sink sink = new DirectUtf8Sink(32)) {
-            scrapable.scrapeIntoPrometheus(sink);
+            target.scrapeIntoPrometheus(sink);
             TestUtils.assertEquals("", sink.toString());
         }
     }

--- a/core/src/test/java/io/questdb/test/mp/TestWorkerPool.java
+++ b/core/src/test/java/io/questdb/test/mp/TestWorkerPool.java
@@ -35,11 +35,11 @@ public class TestWorkerPool extends WorkerPool {
     private final ObjList<PageFrameReduceJob> pageFrameReduceJobs = new ObjList<>();
 
     public TestWorkerPool(int workerCount) {
-        this("testing", workerCount, Metrics.disabled());
+        this("testing", workerCount, Metrics.DISABLED);
     }
 
     public TestWorkerPool(String poolName, int workerCount) {
-        this(poolName, workerCount, Metrics.disabled());
+        this(poolName, workerCount, Metrics.DISABLED);
     }
 
     public TestWorkerPool(int workerCount, Metrics metrics) {
@@ -47,7 +47,12 @@ public class TestWorkerPool extends WorkerPool {
     }
 
     public TestWorkerPool(String poolName, int workerCount, Metrics metrics) {
-        super(new WorkerPoolConfiguration() {
+        this(new WorkerPoolConfiguration() {
+            @Override
+            public Metrics getMetrics() {
+                return metrics;
+            }
+
             @Override
             public String getPoolName() {
                 return poolName;
@@ -57,7 +62,11 @@ public class TestWorkerPool extends WorkerPool {
             public int getWorkerCount() {
                 return workerCount;
             }
-        }, metrics);
+        });
+    }
+
+    public TestWorkerPool(WorkerPoolConfiguration configuration) {
+        super(configuration);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -26,7 +26,6 @@ package io.questdb.test.tools;
 
 import io.questdb.MessageBus;
 import io.questdb.MessageBusImpl;
-import io.questdb.Metrics;
 import io.questdb.ServerMain;
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
@@ -1132,13 +1131,12 @@ public final class TestUtils {
             @Nullable WorkerPool pool,
             CustomisableRunnable runnable,
             CairoConfiguration configuration,
-            Metrics metrics,
             Log log
     ) throws Exception {
         final int workerCount = pool != null ? pool.getWorkerCount() : 1;
         final BindVariableServiceImpl bindVariableService = new BindVariableServiceImpl(configuration);
         try (
-                final CairoEngine engine = new CairoEngine(configuration, metrics);
+                final CairoEngine engine = new CairoEngine(configuration);
                 final SqlCompiler compiler = engine.getSqlCompiler();
                 final SqlExecutionContext sqlExecutionContext = createSqlExecutionCtx(engine, bindVariableService, workerCount)
         ) {
@@ -1157,12 +1155,6 @@ public final class TestUtils {
             Assert.assertEquals(0, engine.getBusyWriterCount());
             Assert.assertEquals(0, engine.getBusyReaderCount());
         }
-    }
-
-    public static void execute(
-            @Nullable WorkerPool pool, CustomisableRunnable runner, CairoConfiguration configuration, Log log
-    ) throws Exception {
-        execute(pool, runner, configuration, Metrics.disabled(), log);
     }
 
     @NotNull
@@ -1398,22 +1390,13 @@ public final class TestUtils {
         }
     }
 
-    public static TableWriter newOffPoolWriter(
-            CairoConfiguration configuration, TableToken tableToken, CairoEngine engine
-    ) {
-        return newOffPoolWriter(configuration, tableToken, Metrics.disabled(), engine);
-    }
-
-    public static TableWriter newOffPoolWriter(
-            CairoConfiguration configuration, TableToken tableToken, Metrics metrics, CairoEngine engine
-    ) {
-        return newOffPoolWriter(configuration, tableToken, metrics, new MessageBusImpl(configuration), engine);
+    public static TableWriter newOffPoolWriter(CairoConfiguration configuration, TableToken tableToken, CairoEngine engine) {
+        return newOffPoolWriter(configuration, tableToken, new MessageBusImpl(configuration), engine);
     }
 
     public static TableWriter newOffPoolWriter(
             CairoConfiguration configuration,
             TableToken tableToken,
-            Metrics metrics,
             MessageBus messageBus,
             CairoEngine engine
     ) {
@@ -1427,7 +1410,7 @@ public final class TestUtils {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                metrics,
+                configuration.getMetrics(),
                 engine
         );
     }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1410,7 +1410,6 @@ public final class TestUtils {
                 configuration.getRoot(),
                 DefaultDdlListener.INSTANCE,
                 () -> Numbers.LONG_NULL,
-                configuration.getMetrics(),
                 engine
         );
     }


### PR DESCRIPTION
tandem: https://github.com/questdb/questdb-enterprise/pull/536

```
testHttpConnectionLimitReload();
testPgWireConnectionLimitReload();
```

Tests had race condition where "wait" condition was met before the server would resume listening. The fix was to introduce another condition that would guarantee that it is met after server has resumed listening. To do that without refactoring I would have to propagate 2 more args to IO Dispatcher across the codebase. Instead I refactored configuration to contain all metrics. So all metrics can be propagated via just the config, which was already there.

Also:

- refactored metrics into "configuration"
- refactored `ConcurrentCache` args into "configuration"
- renamed "scrapable" to "target", according to this:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/b84d70f4-dad8-434d-87c1-d16397c84448" />

