### PR TITLE
fix(core): fix updates failing with table busy when non-WAL table is created from ILP

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -887,7 +887,7 @@ public class CairoEngine implements Closeable, WriterSource {
         return lockReadersByTableToken(tableToken);
     }
 
-    public boolean lockReadersIfNoCheckpoint(TableToken tableToken) {
+    public boolean lockReadersOnDrop(TableToken tableToken) {
         if (checkpointAgent.isInProgress()) {
             // prevent reader locking before checkpoint is released
             return false;
@@ -1215,6 +1215,10 @@ public class CairoEngine implements Closeable, WriterSource {
 
     public void unlockReaders(TableToken tableToken) {
         verifyTableToken(tableToken);
+        readerPool.unlock(tableToken);
+    }
+
+    public void unlockReadersOnDrop(TableToken tableToken) {
         readerPool.unlock(tableToken);
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -196,7 +196,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
             CairoEngine engine,
             @Transient Path tempPath
     ) {
-        if (engine.lockReadersAndMetadata(tableToken)) {
+        if (engine.lockReadersIfNoCheckpoint(tableToken)) {
             TableWriter writerToClose = null;
             try {
                 final CairoConfiguration configuration = engine.getConfiguration();
@@ -222,7 +222,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 cleanDroppedTableDirectory(engine, tempPath, tableToken);
             } finally {
                 Misc.free(writerToClose);
-                engine.unlockReadersAndMetadata(tableToken);
+                engine.unlockReaders(tableToken);
             }
         } else {
             LOG.info().$("table '").utf8(tableToken.getDirName())

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -196,7 +196,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
             CairoEngine engine,
             @Transient Path tempPath
     ) {
-        if (engine.lockReadersIfNoCheckpoint(tableToken)) {
+        if (engine.lockReadersOnDrop(tableToken)) {
             TableWriter writerToClose = null;
             try {
                 final CairoConfiguration configuration = engine.getConfiguration();
@@ -222,7 +222,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 cleanDroppedTableDirectory(engine, tempPath, tableToken);
             } finally {
                 Misc.free(writerToClose);
-                engine.unlockReaders(tableToken);
+                engine.unlockReadersOnDrop(tableToken);
             }
         } else {
             LOG.info().$("table '").utf8(tableToken.getDirName())


### PR DESCRIPTION
Found by fuzz tests

When the table is created from ILP a concurrent update can fail with "table busy" error.
This PR unlocks table reading and metadata early to prevent such exceptions