### PR TITLE
chore(build): relax required rust toolchain version

### DIFF
--- a/core/rust/qdbr/rust-toolchain.toml
+++ b/core/rust/qdbr/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-01-07"
+channel = "nightly"


### PR DESCRIPTION
[prepare_rust_env.py](https://github.com/questdb/questdb/blob/2ced1178594cb4b61b71b4f7075a8e2a3dc813d9/.github/prepare_rust_env.py#L58) install whatever version
is default for nightly channel -> rust-toolchain.toml should not assume a specific version.