### PR TITLE
fix(sql): prevent stale metadata after table DROP and (re-)CREATE

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -422,7 +422,8 @@ public class MetadataCache implements QuietCloseable {
 
                 if (
                         (cachedTable == null
-                                || cachedTable.getMetadataVersion() < latestTable.getMetadataVersion())
+                                || cachedTable.getMetadataVersion() < latestTable.getMetadataVersion()
+                                || cachedTable.getTableToken().getTableId() != latestTable.getTableToken().getTableId())
                                 && isVisibleTable(latestTable.getTableName())) {
                     localCache.put(latestTable.getTableName(), latestTable);
                 }
@@ -434,12 +435,6 @@ public class MetadataCache implements QuietCloseable {
 
                 if (latestTable == null) {
                     localCache.remove(cachedTable.getTableName());
-                    continue;
-                }
-
-                if (cachedTable.getMetadataVersion() < latestTable.getMetadataVersion()
-                        && isVisibleTable(cachedTable.getTableName())) {
-                    localCache.put(cachedTable.getTableName(), latestTable);
                 }
             }
 

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -31,6 +31,7 @@ import io.questdb.cairo.TableToken;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.std.CharSequenceObjHashMap;
 import io.questdb.std.Os;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
@@ -45,8 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 
 public class MetadataCacheTest extends AbstractCairoTest {
-    private static final String xMetaString = "MetadataCache [tableCount=1]\n" +
-            "\tCairoTable [name=x, id=1, directoryName=x~, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=false, columnCount=16]\n" +
+    private static final String xMetaStringSansHeader = "CairoTable [name=x, id=1, directoryName=x~, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=false, columnCount=16]\n" +
             "\t\tCairoColumn [name=i, position=0, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
             "\t\tCairoColumn [name=sym, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
             "\t\tCairoColumn [name=amt, position=2, type=DOUBLE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -62,7 +62,11 @@ public class MetadataCacheTest extends AbstractCairoTest {
             "\t\tCairoColumn [name=k, position=12, type=TIMESTAMP, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=12]\n" +
             "\t\tCairoColumn [name=l, position=13, type=BYTE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=13]\n" +
             "\t\tCairoColumn [name=m, position=14, type=BINARY, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=14]\n" +
-            "\t\tCairoColumn [name=n, position=15, type=STRING, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=15]\n";
+            "\t\tCairoColumn [name=n, position=15, type=STRING, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=15]";
+
+    private static final String xMetaString = "MetadataCache [tableCount=1]\n" +
+            "\t" + xMetaStringSansHeader + "\n";
+
     private static final String yMetaString = "MetadataCache [tableCount=1]\n" +
             "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
             "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n";
@@ -641,6 +645,36 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertException("table_columns('y')", -1, "table does not exist");
+        });
+    }
+
+    @Test
+    public void testDropAndRecreateTableRefreshSnapshots() throws Exception {
+        assertMemoryLeak(() -> {
+            createX();
+            CharSequenceObjHashMap<CairoTable> cache = new CharSequenceObjHashMap<>();
+            long tableCacheVersion = -1;
+
+            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
+                tableCacheVersion = metadataRO.snapshot(cache, tableCacheVersion);
+            }
+
+            CairoTable x = cache.get("x");
+            sink.clear();
+            x.toSink(sink);
+            TestUtils.assertEquals(xMetaStringSansHeader, sink);
+
+            execute("DROP TABLE x");
+            createX();
+            drainWalQueue();
+
+            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
+                metadataRO.snapshot(cache, tableCacheVersion);
+            }
+            x = cache.get("x");
+            sink.clear();
+            x.toSink(sink);
+            TestUtils.assertEquals(xMetaStringSansHeader, sink);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -67,6 +67,8 @@ public class MetadataCacheTest extends AbstractCairoTest {
     private static final String xMetaString = "MetadataCache [tableCount=1]\n" +
             "\t" + xMetaStringSansHeader + "\n";
 
+    private static final String xMetaStringId2SansHeader = xMetaStringSansHeader.replace("id=1", "id=2");
+
     private static final String yMetaString = "MetadataCache [tableCount=1]\n" +
             "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
             "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n";
@@ -674,7 +676,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             x = cache.get("x");
             sink.clear();
             x.toSink(sink);
-            TestUtils.assertEquals(xMetaStringSansHeader, sink);
+            TestUtils.assertEquals(xMetaStringId2SansHeader, sink);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -1424,6 +1424,30 @@ if __name__ == "__main__":
     }
 
     @Test
+    public void testCreateDropCreateTable() throws Exception {
+        assertWithPgServer(CONN_AWARE_EXTENDED, (connection, binary, mode, port) -> {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("create table x as (select x::timestamp as ts from long_sequence(100)) timestamp (ts)");
+                try (ResultSet rs = stmt.executeQuery("tables();")) {
+                    assertResultSet("id[INTEGER],table_name[VARCHAR],designatedTimestamp[VARCHAR],partitionBy[VARCHAR],maxUncommittedRows[INTEGER],o3MaxLag[BIGINT],walEnabled[BIT],directoryName[VARCHAR],dedup[BIT],ttlValue[INTEGER],ttlUnit[VARCHAR],isMatView[BIT]\n" +
+                                    "2,x,ts,NONE,1000,300000000,false,x~,false,0,HOUR,false\n",
+                            sink, rs);
+                }
+
+                stmt.execute("drop table x");
+                drainWalQueue();
+                stmt.execute("create table x as (select x::timestamp as ts from long_sequence(100)) timestamp (ts)");
+
+                try (ResultSet rs = stmt.executeQuery("tables();")) {
+                    assertResultSet("id[INTEGER],table_name[VARCHAR],designatedTimestamp[VARCHAR],partitionBy[VARCHAR],maxUncommittedRows[INTEGER],o3MaxLag[BIGINT],walEnabled[BIT],directoryName[VARCHAR],dedup[BIT],ttlValue[INTEGER],ttlUnit[VARCHAR],isMatView[BIT]\n" +
+                                    "3,x,ts,NONE,1000,300000000,false,x~,false,0,HOUR,false\n",
+                            sink, rs);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testBasicFetch() throws Exception {
         skipOnWalRun(); // Non-partitioned
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {

--- a/core/src/test/java/io/questdb/test/griffin/ShowTablesTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowTablesTest.java
@@ -25,6 +25,10 @@
 package io.questdb.test.griffin;
 
 import io.questdb.PropertyKey;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.CompiledQuery;
+import io.questdb.griffin.SqlCompiler;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -209,6 +213,49 @@ public class ShowTablesTest extends AbstractCairoTest {
                             "2\tbalances_1h\tts\tWEEK\t0\t-1\ttrue\tbalances_1h~2\ttrue\t0\tHOUR\ttrue\n",
                     "tables() order by table_name"
             );
+        });
+    }
+
+    @Test
+    public void testDropAndRecreateTable() throws Exception {
+        // Tests that cached query plans of `tables() correctly handle table recreation
+        //
+        // Purpose: Verify that when a table is dropped and recreated, pre-existing
+        // query plans using tables() function correctly show the new table ID.
+        //
+        // Key assumption: Table IDs must change when a table is dropped and recreated.
+        //
+        // Background: This is a regression test for an issue where the tables() function
+        // returned stale table IDs from cached plans after DROP TABLE + CREATE TABLE operations.
+
+        assertMemoryLeak(() -> {
+            execute("create table x (ts timestamp) timestamp(ts) partition by DAY");
+
+            try (SqlCompiler compiler = engine.getSqlCompiler()) {
+                CompiledQuery compile = compiler.compile("tables()", sqlExecutionContext);
+
+                // we use a single instance of RecordCursorFactory before and after table drop
+                // this mimic behavior of a query cache.
+                try (RecordCursorFactory recordCursorFactory = compile.getRecordCursorFactory()) {
+                    try (RecordCursor cursor = recordCursorFactory.getCursor(sqlExecutionContext)) {
+                        assertCursor("id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                                        "1\tx\tts\tDAY\t1000\t300000000\tfalse\tx~\tfalse\t0\tHOUR\tfalse\n",
+                                false, true, true, cursor, recordCursorFactory.getMetadata(), false);
+                    }
+
+                    // recreate the same table again
+                    execute("drop table x");
+                    execute("create table x (ts timestamp) timestamp(ts) partition by DAY");
+                    drainWalQueue();
+
+                    try (RecordCursor cursor = recordCursorFactory.getCursor(sqlExecutionContext)) {
+                        // note the ID is 2 now!
+                        assertCursor("id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                                        "2\tx\tts\tDAY\t1000\t300000000\tfalse\tx~\tfalse\t0\tHOUR\tfalse\n",
+                                false, true, true, cursor, recordCursorFactory.getMetadata(), false);
+                    }
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
This change fixes stale results returned by metadata functions when a table is dropped and recreated with the same name.

The bug affected the following table functions: tables(),
 information_schema.columns() and pg_attribute().

Mitigation before this fix is released: Disable query cache or execute `SELECT flush_query_cache()` after dropping a table.