### PR TITLE
fix(sql): `SHOW CREATE TABLE` provides invalid ddl when table is not partitioned

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GenericRecordMetadata;
 import io.questdb.cairo.MetadataCacheReader;
-import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
@@ -295,9 +294,7 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
         }
 
         protected void putPartitionBy() {
-            if (table.getPartitionBy() != PartitionBy.NONE) {
-                sink.putAscii(" PARTITION BY ").put(table.getPartitionByName());
-            }
+            sink.putAscii(" PARTITION BY ").put(table.getPartitionByName());
         }
 
         protected void putTimestamp() {

--- a/core/src/test/java/io/questdb/test/TelemetryTest.java
+++ b/core/src/test/java/io/questdb/test/TelemetryTest.java
@@ -194,9 +194,10 @@ public class TelemetryTest extends AbstractCairoTest {
                     "\tevent SHORT,\n" +
                     "\torigin SHORT\n" +
                     ") timestamp(created)";
+            String middle = " PARTITION BY NONE";
             String end = " BYPASS WAL\nWITH maxUncommittedRows=1000, o3MaxLag=300000000us;\n";
 
-            assertSql(start + end, showCreateTable);
+            assertSql(start + middle + end, showCreateTable);
             try (TelemetryJob ignore = new TelemetryJob(engine)) {
                 assertSql(start + " PARTITION BY DAY TTL 1 WEEK" + end, showCreateTable);
             }


### PR DESCRIPTION
The current impl elided the `PARTITION BY` clause when it was equivalent to `PARTITION BY NONE`.

Unfortunately,  `BYPASS WAL` would still be printed, leading to invalid syntax.

Rather than elide them, both will be printed to make it explicit that the table is non-partitioned and non-WAL.

Before:

```sql
timestamp(ts) BYPASS WAL;
```

After:

```sql
timestamp(ts) PARTITION BY NONE BYPASS WAL;
```