### PR TITLE
test(sql): fix flaky testNonAdminCanNotSeeOtherUsersCommands()

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/activity/QueryActivityFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/activity/QueryActivityFunctionFactoryTest.java
@@ -36,6 +36,7 @@ import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.SOCountDownLatch;
+import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -162,7 +163,7 @@ public class QueryActivityFunctionFactoryTest extends AbstractCairoTest {
                 started.countDown();
                 try {
                     try (SqlCompiler compiler = engine.getSqlCompiler()) {
-                        TestUtils.assertSql(compiler, adminUserContext1, query, sink, "t\n1\n");
+                        TestUtils.assertSql(compiler, adminUserContext1, query, new StringSink(), "t\n1\n");
                         Assert.fail("Query should have been cancelled");
                     } catch (Exception e) {
                         if (!e.getMessage().contains("cancelled by user")) {


### PR DESCRIPTION
the test is racy: it starts a new thread and then both the main test thread and the newly started thread uses the main test string sink concurrently.

the problem can be easily reproduced by injecting a bit of sleeping to `printSql()`.

```java
    public static void printSql(
            SqlCompiler compiler,
            SqlExecutionContext sqlExecutionContext,
            CharSequence sql,
            MutableUtf16Sink sink
    ) throws SqlException {
        try (RecordCursorFactory factory = compiler.compile(sql, sqlExecutionContext).getRecordCursorFactory()) {
            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                RecordMetadata metadata = factory.getMetadata();
                Os.sleep(1); // <--- NEW LINE
                sink.clear();
                CursorPrinter.println(metadata, sink);
                Os.sleep(1);  // <--- NEW LINE

                final Record record = cursor.getRecord();
                while (cursor.hasNext()) {
                    println(record, metadata, sink);
                }
            }
        }
    }
```

solution is simple: the newly started thread uses its own private sink.

fixes #5084