### PR TITLE
fix(sql): missing null symbol value in query with not in symbol filter

### DIFF
--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -221,7 +221,7 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             // we need to make sure we have access to the last element
             // which will indicate size of the char column
             offsetMem.extend(maxOffset + Long.BYTES);
-            charMem.extend(this.offsetMem.getLong(maxOffset));
+            charMem.extend(offsetMem.getLong(maxOffset));
         } else if (symbolCount < this.symbolCount) {
             cache.remove(symbolCount + 1, this.symbolCount);
             this.symbolCount = symbolCount;

--- a/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapReaderImpl.java
@@ -32,7 +32,13 @@ import io.questdb.cairo.vm.api.MemoryCMR;
 import io.questdb.cairo.vm.api.MemoryR;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.*;
+import io.questdb.std.Chars;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.Hash;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
 import io.questdb.std.str.DirectString;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
@@ -71,8 +77,8 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
     public void close() {
         Misc.free(indexReader);
         Misc.free(charMem);
-        this.cache.clear();
-        long fd = this.offsetMem.getFd();
+        cache.clear();
+        long fd = offsetMem.getFd();
         Misc.free(offsetMem);
         Misc.free(path);
         LOG.debug().$("closed [fd=").$(fd).$(']').$();
@@ -143,7 +149,7 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
     }
 
     public void of(CairoConfiguration configuration, Path path, CharSequence columnName, long columnNameTxn, int symbolCount) {
-        FilesFacade ff = configuration.getFilesFacade();
+        final FilesFacade ff = configuration.getFilesFacade();
         this.configuration = configuration;
         this.path.of(path);
         this.columnNameSink.clear();
@@ -171,30 +177,33 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             // we left off. Where we left off is stored externally to symbol map
             final long offsetMemSize = SymbolMapWriter.keyToOffset(symbolCount) + Long.BYTES;
             LOG.debug().$("offsetMem.of [columnName=").$(path).$(",offsetMemSize=").$(offsetMemSize).I$();
-            this.offsetMem.of(ff, path.$(), offsetMemSize, offsetMemSize, MemoryTag.MMAP_INDEX_READER);
+            offsetMem.of(ff, path.$(), offsetMemSize, offsetMemSize, MemoryTag.MMAP_INDEX_READER);
             this.symbolCapacity = offsetMem.getInt(SymbolMapWriter.HEADER_CAPACITY);
-            assert this.symbolCapacity > 0;
+            assert symbolCapacity > 0;
             this.cached = offsetMem.getBool(SymbolMapWriter.HEADER_CACHE_ENABLED);
             this.nullValue = offsetMem.getBool(SymbolMapWriter.HEADER_NULL_FLAG);
 
             // index reader is used to identify attempts to store duplicate symbol value
-            this.indexReader.of(configuration, path.trimTo(plen), columnName, columnNameTxn, 0);
+            indexReader.of(configuration, path.trimTo(plen), columnName, columnNameTxn, 0);
 
             // this is the place where symbol values are stored
-            this.charMem.wholeFile(ff, charFileName(path.trimTo(plen), columnName, columnNameTxn), MemoryTag.MMAP_INDEX_READER);
+            charMem.wholeFile(ff, charFileName(path.trimTo(plen), columnName, columnNameTxn), MemoryTag.MMAP_INDEX_READER);
 
             // move append pointer for symbol values in the correct place
-            this.charMem.extend(this.offsetMem.getLong(maxOffset));
+            charMem.extend(offsetMem.getLong(maxOffset));
 
             // we use index hash maximum equals to half of symbol capacity, which
             // theoretically should require 2 value cells in index per hash
             // we use 4 cells to compensate for occasionally unlucky hash distribution
             this.maxHash = Math.max(Numbers.ceilPow2(symbolCapacity / 2) - 1, 1);
             if (cached) {
-                this.cache.setPos(symbolCapacity);
+                cache.setPos(symbolCapacity);
             }
-            this.cache.clear();
-            LOG.debug().$("open [columnName=").$(path.trimTo(plen).concat(columnName).$()).$(", fd=").$(this.offsetMem.getFd()).$(", capacity=").$(symbolCapacity).$(']').$();
+            cache.clear();
+            LOG.debug().$("open [columnName=").$(path.trimTo(plen).concat(columnName).$())
+                    .$(", fd=").$(offsetMem.getFd())
+                    .$(", capacity=").$(symbolCapacity)
+                    .I$();
         } catch (Throwable e) {
             close();
             throw e;
@@ -211,14 +220,16 @@ public class SymbolMapReaderImpl implements Closeable, SymbolMapReader {
             // offset mem contains offsets of symbolCount + 1
             // we need to make sure we have access to the last element
             // which will indicate size of the char column
-            this.offsetMem.extend(maxOffset + Long.BYTES);
-            this.charMem.extend(this.offsetMem.getLong(maxOffset));
+            offsetMem.extend(maxOffset + Long.BYTES);
+            charMem.extend(this.offsetMem.getLong(maxOffset));
         } else if (symbolCount < this.symbolCount) {
             cache.remove(symbolCount + 1, this.symbolCount);
             this.symbolCount = symbolCount;
         }
+        // Refresh contains null flag.
+        this.nullValue = offsetMem.getBool(SymbolMapWriter.HEADER_NULL_FLAG);
         // Refresh index reader to avoid memory remapping on keyOf() calls.
-        this.indexReader.of(configuration, path, columnNameSink, columnNameTxn, 0);
+        indexReader.of(configuration, path, columnNameSink, columnNameTxn, 0);
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderReloadTest.java
@@ -154,7 +154,6 @@ public class TableReaderReloadTest extends AbstractCairoTest {
 
         long timestamp = 0;
         try (TableWriter writer = newOffPoolWriter(configuration, "all")) {
-
             try (TableReader reader = newOffPoolReader(configuration, "all")) {
                 Assert.assertFalse(reader.reload());
             }

--- a/core/src/test/java/io/questdb/test/griffin/SymbolTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SymbolTest.java
@@ -29,6 +29,41 @@ import org.junit.Test;
 public class SymbolTest extends AbstractCairoTest {
 
     @Test
+    public void testNullIsReturnedAfterReaderReload() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (sym SYMBOL INDEX, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY;");
+            final String query = "select * from x where sym not in ('foo', 'bar')";
+            // Load table reader on empty table.
+            assertQueryNoLeakCheck(
+                    "sym\tts\n",
+                    query,
+                    "ts",
+                    true,
+                    false,
+                    false
+            );
+            execute(
+                    "insert into x values ('foo', '2024-05-14T16:00:00.000000Z')," +
+                            "('bar', '2024-05-14T16:00:01.000000Z')," +
+                            "('baz', '2024-05-14T16:00:02.000000Z')," +
+                            "(null, '2024-05-14T16:00:02.000000Z');"
+            );
+            // The reader should refresh contain null flag in symbol readers,
+            // so NULL row should be included in the result set.
+            assertQueryNoLeakCheck(
+                    "sym\tts\n" +
+                            "baz\t2024-05-14T16:00:02.000000Z\n" +
+                            "\t2024-05-14T16:00:02.000000Z\n",
+                    query,
+                    "ts",
+                    true,
+                    false,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testNullSymbolOrderByRegression() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE x (" +


### PR DESCRIPTION
Refs #5427

Symbol readers didn't refresh "contains null" flag on table reader reload. As a result, NOT IN indexed symbol filter queries that use `FilterOnExcludedValuesRecordCursorFactory` could return wrong result set, without null values being included, if they were first run on empty table.