### PR TITLE
test(sql): makes r2dbc test to use ipv4

### DIFF
--- a/compat/src/test/java/io/questdb/compat/R2DBCTest.java
+++ b/compat/src/test/java/io/questdb/compat/R2DBCTest.java
@@ -165,7 +165,7 @@ public class R2DBCTest extends AbstractTest {
             serverMain.start();
             ConnectionFactory connectionFactory = new PostgresqlConnectionFactory(
                     PostgresqlConnectionConfiguration.builder()
-                            .host("localhost")
+                            .host("127.0.0.1")
                             .port(serverMain.getPgWireServerPort())
                             .database("qdb")
                             .username("admin")


### PR DESCRIPTION
this was failing on platforms where ipv6 is preferred by default