### PR TITLE
fix(sql): enhance join compatibility for widening casts

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -6223,7 +6223,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             final String columnNameA = slaveMetadata.getColumnName(columnIndexA);
             final int columnTypeB = masterMetadata.getColumnType(columnIndexB);
             final String columnNameB = masterMetadata.getColumnName(columnIndexB);
-            if (columnTypeB != columnTypeA && !(ColumnType.isSymbolOrString(columnTypeB) && ColumnType.isSymbolOrString(columnTypeA))) {
+            if (columnTypeB != columnTypeA &&
+                    !(ColumnType.isSymbolOrString(columnTypeB) && ColumnType.isSymbolOrString(columnTypeA)) &&
+                    !(ColumnType.isBuiltInWideningCast(columnTypeB, columnTypeA) || ColumnType.isBuiltInWideningCast(columnTypeA, columnTypeB))) {
                 // index in column filter and join context is the same
                 throw SqlException.$(jc.aNodes.getQuick(k).position, "join column type mismatch");
             }
@@ -6248,6 +6250,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 keyTypes.add(columnTypeB);
                 writeSymbolAsString.set(columnIndexA);
                 writeSymbolAsString.set(columnIndexB);
+            } else if (ColumnType.isBuiltInWideningCast(columnTypeB, columnTypeA)) {
+                keyTypes.add(columnTypeA);
             } else {
                 keyTypes.add(columnTypeB);
             }

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -2117,6 +2117,38 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testJoinWideningCast() throws Exception {
+        String[] types = {"short", "int", "long"};
+        for (var tp : types) {
+            assertQuery(
+                    "x\ty\n" +
+                            "1\t1\n" +
+                            "2\t2\n" +
+                            "3\t3\n" +
+                            "4\t4\n" +
+                            "5\t5\n",
+                    "select x, y from long_sequence(5) ls join (select cast(x as " + tp + ") y from long_sequence(5)) as ls2 on ls.x = ls2.y",
+                    null,
+                    false,
+                    true
+            );
+
+            assertQuery(
+                    "x\ty\n" +
+                            "1\t1\n" +
+                            "2\t2\n" +
+                            "3\t3\n" +
+                            "4\t4\n" +
+                            "5\t5\n",
+                    "select x, y from (select cast(x as " + tp + ") y from long_sequence(5)) as ls2 join long_sequence(5) ls on ls.x = ls2.y",
+                    null,
+                    false,
+                    true
+            );
+        }
+    }
+
+    @Test
     public void testJoinOnExecutionOrder() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table l as( select x from long_sequence(100) )");


### PR DESCRIPTION
If joined types are different but one is widening the other do not throw SqlException "join column type mismatch" and use the wider type as keyType. 

Fixes #1679