### PR TITLE
test(sql): add non-fuzz reproducer for bwd indexed scan bug

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -381,6 +381,7 @@ public class FuzzRunner {
                                 tableNameNoWal,
                                 tableNameWal,
                                 rnd,
+                                reader.size(),
                                 metadata.getColumnName(columnIndex),
                                 metadata.getColumnName(metadata.getTimestampIndex())
                         );
@@ -609,10 +610,11 @@ public class FuzzRunner {
             String expectedTableName,
             String actualTableName,
             Rnd rnd,
+            long recordCount,
             String symbolColumnName,
             String tsColumnName
     ) throws SqlException {
-        long randomRow = rnd.nextLong(3);
+        long randomRow = rnd.nextLong(recordCount);
         sink.clear();
         try (SqlCompiler compiler = engine.getSqlCompiler()) {
             TestUtils.printSql(compiler, sqlExecutionContext, "select \"" + symbolColumnName + "\" as a from " + expectedTableName + " limit " + randomRow + ", 1", sink);

--- a/core/src/test/java/io/questdb/test/griffin/SymbolTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SymbolTest.java
@@ -29,6 +29,35 @@ import org.junit.Test;
 public class SymbolTest extends AbstractCairoTest {
 
     @Test
+    public void testIndexedScanOverColTopColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "create atomic table x as ( " +
+                            "  select rnd_symbol('AB', 'BC', 'CD') sym, timestamp_sequence('2022-02-24', 1000000L) ts " +
+                            "  from long_sequence(480585)" +
+                            "), index(sym) timestamp(ts) partition by DAY BYPASS WAL;"
+            );
+            execute("alter table x add column sym_top symbol index;");
+            execute("insert into x values('EF', '2022-02-01T00:00','STWEFZMJCWHFQEDUY');");
+
+            assertQueryNoLeakCheck(
+                    "sym\tts\tsym_top\n" +
+                            "EF\t2022-02-01T00:00:00.000000Z\tSTWEFZMJCWHFQEDUY\n",
+                    "x where \"sym_top\" = 'STWEFZMJCWHFQEDUY' order by ts asc",
+                    "ts",
+                    true
+            );
+            assertQueryNoLeakCheck(
+                    "sym\tts\tsym_top\n" +
+                            "EF\t2022-02-01T00:00:00.000000Z\tSTWEFZMJCWHFQEDUY\n",
+                    "x where \"sym_top\" = 'STWEFZMJCWHFQEDUY' order by ts desc",
+                    "ts###desc",
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testNullIsReturnedAfterReaderReload() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE x (sym SYMBOL INDEX, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY;");
@@ -118,7 +147,11 @@ public class SymbolTest extends AbstractCairoTest {
                     "select sym from x" +
                             " where timestamp in '2024-03-05T12:13'" +
                             " order by sym desc",
-                    null, true, true, false);
+                    null,
+                    true,
+                    true,
+                    false
+            );
         });
     }
 


### PR DESCRIPTION
Adds non-fuzz reproducer test for the bug fixed by #5432

Also reverts changes in `FuzzRunner#checkIndexRandomValueScan()` from #5377 that look like temporary debug code