### PR TITLE
chore(core): log leaked table readers are critical

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -107,7 +107,7 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
         try {
             final int leakedReadersCount = leakedReaders != null ? leakedReaders.size() : 0;
             if (leakedReadersCount > 0) {
-                log = LOG.errorW();
+                log = LOG.critical();
                 executionContext.getCairoEngine().getMetrics().healthMetrics()
                         .incrementReaderLeakCounter(leakedReadersCount);
                 log.$("brk");
@@ -172,12 +172,11 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
                     executionContext.getCairoEngine().getConfiguration().getNanosecondClock().getTicks() - beginNanos;
             CharSequence principal = executionContext.getSecurityContext().getPrincipal();
             boolean cacheHit = executionContext.isCacheHit();
-            log = LOG.errorW();
             if (leakedReadersCount > 0) {
-                log.$("brk");
+                log = LOG.critical().$("brk");
                 executionContext.getCairoEngine().getMetrics().healthMetrics().incrementReaderLeakCounter(leakedReadersCount);
             } else {
-                log.$("err");
+                log = LOG.errorW().$("err");
             }
             if (e instanceof FlyweightMessageContainer) {
                 final int pos = ((FlyweightMessageContainer) e).getPosition();


### PR DESCRIPTION
leaked reader is a critical issue, and it
should be logged as such. this is useful
for log-scrappers, alerting, etc.