### PR TITLE
fix(core): fix occasional config parsing error when the context path is set per service

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -2096,7 +2096,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         } else {
             parts = unparsedResult.split(",");
         }
-        for (int i = 0, n = defaultValue.length; i < n; i++) {
+        for (int i = 0, n = parts.length; i < n; i++) {
             String url = parts[i].trim();
             if (url.isEmpty()) {
                 throw ServerConfigurationException.forInvalidKey(key.getPropertyPath(), "empty URL in the list");

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -504,6 +504,26 @@ public class PropServerConfigurationTest {
     }
 
     @Test
+    public void testContextPath() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(PropertyKey.HTTP_CONTEXT_WEB_CONSOLE.getPropertyPath(), "/context");
+        PropServerConfiguration configuration = newPropServerConfiguration(properties);
+        Assert.assertEquals("/context", configuration.getHttpServerConfiguration().getContextPathWebConsole());
+
+        properties.setProperty(PropertyKey.HTTP_CONTEXT_ILP.getPropertyPath(), "/ilp/write");
+        configuration = newPropServerConfiguration(properties);
+        Assert.assertEquals(1, configuration.getHttpServerConfiguration().getContextPathILP().size());
+        Assert.assertEquals("/ilp/write", configuration.getHttpServerConfiguration().getContextPathILP().get(0));
+
+        properties.setProperty(PropertyKey.HTTP_CONTEXT_ILP.getPropertyPath(), "/ilp/write,/write,/ilp");
+        configuration = newPropServerConfiguration(properties);
+        Assert.assertEquals(3, configuration.getHttpServerConfiguration().getContextPathILP().size());
+        Assert.assertEquals("/ilp/write", configuration.getHttpServerConfiguration().getContextPathILP().get(0));
+        Assert.assertEquals("/write", configuration.getHttpServerConfiguration().getContextPathILP().get(1));
+        Assert.assertEquals("/ilp", configuration.getHttpServerConfiguration().getContextPathILP().get(2));
+    }
+
+    @Test
     public void testDefaultAddColumnTypeForFloat() throws Exception {
         Properties properties = new Properties();
 


### PR DESCRIPTION
fix occasional config parsing error when the context path is set per service