### PR TITLE
ci(build): install the correct rust version

### DIFF
--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -107,7 +107,7 @@ def linux_glibc_version():
 def call_rustup_install(args):
     # We need watch the output for Azure CI setup issues and rectify them.
     proc = subprocess.Popen(
-        log_command(args),
+        args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -156,6 +156,7 @@ def call_rustup_install(args):
         tool_filename = f'{tool}.exe' \
             if sys.platform == 'win32' else tool
         tool_path = path / tool_filename
+        sys.stderr.write(f'removing broken tool: {tool_path}\n')
         tool_path.unlink()
 
     return components
@@ -163,8 +164,9 @@ def call_rustup_install(args):
 
 def ensure_rust_version(rustup_bin, version, components):
     """Ensure the specified version of Rust is installed and defaulted."""
-    subprocess.check_call(log_command([
-        rustup_bin, 'self', 'update']))
+    if subprocess.call(log_command([
+        rustup_bin, 'self', 'update'])) != 0:
+        print('Failed to update rustup. Ignoring and hoping for the best.')
     components = components + call_rustup_install(log_command([
         rustup_bin, 'install', '--allow-downgrade', version]))
     subprocess.check_call(log_command([

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -168,7 +168,7 @@ def ensure_rust_version(rustup_bin, version, components):
         rustup_bin, 'self', 'update'])) != 0:
         print('Failed to update rustup. Ignoring and hoping for the best.')
     components = components + call_rustup_install(log_command([
-        rustup_bin, 'install', '--allow-downgrade', version]))
+        rustup_bin, 'toolchain', 'install', '--allow-downgrade', version]))
     subprocess.check_call(log_command([
         rustup_bin, 'default', version]))
     if components:

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -192,7 +192,7 @@ def ensure_rust(version, components):
     cargo_bin = shutil.which('cargo')
     if rustup_bin and cargo_bin:
         cargo_path = pathlib.Path(cargo_bin).parent.parent
-        print(f'Rustup and cargo are already installed. `cargo` path: {cargo_path}')
+        sys.stderr.write(f'Rustup and cargo are already installed. `cargo` path: {cargo_path}\n')
         ensure_rust_version(version, components)
         may_export_cargo_home(cargo_path)
     else:

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -162,18 +162,19 @@ def call_rustup_install(args):
     return components
 
 
-def ensure_rust_version(rustup_bin, version, components):
+def ensure_rust_version(version, components):
     """Ensure the specified version of Rust is installed and defaulted."""
     if subprocess.call(log_command([
-        rustup_bin, 'self', 'update'])) != 0:
-        print('Failed to update rustup. Ignoring and hoping for the best.')
+        'rustup', 'self', 'update'])) != 0:
+        sys.stderr('    !!! Failed to update rustup. Hoping for the best.\n')
+        sys.stderr.flush()
     components = components + call_rustup_install(log_command([
-        rustup_bin, 'toolchain', 'install', '--allow-downgrade', version]))
+        'rustup', 'toolchain', 'install', '--allow-downgrade', version]))
     subprocess.check_call(log_command([
-        rustup_bin, 'default', version]))
+        'rustup', 'default', version]))
     if components:
         subprocess.check_call(log_command([
-            rustup_bin, 'update']))
+            'rustup', 'update']))
         install_components(components)
 
 
@@ -183,7 +184,7 @@ def ensure_rust(version, components):
     if rustup_bin and cargo_bin:
         cargo_path = pathlib.Path(cargo_bin).parent.parent
         print(f'Rustup and cargo are already installed. `cargo` path: {cargo_path}')
-        ensure_rust_version(rustup_bin, version, components)
+        ensure_rust_version(version, components)
         may_export_cargo_home(cargo_path)
     else:
         install_rust(version)

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -95,6 +95,8 @@ def linux_glibc_version():
 def ensure_rust_version(rustup_bin, version):
     """Ensure the specified version of Rust is installed and defaulted."""
     subprocess.check_call([
+        rustup_bin, 'self', 'update'])
+    subprocess.check_call([
         rustup_bin, 'install', '--allow-downgrade', version])
     subprocess.check_call([
         rustup_bin, 'default', version])

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -17,7 +17,8 @@ from collections import deque
 
 
 def log_command(args):
-    print(f'>>> {shlex.join(args)}')
+    sys.stderr.write(f'>>> {shlex.join(args)}\n')
+    sys.stderr.flush()
     return args
 
 
@@ -95,7 +96,7 @@ def linux_glibc_version():
     if sys.platform != 'linux':
         return ''
     output = subprocess.check_output(
-        ['ldd', '--version'],
+        log_command(['ldd', '--version']),
         stderr=subprocess.STDOUT).decode('utf-8')
     for line in output.splitlines():
         if line.startswith('ldd ('):

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -61,7 +61,7 @@ def may_export_cargo_home(cargo_home):
         export_ci_var('CARGO_HOME', cargo_home)
 
 
-def install_rust(nightly):
+def install_rust(version):
     platform_key = {'linux': 'unix', 'darwin': 'unix',
                     'win32': 'windows'}.get(sys.platform)
     if not platform_key:
@@ -78,8 +78,7 @@ def install_rust(nightly):
             ['rustup-init.exe', '-y', '--profile', 'minimal'],
         ),
     }[platform_key]
-    if nightly:
-        install_cmd.extend(['--default-toolchain', 'nightly'])
+    install_cmd.extend(['--default-toolchain', version])
     try:
         download_file(download_url, file_name)
         subprocess.check_call(

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -79,7 +79,7 @@ def parse_rustc_info(output):
 def install_components(components):
     if components:
         subprocess.check_call(
-            ['rustup', 'component', 'add'] + components,
+            ['rustup', 'component', 'add'] + list(set(components)),
             stderr=subprocess.STDOUT)
 
 
@@ -135,13 +135,19 @@ def call_rustup_install(args):
     if return_code:
         raise subprocess.CalledProcessError(return_code, args)
     
+    tool2component = {
+        'rust-analyzer': 'rust-analyzer',
+        'rustfmt': 'rustfmt',
+        'cargo-fmt': 'rustfmt',
+    }
+
     components = []
-    for component, path in broken_tools:
-        components.append(component)
-        component_filename = f'{component}.exe' \
-            if sys.platform == 'win32' else component
-        component_path = path / component_filename
-        component_path.unlink()
+    for tool, path in broken_tools:
+        components.append(tool2component[tool])
+        tool_filename = f'{tool}.exe' \
+            if sys.platform == 'win32' else tool
+        tool_path = path / tool_filename
+        tool_path.unlink()
 
     return components
 

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -29,7 +29,8 @@ def export_ci_var(name, value):
 
 
 def log_command(args):
-    sys.stderr.write(f'>>> {shlex.join(args)}\n')
+    args_line = ' '.join(shlex.quote(arg) for arg in args)
+    sys.stderr.write(f'>>> {args_line}\n')
     sys.stderr.flush()
     return args
 

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -177,11 +177,6 @@ def call_rustup_install(args):
 
 def ensure_rust_version(version, components):
     """Ensure the specified version of Rust is installed and defaulted."""
-    if subprocess.call(log_command([
-        'rustup', 'self', 'update'])) != 0:
-        sys.stderr.write(
-            '    !!! Failed to update rustup. Hoping for the best.\n')
-        sys.stderr.flush()
     components = components + call_rustup_install(log_command([
         'rustup', 'toolchain', 'install', '--allow-downgrade', version]))
     subprocess.check_call(log_command([

--- a/.github/prepare_rust_env.py
+++ b/.github/prepare_rust_env.py
@@ -118,7 +118,7 @@ def call_rustup_install(args):
             match = warn_pat.match(line)
             if match:
                 tool, path = match.groups()
-                broken_tools.append((tool, path))
+                broken_tools.append((tool, pathlib.Path(path)))
 
     stdout_thread = threading.Thread(
         target=monitor_output, args=(proc.stdout, sys.stdout), daemon=True)
@@ -138,7 +138,10 @@ def call_rustup_install(args):
     components = []
     for component, path in broken_tools:
         components.append(component)
-        os.remove(path)
+        component_filename = f'{component}.exe' \
+            if sys.platform == 'win32' else component
+        component_path = path / component_filename
+        component_path.unlink()
 
     return components
 

--- a/.github/workflows/rebuild_rust.yml
+++ b/.github/workflows/rebuild_rust.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install toolchains (Rust)
         run: |
           python3 ./.github/prepare_rust_env.py --match core/rust/qdbr/rust-toolchain.toml
-          echo "PATH=/github/home/.cargo/bin/:$PATH" >> "$GITHUB_ENV"
+          echo "PATH=/github/home/.cargo/bin:$PATH" >> "$GITHUB_ENV"
       - name: Build linux-x86-64 Rust Library
         run: |
           cd core/rust/qdbr

--- a/.github/workflows/rebuild_rust.yml
+++ b/.github/workflows/rebuild_rust.yml
@@ -109,7 +109,7 @@ jobs:
           submodules: false
       - name: Install toolchains (Rust)
         run: |
-          python3 ./.github/prepare_rust_env.py --nightly
+          python3 ./.github/prepare_rust_env.py --match core/rust/qdbr/rust-toolchain.toml
           echo "PATH=/github/home/.cargo/bin/:$PATH" >> "$GITHUB_ENV"
       - name: Build linux-x86-64 Rust Library
         run: |
@@ -139,7 +139,7 @@ jobs:
           yum install wget zstd curl python3 -y
       - name: Install toolchains (Rust)
         run: |
-          python3 ./.github/prepare_rust_env.py --nightly
+          python3 ./.github/prepare_rust_env.py --match core/rust/qdbr/rust-toolchain.toml
           echo "PATH=/github/home/.cargo/bin/:$PATH" >> "$GITHUB_ENV"
       - name: Build linux-aarch64 Rust Library
         run: |

--- a/.github/workflows/rebuild_rust_test.yml
+++ b/.github/workflows/rebuild_rust_test.yml
@@ -94,7 +94,7 @@ jobs:
           submodules: false
       - name: Install toolchains (Rust)
         run: |
-          python3 ./.github/prepare_rust_env.py --nightly
+          python3 ./.github/prepare_rust_env.py --match core/rust/qdbr/rust-toolchain.toml
           echo "PATH=/github/home/.cargo/bin/:$PATH" >> "$GITHUB_ENV"
       - name: Build linux-x86-64 Rust Library
         run: |

--- a/ci/rust-test-and-lint.yaml
+++ b/ci/rust-test-and-lint.yaml
@@ -19,7 +19,7 @@ jobs:
         lfs: false
         submodules: true
       - script: |
-          python3 .github/prepare_rust_env.py --export-cargo-install-env --components rustfmt clippy --version $RUST_VERSION
+          python3 .github/prepare_rust_env.py --export-cargo-install-env --components rustfmt clippy --match core/rust/qdbr/rust-toolchain.toml
         displayName: "Ensure Rust is installed"
         # Note, the `prepare_rust_env.py` script exports a number of variables.
       - task: Cache@2

--- a/ci/rust-test-and-lint.yaml
+++ b/ci/rust-test-and-lint.yaml
@@ -19,7 +19,7 @@ jobs:
         lfs: false
         submodules: true
       - script: |
-          python3 .github/prepare_rust_env.py --export-cargo-install-env --components rustfmt clippy --nightly
+          python3 .github/prepare_rust_env.py --export-cargo-install-env --components rustfmt clippy --version $RUST_VERSION
         displayName: "Ensure Rust is installed"
         # Note, the `prepare_rust_env.py` script exports a number of variables.
       - task: Cache@2

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -60,7 +60,7 @@ steps:
       destinationFolder: '$(build.sourcesdirectory)/maven'
     condition: and(ne(variables['MAVEN_VERSION_OPTION'], 'Default'), ne(variables.MVN_CACHE_RESTORED, 'true'))
 
-  - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --version $RUST_VERSION
+  - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --match core/rust/qdbr/rust-toolchain.toml
     displayName: "Ensure Rust is installed"
     # Note, the `prepare_rust_env.py` script exports a number of variables.
 

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -60,7 +60,7 @@ steps:
       destinationFolder: '$(build.sourcesdirectory)/maven'
     condition: and(ne(variables['MAVEN_VERSION_OPTION'], 'Default'), ne(variables.MVN_CACHE_RESTORED, 'true'))
 
-  - script: python3 .github/prepare_rust_env.py --nightly --export-cargo-install-env
+  - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --version $RUST_VERSION
     displayName: "Ensure Rust is installed"
     # Note, the `prepare_rust_env.py` script exports a number of variables.
 

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -17,6 +17,7 @@ variables:
   MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
+  RUST_VERSION: "nightly-2025-01-07"
 
 stages:
   - stage: CheckChanges
@@ -110,7 +111,7 @@ stages:
           - download: current
             artifact: rust-llvm-coverage
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
-          - script: python3 .github/prepare_rust_env.py --nightly --export-cargo-install-env
+          - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --version $RUST_VERSION
             displayName: "Ensure Rust is installed"
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
           - template: templates/install-llvm.yml

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -17,7 +17,6 @@ variables:
   MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
-  RUST_VERSION: "nightly-2025-01-07"
 
 stages:
   - stage: CheckChanges
@@ -111,7 +110,7 @@ stages:
           - download: current
             artifact: rust-llvm-coverage
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
-          - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --version $RUST_VERSION
+          - script: python3 .github/prepare_rust_env.py --export-cargo-install-env --match core/rust/qdbr/rust-toolchain.toml
             displayName: "Ensure Rust is installed"
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['RUST_SOURCE_CODE_CHANGED'], 'true'))
           - template: templates/install-llvm.yml


### PR DESCRIPTION
Fixed CI to install the required nightly Rust version.
The install script parses the `qdbr/rust-toolchain.toml` file as the source of the version to install.