### PR TITLE
chore(core): ignore unknown properties when reloading server config

### DIFF
--- a/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
@@ -218,12 +218,12 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
             if (oldVal == null || !oldVal.equals(entry.getValue())) {
                 final ConfigPropertyKey propKey = keyResolver.apply(key);
                 if (propKey == null) {
-                    return false;
+                    log.error().$("unknown property, ignoring [update, key=").$(key).I$();
+                    continue;
                 }
 
                 if (reloadableProps.contains(propKey)) {
-                    final LogRecord rec = log.info()
-                            .$("reloaded config option [update, key=").$(key);
+                    final LogRecord rec = log.info().$("reloaded config option [update, key=").$(key);
                     if (!propKey.isSensitive()) {
                         rec
                                 .$(", oldValue=").$(oldVal)
@@ -246,11 +246,12 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
             if (!newProperties.containsKey(key)) {
                 final ConfigPropertyKey propKey = keyResolver.apply((String) key);
                 if (propKey == null) {
+                    log.error().$("unknown property, ignoring [remove, key=").$(key).I$();
                     continue;
                 }
+
                 if (reloadableProps.contains(propKey)) {
-                    final LogRecord rec = log.info()
-                            .$("reloaded config option [remove, key=").$(key);
+                    final LogRecord rec = log.info().$("reloaded config option [remove, key=").$(key);
                     if (!propKey.isSensitive()) {
                         rec.$(", value=").$(oldProperties.getProperty((String) key));
                     }

--- a/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
@@ -558,8 +558,9 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
                 serverMain.start();
 
                 String tableName = QueryTracingJob.TABLE_NAME;
-                try (Connection conn = getConnection("admin", "quest");
-                     PreparedStatement queryTraceStmt = conn.prepareStatement(tableName)
+                try (
+                        Connection conn = getConnection("admin", "quest");
+                        PreparedStatement queryTraceStmt = conn.prepareStatement(tableName)
                 ) {
                     Runnable assertTableEmpty = () -> {
                         try (ResultSet rs = queryTraceStmt.executeQuery()) {
@@ -678,6 +679,50 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
 
                 // unsupported property should stay as it was before reload
                 Assert.assertTrue(serverMain.getConfiguration().getLineTcpReceiverConfiguration().isUseLegacyStringDefault());
+            }
+        });
+    }
+
+    @Test
+    public void testUnknownPropertyAdditionIsIgnored() throws Exception {
+        assertMemoryLeak(() -> {
+            try (FileWriter w = new FileWriter(serverConf)) {
+                w.write("query.tracing.enabled=false\n");
+            }
+
+            try (ServerMain serverMain = new ServerMain(getBootstrap())) {
+                serverMain.start();
+
+                try (FileWriter w = new FileWriter(serverConf, false)) {
+                    w.write("query.tracing.enabled=true\n");
+                    w.write("foo.bar=baz\n");
+                }
+
+                assertReloadConfig(true, "admin", "quest");
+
+                Assert.assertTrue(serverMain.getConfiguration().getCairoConfiguration().isQueryTracingEnabled());
+            }
+        });
+    }
+
+    @Test
+    public void testUnknownPropertyRemovalIsIgnored() throws Exception {
+        assertMemoryLeak(() -> {
+            try (FileWriter w = new FileWriter(serverConf)) {
+                w.write("query.tracing.enabled=false\n");
+                w.write("foo.bar=baz\n");
+            }
+
+            try (ServerMain serverMain = new ServerMain(getBootstrap())) {
+                serverMain.start();
+
+                try (FileWriter w = new FileWriter(serverConf, false)) {
+                    w.write("query.tracing.enabled=true\n");
+                }
+
+                assertReloadConfig(true, "admin", "quest");
+
+                Assert.assertTrue(serverMain.getConfiguration().getCairoConfiguration().isQueryTracingEnabled());
             }
         });
     }


### PR DESCRIPTION
Unknown properties are now handled consistently and ignored when reloading server config.