### PR TITLE
fix(sql): fix memory leaks when parsing sub-queries in timestamp filter

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/eq/EqTimestampCursorFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/eq/EqTimestampCursorFunctionFactoryTest.java
@@ -155,6 +155,25 @@ public class EqTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCompareTimestampWithVarcharFromTable() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x as (" +
+                            "select rnd_varchar() a, timestamp_sequence(0, 2500000) ts from long_sequence(100000)" +
+                            ") timestamp(ts) partition by day"
+            );
+
+            assertQueryNoLeakCheck(
+                    "a\tts\n" +
+                            "&\uDA1F\uDE98|\uD924\uDE04۲ӄǈ2L\t1970-01-01T00:00:00.000000Z\n",
+                    "select * from x where ts = (select ts::varchar from x limit 2)",
+                    "ts",
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testCompareTimestampWithVarcharNegated() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table x as (" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/GtTimestampCursorFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/GtTimestampCursorFunctionFactoryTest.java
@@ -153,11 +153,32 @@ public class GtTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCompareTimestampWithVarcharNegated() throws Exception {
+    public void testCompareTimestampWithVarcharFromTable() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table x as (" +
-                    "select rnd_varchar() a, timestamp_sequence(0, 2500000) ts from long_sequence(2)" +
+                    "select rnd_varchar() a, timestamp_sequence(0, 2500000) ts from long_sequence(100000)" +
                     ") timestamp(ts) partition by day");
+
+            assertQueryNoLeakCheck(
+                    "a\tts\n" +
+                            "8#3TsZ\t1970-01-01T00:00:02.500000Z\n" +
+                            "zV衞͛Ԉ龘и\uDA89\uDFA4~\t1970-01-01T00:00:05.000000Z\n" +
+                            "ṟ\u1AD3ڎBH뤻䰭\u008B}ѱ\t1970-01-01T00:00:07.500000Z\n",
+                    "select * from x where ts > (select ts::varchar from x limit 2) limit 3",
+                    "ts",
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testCompareTimestampWithVarcharNegated() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x as (" +
+                            "select rnd_varchar() a, timestamp_sequence(0, 2500000) ts from long_sequence(2)" +
+                            ") timestamp(ts) partition by day"
+            );
 
             assertSql(
                     "a\tts\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/LtTimestampCursorFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/LtTimestampCursorFunctionFactoryTest.java
@@ -156,6 +156,27 @@ public class LtTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCompareTimestampWithVarcharFromTable() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x as (" +
+                            "select rnd_varchar() a, timestamp_sequence(0, 2500000) ts from long_sequence(100000)" +
+                            ") timestamp(ts) partition by day"
+            );
+
+            assertQueryNoLeakCheck(
+                    "a\tts\n" +
+                            "&\uDA1F\uDE98|\uD924\uDE04۲ӄǈ2L\t1970-01-01T00:00:00.000000Z\n" +
+                            "8#3TsZ\t1970-01-01T00:00:02.500000Z\n" +
+                            "zV衞͛Ԉ龘и\uDA89\uDFA4~\t1970-01-01T00:00:05.000000Z\n",
+                    "select * from x where ts < (select ts::varchar from x order by ts desc limit 2) limit 3",
+                    "ts",
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testCompareTimestampWithVarcharNegated() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table x as (" +


### PR DESCRIPTION
WHERE clauses like this one led to memory leaks due to missing close calls in `WhereClauseParser`:
```sql
WHERE ts = (SELECT ts::varchar FROM x LIMIT 2)
```