### PR TITLE
chore(sql): sample-by clean ups and fixes

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCountGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractCountGroupByFunction.java
@@ -54,6 +54,11 @@ public abstract class AbstractCountGroupByFunction extends LongFunction implemen
     }
 
     @Override
+    public int getSampleByFlags() {
+        return GroupByFunction.SAMPLE_BY_FILL_ALL;
+    }
+
+    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctIPv4GroupByFunction.java
@@ -98,6 +98,11 @@ public class CountDistinctIPv4GroupByFunction extends LongFunction implements Un
     }
 
     @Override
+    public int getSampleByFlags() {
+        return GroupByFunction.SAMPLE_BY_FILL_ALL;
+    }
+
+    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctVarcharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CountDistinctVarcharGroupByFunction.java
@@ -107,6 +107,11 @@ public class CountDistinctVarcharGroupByFunction extends LongFunction implements
     }
 
     @Override
+    public int getSampleByFlags() {
+        return GroupByFunction.SAMPLE_BY_FILL_ALL;
+    }
+
+    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstDateGroupByFunction.java
@@ -70,11 +70,6 @@ public class FirstDateGroupByFunction extends DateFunction implements GroupByFun
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
@@ -76,11 +76,6 @@ public class FirstGeoHashGroupByFunctionShort extends GeoByteFunction implements
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public int getValueIndex() {
         return valueIndex;
     }
@@ -114,13 +109,14 @@ public class FirstGeoHashGroupByFunctionShort extends GeoByteFunction implements
 
     @Override
     public void setNull(MapValue mapValue) {
-        setShort(mapValue, GeoHashes.SHORT_NULL);
+        // This method is used to init an empty value, so it's ok to reset the row id field here.
+        mapValue.putLong(valueIndex, Numbers.LONG_NULL);
+        mapValue.putShort(valueIndex + 1, GeoHashes.SHORT_NULL);
     }
 
     @Override
     public void setShort(MapValue mapValue, short value) {
-        // This method is used to define interpolated points and to init
-        // an empty value, so it's ok to reset the row id field here.
+        // This method is used to define interpolated points so it's ok to reset the row id field here.
         mapValue.putLong(valueIndex, Numbers.LONG_NULL);
         mapValue.putShort(valueIndex + 1, value);
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstGeoHashGroupByFunctionShort.java
@@ -115,13 +115,6 @@ public class FirstGeoHashGroupByFunctionShort extends GeoByteFunction implements
     }
 
     @Override
-    public void setShort(MapValue mapValue, short value) {
-        // This method is used to define interpolated points so it's ok to reset the row id field here.
-        mapValue.putLong(valueIndex, Numbers.LONG_NULL);
-        mapValue.putShort(valueIndex + 1, value);
-    }
-
-    @Override
     public boolean supportsParallelism() {
         return UnaryFunction.super.supportsParallelism();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstStrGroupByFunction.java
@@ -81,11 +81,6 @@ public class FirstStrGroupByFunction extends StrFunction implements GroupByFunct
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public CharSequence getStrA(Record rec) {
         final boolean nullValue = rec.getBool(valueIndex + 2);
         if (nullValue) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstVarcharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/FirstVarcharGroupByFunction.java
@@ -83,11 +83,6 @@ public class FirstVarcharGroupByFunction extends VarcharFunction implements Grou
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxDateGroupByFunction.java
@@ -69,11 +69,6 @@ public class MaxDateGroupByFunction extends DateFunction implements GroupByFunct
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MaxStrGroupByFunction.java
@@ -91,11 +91,6 @@ public class MaxStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public CharSequence getStrA(Record rec) {
         final long ptr = rec.getLong(valueIndex);
         return ptr == 0 ? null : sinkA.of(ptr);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinStrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/MinStrGroupByFunction.java
@@ -91,11 +91,6 @@ public class MinStrGroupByFunction extends StrFunction implements GroupByFunctio
     }
 
     @Override
-    public int getSampleByFlags() {
-        return GroupByFunction.SAMPLE_BY_FILL_ALL;
-    }
-
-    @Override
     public CharSequence getStrA(Record rec) {
         final long ptr = rec.getLong(valueIndex);
         return ptr == 0 ? null : sinkA.of(ptr);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/VwapDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/VwapDoubleGroupByFunction.java
@@ -95,6 +95,11 @@ public class VwapDoubleGroupByFunction extends DoubleFunction implements GroupBy
     }
 
     @Override
+    public int getSampleByFlags() {
+        return GroupByFunction.SAMPLE_BY_FILL_ALL;
+    }
+
+    @Override
     public int getValueIndex() {
         return valueIndex;
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctVarcharGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CountDistinctVarcharGroupByFunctionFactoryTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class CountDistinctVarcharGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testNonKeyedHappy() throws Exception {
+        String expected = "count_distinct\n" +
+                "3\n";
+        assertQuery(
+                expected,
+                "select count_distinct(a) from x",
+                "create table x as (select * from (select rnd_varchar('a','b','c') a from long_sequence(20)))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testSampleBy() throws Exception {
+        execute("create table x (ts timestamp, vch varchar) timestamp(ts);");
+        execute("insert into x values ('2000-01-01', 'foo'), ('2000-01-01T04:30', 'bar'), ('2000-01-01T05:30', 'foobar'), ('2000-01-03', 'foo');");
+
+        String expectedDefault = "ts\tcount_distinct\n" +
+                "2000-01-01T00:00:00.000000Z\t3\n" +
+                "2000-01-03T00:00:00.000000Z\t1\n";
+        assertQuery(
+                expectedDefault,
+                "select ts, count_distinct(vch) from x sample by 1d",
+                "ts",
+                true,
+                true
+        );
+
+        String expectedInterpolated = "ts\tcount_distinct\n" +
+                "2000-01-01T00:00:00.000000Z\t3\n" +
+                "2000-01-02T00:00:00.000000Z\t2\n" +
+                "2000-01-03T00:00:00.000000Z\t1\n";
+        assertQuery(
+                expectedInterpolated,
+                "select ts, count_distinct(vch) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+    }
+
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MaxStrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MaxStrGroupByFunctionFactoryTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -154,7 +155,7 @@ public class MaxStrGroupByFunctionFactoryTest extends AbstractCairoTest {
                 cursor.hasNext();
                 Assert.fail();
             } catch (SqlException e) {
-                Assert.assertEquals("[0] interpolation is not supported for function: io.questdb.griffin.engine.functions.groupby.MaxStrGroupByFunction", e.getMessage());
+                TestUtils.assertContains(e.getMessage(), "support for LINEAR fill is not yet implemented");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MinStrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/MinStrGroupByFunctionFactoryTest.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -137,7 +138,7 @@ public class MinStrGroupByFunctionFactoryTest extends AbstractCairoTest {
                 cursor.hasNext();
                 Assert.fail();
             } catch (SqlException e) {
-                Assert.assertEquals("[0] interpolation is not supported for function: io.questdb.griffin.engine.functions.groupby.MinStrGroupByFunction", e.getMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "support for LINEAR fill is not yet implemented");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
@@ -94,9 +94,9 @@ public class CountTest extends AbstractCairoTest {
 
     @Test
     public void testInterpolation() throws Exception {
-        execute("create table x (ts timestamp, d double, f float, ip ipv4, i int, l256 long256, l long, s string, sym symbol, vch varchar, gb geohash) timestamp(ts);");
+        execute("create table x (ts timestamp, d double, f float, ip ipv4, i int, l256 long256, l long, s string, sym symbol, vch varchar) timestamp(ts);");
         execute("insert into x values " +
-                "('2000-01-01T00:00', 1, 1, '192.168.1.1', 1, '0x42', 1, 'foo', 'foo', 'foo', 'a'), " +
+                "('2000-01-01T00:00', 1, 1, '192.168.1.1', 1, '0x42', 1, 'foo', 'foo', 'foo'), " +
                 "('2000-01-01T04:30', 2, 2, '192.168.1.2', 2, '0x43', 2, 'bar', 'bar', 'bar'), " +
                 "('2000-01-01T05:30', 2, 2, '192.168.1.2', 2, '0x43', 2, 'bar', 'bar', 'bar'), " +
                 "('2000-01-03T00:00', 1, 1, '192.168.1.1', 1, '0x42', 1, 'foo', 'foo', 'foo');"

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
@@ -93,6 +93,103 @@ public class CountTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testInterpolation() throws Exception {
+        execute("create table x (ts timestamp, d double, f float, ip ipv4, i int, l256 long256, l long, s string, sym symbol, vch varchar, gb geohash) timestamp(ts);");
+        execute("insert into x values " +
+                "('2000-01-01T00:00', 1, 1, '192.168.1.1', 1, '0x42', 1, 'foo', 'foo', 'foo', 'a'), " +
+                "('2000-01-01T04:30', 2, 2, '192.168.1.2', 2, '0x43', 2, 'bar', 'bar', 'bar'), " +
+                "('2000-01-01T05:30', 2, 2, '192.168.1.2', 2, '0x43', 2, 'bar', 'bar', 'bar'), " +
+                "('2000-01-03T00:00', 1, 1, '192.168.1.1', 1, '0x42', 1, 'foo', 'foo', 'foo');"
+        );
+
+        String expected = "ts\tcount\n" +
+                "2000-01-01T00:00:00.000000Z\t3\n" +
+                "2000-01-02T00:00:00.000000Z\t2\n" +
+                "2000-01-03T00:00:00.000000Z\t1\n";
+
+        // double
+        assertQuery(
+                expected,
+                "select ts, count(d) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // float
+        assertQuery(
+                expected,
+                "select ts, count(f) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // ipv4
+        assertQuery(
+                expected,
+                "select ts, count(ip) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // int
+        assertQuery(
+                expected,
+                "select ts, count(i) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // long256
+        assertQuery(
+                expected,
+                "select ts, count(l256) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // long
+        assertQuery(
+                expected,
+                "select ts, count(l) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // string
+        assertQuery(
+                expected,
+                "select ts, count(s) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // symbol
+        assertQuery(
+                expected,
+                "select ts, count(sym) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+
+        // varchar
+        assertQuery(
+                expected,
+                "select ts, count(vch) from x sample by 1d fill(linear)",
+                "ts",
+                true,
+                true
+        );
+    }
+
+    @Test
     public void testKnownSize() throws Exception {
         assertQuery(
                 "count\n" +


### PR DESCRIPTION
Follow-up to PR #5324

This PR addresses two issues related to function linear interpolation support:
1. Added explicit interpolation support declarations for aggregate functions:
  - `count()`
  - `count_distinct()`
  - `vwap()`

These functions already supported interpolation, but this wasn't properly declared. Added tests to verify this behavior.

2. Removed incorrect interpolation support declarations from string and geohash functions:
  - Some string functions interpolation was erroneously marked as supported, though it's not applicable
 - This appears to have been an accidental addition during test development, where tests were checking for specific error messages
 - The recent validation changes caused these tests to fail earlier with different error messages
 - Removed the invalid support declarations to reflect actual functionality