### PR TITLE
fix(sql): null values returned from index-based non-null filter in backward-scan query

### DIFF
--- a/core/src/main/java/io/questdb/cairo/BitmapIndexBwdNullReader.java
+++ b/core/src/main/java/io/questdb/cairo/BitmapIndexBwdNullReader.java
@@ -33,7 +33,8 @@ public class BitmapIndexBwdNullReader implements BitmapIndexReader {
     @Override
     public RowCursor getCursor(boolean cachedInstance, int key, long minValue, long maxValue) {
         final NullCursor cursor = getCursor(cachedInstance);
-        cursor.value = maxValue - minValue;
+        // Cursor only returns records when key is for the NULL value.
+        cursor.value = key == 0 ? maxValue - minValue : -1;
         return cursor;
     }
 

--- a/core/src/main/java/io/questdb/cairo/BitmapIndexFwdNullReader.java
+++ b/core/src/main/java/io/questdb/cairo/BitmapIndexFwdNullReader.java
@@ -35,7 +35,7 @@ public class BitmapIndexFwdNullReader implements BitmapIndexReader {
     @Override
     public RowCursor getCursor(boolean cachedInstance, int key, long minValue, long maxValue) {
         final NullCursor cursor = getCursor(cachedInstance);
-        // Cursor only returns records when key is for the NULL value
+        // Cursor only returns records when key is for the NULL value.
         cursor.maxValue = key == 0 ? maxValue - minValue + 1 : 0;
         cursor.value = 0;
         return cursor;

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexBwdNullReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexBwdNullReaderTest.java
@@ -31,7 +31,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class BitmapIndexBwdNullReaderTest {
-
     private static final BitmapIndexBwdNullReader reader = new BitmapIndexBwdNullReader();
 
     @Test
@@ -43,14 +42,18 @@ public class BitmapIndexBwdNullReaderTest {
     public void testCursor() {
         final Rnd rnd = new Rnd();
         for (int i = 0; i < 10; i++) {
-            int n = rnd.nextPositiveInt() % 1024;
+            final int n = rnd.nextPositiveInt() % 1024;
+
             int m = n;
             RowCursor cursor = reader.getCursor(true, 0, 0, n);
             while (cursor.hasNext()) {
                 Assert.assertEquals(m--, cursor.next());
             }
-
             Assert.assertEquals(-1, m);
+
+            // non-null key
+            cursor = reader.getCursor(true, 42, 0, n);
+            Assert.assertFalse(cursor.hasNext());
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexFwdNullReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexFwdNullReaderTest.java
@@ -31,7 +31,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class BitmapIndexFwdNullReaderTest {
-
     private static final BitmapIndexFwdNullReader reader = new BitmapIndexFwdNullReader();
 
     @Test
@@ -43,14 +42,18 @@ public class BitmapIndexFwdNullReaderTest {
     public void testCursor() {
         final Rnd rnd = new Rnd();
         for (int i = 0; i < 10; i++) {
-            int n = rnd.nextPositiveInt() % 1024;
+            final int n = rnd.nextPositiveInt() % 1024;
+
             int m = 0;
             RowCursor cursor = reader.getCursor(true, 0, 0, n);
             while (cursor.hasNext()) {
                 Assert.assertEquals(m++, cursor.next());
             }
-
             Assert.assertEquals(n + 1, m);
+
+            // non-null key
+            cursor = reader.getCursor(true, 42, 0, n);
+            Assert.assertFalse(cursor.hasNext());
         }
     }
 
@@ -69,5 +72,4 @@ public class BitmapIndexFwdNullReaderTest {
         Assert.assertEquals(0, reader.getUnIndexedNullCount());
         Assert.assertEquals(0, reader.getValueBlockCapacity());
     }
-
 }


### PR DESCRIPTION
Queries like
```sql
SELECT *
FROM my_table
WHERE sym = 'foobar'
ORDER BY ts DESC;
```
on tables with filtered indexed symbol column could return rows with NULL symbol values instead of the filtered value.

Also, fixes `FrameAppendFuzzTest#testFullRandom()` failure that can be observed with this patch: edfaf8c39da1657ad0a24bff3a0982f05096b9ad