### PR TITLE
chore(ui): upgrade web console to 0.7.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.7.4</web.console.version>
+        <web.console.version>0.7.5</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 


### PR DESCRIPTION
upgrade web console to 0.7.5

Includes two UI fixes:
- Fix floating-point regex capturing words beginning with 'E' [#394](https://github.com/questdb/ui/pull/394)
- Prevent login loop when token expires without a valid refresh token [#395](https://github.com/questdb/ui/pull/395)
