### PR TITLE
fix(core): fix resource leak on query errors

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -780,6 +780,11 @@ public class TableReader implements Closeable, SymbolTableSource {
                         }
                     }
                 }
+            } catch (Throwable th) {
+                closePartitionColumns(fromBase);
+                openPartitionInfo.setQuick(partitionIndex * PARTITIONS_SLOT_SIZE + PARTITIONS_SLOT_OFFSET_SIZE, -1);
+                Misc.freeObjListIfCloseable(toColumns);
+                throw th;
             } finally {
                 path.trimTo(rootLen);
             }


### PR DESCRIPTION
Found by fuzz test

When a mapping exception is thrown on TableReader resizing the columns on a column add it can lead to a leak of file descriptors and memory.