### PR TITLE
fix(core): fix column name case sensitivity in alter column SQL

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1959,7 +1959,7 @@ public class WalWriter implements TableWriterAPI {
 
         @Override
         public void changeColumnType(
-                CharSequence columnName,
+                CharSequence columnNameSeq,
                 int newType,
                 int symbolCapacity,
                 boolean symbolCacheFlag,
@@ -1968,8 +1968,9 @@ public class WalWriter implements TableWriterAPI {
                 boolean isSequential,
                 SecurityContext securityContext
         ) {
-            final int existingColumnIndex = metadata.getColumnIndexQuiet(columnName);
+            final int existingColumnIndex = metadata.getColumnIndexQuiet(columnNameSeq);
             if (existingColumnIndex > -1) {
+                String columnName = metadata.getColumnName(existingColumnIndex);
                 int existingColumnType = metadata.getColumnType(existingColumnIndex);
                 if (existingColumnType > 0) {
                     if (existingColumnType != newType) {
@@ -2031,7 +2032,7 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnName).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
             }
         }
 
@@ -2056,9 +2057,10 @@ public class WalWriter implements TableWriterAPI {
         }
 
         @Override
-        public void removeColumn(@NotNull CharSequence columnName) {
-            final int columnIndex = metadata.getColumnIndexQuiet(columnName);
+        public void removeColumn(@NotNull CharSequence columnNameSeq) {
+            final int columnIndex = metadata.getColumnIndexQuiet(columnNameSeq);
             if (columnIndex > -1) {
+                String columnName = metadata.getColumnName(columnIndex);
                 int type = metadata.getColumnType(columnIndex);
                 if (type > 0) {
                     if (currentTxnStartRowNum > 0) {
@@ -2092,18 +2094,19 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnName).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
             }
         }
 
         @Override
         public void renameColumn(
-                @NotNull CharSequence columnName,
+                @NotNull CharSequence columnNameSeq,
                 @NotNull CharSequence newColumnName,
                 SecurityContext securityContext
         ) {
-            final int columnIndex = metadata.getColumnIndexQuiet(columnName);
+            final int columnIndex = metadata.getColumnIndexQuiet(columnNameSeq);
             if (columnIndex > -1) {
+                String columnName = metadata.getColumnName(columnIndex);
                 int columnType = metadata.getColumnType(columnIndex);
                 if (columnType > 0) {
                     if (currentTxnStartRowNum > 0) {
@@ -2145,7 +2148,7 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnName).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
             }
         }
 

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzChangeColumnTypeOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzChangeColumnTypeOperation.java
@@ -33,6 +33,7 @@ import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 
 public class FuzzChangeColumnTypeOperation implements FuzzTransactionOperation {
     private static final long MAX_TABLE_ROWS_TO_CONVERT_TO_SYMBOL = 60_000;
@@ -56,8 +57,8 @@ public class FuzzChangeColumnTypeOperation implements FuzzTransactionOperation {
     private final int newColumnType;
     private final int symbolCapacity;
 
-    public FuzzChangeColumnTypeOperation(String columName, int newColumnType, int symbolCapacity, boolean indexFlag, int indexValueBlockCapacity, boolean cacheSymbolMap) {
-        this.columName = columName;
+    public FuzzChangeColumnTypeOperation(Rnd rnd, String columName, int newColumnType, int symbolCapacity, boolean indexFlag, int indexValueBlockCapacity, boolean cacheSymbolMap) {
+        this.columName = TestUtils.randomiseCase(rnd, columName);
         this.newColumnType = newColumnType;
         this.indexFlag = indexFlag;
         this.indexValueBlockCapacity = indexValueBlockCapacity;
@@ -139,7 +140,7 @@ public class FuzzChangeColumnTypeOperation implements FuzzTransactionOperation {
                 boolean indexFlag = ColumnType.isSymbol(newColType) && (columnType == ColumnType.BOOLEAN || columnType == ColumnType.BYTE);
                 int indexValueBlockCapacity = (columnType == ColumnType.BOOLEAN) ? 4 : 128;
                 boolean cacheSymbolMap = ColumnType.isSymbol(newColType) && rnd.nextBoolean();
-                transaction.operationList.add(new FuzzChangeColumnTypeOperation(columnName, newColType, capacity, indexFlag, indexValueBlockCapacity, cacheSymbolMap));
+                transaction.operationList.add(new FuzzChangeColumnTypeOperation(rnd, columnName, newColType, capacity, indexFlag, indexValueBlockCapacity, cacheSymbolMap));
                 transaction.structureVersion = metadataVersion;
                 transaction.waitBarrierVersion = waitBarrierVersion;
                 transactionList.add(transaction);

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzDropColumnOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzDropColumnOperation.java
@@ -29,12 +29,13 @@ import io.questdb.cairo.TableWriterAPI;
 import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 
 public class FuzzDropColumnOperation implements FuzzTransactionOperation {
     private final String columnName;
 
-    public FuzzDropColumnOperation(String columnName) {
-        this.columnName = columnName;
+    public FuzzDropColumnOperation(Rnd rnd, String columnName) {
+        this.columnName = TestUtils.randomiseCase(rnd, columnName);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzDropPartitionOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzDropPartitionOperation.java
@@ -36,6 +36,7 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.std.Chars;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 
 public class FuzzDropPartitionOperation implements FuzzTransactionOperation {
 
@@ -53,7 +54,7 @@ public class FuzzDropPartitionOperation implements FuzzTransactionOperation {
             context.with(AllowAllSecurityContext.INSTANCE);
             TableRecordMetadata metadata = wApi.getMetadata();
             String sql = String.format("ALTER TABLE %s DROP PARTITION WHERE %s < %d AND %s > %d - 86400000000",
-                    wApi.getTableToken().getTableName(),
+                    TestUtils.randomiseCase(tempRnd, wApi.getTableToken().getTableName()),
                     metadata.getColumnName(metadata.getTimestampIndex()),
                     cutoffTimestamp,
                     metadata.getColumnName(metadata.getTimestampIndex()),

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzRenameColumnOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzRenameColumnOperation.java
@@ -29,13 +29,14 @@ import io.questdb.cairo.TableWriterAPI;
 import io.questdb.griffin.engine.ops.AlterOperation;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 
 public class FuzzRenameColumnOperation implements FuzzTransactionOperation {
     private final String columName;
     private final String newColName;
 
-    public FuzzRenameColumnOperation(String columName, String newColName) {
-        this.columName = columName;
+    public FuzzRenameColumnOperation(Rnd rnd, String columName, String newColName) {
+        this.columName = TestUtils.randomiseCase(rnd, columName);
         this.newColName = newColName;
     }
 

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
@@ -318,7 +318,7 @@ public class FuzzTransactionGenerator {
                     }
                 }
 
-                transaction.operationList.add(new FuzzRenameColumnOperation(columnName, newColName));
+                transaction.operationList.add(new FuzzRenameColumnOperation(rnd, columnName, newColName));
                 transaction.structureVersion = metadataVersion;
                 transaction.waitBarrierVersion = waitBarrierVersion;
                 transactionList.add(transaction);
@@ -471,7 +471,7 @@ public class FuzzTransactionGenerator {
             int type = tableMetadata.getColumnType(columnIndex);
             if (type > 0 && columnIndex != tableMetadata.getTimestampIndex()) {
                 String columnName = tableMetadata.getColumnName(columnIndex);
-                transaction.operationList.add(new FuzzDropColumnOperation(columnName));
+                transaction.operationList.add(new FuzzDropColumnOperation(rnd, columnName));
                 transaction.structureVersion = metadataVersion;
                 transaction.waitBarrierVersion = waitBarrierVersion;
                 transactionList.add(transaction);

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -1506,6 +1506,26 @@ public final class TestUtils {
         return seq;
     }
 
+    public static String randomiseCase(Rnd rnd, String columName) {
+        int changeCase = rnd.nextInt(3);
+        if (changeCase == 0) {
+            return columName;
+        }
+        StringSink sink = Misc.getThreadLocalSink();
+        sink.put(columName);
+
+        for (int i = 0; i < changeCase; i++) {
+            int pos = rnd.nextInt(columName.length());
+            char ch = columName.charAt(pos);
+            if (Character.isLowerCase(ch)) {
+                sink.setCharAt(pos, Character.toUpperCase(ch));
+            } else {
+                sink.setCharAt(pos, Character.toLowerCase(ch));
+            }
+        }
+        return sink.toString();
+    }
+
     public static String readStringFromFile(File file) {
         try {
             try (FileInputStream fis = new FileInputStream(file)) {


### PR DESCRIPTION
Before v8.2.2 differences in column name casing in change column type SQL failed in the Apply WAL stage on Linux. This is quite unpleasant to deal with, the table is suspended.

It is fixed in 8.2.2 as a side effect of PR https://github.com/questdb/questdb/pull/5242/files#diff-92e19a7ebb8d2d8603f78fa9cbef967a936887bed8476a0a3e70c736c65ecc41 and this PR adds fuzz tests that randomly change column name casing in fuzz tests.

Fuzz tests discovered that there is still sensitivity in column name casing, this is addressed in `WalWriter` now.