### PR TITLE
fix(core): fix rare ILP commit exception when writing large string values

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -758,7 +758,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.walSupported = getBoolean(properties, env, PropertyKey.CAIRO_WAL_SUPPORTED, true);
         walApplyEnabled = getBoolean(properties, env, PropertyKey.CAIRO_WAL_APPLY_ENABLED, true);
         this.walSegmentRolloverRowCount = getLong(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 200_000);
-        this.walSegmentRolloverSize = getLongSize(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_SIZE, 50 * Numbers.SIZE_1MB);  // disabled by default.
+        this.walSegmentRolloverSize = getLongSize(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_SIZE, 50 * Numbers.SIZE_1MB);
         if ((this.walSegmentRolloverSize != 0) && (this.walSegmentRolloverSize < 1024)) {  // 1KiB segments minimum
             throw CairoException.critical(0).put("cairo.wal.segment.rollover.size must be 0 (disabled) or >= 1024 (1KiB)");
         }

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -758,7 +758,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         this.walSupported = getBoolean(properties, env, PropertyKey.CAIRO_WAL_SUPPORTED, true);
         walApplyEnabled = getBoolean(properties, env, PropertyKey.CAIRO_WAL_APPLY_ENABLED, true);
         this.walSegmentRolloverRowCount = getLong(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 200_000);
-        this.walSegmentRolloverSize = getLongSize(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_SIZE, 0);  // disabled by default.
+        this.walSegmentRolloverSize = getLongSize(properties, env, PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_SIZE, 50 * Numbers.SIZE_1MB);  // disabled by default.
         if ((this.walSegmentRolloverSize != 0) && (this.walSegmentRolloverSize < 1024)) {  // 1KiB segments minimum
             throw CairoException.critical(0).put("cairo.wal.segment.rollover.size must be 0 (disabled) or >= 1024 (1KiB)");
         }

--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -88,7 +88,7 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public static CairoException duplicateColumn(CharSequence column, CharSequence columnAlias) {
-        CairoException exception = critical(METADATA_VALIDATION).put("Duplicate column [name=").put(column);
+        CairoException exception = critical(METADATA_VALIDATION).put("duplicate column [name=").put(column);
         if (columnAlias != null) {
             exception.put(", alias=").put(columnAlias);
         }

--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -228,6 +228,10 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         return interruption;
     }
 
+    public boolean isMetadataValidation() {
+        return errno == METADATA_VALIDATION;
+    }
+
     public boolean isOutOfMemory() {
         return outOfMemory;
     }

--- a/core/src/main/java/io/questdb/cairo/wal/SegmentColumnRollSink.java
+++ b/core/src/main/java/io/questdb/cairo/wal/SegmentColumnRollSink.java
@@ -46,7 +46,7 @@ public class SegmentColumnRollSink implements ColumnConversionOffsetSink {
     }
 
     public long getDestAuxSize(int columnIndex) {
-        return (int) data.get(columnIndex * ENTRIES_PER_COLUMN + 5);
+        return data.get(columnIndex * ENTRIES_PER_COLUMN + 5);
     }
 
     public long getDestPrimaryFd(int columnIndex) {
@@ -54,15 +54,15 @@ public class SegmentColumnRollSink implements ColumnConversionOffsetSink {
     }
 
     public long getDestPrimarySize(int columnIndex) {
-        return (int) data.get(columnIndex * ENTRIES_PER_COLUMN + 4);
+        return data.get(columnIndex * ENTRIES_PER_COLUMN + 4);
     }
 
     public long getSrcAuxOffset(int c) {
-        return (int) data.get(c * ENTRIES_PER_COLUMN + 3);
+        return data.get(c * ENTRIES_PER_COLUMN + 3);
     }
 
     public long getSrcPrimaryOffset(int columnIndex) {
-        return (int) data.get(columnIndex * ENTRIES_PER_COLUMN + 2);
+        return data.get(columnIndex * ENTRIES_PER_COLUMN + 2);
     }
 
     public void nextColumn() {

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -1876,7 +1876,7 @@ public class WalWriter implements TableWriterAPI {
                 throw CairoException.nonCritical().put("invalid column name: ").put(columnName);
             }
             if (metadata.getColumnIndexQuiet(columnName) > -1) {
-                throw CairoException.nonCritical().put("duplicate column name: ").put(columnName);
+                throw CairoException.duplicateColumn("duplicate column name: ").put(columnName);
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
@@ -222,7 +222,11 @@ public class AlterOperation extends AbstractOperation implements Mutable {
         } catch (EntryUnavailableException ex) {
             throw ex;
         } catch (CairoException e) {
-            final LogRecord log = e.isCritical() ? LOG.critical() : LOG.error();
+            boolean isCritical = e.isCritical();
+            // "duplicate column name:" is BAU when column is added from ILP, don't log it as an error
+            boolean isInfo = command == ADD_COLUMN && e.isMetadataValidation();
+
+            final LogRecord log = isCritical ? LOG.critical() : (isInfo ? LOG.info() : LOG.error());
             log.$("could not alter table [table=").$(svc.getTableToken())
                     .$(", command=").$(command)
                     .$(", msg=").$(e.getFlyweightMessage())

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -136,7 +136,13 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
         this.peerNoLinger = configuration.getPeerNoLinger();
         this.port = 0;
         this.heartbeatIntervalMs = configuration.getHeartbeatInterval() > 0 ? configuration.getHeartbeatInterval() : Long.MIN_VALUE;
-        createListenerFd();
+
+        try {
+            createListenerFd();
+        } catch(Throwable th) {
+            close();
+            throw th;
+        }
         listening = true;
     }
 

--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -139,7 +139,7 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
 
         try {
             createListenerFd();
-        } catch(Throwable th) {
+        } catch (Throwable th) {
             close();
             throw th;
         }

--- a/core/src/test/java/io/questdb/test/AbstractBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractBootstrapTest.java
@@ -93,8 +93,13 @@ public abstract class AbstractBootstrapTest extends AbstractTest {
             envMap.put(envs[i], envs[i + 1]);
         }
         TestServerMain serverMain = new TestServerMain(newBootstrapWithEnvVariables(envMap));
-        serverMain.start();
-        return serverMain;
+        try {
+            serverMain.start();
+            return serverMain;
+        } catch (Throwable th) {
+            serverMain.close();
+            throw th;
+        }
     }
 
     @AfterClass

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -371,7 +371,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.wal.purge.interval\tQDB_CAIRO_WAL_PURGE_INTERVAL\t30000\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.recreate.distressed.sequencer.attempts\tQDB_CAIRO_WAL_RECREATE_DISTRESSED_SEQUENCER_ATTEMPTS\t3\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.segment.rollover.row.count\tQDB_CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT\t200000\tdefault\tfalse\tfalse\n" +
-                                    "cairo.wal.segment.rollover.size\tQDB_CAIRO_WAL_SEGMENT_ROLLOVER_SIZE\t0\tdefault\tfalse\tfalse\n" +
+                                    "cairo.wal.segment.rollover.size\tQDB_CAIRO_WAL_SEGMENT_ROLLOVER_SIZE\t52428800\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.squash.uncommitted.rows.multiplier\tQDB_CAIRO_WAL_SQUASH_UNCOMMITTED_ROWS_MULTIPLIER\t20.0\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.supported\tQDB_CAIRO_WAL_SUPPORTED\ttrue\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.temp.pending.rename.table.prefix\tQDB_CAIRO_WAL_TEMP_PENDING_RENAME_TABLE_PREFIX\ttemp_5822f658-31f6-11ee-be56-0242ac120002\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cairo/GenericRecordMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/GenericRecordMetadataTest.java
@@ -73,7 +73,7 @@ public class GenericRecordMetadataTest {
             metadata.add(new TableColumnMetadata("abc", ColumnType.FLOAT));
             Assert.fail();
         } catch (CairoException e) {
-            TestUtils.assertContains(e.getFlyweightMessage(), "Duplicate column [name=abc]");
+            TestUtils.assertContains(e.getFlyweightMessage(), "duplicate column [name=abc]");
         }
 
         sink.clear();
@@ -97,7 +97,7 @@ public class GenericRecordMetadataTest {
             metadata.add(new TableColumnMetadata("ABC", ColumnType.FLOAT));
             Assert.fail();
         } catch (CairoException e) {
-            TestUtils.assertContains(e.getFlyweightMessage(), "Duplicate column [name=ABC]");
+            TestUtils.assertContains(e.getFlyweightMessage(), "duplicate column [name=ABC]");
         }
 
         sink.clear();

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
@@ -561,5 +561,6 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
     protected void setFuzzProperties(Rnd rnd) {
         super.setFuzzProperties(rnd);
         node1.setProperty(PropertyKey.DEBUG_CAIRO_ALLOW_MIXED_IO, fsAllowsMixedIO);
+        node1.setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 1 + rnd.nextLong(engine.getConfiguration().getWalSegmentRolloverRowCount()));
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
@@ -221,16 +221,16 @@ abstract class AbstractLineHttpFuzzTest extends AbstractBootstrapTest {
                         PropertyKey.PG_LEGACY_MODE_ENABLED.getEnvVarName(), "false",
                         PropertyKey.LINE_TCP_ENABLED.getEnvVarName(), "false",
                         PropertyKey.HTTP_MIN_ENABLED.getEnvVarName(), "false",
-                    PropertyKey.PG_ENABLED.getEnvVarName(), "false",
-                    PropertyKey.PG_LEGACY_MODE_ENABLED.getEnvVarName(), "false",
-                    PropertyKey.LINE_TCP_ENABLED.getEnvVarName(), "false",
-                    PropertyKey.HTTP_BIND_TO.getEnvVarName(), "127.0.0.1:" + httpPortRandom
-            )) {
-                Assert.assertEquals(0, tables.size());
-                for (int i = 0; i < numOfTables; i++) {
-                    final CharSequence tableName = getTableName(i);
-                    tables.put(tableName, new TableData(tableName));
-                }
+                        PropertyKey.PG_ENABLED.getEnvVarName(), "false",
+                        PropertyKey.PG_LEGACY_MODE_ENABLED.getEnvVarName(), "false",
+                        PropertyKey.LINE_TCP_ENABLED.getEnvVarName(), "false",
+                        PropertyKey.HTTP_BIND_TO.getEnvVarName(), "127.0.0.1:" + httpPortRandom
+                )) {
+                    Assert.assertEquals(0, tables.size());
+                    for (int i = 0; i < numOfTables; i++) {
+                        final CharSequence tableName = getTableName(i);
+                        tables.put(tableName, new TableData(tableName));
+                    }
 
                     try {
                         ingest(serverMain.getEngine(), serverMain.getHttpServerPort());

--- a/core/src/test/java/io/questdb/test/griffin/TableWriterAsyncCmdTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TableWriterAsyncCmdTest.java
@@ -122,7 +122,7 @@ public class TableWriterAsyncCmdTest extends AbstractCairoTest {
                             qf.await();
                             Assert.fail();
                         } catch (SqlException exception) {
-                            TestUtils.assertContains(exception.getFlyweightMessage(), "Duplicate column [name=column5]");
+                            TestUtils.assertContains(exception.getFlyweightMessage(), "duplicate column [name=column5]");
                         }
                     }
                 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/JoinRecordMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/JoinRecordMetadataTest.java
@@ -41,14 +41,14 @@ public class JoinRecordMetadataTest extends AbstractCairoTest {
             metadata.add("a", "X", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X, alias=a]");
+            TestUtils.assertContains(e.getMessage(), "duplicate column [name=X, alias=a]");
         }
 
         try {
             metadata.add("A", "X", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=X, alias=A]");
+            TestUtils.assertContains(e.getMessage(), "duplicate column [name=X, alias=A]");
         }
 
         Assert.assertEquals(0, metadata.getColumnIndexQuiet("x"));
@@ -71,7 +71,7 @@ public class JoinRecordMetadataTest extends AbstractCairoTest {
             metadata.add("b", "y", ColumnType.FLOAT, false, 0, false, null);
             Assert.fail();
         } catch (Exception e) {
-            TestUtils.assertContains(e.getMessage(), "Duplicate column [name=y, alias=b]");
+            TestUtils.assertContains(e.getMessage(), "duplicate column [name=y, alias=b]");
         }
 
         metadata.add(null, "c.x", ColumnType.STRING, false, 0, false, null);


### PR DESCRIPTION
fixes error on ILP commit

```
java.lang.AssertionError
        at io.questdb.cairo.vm.MemoryPARWImpl.jumpTo(MemoryPARWImpl.java:406)
        at io.questdb.cairo.wal.WalWriter.switchColumnsToNewSegmentRollColumn(WalWriter.java:1640)
        at io.questdb.cairo.wal.WalWriter.switchColumnsToNewSegment(WalWriter.java:1628)
        at io.questdb.cairo.wal.WalWriter.rollUncommittedToNewSegment(WalWriter.java:606)
        at io.questdb.cairo.wal.WalWriter$MetadataWriterService.addColumn(WalWriter.java:1906)
        at io.questdb.griffin.engine.ops.AlterOperation.applyAddColumn(AlterOperation.java:417)
        at io.questdb.griffin.engine.ops.AlterOperation.apply(AlterOperation.java:142)
        at io.questdb.cairo.wal.WalWriter.applyStructural(WalWriter.java:867)
        at io.questdb.cairo.wal.WalWriter.apply(WalWriter.java:253)
        at io.questdb.cairo.wal.WalWriter.addColumn(WalWriter.java:784)
        at io.questdb.cairo.wal.WalWriter.addColumn(WalWriter.java:215)
        at io.questdb.cutlass.line.tcp.LineWalAppender.appendToWal0(LineWalAppender.java:154)
        at io.questdb.cutlass.line.tcp.LineWalAppender.appendToWal(LineWalAppender.java:66)
        at io.questdb.cutlass.line.tcp.LineTcpMeasurementScheduler.scheduleEvent(LineTcpMeasurementScheduler.java:313)
        at io.questdb.cutlass.line.tcp.LineTcpConnectionContext.parseMeasurements(LineTcpConnectionContext.java:378)
        at io.questdb.cutlass.line.tcp.LineTcpConnectionContext.handleIO(LineTcpConnectionContext.java:199)
        at io.questdb.cutlass.line.tcp.LineTcpNetworkIOJob.handleIO(LineTcpNetworkIOJob.java:144)
        at io.questdb.cutlass.line.tcp.LineTcpNetworkIOJob.onRequest(LineTcpNetworkIOJob.java:167)
        at io.questdb.network.AbstractIODispatcher.processIOQueue(AbstractIODispatcher.java:210)
        at io.questdb.cutlass.line.tcp.LineTcpNetworkIOJob.run(LineTcpNetworkIOJob.java:127)
        at io.questdb.mp.Worker.run(Worker.java:152)

```

Also, it moves this error messages into info category, this is normal workflow in ILP when a column is added concurrently

```
E i.q.g.e.o.AlterOperation could not alter table [table=TableToken{tableName=...}, command=1, errno=-1, message=`duplicate column name: col_name`]
```