### PR TITLE
Reduce heap allocation during WAL writing

### DIFF
--- a/benchmarks/src/main/java/org/questdb/CharSequenceIntHashMapBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CharSequenceIntHashMapBenchmark.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.std.CharSequenceIntHashMap;
+import io.questdb.std.DirectCharSequenceIntHashHashMap;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.DirectUtf8String;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class CharSequenceIntHashMapBenchmark {
+    @Param({"8", "16", "16384"})
+    public int charSequenceLength;
+
+    private CharSequenceIntHashMap charSequenceIntHashMap;
+    private DirectCharSequenceIntHashHashMap directCharSequenceIntHashHashMap;
+
+    private CharSequence charSequence;
+    private CharSequence preInsertedCharSequence;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+        charSequenceIntHashMap = new CharSequenceIntHashMap();
+        directCharSequenceIntHashHashMap = new DirectCharSequenceIntHashHashMap();
+        charSequence = createCharSequence('1');
+        preInsertedCharSequence = createCharSequence('2');
+        charSequenceIntHashMap.put(preInsertedCharSequence, 2);
+        directCharSequenceIntHashHashMap.put(preInsertedCharSequence, 2);
+    }
+
+    private CharSequence createCharSequence(char c) {
+        long mem = Unsafe.malloc(charSequenceLength * 2, MemoryTag.NATIVE_DEFAULT);
+        DirectUtf8String actualString = new DirectUtf8String();
+        actualString.of(mem, mem + (charSequenceLength * 2));
+        for (int i = 0; i < charSequenceLength; i++) {
+            Unsafe.getUnsafe().putChar(mem + (i * 2), c);
+        }
+        return actualString.asAsciiCharSequence();
+    }
+
+    @TearDown
+    public void tearDown() {
+        directCharSequenceIntHashHashMap.close();
+    }
+
+    @Benchmark
+    public boolean testHeapMapPut() {
+        return charSequenceIntHashMap.put(charSequence, 1);
+    }
+
+    @Benchmark
+    public boolean testOffHeapMapPut() {
+        return directCharSequenceIntHashHashMap.put(charSequence, 1);
+    }
+
+    @Benchmark
+    public CharSequence testHeapMapGet() {
+        var index = charSequenceIntHashMap.keyIndex(preInsertedCharSequence);
+        return charSequenceIntHashMap.keyAt(index);
+    }
+
+    @Benchmark
+    public CharSequence testOffHeapMapGet() {
+        var index = directCharSequenceIntHashHashMap.keyIndex(preInsertedCharSequence);
+        return directCharSequenceIntHashHashMap.keyAt(index);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CharSequenceIntHashMapBenchmark.class.getSimpleName())
+                .warmupIterations(3)
+                .measurementIterations(3)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.7.0</web.console.version>
+        <web.console.version>0.7.1</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 

--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -126,7 +126,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
             this.maxHash = Math.max(Numbers.ceilPow2(symbolCapacity / 2) - 1, 1);
 
             if (useCache) {
-                this.cache = new CharSequenceIntHashMap(symbolCapacity, 0.3, CharSequenceIntHashMap.NO_ENTRY_VALUE);
+                this.cache = new CharSequenceIntHashMap(symbolCapacity, 0.3, AbstractCharSequenceIntHashMap.NO_ENTRY_VALUE);
                 cachedFlag = true;
             } else {
                 this.cache = null;

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -53,7 +53,7 @@ class WalEventWriter implements Closeable {
     private long startOffset = 0;
     private BoolList symbolMapNullFlags;
     private int txn = 0;
-    private ObjList<CharSequenceIntHashMap> txnSymbolMaps;
+    private ObjList<DirectCharSequenceIntHashHashMap> txnSymbolMaps;
 
     WalEventWriter(CairoConfiguration configuration) {
         this.configuration = configuration;
@@ -190,7 +190,7 @@ class WalEventWriter implements Closeable {
     private void writeSymbolMapDiffs() {
         final int columns = txnSymbolMaps.size();
         for (int i = 0; i < columns; i++) {
-            final CharSequenceIntHashMap symbolMap = txnSymbolMaps.getQuick(i);
+            final DirectCharSequenceIntHashHashMap symbolMap = txnSymbolMaps.getQuick(i);
             if (symbolMap != null) {
                 final int initialCount = initialSymbolCounts.get(i);
                 if (initialCount > 0 || (initialCount == 0 && symbolMap.size() > 0)) {
@@ -265,7 +265,7 @@ class WalEventWriter implements Closeable {
         return txn++;
     }
 
-    void of(ObjList<CharSequenceIntHashMap> txnSymbolMaps, AtomicIntList initialSymbolCounts, BoolList symbolMapNullFlags) {
+    void of(ObjList<DirectCharSequenceIntHashHashMap> txnSymbolMaps, AtomicIntList initialSymbolCounts, BoolList symbolMapNullFlags) {
         this.txnSymbolMaps = txnSymbolMaps;
         this.initialSymbolCounts = initialSymbolCounts;
         this.symbolMapNullFlags = symbolMapNullFlags;

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1713,8 +1713,7 @@ public class WalWriter implements TableWriterAPI {
                         // Locally added symbols must have a continuous range of keys
                         key = localSymbolIds.postIncrement(columnIndex);
                     }
-                    // Chars.toString used as value is a parser buffer memory slice or mapped memory of symbolMapReader
-                    utf16Map.putAt(index, Chars.toString(utf16Value), key);
+                    utf16Map.putAt(index, utf16Value, key);
                 } else {
                     key = utf16Map.valueAt(index);
                 }
@@ -2450,8 +2449,7 @@ public class WalWriter implements TableWriterAPI {
                         final int initialSymCount = initialSymbolCounts.get(columnIndex);
                         key = initialSymCount + localSymbolIds.postIncrement(columnIndex);
                     }
-                    // Chars.toString used as value is a parser buffer memory slice or mapped memory of symbolMapReader
-                    utf16Map.putAt(index, Chars.toString(utf16Value), key);
+                    utf16Map.putAt(index, utf16Value, key);
                 } else {
                     key = utf16Map.valueAt(index);
                 }

--- a/core/src/main/java/io/questdb/std/AbstractCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/AbstractCharSequenceIntHashMap.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.std;
+
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractCharSequenceIntHashMap extends AbstractCharSequenceHashSet {
+    public static final int NO_ENTRY_VALUE = -1;
+    protected final ObjList<CharSequence> list;
+    protected final int noEntryValue;
+    protected int[] values;
+
+    public AbstractCharSequenceIntHashMap() {
+        this(8);
+    }
+
+    public AbstractCharSequenceIntHashMap(int initialCapacity) {
+        this(initialCapacity, 0.4, NO_ENTRY_VALUE);
+    }
+
+    public AbstractCharSequenceIntHashMap(int initialCapacity, double loadFactor, int noEntryValue) {
+        super(initialCapacity, loadFactor);
+        this.noEntryValue = noEntryValue;
+        this.list = new ObjList<>(capacity);
+        values = new int[keys.length];
+        clear();
+    }
+
+    public abstract void putIfAbsent(@NotNull CharSequence key, int value);
+
+    public abstract boolean putAt(int index, CharSequence cs, int i);
+
+    public abstract void increment(CharSequence cs);
+
+    public boolean put(@NotNull CharSequence key, int value) {
+        return putAt(keyIndex(key), key, value);
+    }
+
+    public int get(@NotNull CharSequence key) {
+        return valueAt(keyIndex(key));
+    }
+
+    public void putAll(AbstractCharSequenceIntHashMap other) {
+        CharSequence[] otherKeys = other.keys;
+        int[] otherValues = other.values;
+        for (int i = 0, n = otherKeys.length; i < n; i++) {
+            if (otherKeys[i] != noEntryKey) {
+                put(otherKeys[i], otherValues[i]);
+            }
+        }
+    };
+
+    public int valueAt(int index) {
+        int index1 = -index - 1;
+        return index < 0 ? values[index1] : noEntryValue;
+    }
+
+    public int valueQuick(int index) {
+        return get(list.getQuick(index));
+    }
+
+    public ObjList<CharSequence> keys() {
+        return list;
+    }
+
+    protected void putAt0(int index, CharSequence key, int value) {
+        keys[index] = key;
+        values[index] = value;
+        if (--free == 0) {
+            rehash();
+        }
+    }
+
+    protected void rehash() {
+        int[] oldValues = values;
+        CharSequence[] oldKeys = keys;
+        int size = capacity - free;
+        capacity = capacity * 2;
+        free = capacity - size;
+        mask = Numbers.ceilPow2((int) (capacity / loadFactor)) - 1;
+        this.keys = new CharSequence[mask + 1];
+        this.values = new int[mask + 1];
+        for (int i = oldKeys.length - 1; i > -1; i--) {
+            CharSequence key = oldKeys[i];
+            if (key != null) {
+                final int index = keyIndex(key);
+                keys[index] = key;
+                values[index] = oldValues[i];
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/io/questdb/std/AbstractCharSequenceIntHashMap.java
+++ b/core/src/main/java/io/questdb/std/AbstractCharSequenceIntHashMap.java
@@ -70,7 +70,7 @@ public abstract class AbstractCharSequenceIntHashMap extends AbstractCharSequenc
                 put(otherKeys[i], otherValues[i]);
             }
         }
-    };
+    }
 
     public int valueAt(int index) {
         int index1 = -index - 1;

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.CairoException;
 import io.questdb.griffin.engine.functions.constants.CharConstant;
 import io.questdb.griffin.engine.functions.str.TrimType;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.DirectUtf16Sink;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf16Sink;
@@ -1076,6 +1077,15 @@ public final class Chars {
 
     public static String toString(CharSequence s) {
         return s == null ? null : s.toString();
+    }
+
+    public static DirectUtf16Sink toDirectUtf16Sink(CharSequence s) {
+        if (s == null) {
+            return null;
+        }
+        DirectUtf16Sink sink = new DirectUtf16Sink(s.length() * 2L);
+        sink.put(s);
+        return sink;
     }
 
     public static String toString(CharSequence cs, int start, int end) {

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -1079,15 +1079,6 @@ public final class Chars {
         return s == null ? null : s.toString();
     }
 
-    public static DirectUtf16Sink toDirectUtf16Sink(CharSequence s) {
-        if (s == null) {
-            return null;
-        }
-        DirectUtf16Sink sink = new DirectUtf16Sink(s.length() * 2L);
-        sink.put(s);
-        return sink;
-    }
-
     public static String toString(CharSequence cs, int start, int end) {
         final Utf16Sink b = Misc.getThreadLocalSink();
         b.put(cs, start, end);

--- a/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
+++ b/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
@@ -61,7 +61,7 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
         if (index < 0) {
             values[-index - 1] = values[-index - 1] + 1;
         } else {
-            putAt0(index, Chars.toDirectUtf16Sink(key), 0);
+            putAt0(index, toDirectUtf16Sink(key), 0);
         }
     }
 
@@ -71,7 +71,7 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
             values[-index - 1] = value;
             return false;
         }
-        DirectUtf16Sink directUtf16Sink = Chars.toDirectUtf16Sink(key);
+        DirectUtf16Sink directUtf16Sink = toDirectUtf16Sink(key);
         putAt0(index, directUtf16Sink, value);
         list.add(directUtf16Sink);
         return true;
@@ -81,7 +81,7 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
     public void putIfAbsent(@NotNull CharSequence key, int value) {
         int index = keyIndex(key);
         if (index > -1) {
-            DirectUtf16Sink directUtf16Sink = Chars.toDirectUtf16Sink(key);
+            DirectUtf16Sink directUtf16Sink = toDirectUtf16Sink(key);
             putAt0(index, directUtf16Sink, value);
             list.add(directUtf16Sink);
         }
@@ -124,5 +124,14 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
         for (int i = 0; i < keys.length; i++) {
             closeDirectMemory(keys[i]);
         }
+    }
+
+    private static DirectUtf16Sink toDirectUtf16Sink(CharSequence s) {
+        if (s == null) {
+            return null;
+        }
+        DirectUtf16Sink sink = new DirectUtf16Sink(s.length() * 2L);
+        sink.put(s);
+        return sink;
     }
 }

--- a/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
+++ b/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
@@ -27,9 +27,11 @@ package io.questdb.std;
 import io.questdb.std.str.DirectUtf16Sink;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 
-public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHashMap {
+public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHashMap implements Closeable {
 
     public DirectCharSequenceIntHashHashMap() {
         this(8);
@@ -114,6 +116,13 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
     private void closeDirectMemory(CharSequence key) {
         if (key != noEntryKey) {
             ((DirectUtf16Sink) key).close();
+        }
+    }
+
+    @Override
+    public void close() {
+        for (int i = 0; i < keys.length; i++) {
+            closeDirectMemory(keys[i]);
         }
     }
 }

--- a/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
+++ b/core/src/main/java/io/questdb/std/DirectCharSequenceIntHashHashMap.java
@@ -70,6 +70,8 @@ public class DirectCharSequenceIntHashHashMap extends AbstractCharSequenceIntHas
         if (index < 0) {
             values[-index - 1] = value;
             return false;
+        } else {
+            closeDirectMemory(keys[index]);
         }
         DirectUtf16Sink directUtf16Sink = toDirectUtf16Sink(key);
         putAt0(index, directUtf16Sink, value);

--- a/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
@@ -40,6 +40,7 @@ import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
 
 public abstract class AbstractCharSequenceIntHashMapTest extends AbstractTest {
     protected abstract AbstractCharSequenceIntHashMap createInstance();
+
     protected abstract void closeInstance(AbstractCharSequenceIntHashMap instance);
 
     @Test

--- a/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.std;
+
+
+import io.questdb.std.AbstractCharSequenceIntHashMap;
+import io.questdb.std.DirectCharSequenceIntHashHashMap;
+import io.questdb.std.LowerCaseCharSequenceIntHashMap;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.str.StringSink;
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class AbstractCharSequenceIntHashMapTest {
+    protected abstract AbstractCharSequenceIntHashMap createInstance();
+
+    @Test
+    public void testAll() {
+        Rnd rnd = new Rnd();
+        // populate map
+        AbstractCharSequenceIntHashMap map = createInstance();
+        final int N = 1000;
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            boolean b = map.put(cs, rnd.nextInt());
+            Assert.assertTrue(b);
+        }
+        Assert.assertEquals(N, map.size());
+
+        rnd.reset();
+
+        // assert that map contains the values we just added
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            Assert.assertFalse(map.excludes(cs));
+            Assert.assertEquals(rnd.nextInt(), map.get(cs));
+        }
+
+        Rnd rnd2 = new Rnd();
+
+        rnd.reset();
+
+        // remove some keys and assert that the size() complies
+        int removed = 0;
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            rnd.nextInt();
+            if (rnd2.nextPositiveInt() % 16 == 0) {
+                Assert.assertTrue(map.remove(cs) > -1);
+                removed++;
+                Assert.assertEquals(N - removed, map.size());
+            }
+        }
+
+        // if we didn't remove anything test has no value
+        Assert.assertTrue(removed > 0);
+
+        rnd2.reset();
+        rnd.reset();
+
+        Rnd rnd3 = new Rnd();
+
+        // assert that keys we didn't remove are still there and
+        // keys we removed are not
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            int value = rnd.nextInt();
+            if (rnd2.nextPositiveInt() % 16 == 0) {
+                Assert.assertTrue(map.excludes(cs));
+            } else {
+                System.out.println(cs);
+                Assert.assertFalse(map.excludes(cs));
+
+                int index = map.keyIndex(cs);
+                Assert.assertEquals(value, map.valueAt(index));
+
+                // update value
+                map.putAt(index, cs, rnd3.nextInt());
+            }
+        }
+
+        rnd.reset();
+        rnd2.reset();
+        rnd3.reset();
+
+        // increment values
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            rnd.nextInt();
+            if (rnd2.nextPositiveInt() % 16 != 0) {
+                map.increment(cs);
+                int index = map.keyIndex(cs);
+                Assert.assertTrue(index < 0);
+                Assert.assertEquals(rnd3.nextInt() + 1, map.valueAt(index));
+            } else {
+                map.increment(cs);
+                int index = map.keyIndex(cs);
+                Assert.assertTrue(index < 0);
+                Assert.assertEquals(0, map.valueAt(index));
+            }
+        }
+
+        // put all values into another map
+
+        AbstractCharSequenceIntHashMap map2 = createInstance();
+        map2.putAll(map);
+
+        // assert values
+        rnd.reset();
+        rnd2.reset();
+        rnd3.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            rnd.nextInt();
+            if (rnd2.nextPositiveInt() % 16 != 0) {
+                int index = map2.keyIndex(cs);
+                Assert.assertTrue(index < 0);
+                Assert.assertEquals(rnd3.nextInt() + 1, map2.valueAt(index));
+            } else {
+                int index = map2.keyIndex(cs);
+                Assert.assertTrue(index < 0);
+                Assert.assertEquals(0, map2.valueAt(index));
+            }
+        }
+
+        // re-populate map
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            map.put(cs, rnd.nextInt());
+        }
+
+        // remove some keys again
+        rnd.reset();
+        rnd2.reset();
+        removed = 0;
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            rnd.nextInt();
+            if (rnd2.nextPositiveInt() % 4 == 0) {
+                map.remove(cs);
+                removed++;
+                Assert.assertEquals(N - removed, map.size());
+            }
+        }
+
+        // assert
+        rnd.reset();
+        rnd2.reset();
+        rnd3.reset();
+
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            rnd.nextInt();
+            map.putIfAbsent(cs, rnd3.nextInt());
+        }
+
+        // assert
+        rnd.reset();
+        rnd2.reset();
+        rnd3.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextChars(15);
+            int value1 = rnd.nextInt();
+            int value2 = rnd3.nextInt();
+            if (rnd2.nextPositiveInt() % 4 == 0) {
+                Assert.assertEquals(value2, map.get(cs));
+            } else {
+                Assert.assertEquals(value1, map.get(cs));
+            }
+        }
+    }
+
+    @Test
+    public void testPartialLookup() {
+        AbstractCharSequenceIntHashMap map = createInstance();
+        Rnd rnd = new Rnd();
+        final int N = 1000;
+
+        for (int i = 0; i < N; i++) {
+            String s = rnd.nextString(10).substring(1, 9);
+            map.put(s, i);
+        }
+
+        rnd.reset();
+
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextString(10);
+            int index = map.keyIndex(cs, 1, 9);
+            Assert.assertEquals(i, map.valueAt(index));
+        }
+
+        rnd.reset();
+        for (int i = 0; i < N; i++) {
+            CharSequence cs = rnd.nextString(10);
+            Assert.assertFalse(map.excludes(cs, 1, 9));
+        }
+    }
+
+    @Test
+    public void testPutMutableCharSequence() {
+        final LowerCaseCharSequenceIntHashMap lowerCaseMap = new LowerCaseCharSequenceIntHashMap();
+
+        StringSink ss = new StringSink();
+        ss.put("a");
+
+        lowerCaseMap.putIfAbsent(ss, 1);
+
+        ss.clear();
+        ss.put("bb");
+
+        lowerCaseMap.putIfAbsent(ss, 2);
+
+        Assert.assertEquals(1, lowerCaseMap.get("a"));
+        Assert.assertEquals(2, lowerCaseMap.get("bb"));
+
+        ObjList<CharSequence> keys = lowerCaseMap.keys();
+        Assert.assertEquals(2, keys.size());
+        Assert.assertEquals("a", keys.get(0));
+        Assert.assertEquals("bb", keys.get(1));
+    }
+}

--- a/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
@@ -230,15 +230,25 @@ public abstract class AbstractCharSequenceIntHashMapTest extends AbstractTest {
     }
 
     @Test
-    public void testMemoryLeak() throws Exception {
+    public void testMemoryLeaks() throws Exception {
         assertMemoryLeak(() -> {
             Rnd rnd = new Rnd();
             AbstractCharSequenceIntHashMap map = createInstance();
             final int N = 1000;
             for (int i = 0; i < N; i++) {
-                CharSequence cs = rnd.nextChars(15);
-                boolean b = map.put(cs, rnd.nextInt());
+                CharSequence nextKey = rnd.nextChars(15);
+                var nextValue = rnd.nextInt();
+                map.put(nextKey, nextValue);
             }
+            closeInstance(map);
+        });
+        assertMemoryLeak(() -> {
+            Rnd rnd = new Rnd();
+            AbstractCharSequenceIntHashMap map = createInstance();
+            CharSequence nextKey = rnd.nextChars(15);
+            var nextValue = rnd.nextInt();
+            map.putAt(1, nextKey, nextValue);
+            map.putAt(1, nextKey, nextValue);
             closeInstance(map);
         });
     }

--- a/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/AbstractCharSequenceIntHashMapTest.java
@@ -251,5 +251,15 @@ public abstract class AbstractCharSequenceIntHashMapTest extends AbstractTest {
             map.putAt(1, nextKey, nextValue);
             closeInstance(map);
         });
+        assertMemoryLeak(() -> {
+            Rnd rnd = new Rnd();
+            AbstractCharSequenceIntHashMap map = createInstance();
+            CharSequence nextKey = rnd.nextChars(15);
+            var nextValue = rnd.nextInt();
+            map.put(nextKey, nextValue);
+            map.increment(nextKey);
+            map.increment(rnd.nextChars(15));
+            closeInstance(map);
+        });
     }
 }

--- a/core/src/test/java/io/questdb/test/std/CharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/CharSequenceIntHashMapTest.java
@@ -32,4 +32,8 @@ public class CharSequenceIntHashMapTest extends AbstractCharSequenceIntHashMapTe
     protected AbstractCharSequenceIntHashMap createInstance() {
         return new CharSequenceIntHashMap();
     }
+
+    @Override
+    protected void closeInstance(AbstractCharSequenceIntHashMap instance) {
+    }
 }

--- a/core/src/test/java/io/questdb/test/std/DirectCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/DirectCharSequenceIntHashMapTest.java
@@ -24,12 +24,13 @@
 
 package io.questdb.test.std;
 
-import io.questdb.std.AbstractCharSequenceIntHashMap;
-import io.questdb.std.CharSequenceIntHashMap;
 
-public class CharSequenceIntHashMapTest extends AbstractCharSequenceIntHashMapTest {
+import io.questdb.std.AbstractCharSequenceIntHashMap;
+import io.questdb.std.DirectCharSequenceIntHashHashMap;
+
+public class DirectCharSequenceIntHashMapTest extends AbstractCharSequenceIntHashMapTest {
     @Override
     protected AbstractCharSequenceIntHashMap createInstance() {
-        return new CharSequenceIntHashMap();
+        return new DirectCharSequenceIntHashHashMap();
     }
 }

--- a/core/src/test/java/io/questdb/test/std/DirectCharSequenceIntHashMapTest.java
+++ b/core/src/test/java/io/questdb/test/std/DirectCharSequenceIntHashMapTest.java
@@ -33,4 +33,9 @@ public class DirectCharSequenceIntHashMapTest extends AbstractCharSequenceIntHas
     protected AbstractCharSequenceIntHashMap createInstance() {
         return new DirectCharSequenceIntHashHashMap();
     }
+
+    @Override
+    protected void closeInstance(AbstractCharSequenceIntHashMap instance) {
+        ((DirectCharSequenceIntHashHashMap) instance).close();
+    }
 }

--- a/core/src/test/java/io/questdb/test/std/str/CharsTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/CharsTest.java
@@ -439,6 +439,15 @@ public class CharsTest {
         Assert.assertFalse(Chars.startsWithLowerCase("ABC", "ABC"));
     }
 
+    @Test
+    public void testToDirectUtf16Sink() {
+        String[] testStrings = {"", "Aaaa", "ABC"};
+        for (String testString : testStrings) {
+            DirectUtf16Sink directUtf16Sink = Chars.toDirectUtf16Sink(testString);
+            Assert.assertTrue(Chars.equals(testString, directUtf16Sink));
+        }
+    }
+
     private void assertThat(String expected, ObjList<Path> list) {
         Assert.assertEquals(expected, list.toString());
         for (int i = 0, n = list.size(); i < n; i++) {

--- a/core/src/test/java/io/questdb/test/std/str/CharsTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/CharsTest.java
@@ -439,15 +439,6 @@ public class CharsTest {
         Assert.assertFalse(Chars.startsWithLowerCase("ABC", "ABC"));
     }
 
-    @Test
-    public void testToDirectUtf16Sink() {
-        String[] testStrings = {"", "Aaaa", "ABC"};
-        for (String testString : testStrings) {
-            DirectUtf16Sink directUtf16Sink = Chars.toDirectUtf16Sink(testString);
-            Assert.assertTrue(Chars.equals(testString, directUtf16Sink));
-        }
-    }
-
     private void assertThat(String expected, ObjList<Path> list) {
         Assert.assertEquals(expected, list.toString());
         for (int i = 0, n = list.size(); i < n; i++) {


### PR DESCRIPTION
Resolves https://github.com/questdb/questdb/issues/5336.

JMH use cases taken from `WalWriter` usage of `CharSequenceIntHashMap`. 

JMH result (laptop i9-12900H)
```
Benchmark                                          (charSequenceLength)  Mode  Cnt      Score       Error  Units
CharSequenceIntHashMapBenchmark.testHeapMapGet                        8  avgt    3     33,428 ±    0,775  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapGet                     8  avgt    3     38,963 ±    0,440  ns/op
----------------------------------------------------------------------------------------------------------------
CharSequenceIntHashMapBenchmark.testHeapMapGet                       16  avgt    3     59,577 ±    0,950  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapGet                    16  avgt    3     69,673 ±    0,659  ns/op
----------------------------------------------------------------------------------------------------------------
CharSequenceIntHashMapBenchmark.testHeapMapGet                    16384  avgt    3  52326,719 ±  725,759  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapGet                 16384  avgt    3  46323,714 ± 2088,719  ns/op
----------------------------------------------------------------------------------------------------------------
CharSequenceIntHashMapBenchmark.testHeapMapPut                        8  avgt    3     32,682 ±    0,725  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapPut                     8  avgt    3     32,167 ±    3,089  ns/op
----------------------------------------------------------------------------------------------------------------
CharSequenceIntHashMapBenchmark.testHeapMapPut                       16  avgt    3     58,369 ±    1,960  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapPut                    16  avgt    3     56,655 ±    1,127  ns/op
----------------------------------------------------------------------------------------------------------------
CharSequenceIntHashMapBenchmark.testHeapMapPut                    16384  avgt    3  51868,332 ± 1963,947  ns/op
CharSequenceIntHashMapBenchmark.testOffHeapMapPut                 16384  avgt    3  46207,838 ±   44,997  ns/op
----------------------------------------------------------------------------------------------------------------
```

Get 8 chars:
![image](https://github.com/user-attachments/assets/96ff1651-af68-47bf-ad20-8242d38c7e7c)

Put 8 chars:
![image](https://github.com/user-attachments/assets/77d89f65-a222-496e-9d67-0b61a0a8326e)

Get 16k chars:
![image](https://github.com/user-attachments/assets/9b18945a-7be2-4d02-9f39-6c81d2a18499)

Put 16k chars:
![image](https://github.com/user-attachments/assets/bd38e2c9-3c7a-4237-b725-93b78525de6a)

