### PR TITLE
chore(core): add batch IDAllocator when DB running in sync mode

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -231,6 +231,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final long httpWorkerSleepThreshold;
     private final long httpWorkerSleepTimeout;
     private final long httpWorkerYieldThreshold;
+    private final int idGenerateBatchStep;
     private final long idleCheckInterval;
     private final boolean ilpAutoCreateNewColumns;
     private final boolean ilpAutoCreateNewTables;
@@ -1279,6 +1280,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.defaultSymbolCapacity = getInt(properties, env, PropertyKey.CAIRO_DEFAULT_SYMBOL_CAPACITY, 256);
             this.fileOperationRetryCount = getInt(properties, env, PropertyKey.CAIRO_FILE_OPERATION_RETRY_COUNT, 30);
             this.idleCheckInterval = getMillis(properties, env, PropertyKey.CAIRO_IDLE_CHECK_INTERVAL, 5 * 60 * 1000L);
+            this.idGenerateBatchStep = getInt(properties, env, PropertyKey.CAIRO_ID_GENERATE_STEP, 512);
             this.inactiveReaderMaxOpenPartitions = getInt(properties, env, PropertyKey.CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS, 10000);
             this.inactiveReaderTTL = getMillis(properties, env, PropertyKey.CAIRO_INACTIVE_READER_TTL, 120_000);
             this.inactiveWriterTTL = getMillis(properties, env, PropertyKey.CAIRO_INACTIVE_WRITER_TTL, 600_000);
@@ -2812,6 +2814,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getGroupByShardingThreshold() {
             return cairoGroupByShardingThreshold;
+        }
+
+        @Override
+        public int getIdGenerateBatchStep() {
+            return idGenerateBatchStep;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -49,6 +49,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_DEFAULT_SYMBOL_CACHE_FLAG("cairo.default.symbol.cache.flag"),
     CAIRO_DEFAULT_SYMBOL_CAPACITY("cairo.default.symbol.capacity"),
     CAIRO_FILE_OPERATION_RETRY_COUNT("cairo.file.operation.retry.count"),
+    CAIRO_ID_GENERATE_STEP("cairo.id.generator.batch.step"),
     CAIRO_IDLE_CHECK_INTERVAL("cairo.idle.check.interval"),
     CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS("cairo.inactive.reader.max.open.partitions"),
     CAIRO_INACTIVE_READER_TTL("cairo.inactive.reader.ttl"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -222,6 +222,8 @@ public interface CairoConfiguration {
         return IOURingFacadeImpl.INSTANCE;
     }
 
+    int getIdGenerateBatchStep();
+
     long getIdleCheckInterval();
 
     int getInactiveReaderMaxOpenPartitions();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -342,6 +342,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getIdGenerateBatchStep() {
+        return getDelegate().getIdGenerateBatchStep();
+    }
+
+    @Override
     public long getIdleCheckInterval() {
         return getDelegate().getIdleCheckInterval();
     }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -188,7 +188,7 @@ public class CairoEngine implements Closeable, WriterSource {
             this.telemetryWal = createTelemetry(TelemetryWalTask.WAL_TELEMETRY, configuration);
             this.telemetryMatView = createTelemetry(TelemetryMatViewTask.MAT_VIEW_TELEMETRY, configuration);
             this.telemetries = new ObjList<>(telemetry, telemetryWal, telemetryMatView);
-            this.tableIdGenerator = new IDGenerator(configuration, TableUtils.TAB_INDEX_FILE_NAME);
+            this.tableIdGenerator = IDGeneratorFactory.newIDGenerator(configuration, TableUtils.TAB_INDEX_FILE_NAME, 1);
             this.checkpointAgent = new DatabaseCheckpointAgent(this);
             this.queryRegistry = new QueryRegistry(configuration);
             this.rootExecutionContext = new SqlExecutionContextImpl(this, 1)

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -375,6 +375,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getIdGenerateBatchStep() {
+        return 512;
+    }
+
+    @Override
     public long getIdleCheckInterval() {
         return 100;
     }

--- a/core/src/main/java/io/questdb/cairo/IDGenerator.java
+++ b/core/src/main/java/io/questdb/cairo/IDGenerator.java
@@ -24,82 +24,20 @@
 
 package io.questdb.cairo;
 
-import io.questdb.std.Files;
-import io.questdb.std.FilesFacade;
-import io.questdb.std.MemoryTag;
-import io.questdb.std.Os;
-import io.questdb.std.Unsafe;
 import io.questdb.std.str.Path;
 
 import java.io.Closeable;
 
-public class IDGenerator implements Closeable {
-    private final CairoConfiguration configuration;
-    private final String uniqueIdFileName;
-    private final long uniqueIdMemSize;
-
-    private long uniqueIdFd = -1;
-    private long uniqueIdMem = 0;
-
-    public IDGenerator(CairoConfiguration configuration, String uniqueIdFileName) {
-        this.configuration = configuration;
-        this.uniqueIdFileName = uniqueIdFileName;
-        this.uniqueIdMemSize = Files.PAGE_SIZE;
-    }
-
-    @Override
-    public void close() {
-        final FilesFacade ff = configuration.getFilesFacade();
-        if (uniqueIdMem != 0) {
-            ff.munmap(uniqueIdMem, uniqueIdMemSize, MemoryTag.MMAP_DEFAULT);
-            uniqueIdMem = 0;
-        }
-        if (ff.close(uniqueIdFd)) {
-            uniqueIdFd = -1;
-        }
-    }
-
-    public long getNextId() {
-        long next;
-        long x = getCurrentId();
-        do {
-            next = x;
-            x = Os.compareAndSwap(uniqueIdMem, next, next + 1);
-        } while (next != x);
-        return next + 1;
-    }
-
-    public void open() {
+public interface IDGenerator extends Closeable {
+    default void open() {
         open(null);
     }
 
-    public void open(Path path) {
-        close();
-        if (path == null) {
-            path = Path.getThreadLocal(configuration.getDbRoot());
-        }
-        final int rootLen = path.size();
-        try {
-            path.concat(uniqueIdFileName);
-            final FilesFacade ff = configuration.getFilesFacade();
-            uniqueIdFd = TableUtils.openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
-            uniqueIdMem = TableUtils.mapRW(ff, uniqueIdFd, uniqueIdMemSize, MemoryTag.MMAP_DEFAULT);
-        } catch (Throwable th) {
-            close();
-            throw th;
-        } finally {
-            path.trimTo(rootLen);
-        }
-    }
+    void open(Path path);
 
-    // This is not thread safe way to reset the id back to 0
-    // It is useful for testing only
-    public void reset() {
-        Unsafe.getUnsafe().putLong(uniqueIdMem, 0);
-    }
+    long getNextId();
 
-    long getCurrentId() {
-        assert uniqueIdMem != 0;
-        return Unsafe.getUnsafe().getLong(uniqueIdMem);
-    }
+    void reset();
+
+    void close();
 }

--- a/core/src/main/java/io/questdb/cairo/IDGeneratorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/IDGeneratorFactory.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cairo;
+
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.Path;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class IDGeneratorFactory {
+
+    public static IDGenerator newIDGenerator(CairoConfiguration configuration, String uniqueIdFileName, int step) {
+        if (configuration.getCommitMode() == CommitMode.NOSYNC) {
+            return new NoSyncIDGenerator(configuration, uniqueIdFileName);
+        } else {
+            return new SyncIDGenerator(configuration, uniqueIdFileName, step);
+        }
+    }
+
+    public static abstract class AbstractIDGenerator implements IDGenerator {
+        protected final CairoConfiguration configuration;
+        protected final String uniqueIdFileName;
+        protected final long uniqueIdMemSize;
+        protected long uniqueIdFd = -1;
+        protected long uniqueIdMem = 0;
+
+        public AbstractIDGenerator(CairoConfiguration configuration, String uniqueIdFileName) {
+            this.configuration = configuration;
+            this.uniqueIdFileName = uniqueIdFileName;
+            this.uniqueIdMemSize = Files.PAGE_SIZE;
+        }
+
+        @Override
+        public void close() {
+            final FilesFacade ff = configuration.getFilesFacade();
+            if (uniqueIdMem != 0) {
+                ff.munmap(uniqueIdMem, uniqueIdMemSize, MemoryTag.MMAP_DEFAULT);
+                uniqueIdMem = 0;
+            }
+            if (ff.close(uniqueIdFd)) {
+                uniqueIdFd = -1;
+            }
+        }
+
+        @Override
+        public void open(Path path) {
+            close();
+            if (path == null) {
+                path = Path.getThreadLocal(configuration.getDbRoot());
+            }
+            final int rootLen = path.size();
+            try {
+                path.concat(uniqueIdFileName);
+                final FilesFacade ff = configuration.getFilesFacade();
+                uniqueIdFd = TableUtils.openFileRWOrFail(ff, path.$(), configuration.getWriterFileOpenOpts());
+                uniqueIdMem = TableUtils.mapRW(ff, uniqueIdFd, uniqueIdMemSize, MemoryTag.MMAP_DEFAULT);
+            } catch (Throwable th) {
+                close();
+                throw th;
+            } finally {
+                path.trimTo(rootLen);
+            }
+        }
+
+        // This is not thread safe way to reset the id back to 0
+        // It is useful for testing only
+        @Override
+        public void reset() {
+            Unsafe.getUnsafe().putLong(uniqueIdMem, 0);
+        }
+
+        long getCurrentId() {
+            assert uniqueIdMem != 0;
+            return Unsafe.getUnsafe().getLong(uniqueIdMem);
+        }
+    }
+
+    static class NoSyncIDGenerator extends AbstractIDGenerator {
+        public NoSyncIDGenerator(CairoConfiguration configuration, String uniqueIdFileName) {
+            super(configuration, uniqueIdFileName);
+        }
+
+        @Override
+        public long getNextId() {
+            long next;
+            long x = getCurrentId();
+            do {
+                next = x;
+                x = Os.compareAndSwap(uniqueIdMem, next, next + 1);
+            } while (next != x);
+            return next + 1;
+        }
+    }
+
+    static class SyncIDGenerator extends AbstractIDGenerator {
+        private AtomicLong base;
+        private long end;
+        private final int step;
+
+        public SyncIDGenerator(CairoConfiguration configuration, String uniqueIdFileName, int step) {
+            super(configuration, uniqueIdFileName);
+            this.step = step;
+        }
+
+        @Override
+        public void open(Path path) {
+            super.open(path);
+            end = getCurrentId();
+            base = new AtomicLong(end);
+        }
+
+        @Override
+        public synchronized long getNextId() {
+            while (true) {
+                long next = base.incrementAndGet();
+                if (next <= end) {
+                    // hotPath
+                    return next;
+                }
+
+                synchronized (this) {
+                    // Check if new batch allocation still needed
+                    if (base.get() > end) {
+                        // Allocate new batch
+                        long newEnd = end + step;
+                        Unsafe.getUnsafe().putLong(uniqueIdMem, newEnd);
+                        configuration.getFilesFacade().msync(uniqueIdMem, uniqueIdMemSize, configuration.getCommitMode() == CommitMode.ASYNC);
+                        base.set(newEnd - step);
+                        end = newEnd;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.BinaryAlterSerializer;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.IDGeneratorFactory;
 import io.questdb.cairo.IDGenerator;
 import io.questdb.cairo.TableStructure;
 import io.questdb.cairo.TableToken;
@@ -93,7 +94,7 @@ public class TableSequencerImpl implements TableSequencer {
 
             metadata = new SequencerMetadata(ff, configuration.getCommitMode());
             metadataSvc = new SequencerMetadataService(metadata, tableToken);
-            walIdGenerator = new IDGenerator(configuration, WAL_INDEX_FILE_NAME);
+            walIdGenerator = IDGeneratorFactory.newIDGenerator(configuration, WAL_INDEX_FILE_NAME, configuration.getIdGenerateBatchStep() < 0 ? 512 : configuration.getIdGenerateBatchStep());
             tableTransactionLog = new TableTransactionLog(configuration);
             microClock = configuration.getMicrosecondClock();
             if (tableStruct != null) {

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -222,6 +222,9 @@ query.timeout=1m
 # number of attempts to open files
 #cairo.file.operation.retry.count=30
 
+# when DB is running in sync/async mode, how many 'steps' IDGenerators will  pre-allocate and synchronize sync to disk
+#cairo.id.generator.batch.step=512
+
 # how often the writer maintenance job gets run
 #cairo.idle.check.interval=5m
 

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -204,6 +204,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.expression.pool.capacity\tQDB_CAIRO_EXPRESSION_POOL_CAPACITY\t8192\tdefault\tfalse\tfalse\n" +
                                     "cairo.fast.map.load.factor\tQDB_CAIRO_FAST_MAP_LOAD_FACTOR\t0.7\tdefault\tfalse\tfalse\n" +
                                     "cairo.file.operation.retry.count\tQDB_CAIRO_FILE_OPERATION_RETRY_COUNT\t30\tdefault\tfalse\tfalse\n" +
+                                    "cairo.id.generator.batch.step\tQDB_CAIRO_ID_GENERATOR_BATCH_STEP\t512\tdefault\tfalse\tfalse\n" +
                                     "cairo.idle.check.interval\tQDB_CAIRO_IDLE_CHECK_INTERVAL\t300000\tdefault\tfalse\tfalse\n" +
                                     "cairo.inactive.reader.max.open.partitions\tQDB_CAIRO_INACTIVE_READER_MAX_OPEN_PARTITIONS\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.inactive.reader.ttl\tQDB_CAIRO_INACTIVE_READER_TTL\t120000\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cairo/IDGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IDGeneratorTest.java
@@ -24,7 +24,11 @@
 
 package io.questdb.test.cairo;
 
-import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoConfigurationWrapper;
+import io.questdb.cairo.CommitMode;
+import io.questdb.cairo.IDGenerator;
+import io.questdb.cairo.IDGeneratorFactory;
 import io.questdb.std.LongList;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
@@ -39,51 +43,94 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class IDGeneratorTest extends AbstractCairoTest {
 
     @Test
-    public void testNextTableId() throws Exception {
+    public void testNoSyncMode() throws Exception {
         assertMemoryLeak(() -> {
-            try (
-                    CairoEngine engineA = new CairoEngine(configuration);
-                    CairoEngine engineB = new CairoEngine(configuration)
-            ) {
-                final LongList listA = new LongList();
-                final LongList listB = new LongList();
-                final CyclicBarrier startBarrier = new CyclicBarrier(2);
-                final AtomicInteger errors = new AtomicInteger();
+            Set<Long> set = testGenerateId(configuration, CommitMode.NOSYNC, 1, 5000);
+            Assert.assertEquals(10000, set.size());
+        });
+    }
 
-                final Thread th = new Thread(() -> {
-                    try {
-                        startBarrier.await();
-                        for (int i = 0; i < 5000; i++) {
-                            listA.add(engineA.getNextTableId());
-                        }
-                    } catch (InterruptedException | BrokenBarrierException e) {
-                        e.printStackTrace();
-                        errors.incrementAndGet();
+    @Test
+    public void testASyncMode() throws Exception {
+        assertMemoryLeak(() -> {
+            Set<Long> set = testGenerateId(configuration, CommitMode.ASYNC, 256, 5000);
+            Assert.assertEquals(10000, set.size());
+        });
+    }
+
+    @Test
+    public void testSyncMode() throws Exception {
+        assertMemoryLeak(() -> {
+            Set<Long> set = testGenerateId(configuration, CommitMode.SYNC, 512, 5000);
+            Assert.assertEquals(10000, set.size());
+        });
+    }
+
+    @Test
+    public void testSwitchMode() throws Exception {
+        assertMemoryLeak(() -> {
+            int count = 10000;
+            Set<Long> set1 = testGenerateId(configuration, CommitMode.SYNC, 512, count);
+            Assert.assertEquals(count * 2, set1.size());
+            Set<Long> set2 = testGenerateId(configuration, CommitMode.NOSYNC, 1, count);
+            Assert.assertEquals(count * 2, set2.size());
+            set1.addAll(set2);
+            Assert.assertEquals(count * 4, set1.size());
+            Set<Long> set3 = testGenerateId(configuration, CommitMode.ASYNC, 100, count);
+            Assert.assertEquals(count * 2, set3.size());
+            set1.addAll(set3);
+            Assert.assertTrue(set1.size() <= count * 6);
+        });
+    }
+
+    private Set<Long> testGenerateId(CairoConfiguration configuration, int commitMode, int step, int count) throws Exception {
+        try (
+                IDGenerator idGenerator = IDGeneratorFactory.newIDGenerator(new CairoConfigurationWrapper(configuration) {
+                    @Override
+                    public int getCommitMode() {
+                        return commitMode;
                     }
-                });
-                th.start();
+                }, "id_generator.test", step);
+        ) {
+            idGenerator.open();
+            final LongList listA = new LongList();
+            final LongList listB = new LongList();
+            final CyclicBarrier startBarrier = new CyclicBarrier(2);
+            final AtomicInteger errors = new AtomicInteger();
 
+            final Thread th = new Thread(() -> {
                 try {
                     startBarrier.await();
-                    for (int i = 0; i < 5000; i++) {
-                        listB.add(engineB.getNextTableId());
+                    for (int i = 0; i < count; i++) {
+                        listA.add(idGenerator.getNextId());
                     }
-                    th.join();
                 } catch (InterruptedException | BrokenBarrierException e) {
                     e.printStackTrace();
                     errors.incrementAndGet();
                 }
+            });
+            th.start();
 
-                Set<Long> set = new HashSet<>();
-                // add both arrays to the set and assert that there are no duplicates
-                for (int i = 0, n = listA.size(); i < n; i++) {
-                    Assert.assertTrue(set.add(listA.getQuick(i)));
+            try {
+                startBarrier.await();
+                for (int i = 0; i < count; i++) {
+                    listB.add(idGenerator.getNextId());
                 }
-                for (int i = 0, n = listB.size(); i < n; i++) {
-                    Assert.assertTrue(set.add(listB.getQuick(i)));
-                }
-                Assert.assertEquals(10000, set.size());
+                th.join();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                e.printStackTrace();
+                errors.incrementAndGet();
             }
-        });
+
+            Set<Long> set = new HashSet<>();
+            // add both arrays to the set and assert that there are no duplicates
+            for (int i = 0, n = listA.size(); i < n; i++) {
+                Assert.assertTrue(set.add(listA.getQuick(i)));
+            }
+            for (int i = 0, n = listB.size(); i < n; i++) {
+                Assert.assertTrue(set.add(listB.getQuick(i)));
+            }
+            return set;
+        }
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/Overrides.java
+++ b/core/src/test/java/io/questdb/test/cairo/Overrides.java
@@ -239,6 +239,7 @@ public class Overrides {
         properties.setProperty(PropertyKey.CAIRO_SQL_GROUPBY_ALLOCATOR_MAX_CHUNK_SIZE.getPropertyPath(), "1073741824");
         properties.setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_MERGE_QUEUE_CAPACITY.getPropertyPath(), "32");
         properties.setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD.getPropertyPath(), "1000");
+        properties.setProperty(PropertyKey.CAIRO_ID_GENERATE_STEP.getPropertyPath(), "512");
         properties.setProperty(PropertyKey.CAIRO_IDLE_CHECK_INTERVAL.getPropertyPath(), "100");
         properties.setProperty(PropertyKey.CAIRO_INACTIVE_READER_TTL.getPropertyPath(), "-10000");
         properties.setProperty(PropertyKey.CAIRO_INACTIVE_WRITER_TTL.getPropertyPath(), "-10000");

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -170,6 +170,9 @@ query.timeout.sec=60
 # number of attempts to open files
 #cairo.file.operation.retry.count=30
 
+# when DB is running in sync/async mode, how many 'steps' IDGenerators will  pre-allocate and synchronize sync to disk
+#cairo.id.generator.batch.step=512
+
 # how often the writer maintenance job gets run,  in milliseconds
 #cairo.idle.check.interval=300000
 


### PR DESCRIPTION
Fix https://github.com/questdb/questdb/issues/5322
Add a batch IDAllocator when server running in sync mode.
