### PR TITLE
test(sql): speed up ParallelGroupByFuzzTest

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
@@ -82,16 +82,25 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
 
     @Parameterized.Parameters(name = "parallel={0} JIT={1} parquet={2}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {true, true, true},
-                {true, true, false},
-                {true, false, true},
-                {true, false, false},
-                {false, true, true},
-                {false, true, false},
-                {false, false, true},
-                {false, false, false},
-        });
+        // only run a single combination per CI run
+        final Rnd rnd = TestUtils.generateRandom(AbstractCairoTest.LOG);
+        // make sure to have a run with all equal flags occasionally
+        if (rnd.nextInt(100) >= 90) {
+            boolean flag = rnd.nextBoolean();
+            return Arrays.asList(new Object[][]{{flag, flag, flag}});
+        }
+        return Arrays.asList(new Object[][]{{rnd.nextBoolean(), rnd.nextBoolean(), rnd.nextBoolean()}});
+        // uncomment to run all combinations
+//        return Arrays.asList(new Object[][]{
+//                {true, true, true},
+//                {true, true, false},
+//                {true, false, true},
+//                {true, false, false},
+//                {false, true, true},
+//                {false, true, false},
+//                {false, false, true},
+//                {false, false, false},
+//        });
     }
 
     @Override
@@ -263,8 +272,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT CASE WHEN (key = 'k0') THEN 'foo' ELSE 'bar' END AS key, count(*) " +
                         "FROM tab GROUP BY key ORDER BY key",
                 "key\tcount\n" +
-                        "bar\t6400\n" +
-                        "foo\t1600\n"
+                        "bar\t3200\n" +
+                        "foo\t800\n"
         );
     }
 
@@ -276,8 +285,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT CASE WHEN (key::symbol = 'k0') THEN 'foo' ELSE 'bar' END AS key, count(*) " +
                         "FROM tab GROUP BY key ORDER BY key",
                 "key\tcount\n" +
-                        "bar\t6400\n" +
-                        "foo\t1600\n"
+                        "bar\t3200\n" +
+                        "foo\t800\n"
         );
     }
 
@@ -287,12 +296,12 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 "SELECT CASE WHEN (value > 2023.5) THEN key ELSE '' END AS key, avg(value) " +
                         "FROM tab GROUP BY key ORDER BY key",
                 "key\tavg\n" +
-                        "\t1024.3435935935936\n" +
-                        "k0\t3025.155860349127\n" +
-                        "k1\t3023.65625\n" +
-                        "k2\t3024.65625\n" +
-                        "k3\t3025.65625\n" +
-                        "k4\t3024.155860349127\n"
+                        "\t1018.6259753335012\n" +
+                        "k0\t2037.5\n" +
+                        "k1\t2036.0\n" +
+                        "k2\t2037.0\n" +
+                        "k3\t2038.0\n" +
+                        "k4\t2036.5\n"
         );
     }
 
@@ -673,11 +682,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key::symbol key, avg(value), sum(colTop) FROM tab ORDER BY key",
                 "key\tavg\tsum\n" +
-                        "k0\t2027.5\t1642000.0\n" +
-                        "k1\t2023.5\t1638800.0\n" +
-                        "k2\t2024.5\t1639600.0\n" +
-                        "k3\t2025.5\t1640400.0\n" +
-                        "k4\t2026.5\t1641200.0\n"
+                        "k0\t1027.5\t421000.0\n" +
+                        "k1\t1023.5\t419400.0\n" +
+                        "k2\t1024.5\t419800.0\n" +
+                        "k3\t1025.5\t420200.0\n" +
+                        "k4\t1026.5\t420600.0\n"
         );
     }
 
@@ -815,11 +824,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         "FROM tab " +
                         "ORDER BY key",
                 "key\tksum\tnsum\n" +
-                        "k0\t3244000.0\t3244000.0\n" +
-                        "k1\t3237600.0\t3237600.0\n" +
-                        "k2\t3239200.0\t3239200.0\n" +
-                        "k3\t3240800.0\t3240800.0\n" +
-                        "k4\t3242400.0\t3242400.0\n"
+                        "k0\t822000.0\t822000.0\n" +
+                        "k1\t818800.0\t818800.0\n" +
+                        "k2\t819600.0\t819600.0\n" +
+                        "k3\t820400.0\t820400.0\n" +
+                        "k4\t821200.0\t821200.0\n"
         );
     }
 
@@ -1366,7 +1375,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT avg(length(CASE WHEN (key = 'k0') THEN 'foobar' ELSE 'foo' END)), avg(value) FROM tab",
                 "avg\tavg1\n" +
-                        "3.6\t2025.5\n"
+                        "3.6\t1025.5\n"
         );
     }
 
@@ -1377,7 +1386,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT sum(length(CASE WHEN (key::symbol = 'k0') THEN 'foobar' ELSE 'foo' END)) FROM tab",
                 "sum\n" +
-                        "28800\n"
+                        "14400\n"
         );
     }
 
@@ -1496,7 +1505,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT sum(CASE WHEN (key = 'k0') THEN 1 ELSE 0 END) FROM tab",
                 "sum\n" +
-                        "1600\n"
+                        "800\n"
         );
     }
 
@@ -1992,11 +2001,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, avg(value), sum(colTop), count() FROM tab ORDER BY key",
                 "key\tavg\tsum\tcount\n" +
-                        "k0\t2027.5\t1642000.0\t1600\n" +
-                        "k1\t2023.5\t1638800.0\t1600\n" +
-                        "k2\t2024.5\t1639600.0\t1600\n" +
-                        "k3\t2025.5\t1640400.0\t1600\n" +
-                        "k4\t2026.5\t1641200.0\t1600\n"
+                        "k0\t1027.5\t421000.0\t800\n" +
+                        "k1\t1023.5\t419400.0\t800\n" +
+                        "k2\t1024.5\t419800.0\t800\n" +
+                        "k3\t1025.5\t420200.0\t800\n" +
+                        "k4\t1026.5\t420600.0\t800\n"
         );
     }
 
@@ -2007,8 +2016,8 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, avg(value), sum(colTop), first(ts)::long c FROM tab ORDER BY c DESC LIMIT 2",
                 "key\tavg\tsum\tc\n" +
-                        "k0\t2027.5\t1642000.0\t4320000000\n" +
-                        "k4\t2026.5\t1641200.0\t3456000000\n"
+                        "k0\t1027.5\t421000.0\t4320000000\n" +
+                        "k4\t1026.5\t420600.0\t3456000000\n"
         );
     }
 
@@ -2165,11 +2174,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         "SELECT key, avg(value), sum(colTop) FROM tab" +
                         ") ORDER BY key",
                 "key\tcolumn\n" +
-                        "k0\t1644027.5\n" +
-                        "k1\t1640823.5\n" +
-                        "k2\t1641624.5\n" +
-                        "k3\t1642425.5\n" +
-                        "k4\t1643226.5\n"
+                        "k0\t422027.5\n" +
+                        "k1\t420423.5\n" +
+                        "k2\t420824.5\n" +
+                        "k3\t421225.5\n" +
+                        "k4\t421626.5\n"
         );
     }
 
@@ -2283,7 +2292,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, avg(value), sum(colTop), count() FROM tab WHERE upper(key) = 'K3' ORDER BY key",
                 "key\tavg\tsum\tcount\n" +
-                        "k3\t2025.5\t1640400.0\t1600\n"
+                        "k3\t1025.5\t420200.0\t800\n"
         );
     }
 
@@ -2292,7 +2301,7 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, avg(value), sum(colTop), count() FROM tab WHERE substring(key,2,1) = '3' ORDER BY key",
                 "key\tavg\tsum\tcount\n" +
-                        "k3\t2025.5\t1640400.0\t1600\n"
+                        "k3\t1025.5\t420200.0\t800\n"
         );
     }
 
@@ -2303,14 +2312,14 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, avg(value), sum(colTop) FROM tab ORDER BY key LIMIT 3",
                 "key\tavg\tsum\n" +
-                        "k0\t2027.5\t1642000.0\n" +
-                        "k1\t2023.5\t1638800.0\n" +
-                        "k2\t2024.5\t1639600.0\n",
+                        "k0\t1027.5\t421000.0\n" +
+                        "k1\t1023.5\t419400.0\n" +
+                        "k2\t1024.5\t419800.0\n",
                 "SELECT key, avg(value), sum(colTop) FROM tab ORDER BY key LIMIT -3",
                 "key\tavg\tsum\n" +
-                        "k2\t2024.5\t1639600.0\n" +
-                        "k3\t2025.5\t1640400.0\n" +
-                        "k4\t2026.5\t1641200.0\n"
+                        "k2\t1024.5\t419800.0\n" +
+                        "k3\t1025.5\t420200.0\n" +
+                        "k4\t1026.5\t420600.0\n"
         );
     }
 
@@ -2363,11 +2372,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, min(ts), max(ts) FROM tab WHERE key IS NOT NULL ORDER BY key",
                 "key\tmin\tmax\n" +
-                        "k0\t1970-01-01T01:12:00.000000Z\t1971-02-10T00:00:00.000000Z\n" +
-                        "k1\t1970-01-01T00:14:24.000000Z\t1971-02-09T14:24:00.000000Z\n" +
-                        "k2\t1970-01-01T00:28:48.000000Z\t1971-02-09T16:48:00.000000Z\n" +
-                        "k3\t1970-01-01T00:43:12.000000Z\t1971-02-09T19:12:00.000000Z\n" +
-                        "k4\t1970-01-01T00:57:36.000000Z\t1971-02-09T21:36:00.000000Z\n"
+                        "k0\t1970-01-01T01:12:00.000000Z\t1970-07-25T00:00:00.000000Z\n" +
+                        "k1\t1970-01-01T00:14:24.000000Z\t1970-07-24T14:24:00.000000Z\n" +
+                        "k2\t1970-01-01T00:28:48.000000Z\t1970-07-24T16:48:00.000000Z\n" +
+                        "k3\t1970-01-01T00:43:12.000000Z\t1970-07-24T19:12:00.000000Z\n" +
+                        "k4\t1970-01-01T00:57:36.000000Z\t1970-07-24T21:36:00.000000Z\n"
         );
     }
 
@@ -2430,15 +2439,15 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     @Test
     public void testParallelStringKeyLikeFilter() throws Exception {
         final String fullResult = "key\tcount\n" +
-                "k0\t1600\n" +
-                "k1\t1600\n" +
-                "k2\t1600\n" +
-                "k3\t1600\n" +
-                "k4\t1600\n";
+                "k0\t800\n" +
+                "k1\t800\n" +
+                "k2\t800\n" +
+                "k3\t800\n" +
+                "k4\t800\n";
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, count(*) FROM tab WHERE key like '%0' ORDER BY key",
                 "key\tcount\n" +
-                        "k0\t1600\n",
+                        "k0\t800\n",
                 "SELECT key, count(*) FROM tab WHERE key like 'k%' ORDER BY key",
                 fullResult,
                 "SELECT key, count(*) FROM tab WHERE key like 'k_' ORDER BY key",
@@ -2455,10 +2464,10 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
         testParallelStringAndVarcharKeyGroupBy(
                 "SELECT key, count(*) FROM tab WHERE key not like 'k0%' ORDER BY key",
                 "key\tcount\n" +
-                        "k1\t1600\n" +
-                        "k2\t1600\n" +
-                        "k3\t1600\n" +
-                        "k4\t1600\n"
+                        "k1\t800\n" +
+                        "k2\t800\n" +
+                        "k3\t800\n" +
+                        "k4\t800\n"
         );
     }
 
@@ -3289,6 +3298,9 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                     (engine, compiler, sqlExecutionContext) -> {
                         sqlExecutionContext.setJitMode(enableJitCompiler ? SqlJitMode.JIT_MODE_ENABLED : SqlJitMode.JIT_MODE_DISABLED);
 
+                        // Use 2x fewer rows in this test as otherwise it's slow.
+                        final int rowCount = ROW_COUNT / 2;
+
                         // try with a String table first
                         engine.execute(
                                 "CREATE TABLE tab (" +
@@ -3298,14 +3310,14 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                 sqlExecutionContext
                         );
                         engine.execute(
-                                "insert into tab select (x * 864000000)::timestamp, 'k' || (x % 5), x from long_sequence(" + ROW_COUNT + ")",
+                                "insert into tab select (x * 864000000)::timestamp, 'k' || (x % 5), x from long_sequence(" + rowCount + ")",
                                 sqlExecutionContext
                         );
                         engine.execute("ALTER TABLE tab ADD COLUMN colTop DOUBLE", sqlExecutionContext);
                         engine.execute(
                                 "insert into tab " +
                                         "select ((50 + x) * 8640000000)::timestamp, 'k' || ((50 + x) % 5), 50 + x, 50 + x " +
-                                        "from long_sequence(" + ROW_COUNT + ")",
+                                        "from long_sequence(" + rowCount + ")",
                                 sqlExecutionContext
                         );
                         if (convertToParquet) {
@@ -3323,14 +3335,14 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                                 sqlExecutionContext
                         );
                         engine.execute(
-                                "insert into tab select (x * 864000000)::timestamp, 'k' || (x % 5), x from long_sequence(" + ROW_COUNT + ")",
+                                "insert into tab select (x * 864000000)::timestamp, 'k' || (x % 5), x from long_sequence(" + rowCount + ")",
                                 sqlExecutionContext
                         );
                         engine.execute("ALTER TABLE tab ADD COLUMN colTop DOUBLE", sqlExecutionContext);
                         engine.execute(
                                 "insert into tab " +
                                         "select ((50 + x) * 8640000000)::timestamp, 'k' || ((50 + x) % 5), 50 + x, 50 + x " +
-                                        "from long_sequence(" + ROW_COUNT + ")",
+                                        "from long_sequence(" + rowCount + ")",
                                 sqlExecutionContext
                         );
                         if (convertToParquet) {


### PR DESCRIPTION
Instead of running all parameter combinations, now we run only single combination per CI run. Another change is using 2x fewer rows in `testParallelStringAndVarcharKeyGroupBy()` to speed up all tests based on this method.