### PR TITLE
fix(pgwire): compatibility with PHP PDO client

### DIFF
--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -24,6 +24,11 @@ jobs:
         run: tar -xzf core/target/questdb-*-no-jre-bin.tar.gz
       - name: Start QuestDB
         run: ./questdb-*bin/questdb.sh start
+      - name: Setup PHP
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt update
+          sudo apt install php php-pdo php-pgsql composer -y
       - name: Setup Rust toolchain
         # 4d1965c9142484e48d40c19de54b5cba84953a06 is the same as @v1, except it's guaranteed to be immutable
         # even if the original tag is moved or deleted

--- a/compat/src/test/php/composer.json
+++ b/compat/src/test/php/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "symfony/yaml": "^6.0"
+  }
+}

--- a/compat/src/test/php/runner.php
+++ b/compat/src/test/php/runner.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * QuestDB Test Runner
+ * PHP Port of the Python test runner using PDO
+ */
+
+require 'vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+
+class TestRunner {
+    private $connection;
+    private $variables;
+
+    public function loadYaml(string $filePath): array {
+        return Yaml::parseFile($filePath);
+    }
+
+    private function substituteVariables(string $text = null, array $variables): ?string {
+        if ($text === null) {
+            return null;
+        }
+        return preg_replace_callback('/\${(\w+)}/', function($matches) use ($variables) {
+            return $variables[$matches[1]] ?? $matches[0];
+        }, $text);
+    }
+
+    private function adjustPlaceholderSyntax(string $query): string {
+        // Replace $[n] with ?
+        return preg_replace('/\$\[\d+\]/', '?', $query);
+    }
+
+    private function executeQuery($stmt, array $parameters = []) {
+        if (!empty($parameters)) {
+            $stmt->execute($parameters);
+        } else {
+            $stmt->execute();
+        }
+
+        try {
+            if ($stmt->columnCount() > 0) {
+                $result = $stmt->fetchAll(PDO::FETCH_NUM);
+                // Normalize data formats to match Python version
+                foreach ($result as &$row) {
+                    foreach ($row as &$value) {
+                        // Handle timestamps
+                        if (preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $value)) {
+                            // Ensure 6 decimal places for microseconds
+                            if (strpos($value, '.') === false) {
+                                $value .= '.000000';
+                            } else {
+                                // Pad existing microseconds to 6 digits
+                                $parts = explode('.', $value);
+                                $parts[1] = str_pad(rtrim($parts[1], '0'), 6, '0');
+                                $value = implode('.', $parts);
+                            }
+                            // Convert space to T and add Z
+                            $value = str_replace(' ', 'T', $value) . 'Z';
+                        }
+                        // Handle dates
+                        elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                            $value .= 'T00:00:00.000000Z';
+                        }
+                        // Handle numeric strings that should be numbers
+                        elseif (is_string($value) && preg_match('/^-?\d+\.?\d*$/', $value)) {
+                            if (strpos($value, '.') !== false) {
+                                $value = (float)$value;
+                            } else {
+                                $value = (int)$value;
+                            }
+                        }
+                        // Handle booleans (PDO returns them as strings)
+                        elseif ($value === '0' || $value === '1') {
+                            $value = (bool)$value;
+                        }
+                    }
+                }
+                return $result;
+            } else {
+                $rowCount = $stmt->rowCount();
+                return $rowCount === 0 ? null : [[$rowCount]];
+            }
+        } catch (PDOException $e) {
+            return $stmt->errorInfo()[2];
+        }
+    }
+
+    private function resolveParameters(array $typedParameters, array $variables): array {
+        $resolvedParameters = [];
+        foreach ($typedParameters as $typedParam) {
+            $type = strtolower($typedParam['type']);
+            $value = $typedParam['value'];
+
+            if (is_string($value)) {
+                $resolvedStrValue = $this->substituteVariables($value, $variables);
+                $this->convertAndAppendParameters($resolvedStrValue, $type, $resolvedParameters);
+            } else {
+                $this->convertAndAppendParameters($value, $type, $resolvedParameters);
+            }
+        }
+        return $resolvedParameters;
+    }
+
+    private function convertAndAppendParameters($value, string $type, array &$resolvedParameters): void {
+        switch ($type) {
+            case 'int4':
+            case 'int8':
+                $resolvedParameters[] = (int)$value;
+                break;
+            case 'float4':
+            case 'float8':
+                $resolvedParameters[] = (float)$value;
+                break;
+            case 'boolean':
+                $value = strtolower(trim($value));
+                if ($value === 'true') {
+                    $resolvedParameters[] = true;
+                } elseif ($value === 'false') {
+                    $resolvedParameters[] = false;
+                } else {
+                    throw new InvalidArgumentException("Invalid boolean value: {$value}");
+                }
+                break;
+            case 'varchar':
+            case 'char':
+                $resolvedParameters[] = (string)$value;
+                break;
+            case 'timestamp':
+            case 'date':
+                $resolvedParameters[] = $value;
+                break;
+            default:
+                $resolvedParameters[] = $value;
+        }
+    }
+
+    private function assertResult(array $expect, $actual): void {
+        if (isset($expect['result'])) {
+            $expectedResult = $expect['result'];
+            if (is_array($expectedResult)) {
+                if (is_string($actual)) {
+                    throw new RuntimeException("Expected result " . json_encode($expectedResult) . ", got status '{$actual}'");
+                }
+                if ($actual != $expectedResult) {
+                    throw new RuntimeException("Expected result " . json_encode($expectedResult) . ", got " . json_encode($actual));
+                }
+            } else {
+                if (strval($actual) !== strval($expectedResult)) {
+                    throw new RuntimeException("Expected result '{$expectedResult}', got '{$actual}'");
+                }
+            }
+        } elseif (isset($expect['result_contains'])) {
+            if (is_string($actual)) {
+                throw new RuntimeException("Expected result containing " . json_encode($expect['result_contains']) . ", got status '{$actual}'");
+            }
+            foreach ($expect['result_contains'] as $expectedRow) {
+                $found = false;
+                foreach ($actual as $actualRow) {
+                    if ($actualRow == $expectedRow) {
+                        $found = true;
+                        break;
+                    }
+                }
+                if (!$found) {
+                    throw new RuntimeException("Expected row " . json_encode($expectedRow) . " not found in actual results.");
+                }
+            }
+        }
+    }
+
+    private function executeLoop(array $loopDef, array $variables, PDO $connection): void {
+        $loopVarName = $loopDef['as'];
+        $loopVariables = $variables;
+
+        if (isset($loopDef['over'])) {
+            $iterable = $loopDef['over'];
+        } elseif (isset($loopDef['range'])) {
+            $start = $loopDef['range']['start'];
+            $end = $loopDef['range']['end'];
+            $iterable = range($start, $end);
+        } else {
+            throw new InvalidArgumentException("Loop must have 'over' or 'range' defined.");
+        }
+
+        foreach ($iterable as $item) {
+            $loopVariables[$loopVarName] = $item;
+            $this->executeSteps($loopDef['steps'], $loopVariables, $connection);
+        }
+    }
+
+    private function executeStep(array $step, array $variables, PDO $connection): void {
+        $queryTemplate = $step['query'] ?? null;
+        $parameters = $step['parameters'] ?? [];
+        $expect = $step['expect'] ?? [];
+
+        $queryWithVars = $this->substituteVariables($queryTemplate, $variables);
+        $query = $this->adjustPlaceholderSyntax($queryWithVars);
+
+        $resolvedParameters = $this->resolveParameters($parameters, $variables);
+        $stmt = $connection->prepare($query);
+        $result = $this->executeQuery($stmt, $resolvedParameters);
+
+        if (!empty($expect)) {
+            $this->assertResult($expect, $result);
+        }
+    }
+
+    private function executeSteps(array $steps, array $variables, PDO $connection): void {
+        foreach ($steps as $step) {
+            if (isset($step['loop'])) {
+                $this->executeLoop($step['loop'], $variables, $connection);
+            } else {
+                $this->executeStep($step, $variables, $connection);
+            }
+        }
+    }
+
+    public function runTest(array $test, array $globalVariables, PDO $connection): void {
+        $variables = array_merge($globalVariables, $test['variables'] ?? []);
+        $testFailed = false;
+
+        try {
+            // Prepare phase
+            $prepareSteps = $test['prepare'] ?? [];
+            $this->executeSteps($prepareSteps, $variables, $connection);
+
+            // Test steps
+            $testSteps = $test['steps'] ?? [];
+            $this->executeSteps($testSteps, $variables, $connection);
+
+            echo "Test '{$test['name']}' passed.\n";
+        } catch (Exception $e) {
+            echo "Test '{$test['name']}' failed: {$e->getMessage()}\n";
+            $testFailed = true;
+        } finally {
+            // Teardown phase
+            $teardownSteps = $test['teardown'] ?? [];
+            try {
+                $this->executeSteps($teardownSteps, $variables, $connection);
+            } catch (Exception $e) {
+                echo "Teardown for test '{$test['name']}' failed: {$e->getMessage()}\n";
+            }
+        }
+
+        if ($testFailed) {
+            exit(1);
+        }
+    }
+
+    public function main(string $yamlFile): void {
+        $data = $this->loadYaml($yamlFile);
+        $globalVariables = $data['variables'] ?? [];
+        $tests = $data['tests'] ?? [];
+
+        $port = getenv('PGPORT') ?: 8812;
+
+        foreach ($tests as $test) {
+            $iterations = $test['iterations'] ?? 50;
+            for ($i = 0; $i < $iterations; $i++) {
+                echo "Running test '{$test['name']}' iteration " . ($i + 1) . "...\n";
+
+                $connection = new PDO(
+                    "pgsql:host=localhost;port={$port};dbname=qdb",
+                    'admin',
+                    'quest',
+                    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+                );
+
+                $this->runTest($test, $globalVariables, $connection);
+                $connection = null;
+            }
+        }
+    }
+}
+
+// Command line execution
+if (php_sapi_name() === 'cli') {
+    if ($argc !== 2) {
+        echo "Usage: php runner.php <test_file.yaml>\n";
+        exit(1);
+    }
+
+    $yamlFile = $argv[1];
+    $runner = new TestRunner();
+    $runner->main($yamlFile);
+}

--- a/compat/src/test/scenarios_stable.sh
+++ b/compat/src/test/scenarios_stable.sh
@@ -98,3 +98,30 @@ if [[ $CLIENTS == 'ALL' || $CLIENTS == *'csharp'* ]]; then
 else
   echo "skipping csharp tests"
 fi
+
+if [[ $CLIENTS == 'ALL' || $CLIENTS == *'php'* ]]; then
+  echo "starting php tests"
+
+  # check if php is installed
+  if ! command -v php &> /dev/null
+  then
+      echo "php could not be found! Please install PHP or exclude PHP tests"
+      exit 1
+  fi
+
+  echo "$base_dir/compat/src/test/php"
+  cd "$base_dir/compat/src/test/php" || exit
+
+  # install deps
+  composer install
+
+  # run
+  php runner.php ../resources/test_cases.yaml
+  if [ $? -ne 0 ]; then
+      echo "php tests failed"
+      exit 1
+  fi
+  echo "php tests finished"
+else
+  echo "skipping php tests"
+fi

--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
@@ -244,7 +244,12 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
 
     @Override
     public void clear() {
-        // no-op, we clear entries before returning them to the pool
+        // paranoid mode: if there is dirty entry in entry pool, we want to make sure it is clean before
+        // we return it to the pool
+        if (sqlType != CompiledQuery.NONE) {
+            //todo: consider logging
+            close();
+        }
     }
 
     @Override


### PR DESCRIPTION
fixes #5368

### Issue
PHP clients were experiencing incorrect "cached plan must not change result type" errors. These errors were spurious and occurred due to improper handling of prepared statement cleanup.

### Root Cause
When PHP clients use the SQL DEALLOCATE command to release named prepared statements:
- The `PGPipelineEntry` object was removed from the prepared statements map
- However, the entry was not returned to the object pool
- The entry also remained in a "dirty" state (was not cleared)
- When a connection closed and `pool.clear()` was called, these dirty entries became available for reuse by new connections

### Solution
#### Fix Core Issue
- Properly return `PGPipelineEntry` objects to the pool after deallocation via SQL `DEALLOCATE`
- Ensure entries are cleared before returning to the pool

#### Added Safety Check
Added a defensive check in `PGPipelineEntry.clear()` that:
- Detects if an entry in the object pool is in a dirty state (sqlType != NONE)
- Logs an error message with instructions to report the bug if a dirty entry is found
- Forces cleanup of the dirty entry to prevent cascading issues
- This serves as a safeguard against potential future bugs where cleanup is missed