### PR TITLE
chore(core): persist refresh type in materialized view definition file

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -201,8 +201,11 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                         case COLUMN_VIEW_NAME:
                             return viewDefinition.getMatViewToken().getTableName();
                         case COLUMN_REFRESH_TYPE:
-                            // For now, incremental refresh is the only supported strategy.
-                            return "incremental";
+                            // For now, incremental refresh is the only supported refresh type.
+                            if (viewDefinition.getRefreshType() == MatViewDefinition.INCREMENTAL_REFRESH_TYPE) {
+                                return "incremental";
+                            }
+                            return "unknown";
                         case COLUMN_BASE_TABLE_NAME:
                             return viewDefinition.getBaseTableName();
                         case COLUMN_VIEW_SQL:

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
@@ -284,7 +284,7 @@ public class TablesFunctionFactory implements FunctionFactory {
         metadata.add(new TableColumnMetadata("dedup", ColumnType.BOOLEAN));
         metadata.add(new TableColumnMetadata("ttlValue", ColumnType.INT));
         metadata.add(new TableColumnMetadata("ttlUnit", ColumnType.STRING));
-        metadata.add(new TableColumnMetadata("isMatView", ColumnType.BOOLEAN));
+        metadata.add(new TableColumnMetadata("matView", ColumnType.BOOLEAN));
         METADATA = metadata;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperation.java
@@ -36,6 +36,8 @@ public interface CreateMatViewOperation extends TableStructure, Operation {
 
     CreateTableOperation getCreateTableOperation();
 
+    int getRefreshType();
+
     CharSequence getSqlText();
 
     int getTableNamePosition();

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationBuilderImpl.java
@@ -44,6 +44,7 @@ public class CreateMatViewOperationBuilderImpl implements CreateMatViewOperation
     private final CharSequenceHashSet baseKeyColumnNames = new CharSequenceHashSet();
     private final CreateTableOperationBuilderImpl createTableOperationBuilder = new CreateTableOperationBuilderImpl();
     private String baseTableName;
+    private int refreshType = -1;
     private long samplingInterval = -1;
     private char samplingIntervalUnit = '\0';
     private String timeZone;
@@ -55,6 +56,7 @@ public class CreateMatViewOperationBuilderImpl implements CreateMatViewOperation
         final CreateTableOperation createTableOperation = createTableOperationBuilder.build(compiler, sqlExecutionContext, sqlText);
         return new CreateMatViewOperationImpl(
                 createTableOperation,
+                refreshType,
                 baseTableName,
                 baseKeyColumnNames,
                 samplingInterval,
@@ -69,6 +71,7 @@ public class CreateMatViewOperationBuilderImpl implements CreateMatViewOperation
     public void clear() {
         createTableOperationBuilder.clear();
         baseKeyColumnNames.clear();
+        refreshType = -1;
         baseTableName = null;
         samplingInterval = -1;
         samplingIntervalUnit = '\0';
@@ -101,6 +104,10 @@ public class CreateMatViewOperationBuilderImpl implements CreateMatViewOperation
 
     public void setBaseTableName(String baseTableName) {
         this.baseTableName = baseTableName;
+    }
+
+    public void setRefreshType(int refreshType) {
+        this.refreshType = refreshType;
     }
 
     public void setSamplingInterval(long samplingInterval) {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.Nullable;
 public class CreateMatViewOperationImpl implements CreateMatViewOperation {
     private final ObjList<String> baseKeyColumnNames = new ObjList<>();
     private final String baseTableName;
+    private final int refreshType;
     private final long samplingInterval;
     private final char samplingIntervalUnit;
     private final String timeZone;
@@ -54,6 +55,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
 
     public CreateMatViewOperationImpl(
             CreateTableOperation createTableOperation,
+            int refreshType,
             String baseTableName,
             @Transient CharSequenceHashSet baseKeyColumnNames,
             long samplingInterval,
@@ -63,6 +65,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
             String viewSql
     ) {
         this.createTableOperation = createTableOperation;
+        this.refreshType = refreshType;
         this.baseTableName = baseTableName;
         for (int i = 0, n = baseKeyColumnNames.getList().size(); i < n; i++) {
             CharSequence colName = baseKeyColumnNames.getList().get(i);
@@ -92,6 +95,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
     public CharSequence getBaseTableName() {
         return baseTableName;
     }
+
 
     @Override
     public int getColumnCount() {
@@ -153,6 +157,12 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
         return createTableOperation.getPartitionBy();
     }
 
+    @Override
+    public int getRefreshType() {
+        return refreshType;
+    }
+
+    @Override
     public CharSequence getSqlText() {
         return createTableOperation.getSqlText();
     }
@@ -172,6 +182,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
         return createTableOperation.getTableName();
     }
 
+    @Override
     public int getTableNamePosition() {
         return createTableOperation.getTableNamePosition();
     }
@@ -199,6 +210,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
     @Override
     public void init(TableToken matViewToken) {
         matViewDefinition = new MatViewDefinition(
+                refreshType,
                 matViewToken,
                 viewSql,
                 baseTableName,

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -89,12 +89,12 @@ public class ServerMainTest extends AbstractBootstrapTest {
                 try {
                     serverMain.getEngine();
                 } catch (IllegalStateException ex) {
-                    assertContains("close was called", ex.getMessage());
+                    assertContains(ex.getMessage(), "close was called");
                 }
                 try {
                     serverMain.getWorkerPoolManager();
                 } catch (IllegalStateException ex) {
-                    assertContains("close was called", ex.getMessage());
+                    assertContains(ex.getMessage(), "close was called");
                 }
                 serverMain.start(); // <== no effect
                 serverMain.close(); // <== no effect

--- a/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
+++ b/core/src/test/java/io/questdb/test/WorkerPoolManagerTest.java
@@ -157,8 +157,8 @@ public class WorkerPoolManagerTest {
                 }
             }, WorkerPoolManager.Requester.OTHER);
             Assert.fail();
-        } catch (IllegalStateException err) {
-            TestUtils.assertContains("can only get instance before start", err.getMessage());
+        } catch (IllegalStateException e) {
+            TestUtils.assertContains(e.getMessage(), "can only get instance before start");
         } finally {
             workerPoolManager.halt();
         }
@@ -247,6 +247,11 @@ public class WorkerPoolManagerTest {
             }
 
             @Override
+            public WorkerPoolConfiguration getMatViewRefreshPoolConfiguration() {
+                return null;
+            }
+
+            @Override
             public MemoryConfiguration getMemoryConfiguration() {
                 return null;
             }
@@ -268,11 +273,6 @@ public class WorkerPoolManagerTest {
 
             @Override
             public PublicPassthroughConfiguration getPublicPassthroughConfiguration() {
-                return null;
-            }
-
-            @Override
-            public WorkerPoolConfiguration getMatViewRefreshPoolConfiguration() {
                 return null;
             }
 

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -1233,7 +1233,7 @@ public class BitmapIndexTest extends AbstractCairoTest {
             BitmapIndexUtils.searchValueBlock(new NullMemoryCMR(), 0L, 63L, 1L);
             Assert.fail();
         } catch (CairoException e) {
-            TestUtils.assertContains("index is corrupt, rowid not found [offset=0, cellCount=63, value=1]", e.getFlyweightMessage());
+            TestUtils.assertContains(e.getFlyweightMessage(), "index is corrupt, rowid not found [offset=0, cellCount=63, value=1]");
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -234,7 +234,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
                 Assert.assertFalse(cacheString.contains("name=foo"));
                 Assert.assertTrue(cacheString.contains("name=bah"));
                 assertQueryNoLeakCheck(
-                        "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                        "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
                                 "1\tbah\tts\tDAY\t1000\t300000000\ttrue\tfoo~1\tfalse\t0\tHOUR\tfalse\n",
                         "tables()",
                         ""
@@ -244,7 +244,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
                 Assert.assertFalse(cacheString.contains("name=bah"));
                 Assert.assertTrue(cacheString.contains("name=foo"));
                 assertQueryNoLeakCheck(
-                        "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                        "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
                                 "1\tfoo\tts\tDAY\t1000\t300000000\ttrue\tfoo~1\tfalse\t0\tHOUR\tfalse\n",
                         "tables()",
                         ""
@@ -631,26 +631,6 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testDropTable() throws Exception {
-        assertMemoryLeak(() -> {
-
-
-            execute("CREATE TABLE y ( ts TIMESTAMP, x INT ) timestamp(ts) partition by day wal;");
-            drainWalQueue();
-
-            assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
-                    "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
-                    "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
-
-            execute("DROP TABLE y");
-            drainWalQueue();
-
-            assertException("table_columns('y')", -1, "table does not exist");
-        });
-    }
-
-    @Test
     public void testDropAndRecreateTableRefreshSnapshots() throws Exception {
         assertMemoryLeak(() -> {
             createX();
@@ -681,11 +661,31 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDropTable() throws Exception {
+        assertMemoryLeak(() -> {
+
+
+            execute("CREATE TABLE y ( ts TIMESTAMP, x INT ) timestamp(ts) partition by day wal;");
+            drainWalQueue();
+
+            assertCairoMetadata("MetadataCache [tableCount=1]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
+                    "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
+
+            execute("DROP TABLE y");
+            drainWalQueue();
+
+            assertException("table_columns('y')", -1, "table does not exist");
+        });
+    }
+
+    @Test
     public void testMetadataUpdatedCorrectlyWhenRenamingTables() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table foo ( ts timestamp, x int) timestamp(ts) partition by day wal;");
             assertSql(
-                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
                             "1\tfoo\tts\tDAY\t1000\t300000000\ttrue\tfoo~1\tfalse\t0\tHOUR\tfalse\n",
                     "tables()"
             );
@@ -693,7 +693,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             execute("rename table foo to bah");
             drainWalQueue();
             assertSql(
-                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
                             "1\tbah\tts\tDAY\t1000\t300000000\ttrue\tfoo~1\tfalse\t0\tHOUR\tfalse\n",
                     "tables()"
             );

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewGraphImplTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewGraphImplTest.java
@@ -99,7 +99,16 @@ public class MatViewGraphImplTest extends AbstractCairoTest {
     }
 
     private void addDefinition(TableToken viewToken, TableToken baseTableToken) {
-        MatViewDefinition def = new MatViewDefinition(viewToken, "x", baseTableToken.getTableName(), 0, 'm', null, null);
+        MatViewDefinition def = new MatViewDefinition(
+                MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
+                viewToken,
+                "x",
+                baseTableToken.getTableName(),
+                0,
+                'm',
+                null,
+                null
+        );
         graph.addView(def);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/KeywordAsTableNameTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/KeywordAsTableNameTest.java
@@ -130,7 +130,7 @@ public class KeywordAsTableNameTest extends AbstractCairoTest {
             assertException("rename table \"from\" to to", 23, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"to\"");
             execute("rename table \"from\" to \"to\"");
             assertSql(
-                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tisMatView\n" +
+                    "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
                             "1\tto\t\tNONE\t1000\t300000000\tfalse\tto~\tfalse\t0\tHOUR\tfalse\n",
                     "tables()"
             );

--- a/core/src/test/java/io/questdb/test/griffin/SqlUtilTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlUtilTest.java
@@ -77,7 +77,7 @@ public class SqlUtilTest {
             SqlUtil.implicitCastCharAsGeoHash('c', ColumnType.getGeoHashTypeWithBits(bits));
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertContains("inconvertible value: c [CHAR -> GEOHASH(6b)]", e.getFlyweightMessage());
+            TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible value: c [CHAR -> GEOHASH(6b)]");
         }
     }
 
@@ -693,7 +693,7 @@ public class SqlUtilTest {
             SqlUtil.implicitCastCharAsGeoHash(c, ColumnType.getGeoHashTypeWithBits(bits));
             Assert.fail();
         } catch (ImplicitCastException e) {
-            TestUtils.assertContains("inconvertible value: " + c + " [CHAR -> GEOHASH(1c)]", e.getFlyweightMessage());
+            TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible value: " + c + " [CHAR -> GEOHASH(1c)]");
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/bin/Base64FunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/bin/Base64FunctionFactoryTest.java
@@ -40,7 +40,7 @@ public class Base64FunctionFactoryTest extends AbstractFunctionFactoryTest {
         try {
             assertQueryNoLeakCheck("", "select base64(rnd_bin(6,6,0), 0)", null);
         } catch (SqlException e) {
-            TestUtils.assertContains("maxLength has to be greater than 0", e.getFlyweightMessage());
+            TestUtils.assertContains(e.getFlyweightMessage(), "maxLength has to be greater than 0");
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampCeilFloorFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampCeilFloorFunctionFactoryTest.java
@@ -38,7 +38,7 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_ceil('o', null)");
             } catch (SqlException e) {
                 Assert.assertEquals(22, e.getPosition());
-                TestUtils.assertContains("invalid unit 'o'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit 'o'");
             }
         });
     }
@@ -50,7 +50,7 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_ceil(null, null)");
             } catch (SqlException e) {
                 Assert.assertEquals(22, e.getPosition());
-                TestUtils.assertContains("invalid unit 'null'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit 'null'");
             }
         });
     }
@@ -62,7 +62,7 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_floor('', null)");
             } catch (SqlException e) {
                 Assert.assertEquals(23, e.getPosition());
-                TestUtils.assertContains("invalid unit ''", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit ''");
             }
         });
     }
@@ -74,7 +74,7 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_floor('z', null)");
             } catch (SqlException e) {
                 Assert.assertEquals(23, e.getPosition());
-                TestUtils.assertContains("invalid unit 'z'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit 'z'");
             }
         });
     }
@@ -86,13 +86,13 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_floor('-3m', null)");
             } catch (SqlException e) {
                 Assert.assertEquals(23, e.getPosition());
-                TestUtils.assertContains("invalid unit '-3m'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit '-3m'");
             }
             try {
                 assertExceptionNoLeakCheck("select timestamp_floor('0Y', null)");
             } catch (SqlException e) {
                 Assert.assertEquals(23, e.getPosition());
-                TestUtils.assertContains("invalid unit '0Y'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit '0Y'");
             }
         });
     }
@@ -104,7 +104,7 @@ public class TimestampCeilFloorFunctionFactoryTest extends AbstractCairoTest {
                 assertExceptionNoLeakCheck("select timestamp_floor(null, null)");
             } catch (SqlException e) {
                 Assert.assertEquals(23, e.getPosition());
-                TestUtils.assertContains("invalid unit 'null'", e.getFlyweightMessage());
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid unit 'null'");
             }
         });
     }


### PR DESCRIPTION
Depends on #5414

Also renames `isMatView` column to `matView` in `tables()` SQL function.