### PR TITLE
fix(sql): fix UnsupportedOperationException thrown when sorting an IPv4 column

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
@@ -327,11 +327,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
     }
 
     @Override
-    public long getLongIPv4(int columnIndex) {
-        return Numbers.ipv4ToLong(getIPv4(columnIndex));
-    }
-
-    @Override
     public long getRowId() {
         return Rows.toRowID(frameIndex, rowIndex);
     }

--- a/core/src/main/java/io/questdb/cairo/sql/Record.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Record.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.TableUtils;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Interval;
 import io.questdb.std.Long256;
+import io.questdb.std.Numbers;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.MutableUtf16Sink;
 import io.questdb.std.str.Utf16Sink;
@@ -272,7 +273,7 @@ public interface Record {
      */
     @SuppressWarnings("unused")
     default long getLongIPv4(int col) {
-        throw new UnsupportedOperationException();
+        return Numbers.ipv4ToLong(getIPv4(col));
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/sql/VirtualRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/VirtualRecord.java
@@ -25,7 +25,10 @@
 package io.questdb.cairo.sql;
 
 import io.questdb.cairo.ColumnTypes;
-import io.questdb.std.*;
+import io.questdb.std.BinarySequence;
+import io.questdb.std.Interval;
+import io.questdb.std.Long256;
+import io.questdb.std.ObjList;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Utf8Sequence;
 
@@ -160,11 +163,6 @@ public class VirtualRecord implements ColumnTypes, Record {
     @Override
     public Long256 getLong256B(int col) {
         return getFunction(col).getLong256B(base);
-    }
-
-    @Override
-    public long getLongIPv4(int col) {
-        return Numbers.ipv4ToLong(getIPv4(col));
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -533,11 +533,6 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             }
 
             @Override
-            public long getLongIPv4(int col) {
-                return getLong(col);
-            }
-
-            @Override
             public short getShort(int col) {
                 if (gapFilling) {
                     return getFillFunction(col).getShort(null);

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecord.java
@@ -29,6 +29,7 @@ import io.questdb.std.BinarySequence;
 import io.questdb.std.IntList;
 import io.questdb.std.Interval;
 import io.questdb.std.Long256;
+import io.questdb.std.Numbers;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Utf8Sequence;
 
@@ -143,6 +144,11 @@ class SelectedRecord implements Record {
     @Override
     public Long256 getLong256B(int col) {
         return base.getLong256B(getColumnIndex(col));
+    }
+
+    @Override
+    public long getLongIPv4(int col) {
+        return Numbers.ipv4ToLong(getIPv4(col));
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecord.java
@@ -29,7 +29,6 @@ import io.questdb.std.BinarySequence;
 import io.questdb.std.IntList;
 import io.questdb.std.Interval;
 import io.questdb.std.Long256;
-import io.questdb.std.Numbers;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Utf8Sequence;
 
@@ -144,11 +143,6 @@ class SelectedRecord implements Record {
     @Override
     public Long256 getLong256B(int col) {
         return base.getLong256B(getColumnIndex(col));
-    }
-
-    @Override
-    public long getLongIPv4(int col) {
-        return Numbers.ipv4ToLong(getIPv4(col));
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByWithFilterTest.java
@@ -810,6 +810,55 @@ public class OrderByWithFilterTest extends AbstractCairoTest {
         }
     }
 
+    @Test
+    public void testOrderByWithFilterAndIPv4ConversionToLong() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE 'network_nodes_test' ( \n" +
+                    "\ttimestamp TIMESTAMP,\n" +
+                    "\tnode_name SYMBOL CAPACITY 65536 CACHE INDEX CAPACITY 65536,\n" +
+                    "\thost_ip IPv4,\n" +
+                    "\tstatus SYMBOL CAPACITY 8 CACHE\n" +
+                    ") timestamp(timestamp) PARTITION by DAY BYPASS WAL\n" +
+                    "WITH maxUncommittedRows=500000, o3MaxLag=600000000us;");
+
+            execute("insert into network_nodes_test\n" +
+                    "  select\n" +
+                    "    rnd_timestamp(to_timestamp('20241231', 'yyyyMMdd'),to_timestamp('20250101', 'yyyyMMdd'),0),\n" +
+                    "    rnd_symbol('node01','node02','node03'),\n" +
+                    "    rnd_ipv4('10.13.0.0/16',0),\n" +
+                    "    rnd_symbol('active','removed')\n" +
+                    "  from long_sequence(30);\n");
+
+            // this would fail with an UnsupportedOperationException due to getLongIPv4 not being implemented
+            // for SelectedRecord
+            assertSql("timestamp\tnode_name\thost_ip\tstatus\n" +
+                            "2024-12-31T19:10:58.038243Z\tnode01\t10.13.2.123\tactive\n" +
+                            "2024-12-31T13:35:33.630915Z\tnode03\t10.13.31.14\tactive\n" +
+                            "2024-12-31T12:09:29.743508Z\tnode03\t10.13.31.173\tactive\n" +
+                            "2024-12-31T05:28:56.199865Z\tnode03\t10.13.35.79\tactive\n" +
+                            "2024-12-31T14:04:07.197985Z\tnode03\t10.13.37.167\tactive\n" +
+                            "2024-12-31T08:12:46.122052Z\tnode01\t10.13.57.52\tactive\n" +
+                            "2024-12-31T22:29:40.370707Z\tnode02\t10.13.72.212\tactive\n" +
+                            "2024-12-31T19:23:32.364885Z\tnode02\t10.13.112.55\tactive\n" +
+                            "2024-12-31T02:22:01.436568Z\tnode02\t10.13.128.249\tactive\n" +
+                            "2024-12-31T04:42:29.244760Z\tnode02\t10.13.136.54\tactive\n" +
+                            "2024-12-31T23:26:59.485737Z\tnode01\t10.13.144.59\tactive\n" +
+                            "2024-12-31T07:23:12.483203Z\tnode03\t10.13.151.135\tactive\n" +
+                            "2024-12-31T10:17:14.723035Z\tnode01\t10.13.157.242\tactive\n" +
+                            "2024-12-31T21:31:53.805150Z\tnode01\t10.13.166.106\tactive\n" +
+                            "2024-12-31T09:30:33.694129Z\tnode02\t10.13.168.230\tactive\n" +
+                            "2024-12-31T22:56:53.598432Z\tnode03\t10.13.213.95\tactive\n" +
+                            "2024-12-31T07:27:38.262625Z\tnode02\t10.13.217.59\tactive\n" +
+                            "2024-12-31T04:22:52.424548Z\tnode02\t10.13.237.229\tactive\n" +
+                            "2024-12-31T06:40:02.794603Z\tnode02\t10.13.249.36\tactive\n" +
+                            "2024-12-31T14:59:11.599601Z\tnode01\t10.13.249.187\tactive\n" +
+                            "2024-12-31T18:42:59.090116Z\tnode03\t10.13.253.254\tactive\n",
+                    "select * from (network_nodes_test LATEST on timestamp PARTITION by host_ip)\n" +
+                            "where status = 'active'\n" +
+                            "order by host_ip;");
+        });
+    }
+
     private void assertLimitQueries(String result, String query, String expectedTimestamp) throws Exception {
         int firstLineStart = result.indexOf('\n') + 1;
         String header = result.substring(0, firstLineStart);


### PR DESCRIPTION
`getLongAsIPv4` was not supported for `SelectedRecord`. This was required by `LongSortedLightRecordCursor`, and presented as an internal server error.

The workaround before this fix is to add an extra column with a cast, causing a `VirtualRecord` to be produced, which had this function implemented.