### PR TITLE
fix(core): fix column conversion error leading to file descriptor leaks

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnTypeConverter.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnTypeConverter.java
@@ -453,10 +453,10 @@ public class ColumnTypeConverter {
     private static void convertFromVarcharToFixed(long rowLo, long rowHi, long dstFixFd, FilesFacade ff, @Nullable MemoryCMORImpl srcVarMem, MemoryCMORImpl srcFixMem, ColumnConversionOffsetSink columnSizesSink, int dstColumnType, Var2FixedConverter<CharSequence> converter) {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
         int dstTypeSize = ColumnType.sizeOf(dstColumnType);
-        dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, (rowHi - rowLo) * dstTypeSize, memoryTag);
-        dstFixMem.jumpTo(0);
 
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, (rowHi - rowLo) * dstTypeSize, memoryTag);
+            dstFixMem.jumpTo(0);
             for (long i = rowLo; i < rowHi; i++) {
                 Utf8Sequence utf8 = VarcharTypeDriver.getSplitValue(srcFixMem, srcVarMem, i, 1);
                 converter.convert(utf8 != null ? utf8.asAsciiCharSequence() : null, dstFixMem);
@@ -472,15 +472,15 @@ public class ColumnTypeConverter {
                                                    @Nullable MemoryCMORImpl srcVarMem, MemoryCMORImpl srcFixMem, ColumnConversionOffsetSink columnSizesSink) {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
         MemoryCMARW dstVarMem = dstVarMemTL.get();
-
-        dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
-        dstVarMem.jumpTo(0);
-        dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, StringTypeDriver.INSTANCE.getAuxVectorSize(rowHi - rowLo), memoryTag);
-        dstFixMem.jumpTo(0);
-        dstFixMem.putLong(0L);
         StringSink sink = sinkUtf16TL.get();
 
         try {
+            dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
+            dstVarMem.jumpTo(0);
+            dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, StringTypeDriver.INSTANCE.getAuxVectorSize(rowHi - rowLo), memoryTag);
+            dstFixMem.jumpTo(0);
+            dstFixMem.putLong(0L);
+
             for (long i = rowLo; i < rowHi; i++) {
                 Utf8Sequence utf8 = VarcharTypeDriver.getSplitValue(srcFixMem, srcVarMem, i, 1);
 
@@ -501,12 +501,11 @@ public class ColumnTypeConverter {
 
     private static void convertFromVarcharToSymbol(long rowLo, long rowHi, long dstFixFd, FilesFacade ff, SymbolMapWriterLite symbolMapWriterLite, @Nullable MemoryCMORImpl srcVarMem, MemoryCMORImpl srcFixMem, ColumnConversionOffsetSink columnSizesSink) {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
-
-        dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, (rowHi - rowLo) * Integer.BYTES, memoryTag);
-        dstFixMem.jumpTo(0);
         StringSink sink = sinkUtf16TL.get();
 
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, (rowHi - rowLo) * Integer.BYTES, memoryTag);
+            dstFixMem.jumpTo(0);
             for (long i = rowLo; i < rowHi; i++) {
                 Utf8Sequence utf8 = VarcharTypeDriver.getSplitValue(srcFixMem, srcVarMem, i, 1);
 
@@ -530,9 +529,10 @@ public class ColumnTypeConverter {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
         int dstTypeSize = ColumnType.sizeOf(dstColumnType);
         assert dstTypeSize > 0;
-        dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, rowCount * dstTypeSize, memoryTag);
-        dstFixMem.jumpTo(0);
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, rowCount * dstTypeSize, memoryTag);
+            dstFixMem.jumpTo(0);
+
             long offset = skipOffset;
             for (long i = 0; i < rowCount; i++) {
                 CharSequence str = srcVarMem.getStrA(offset);
@@ -548,9 +548,9 @@ public class ColumnTypeConverter {
 
     private static void convertStringToSymbol(long skipOffset, long rowCount, long dstFixFd, FilesFacade ff, SymbolMapWriterLite symbolMapWriter, MemoryCMORImpl srcVarMem, ColumnConversionOffsetSink columnSizesSink) {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
-        dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, rowCount * Integer.BYTES, memoryTag);
-        dstFixMem.jumpTo(0);
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, Files.PAGE_SIZE, rowCount * Integer.BYTES, memoryTag);
+            dstFixMem.jumpTo(0);
             long offset = skipOffset;
             for (long i = 0; i < rowCount; i++) {
                 CharSequence str = srcVarMem.getStrA(offset);
@@ -604,10 +604,10 @@ public class ColumnTypeConverter {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
         int dstSize = ColumnType.sizeOf(dstColumnType);
         assert dstSize > 0;
-        dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, rowCount * dstSize, memoryTag);
-        dstFixMem.jumpTo(0);
 
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, rowCount * dstSize, memoryTag);
+            dstFixMem.jumpTo(0);
             for (long lo = symbolMapAddress, hi = symbolMapAddress + rowCount * Integer.BYTES; lo < hi; lo += Integer.BYTES) {
                 int symbol = Unsafe.getUnsafe().getInt(lo);
                 CharSequence str = symbolTable.valueOf(symbol);
@@ -626,14 +626,15 @@ public class ColumnTypeConverter {
 
         ColumnTypeDriver typeDriver = StringTypeDriver.INSTANCE;
         long dstFixSize = typeDriver.getAuxVectorSize(rowCount);
-        dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, dstFixSize, memoryTag);
-        dstFixMem.jumpTo(0);
-        dstFixMem.putLong(0);
-
-        dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
-        dstVarMem.jumpTo(0);
 
         try {
+            dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, dstFixSize, memoryTag);
+            dstFixMem.jumpTo(0);
+            dstFixMem.putLong(0);
+
+            dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
+            dstVarMem.jumpTo(0);
+
             for (long lo = symbolMapAddress, hi = symbolMapAddress + rowCount * Integer.BYTES; lo < hi; lo += Integer.BYTES) {
                 int symbol = Unsafe.getUnsafe().getInt(lo);
                 CharSequence str = symbolTable.valueOf(symbol);
@@ -653,16 +654,16 @@ public class ColumnTypeConverter {
     private static void convertSymbolToVarchar(long rowCount, long symbolMapAddress, long dstFixFd, long dstVarFd, FilesFacade ff, long appendPageSize, SymbolTable symbolTable, ColumnConversionOffsetSink columnSizesSink) {
         MemoryCMARW dstFixMem = dstFixMemTL.get();
         MemoryCMARW dstVarMem = dstVarMemTL.get();
-
-        ColumnTypeDriver typeDriver = VarcharTypeDriver.INSTANCE;
-        dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, typeDriver.getAuxVectorSize(rowCount), memoryTag);
-        dstFixMem.jumpTo(0);
-
-        dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
-        dstVarMem.jumpTo(0);
-
         Utf8StringSink sink = sinkUtf8TL.get();
+
         try {
+            ColumnTypeDriver typeDriver = VarcharTypeDriver.INSTANCE;
+            dstFixMem.of(ff, dstFixFd, true, null, appendPageSize, typeDriver.getAuxVectorSize(rowCount), memoryTag);
+            dstFixMem.jumpTo(0);
+
+            dstVarMem.of(ff, dstVarFd, true, null, appendPageSize, appendPageSize, memoryTag);
+            dstVarMem.jumpTo(0);
+
             for (long lo = symbolMapAddress, hi = symbolMapAddress + rowCount * Integer.BYTES; lo < hi; lo += Integer.BYTES) {
                 int symbol = Unsafe.getUnsafe().getInt(lo);
                 CharSequence str = symbolTable.valueOf(symbol);

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -126,7 +126,8 @@ public class TableReader implements Closeable, SymbolTableSource {
             metadata = openMetaFile();
             partitionBy = metadata.getPartitionBy();
             columnVersionReader = new ColumnVersionReader().ofRO(ff, path.trimTo(rootLen).concat(TableUtils.COLUMN_VERSION_FILE_NAME).$());
-            txnScoreboard = new TxnScoreboard(ff, configuration.getTxnScoreboardEntryCount()).ofRW(path.trimTo(rootLen));
+            txnScoreboard = new TxnScoreboard(ff, configuration.getTxnScoreboardEntryCount());
+            txnScoreboard.ofRW(path.trimTo(rootLen));
             LOG.debug()
                     .$("open [id=").$(metadata.getTableId())
                     .$(", table=").utf8(tableToken.getTableName())

--- a/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
+++ b/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
@@ -136,6 +136,7 @@ public class ConvertOperatorImpl implements Closeable {
     }
 
     private void closeFds(long srcFixFd, long srcVarFd, long dstFixFd, long dstVarFd) {
+        LOG.debug().$("closing fds[srcFixFd=").$(srcFixFd).$(", srcVarFd=").$(srcVarFd).$(", dstFixFd=").$(dstFixFd).$(", dstVarFd=").$(dstVarFd).I$();
         ff.close(srcFixFd);
         ff.close(srcVarFd);
         ff.close(dstFixFd);


### PR DESCRIPTION
Found by fuzz test. 
Error at the end can be an FD leak or error of double file close.