### PR TITLE
fix(http): fix bad error message to Web Console when SQL times out

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -95,7 +95,7 @@
         <!--
             JMH version to use with this project.
           -->
-        <jmh.version>1.35</jmh.version>
+        <jmh.version>1.37</jmh.version>
 
         <!--
             Java source/target to use for compilation.

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -309,7 +309,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final String publicDirectory;
     private final PublicPassthroughConfiguration publicPassthroughConfiguration = new PropPublicPassthroughConfiguration();
     private final int queryCacheEventQueueCapacity;
-    private final long queryTimeout;
     private final int readerPoolMaxSegments;
     private final int repeatMigrationFromVersion;
     private final double rerunExponentialWaitMultiplier;
@@ -590,6 +589,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private long pgWorkerNapThreshold;
     private long pgWorkerSleepThreshold;
     private long pgWorkerYieldThreshold;
+    private long queryTimeout;
     private boolean stringToCharCastAllowed;
     private long symbolCacheWaitBeforeReload;
 
@@ -1049,7 +1049,10 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.rerunMaxProcessingQueueSize = getIntSize(properties, env, PropertyKey.HTTP_BUSY_RETRY_MAX_PROCESSING_QUEUE_SIZE, 4096);
 
             this.circuitBreakerThrottle = getInt(properties, env, PropertyKey.CIRCUIT_BREAKER_THROTTLE, 2_000_000);
+            // obsolete
             this.queryTimeout = (long) (getDouble(properties, env, PropertyKey.QUERY_TIMEOUT_SEC, "60") * Timestamps.SECOND_MILLIS);
+            this.queryTimeout = getMillis(properties, env, PropertyKey.QUERY_TIMEOUT, this.queryTimeout);
+
             this.netTestConnectionBufferSize = getInt(properties, env, PropertyKey.CIRCUIT_BREAKER_BUFFER_SIZE, 64);
             this.netTestConnectionBufferSize = getInt(properties, env, PropertyKey.NET_TEST_CONNECTION_BUFFER_SIZE, netTestConnectionBufferSize);
 
@@ -2061,6 +2064,10 @@ public class PropServerConfiguration implements ServerConfiguration {
             registerDeprecated(
                     PropertyKey.CIRCUIT_BREAKER_BUFFER_SIZE,
                     PropertyKey.NET_TEST_CONNECTION_BUFFER_SIZE
+            );
+            registerDeprecated(
+                    PropertyKey.QUERY_TIMEOUT_SEC,
+                    PropertyKey.QUERY_TIMEOUT
             );
             registerDeprecated(
                     PropertyKey.CAIRO_PAGE_FRAME_TASK_POOL_CAPACITY

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -421,6 +421,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     DEBUG_HTTP_FORCE_SEND_FRAGMENTATION_CHUNK_SIZE("debug.http.force.send.fragmentation.chunk.size", false, true),
     DEBUG_HTTP_FORCE_RECV_FRAGMENTATION_CHUNK_SIZE("debug.http.force.recv.fragmentation.chunk.size", false, true),
     QUERY_TIMEOUT_SEC("query.timeout.sec"),
+    QUERY_TIMEOUT("query.timeout"),
     SHARED_WORKER_COUNT("shared.worker.count"),
     SHARED_WORKER_AFFINITY("shared.worker.affinity"),
     SHARED_WORKER_HALT_ON_ERROR("shared.worker.haltOnError"),

--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -139,8 +139,18 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         return nonCritical().put("cancelled by user").setInterruption(true).setCancellation(true);
     }
 
-    public static CairoException queryTimedOut(long fd) {
-        return nonCritical().put("timeout, query aborted [fd=").put(fd).put(']').setInterruption(true);
+    public static CairoException queryTimedOut(long fd, long runtime, long timeout) {
+        if (runtime > 0) {
+            return nonCritical()
+                    .put("timeout, query aborted [fd=").put(fd)
+                    .put(", runtime=").put(runtime).put("us")
+                    .put(", timeout=").put(timeout).put("us")
+                    .put(']').setInterruption(true);
+        }
+        return nonCritical()
+                .put("timeout, query aborted [fd=").put(fd)
+                .put(", forced=true]")
+                .setInterruption(true);
     }
 
     public static CairoException queryTimedOut() {

--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -140,17 +140,11 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public static CairoException queryTimedOut(long fd, long runtime, long timeout) {
-        if (runtime > 0) {
-            return nonCritical()
-                    .put("timeout, query aborted [fd=").put(fd)
-                    .put(", runtime=").put(runtime).put("us")
-                    .put(", timeout=").put(timeout).put("us")
-                    .put(']').setInterruption(true);
-        }
         return nonCritical()
                 .put("timeout, query aborted [fd=").put(fd)
-                .put(", forced=true]")
-                .setInterruption(true);
+                .put(", runtime=").put(runtime).put("us")
+                .put(", timeout=").put(timeout).put("us")
+                .put(']').setInterruption(true);
     }
 
     public static CairoException queryTimedOut() {

--- a/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
@@ -241,11 +241,12 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
     }
 
     private void testTimeout() {
-        if (clock.getTicks() - timeout > powerUpTime) {
+        long runtime = clock.getTicks() - powerUpTime;
+        if (runtime > timeout) {
             if (isCancelled()) {
                 throw CairoException.queryCancelled(fd);
             } else {
-                throw CairoException.queryTimedOut(fd);
+                throw CairoException.queryTimedOut(fd, runtime, timeout);
             }
         }
     }

--- a/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
+++ b/core/src/main/java/io/questdb/cairo/vm/api/MemoryCR.java
@@ -94,7 +94,7 @@ public interface MemoryCR extends MemoryC, MemoryR {
     }
 
     default long getLong(long offset) {
-        assert addressOf(offset + Long.BYTES) > 0;
+        assert offset > -1 && addressOf(offset + Long.BYTES) > 0;
         return Unsafe.getUnsafe().getLong(addressOf(offset));
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -392,9 +392,6 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
         if (e.isAuthorizationError()) {
             return HTTP_FORBIDDEN;
         }
-        if (e.isInterruption()) {
-            return HTTP_CLIENT_TIMEOUT;
-        }
         return HTTP_BAD_REQUEST;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -336,13 +336,24 @@ public class JsonQueryProcessor implements HttpRequestProcessor, Closeable {
             try {
                 doResumeSend(state, context, sqlExecutionContext);
             } catch (CairoError e) {
-                internalError(context.getChunkedResponse(), context.getLastRequestBytesSent(), e.getFlyweightMessage(),
-                        HTTP_INTERNAL_ERROR, e, state, context.getMetrics()
+                internalError(
+                        context.getChunkedResponse(),
+                        context.getLastRequestBytesSent(),
+                        e.getFlyweightMessage(),
+                        HTTP_INTERNAL_ERROR,
+                        e,
+                        state,
+                        context.getMetrics()
                 );
             } catch (CairoException e) {
-                int statusCode = e.isInterruption() && !e.isCancellation() ? HTTP_CLIENT_TIMEOUT : HTTP_BAD_REQUEST;
-                internalError(context.getChunkedResponse(), context.getLastRequestBytesSent(), e.getFlyweightMessage(),
-                        statusCode, e, state, context.getMetrics()
+                internalError(
+                        context.getChunkedResponse(),
+                        context.getLastRequestBytesSent(),
+                        e.getFlyweightMessage(),
+                        HTTP_BAD_REQUEST,
+                        e,
+                        state,
+                        context.getMetrics()
                 );
             }
         }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/UpdateOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/UpdateOperation.java
@@ -99,7 +99,7 @@ public class UpdateOperation extends AbstractOperation {
             if (state == SqlExecutionCircuitBreaker.STATE_CANCELLED) {
                 throw CairoException.queryCancelled(circuitBreaker.getFd());
             } else {
-                throw CairoException.queryTimedOut(circuitBreaker.getFd());
+                throw CairoException.queryTimedOut(circuitBreaker.getFd(), 0, 0);
             }
         }
     }
@@ -137,7 +137,7 @@ public class UpdateOperation extends AbstractOperation {
 
     public void testTimeout() {
         if (requesterTimeout) {
-            throw CairoException.queryTimedOut(circuitBreaker.getFd());
+            throw CairoException.queryTimedOut(circuitBreaker.getFd(), 0, 0);
         }
 
         circuitBreaker.statefulThrowExceptionIfTripped();

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -142,10 +142,10 @@ config.validation.strict=true
 # the check reads \r\n from the input stream and discards it since some HTTP clients send this as a keep alive in between requests
 #net.test.connection.buffer.size=64
 
-# max execution time for read-only query in seconds, this can be a floating point value to specify 0.5s
+# max execution time for read-only query in seconds
 # "insert" type of queries are not aborted unless they
 # it is "insert as select", where select takes long time before producing rows for the insert
-query.timeout.sec=60
+query.timeout=1m
 
 ## HTTP MIN settings
 ##

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -896,7 +896,7 @@ public class PropServerConfigurationTest {
     @Test
     public void testJpTimestampTimezoneCustomUtcOffset() throws Exception {
         assertTimestampTimezone(
-                "月, 11 3 2024 06:11:40 UTC+08",
+                "月, 11 3月 2024 06:11:40 UTC+08",
                 "UTC+08",
                 "ja",
                 "E, d MMM yyyy HH:mm:ss Z",
@@ -912,7 +912,7 @@ public class PropServerConfigurationTest {
         );
 
         assertTimestampTimezone(
-                "星期日, 10 三月 2024 13:11:40.222555 -10:00",
+                "周日, 10 3月 2024 13:11:40.222555 -10:00",
                 "-10:00",
                 "zh",
                 "E, d MMM yyyy HH:mm:ss.SSSUUU Z",

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -896,7 +896,7 @@ public class PropServerConfigurationTest {
     @Test
     public void testJpTimestampTimezoneCustomUtcOffset() throws Exception {
         assertTimestampTimezone(
-                "月, 11 3月 2024 06:11:40 UTC+08",
+                "月, 11 3 2024 06:11:40 UTC+08",
                 "UTC+08",
                 "ja",
                 "E, d MMM yyyy HH:mm:ss Z",
@@ -912,7 +912,7 @@ public class PropServerConfigurationTest {
         );
 
         assertTimestampTimezone(
-                "周日, 10 3月 2024 13:11:40.222555 -10:00",
+                "星期日, 10 三月 2024 13:11:40.222555 -10:00",
                 "-10:00",
                 "zh",
                 "E, d MMM yyyy HH:mm:ss.SSSUUU Z",

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -602,7 +602,8 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.create.table.column.model.pool.capacity\tQDB_CAIRO_CREATE_TABLE_COLUMN_MODEL_POOL_CAPACITY\t16\tdefault\tfalse\tfalse\n" +
                                     "log.timestamp.format\tQDB_LOG_TIMESTAMP_FORMAT\tyyyy-MM-ddTHH:mm:ss.SSSUUUz\tdefault\tfalse\tfalse\n" +
                                     "log.timestamp.locale\tQDB_LOG_TIMESTAMP_LOCALE\ten\tdefault\tfalse\tfalse\n" +
-                                    "log.timestamp.timezone\tQDB_LOG_TIMESTAMP_TIMEZONE\tZ\tdefault\tfalse\tfalse\n"
+                                    "log.timestamp.timezone\tQDB_LOG_TIMESTAMP_TIMEZONE\tZ\tdefault\tfalse\tfalse\n" +
+                                    "query.timeout\tQDB_QUERY_TIMEOUT\t60000\tdefault\tfalse\tfalse\n"
                             )
                                     .split("\n");
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -7856,10 +7856,10 @@ public class IODispatcherTest extends AbstractTest {
                         engine.execute(QUERY_TIMEOUT_TABLE_DDL, executionContext);
                         testHttpClient.assertGetRegexp(
                                 "/exp",
-                                "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"\\[-1\\] timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
+                                "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"\\[-1\\] timeout, query aborted \\[fd=\\d+, runtime=\\d+us, timeout=-100us\\]\",\"position\":0\\}",
                                 QUERY_TIMEOUT_SELECT,
                                 null, null, null, null,
-                                "408"
+                                "400"
                         );
                     }
                 });

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -4009,10 +4009,10 @@ public class IODispatcherTest extends AbstractTest {
                 .withQueryTimeout(100)
                 .run((engine, sqlExecutionContext) -> testHttpClient.assertGetRegexp(
                         "/query",
-                        "\\{\"query\":\"select \\* from test_data_unavailable\\(1, 10\\)\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
+                        "\\{\"query\":\"select \\* from test_data_unavailable\\(1, 10\\)\",\"error\":\"timeout, query aborted \\[fd=\\d+, runtime=\\d+us, timeout=\\d+us\\]\",\"position\":0\\}",
                         "select * from test_data_unavailable(1, 10)",
                         null, null, null, null,
-                        "408" // Request Timeout
+                        "400" // Request Timeout
                 ));
     }
 
@@ -5163,7 +5163,7 @@ public class IODispatcherTest extends AbstractTest {
                         // we use regexp, because the fd is different every time
                         testHttpClient.assertGetRegexp(
                                 "/query",
-                                "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
+                                "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted \\[fd=\\d+, runtime=\\d+us, timeout=-100us\\]\",\"position\":0\\}",
                                 "select i, avg(l), max(l) from t group by i order by i asc limit 3",
                                 null, null, null, null,
                                 "400"

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -5166,7 +5166,7 @@ public class IODispatcherTest extends AbstractTest {
                                 "\\{\"query\":\"select i, avg\\(l\\), max\\(l\\) from t group by i order by i asc limit 3\",\"error\":\"timeout, query aborted \\[fd=\\d+\\]\",\"position\":0\\}",
                                 "select i, avg(l), max(l) from t group by i order by i asc limit 3",
                                 null, null, null, null,
-                                "408"
+                                "400"
                         );
                     }
                 });

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1021,7 +1021,7 @@ public class CheckpointTest extends AbstractCairoTest {
                 latch1.countDown();
                 t.join();
                 Assert.assertFalse(lock.isLocked());
-                Assert.assertTrue(ex.getMessage().startsWith("[-1] timeout, query aborted [fd=-1]"));
+                TestUtils.assertContains(ex.getFlyweightMessage(), "timeout, query aborted [fd=-1");
             } finally {
                 execute("checkpoint release");
                 Assert.assertFalse(lock.isLocked());


### PR DESCRIPTION
We are going from this:

![image](https://github.com/user-attachments/assets/8f7b1ca1-cb29-4d0f-b397-b44dd03e97a2)

to this:

![image](https://github.com/user-attachments/assets/940971f0-2266-47e2-9ab8-aadd501e29fd)

### Extra changes:
- added an assertion to `RecordChain.of()` so that record chain cannot take illegal offset
- replaced `query.timeout.sec` with `query.timeout`. The value can be set as `query.timeout=5s` or `query.timeout=1m` etc. Old property is still supported but deprecated