### PR TITLE
fix(sql): spurious query cancellation on high server load

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/AtomicBooleanCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/AtomicBooleanCircuitBreaker.java
@@ -92,11 +92,6 @@ public class AtomicBooleanCircuitBreaker implements SqlExecutionCircuitBreaker {
     }
 
     @Override
-    public void init(SqlExecutionCircuitBreaker circuitBreaker) {
-        fd = circuitBreaker.getFd();
-    }
-
-    @Override
     public boolean isThreadsafe() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
@@ -145,7 +145,6 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
         return timeout;
     }
 
-    @Override
     public void init(SqlExecutionCircuitBreaker circuitBreaker) {
         fd = circuitBreaker.getFd();
         timeout = circuitBreaker.getTimeout();

--- a/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreaker.java
@@ -72,10 +72,6 @@ public interface SqlExecutionCircuitBreaker extends ExecutionCircuitBreaker {
         }
 
         @Override
-        public void init(SqlExecutionCircuitBreaker circuitBreaker) {
-        }
-
-        @Override
         public boolean isThreadsafe() {
             return true;
         }
@@ -151,11 +147,6 @@ public interface SqlExecutionCircuitBreaker extends ExecutionCircuitBreaker {
     int getState(long millis, long fd);
 
     long getTimeout();
-
-    /**
-     * Initializes this circuit breaker from the one passed as a parameter by copying its state
-     */
-    void init(SqlExecutionCircuitBreaker circuitBreaker);
 
     boolean isThreadsafe();
 

--- a/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreakerWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/sql/SqlExecutionCircuitBreakerWrapper.java
@@ -96,12 +96,12 @@ public class SqlExecutionCircuitBreakerWrapper implements SqlExecutionCircuitBre
         return delegate.getTimeout();
     }
 
-    public void init(SqlExecutionCircuitBreakerWrapper wrapper) {
-        init(wrapper.delegate);
+    public SqlExecutionCircuitBreaker init(SqlExecutionCircuitBreakerWrapper wrapper) {
+        return init(wrapper.delegate);
     }
 
-    @Override
-    public void init(SqlExecutionCircuitBreaker executionContextCircuitBreaker) {
+    public SqlExecutionCircuitBreaker init(SqlExecutionCircuitBreaker executionContextCircuitBreaker) {
+        final SqlExecutionCircuitBreaker oldDelegate = delegate;
         if (executionContextCircuitBreaker.isThreadsafe()) {
             delegate = executionContextCircuitBreaker;
         } else {
@@ -109,6 +109,7 @@ public class SqlExecutionCircuitBreakerWrapper implements SqlExecutionCircuitBre
             networkSqlExecutionCircuitBreaker.resetTimer();
             delegate = networkSqlExecutionCircuitBreaker;
         }
+        return oldDelegate;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -175,6 +175,7 @@ public class PageFrameReduceJob implements Job, Closeable {
             if (cursor > -1) {
                 final PageFrameReduceTask task = queue.get(cursor);
                 final PageFrameSequence<?> frameSequence = task.getFrameSequence();
+                SqlExecutionCircuitBreaker ogWrappedCircuitBreaker = null;
                 try {
                     LOG.debug()
                             .$("reducing [shard=").$(frameSequence.getShard())
@@ -193,7 +194,7 @@ public class PageFrameReduceJob implements Job, Closeable {
                         // If this is not work stealing, or the stealing frame sequence is not working on its own task,
                         // we need to initialize the circuit breaker wrapper with the task's circuit breaker.
                         if (workerId != -1 || frameSequence != stealingFrameSequence) {
-                            circuitBreaker.init(frameSequence.getCircuitBreaker());
+                            ogWrappedCircuitBreaker = circuitBreaker.init(frameSequence.getWorkStealCircuitBreaker());
                         }
                         reduce(workerId, record, circuitBreaker, task, frameSequence, stealingFrameSequence);
                     }
@@ -217,6 +218,10 @@ public class PageFrameReduceJob implements Job, Closeable {
                     // Reduced counter has to be incremented only when we make
                     // sure that the task is available for consumers.
                     frameSequence.getReduceFinishedCounter().incrementAndGet();
+                    // Restore frame sequence's circuit breaker to the original state.
+                    if (ogWrappedCircuitBreaker != null) {
+                        circuitBreaker.init(ogWrappedCircuitBreaker);
+                    }
                 }
                 return false;
             } else if (cursor == -1) {

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -74,7 +74,6 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     private final AtomicBoolean valid = new AtomicBoolean(true);
     private final WorkStealingStrategy workStealingStrategy;
     public volatile boolean done;
-    private SqlExecutionCircuitBreakerWrapper circuitBreaker;
     private long circuitBreakerFd;
     private SCSequence collectSubSeq;
     private int collectedFrameIndex = -1;
@@ -91,6 +90,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     private SqlExecutionContext sqlExecutionContext;
     private long startTime;
     private boolean uninterruptible;
+    private SqlExecutionCircuitBreakerWrapper workStealCircuitBreaker;
 
     public PageFrameSequence(
             CairoConfiguration configuration,
@@ -109,7 +109,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         this.localTaskFactory = localTaskFactory;
         this.workStealingStrategy = WorkStealingStrategyFactory.getInstance(configuration, sharedWorkerCount);
         this.taskType = taskType;
-        this.circuitBreaker = new SqlExecutionCircuitBreakerWrapper(configuration.getCircuitBreakerConfiguration());
+        this.workStealCircuitBreaker = new SqlExecutionCircuitBreakerWrapper(configuration.getCircuitBreakerConfiguration());
     }
 
     /**
@@ -148,7 +148,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                         reduceQueue,
                         pageFrameReduceSubSeq,
                         localRecord,
-                        circuitBreaker,
+                        workStealCircuitBreaker,
                         this
                 );
             } catch (Throwable th) {
@@ -212,7 +212,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     public void close() {
         clear();
         localRecord = Misc.free(localRecord);
-        circuitBreaker = Misc.free(circuitBreaker);
+        workStealCircuitBreaker = Misc.free(workStealCircuitBreaker);
         localTask = Misc.free(localTask);
         Misc.free(atom);
     }
@@ -236,10 +236,6 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
     public int getCancelReason() {
         return cancelReason.get();
-    }
-
-    public SqlExecutionCircuitBreakerWrapper getCircuitBreaker() {
-        return circuitBreaker;
     }
 
     public long getCircuitBreakerFd() {
@@ -301,6 +297,10 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
 
     public byte getTaskType() {
         return taskType;
+    }
+
+    public SqlExecutionCircuitBreakerWrapper getWorkStealCircuitBreaker() {
+        return workStealCircuitBreaker;
     }
 
     public WorkStealingStrategy getWorkStealingStrategy() {
@@ -374,7 +374,10 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         circuitBreakerFd = executionContext.getCircuitBreaker().getFd();
         uninterruptible = executionContext.isUninterruptible();
 
-        initRecord(executionContext.getCircuitBreaker());
+        if (localRecord == null) {
+            localRecord = new PageFrameMemoryRecord(PageFrameMemoryRecord.RECORD_A_LETTER);
+        }
+        workStealCircuitBreaker.init(sqlExecutionContext.getCircuitBreaker());
 
         final Rnd rnd = executionContext.getAsyncRandom();
         try {
@@ -526,7 +529,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                     }
                     // start stealing work to unload the queue
                     idle = false;
-                    if (stealWork(reduceQueue, reduceSubSeq, localRecord, circuitBreaker)) {
+                    if (stealWork(reduceQueue, reduceSubSeq, localRecord, workStealCircuitBreaker)) {
                         if (reduceFinishedCounter.get() > collectedFrameCount) {
                             // We have something to collect, so let's do it!
                             return true;
@@ -553,7 +556,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         // join the gang to consume published tasks
         while (reduceFinishedCounter.get() < dispatchStartFrameIndex) {
             idle = false;
-            if (stealWork(reduceQueue, reduceSubSeq, localRecord, circuitBreaker)) {
+            if (stealWork(reduceQueue, reduceSubSeq, localRecord, workStealCircuitBreaker)) {
                 if (isActive()) {
                     continue;
                 }
@@ -562,17 +565,10 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
         }
 
         if (idle) {
-            stealWork(reduceQueue, reduceSubSeq, localRecord, circuitBreaker);
+            stealWork(reduceQueue, reduceSubSeq, localRecord, workStealCircuitBreaker);
         }
 
         return dispatched;
-    }
-
-    private void initRecord(SqlExecutionCircuitBreaker executionContextCircuitBreaker) {
-        if (localRecord == null) {
-            localRecord = new PageFrameMemoryRecord(PageFrameMemoryRecord.RECORD_A_LETTER);
-        }
-        circuitBreaker.init(executionContextCircuitBreaker);
     }
 
     private boolean stealWork(
@@ -607,7 +603,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
                     .$(", active=").$(isActive())
                     .I$();
             if (isActive()) {
-                PageFrameReduceJob.reduce(localRecord, circuitBreaker, localTask, this, this);
+                PageFrameReduceJob.reduce(localRecord, workStealCircuitBreaker, localTask, this, this);
             }
         } catch (Throwable th) {
             LOG.error()

--- a/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
@@ -161,10 +161,6 @@ public class SecurityTest extends AbstractCairoTest {
             }
 
             @Override
-            public void init(SqlExecutionCircuitBreaker circuitBreaker) {
-            }
-
-            @Override
             public boolean isThreadsafe() {
                 return true;
             }


### PR DESCRIPTION
When a lot of work stealing happens, page seq's CB wrapper may get initialized with a CB from another page seq. On subsequent work stealing this wrapped CB may be accessed concurrently from multiple owner threads (think, queries) leading to a data race. The symptom is usually a "query cancelled" error that appears out of the blue.

Tests are in-progress