### PR TITLE
perf(sql): speed up execution of window functions and joins on Windows platform

### DIFF
--- a/benchmarks/src/main/java/org/questdb/UnorderedVarcharMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/UnorderedVarcharMapBenchmark.java
@@ -152,8 +152,8 @@ public class UnorderedVarcharMapBenchmark {
     public void createMem() {
         FilesFacade ff = FilesFacadeImpl.INSTANCE;
         try (
-                MemoryMA auxAppendMem = Vm.getMAInstance(null);
-                MemoryMA dataAppendMem = Vm.getMAInstance(null)
+                MemoryMA auxAppendMem = Vm.getPMARInstance(null);
+                MemoryMA dataAppendMem = Vm.getPMARInstance(null)
         ) {
             try (Path path = new Path()) {
                 path.of(AUX_MEM_FILENAME);

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -46,7 +46,7 @@ jobs:
           jdk: "1.11"
           testset: "all"
           includeTests: "**/griffin/**"
-          excludeTests: "**/O3*Test**,**/Wal**Fuzz**"
+          excludeTests: "**/O3*Test**,**/**Fuzz**"
           javadoc_step: ""
           javadoc_profile: ""
         windows-griffin-O3-Fuzz:
@@ -55,7 +55,7 @@ jobs:
           os: Windows
           jdk: "1.11"
           testset: "all"
-          includeTests: "**/griffin/O3*Test**,**/Wal**Fuzz**"
+          includeTests: "**/O3*Test**,**/**Fuzz**"
           javadoc_step: ""
           javadoc_profile: ""
         windows-cairo:
@@ -65,6 +65,7 @@ jobs:
           jdk: "1.11"
           testset: "all"
           includeTests: "**/cairo/**"
+          excludeTests: "**/O3*Test**,**/**Fuzz**"
           javadoc_step: ""
           javadoc_profile: ""
         windows-pgwire:

--- a/core/rust/qdbr/rust-toolchain.toml
+++ b/core/rust/qdbr/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2025-01-07"

--- a/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/BitmapIndexWriter.java
@@ -43,8 +43,8 @@ public class BitmapIndexWriter implements Closeable, Mutable {
     private final CairoConfiguration configuration;
     private final Cursor cursor = new Cursor();
     private final FilesFacade ff;
-    private final MemoryMARW keyMem = Vm.getMARWInstance();
-    private final MemoryMARW valueMem = Vm.getMARWInstance();
+    private final MemoryMARW keyMem = Vm.getCMARWInstance();
+    private final MemoryMARW valueMem = Vm.getCMARWInstance();
     private int blockCapacity;
     private int blockValueCountMod;
     private int keyCount = -1;

--- a/core/src/main/java/io/questdb/cairo/IndexBuilder.java
+++ b/core/src/main/java/io/questdb/cairo/IndexBuilder.java
@@ -45,7 +45,7 @@ public class IndexBuilder extends RebuildColumnBase {
 
     public IndexBuilder(CairoConfiguration configuration) {
         super(configuration);
-        ddlMem = Vm.getMARInstance(configuration);
+        ddlMem = Vm.getPMARInstance(configuration);
         indexer = new SymbolColumnIndexer(configuration);
         unsupportedColumnMessage = "Column is not indexed";
     }

--- a/core/src/main/java/io/questdb/cairo/SymbolMapUtil.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapUtil.java
@@ -158,7 +158,7 @@ public class SymbolMapUtil {
 
     private static MemoryMARW open(CairoConfiguration configuration, FilesFacade ff, long mapPageSize, long size, LPSZ path, MemoryMARW mem) {
         if (mem == null) {
-            mem = Vm.getMARWInstance(
+            mem = Vm.getCMARWInstance(
                     ff,
                     path,
                     mapPageSize,

--- a/core/src/main/java/io/questdb/cairo/TableConverter.java
+++ b/core/src/main/java/io/questdb/cairo/TableConverter.java
@@ -83,7 +83,7 @@ public class TableConverter {
                                 .I$();
 
                         path.trimTo(rootLen).concat(dirNameSink);
-                        try (final MemoryMARW metaMem = Vm.getMARWInstance()) {
+                        try (final MemoryMARW metaMem = Vm.getCMARWInstance()) {
                             openSmallFile(ff, path, rootLen, metaMem, META_FILE_NAME, MemoryTag.MMAP_SEQUENCER_METADATA);
                             final String dirName = dirNameSink.toString();
                             TableToken existingToken = tableNameRegistry.getTableTokenByDirName(dirName);

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -397,12 +397,10 @@ public final class TableUtils {
             CharSequence dirName
     ) {
         try (
-                Path path = new Path()
+                Path path = new Path();
+                MemoryMARW mem = Vm.getCMARWInstance()
         ) {
-            try (MemoryMARW mem = Vm.getCMARWInstance()
-            ) {
-                createTable(ff, root, mkDirMode, mem, path, dirName, structure, tableVersion, tableId);
-            }
+            createTable(ff, root, mkDirMode, mem, path, dirName, structure, tableVersion, tableId);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -229,7 +229,7 @@ public final class TableUtils {
         // If Low short mismatches it means we cannot rely on High short value.
         // High short is TableUtils.META_MINOR_VERSION_LATEST.
         // Metadata minor version mismatch still allows to read the table, the table storage is forward and backward compatible.
-        // However it indicates some minor flags may be stored incorrectly and have to be re-calculated.
+        // However, it indicates some minor flags may be stored incorrectly and have to be re-calculated.
         return Numbers.encodeLowHighShorts(Numbers.decodeLowShort(metadataVersion), META_MINOR_VERSION_LATEST);
     }
 
@@ -397,10 +397,12 @@ public final class TableUtils {
             CharSequence dirName
     ) {
         try (
-                Path path = new Path();
-                MemoryMARW mem = Vm.getMARWInstance()
+                Path path = new Path()
         ) {
-            createTable(ff, root, mkDirMode, mem, path, dirName, structure, tableVersion, tableId);
+            try (MemoryMARW mem = Vm.getCMARWInstance()
+            ) {
+                createTable(ff, root, mkDirMode, mem, path, dirName, structure, tableVersion, tableId);
+            }
         }
     }
 
@@ -588,21 +590,6 @@ public final class TableUtils {
 
     public static LPSZ dFile(Path path, CharSequence columnName) {
         return dFile(path, columnName, COLUMN_NAME_TXN_NONE);
-    }
-
-    public static boolean equalColumnNamesAndTypes(RecordMetadata metadataA, RecordMetadata metadataB) {
-        if (metadataA.getColumnCount() != metadataB.getColumnCount()) {
-            return false;
-        }
-        for (int i = 0, n = metadataA.getColumnCount(); i < n; i++) {
-            if (metadataA.getColumnType(i) != metadataB.getColumnType(i)) {
-                return false;
-            }
-            if (!Chars.equals(metadataA.getColumnName(i), metadataB.getColumnName(i))) {
-                return false;
-            }
-        }
-        return true;
     }
 
     public static long estimateAvgRecordSize(RecordMetadata metadata) {
@@ -1929,7 +1916,6 @@ public final class TableUtils {
     }
 
     static {
-        //noinspection ConstantValue
         assert TX_OFFSET_LAG_MAX_TIMESTAMP_64 + 8 <= TX_OFFSET_MAP_WRITER_COUNT_32;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -241,7 +241,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final TxReader slaveTxReader;
     private final ObjList<MapWriter> symbolMapWriters;
     private final IntList symbolRewriteMap = new IntList();
-    private final MemoryMARW todoMem = Vm.getMARWInstance();
+    private final MemoryMARW todoMem = Vm.getCMARWInstance();
     private final TxWriter txWriter;
     private final TxnScoreboard txnScoreboard;
     private final Utf8StringSink utf8Sink = new Utf8StringSink();
@@ -3967,12 +3967,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final MemoryCARW o3AuxMem2;
 
         if (type > 0) {
-            dataMem = Vm.getMAInstance(configuration);
+            dataMem = Vm.getPMARInstance(configuration);
             o3DataMem1 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
             o3DataMem2 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
 
             if (ColumnType.isVarSize(type)) {
-                auxMem = Vm.getMAInstance(configuration);
+                auxMem = Vm.getPMARInstance(configuration);
                 o3AuxMem1 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
                 o3AuxMem2 = Vm.getCARWInstance(o3ColumnMemorySize, configuration.getO3MemMaxPages(), MemoryTag.NATIVE_O3);
             } else {

--- a/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
+++ b/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
@@ -68,82 +68,85 @@ public class EngineMigration {
         int tempMemSize = Long.BYTES;
         long mem = Unsafe.malloc(tempMemSize, MemoryTag.NATIVE_MIG);
 
-        try (
-                MemoryARW virtualMem = Vm.getARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_MIG_MMAP);
-                Path path = new Path();
-                MemoryMARW rwMemory = Vm.getMARWInstance()
-        ) {
-            MigrationContext context = new MigrationContext(engine, mem, tempMemSize, virtualMem, rwMemory);
-            path.of(configuration.getRoot());
+        try {
+            try (MemoryARW virtualMem = Vm.getCARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_MIG_MMAP);
+                 Path path = new Path()
+            ) {
+                try (MemoryMARW rwMemory = Vm.getCMARWInstance()
+                ) {
+                    MigrationContext context = new MigrationContext(engine, mem, tempMemSize, virtualMem, rwMemory);
+                    path.of(configuration.getRoot());
 
-            // check if all tables have been upgraded already
-            path.concat(TableUtils.UPGRADE_FILE_NAME);
-            final boolean existed = !force && ff.exists(path.$());
-            long upgradeFd = openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
-            LOG.debug()
-                    .$("open [fd=").$(upgradeFd)
-                    .$(", path=").$(path)
-                    .I$();
-            if (existed) {
-                int currentTableVersion = ff.readNonNegativeInt(upgradeFd, 0);
+                    // check if all tables have been upgraded already
+                    path.concat(TableUtils.UPGRADE_FILE_NAME);
+                    final boolean existed = !force && ff.exists(path.$());
+                    long upgradeFd = openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
+                    LOG.debug()
+                            .$("open [fd=").$(upgradeFd)
+                            .$(", path=").$(path)
+                            .I$();
+                    if (existed) {
+                        int currentTableVersion = ff.readNonNegativeInt(upgradeFd, 0);
 
-                if (currentTableVersion > latestTableVersion) {
-                    ff.close(upgradeFd);
-                    LOG.critical().$("database storage is marked as upgraded to an incompatible version, ")
-                            .$(". Upgrade the database or ")
-                            .$("remove file ")
-                            .$(TableUtils.UPGRADE_FILE_NAME)
-                            .$((" to force proceed"))
-                            .$(" [storageVersion=").$(currentTableVersion)
-                            .$(", databaseVersion=").$(latestTableVersion).I$();
+                        if (currentTableVersion > latestTableVersion) {
+                            ff.close(upgradeFd);
+                            LOG.critical().$("database storage is marked as upgraded to an incompatible version, ")
+                                    .$(". Upgrade the database or ")
+                                    .$("remove file ")
+                                    .$(TableUtils.UPGRADE_FILE_NAME)
+                                    .$((" to force proceed"))
+                                    .$(" [storageVersion=").$(currentTableVersion)
+                                    .$(", databaseVersion=").$(latestTableVersion).I$();
 
-                    throw CairoException.critical(0)
-                            .put("database storage is marked as upgraded to an incompatible version, ")
-                            .put(". Upgrade the database or ")
-                            .put("remove file ")
-                            .put(TableUtils.UPGRADE_FILE_NAME)
-                            .put(" [storageVersion=").put(currentTableVersion)
-                            .put(", databaseVersion=").put(latestTableVersion);
+                            throw CairoException.critical(0)
+                                    .put("database storage is marked as upgraded to an incompatible version, ")
+                                    .put(". Upgrade the database or ")
+                                    .put("remove file ")
+                                    .put(TableUtils.UPGRADE_FILE_NAME)
+                                    .put(" [storageVersion=").put(currentTableVersion)
+                                    .put(", databaseVersion=").put(latestTableVersion);
+                        }
+
+                        int currentMigrationVersion = ff.readNonNegativeInt(upgradeFd, 4);
+                        if (currentMigrationVersion <= 0 || configuration.getRepeatMigrationsFromVersion() == currentTableVersion) {
+                            currentMigrationVersion = currentTableVersion;
+                        }
+
+                        if (currentMigrationVersion == latestMigrationVersion) {
+                            LOG.info().$("upgraded to [migrationVersion=").$(currentMigrationVersion).I$();
+                            ff.fsyncAndClose(upgradeFd);
+                            return;
+                        }
+                    }
+
+                    try {
+                        LOG.info().$("upgrading database [version=").$(latestMigrationVersion).I$();
+                        upgradeTables(context, latestTableVersion, latestMigrationVersion);
+                        TableUtils.writeIntOrFail(
+                                ff,
+                                upgradeFd,
+                                0,
+                                latestTableVersion,
+                                mem,
+                                path
+                        );
+                        TableUtils.writeIntOrFail(
+                                ff,
+                                upgradeFd,
+                                4,
+                                latestMigrationVersion,
+                                mem,
+                                path
+                        );
+                    } finally {
+                        Vm.bestEffortClose(
+                                ff,
+                                LOG,
+                                upgradeFd,
+                                2 * Integer.BYTES
+                        );
+                    }
                 }
-
-                int currentMigrationVersion = ff.readNonNegativeInt(upgradeFd, 4);
-                if (currentMigrationVersion <= 0 || configuration.getRepeatMigrationsFromVersion() == currentTableVersion) {
-                    currentMigrationVersion = currentTableVersion;
-                }
-
-                if (currentMigrationVersion == latestMigrationVersion) {
-                    LOG.info().$("upgraded to [migrationVersion=").$(currentMigrationVersion).I$();
-                    ff.fsyncAndClose(upgradeFd);
-                    return;
-                }
-            }
-
-            try {
-                LOG.info().$("upgrading database [version=").$(latestMigrationVersion).I$();
-                upgradeTables(context, latestTableVersion, latestMigrationVersion);
-                TableUtils.writeIntOrFail(
-                        ff,
-                        upgradeFd,
-                        0,
-                        latestTableVersion,
-                        mem,
-                        path
-                );
-                TableUtils.writeIntOrFail(
-                        ff,
-                        upgradeFd,
-                        4,
-                        latestMigrationVersion,
-                        mem,
-                        path
-                );
-            } finally {
-                Vm.bestEffortClose(
-                        ff,
-                        LOG,
-                        upgradeFd,
-                        2 * Integer.BYTES
-                );
             }
         } finally {
             Unsafe.free(mem, tempMemSize, MemoryTag.NATIVE_MIG);

--- a/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
+++ b/core/src/main/java/io/questdb/cairo/mig/EngineMigration.java
@@ -68,84 +68,82 @@ public class EngineMigration {
         int tempMemSize = Long.BYTES;
         long mem = Unsafe.malloc(tempMemSize, MemoryTag.NATIVE_MIG);
 
-        try {
-            try (
-                    MemoryARW virtualMem = Vm.getCARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_MIG_MMAP);
-                    Path path = new Path();
-                    MemoryMARW rwMemory = Vm.getCMARWInstance()
-            ) {
-                MigrationContext context = new MigrationContext(engine, mem, tempMemSize, virtualMem, rwMemory);
-                path.of(configuration.getRoot());
+        try (
+                MemoryARW virtualMem = Vm.getCARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_MIG_MMAP);
+                Path path = new Path();
+                MemoryMARW rwMemory = Vm.getCMARWInstance()
+        ) {
+            MigrationContext context = new MigrationContext(engine, mem, tempMemSize, virtualMem, rwMemory);
+            path.of(configuration.getRoot());
 
-                // check if all tables have been upgraded already
-                path.concat(TableUtils.UPGRADE_FILE_NAME);
-                final boolean existed = !force && ff.exists(path.$());
-                long upgradeFd = openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
-                LOG.debug()
-                        .$("open [fd=").$(upgradeFd)
-                        .$(", path=").$(path)
-                        .I$();
-                if (existed) {
-                    int currentTableVersion = ff.readNonNegativeInt(upgradeFd, 0);
+            // check if all tables have been upgraded already
+            path.concat(TableUtils.UPGRADE_FILE_NAME);
+            final boolean existed = !force && ff.exists(path.$());
+            long upgradeFd = openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
+            LOG.debug()
+                    .$("open [fd=").$(upgradeFd)
+                    .$(", path=").$(path)
+                    .I$();
+            if (existed) {
+                int currentTableVersion = ff.readNonNegativeInt(upgradeFd, 0);
 
-                    if (currentTableVersion > latestTableVersion) {
-                        ff.close(upgradeFd);
-                        LOG.critical().$("database storage is marked as upgraded to an incompatible version, ")
-                                .$(". Upgrade the database or ")
-                                .$("remove file ")
-                                .$(TableUtils.UPGRADE_FILE_NAME)
-                                .$((" to force proceed"))
-                                .$(" [storageVersion=").$(currentTableVersion)
-                                .$(", databaseVersion=").$(latestTableVersion).I$();
+                if (currentTableVersion > latestTableVersion) {
+                    ff.close(upgradeFd);
+                    LOG.critical().$("database storage is marked as upgraded to an incompatible version, ")
+                            .$(". Upgrade the database or ")
+                            .$("remove file ")
+                            .$(TableUtils.UPGRADE_FILE_NAME)
+                            .$((" to force proceed"))
+                            .$(" [storageVersion=").$(currentTableVersion)
+                            .$(", databaseVersion=").$(latestTableVersion).I$();
 
-                        throw CairoException.critical(0)
-                                .put("database storage is marked as upgraded to an incompatible version, ")
-                                .put(". Upgrade the database or ")
-                                .put("remove file ")
-                                .put(TableUtils.UPGRADE_FILE_NAME)
-                                .put(" [storageVersion=").put(currentTableVersion)
-                                .put(", databaseVersion=").put(latestTableVersion);
-                    }
-
-                    int currentMigrationVersion = ff.readNonNegativeInt(upgradeFd, 4);
-                    if (currentMigrationVersion <= 0 || configuration.getRepeatMigrationsFromVersion() == currentTableVersion) {
-                        currentMigrationVersion = currentTableVersion;
-                    }
-
-                    if (currentMigrationVersion == latestMigrationVersion) {
-                        LOG.info().$("upgraded to [migrationVersion=").$(currentMigrationVersion).I$();
-                        ff.fsyncAndClose(upgradeFd);
-                        return;
-                    }
+                    throw CairoException.critical(0)
+                            .put("database storage is marked as upgraded to an incompatible version, ")
+                            .put(". Upgrade the database or ")
+                            .put("remove file ")
+                            .put(TableUtils.UPGRADE_FILE_NAME)
+                            .put(" [storageVersion=").put(currentTableVersion)
+                            .put(", databaseVersion=").put(latestTableVersion);
                 }
 
-                try {
-                    LOG.info().$("upgrading database [version=").$(latestMigrationVersion).I$();
-                    upgradeTables(context, latestTableVersion, latestMigrationVersion);
-                    TableUtils.writeIntOrFail(
-                            ff,
-                            upgradeFd,
-                            0,
-                            latestTableVersion,
-                            mem,
-                            path
-                    );
-                    TableUtils.writeIntOrFail(
-                            ff,
-                            upgradeFd,
-                            4,
-                            latestMigrationVersion,
-                            mem,
-                            path
-                    );
-                } finally {
-                    Vm.bestEffortClose(
-                            ff,
-                            LOG,
-                            upgradeFd,
-                            2 * Integer.BYTES
-                    );
+                int currentMigrationVersion = ff.readNonNegativeInt(upgradeFd, 4);
+                if (currentMigrationVersion <= 0 || configuration.getRepeatMigrationsFromVersion() == currentTableVersion) {
+                    currentMigrationVersion = currentTableVersion;
                 }
+
+                if (currentMigrationVersion == latestMigrationVersion) {
+                    LOG.info().$("upgraded to [migrationVersion=").$(currentMigrationVersion).I$();
+                    ff.fsyncAndClose(upgradeFd);
+                    return;
+                }
+            }
+
+            try {
+                LOG.info().$("upgrading database [version=").$(latestMigrationVersion).I$();
+                upgradeTables(context, latestTableVersion, latestMigrationVersion);
+                TableUtils.writeIntOrFail(
+                        ff,
+                        upgradeFd,
+                        0,
+                        latestTableVersion,
+                        mem,
+                        path
+                );
+                TableUtils.writeIntOrFail(
+                        ff,
+                        upgradeFd,
+                        4,
+                        latestMigrationVersion,
+                        mem,
+                        path
+                );
+            } finally {
+                Vm.bestEffortClose(
+                        ff,
+                        LOG,
+                        upgradeFd,
+                        2 * Integer.BYTES
+                );
             }
         } finally {
             Unsafe.free(mem, tempMemSize, MemoryTag.NATIVE_MIG);

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCARWImpl.java
@@ -28,7 +28,11 @@ import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.engine.LimitOverflowException;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.*;
+import io.questdb.std.Long256Acceptor;
+import io.questdb.std.Mutable;
+import io.questdb.std.Numbers;
+import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -167,29 +171,39 @@ public class MemoryCARWImpl extends AbstractMemoryCR implements MemoryCARW, Muta
         extend0(address - pageAddress);
     }
 
-    private void extend0(long size) {
-        if (size == 0 && pageAddress == 0) {
+    private void extend0(final long requiredSize) {
+        if (requiredSize == 0 && pageAddress == 0) {
             return;
         }
 
-        long nPages = size > 0 ? ((size - 1) >>> sizeMsb) + 1 : 1;
-        size = nPages << sizeMsb;
         final long oldSize = size();
+        final long newPageCount = getNewPageCount(requiredSize, oldSize);
+        final long newSize = newPageCount << sizeMsb;
 
         // sometimes the resize request ends up being the same
         // as existing memory size
-        if (size == oldSize) {
+        if (newSize <= oldSize && requiredSize > 0) {
             return;
         }
 
-        if (nPages > maxPages) {
+        if (newPageCount > maxPages) {
             throw LimitOverflowException.instance().put("Maximum number of pages (").put(maxPages).put(") breached in VirtualMemory");
         }
-        final long newBaseAddress = reallocateMemory(pageAddress, size(), size);
+        final long newBaseAddress = reallocateMemory(pageAddress, size(), newSize);
         if (oldSize > 0) {
-            LOG.debug().$("extended [oldBase=").$(pageAddress).$(", newBase=").$(newBaseAddress).$(", oldSize=").$(oldSize).$(", newSize=").$(size).$(']').$();
+            LOG.debug().$("extended [oldBase=").$(pageAddress).$(", newBase=").$(newBaseAddress).$(", oldSize=").$(oldSize).$(", newSize=").$(newSize).$(']').$();
         }
-        handleMemoryReallocation(newBaseAddress, size);
+        handleMemoryReallocation(newBaseAddress, newSize);
+    }
+
+    private long getNewPageCount(long requiredSize, long oldSize) {
+        final long minPageCount = requiredSize > 0 ? ((requiredSize - 1) >>> sizeMsb) + 1 : 1;
+        if (oldSize > 0 && requiredSize > 0 && minPageCount * 2 < maxPages) {
+            // double the page count on each resize to avoid frequent resizes, unless this is
+            // are request to downsize the memory or aggressive resize will throw us over the limit
+            return minPageCount * 2;
+        }
+        return minPageCount;
     }
 
     protected final void handleMemoryReallocation(long newBaseAddress, long newSize) {

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCARWImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCARWImpl.java
@@ -200,7 +200,7 @@ public class MemoryCARWImpl extends AbstractMemoryCR implements MemoryCARW, Muta
         final long minPageCount = requiredSize > 0 ? ((requiredSize - 1) >>> sizeMsb) + 1 : 1;
         if (oldSize > 0 && requiredSize > 0 && minPageCount * 2 < maxPages) {
             // double the page count on each resize to avoid frequent resizes, unless this is
-            // are request to downsize the memory or aggressive resize will throw us over the limit
+            // a request to downsize the memory or aggressive resize will throw us over the limit
             return minPageCount * 2;
         }
         return minPageCount;

--- a/core/src/main/java/io/questdb/cairo/vm/Vm.java
+++ b/core/src/main/java/io/questdb/cairo/vm/Vm.java
@@ -25,7 +25,12 @@
 package io.questdb.cairo.vm;
 
 import io.questdb.cairo.CairoConfiguration;
-import io.questdb.cairo.vm.api.*;
+import io.questdb.cairo.vm.api.MemoryCARW;
+import io.questdb.cairo.vm.api.MemoryCMARW;
+import io.questdb.cairo.vm.api.MemoryCMOR;
+import io.questdb.cairo.vm.api.MemoryCMR;
+import io.questdb.cairo.vm.api.MemoryMAR;
+import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.log.Log;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
@@ -71,20 +76,12 @@ public class Vm {
         return bestEffortTruncate(ff, log, fd, size, TRUNCATE_TO_PAGE);
     }
 
-    public static MemoryAR getARInstance(long pageSize, int maxPages, int memoryTag) {
-        return new MemoryCARWImpl(pageSize, maxPages, memoryTag);
-    }
-
-    public static MemoryARW getARWInstance(long pageSize, int maxPages, int memoryTag) {
-        return new MemoryCARWImpl(pageSize, maxPages, memoryTag);
-    }
-
     public static MemoryCARW getCARWInstance(long pageSize, int maxPages, int memoryTag) {
         return new MemoryCARWImpl(pageSize, maxPages, memoryTag);
     }
 
-    public static MemoryCMARW getCMARWInstance(FilesFacade ff, LPSZ name, long pageSize, long size, int memoryTag, long opts) {
-        return new MemoryCMARWImpl(ff, name, pageSize, size, memoryTag, opts);
+    public static MemoryCMARW getCMARWInstance(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag, long opts) {
+        return new MemoryCMARWImpl(ff, name, extendSegmentSize, size, memoryTag, opts);
     }
 
     public static MemoryCMARW getCMARWInstance() {
@@ -99,31 +96,15 @@ public class Vm {
         return new MemoryCMRImpl(ff, name, size, memoryTag);
     }
 
-    public static MemoryMA getMAInstance(CairoConfiguration configuration) {
-        return new MemoryPMARImpl(configuration);
-    }
-
-    public static MemoryMAR getMARInstance(CairoConfiguration configuration) {
-        return new MemoryPMARImpl(configuration);
-    }
-
-    public static MemoryMARW getMARWInstance() {
-        return new MemoryCMARWImpl();
-    }
-
-    public static MemoryMARW getMARWInstance(FilesFacade ff, LPSZ name, long extendSegmentSize, long size, int memoryTag, long opts) {
-        return new MemoryCMARWImpl(ff, name, extendSegmentSize, size, memoryTag, opts);
-    }
-
     public static MemoryCMOR getMemoryCMOR() {
         return new MemoryCMORImpl();
     }
 
-    public static MemoryCMARW getSmallCMARWInstance(FilesFacade ff, LPSZ name, int memoryTag, long opts) {
-        return new MemoryCMARWImpl(ff, name, ff.getPageSize(), -1, memoryTag, opts);
+    public static MemoryMAR getPMARInstance(CairoConfiguration configuration) {
+        return new MemoryPMARImpl(configuration);
     }
 
-    public static MemoryMA getSmallMAInstance(FilesFacade ff, LPSZ name, int memoryTag, long opts) {
+    public static MemoryCMARW getSmallCMARWInstance(FilesFacade ff, LPSZ name, int memoryTag, long opts) {
         return new MemoryCMARWImpl(ff, name, ff.getPageSize(), -1, memoryTag, opts);
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -44,7 +44,7 @@ import static io.questdb.cairo.wal.WalUtils.*;
 
 class WalEventWriter implements Closeable {
     private final CairoConfiguration configuration;
-    private final MemoryMARW eventMem = Vm.getMARWInstance();
+    private final MemoryMARW eventMem = Vm.getCMARWInstance();
     private final FilesFacade ff;
     private final StringSink sink = new StringSink();
     private long indexFd;

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -180,7 +180,7 @@ public class WalWriter implements TableWriterAPI {
         this.pathSize = path.size();
         this.metrics = configuration.getMetrics();
         this.open = true;
-        this.symbolMapMem = Vm.getMARInstance(configuration);
+        this.symbolMapMem = Vm.getPMARInstance(configuration);
 
         try {
             lockWal();
@@ -933,7 +933,7 @@ public class WalWriter implements TableWriterAPI {
     private void configureColumn(int columnIndex, int columnType) {
         final int dataColumnOffset = getDataColumnOffset(columnIndex);
         if (columnType > 0) {
-            final MemoryMA dataMem = Vm.getMAInstance(configuration);
+            final MemoryMA dataMem = Vm.getPMARInstance(configuration);
             final MemoryMA auxMem = createAuxColumnMem(columnType);
             columns.extendAndSet(dataColumnOffset, dataMem);
             columns.extendAndSet(dataColumnOffset + 1, auxMem);
@@ -1126,7 +1126,7 @@ public class WalWriter implements TableWriterAPI {
     }
 
     private MemoryMA createAuxColumnMem(int columnType) {
-        return ColumnType.isVarSize(columnType) ? Vm.getMAInstance(configuration) : null;
+        return ColumnType.isVarSize(columnType) ? Vm.getPMARInstance(configuration) : null;
     }
 
     private SegmentColumnRollSink createSegmentColumnRollSink() {

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriterMetadata.java
@@ -61,7 +61,7 @@ public class WalWriterMetadata extends AbstractRecordMetadata implements TableRe
     public WalWriterMetadata(FilesFacade ff, boolean readonly) {
         this.ff = ff;
         if (!readonly) {
-            roMetaMem = metaMem = Vm.getMARWInstance();
+            roMetaMem = metaMem = Vm.getCMARWInstance();
         } else {
             metaMem = null;
             roMetaMem = Vm.getCMRInstance();

--- a/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/SequencerMetadata.java
@@ -67,7 +67,7 @@ public class SequencerMetadata extends AbstractRecordMetadata implements TableRe
         this.ff = ff;
         this.readonly = readonly;
         if (!readonly) {
-            roMetaMem = metaMem = Vm.getMARWInstance();
+            roMetaMem = metaMem = Vm.getCMARWInstance();
         } else {
             metaMem = null;
             roMetaMem = Vm.getCMRInstance();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpTudCache.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpTudCache.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.NotNull;
 public class LineHttpTudCache implements QuietCloseable {
     private final boolean autoCreateNewColumns;
     private final boolean autoCreateNewTables;
-    private final MemoryMARW ddlMem = Vm.getMARWInstance();
+    private final MemoryMARW ddlMem = Vm.getCMARWInstance();
     private final DefaultColumnTypes defaultColumnTypes;
     private final CairoEngine engine;
     private final TableCreateException parseException = new TableCreateException();

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -55,7 +55,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
     private final boolean autoCreateNewTables;
     private final MillisecondClock clock;
     private final LineTcpReceiverConfiguration configuration;
-    private final MemoryMARW ddlMem = Vm.getMARWInstance();
+    private final MemoryMARW ddlMem = Vm.getCMARWInstance();
     private final DefaultColumnTypes defaultColumnTypes;
     private final CairoEngine engine;
     private final LowerCaseCharSequenceObjHashMap<TableUpdateDetails> idleTableUpdateDetailsUtf16;

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -73,7 +73,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
     private final LongList columnValues = new LongList();
     private final CharSequenceObjHashMap<TableWriter> commitList = new CharSequenceObjHashMap<>();
     private final CairoConfiguration configuration;
-    private final MemoryMARW ddlMem = Vm.getMARWInstance();
+    private final MemoryMARW ddlMem = Vm.getCMARWInstance();
     private final short defaultFloatColumnType;
     private final short defaultIntegerColumnType;
     private final CairoEngine engine;

--- a/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CairoTextWriter.java
@@ -68,7 +68,7 @@ public class CairoTextWriter implements Closeable, Mutable {
     private static final String WRITER_LOCK_REASON = "textWriter";
     private final LongList columnErrorCounts = new LongList();
     private final CairoConfiguration configuration;
-    private final MemoryMARW ddlMem = Vm.getMARWInstance();
+    private final MemoryMARW ddlMem = Vm.getCMARWInstance();
     private final CairoEngine engine;
     private final ObjectPool<OtherToTimestampAdapter> otherToTimestampAdapterPool = new ObjectPool<>(OtherToTimestampAdapter::new, 4);
     private final IntList remapIndex = new IntList();

--- a/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
+++ b/core/src/main/java/io/questdb/cutlass/text/ParallelCsvFileImporter.java
@@ -302,7 +302,7 @@ public class ParallelCsvFileImporter implements Closeable, Mutable {
                     }
                 case TableUtils.TABLE_DOES_NOT_EXIST:
                     securityContext.authorizeTableCreate();
-                    try (MemoryMARW memory = Vm.getMARWInstance()) {
+                    try (MemoryMARW memory = Vm.getCMARWInstance()) {
                         TableUtils.createTable(
                                 ff,
                                 root,

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -167,7 +167,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
     private final FunctionParser functionParser;
     private final ListColumnFilter listColumnFilter = new ListColumnFilter();
     private final int maxRecompileAttempts;
-    private final MemoryMARW mem = Vm.getMARWInstance();
+    private final MemoryMARW mem = Vm.getCMARWInstance();
     private final MessageBus messageBus;
     private final SqlParser parser;
     private final TimestampValueRecord partitionFunctionRec = new TimestampValueRecord();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringMemory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringMemory.java
@@ -63,8 +63,8 @@ class RndStringMemory implements Closeable {
             }
 
             final int idxPages = count * 8 / pageSize + 1;
-            strMem = Vm.getARInstance(pageSize, maxPages - idxPages, MemoryTag.NATIVE_FUNC_RSS);
-            idxMem = Vm.getARInstance(pageSize, idxPages, MemoryTag.NATIVE_FUNC_RSS);
+            strMem = Vm.getCARWInstance(pageSize, maxPages - idxPages, MemoryTag.NATIVE_FUNC_RSS);
+            idxMem = Vm.getCARWInstance(pageSize, idxPages, MemoryTag.NATIVE_FUNC_RSS);
         } catch (Throwable th) {
             close();
             throw th;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/AvgDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/AvgDoubleWindowFunctionFactory.java
@@ -131,7 +131,7 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 AVG_OVER_PARTITION_RANGE_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -204,7 +204,7 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 AVG_OVER_PARTITION_ROWS_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -265,7 +265,7 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     return new AvgOverWholeResultSetFunction(args.get(0));
                 } // between [unbounded | x] preceding and [x preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -403,11 +403,11 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
         private final long maxDiff;
         // holds resizable ring buffers
         private final MemoryARW memory;
+        private final RingBufferDesc memoryDesc = new RingBufferDesc();
         private final long minDiff;
         private final int timestampIndex;
         protected double sum;
         private double avg;
-        private final RingBufferDesc memoryDesc = new RingBufferDesc();
 
         public AvgOverPartitionRangeFrameFunction(
                 Map map,
@@ -883,7 +883,11 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     rangeHi,
                     arg,
                     configuration.getSqlWindowStorePageSize() / RECORD_SIZE,
-                    Vm.getARWInstance(configuration.getSqlWindowStorePageSize(), configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER),
+                    Vm.getCARWInstance(
+                            configuration.getSqlWindowStorePageSize(),
+                            configuration.getSqlWindowStoreMaxPages(),
+                            MemoryTag.NATIVE_CIRCULAR_BUFFER
+                    ),
                     timestampIdx
             );
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/CountConstWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/CountConstWindowFunctionFactory.java
@@ -112,7 +112,7 @@ public class CountConstWindowFunctionFactory extends AbstractWindowFunctionFacto
                                 partitionByKeyTypes,
                                 CountFunctionFactoryHelper.COUNT_OVER_PARTITION_RANGE_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/CountDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/CountDoubleWindowFunctionFactory.java
@@ -42,6 +42,6 @@ public class CountDoubleWindowFunctionFactory extends AbstractWindowFunctionFact
 
     @Override
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
-        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, argPositions, configuration, sqlExecutionContext, isRecordNotNull);
+        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, configuration, sqlExecutionContext, isRecordNotNull);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/CountFunctionFactoryHelper.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/CountFunctionFactoryHelper.java
@@ -46,7 +46,6 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.window.WindowContext;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.model.WindowColumn;
-import io.questdb.std.IntList;
 import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
@@ -63,7 +62,6 @@ public class CountFunctionFactoryHelper {
     static Function newCountWindowFunction(AbstractWindowFunctionFactory factory,
                                            int position,
                                            ObjList<Function> args,
-                                           IntList argPositions,
                                            CairoConfiguration configuration,
                                            SqlExecutionContext sqlExecutionContext,
                                            IsRecordNotNull isRecordNotNull) throws SqlException {
@@ -124,7 +122,7 @@ public class CountFunctionFactoryHelper {
                                 partitionByKeyTypes,
                                 CountFunctionFactoryHelper.COUNT_OVER_PARTITION_RANGE_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -193,7 +191,7 @@ public class CountFunctionFactoryHelper {
                                 partitionByKeyTypes,
                                 CountFunctionFactoryHelper.COUNT_OVER_PARTITION_ROWS_COLUMN_TYPES
                         );
-                        MemoryARW mem = Vm.getARWInstance(
+                        MemoryARW mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -254,7 +252,7 @@ public class CountFunctionFactoryHelper {
                     return new CountOverWholeResultSetFunction(args.get(0), isRecordNotNull);
                 } // between [unbounded | x] preceding and [x preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -788,7 +786,11 @@ public class CountFunctionFactoryHelper {
         ) {
             super(arg);
             this.initialCapacity = configuration.getSqlWindowStorePageSize() / RECORD_SIZE;
-            this.memory = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(), configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER);
+            this.memory = Vm.getCARWInstance(
+                    configuration.getSqlWindowStorePageSize(),
+                    configuration.getSqlWindowStoreMaxPages(),
+                    MemoryTag.NATIVE_CIRCULAR_BUFFER
+            );
             this.isRecordNotNull = isRecordNotNull;
             frameLoBounded = rangeLo != Long.MIN_VALUE;
             maxDiff = frameLoBounded ? Math.abs(rangeLo) : Long.MAX_VALUE; // maxDiff must be used only if frameLoBounded

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/CountSymbolWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/CountSymbolWindowFunctionFactory.java
@@ -42,6 +42,6 @@ public class CountSymbolWindowFunctionFactory extends AbstractWindowFunctionFact
 
     @Override
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
-        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, argPositions, configuration, sqlExecutionContext, isRecordNotNull);
+        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, configuration, sqlExecutionContext, isRecordNotNull);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/CountVarcharWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/CountVarcharWindowFunctionFactory.java
@@ -41,6 +41,6 @@ public class CountVarcharWindowFunctionFactory extends AbstractWindowFunctionFac
 
     @Override
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
-        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, argPositions, configuration, sqlExecutionContext, isRecordNotNull);
+        return CountFunctionFactoryHelper.newCountWindowFunction(this, position, args, configuration, sqlExecutionContext, isRecordNotNull);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstNotNullValueDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstNotNullValueDoubleWindowFunctionFactory.java
@@ -128,7 +128,11 @@ public class FirstNotNullValueDoubleWindowFunctionFactory extends AbstractWindow
                     );
 
                     final int initialBufferSize = configuration.getSqlWindowInitialRangeBufferSize();
-                    MemoryARW mem = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(), configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER);
+                    MemoryARW mem = Vm.getCARWInstance(
+                            configuration.getSqlWindowStorePageSize(),
+                            configuration.getSqlWindowStoreMaxPages(),
+                            MemoryTag.NATIVE_CIRCULAR_BUFFER
+                    );
 
                     // moving average over range between timestamp - rowsLo and timestamp + rowsHi (inclusive)
                     return new FirstNotNullValueOverPartitionRangeFrameFunction(
@@ -195,8 +199,10 @@ public class FirstNotNullValueDoubleWindowFunctionFactory extends AbstractWindow
                             columnTypes
                     );
 
-                    MemoryARW mem = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(),
-                            configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER
+                    MemoryARW mem = Vm.getCARWInstance(
+                            configuration.getSqlWindowStorePageSize(),
+                            configuration.getSqlWindowStoreMaxPages(),
+                            MemoryTag.NATIVE_CIRCULAR_BUFFER
                     );
 
                     // moving first over preceding N rows
@@ -247,7 +253,7 @@ public class FirstNotNullValueDoubleWindowFunctionFactory extends AbstractWindow
                     return new FirstValueDoubleWindowFunctionFactory.FirstValueOverCurrentRowFunction(args.get(0));
                 } // between [unbounded | x] preceding and [y preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstValueDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/FirstValueDoubleWindowFunctionFactory.java
@@ -48,7 +48,6 @@ import io.questdb.griffin.model.WindowColumn;
 import io.questdb.std.IntList;
 import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
-import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
 import io.questdb.std.Vect;
@@ -133,7 +132,11 @@ public class FirstValueDoubleWindowFunctionFactory extends AbstractWindowFunctio
                     );
 
                     final int initialBufferSize = configuration.getSqlWindowInitialRangeBufferSize();
-                    MemoryARW mem = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(), configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER);
+                    MemoryARW mem = Vm.getCARWInstance(
+                            configuration.getSqlWindowStorePageSize(),
+                            configuration.getSqlWindowStoreMaxPages(),
+                            MemoryTag.NATIVE_CIRCULAR_BUFFER
+                    );
 
                     // moving average over range between timestamp - rowsLo and timestamp + rowsHi (inclusive)
                     return new FirstValueOverPartitionRangeFrameFunction(
@@ -194,8 +197,10 @@ public class FirstValueDoubleWindowFunctionFactory extends AbstractWindowFunctio
                             columnTypes
                     );
 
-                    MemoryARW mem = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(),
-                            configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER
+                    MemoryARW mem = Vm.getCARWInstance(
+                            configuration.getSqlWindowStorePageSize(),
+                            configuration.getSqlWindowStoreMaxPages(),
+                            MemoryTag.NATIVE_CIRCULAR_BUFFER
                     );
 
                     // moving average over preceding N rows
@@ -246,7 +251,7 @@ public class FirstValueDoubleWindowFunctionFactory extends AbstractWindowFunctio
                     return new FirstValueOverCurrentRowFunction(args.get(0));
                 } // between [unbounded | x] preceding and [y preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -765,7 +770,11 @@ public class FirstValueDoubleWindowFunctionFactory extends AbstractWindowFunctio
             initialCapacity = configuration.getSqlWindowStorePageSize() / RECORD_SIZE;
 
             capacity = initialCapacity;
-            memory = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(), configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER);
+            memory = Vm.getCARWInstance(
+                    configuration.getSqlWindowStorePageSize(),
+                    configuration.getSqlWindowStoreMaxPages(),
+                    MemoryTag.NATIVE_CIRCULAR_BUFFER
+            );
             startOffset = memory.appendAddressFor(capacity * RECORD_SIZE) - memory.getPageAddress(0);
             firstIdx = 0;
             frameSize = 0;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/MaxDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/MaxDoubleWindowFunctionFactory.java
@@ -136,13 +136,13 @@ public class MaxDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 rowsLo == Long.MIN_VALUE ? MAX_OVER_PARTITION_RANGE_COLUMN_TYPES : MAX_OVER_PARTITION_RANGE_BOUNDED_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -219,13 +219,13 @@ public class MaxDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 rowsLo == Long.MIN_VALUE ? MAX_OVER_PARTITION_ROWS_COLUMN_TYPES : MAX_OVER_PARTITION_ROWS_BOUNDED_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -272,13 +272,13 @@ public class MaxDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     MemoryARW mem = null;
                     MemoryARW dequeMem = null;
                     try {
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -314,14 +314,14 @@ public class MaxDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     return new MaxMinOverWholeResultSetFunction(args.get(0), GREATER_THAN, NAME);
                 } // between [unbounded | x] preceding and [x preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER
                     );
                     MemoryARW dequeMem = null;
                     if (rowsLo != Long.MIN_VALUE) {
-                        dequeMem = Vm.getARWInstance(
+                        dequeMem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/MinDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/MinDoubleWindowFunctionFactory.java
@@ -39,10 +39,11 @@ import io.questdb.griffin.model.WindowColumn;
 import io.questdb.std.IntList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactory {
-    public static final MaxDoubleWindowFunctionFactory.DoubleComparator LESS_THAN = (a, b) -> Double.compare(a, b) < 0;
+    public static final MaxDoubleWindowFunctionFactory.DoubleComparator LESS_THAN = (a, b) -> Numbers.compare(a, b) < 0;
     public static final String NAME = "min";
     private static final String SIGNATURE = NAME + "(D)";
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/MinDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/MinDoubleWindowFunctionFactory.java
@@ -42,9 +42,9 @@ import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
 
 public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactory {
+    public static final MaxDoubleWindowFunctionFactory.DoubleComparator LESS_THAN = (a, b) -> Double.compare(a, b) < 0;
     public static final String NAME = "min";
     private static final String SIGNATURE = NAME + "(D)";
-    public static final MaxDoubleWindowFunctionFactory.DoubleComparator LESS_THAN = (a, b) -> Double.compare(a, b) < 0;
 
     @Override
     public String getSignature() {
@@ -117,13 +117,13 @@ public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 rowsLo == Long.MIN_VALUE ? MaxDoubleWindowFunctionFactory.MAX_OVER_PARTITION_RANGE_COLUMN_TYPES :
                                         MaxDoubleWindowFunctionFactory.MAX_OVER_PARTITION_RANGE_BOUNDED_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -201,13 +201,13 @@ public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 rowsLo == Long.MIN_VALUE ? MaxDoubleWindowFunctionFactory.MAX_OVER_PARTITION_ROWS_COLUMN_TYPES :
                                         MaxDoubleWindowFunctionFactory.MAX_OVER_PARTITION_ROWS_BOUNDED_COLUMN_TYPES
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -254,13 +254,13 @@ public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     MemoryARW mem = null;
                     MemoryARW dequeMem = null;
                     try {
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
                         if (rowsLo != Long.MIN_VALUE) {
-                            dequeMem = Vm.getARWInstance(
+                            dequeMem = Vm.getCARWInstance(
                                     configuration.getSqlWindowStorePageSize(),
                                     configuration.getSqlWindowStoreMaxPages(),
                                     MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -296,14 +296,14 @@ public class MinDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     return new MaxDoubleWindowFunctionFactory.MaxMinOverWholeResultSetFunction(args.get(0), LESS_THAN, NAME);
                 } // between [unbounded | x] preceding and [x preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER
                     );
                     MemoryARW dequeMem = null;
                     if (rowsLo != Long.MIN_VALUE) {
-                        dequeMem = Vm.getARWInstance(
+                        dequeMem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/SumDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/SumDoubleWindowFunctionFactory.java
@@ -121,7 +121,7 @@ public class SumDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 columnTypes
                         );
-                        mem = Vm.getARWInstance(
+                        mem = Vm.getCARWInstance(
                                 configuration.getSqlWindowStorePageSize(),
                                 configuration.getSqlWindowStoreMaxPages(),
                                 MemoryTag.NATIVE_CIRCULAR_BUFFER
@@ -194,8 +194,10 @@ public class SumDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                                 partitionByKeyTypes,
                                 columnTypes
                         );
-                        mem = Vm.getARWInstance(configuration.getSqlWindowStorePageSize(),
-                                configuration.getSqlWindowStoreMaxPages(), MemoryTag.NATIVE_CIRCULAR_BUFFER
+                        mem = Vm.getCARWInstance(
+                                configuration.getSqlWindowStorePageSize(),
+                                configuration.getSqlWindowStoreMaxPages(),
+                                MemoryTag.NATIVE_CIRCULAR_BUFFER
                         );
 
                         // moving sum over preceding N rows
@@ -253,7 +255,7 @@ public class SumDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
                     return new SumOverWholeResultSetFunction(args.get(0));
                 } // between [unbounded | x] preceding and [x preceding | current row]
                 else {
-                    MemoryARW mem = Vm.getARWInstance(
+                    MemoryARW mem = Vm.getCARWInstance(
                             configuration.getSqlWindowStorePageSize(),
                             configuration.getSqlWindowStoreMaxPages(),
                             MemoryTag.NATIVE_CIRCULAR_BUFFER

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -1972,7 +1972,7 @@ public abstract class AbstractCairoTest extends AbstractTest {
 
     protected TableToken createPopulateTable(int tableId, TableModel tableModel, int insertIterations, int totalRowsPerIteration, String startDate, int partitionCount) throws NumericException, SqlException {
         try (
-                MemoryMARW mem = Vm.getMARWInstance();
+                MemoryMARW mem = Vm.getCMARWInstance();
                 Path path = new Path()
         ) {
             TableToken token = TestUtils.createTable(engine, mem, path, tableModel, tableId, tableModel.getTableName());

--- a/core/src/test/java/io/questdb/test/cairo/BinarySearchTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BinarySearchTest.java
@@ -322,7 +322,7 @@ public class BinarySearchTest extends AbstractCairoTest {
             try (Path path = new Path()) {
                 path.of(root).concat("binsearch.d").$();
                 try (
-                        MemoryA appendMem = Vm.getSmallMAInstance(
+                        MemoryA appendMem = Vm.getSmallCMARWInstance(
                                 TestFilesFacadeImpl.INSTANCE,
                                 path.$(),
                                 MemoryTag.MMAP_DEFAULT,

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -89,7 +89,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
         try {
             final FilesFacade ff = configuration.getFilesFacade();
             try (
-                    MemoryMA mem = Vm.getSmallMAInstance(
+                    MemoryMA mem = Vm.getSmallCMARWInstance(
                             ff,
                             BitmapIndexUtils.keyFileName(path, name, COLUMN_NAME_TXN_NONE),
                             MemoryTag.MMAP_DEFAULT,
@@ -238,7 +238,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
 
             try (BitmapIndexBwdReader reader = new BitmapIndexBwdReader(configuration, path.trimTo(plen), "x", COLUMN_NAME_TXN_NONE, 0)) {
 
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     try (Path path = new Path()) {
                         path.of(configuration.getRoot()).concat("x").put(".k");
                         mem.wholeFile(configuration.getFilesFacade(), path.$(), MemoryTag.MMAP_DEFAULT);
@@ -887,7 +887,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
 
             try (BitmapIndexFwdReader reader = new BitmapIndexFwdReader(configuration, path.trimTo(plen), "x", COLUMN_NAME_TXN_NONE, 0)) {
 
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     try (Path path = new Path()) {
                         path.of(configuration.getRoot()).concat("x").put(".k");
                         mem.smallFile(configuration.getFilesFacade(), path.$(), MemoryTag.MMAP_DEFAULT);

--- a/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
@@ -430,9 +430,9 @@ public class CairoEngineTest extends AbstractCairoTest {
                     try (MemoryMARW mem = Vm.getCMARWInstance()) {
                         engine.rename(securityContext, path, mem, "x", otherPath, "y");
                         Assert.fail();
+                    } catch (CairoException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "table busy [reason=missing or owned by other process]");
                     }
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "table busy [reason=missing or owned by other process]");
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
@@ -177,8 +177,7 @@ public class CairoEngineTest extends AbstractCairoTest {
             try (
                     Path path = new Path()
             ) {
-                try (MemoryMARW mem = Vm.getCMARWInstance()
-                ) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     engine.createTable(securityContext, mem, path, false, model, false);
                     fail("duplicated tables should not be permitted!");
                 }

--- a/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoEngineTest.java
@@ -427,14 +427,12 @@ public class CairoEngineTest extends AbstractCairoTest {
                     } catch (CairoException ignored) {
                     }
 
-                    try {
-                        try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                            engine.rename(securityContext, path, mem, "x", otherPath, "y");
-                            Assert.fail();
-                        }
-                    } catch (CairoException e) {
-                        TestUtils.assertContains(e.getFlyweightMessage(), "table busy [reason=missing or owned by other process]");
+                    try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                        engine.rename(securityContext, path, mem, "x", otherPath, "y");
+                        Assert.fail();
                     }
+                } catch (CairoException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "table busy [reason=missing or owned by other process]");
                 }
             }
         });
@@ -459,26 +457,27 @@ public class CairoEngineTest extends AbstractCairoTest {
             };
             AbstractCairoTest.ff = ff;
 
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                    TableToken x = createX(engine);
+            try (
+                    CairoEngine engine = new CairoEngine(configuration);
+                    MemoryMARW mem = Vm.getCMARWInstance()
+            ) {
+                TableToken x = createX(engine);
 
-                    assertReader(engine, x);
-                    assertWriter(engine, x);
+                assertReader(engine, x);
+                assertWriter(engine, x);
 
-                    try {
-                        engine.rename(securityContext, path, mem, "x", otherPath, "y");
-                        Assert.fail();
-                    } catch (CairoException e) {
-                        TestUtils.assertContains(e.getFlyweightMessage(), "could not rename");
-                    }
-
-                    assertReader(engine, x);
-                    assertWriter(engine, x);
-                    TableToken y = engine.rename(securityContext, path, mem, "x", otherPath, "y");
-                    assertReader(engine, y);
-                    assertWriter(engine, y);
+                try {
+                    engine.rename(securityContext, path, mem, "x", otherPath, "y");
+                    Assert.fail();
+                } catch (CairoException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "could not rename");
                 }
+
+                assertReader(engine, x);
+                assertWriter(engine, x);
+                TableToken y = engine.rename(securityContext, path, mem, "x", otherPath, "y");
+                assertReader(engine, y);
+                assertWriter(engine, y);
             }
 
             Assert.assertTrue(ff.wasCalled());
@@ -488,15 +487,15 @@ public class CairoEngineTest extends AbstractCairoTest {
     @Test
     public void testRenameNonExisting() throws Exception {
         assertMemoryLeak(() -> {
-
             TableModel model = new TableModel(configuration, "z", PartitionBy.NONE).col("a", ColumnType.INT);
             AbstractCairoTest.create(model);
 
-            try (CairoEngine engine = new CairoEngine(configuration)) {
-                try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                    engine.rename(securityContext, path, mem, "x", otherPath, "y");
-                    Assert.fail();
-                }
+            try (
+                    CairoEngine engine = new CairoEngine(configuration);
+                    MemoryMARW mem = Vm.getCMARWInstance()
+            ) {
+                engine.rename(securityContext, path, mem, "x", otherPath, "y");
+                Assert.fail();
             } catch (CairoException e) {
                 TestUtils.assertContains(e.getFlyweightMessage(), "does not exist");
             }
@@ -513,11 +512,9 @@ public class CairoEngineTest extends AbstractCairoTest {
 
                 assertWriter(engine, x);
                 assertReader(engine, x);
-                try {
-                    try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                        engine.rename(securityContext, path, mem, "x", otherPath, "y");
-                        Assert.fail();
-                    }
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                    engine.rename(securityContext, path, mem, "x", otherPath, "y");
+                    Assert.fail();
                 } catch (CairoException e) {
                     TestUtils.assertContains(e.getFlyweightMessage(), "exists");
                 }

--- a/core/src/test/java/io/questdb/test/cairo/CairoMemoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoMemoryTest.java
@@ -78,7 +78,7 @@ public class CairoMemoryTest extends AbstractTest {
         int failureCount = 0;
         try (Path path = new Path()) {
             path.of(temp.newFile().getAbsolutePath());
-            try (MemoryMA mem = Vm.getMAInstance(null)) {
+            try (MemoryMA mem = Vm.getPMARInstance(null)) {
                 mem.of(ff, path.$(), ff.getPageSize() * 2, MemoryTag.MMAP_DEFAULT, CairoConfiguration.O_NONE);
                 int i = 0;
                 while (i < N) {
@@ -159,7 +159,7 @@ public class CairoMemoryTest extends AbstractTest {
         try (Path path = new Path()) {
             path.of(temp.getRoot().getAbsolutePath());
             int prefixLen = path.size();
-            try (MemoryMA mem = Vm.getMAInstance(null)) {
+            try (MemoryMA mem = Vm.getPMARInstance(null)) {
                 Rnd rnd = new Rnd();
                 for (int k = 0; k < 10; k++) {
                     path.trimTo(prefixLen).concat(rnd.nextString(10));

--- a/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
@@ -128,16 +128,18 @@ public class CairoReadonlyEngineTest extends AbstractCairoTest {
                 createTable(tableName, engine);
 
                 roEngine.reloadTableNames();
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
-                    roEngine.rename(
-                            AllowAllSecurityContext.INSTANCE,
-                            Path.getThreadLocal(root),
-                            mem,
-                            tableName,
-                            Path.getThreadLocal2(root),
-                            tableName + "_renamed"
-                    );
-                    Assert.fail();
+                try {
+                    try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                        roEngine.rename(
+                                AllowAllSecurityContext.INSTANCE,
+                                Path.getThreadLocal(root),
+                                mem,
+                                tableName,
+                                Path.getThreadLocal2(root),
+                                tableName + "_renamed"
+                        );
+                        Assert.fail();
+                    }
                 } catch (CairoException e) {
                     TestUtils.assertEquals("instance is read only", e.getFlyweightMessage());
                 }

--- a/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoReadonlyEngineTest.java
@@ -24,7 +24,12 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableToken;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
@@ -128,18 +133,16 @@ public class CairoReadonlyEngineTest extends AbstractCairoTest {
                 createTable(tableName, engine);
 
                 roEngine.reloadTableNames();
-                try {
-                    try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                        roEngine.rename(
-                                AllowAllSecurityContext.INSTANCE,
-                                Path.getThreadLocal(root),
-                                mem,
-                                tableName,
-                                Path.getThreadLocal2(root),
-                                tableName + "_renamed"
-                        );
-                        Assert.fail();
-                    }
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                    roEngine.rename(
+                            AllowAllSecurityContext.INSTANCE,
+                            Path.getThreadLocal(root),
+                            mem,
+                            tableName,
+                            Path.getThreadLocal2(root),
+                            tableName + "_renamed"
+                    );
+                    Assert.fail();
                 } catch (CairoException e) {
                     TestUtils.assertEquals("instance is read only", e.getFlyweightMessage());
                 }

--- a/core/src/test/java/io/questdb/test/cairo/MemRemappedFileTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MemRemappedFileTest.java
@@ -78,7 +78,7 @@ public class MemRemappedFileTest extends AbstractTest {
 
     private double test(MemoryMR readMem) {
         long nanos = 0;
-        try (MemoryMA appMem = Vm.getMAInstance(null)) {
+        try (MemoryMA appMem = Vm.getPMARInstance(null)) {
             for (int cycle = 0; cycle < NCYCLES; cycle++) {
                 path.trimTo(0).concat(root).concat("file" + nFile).$();
                 nFile++;

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -776,7 +776,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             engine.reconcileTableNameRegistryState();
 
             TableToken tt2;
-            try (MemoryMARW mem = Vm.getMARWInstance()) {
+            try (MemoryMARW mem = Vm.getCMARWInstance()) {
                 tt2 = engine.rename(
                         securityContext,
                         Path.getThreadLocal(""),
@@ -935,7 +935,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             Assert.assertTrue(engine.isWalTable(tt1));
 
             TableToken tt2;
-            try (MemoryMARW mem = Vm.getMARWInstance()) {
+            try (MemoryMARW mem = Vm.getCMARWInstance()) {
                 tt2 = engine.rename(
                         securityContext,
                         Path.getThreadLocal(""),
@@ -982,7 +982,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             tt3 = createTable(model);
             Assert.assertFalse(engine.isWalTable(tt3));
 
-            try (MemoryMARW mem = Vm.getMARWInstance()) {
+            try (MemoryMARW mem = Vm.getCMARWInstance()) {
                 tt2 = engine.rename(
                         securityContext,
                         Path.getThreadLocal(""),

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataCorruptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataCorruptionTest.java
@@ -252,7 +252,7 @@ public class TableReaderMetadataCorruptionTest extends AbstractCairoTest {
                     throw CairoException.critical(TestFilesFacadeImpl.INSTANCE.errno()).put("Cannot create dir: ").put(path);
                 }
 
-                try (MemoryMA mem = Vm.getMAInstance(null)) {
+                try (MemoryMA mem = Vm.getPMARInstance(null)) {
                     mem.of(
                             TestFilesFacadeImpl.INSTANCE,
                             path.trimTo(rootLen).concat(TableUtils.META_FILE_NAME).$(),

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -2000,7 +2000,7 @@ public class TableReaderTest extends AbstractCairoTest {
                 }
                 try (
                         Path path = getPath(tableName);
-                        MemoryMARW mem = Vm.getMARWInstance(
+                        MemoryMARW mem = Vm.getCMARWInstance(
                                 TestFilesFacadeImpl.INSTANCE,
                                 path.$(),
                                 -1,

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -239,8 +239,10 @@ public class TableWriterTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "testAddColumnConcurrentWithDataUpdates", PartitionBy.NONE);
             model.timestamp();
             TableToken token;
-            try (Path path = new Path(); MemoryMARW mem = Vm.getMARWInstance()) {
-                token = TestUtils.createTable(engine, mem, path, model, tableId, model.getTableName());
+            try (Path path = new Path()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                    token = TestUtils.createTable(engine, mem, path, model, tableId, model.getTableName());
+                }
             }
 
             // Write data in a loop getting writer in and out of pool
@@ -1030,7 +1032,8 @@ public class TableWriterTest extends AbstractCairoTest {
 
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
-            try (MemoryARW vmem = Vm.getARWInstance(FF.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+            long pageSize = FF.getPageSize();
+            try (MemoryARW vmem = Vm.getCARWInstance(pageSize, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
                 try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;
@@ -1209,7 +1212,8 @@ public class TableWriterTest extends AbstractCairoTest {
 
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
-            try (MemoryARW vmem = Vm.getARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+            long pageSize = ff.getPageSize();
+            try (MemoryARW vmem = Vm.getCARWInstance(pageSize, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
                 try (TableWriter writer = newOffPoolWriter(new DefaultTestCairoConfiguration(root) {
                     @Override
                     public @NotNull FilesFacade getFilesFacade() {

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -1212,8 +1212,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
-            long pageSize = ff.getPageSize();
-            try (MemoryARW vmem = Vm.getCARWInstance(pageSize, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+            try (MemoryARW vmem = Vm.getCARWInstance(ff.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
                 try (TableWriter writer = newOffPoolWriter(new DefaultTestCairoConfiguration(root) {
                     @Override
                     public @NotNull FilesFacade getFilesFacade() {

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -239,10 +239,11 @@ public class TableWriterTest extends AbstractCairoTest {
             TableModel model = new TableModel(configuration, "testAddColumnConcurrentWithDataUpdates", PartitionBy.NONE);
             model.timestamp();
             TableToken token;
-            try (Path path = new Path()) {
-                try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                    token = TestUtils.createTable(engine, mem, path, model, tableId, model.getTableName());
-                }
+            try (
+                    Path path = new Path();
+                    MemoryMARW mem = Vm.getCMARWInstance()
+            ) {
+                token = TestUtils.createTable(engine, mem, path, model, tableId, model.getTableName());
             }
 
             // Write data in a loop getting writer in and out of pool
@@ -1032,8 +1033,7 @@ public class TableWriterTest extends AbstractCairoTest {
 
             // this contraption will verify that all timestamps that are
             // supposed to be stored have matching partitions
-            long pageSize = FF.getPageSize();
-            try (MemoryARW vmem = Vm.getCARWInstance(pageSize, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+            try (MemoryARW vmem = Vm.getCARWInstance(FF.getPageSize(), Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
                 try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
                     long ts = TimestampFormatUtils.parseTimestamp("2013-03-04T00:00:00.000Z");
                     int i = 0;

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContiguousMemoryMTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContiguousMemoryMTest.java
@@ -340,7 +340,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
         try (Path path = new Path().of(root).concat("tmp1")) {
             ff.touch(path.$());
             final long fd = TableUtils.openRW(ff, path.$(), LOG, configuration.getWriterFileOpenOpts());
-            try (MemoryMARW mem = Vm.getMARWInstance()) {
+            try (MemoryMARW mem = Vm.getCMARWInstance()) {
                 mem.of(ff, fd, null, -1, MemoryTag.MMAP_DEFAULT);
 
                 mem.extend(ff.getMapPageSize() * 2);
@@ -406,7 +406,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
         try (Path path = new Path().of(root).concat("tmp3")) {
             ff.touch(path.$());
             try {
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     mem.of(ff, TableUtils.openRW(ff, path.$(), LOG, configuration.getWriterFileOpenOpts()), null, -1, MemoryTag.MMAP_DEFAULT);
 
                     mem.extend(ff.getMapPageSize() * 2);
@@ -417,7 +417,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
                     mem.jumpTo(1024);
                 }
 
-                Assert.assertEquals(ff.length(path.$()), Files.PAGE_SIZE);
+                Assert.assertEquals(Files.PAGE_SIZE, ff.length(path.$()));
             } finally {
                 Assert.assertTrue(ff.removeQuiet(path.$()));
             }
@@ -624,7 +624,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
             final FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
             try (final Path path = Path.getThreadLocal(root).concat("t.d")) {
                 rnd.reset();
-                MemoryMARW rwMem = Vm.getMARWInstance(
+                MemoryMARW rwMem = Vm.getCMARWInstance(
                         ff,
                         path.$(),
                         ff.getMapPageSize(),
@@ -693,7 +693,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
         try (Path path = new Path().of(root).concat("tmp1")) {
             ff.touch(path.$());
             try {
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     mem.of(ff, path.$(), FilesFacadeImpl._16M, -1, MemoryTag.MMAP_DEFAULT, CairoConfiguration.O_NONE);
                     // this is larger than page size
                     for (int i = 0; i < 3_000_000; i++) {
@@ -739,7 +739,7 @@ public class ContiguousMemoryMTest extends AbstractCairoTest {
         try (Path path = new Path().of(root).concat("tmp4")) {
             ff.touch(path.$());
             try {
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     mem.of(ff, path.$(), FilesFacadeImpl._16M, -1, MemoryTag.MMAP_DEFAULT, CairoConfiguration.O_NONE);
                     // this is larger than page size
                     for (int i = 0; i < 3_000_000; i++) {

--- a/core/src/test/java/io/questdb/test/cairo/vm/ContiguousOffsetMappedMemoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/vm/ContiguousOffsetMappedMemoryTest.java
@@ -58,8 +58,8 @@ public class ContiguousOffsetMappedMemoryTest extends AbstractTest {
                 try (MemoryCMORImpl memoryROffset = new MemoryCMORImpl()) {
                     memoryROffset.ofOffset(ff, path.$(), Files.PAGE_SIZE, Files.PAGE_SIZE, MemoryTag.NATIVE_DEFAULT);
                     memoryROffset.extend(Files.PAGE_SIZE);
-                    Assert.assertEquals(memoryROffset.size(), Files.PAGE_SIZE);
-                    Assert.assertEquals(memoryROffset.getOffset(), 0);
+                    Assert.assertEquals(Files.PAGE_SIZE, memoryROffset.size());
+                    Assert.assertEquals(0, memoryROffset.getOffset());
                 }
             });
         }
@@ -201,8 +201,8 @@ public class ContiguousOffsetMappedMemoryTest extends AbstractTest {
 
                     memoryROffset.growToFileSize();
                     Assert.assertEquals(2 * Files.PAGE_SIZE, memoryROffset.size());
-                    Assert.assertEquals(memoryROffset.size(), 2 * Files.PAGE_SIZE);
-                    Assert.assertEquals(memoryROffset.getOffset() + memoryROffset.size(), 3 * Files.PAGE_SIZE);
+                    Assert.assertEquals(2 * Files.PAGE_SIZE, memoryROffset.size());
+                    Assert.assertEquals(3 * Files.PAGE_SIZE, memoryROffset.getOffset() + memoryROffset.size());
                 }
             });
         }
@@ -255,7 +255,7 @@ public class ContiguousOffsetMappedMemoryTest extends AbstractTest {
         Assert.assertTrue(fd > 0);
 
         try (
-                MemoryMARW memoryW = Vm.getMARWInstance();
+                MemoryMARW memoryW = Vm.getCMARWInstance();
                 Path fileName = new Path().of(testName.getMethodName())
         ) {
             memoryW.of(ff, fd, fileName.$(), 16, 0);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalListenerTest.java
@@ -113,7 +113,7 @@ public class WalListenerTest extends AbstractCairoTest {
                 Assert.assertEquals(0, listener.events.size());
 
                 final String newTableName = tableToken1.get().getTableName() + "_new";
-                try (MemoryMARW mem = Vm.getMARWInstance()) {
+                try (MemoryMARW mem = Vm.getCMARWInstance()) {
                     tableToken2.set(engine.rename(
                             securityContext,
                             Path.getThreadLocal(""),

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverTest.java
@@ -1837,7 +1837,7 @@ public class LineTcpReceiverTest extends AbstractLineTcpReceiverTest {
     }
 
     private void renameTable(CharSequence from, CharSequence to) {
-        try (MemoryMARW mem = Vm.getMARWInstance(); Path otherPath = new Path()) {
+        try (MemoryMARW mem = Vm.getCMARWInstance(); Path otherPath = new Path()) {
             engine.rename(securityContext, path, mem, from, otherPath, to);
         }
     }

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzDropCreateTableOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzDropCreateTableOperation.java
@@ -48,7 +48,7 @@ public class FuzzDropCreateTableOperation implements FuzzTransactionOperation {
         int timestampIndex = tableWriter.getMetadata().getTimestampIndex();
         RecordMetadata copyDenseMeta = denseMetaCopy(tableWriter.getMetadata(), timestampIndex);
 
-        try (MemoryMARW vm = Vm.getMARWInstance(); Path path = new Path()) {
+        try (MemoryMARW vm = Vm.getCMARWInstance(); Path path = new Path()) {
             engine.releaseInactive();
             while (true) {
                 try {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDetachPartitionTest.java
@@ -941,7 +941,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
             TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    MemoryMARW mem = Vm.getMARWInstance()
+                    MemoryMARW mem = Vm.getCMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
                 createPopulateTable(
@@ -1368,7 +1368,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
             TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    MemoryMARW mem = Vm.getMARWInstance()
+                    MemoryMARW mem = Vm.getCMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
                 createPopulateTable(
@@ -1445,7 +1445,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
 
             try (
-                    MemoryMARW mem = Vm.getMARWInstance()
+                    MemoryMARW mem = Vm.getCMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
                 createPopulateTable(
@@ -1524,7 +1524,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
 
             try (
-                    MemoryMARW mem = Vm.getMARWInstance()
+                    MemoryMARW mem = Vm.getCMARWInstance()
             ) {
                 String timestampDay = "2022-06-01";
                 createPopulateTable(
@@ -2330,7 +2330,7 @@ public class AlterTableDetachPartitionTest extends AbstractAlterTableAttachParti
             TableModel tab = new TableModel(configuration, tableName, PartitionBy.DAY);
             TableModel brokenMeta = new TableModel(configuration, brokenTableName, PartitionBy.DAY);
             try (
-                    MemoryMARW mem = Vm.getMARWInstance()
+                    MemoryMARW mem = Vm.getCMARWInstance()
             ) {
                 createPopulateTable(
                         1,

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1028,13 +1028,15 @@ public final class TestUtils {
             int tableId,
             TableToken tableToken
     ) {
-        try (Path path = new Path(); MemoryMARW mem = Vm.getMARWInstance()) {
-            TableUtils.createTable(configuration, mem, path, model, tableVersion, tableId, tableToken.getDirName());
+        try (Path path = new Path()) {
+            try (MemoryMARW mem = Vm.getCMARWInstance()) {
+                TableUtils.createTable(configuration, mem, path, model, tableVersion, tableId, tableToken.getDirName());
+            }
         }
     }
 
     public static TableToken createTable(CairoEngine engine, TableStructure structure, int tableId) {
-        try (MemoryMARW mem = Vm.getMARWInstance(); Path path = new Path()) {
+        try (MemoryMARW mem = Vm.getCMARWInstance(); Path path = new Path()) {
             return TestUtils.createTable(engine, mem, path, structure, tableId, structure.getTableName());
         }
     }

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1028,10 +1028,11 @@ public final class TestUtils {
             int tableId,
             TableToken tableToken
     ) {
-        try (Path path = new Path()) {
-            try (MemoryMARW mem = Vm.getCMARWInstance()) {
-                TableUtils.createTable(configuration, mem, path, model, tableVersion, tableId, tableToken.getDirName());
-            }
+        try (
+                Path path = new Path();
+                MemoryMARW mem = Vm.getCMARWInstance()
+        ) {
+            TableUtils.createTable(configuration, mem, path, model, tableVersion, tableId, tableToken.getDirName());
         }
     }
 


### PR DESCRIPTION
Replace 1MiB-at-a-time allocator with quadratic one for memory, which underpins window functions and joins as well as few other things.

Previous allocator was prohibitively expensive on **Windows** platform and window function spent 99% of the time allocating vs doing the work. For example on Windows, `avg(x) over (partition by symbol)` for 100M rows went from 5 mins to 7s.

The new allocator provides marginal performance gains on Linux.