### PR TITLE
fix(http): memory leak when querying tables with changing metadata

### DIFF
--- a/core/src/main/java/io/questdb/cairo/FullBwdPartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/FullBwdPartitionFrameCursorFactory.java
@@ -40,6 +40,13 @@ public class FullBwdPartitionFrameCursorFactory extends AbstractPartitionFrameCu
     }
 
     @Override
+    public void close() {
+        super.close();
+        Misc.free(cursor);
+        Misc.free(fwdCursor);
+    }
+
+    @Override
     public PartitionFrameCursor getCursor(SqlExecutionContext executionContext, int order) {
         final TableReader reader = getReader(executionContext);
         try {

--- a/core/src/main/java/io/questdb/cairo/FullFwdPartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/FullFwdPartitionFrameCursorFactory.java
@@ -40,6 +40,13 @@ public class FullFwdPartitionFrameCursorFactory extends AbstractPartitionFrameCu
     }
 
     @Override
+    public void close() {
+        super.close();
+        Misc.free(cursor);
+        Misc.free(bwdCursor);
+    }
+
+    @Override
     public PartitionFrameCursor getCursor(SqlExecutionContext executionContext, int order) {
         final TableReader reader = getReader(executionContext);
         try {

--- a/core/src/main/java/io/questdb/cairo/IntervalFwdPartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/IntervalFwdPartitionFrameCursorFactory.java
@@ -53,6 +53,7 @@ public class IntervalFwdPartitionFrameCursorFactory extends AbstractPartitionFra
     public void close() {
         super.close();
         Misc.free(cursor);
+        Misc.free(bwdCursor);
         Misc.free(intervalModel);
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -927,23 +927,25 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
 
     boolean of(
             RecordCursorFactory factory,
+            RecordCursor cursor,
             SqlExecutionContextImpl sqlExecutionContext
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, SqlException {
-        return of(factory, true, sqlExecutionContext);
+        return of(factory, cursor, true, sqlExecutionContext);
     }
 
     boolean of(
             RecordCursorFactory factory,
+            RecordCursor cursor,
             boolean queryCacheable,
             SqlExecutionContextImpl sqlExecutionContext
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, SqlException {
         this.recordCursorFactory = factory;
+        this.cursor = cursor;
         this.queryCacheable = queryCacheable;
         this.queryJitCompiled = factory.usesCompiledFilter();
         // Enable column pre-touch in REST API only when LIMIT K,N is not specified since when limit is defined
         // we do a no-op loop over the cursor to calculate the total row count and pre-touch only slows things down.
         sqlExecutionContext.setColumnPreTouchEnabled(stop == Long.MAX_VALUE);
-        this.cursor = factory.getCursor(sqlExecutionContext);
         this.circuitBreaker = sqlExecutionContext.getCircuitBreaker();
         final RecordMetadata metadata = factory.getMetadata();
         this.queryTimestampIndex = metadata.getTimestampIndex();

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -578,11 +578,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             } else {
                 ExpressionNode columnAst = column.getAst();
                 CharSequence token = columnAst.token;
-                if (!SqlKeywords.isFirstKeyword(token) && !SqlKeywords.isLastKeyword(token)) {
+                if (!isFirstKeyword(token) && !isLastKeyword(token)) {
                     return false;
                 }
 
-                if (columnAst.rhs.type != ExpressionNode.LITERAL || metadata.getColumnIndex(columnAst.rhs.token) < 0) {
+                if (columnAst.rhs.type != LITERAL || metadata.getColumnIndex(columnAst.rhs.token) < 0) {
                     return false;
                 }
             }
@@ -734,11 +734,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
     private VectorAggregateFunctionConstructor assembleFunctionReference(RecordMetadata metadata, ExpressionNode ast) {
         int columnIndex;
-        if (ast.type == FUNCTION && ast.paramCount == 1 && SqlKeywords.isSumKeyword(ast.token) && ast.rhs.type == LITERAL) {
+        if (ast.type == FUNCTION && ast.paramCount == 1 && isSumKeyword(ast.token) && ast.rhs.type == LITERAL) {
             columnIndex = metadata.getColumnIndex(ast.rhs.token);
             tempVecConstructorArgIndexes.add(columnIndex);
             return sumConstructors.get(metadata.getColumnType(columnIndex));
-        } else if (ast.type == FUNCTION && SqlKeywords.isCountKeyword(ast.token)
+        } else if (ast.type == FUNCTION && isCountKeyword(ast.token)
                 && (ast.paramCount == 0 || (ast.paramCount == 1 && ast.rhs.type == CONSTANT && !isNullKeyword(ast.rhs.token)))) {
             // count() is a no-arg function, count(1) is the same as count(*)
             tempVecConstructorArgIndexes.add(-1);
@@ -2126,7 +2126,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         final ExpressionNode filterExpr = model.getWhereClause();
 
         // back up in case if the above factory steals the filter
-        model.setBackupWhereClause(ExpressionNode.deepClone(expressionNodePool, filterExpr));
+        model.setBackupWhereClause(deepClone(expressionNodePool, filterExpr));
         // back up in case filters need to be compiled again
         backupWhereClause(filterExpr);
         model.setWhereClause(null);
@@ -2731,7 +2731,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         assert nested != null;
         final LowerCaseCharSequenceIntHashMap orderBy = nested.getOrderHash();
         CharSequence timestampColumn = metadata.getColumnName(timestampIndex);
-        if (orderBy.get(timestampColumn) == QueryModel.ORDER_DIRECTION_ASCENDING) {
+        if (orderBy.get(timestampColumn) == ORDER_DIRECTION_ASCENDING) {
             // ORDER BY the timestamp column case.
             orderedByTimestampAsc = true;
         } else if (timestampIndex == metadata.getTimestampIndex() && orderBy.size() == 0) {
@@ -2839,14 +2839,15 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             assert latestByIndex == metadata.getColumnIndexQuiet(intrinsicModel.keyColumn);
 
             if (intrinsicModel.keySubQuery != null) {
-                final RecordCursorFactory rcf;
+                RecordCursorFactory rcf = null;
                 final Record.CharSequenceFunction func;
                 try {
                     rcf = generate(intrinsicModel.keySubQuery, executionContext);
                     func = validateSubQueryColumnAndGetGetter(intrinsicModel, rcf.getMetadata());
-                } catch (Throwable e) {
+                } catch (Throwable th) {
                     Misc.free(partitionFrameCursorFactory);
-                    throw e;
+                    Misc.free(rcf);
+                    throw th;
                 }
 
                 return new LatestBySubQueryRecordCursorFactory(
@@ -3109,7 +3110,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                     // we also maintain unique set of column indexes for better performance
                     if (intHashSet.add(index)) {
-                        if (orderByColumnNameToIndexMap.get(column) == QueryModel.ORDER_DIRECTION_DESCENDING) {
+                        if (orderByColumnNameToIndexMap.get(column) == ORDER_DIRECTION_DESCENDING) {
                             listColumnFilterA.add(-index - 1);
                         } else {
                             listColumnFilterA.add(index + 1);
@@ -3131,7 +3132,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     int index = metadata.getColumnIndexQuiet(column);
                     if (index == timestampIndex) {
                         if (orderByColumnCount == 1) {
-                            if (orderByColumnNameToIndexMap.get(column) == QueryModel.ORDER_DIRECTION_ASCENDING
+                            if (orderByColumnNameToIndexMap.get(column) == ORDER_DIRECTION_ASCENDING
                                     && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_FORWARD) {
                                 return recordCursorFactory;
                             } else if (orderByColumnNameToIndexMap.get(column) == ORDER_DIRECTION_DESCENDING
@@ -3139,7 +3140,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 return recordCursorFactory;
                             }
                         } else { // orderByColumnCount > 1
-                            preSortedByTs = (orderByColumnNameToIndexMap.get(column) == QueryModel.ORDER_DIRECTION_ASCENDING && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_FORWARD)
+                            preSortedByTs = (orderByColumnNameToIndexMap.get(column) == ORDER_DIRECTION_ASCENDING && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_FORWARD)
                                     || (orderByColumnNameToIndexMap.get(column) == ORDER_DIRECTION_DESCENDING && recordCursorFactory.getScanDirection() == RecordCursorFactory.SCAN_DIRECTION_BACKWARD);
                         }
                     }
@@ -3693,19 +3694,19 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             boolean processJoins
     ) throws SqlException {
         switch (model.getSelectModelType()) {
-            case QueryModel.SELECT_MODEL_CHOOSE:
+            case SELECT_MODEL_CHOOSE:
                 return generateSelectChoose(model, executionContext);
-            case QueryModel.SELECT_MODEL_GROUP_BY:
+            case SELECT_MODEL_GROUP_BY:
                 return generateSelectGroupBy(model, executionContext);
-            case QueryModel.SELECT_MODEL_VIRTUAL:
+            case SELECT_MODEL_VIRTUAL:
                 return generateSelectVirtual(model, executionContext);
-            case QueryModel.SELECT_MODEL_WINDOW:
+            case SELECT_MODEL_WINDOW:
                 return generateSelectWindow(model, executionContext);
-            case QueryModel.SELECT_MODEL_DISTINCT:
+            case SELECT_MODEL_DISTINCT:
                 return generateSelectDistinct(model, executionContext);
-            case QueryModel.SELECT_MODEL_CURSOR:
+            case SELECT_MODEL_CURSOR:
                 return generateSelectCursor(model, executionContext);
-            case QueryModel.SELECT_MODEL_SHOW:
+            case SELECT_MODEL_SHOW:
                 return model.getTableNameFunction();
             default:
                 if (model.getJoinModels().size() > 1 && processJoins) {
@@ -3897,11 +3898,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         if (
                 model.getColumns().size() == 1
                         && (nested = model.getNestedModel()) != null
-                        && model.getNestedModel().getSelectModelType() == QueryModel.SELECT_MODEL_CHOOSE
+                        && model.getNestedModel().getSelectModelType() == SELECT_MODEL_CHOOSE
                         && (twoDeepNested = model.getNestedModel().getNestedModel()) != null
                         && twoDeepNested.getLatestBy().size() == 0
                         && (tableNameEn = twoDeepNested.getTableNameExpr()) != null
-                        && tableNameEn.type == ExpressionNode.LITERAL
+                        && tableNameEn.type == LITERAL
                         && twoDeepNested.getWhereClause() == null
                         && twoDeepNested.getJoinModels().size() == 1 // no joins
         ) {
@@ -4410,7 +4411,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             for (int i = 0; i < columnCount; i++) {
                 final QueryColumn column = columns.getQuick(i);
                 final ExpressionNode node = column.getAst();
-                if (node.type == ExpressionNode.LITERAL && Chars.equalsNc(node.token, timestampColumn)) {
+                if (node.type == LITERAL && Chars.equalsNc(node.token, timestampColumn)) {
                     virtualMetadata.setTimestampIndex(i);
                 }
 
@@ -5412,10 +5413,19 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 final int nKeyExcludedValues = intrinsicModel.keyExcludedValueFuncs.size();
 
                 if (intrinsicModel.keySubQuery != null) {
-                    final RecordCursorFactory rcf = generate(intrinsicModel.keySubQuery, executionContext);
-                    final Record.CharSequenceFunction func = validateSubQueryColumnAndGetGetter(intrinsicModel, rcf.getMetadata());
+                    RecordCursorFactory rcf = null;
+                    final Record.CharSequenceFunction func;
+                    Function filter;
+                    try {
+                        rcf = generate(intrinsicModel.keySubQuery, executionContext);
+                        func = validateSubQueryColumnAndGetGetter(intrinsicModel, rcf.getMetadata());
+                        filter = compileFilter(intrinsicModel, myMeta, executionContext);
+                    } catch (Throwable th) {
+                        Misc.free(dfcFactory);
+                        Misc.free(rcf);
+                        throw th;
+                    }
 
-                    Function filter = compileFilter(intrinsicModel, myMeta, executionContext);
                     if (filter != null && filter.isConstant() && !filter.getBool(null)) {
                         Misc.free(dfcFactory);
                         return new EmptyTableRecordCursorFactory(myMeta);
@@ -5450,7 +5460,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 orderByKeyColumn = true;
                             } else if (Chars.equals(orderByAdvice.getQuick(1).token, model.getTimestamp().token)) {
                                 orderByKeyColumn = true;
-                                if (getOrderByDirectionOrDefault(model, 1) == QueryModel.ORDER_DIRECTION_DESCENDING) {
+                                if (getOrderByDirectionOrDefault(model, 1) == ORDER_DIRECTION_DESCENDING) {
                                     indexDirection = BitmapIndexReader.DIR_BACKWARD;
                                 }
                             }
@@ -5663,7 +5673,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             orderByKeyColumn = true;
                         } else if (Chars.equals(orderByAdvice.getQuick(1).token, model.getTimestamp().token)) {
                             orderByKeyColumn = true;
-                            if (getOrderByDirectionOrDefault(model, 1) == QueryModel.ORDER_DIRECTION_DESCENDING) {
+                            if (getOrderByDirectionOrDefault(model, 1) == ORDER_DIRECTION_DESCENDING) {
                                 indexDirection = BitmapIndexReader.DIR_BACKWARD;
                             }
                         }
@@ -5676,7 +5686,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     myMeta,
                                     dfcFactory,
                                     columnIndex,
-                                    getOrderByDirectionOrDefault(model, 0) == QueryModel.ORDER_DIRECTION_ASCENDING,
+                                    getOrderByDirectionOrDefault(model, 0) == ORDER_DIRECTION_ASCENDING,
                                     indexDirection,
                                     columnIndexes,
                                     columnSizeShifts
@@ -5956,7 +5966,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             return;
         }
 
-        if (curr.getFillValues().size() == 1 && SqlKeywords.isNoneKeyword(curr.getFillValues().getQuick(0).token)) {
+        if (curr.getFillValues().size() == 1 && isNoneKeyword(curr.getFillValues().getQuick(0).token)) {
             return;
         }
 
@@ -6235,7 +6245,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             index++;
 
             // negative column index means descending order of sort
-            if (orderByDirection.getQuick(i) == QueryModel.ORDER_DIRECTION_DESCENDING) {
+            if (orderByDirection.getQuick(i) == ORDER_DIRECTION_DESCENDING) {
                 index = -index;
             }
 

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -5486,7 +5486,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 }
 
                 if (nKeyExcludedValues == 0) {
-                    Function filter = compileFilter(intrinsicModel, myMeta, executionContext);
+                    Function filter;
+                    try {
+                        filter = compileFilter(intrinsicModel, myMeta, executionContext);
+                    } catch (Throwable th) {
+                        Misc.free(dfcFactory);
+                        throw th;
+                    }
                     if (filter != null && filter.isConstant()) {
                         try {
                             if (!filter.getBool(null)) {
@@ -5497,6 +5503,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             filter = Misc.free(filter);
                         }
                     }
+
                     if (nKeyValues == 1) {
                         final RowCursorFactory rcf;
                         final Function symbolFunc = intrinsicModel.keyValueFuncs.get(0);
@@ -5595,7 +5602,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     );
                 } else if (nKeyExcludedValues > 0) {
                     if (reader.getSymbolMapReader(columnIndexes.getQuick(keyColumnIndex)).getSymbolCount() < configuration.getMaxSymbolNotEqualsCount()) {
-                        Function filter = compileFilter(intrinsicModel, myMeta, executionContext);
+                        Function filter;
+                        try {
+                            filter = compileFilter(intrinsicModel, myMeta, executionContext);
+                        } catch (Throwable th) {
+                            Misc.free(dfcFactory);
+                            throw th;
+                        }
                         if (filter != null && filter.isConstant()) {
                             try {
                                 if (!filter.getBool(null)) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestReferenceOutOfDateFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestReferenceOutOfDateFunctionFactory.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.test;
+
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.std.DirectIntList;
+import io.questdb.std.IntList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+
+/**
+ * Throws {@link io.questdb.cairo.sql.TableReferenceOutOfDateException} on getCursor calls
+ * while holding some native memory for the factory.
+ */
+public class TestReferenceOutOfDateFunctionFactory implements FunctionFactory {
+    private static final RecordMetadata METADATA = new GenericRecordMetadata();
+    private static final String SIGNATURE = "test_reference_out_of_date()";
+
+    @Override
+    public String getSignature() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new CursorFunction(new TestReferenceOutOfDateCursorFactory(METADATA));
+    }
+
+    private static class TestReferenceOutOfDateCursorFactory extends AbstractRecordCursorFactory {
+        private final DirectIntList mem = new DirectIntList(42, MemoryTag.NATIVE_DEFAULT);
+
+        public TestReferenceOutOfDateCursorFactory(RecordMetadata metadata) {
+            super(metadata);
+        }
+
+        @Override
+        public RecordCursor getCursor(SqlExecutionContext executionContext) {
+            throw TableReferenceOutOfDateException.of("test_reference_out_of_date");
+        }
+
+        @Override
+        public boolean recordCursorSupportsRandomAccess() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(SIGNATURE);
+        }
+
+        @Override
+        protected void _close() {
+            super._close();
+            Misc.free(mem);
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestTableReferenceOutOfDateFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestTableReferenceOutOfDateFunctionFactory.java
@@ -45,9 +45,9 @@ import io.questdb.std.ObjList;
  * Throws {@link io.questdb.cairo.sql.TableReferenceOutOfDateException} on getCursor calls
  * while holding some native memory for the factory.
  */
-public class TestReferenceOutOfDateFunctionFactory implements FunctionFactory {
+public class TestTableReferenceOutOfDateFunctionFactory implements FunctionFactory {
     private static final RecordMetadata METADATA = new GenericRecordMetadata();
-    private static final String SIGNATURE = "test_reference_out_of_date()";
+    private static final String SIGNATURE = "test_table_reference_out_of_date()";
 
     @Override
     public String getSignature() {
@@ -62,19 +62,19 @@ public class TestReferenceOutOfDateFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new CursorFunction(new TestReferenceOutOfDateCursorFactory(METADATA));
+        return new CursorFunction(new TestTableReferenceOutOfDateCursorFactory(METADATA));
     }
 
-    private static class TestReferenceOutOfDateCursorFactory extends AbstractRecordCursorFactory {
+    private static class TestTableReferenceOutOfDateCursorFactory extends AbstractRecordCursorFactory {
         private final DirectIntList mem = new DirectIntList(42, MemoryTag.NATIVE_DEFAULT);
 
-        public TestReferenceOutOfDateCursorFactory(RecordMetadata metadata) {
+        public TestTableReferenceOutOfDateCursorFactory(RecordMetadata metadata) {
             super(metadata);
         }
 
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
-            throw TableReferenceOutOfDateException.of("test_reference_out_of_date");
+            throw TableReferenceOutOfDateException.of("test_table_reference_out_of_date");
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/AbstractPageFrameRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AbstractPageFrameRecordCursorFactory.java
@@ -92,6 +92,7 @@ abstract class AbstractPageFrameRecordCursorFactory extends AbstractRecordCursor
 
     @Override
     protected void _close() {
+        Misc.free(pageFrameCursor);
         Misc.free(partitionFrameCursorFactory);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnExcludedValuesRecordCursorFactory.java
@@ -255,6 +255,7 @@ public class FilterOnExcludedValuesRecordCursorFactory extends AbstractPageFrame
     protected void _close() {
         super._close();
         Misc.free(filter);
+        Misc.free(cursor);
         Misc.freeObjList(keyExcludedValueFunctions);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnSubQueryRecordCursorFactory.java
@@ -26,8 +26,17 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.PageFrameCursor;
+import io.questdb.cairo.sql.PartitionFrameCursorFactory;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.RowCursorFactory;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.StaticSymbolTable;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -101,6 +110,7 @@ public class FilterOnSubQueryRecordCursorFactory extends AbstractPageFrameRecord
     protected void _close() {
         super._close();
         Misc.free(filter);
+        Misc.free(cursor);
         recordCursorFactory.close();
         factoriesA.clear();
         factoriesB.clear();

--- a/core/src/main/java/io/questdb/griffin/engine/table/FilterOnValuesRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FilterOnValuesRecordCursorFactory.java
@@ -27,13 +27,23 @@ package io.questdb.griffin.engine.table;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.SymbolMapReader;
 import io.questdb.cairo.TableReader;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.PageFrameCursor;
+import io.questdb.cairo.sql.PartitionFrameCursorFactory;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.RowCursorFactory;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.OrderByMnemonic;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.model.QueryModel;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -221,6 +231,7 @@ public class FilterOnValuesRecordCursorFactory extends AbstractPageFrameRecordCu
     protected void _close() {
         super._close();
         Misc.free(filter);
+        Misc.free(cursor);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/SortedSymbolIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SortedSymbolIndexRecordCursorFactory.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
+import io.questdb.std.Misc;
 import org.jetbrains.annotations.NotNull;
 
 public class SortedSymbolIndexRecordCursorFactory extends AbstractPageFrameRecordCursorFactory {
@@ -83,6 +84,12 @@ public class SortedSymbolIndexRecordCursorFactory extends AbstractPageFrameRecor
     @Override
     public boolean usesIndex() {
         return true;
+    }
+
+    @Override
+    protected void _close() {
+        super._close();
+        Misc.free(cursor);
     }
 
     @Override

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -139,6 +139,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory,
+            io.questdb.griffin.engine.functions.test.TestReferenceOutOfDateFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestNPEFactory,

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -139,7 +139,7 @@ open module io.questdb {
             io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory,
-            io.questdb.griffin.engine.functions.test.TestReferenceOutOfDateFunctionFactory,
+            io.questdb.griffin.engine.functions.test.TestTableReferenceOutOfDateFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory,
             io.questdb.griffin.engine.functions.test.TestNPEFactory,

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -34,7 +34,7 @@ io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory
 io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory
 io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory
 io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory
-io.questdb.griffin.engine.functions.test.TestReferenceOutOfDateFunctionFactory
+io.questdb.griffin.engine.functions.test.TestTableReferenceOutOfDateFunctionFactory
 io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory
 io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory
 io.questdb.griffin.engine.functions.test.TestSumTDoubleGroupByFunctionFactory

--- a/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
+++ b/core/src/main/resources/META-INF/services/io.questdb.griffin.FunctionFactory
@@ -34,6 +34,7 @@ io.questdb.griffin.engine.functions.activity.QueryActivityFunctionFactory
 io.questdb.griffin.engine.functions.test.TestDataUnavailableFunctionFactory
 io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory
 io.questdb.griffin.engine.functions.test.TestOwnerCountingFunctionFactory
+io.questdb.griffin.engine.functions.test.TestReferenceOutOfDateFunctionFactory
 io.questdb.griffin.engine.functions.test.TestLatchedCounterFunctionFactory
 io.questdb.griffin.engine.functions.test.TestSumXDoubleGroupByFunctionFactory
 io.questdb.griffin.engine.functions.test.TestSumTDoubleGroupByFunctionFactory

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -901,7 +901,9 @@ public class IODispatcherTest extends AbstractTest {
 
     @Test
     public void testExpNull() throws Exception {
-        testJsonQuery(0, "GET /exp?query=select+null+from+long_sequence(1)&limit=1&src=con HTTP/1.1\r\n" +
+        testJsonQuery(
+                0,
+                "GET /exp?query=select+null+from+long_sequence(1)&limit=1&src=con HTTP/1.1\r\n" +
                         "Host: localhost:9000\r\n" +
                         "Connection: keep-alive\r\n" +
                         "Accept: */*\r\n" +
@@ -5543,8 +5545,20 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testJsonTableReferenceOutOfDate() throws Exception {
+        getSimpleTester().run((engine, sqlExecutionContext) -> {
+            testHttpClient.assertGet(
+                    "{\"query\":\"select * from test_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_reference_out_of_date']\",\"position\":0}",
+                    "select * from test_reference_out_of_date();"
+            );
+        });
+    }
+
+    @Test
     public void testJsonUtf8EncodedColumnName() throws Exception {
-        testJsonQuery(0, "GET /query?query=select+0+%D1%80%D0%B5%D0%BA%D0%BE%D1%80%D0%B4%D0%BD%D0%BE+from+long_sequence(10)&limit=0%2C1000&count=true&src=con HTTP/1.1\r\n" +
+        testJsonQuery(
+                0,
+                "GET /query?query=select+0+%D1%80%D0%B5%D0%BA%D0%BE%D1%80%D0%B4%D0%BD%D0%BE+from+long_sequence(10)&limit=0%2C1000&count=true&src=con HTTP/1.1\r\n" +
                         "Host: localhost:9000\r\n" +
                         "Connection: keep-alive\r\n" +
                         "Accept: */*\r\n" +
@@ -7819,6 +7833,17 @@ public class IODispatcherTest extends AbstractTest {
                         "00\r\n" +
                         "\r\n"
         );
+    }
+
+    @Test
+    public void testTextTableReferenceOutOfDate() throws Exception {
+        getSimpleTester().run((engine, sqlExecutionContext) -> {
+            testHttpClient.assertGet(
+                    "/exp",
+                    "{\"query\":\"select * from test_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_reference_out_of_date']\",\"position\":0}",
+                    "select * from test_reference_out_of_date();"
+            );
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -5546,12 +5546,10 @@ public class IODispatcherTest extends AbstractTest {
 
     @Test
     public void testJsonTableReferenceOutOfDate() throws Exception {
-        getSimpleTester().run((engine, sqlExecutionContext) -> {
-            testHttpClient.assertGet(
-                    "{\"query\":\"select * from test_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_reference_out_of_date']\",\"position\":0}",
-                    "select * from test_reference_out_of_date();"
-            );
-        });
+        getSimpleTester().run((engine, sqlExecutionContext) -> testHttpClient.assertGet(
+                "{\"query\":\"select * from test_table_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_table_reference_out_of_date']\",\"position\":0}",
+                "select * from test_table_reference_out_of_date();"
+        ));
     }
 
     @Test
@@ -7837,13 +7835,11 @@ public class IODispatcherTest extends AbstractTest {
 
     @Test
     public void testTextTableReferenceOutOfDate() throws Exception {
-        getSimpleTester().run((engine, sqlExecutionContext) -> {
-            testHttpClient.assertGet(
-                    "/exp",
-                    "{\"query\":\"select * from test_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_reference_out_of_date']\",\"position\":0}",
-                    "select * from test_reference_out_of_date();"
-            );
-        });
+        getSimpleTester().run((engine, sqlExecutionContext) -> testHttpClient.assertGet(
+                "/exp",
+                "{\"query\":\"select * from test_table_reference_out_of_date();\",\"error\":\"cached query plan cannot be used because table schema has changed [table='test_table_reference_out_of_date']\",\"position\":0}",
+                "select * from test_table_reference_out_of_date();"
+        ));
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -10623,6 +10623,23 @@ create table tab as (
         });
     }
 
+    @Test
+    public void testTableReferenceOutOfDate() throws Exception {
+        Assume.assumeFalse(walEnabled);
+        Assume.assumeFalse(legacyMode);
+        assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
+            final String query = "select * from test_table_reference_out_of_date();";
+            try (
+                    PreparedStatement stmt = connection.prepareStatement(query);
+                    ResultSet ignore = stmt.executeQuery()
+            ) {
+                Assert.fail();
+            } catch (SQLException e) {
+                TestUtils.assertContains(e.getMessage(), "cached query plan cannot be used because table schema has changed");
+            }
+        });
+    }
+
     // TODO(puzpuzpuz): fix schema changes handling in PGWire for extended protocol
     //                  https://github.com/questdb/questdb/issues/4971
     @Ignore


### PR DESCRIPTION
Also adds cursor release calls to some record cursor factories and improves error handling in `SqlCodeGenerator`