### PR TITLE
perf(sql): improve performance of `distinct` queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -298,8 +298,8 @@ import static io.questdb.cairo.ColumnType.getGeoHashBits;
 import static io.questdb.cairo.sql.PartitionFrameCursorFactory.*;
 import static io.questdb.griffin.SqlKeywords.*;
 import static io.questdb.griffin.model.ExpressionNode.*;
-import static io.questdb.griffin.model.QueryModel.QUERY;
 import static io.questdb.griffin.model.QueryModel.*;
+import static io.questdb.griffin.model.QueryModel.QUERY;
 
 public class SqlCodeGenerator implements Mutable, Closeable {
     public static final int GKK_HOUR_INT = 1;
@@ -3148,9 +3148,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             listColumnFilterA.add(-index - 1);
                         } else {
                             listColumnFilterA.add(index + 1);
-                            if (i == 0 && metadata.getColumnType(index) == ColumnType.TIMESTAMP) {
-                                orderedByTimestampIndex = index;
-                            }
+                        }
+                        if (i == 0 && metadata.getColumnType(index) == ColumnType.TIMESTAMP) {
+                            orderedByTimestampIndex = index;
                         }
                     }
                 }
@@ -3227,9 +3227,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         );
                     } else {
                         final int columnType = orderedMetadata.getColumnType(firstOrderByColumnIndex);
-                        if (configuration.isSqlOrderBySortEnabled()
-                                && orderByColumnNames.size() == 1
-                                && LongSortedLightRecordCursorFactory.isSupportedColumnType(columnType)) {
+                        if (
+                                configuration.isSqlOrderBySortEnabled()
+                                        && orderByColumnNames.size() == 1
+                                        && LongSortedLightRecordCursorFactory.isSupportedColumnType(columnType)
+                        ) {
                             return new LongSortedLightRecordCursorFactory(
                                     configuration,
                                     orderedMetadata,

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -196,9 +196,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
         @Override
         public void calculateSize(SqlExecutionCircuitBreaker circuitBreaker, Counter counter) {
-            if (!isDataMapBuilt) {
-                buildDataMap();
-            }
+            buildMapConditionally();
             baseCursor.calculateSize(circuitBreaker, counter);
         }
 
@@ -215,17 +213,13 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
         @Override
         public boolean hasNext() {
-            if (!isDataMapBuilt) {
-                buildDataMap();
-            }
+            buildMapConditionally();
             return super.hasNext();
         }
 
         @Override
         public void longTopK(DirectLongLongHeap heap, int columnIndex) {
-            if (!isDataMapBuilt) {
-                buildDataMap();
-            }
+            buildMapConditionally();
             ((MapRecordCursor) baseCursor).longTopK(heap, recordFunctions.getQuick(columnIndex));
         }
 
@@ -263,6 +257,12 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
             }
             super.of(dataMap.getCursor());
             isDataMapBuilt = true;
+        }
+
+        private void buildMapConditionally() {
+            if (!isDataMapBuilt) {
+                buildDataMap();
+            }
         }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByInterpolateRecordCursorFactory.java
@@ -24,20 +24,39 @@
 
 package io.questdb.griffin.engine.groupby;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.EntityColumnFilter;
+import io.questdb.cairo.ListColumnFilter;
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.RecordSinkFactory;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.columns.TimestampColumn;
 import io.questdb.griffin.model.QueryModel;
-import io.questdb.std.*;
+import io.questdb.std.BytecodeAssembler;
+import io.questdb.std.IntList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.TimeZoneRules;
 import io.questdb.std.datetime.microtime.TimestampFormatUtils;
 import io.questdb.std.datetime.microtime.Timestamps;
@@ -308,10 +327,7 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
 
         @Override
         public boolean hasNext() {
-            if (!isMapBuilt) {
-                buildMap();
-                isMapBuilt = true;
-            }
+            buildMapConditionally();
             return super.hasNext();
         }
 
@@ -499,6 +515,13 @@ public class SampleByInterpolateRecordCursorFactory extends AbstractRecordCursor
             }
             // refresh map cursor
             baseCursor = dataMap.getCursor();
+        }
+
+        private void buildMapConditionally() {
+            if (!isMapBuilt) {
+                buildMap();
+                isMapBuilt = true;
+            }
         }
 
         private void computeYPoints(MapValue x1Value, MapValue x2value) {

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LongTopKRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LongTopKRecordCursor.java
@@ -81,10 +81,7 @@ class LongTopKRecordCursor implements RecordCursor {
 
     @Override
     public boolean hasNext() {
-        if (!initialized) {
-            topK();
-            initialized = true;
-        }
+        setupTopK();
         if (rowIdCursor.hasNext()) {
             circuitBreaker.statefulThrowExceptionIfTripped();
             baseCursor.recordAt(baseRecord, rowIdCursor.index());
@@ -119,7 +116,7 @@ class LongTopKRecordCursor implements RecordCursor {
 
     @Override
     public long size() {
-        return baseCursor.size();
+        return initialized ? heap.size() : -1;
     }
 
     @Override
@@ -128,6 +125,13 @@ class LongTopKRecordCursor implements RecordCursor {
         if (!initialized) {
             heap.clear();
             baseCursor.toTop();
+        }
+    }
+
+    private void setupTopK() {
+        if (!initialized) {
+            topK();
+            initialized = true;
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredNegativeLimitRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredNegativeLimitRecordCursor.java
@@ -26,8 +26,14 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.sql.PageFrameMemory;
+import io.questdb.cairo.sql.PageFrameMemoryPool;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
 import io.questdb.cairo.sql.async.PageFrameSequence;
 import io.questdb.log.Log;

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -93,9 +93,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
 
     @Override
     public void calculateSize(SqlExecutionCircuitBreaker circuitBreaker, Counter counter) {
-        if (!isDataMapBuilt) {
-            buildMap();
-        }
+        buildMapConditionally();
         mapCursor.calculateSize(circuitBreaker, counter);
     }
 
@@ -137,17 +135,13 @@ class AsyncGroupByRecordCursor implements RecordCursor {
 
     @Override
     public boolean hasNext() {
-        if (!isDataMapBuilt) {
-            buildMap();
-        }
+        buildMapConditionally();
         return mapCursor.hasNext();
     }
 
     @Override
     public void longTopK(DirectLongLongHeap heap, int columnIndex) {
-        if (!isDataMapBuilt) {
-            buildMap();
-        }
+        buildMapConditionally();
         mapCursor.longTopK(heap, recordFunctions.getQuick(columnIndex));
     }
 
@@ -245,6 +239,12 @@ class AsyncGroupByRecordCursor implements RecordCursor {
         recordA.of(mapCursor.getRecord());
         recordB.of(mapCursor.getRecordB());
         isDataMapBuilt = true;
+    }
+
+    private void buildMapConditionally() {
+        if (!isDataMapBuilt) {
+            buildMap();
+        }
     }
 
     private ObjList<Map> mergeShards(AsyncGroupByAtom atom) {

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -109,7 +109,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     private static final ObjList<String> modelTypeName = new ObjList<>();
     private final LowerCaseCharSequenceObjHashMap<QueryColumn> aliasToColumnMap = new LowerCaseCharSequenceObjHashMap<>();
     private final LowerCaseCharSequenceObjHashMap<CharSequence> aliasToColumnNameMap = new LowerCaseCharSequenceObjHashMap<>();
-    private final ObjList<CharSequence> bottomUpColumnAliases = new ObjList<>();
     private final ObjList<QueryColumn> bottomUpColumns = new ObjList<>();
     private final LowerCaseCharSequenceIntHashMap columnAliasIndexes = new LowerCaseCharSequenceIntHashMap();
     private final LowerCaseCharSequenceObjHashMap<CharSequence> columnNameToAliasMap = new LowerCaseCharSequenceObjHashMap<>();
@@ -142,6 +141,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     private final ObjList<ExpressionNode> updateSetColumns = new ObjList<>();
     private final ObjList<CharSequence> updateTableColumnNames = new ObjList<>();
     private final IntList updateTableColumnTypes = new IntList();
+    private final ObjList<CharSequence> wildcardColumnNames = new ObjList<>();
     private final LowerCaseCharSequenceObjHashMap<WithClauseModel> withClauseModel = new LowerCaseCharSequenceObjHashMap<>();
     // used for the parallel sample by rewrite. In the future, if we deprecate original SAMPLE BY, then these will
     // be the only fields for these values.
@@ -311,9 +311,9 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         int aliasKeyIndex = aliasToColumnNameMap.keyIndex(alias);
         if (aliasKeyIndex > -1) {
             aliasToColumnNameMap.putAt(aliasKeyIndex, alias, ast.token);
-            bottomUpColumnAliases.add(alias);
+            wildcardColumnNames.add(alias);
             columnNameToAliasMap.put(ast.token, alias);
-            columnAliasIndexes.put(alias, bottomUpColumnAliases.size() - 1);
+            columnAliasIndexes.put(alias, wildcardColumnNames.size() - 1);
             return true;
         }
         return false;
@@ -440,7 +440,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         tableNameFunction = null;
         tableId = -1;
         metadataVersion = -1;
-        bottomUpColumnAliases.clear();
+        wildcardColumnNames.clear();
         expressionModels.clear();
         distinct = false;
         nestedModelIsSubQuery = false;
@@ -480,7 +480,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public void clearColumnMapStructs() {
         this.aliasToColumnNameMap.clear();
-        this.bottomUpColumnAliases.clear();
+        this.wildcardColumnNames.clear();
         this.aliasToColumnMap.clear();
         this.bottomUpColumns.clear();
         this.columnAliasIndexes.clear();
@@ -547,8 +547,8 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
             }
             aliasToColumnMap.put(alias, qc);
         }
-        ObjList<CharSequence> columnNames = other.bottomUpColumnAliases;
-        this.bottomUpColumnAliases.addAll(columnNames);
+        ObjList<CharSequence> columnNames = other.wildcardColumnNames;
+        this.wildcardColumnNames.addAll(columnNames);
         for (int i = 0, n = columnNames.size(); i < n; i++) {
             final CharSequence name = columnNames.getQuick(i);
             this.aliasToColumnNameMap.put(name, name);
@@ -637,7 +637,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
                 && Objects.equals(aliasToColumnNameMap, that.aliasToColumnNameMap)
                 && Objects.equals(columnNameToAliasMap, that.columnNameToAliasMap)
                 && Objects.equals(aliasToColumnMap, that.aliasToColumnMap)
-                && Objects.equals(bottomUpColumnAliases, that.bottomUpColumnAliases)
+                && Objects.equals(wildcardColumnNames, that.wildcardColumnNames)
                 && Objects.equals(orderBy, that.orderBy)
                 && Objects.equals(groupBy, that.groupBy)
                 && Objects.equals(orderByDirection, that.orderByDirection)
@@ -715,10 +715,6 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
 
     public boolean getAllowPropagationOfOrderByAdvice() {
         return allowPropagationOfOrderByAdvice;
-    }
-
-    public ObjList<CharSequence> getBottomUpColumnAliases() {
-        return bottomUpColumnAliases;
     }
 
     public ObjList<QueryColumn> getBottomUpColumns() {
@@ -1009,6 +1005,10 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         return whereClause;
     }
 
+    public ObjList<CharSequence> getWildcardColumnNames() {
+        return wildcardColumnNames;
+    }
+
     public LowerCaseCharSequenceObjHashMap<WithClauseModel> getWithClauses() {
         return withClauseModel;
     }
@@ -1031,7 +1031,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         return 31 * hash + Objects.hash(
                 bottomUpColumns, topDownNameSet, topDownColumns,
                 aliasToColumnNameMap, columnNameToAliasMap, aliasToColumnMap,
-                bottomUpColumnAliases, orderBy,
+                wildcardColumnNames, orderBy,
                 orderByPosition, groupBy, orderByDirection,
                 dependencies, orderedJoinModels1, orderedJoinModels2,
                 columnAliasIndexes, modelAliasIndexes, expressionModels,
@@ -1245,7 +1245,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     public void removeColumn(int columnIndex) {
         CharSequence columnAlias = bottomUpColumns.getQuick(columnIndex).getAlias();
         bottomUpColumns.remove(columnIndex);
-        bottomUpColumnAliases.remove(columnAlias);
+        wildcardColumnNames.remove(columnAlias);
         aliasToColumnMap.remove(columnAlias);
         aliasToColumnNameMap.remove(columnAlias);
         columnAliasIndexes.remove(columnAlias);
@@ -1494,7 +1494,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
     public void updateColumnAliasIndexes() {
         columnAliasIndexes.clear();
         for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
-            columnAliasIndexes.put(bottomUpColumnAliases.getQuick(i), i);
+            columnAliasIndexes.put(wildcardColumnNames.getQuick(i), i);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -212,6 +212,7 @@ public abstract class AbstractCairoTest extends AbstractTest {
             LongList rows,
             boolean fragmentedSymbolTables
     ) {
+        long cursorSizeBeforeFetch = cursor.size();
         if (expected == null) {
             Assert.assertFalse(cursor.hasNext());
             cursor.toTop();
@@ -247,6 +248,13 @@ public abstract class AbstractCairoTest extends AbstractTest {
         }
         if (cursorSize != -1) {
             Assert.assertEquals("Actual cursor records vs cursor.size()", count, cursorSize);
+            if (cursorSizeBeforeFetch != -1) {
+                Assert.assertEquals("Cursor size before fetch and after", cursorSizeBeforeFetch, cursorSize);
+            }
+//            RecordCursor.Counter counter = new RecordCursor.Counter();
+//            cursor.toTop();
+//            cursor.calculateSize(circuitBreaker, counter);
+//            Assert.assertEquals("calculateSize() vs size after fetch", counter.get(), cursorSize);
         }
 
         TestUtils.assertEquals(expected, sink);

--- a/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
@@ -1512,7 +1512,9 @@ public class AggregateTest extends AbstractCairoTest {
                     "count\tcount1\n1\t1\n",
                     sql,
                     ddl,
-                    null, true, false
+                    null,
+                    true,
+                    true
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
@@ -300,7 +300,7 @@ public class DeclareTest extends AbstractSqlParserTest {
         assertMemoryLeak(() -> {
             execute(tradesDdl);
             drainWalQueue();
-            assertModel("select-distinct [symbol] symbol from (select-choose [symbol] symbol from (select [symbol] from trades timestamp (timestamp)))",
+            assertModel("select-choose symbol from (select-group-by [symbol] symbol, count() count from (select [symbol] from trades timestamp (timestamp)))",
                     "DECLARE @x := symbol SELECT DISTINCT symbol FROM trades", ExecutionModel.QUERY);
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/DistinctSymbolTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctSymbolTest.java
@@ -166,7 +166,7 @@ public class DistinctSymbolTest extends AbstractCairoTest {
                         " timestamp(ts) PARTITION BY MONTH",
                 null,
                 true,
-                false
+                true
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/DistinctTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctTest.java
@@ -39,7 +39,7 @@ public class DistinctTest extends AbstractCairoTest {
                         "24814\t24814\n" +
                         "-13027\t-13027\n" +
                         "-22955\t-22955\n",
-                "SELECT DISTINCT event e1, event e2 FROM x;",
+                "SELECT DISTINCT event e1, event e2 FROM x order by 1 desc;",
                 "create table x as (" +
                         "  select" +
                         "    rnd_short() origin," +
@@ -49,7 +49,7 @@ public class DistinctTest extends AbstractCairoTest {
                         ") timestamp(created);",
                 null,
                 true,
-                false
+                true
         );
     }
 
@@ -81,7 +81,7 @@ public class DistinctTest extends AbstractCairoTest {
                         "-24814\t-24814\n" +
                         "13027\t13027\n" +
                         "22955\t22955\n",
-                "SELECT DISTINCT event e1, event e2 FROM (SELECT origin, (-event) event FROM x);",
+                "SELECT DISTINCT event e1, event e2 FROM (SELECT origin, (-event) event FROM x) order by 1;",
                 "create table x as (" +
                         "  select" +
                         "    rnd_short() origin," +
@@ -91,7 +91,7 @@ public class DistinctTest extends AbstractCairoTest {
                         ") timestamp(created);",
                 null,
                 true,
-                false
+                true
         );
     }
 
@@ -100,10 +100,10 @@ public class DistinctTest extends AbstractCairoTest {
         assertQuery(
                 "e1\te2\n" +
                         "42\t42\n" +
-                        "24814\t24814\n" +
+                        "-22955\t-22955\n" +
                         "-13027\t-13027\n" +
-                        "-22955\t-22955\n",
-                "(SELECT 42 e1, 42 e2) UNION (SELECT DISTINCT event e1, event e2 FROM x);",
+                        "24814\t24814\n",
+                "(SELECT 42 e1, 42 e2) UNION (SELECT DISTINCT event e1, event e2 FROM x order by 1);",
                 "create table x as (" +
                         "  select" +
                         "    rnd_short() origin," +

--- a/core/src/test/java/io/questdb/test/griffin/DistinctTimeSeriesTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctTimeSeriesTest.java
@@ -199,7 +199,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                     "insert into x values (11, 'ibm', '1970-01-06T19:42:50.000000Z')",
                     expected,
                     true,
-                    false,
+                    true,
                     false
             );
         });

--- a/core/src/test/java/io/questdb/test/griffin/DistinctTimeSeriesTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctTimeSeriesTest.java
@@ -87,7 +87,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                         "8\tibm\t1970-01-06T19:31:50.000000Z\n" +
                         "9\tmsft\t1970-01-06T19:37:20.000000Z\n" +
                         "10\tibm\t1970-01-06T19:42:50.000000Z\n",
-                "select distinct * from x",
+                "select distinct * from x order by ts",
                 "create table x as (" +
                         "select" +
                         " cast(x as int) i," +
@@ -97,7 +97,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                         ") timestamp (ts) partition by DAY",
                 "ts",
                 true,
-                false
+                true
         ));
     }
 
@@ -151,7 +151,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                     "ibm\t1970-01-06T19:42:50.000000Z\n";
             assertQuery(
                     expected,
-                    "select distinct sym, ts from x",
+                    "select distinct sym, ts from x order by ts",
                     "create table x as (" +
                             "select" +
                             " cast(x as int) i," +
@@ -165,7 +165,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                     expected,
                     true,
                     false,
-                    false
+                    true
             );
         });
     }
@@ -186,7 +186,7 @@ public class DistinctTimeSeriesTest extends AbstractCairoTest {
                     "msft\t1970-01-06T18:53:20.000000Z\n";
             assertQuery(
                     expected,
-                    "select distinct sym, ts from (x order by ts desc)",
+                    "select distinct sym, ts from (x order by ts desc) order by ts desc",
                     "create table x as (" +
                             "select" +
                             " cast(x as int) i," +

--- a/core/src/test/java/io/questdb/test/griffin/DistinctWithLimitTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctWithLimitTest.java
@@ -62,25 +62,27 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
     public void testDistinctOnIndexedSymbolColumnWithLimitInInnerQuery() throws Exception {
         assertQuery(
                 "id\n1\n2\n",
-                "SELECT DISTINCT id from ( select id FROM test LIMIT 2 ) ",
+                "SELECT DISTINCT id from ( select id FROM test LIMIT 2 ) order by 1",
                 "CREATE TABLE test as (" +
                         "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9)), index(id)",
                 null,
                 true,
-                false
+                true
         );
     }
 
     @Test
     public void testDistinctOnIndexedSymbolColumnWithOrderByLimitInInnerQuery() throws Exception {
         assertQuery(
-                "id\n9\n8\n",
-                "SELECT DISTINCT id from ( select id FROM test ORDER BY id desc LIMIT 2 ) ",
+                "id\n" +
+                        "9\n" +
+                        "8\n",
+                "SELECT DISTINCT id from ( select id FROM test ORDER BY id desc LIMIT 2 ) order by 1 desc",
                 "CREATE TABLE test as (" +
                         "select cast(x as symbol) as id, rnd_double() as reading  from long_sequence(9) order by 2), index(id)",
                 null,
                 true,
-                false
+                true
         );
     }
 
@@ -134,7 +136,9 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
                 "select DISTINCT id FROM ( select id from limtest order by id asc LIMIT 4) order by id desc",
                 "CREATE TABLE limtest as (" +
                         "select cast(x%3 as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
-                null
+                null,
+                true,
+                true
         );
     }
 
@@ -145,7 +149,9 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
                 "select DISTINCT id FROM ( select id from limtest order by id desc LIMIT 4) order by id asc",
                 "CREATE TABLE limtest as (" +
                         "select cast(x%3 as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
-                null
+                null,
+                true,
+                true
         );
     }
 
@@ -195,7 +201,7 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
                 "CREATE TABLE limtest as (select cast((x%6) as symbol) as id from long_sequence(20))",
                 null,
                 true,
-                false
+                true
         );
     }
 
@@ -231,7 +237,9 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
                 "select DISTINCT id FROM ( select id from limtest order by id desc LIMIT 2) order by id asc",
                 "CREATE TABLE limtest as (" +
                         "select cast(x as symbol) as id, cast(x as double) as reading  from long_sequence(9))",
-                null
+                null,
+                true,
+                true
         );
     }
 
@@ -342,7 +350,7 @@ public class DistinctWithLimitTest extends AbstractCairoTest {
     public void testDistinctWithLimitOnLongColumn() throws Exception {
         assertQuery(
                 "id\n9\n8\n",
-                "select DISTINCT id FROM limtest LIMIT 2",
+                "select DISTINCT id FROM limtest order by 1 desc LIMIT 2",
                 "CREATE TABLE limtest as (" +
                         "select 10-x as id from long_sequence(9)) ",
                 null,

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -946,9 +946,11 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di order by 1 limit 10",
-                "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
+                "Sort light lo: 10\n" +
+                        "  keys: [ts]\n" +
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: null\n" +
                         "        PageFrame\n" +
                         "            Row forward scan\n" +
                         "            Frame forward scan on: di\n"
@@ -962,11 +964,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select distinct ts from di order by 1 desc limit 10",
                 "Sort light lo: 10\n" +
                         "  keys: [ts desc]\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: null\n" +
                         "        PageFrame\n" +
-                        "            Row forward scan\n" +
-                        "            Frame forward scan on: di\n"
+                        "            Row backward scan\n" +
+                        "            Frame backward scan on: di\n"
         );
     }
 
@@ -976,8 +979,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: null\n" +
                         "        PageFrame\n" +
                         "            Row forward scan\n" +
                         "            Frame forward scan on: di\n"
@@ -990,8 +994,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: null\n" +
                         "        PageFrame\n" +
                         "            Row forward scan\n" +
                         "            Frame forward scan on: di\n"
@@ -1004,14 +1009,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di where y = 5 limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
-                        "        SelectedRecord\n" +
-                        "            Async JIT Filter workers: 1\n" +
-                        "              filter: y=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async JIT Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: y=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1021,14 +1024,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di where y = 5 limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
-                        "        SelectedRecord\n" +
-                        "            Async JIT Filter workers: 1\n" +
-                        "              filter: y=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async JIT Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: y=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1038,14 +1039,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di where abs(y) = 5 limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1055,14 +1054,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di where abs(y) = 5 limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1072,14 +1069,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long, ts timestamp) timestamp(ts)",
                 "select distinct ts from di where abs(y) = 5 limit 10, 20",
                 "Limit lo: 10 hi: 20 skip-over-rows: 10 limit: 10\n" +
-                        "    DistinctTimeSeries\n" +
-                        "      keys: ts\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [ts]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1090,13 +1085,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select distinct x from di order by 1 limit 10",
                 "Sort light lo: 10\n" +
                         "  keys: [x]\n" +
-                        "    DistinctKey\n" +
-                        "        GroupBy vectorized: true workers: 1\n" +
-                        "          keys: [x]\n" +
-                        "          values: [count(*)]\n" +
-                        "            PageFrame\n" +
-                        "                Row forward scan\n" +
-                        "                Frame forward scan on: di\n"
+                        "    GroupBy vectorized: true workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      values: [count(*)]\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1107,13 +1101,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select distinct x from di order by 1 desc limit 10",
                 "Sort light lo: 10\n" +
                         "  keys: [x desc]\n" +
-                        "    DistinctKey\n" +
-                        "        GroupBy vectorized: true workers: 1\n" +
-                        "          keys: [x]\n" +
-                        "          values: [count(*)]\n" +
-                        "            PageFrame\n" +
-                        "                Row forward scan\n" +
-                        "                Frame forward scan on: di\n"
+                        "    GroupBy vectorized: true workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      values: [count(*)]\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1123,13 +1116,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    DistinctKey\n" +
-                        "        GroupBy vectorized: true workers: 1\n" +
-                        "          keys: [x]\n" +
-                        "          values: [count(*)]\n" +
-                        "            PageFrame\n" +
-                        "                Row forward scan\n" +
-                        "                Frame forward scan on: di\n"
+                        "    GroupBy vectorized: true workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      values: [count(*)]\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1139,13 +1131,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    DistinctKey\n" +
-                        "        GroupBy vectorized: true workers: 1\n" +
-                        "          keys: [x]\n" +
-                        "          values: [count(*)]\n" +
-                        "            PageFrame\n" +
-                        "                Row forward scan\n" +
-                        "                Frame forward scan on: di\n"
+                        "    GroupBy vectorized: true workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      values: [count(*)]\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1155,14 +1146,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di where y = 5 limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    Distinct\n" +
-                        "      keys: x\n" +
-                        "        SelectedRecord\n" +
-                        "            Async JIT Filter workers: 1\n" +
-                        "              filter: y=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async JIT Group By workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      filter: y=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1172,14 +1161,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di where y = 5 limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    Distinct\n" +
-                        "      keys: x\n" +
-                        "        SelectedRecord\n" +
-                        "            Async JIT Filter workers: 1\n" +
-                        "              filter: y=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async JIT Group By workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      filter: y=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1189,14 +1176,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di where abs(y) = 5 limit 10",
                 "Limit lo: 10 skip-over-rows: 0 limit: 10\n" +
-                        "    Distinct\n" +
-                        "      keys: x\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1206,14 +1191,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di where abs(y) = 5 limit -10",
                 "Limit lo: -10 skip-over-rows: 0 limit: 0\n" +
-                        "    Distinct\n" +
-                        "      keys: x\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -1223,14 +1206,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "create table di (x int, y long)",
                 "select distinct x from di where abs(y) = 5 limit 10, 20",
                 "Limit lo: 10 hi: 20 skip-over-rows: 10 limit: 10\n" +
-                        "    Distinct\n" +
-                        "      keys: x\n" +
-                        "        SelectedRecord\n" +
-                        "            Async Filter workers: 1\n" +
-                        "              filter: abs(y)=5\n" +
-                        "                PageFrame\n" +
-                        "                    Row forward scan\n" +
-                        "                    Frame forward scan on: di\n"
+                        "    Async Group By workers: 1\n" +
+                        "      keys: [x]\n" +
+                        "      filter: abs(y)=5\n" +
+                        "        PageFrame\n" +
+                        "            Row forward scan\n" +
+                        "            Frame forward scan on: di\n"
         );
     }
 
@@ -4094,7 +4075,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select s, i, ts from a where s in (select distinct s from a) and length(s) = 2 latest on ts partition by s",
                 "LatestBySubQuery\n" +
                         "    Subquery\n" +
-                        "        DistinctSymbol\n" +
+                        "        GroupBy vectorized: true workers: 1\n" +
+                        "          keys: [s]\n" +
+                        "          values: [count(*)]\n" +
                         "            PageFrame\n" +
                         "                Row forward scan\n" +
                         "                Frame forward scan on: a\n" +
@@ -4111,7 +4094,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select s, i, ts from a where s in (select distinct s from a) latest on ts partition by s",
                 "LatestBySubQuery\n" +
                         "    Subquery\n" +
-                        "        DistinctSymbol\n" +
+                        "        GroupBy vectorized: true workers: 1\n" +
+                        "          keys: [s]\n" +
+                        "          values: [count(*)]\n" +
                         "            PageFrame\n" +
                         "                Row forward scan\n" +
                         "                Frame forward scan on: a\n" +
@@ -4127,7 +4112,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select i, ts, s from a where s in (select distinct s from a) and length(s) = 2 latest on ts partition by s",
                 "LatestBySubQuery\n" +
                         "    Subquery\n" +
-                        "        DistinctSymbol\n" +
+                        "        GroupBy vectorized: true workers: 1\n" +
+                        "          keys: [s]\n" +
+                        "          values: [count(*)]\n" +
                         "            PageFrame\n" +
                         "                Row forward scan\n" +
                         "                Frame forward scan on: a\n" +
@@ -4144,7 +4131,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 "select i, ts, s from a where s in (select distinct s from a) latest on ts partition by s",
                 "LatestBySubQuery\n" +
                         "    Subquery\n" +
-                        "        DistinctSymbol\n" +
+                        "        GroupBy vectorized: true workers: 1\n" +
+                        "          keys: [s]\n" +
+                        "          values: [count(*)]\n" +
                         "            PageFrame\n" +
                         "                Row forward scan\n" +
                         "                Frame forward scan on: a\n" +
@@ -7693,8 +7682,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab ( l long, ts timestamp) timestamp(ts);",
                 "select distinct l, ts from tab",
-                "DistinctTimeSeries\n" +
-                        "  keys: l,ts\n" +
+                "Async Group By workers: 1\n" +
+                        "  keys: [l,ts]\n" +
+                        "  filter: null\n" +
                         "    PageFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: tab\n"
@@ -7720,8 +7710,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab ( l long, ts timestamp);",
                 "select distinct(l) from tab",
-                "Distinct\n" +
-                        "  keys: l\n" +
+                "Async Group By workers: 1\n" +
+                        "  keys: [l]\n" +
+                        "  filter: null\n" +
                         "    PageFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: tab\n"
@@ -7733,7 +7724,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab ( s symbol, ts timestamp);",
                 "select distinct(s) from tab",
-                "DistinctSymbol\n" +
+                "GroupBy vectorized: true workers: 1\n" +
+                        "  keys: [s]\n" +
+                        "  values: [count(*)]\n" +
                         "    PageFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: tab\n"
@@ -7745,7 +7738,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab ( s symbol index, ts timestamp);",
                 "select distinct(s) from tab",
-                "DistinctSymbol\n" +
+                "GroupBy vectorized: true workers: 1\n" +
+                        "  keys: [s]\n" +
+                        "  values: [count(*)]\n" +
                         "    PageFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: tab\n"
@@ -7757,8 +7752,9 @@ public class ExplainPlanTest extends AbstractCairoTest {
         assertPlan(
                 "create table tab ( l long, ts timestamp);",
                 "select distinct ts, l  from tab",
-                "Distinct\n" +
-                        "  keys: ts,l\n" +
+                "Async Group By workers: 1\n" +
+                        "  keys: [ts,l]\n" +
+                        "  filter: null\n" +
                         "    PageFrame\n" +
                         "        Row forward scan\n" +
                         "        Frame forward scan on: tab\n"
@@ -8678,13 +8674,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
             assertPlanNoLeakCheck(
                     "select distinct(i) from a limit -5",
                     "Limit lo: -5 skip-over-rows: 5 limit: 5\n" +
-                            "    DistinctKey\n" +
-                            "        GroupBy vectorized: true workers: 1\n" +
-                            "          keys: [i]\n" +
-                            "          values: [count(*)]\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: a\n"
+                            "    GroupBy vectorized: true workers: 1\n" +
+                            "      keys: [i]\n" +
+                            "      values: [count(*)]\n" +
+                            "        PageFrame\n" +
+                            "            Row forward scan\n" +
+                            "            Frame forward scan on: a\n"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -24,6 +24,7 @@
 package io.questdb.test.griffin;
 
 import io.questdb.griffin.SqlException;
+import io.questdb.jit.JitUtil;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -2545,19 +2546,35 @@ public class GroupByTest extends AbstractCairoTest {
                     "GROUP BY tab.created " +
                     "ORDER BY tab.created";
 
-            assertPlanNoLeakCheck(
-                    query,
-                    "Radix sort light\n" +
-                            "  keys: [ref0]\n" +
-                            "    VirtualRecord\n" +
-                            "      functions: [created]\n" +
-                            "        Async Group By workers: 1\n" +
-                            "          keys: [created]\n" +
-                            "          filter: null!=created\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: tab\n"
-            );
+            if (JitUtil.isJitSupported()) {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [ref0]\n" +
+                                "    VirtualRecord\n" +
+                                "      functions: [created]\n" +
+                                "        Async JIT Group By workers: 1\n" +
+                                "          keys: [created]\n" +
+                                "          filter: null!=created\n" +
+                                "            PageFrame\n" +
+                                "                Row forward scan\n" +
+                                "                Frame forward scan on: tab\n"
+                );
+            } else {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [ref0]\n" +
+                                "    VirtualRecord\n" +
+                                "      functions: [created]\n" +
+                                "        Async Group By workers: 1\n" +
+                                "          keys: [created]\n" +
+                                "          filter: null!=created\n" +
+                                "            PageFrame\n" +
+                                "                Row forward scan\n" +
+                                "                Frame forward scan on: tab\n"
+                );
+            }
 
             assertQueryNoLeakCheck(
                     "ref0\n" +
@@ -2585,19 +2602,36 @@ public class GroupByTest extends AbstractCairoTest {
                     "GROUP BY tab.created " +
                     "ORDER BY dateadd('h', 1, tab.created)";
 
-            assertPlanNoLeakCheck(
-                    query,
-                    "Radix sort light\n" +
-                            "  keys: [ref0]\n" +
-                            "    VirtualRecord\n" +
-                            "      functions: [dateadd('h',1,created)]\n" +
-                            "        Async Group By workers: 1\n" +
-                            "          keys: [created]\n" +
-                            "          filter: null!=created\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: tab\n"
-            );
+
+            if (JitUtil.isJitSupported()) {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [ref0]\n" +
+                                "    VirtualRecord\n" +
+                                "      functions: [dateadd('h',1,created)]\n" +
+                                "        Async JIT Group By workers: 1\n" +
+                                "          keys: [created]\n" +
+                                "          filter: null!=created\n" +
+                                "            PageFrame\n" +
+                                "                Row forward scan\n" +
+                                "                Frame forward scan on: tab\n"
+                );
+            } else {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [ref0]\n" +
+                                "    VirtualRecord\n" +
+                                "      functions: [dateadd('h',1,created)]\n" +
+                                "        Async Group By workers: 1\n" +
+                                "          keys: [created]\n" +
+                                "          filter: null!=created\n" +
+                                "            PageFrame\n" +
+                                "                Row forward scan\n" +
+                                "                Frame forward scan on: tab\n"
+                );
+            }
 
             assertQueryNoLeakCheck(
                     "ref0\n" +
@@ -2625,17 +2659,31 @@ public class GroupByTest extends AbstractCairoTest {
                     "GROUP BY tab.created " +
                     "ORDER BY tab.created";
 
-            assertPlanNoLeakCheck(
-                    query,
-                    "Radix sort light\n" +
-                            "  keys: [created]\n" +
-                            "    Async Group By workers: 1\n" +
-                            "      keys: [created]\n" +
-                            "      filter: null!=created\n" +
-                            "        PageFrame\n" +
-                            "            Row forward scan\n" +
-                            "            Frame forward scan on: tab\n"
-            );
+            if (JitUtil.isJitSupported()) {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [created]\n" +
+                                "    Async JIT Group By workers: 1\n" +
+                                "      keys: [created]\n" +
+                                "      filter: null!=created\n" +
+                                "        PageFrame\n" +
+                                "            Row forward scan\n" +
+                                "            Frame forward scan on: tab\n"
+                );
+            } else {
+                assertPlanNoLeakCheck(
+                        query,
+                        "Radix sort light\n" +
+                                "  keys: [created]\n" +
+                                "    Async Group By workers: 1\n" +
+                                "      keys: [created]\n" +
+                                "      filter: null!=created\n" +
+                                "        PageFrame\n" +
+                                "            Row forward scan\n" +
+                                "            Frame forward scan on: tab\n"
+                );
+            }
 
             assertQueryNoLeakCheck(
                     "created\n" +

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -2549,16 +2549,14 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "Radix sort light\n" +
                             "  keys: [ref0]\n" +
-                            "    Distinct\n" +
-                            "      keys: ref0\n" +
-                            "        VirtualRecord\n" +
-                            "          functions: [created]\n" +
-                            "            Async JIT Group By workers: 1\n" +
-                            "              keys: [created]\n" +
-                            "              filter: null!=created\n" +
-                            "                PageFrame\n" +
-                            "                    Row forward scan\n" +
-                            "                    Frame forward scan on: tab\n"
+                            "    VirtualRecord\n" +
+                            "      functions: [created]\n" +
+                            "        Async Group By workers: 1\n" +
+                            "          keys: [created]\n" +
+                            "          filter: null!=created\n" +
+                            "            PageFrame\n" +
+                            "                Row forward scan\n" +
+                            "                Frame forward scan on: tab\n"
             );
 
             assertQueryNoLeakCheck(
@@ -2569,7 +2567,7 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "ref0",
                     true,
-                    false
+                    true
             );
         });
     }
@@ -2591,16 +2589,14 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "Radix sort light\n" +
                             "  keys: [ref0]\n" +
-                            "    Distinct\n" +
-                            "      keys: ref0\n" +
-                            "        VirtualRecord\n" +
-                            "          functions: [dateadd('h',1,created)]\n" +
-                            "            Async JIT Group By workers: 1\n" +
-                            "              keys: [created]\n" +
-                            "              filter: null!=created\n" +
-                            "                PageFrame\n" +
-                            "                    Row forward scan\n" +
-                            "                    Frame forward scan on: tab\n"
+                            "    VirtualRecord\n" +
+                            "      functions: [dateadd('h',1,created)]\n" +
+                            "        Async Group By workers: 1\n" +
+                            "          keys: [created]\n" +
+                            "          filter: null!=created\n" +
+                            "            PageFrame\n" +
+                            "                Row forward scan\n" +
+                            "                Frame forward scan on: tab\n"
             );
 
             assertQueryNoLeakCheck(
@@ -2611,7 +2607,7 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "ref0",
                     true,
-                    false
+                    true
             );
         });
     }
@@ -2633,14 +2629,12 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "Radix sort light\n" +
                             "  keys: [created]\n" +
-                            "    Distinct\n" +
-                            "      keys: created\n" +
-                            "        Async JIT Group By workers: 1\n" +
-                            "          keys: [created]\n" +
-                            "          filter: null!=created\n" +
-                            "            PageFrame\n" +
-                            "                Row forward scan\n" +
-                            "                Frame forward scan on: tab\n"
+                            "    Async Group By workers: 1\n" +
+                            "      keys: [created]\n" +
+                            "      filter: null!=created\n" +
+                            "        PageFrame\n" +
+                            "            Row forward scan\n" +
+                            "            Frame forward scan on: tab\n"
             );
 
             assertQueryNoLeakCheck(
@@ -2651,7 +2645,7 @@ public class GroupByTest extends AbstractCairoTest {
                     query,
                     "created",
                     true,
-                    false
+                    true
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/IPv4Test.java
@@ -2181,7 +2181,7 @@ public class IPv4Test extends AbstractCairoTest {
                         ")",
                 null,
                 true,
-                false
+                true
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/JoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JoinTest.java
@@ -2671,8 +2671,8 @@ public class JoinTest extends AbstractCairoTest {
                     "3456\t3\tqu\t\t9\t1970-01-01T00:00:08.000000Z\t3456\tq\t12\t\t1\t1970-01-01T00:00:00.000000Z\n" +
                     "3456\tq\t12\t\t10\t1970-01-01T00:00:09.000000Z\t3456\tq\t12\t\t1\t1970-01-01T00:00:00.000000Z\n";
 
-            String sql = "with g1 as (select distinct * from t1)," +
-                    "g2 as (select distinct * from t2)" +
+            String sql = "with g1 as (select distinct * from t1 order by ts)," +
+                    "g2 as (select distinct * from t2 order by ts)" +
                     "select * from g1 lt join g2 on g1.geo4 = g2.geo4";
 
             assertSql(sql, expected, true);
@@ -2696,8 +2696,8 @@ public class JoinTest extends AbstractCairoTest {
                     "timestamp_sequence(0, 1000000) ts " +
                     "from long_sequence(2)) timestamp(ts)");
 
-            String sql = "with g1 as (select distinct * from t1)," +
-                    "g2 as (select distinct * from t2)" +
+            String sql = "with g1 as (select distinct * from t1 order by ts)," +
+                    "g2 as (select distinct * from t2 order by ts)" +
                     "select * from g1 lt join g2 on g1.geo4 = g2.geo1";
 
             try {
@@ -2922,7 +2922,8 @@ public class JoinTest extends AbstractCairoTest {
                     "y1 as (select distinct * from y) " +
                     "select g1, gg1, gg2, gg4, gg8, x1.k " +
                     "from x1 " +
-                    "join y1 on y1.kk = x1.k";
+                    "join y1 on y1.kk = x1.k" +
+                    " order by 6";
 
             final String expected = "g1\tgg1\tgg2\tgg4\tgg8\tk\n" +
                     "9v1s\t1\twh4\ts2z2\t10011100111100101000010010010000010001010\t1\n" +
@@ -2957,8 +2958,8 @@ public class JoinTest extends AbstractCairoTest {
     @Test
     public void testJoinWithGeohash2() throws Exception {
         assertMemoryLeak(() -> {
-            final String query = "with x1 as (select distinct * from x)," +
-                    "y1 as (select distinct * from y) " +
+            final String query = "with x1 as (select distinct * from x order by k)," +
+                    "y1 as (select distinct * from y order by kk) " +
                     "select g1, gg1, gg2, gg4, gg8, x1.k " +
                     "from x1 " +
                     "lt join y1 on x1.l = y1.l";

--- a/core/src/test/java/io/questdb/test/griffin/NestedSetOperationTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/NestedSetOperationTest.java
@@ -34,7 +34,8 @@ public class NestedSetOperationTest extends AbstractCairoTest {
 
     @Test
     public void testColumnPushdownWithDistinctAndUnionAll() throws Exception {
-        assertQuery("c\n" +
+        assertQuery(
+                "c\n" +
                         "0\n" +
                         "0\n" +
                         "0\n" +
@@ -45,7 +46,11 @@ public class NestedSetOperationTest extends AbstractCairoTest {
                         "select distinct c, d b from test)",    //0,1 ; 0,2;
                 "create table test as (" +
                         "select 0 as a, x as b, 0 as c, x as d from long_sequence(2)" +
-                        ")", null, false);
+                        ")",
+                null,
+                false,
+                true
+        );
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -68,7 +68,9 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                         " x % 3 b" +
                         " from long_sequence(9)" +
                         ")",
-                null
+                null,
+                true,
+                true
         );
     }
 
@@ -103,7 +105,9 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                         " x % 3 b" +
                         " from long_sequence(9)" +
                         ")",
-                null
+                null,
+                true,
+                true
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/OrderByRadixSortTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByRadixSortTest.java
@@ -459,7 +459,7 @@ public class OrderByRadixSortTest extends AbstractCairoTest {
                         " end as timestamp) as a" +
                         " from long_sequence(25)" +
                         ")",
-                null,
+                "a###desc",
                 true,
                 true
         );

--- a/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
@@ -593,45 +593,6 @@ public class SecurityTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testMemoryRestrictionsWithDistinct() throws Exception {
-        assertMemoryLeak(() -> {
-            sqlExecutionContext.getRandom().reset();
-            execute("create table tb1 as (select" +
-                    " rnd_symbol(40,4,4,20000) sym1," +
-                    " rnd_symbol(40,4,4,20000) sym2," +
-                    " rnd_double(2) d," +
-                    " timestamp_sequence(0, 1000000000) ts" +
-                    " from long_sequence(40)) timestamp(ts)");
-            assertQueryNoLeakCheck(
-                    memoryRestrictedCompiler,
-                    "sym1\tsym2\n" +
-                            "FJGE\tQCEH\n" +
-                            "GPGW\tQSRL\n" +
-                            "OOZZ\tHNZH\n" +
-                            "PEHN\tIPHZ\n",
-                    "select distinct sym1, sym2 from tb1 where d < 0.07 order by 1",
-                    null,
-                    true,
-                    readOnlyExecutionContext,
-                    true
-            );
-            try {
-                assertQueryNoLeakCheck(
-                        memoryRestrictedCompiler,
-                        "TOO MUCH",
-                        "select distinct sym1, sym2 from tb1",
-                        null,
-                        true,
-                        readOnlyExecutionContext
-                );
-                Assert.fail();
-            } catch (Exception ex) {
-                Assert.assertTrue(ex.toString().contains("limit of 2 resizes exceeded"));
-            }
-        });
-    }
-
-    @Test
     public void testMemoryRestrictionsWithFullFatInnerJoin() throws Exception {
         assertMemoryLeak(() -> {
             sqlExecutionContext.getRandom().reset();

--- a/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SecurityTest.java
@@ -605,14 +605,15 @@ public class SecurityTest extends AbstractCairoTest {
             assertQueryNoLeakCheck(
                     memoryRestrictedCompiler,
                     "sym1\tsym2\n" +
-                            "OOZZ\tHNZH\n" +
-                            "GPGW\tQSRL\n" +
                             "FJGE\tQCEH\n" +
+                            "GPGW\tQSRL\n" +
+                            "OOZZ\tHNZH\n" +
                             "PEHN\tIPHZ\n",
-                    "select distinct sym1, sym2 from tb1 where d < 0.07",
+                    "select distinct sym1, sym2 from tb1 where d < 0.07 order by 1",
                     null,
                     true,
-                    readOnlyExecutionContext
+                    readOnlyExecutionContext,
+                    true
             );
             try {
                 assertQueryNoLeakCheck(

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -7345,7 +7345,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                 "select distinct t1.id " +
                         "from  tab t1, tab t2",
                 "create table tab as (select x as id from long_sequence(2))",
-                null, false, false
+                null, true, true
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -7309,7 +7309,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                 Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(0));
                 assertCursor(
                         "foo\n" +
-                        "1\n",
+                                "1\n",
                         factory,
                         true,
                         true
@@ -7328,7 +7328,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
 
                 assertCursor(
                         "foo\n" +
-                        "1\n",
+                                "1\n",
                         factory,
                         true,
                         true

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -769,21 +769,21 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
     @Test
     public void testDistinctFunctionColumn() throws Exception {
         final String expected = "v\n" +
-                "8.0\n" +
+                "0.0\n" +
                 "1.0\n" +
-                "7.0\n" +
                 "2.0\n" +
                 "3.0\n" +
                 "4.0\n" +
-                "0.0\n" +
-                "6.0\n" +
-                "9.0\n" +
                 "5.0\n" +
+                "6.0\n" +
+                "7.0\n" +
+                "8.0\n" +
+                "9.0\n" +
                 "10.0\n";
 
         assertQuery(
                 expected,
-                "select distinct round(val*10, 0) v from prices",
+                "select distinct round(val*10, 0) v from prices order by 1",
                 "create table prices as " +
                         "(" +
                         " SELECT \n" +
@@ -792,6 +792,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                         " long_sequence(1200000)" +
                         ")",
                 null,
+                true,
                 true
         );
     }
@@ -799,21 +800,21 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
     @Test
     public void testDistinctOperatorColumn() throws Exception {
         final String expected = "v\n" +
-                "10.0\n" +
+                "2.0\n" +
                 "3.0\n" +
-                "9.0\n" +
                 "4.0\n" +
                 "5.0\n" +
                 "6.0\n" +
-                "2.0\n" +
-                "8.0\n" +
-                "11.0\n" +
                 "7.0\n" +
+                "8.0\n" +
+                "9.0\n" +
+                "10.0\n" +
+                "11.0\n" +
                 "12.0\n";
 
         assertQuery(
                 expected,
-                "select distinct 2+round(val*10,0) v from prices",
+                "select distinct 2+round(val*10,0) v from prices order by 1",
                 "create table prices as " +
                         "(" +
                         " SELECT \n" +
@@ -822,6 +823,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                         " long_sequence(1200000)" +
                         ")",
                 null,
+                true,
                 true
         );
     }
@@ -848,7 +850,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                         ")",
                 null,
                 true,
-                false
+                true
         );
     }
 
@@ -860,7 +862,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
 
         assertQuery(
                 expected,
-                "select distinct pair from prices where pair in ('A','B')",
+                "select distinct pair from prices where pair in ('A','B') order by 1",
                 "create table prices as " +
                         "(" +
                         " SELECT \n" +
@@ -872,6 +874,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                         " long_sequence(1200000)" +
                         ")",
                 null,
+                true,
                 true
         );
     }
@@ -7293,7 +7296,7 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                 expected2,
                 true,
                 false,
-                false
+                true
         );
     }
 
@@ -7304,8 +7307,13 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
             try (RecordCursorFactory factory = select("select distinct id as foo from my_table")) {
                 RecordMetadata metadata = factory.getMetadata();
                 Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(0));
-                assertCursor("foo\n" +
-                        "1\n", factory, true, false);
+                assertCursor(
+                        "foo\n" +
+                        "1\n",
+                        factory,
+                        true,
+                        true
+                );
             }
         });
     }
@@ -7318,22 +7326,31 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                 RecordMetadata metadata = factory.getMetadata();
                 Assert.assertEquals(ColumnType.LONG, metadata.getColumnType(0));
 
-                assertCursor("foo\n" +
-                        "1\n", factory, true, false);
+                assertCursor(
+                        "foo\n" +
+                        "1\n",
+                        factory,
+                        true,
+                        true
+                );
             }
         });
     }
 
     @Test
     public void testSelectDistinctWithColumnAliasOnExplicitJoin() throws Exception {
-        assertQuery("id\n" +
+        assertQuery(
+                "id\n" +
                         "1\n" +
                         "2\n",
                 "select distinct t1.id " +
                         "from  tab t1 " +
                         "join (select x as id from long_sequence(2)) t2 on (t1.id=t2.id)",
                 "create table tab as (select x as id from long_sequence(3))",
-                null, false, false
+
+                null,
+                true,
+                true
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -5713,18 +5713,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testJoinTimestampPropagationWhenTimestampNotSelected() throws SqlException {
         assertQuery(
-                "select-distinct [id] id from (select-choose [id] id from (select-choose [a.id id] a.created ts_stop, a.id id, b.created ts_start, b.id id1 from " +
-                        "(select [id, created] from (select-choose [id, created] id, created, event, timestamp from " +
-                        "(select-choose [created, id] id, created, event, timestamp from " +
-                        "(select [created, id, event] from telemetry_users timestamp (timestamp) " +
-                        "where event = 101 " +
-                        "and id != '0x05ab1e873d165b00000005743f2c17') " +
-                        "order by created) timestamp (created)) a " +
-                        "lt join select [id, created] from (select-choose [id, created] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp " +
-                        "from (select [created, id, event] from telemetry_users timestamp (timestamp) " +
-                        "where event = 100) " +
-                        "order by created) timestamp (created)) b on b.id = a.id " +
-                        "post-join-where a.created - b.created > 10000000000) a))",
+                "select-choose id from (select-group-by [id] id, count() count from (select-choose [a.id id] a.created ts_stop, a.id id, b.created ts_start, b.id id1 from (select [id, created] from (select-choose [id, created] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 101 and id != '0x05ab1e873d165b00000005743f2c17') order by created) timestamp (created)) a lt join select [id, created] from (select-choose [id, created] id, created, event, timestamp from (select-choose [created, id] id, created, event, timestamp from (select [created, id, event] from telemetry_users timestamp (timestamp) where event = 100) order by created) timestamp (created)) b on b.id = a.id post-join-where a.created - b.created > 10000000000) a))",
                 "with \n" +
                         "    starts as ((telemetry_users where event = 100 order by created) timestamp(created)),\n" +
                         "    stops as ((telemetry_users where event = 101 order by created) timestamp(created))\n" +
@@ -6510,7 +6499,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testNotMoveWhereIntoDistinct() throws SqlException {
         assertQuery(
-                "select-choose a from (select-distinct [a] a from (select-choose [a] a from (select [a] from tab)) where a = 10)",
+                "select-choose a from (select-choose [a] a from (select-group-by [a] a, count() count from (select [a] from tab where a = 10)))",
                 "(select distinct a from tab) where a = 10",
                 modelOf("tab").col("a", ColumnType.INT)
         );
@@ -7067,21 +7056,41 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testOrderByPropagation() throws SqlException {
         assertQuery(
-                "select-choose id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType from " +
-                        "(select-choose [C.contactId id, contactlist.customName customName, contactlist.name name, contactlist.email email, contactlist.country_name country_name, " +
-                        "contactlist.country_code country_code, contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, " +
-                        "contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, timestamp] C.contactId id, contactlist.customName customName, " +
-                        "contactlist.name name, contactlist.email email, contactlist.country_name country_name, contactlist.country_code country_code, contactlist.city city, contactlist.region region, " +
-                        "contactlist.emoji_flag emoji_flag, contactlist.latitude latitude, contactlist.longitude longitude, contactlist.isNotReal isNotReal, contactlist.notRealType notRealType, " +
-                        "timestamp from (select [contactId] from (select-distinct [contactId] contactId from (select-choose [contactId] contactId from (select-choose [contactId, groupId, timestamp] " +
-                        "contactId, groupId, timestamp from (select [groupId, contactId, timestamp] from contact_events latest on timestamp partition by contactId) where groupId = 'qIqlX6qESMtTQXikQA46' order by timestamp) " +
-                        "eventlist) except select-choose [_id contactId] _id contactId from (select-choose [_id, notRealType] _id, customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, " +
-                        "longitude, isNotReal, notRealType, timestamp from (select [notRealType, _id] from contacts latest on timestamp partition by _id) where notRealType = 'bot') contactlist) " +
-                        "C join select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] " +
-                        "from (select-choose [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] _id, " +
-                        "customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp from " +
-                        "(select [customName, name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] from " +
-                        "contacts latest on timestamp partition by _id) order by timestamp) contactlist on contactlist._id = C.contactId) C order by timestamp desc)",
+                "select-choose id, customName, name, email, country_name, country_code, city, region," +
+                        " emoji_flag, latitude, longitude, isNotReal, notRealType from" +
+                        " (select-choose [C.contactId id, contactlist.customName customName, contactlist.name name," +
+                        " contactlist.email email, contactlist.country_name country_name," +
+                        " contactlist.country_code country_code, contactlist.city city," +
+                        " contactlist.region region, contactlist.emoji_flag emoji_flag, contactlist.latitude latitude," +
+                        " contactlist.longitude longitude, contactlist.isNotReal isNotReal," +
+                        " contactlist.notRealType notRealType, timestamp] C.contactId id," +
+                        " contactlist.customName customName, contactlist.name name, contactlist.email email," +
+                        " contactlist.country_name country_name, contactlist.country_code country_code," +
+                        " contactlist.city city, contactlist.region region, contactlist.emoji_flag emoji_flag," +
+                        " contactlist.latitude latitude, contactlist.longitude longitude," +
+                        " contactlist.isNotReal isNotReal, contactlist.notRealType notRealType," +
+                        " timestamp" +
+                        " from (select [contactId] from (select-choose [contactId] contactId" +
+                        " from (select-group-by [contactId, count() count] contactId, count() count" +
+                        " from (select-choose [contactId, groupId] contactId, groupId, timestamp" +
+                        " from (select [groupId, contactId] from contact_events latest on timestamp partition by contactId)" +
+                        " where groupId = 'qIqlX6qESMtTQXikQA46') eventlist) eventlist" +
+                        " except select-choose [_id contactId] _id contactId" +
+                        " from (select-choose [_id, notRealType] _id, customName, name, email, country_name," +
+                        " country_code, city, region, emoji_flag, latitude, longitude, isNotReal, notRealType," +
+                        " timestamp" +
+                        " from (select [notRealType, _id]" +
+                        " from contacts latest on timestamp partition by _id) where notRealType = 'bot') contactlist) C" +
+                        " join select [customName, name, email, country_name, country_code, city, region," +
+                        " emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id]" +
+                        " from (select-choose [customName, name, email, country_name, country_code, city, region," +
+                        " emoji_flag, latitude, longitude, isNotReal, notRealType, timestamp, _id] _id, customName," +
+                        " name, email, country_name, country_code, city, region, emoji_flag, latitude, longitude," +
+                        " isNotReal, notRealType, timestamp" +
+                        " from (select [customName, name, email, country_name, country_code, city, region, emoji_flag," +
+                        " latitude, longitude, isNotReal, notRealType, timestamp, _id]" +
+                        " from contacts latest on timestamp partition by _id) order by timestamp) contactlist on contactlist._id = C.contactId) C" +
+                        " order by timestamp desc)",
 
                 "WITH \n" +
                         "contactlist AS (SELECT * FROM contacts LATEST ON timestamp PARTITION BY _id ORDER BY timestamp),\n" +
@@ -8655,7 +8664,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectAfterOrderBy() throws SqlException {
         assertQuery(
-                "select-distinct [Schema] Schema from (select-choose [Schema] Schema from (select-virtual [Schema, Name] Schema, Name, switch(relkind,'r','table','v','view','m','materialized view','i','index','S','sequence','s','special','f','foreign table','p','table','I','index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c left join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r','p','v','m','S','f','') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name))",
+                "select-choose Schema from (select-group-by [Schema] Schema, count() count from (select-virtual [Schema, Name] Schema, Name, switch(relkind,'r','table','v','view','m','materialized view','i','index','S','sequence','s','special','f','foreign table','p','table','I','index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c left join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r','p','v','m','S','f','') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name))",
                 "select distinct Schema from \n" +
                         "(SELECT n.nspname                              as \"Schema\",\n" +
                         "       c.relname                              as \"Name\",\n" +
@@ -8820,7 +8829,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinct() throws SqlException {
         assertQuery(
-                "select-distinct [a, b] a, b from (select-choose [a, b] a, b from (select [a, b] from tab))",
+                "select-choose a, b from (select-group-by [a, b] a, b, count() count from (select [a, b] from tab))",
                 "select distinct a, b from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -8831,7 +8840,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctArithmetic() throws SqlException {
         assertQuery(
-                "select-distinct [column] column from (select-virtual [a + b column] a + b column from (select [b, a] from tab))",
+                "select-choose column from (select-group-by [a + b column] a + b column, count() count from (select [b, a] from tab))",
                 "select distinct a + b from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -8853,7 +8862,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctGroupByFunctionArithmetic() throws SqlException {
         assertQuery(
-                "select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab)))",
+                "select-choose a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb, count from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1, count() count from (select [a, c, b] from tab)))",
                 "select distinct a, sum(b)+sum(c) bb from tab",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -8865,7 +8874,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctGroupByFunctionArithmeticLimit() throws SqlException {
         assertQuery(
-                "select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 from (select [a, c, b] from tab))) limit 10",
+                "select-choose a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb, count from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1, count() count from (select [a, c, b] from tab)) limit 10)",
                 "select distinct a, sum(b)+sum(c) bb from tab limit 10",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -8877,9 +8886,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctGroupByFunctionArithmeticOrderByLimit() throws SqlException {
         assertQuery(
-                "select-distinct [a, bb] a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb from " +
-                        "(select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1 " +
-                        "from (select [a, c, b] from tab))) order by a limit 10",
+                "select-choose a, bb from (select-virtual [a, sum1 + sum bb] a, sum1 + sum bb, count from (select-group-by [a, sum(c) sum, sum(b) sum1] a, sum(c) sum, sum(b) sum1, count() count from (select [a, c, b] from tab)) order by a limit 10)",
                 "select distinct a, sum(b)+sum(c) bb from tab order by a limit 10",
                 modelOf("tab")
                         .col("a", ColumnType.STRING)
@@ -8891,10 +8898,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSelectDistinctUnion() throws SqlException {
         assertQuery(
-                "select-choose c from (" +
-                        "select-distinct [c, b] c, b from (select-choose [a c, b] a c, b from (select [a, b] from trips)) " +
-                        "union all " +
-                        "select-distinct [c, b] c, b from (select-choose [c, d b] c, d b from (select [c, d] from trips)))",
+                "select-choose c from (select-choose [c] c, b from (select-group-by [a c, b] a c, b, count() count from (select [a, b] from trips)) union all select-choose [c] c, b from (select-group-by [c, d b] c, d b, count() count from (select [c, d] from trips)))",
                 "select c from (select distinct a c, b from trips union all select distinct c, d b from trips)",
                 modelOf("trips")
                         .col("a", ColumnType.INT)

--- a/core/src/test/java/io/questdb/test/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UnionTest.java
@@ -679,7 +679,7 @@ public class UnionTest extends AbstractCairoTest {
             ); // produces PLANE PLANE BICYCLE SCOOTER SCOOTER SCOOTER SCOOTER
 
             try (RecordCursorFactory factory = select("select distinct t from x union all y order by t")) {
-                assertCursor(expected2, factory, true, false);
+                assertCursor(expected2, factory, true, true);
             }
         });
     }
@@ -760,7 +760,7 @@ public class UnionTest extends AbstractCairoTest {
                                     ")"
                     )
             ) {
-                assertCursor(expected2, factory, false, false);
+                assertCursor(expected2, factory, false, true);
             }
         });
     }
@@ -930,7 +930,7 @@ public class UnionTest extends AbstractCairoTest {
                                     ")  order by 1"
                     )
             ) {
-                assertCursor(expected2, factory, true, false);
+                assertCursor(expected2, factory, true, true);
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/UpdateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UpdateTest.java
@@ -3116,7 +3116,7 @@ public class UpdateTest extends AbstractCairoTest {
                     "select distinct symCol from up order by symCol",
                     null,
                     true,
-                    false
+                    true
             );
 
             assertSql(

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/InDoubleTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/InDoubleTest.java
@@ -54,7 +54,7 @@ public class InDoubleTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN (1.1, 2.1, 3.52)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 
@@ -83,7 +83,7 @@ public class InDoubleTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN ($2, $3, $4)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/InLongTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/InLongTest.java
@@ -53,7 +53,7 @@ public class InLongTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN (1, 2, 3)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 
@@ -82,7 +82,7 @@ public class InLongTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN ($2, $3, $4)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/InTimestampTimestampTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/InTimestampTimestampTest.java
@@ -57,7 +57,7 @@ public class InTimestampTimestampTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN ($2, '1970-01-01T00:00:00.005000Z', $3)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/InUUIDTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/InUUIDTest.java
@@ -56,7 +56,7 @@ public class InUUIDTest extends AbstractCairoTest {
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN ('aa7dc4ec-cb68-446f-b37f-1ec82752c7d7', " +
                 "'b5b2159a-2356-4217-965d-4c984f0ffa8a', '4cd64b0b-0a34-4f8e-a698-c6c186b7571a')\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 
@@ -85,7 +85,7 @@ public class InUUIDTest extends AbstractCairoTest {
         assertSql("SELECT DISTINCT initParticipantId AS participantId, initParticipantIdType AS participantIdType\n" +
                 "FROM 'MovementLog'\n" +
                 "WHERE movementBusinessDate=$1 AND slotId IN ($2, $3, $4)\n" +
-                "ORDER BY initParticipantId\n" +
+                "ORDER BY participantId\n" +
                 "LIMIT 0,6", tuples);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/geohash/GeoHashQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/geohash/GeoHashQueryTest.java
@@ -389,6 +389,35 @@ public class GeoHashQueryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGeoHashJoinOnGeoHash1() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t1 as (select " +
+                    "cast(rnd_str('quest', '1234', '3456') as geohash(4c)) geo4," +
+                    "cast(rnd_str('quest', '1234', '3456') as geohash(1c)) geo1," +
+                    "x " +
+                    "from long_sequence(10))");
+            execute("create table t2 as (select " +
+                    "cast(rnd_str('quest', '1234', '3456') as geohash(4c)) geo4," +
+                    "cast(rnd_str('quest', '1234', '3456') as geohash(1c)) geo1," +
+                    "x " +
+                    "from long_sequence(2))");
+
+            assertSql("geo4\tgeo1\tx\tgeo41\tgeo11\tx1\n" +
+                    "ques\tq\t1\tques\t3\t2\n" +
+                    "1234\t3\t2\t1234\tq\t1\n" +
+                    "ques\t1\t5\tques\t3\t2\n" +
+                    "1234\t3\t6\t1234\tq\t1\n" +
+                    "1234\t1\t7\t1234\tq\t1\n" +
+                    "1234\tq\t8\t1234\tq\t1\n" +
+                    "ques\t1\t9\tques\t3\t2\n" +
+                    "ques\t1\t10\tques\t3\t2\n", "with g1 as (select geo4, geo1, x from (select *, count() from t1))," +
+                    "g2 as (select geo4, geo1, x from (select *, count() from t2))" +
+                    "select * from g1 join g2 on g1.geo4 = g2.geo4"
+            );
+        });
+    }
+
+    @Test
     public void testGeoHashJoinOnGeoHash2() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table t1 as (select " +
@@ -414,8 +443,9 @@ public class GeoHashQueryTest extends AbstractCairoTest {
                     "1234\t1\t7\t1970-01-01T00:00:06.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
                     "1234\tq\t8\t1970-01-01T00:00:07.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
                     "ques\t1\t9\t1970-01-01T00:00:08.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n" +
-                    "ques\t1\t10\t1970-01-01T00:00:09.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n", "with g1 as (select distinct * from t1)," +
-                    "g2 as (select distinct * from t2)" +
+                    "ques\t1\t10\t1970-01-01T00:00:09.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n",
+                    "with g1 as (select distinct * from t1 order by ts)," +
+                    "g2 as (select distinct * from t2 order by ts)" +
                     "select * from g1 lt join g2 on g1.geo4 = g2.geo4"
             );
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/geohash/GeoHashQueryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/geohash/GeoHashQueryTest.java
@@ -434,19 +434,19 @@ public class GeoHashQueryTest extends AbstractCairoTest {
                     "from long_sequence(2)) timestamp(ts)");
 
             assertSql("geo4\tgeo1\tx\tts\tgeo41\tgeo11\tx1\tts1\n" +
-                    "ques\tq\t1\t1970-01-01T00:00:00.000000Z\t\t\tnull\t\n" +
-                    "1234\t3\t2\t1970-01-01T00:00:01.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
-                    "3456\t3\t3\t1970-01-01T00:00:02.000000Z\t\t\tnull\t\n" +
-                    "3456\t1\t4\t1970-01-01T00:00:03.000000Z\t\t\tnull\t\n" +
-                    "ques\t1\t5\t1970-01-01T00:00:04.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n" +
-                    "1234\t3\t6\t1970-01-01T00:00:05.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
-                    "1234\t1\t7\t1970-01-01T00:00:06.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
-                    "1234\tq\t8\t1970-01-01T00:00:07.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
-                    "ques\t1\t9\t1970-01-01T00:00:08.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n" +
-                    "ques\t1\t10\t1970-01-01T00:00:09.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n",
+                            "ques\tq\t1\t1970-01-01T00:00:00.000000Z\t\t\tnull\t\n" +
+                            "1234\t3\t2\t1970-01-01T00:00:01.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
+                            "3456\t3\t3\t1970-01-01T00:00:02.000000Z\t\t\tnull\t\n" +
+                            "3456\t1\t4\t1970-01-01T00:00:03.000000Z\t\t\tnull\t\n" +
+                            "ques\t1\t5\t1970-01-01T00:00:04.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n" +
+                            "1234\t3\t6\t1970-01-01T00:00:05.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
+                            "1234\t1\t7\t1970-01-01T00:00:06.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
+                            "1234\tq\t8\t1970-01-01T00:00:07.000000Z\t1234\tq\t1\t1970-01-01T00:00:00.000000Z\n" +
+                            "ques\t1\t9\t1970-01-01T00:00:08.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n" +
+                            "ques\t1\t10\t1970-01-01T00:00:09.000000Z\tques\t3\t2\t1970-01-01T00:00:01.000000Z\n",
                     "with g1 as (select distinct * from t1 order by ts)," +
-                    "g2 as (select distinct * from t2 order by ts)" +
-                    "select * from g1 lt join g2 on g1.geo4 = g2.geo4"
+                            "g2 as (select distinct * from t2 order by ts)" +
+                            "select * from g1 lt join g2 on g1.geo4 = g2.geo4"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/GtTimestampCursorFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/lt/GtTimestampCursorFunctionFactoryTest.java
@@ -208,6 +208,20 @@ public class GtTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
                             "        Frame forward scan on: x\n",
                     "explain select * from x where ts > (select null)"
             );
+
+            assertSql(
+                    "QUERY PLAN\n" +
+                            "Async Filter workers: 1\n" +
+                            "  filter: ts [thread-safe] <= cursor \n" +
+                            "    VirtualRecord\n" +
+                            "      functions: [null]\n" +
+                            "        long_sequence count: 1\n" +
+                            "    PageFrame\n" +
+                            "        Row forward scan\n" +
+                            "        Frame forward scan on: x\n",
+                    "explain select * from x where ts <= (select null)"
+            );
+
             assertSql(
                     "QUERY PLAN\n" +
                             "Async Filter workers: 1\n" +
@@ -224,14 +238,14 @@ public class GtTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
             assertSql(
                     "QUERY PLAN\n" +
                             "Async Filter workers: 1\n" +
-                            "  filter: ts [thread-safe] > cursor \n" +
+                            "  filter: ts [thread-safe] <= cursor \n" +
                             "    VirtualRecord\n" +
                             "      functions: ['2014-09-03']\n" +
                             "        long_sequence count: 1\n" +
                             "    PageFrame\n" +
                             "        Row forward scan\n" +
                             "        Frame forward scan on: x\n",
-                    "explain select * from x where ts > (select '2014-09-03'::string)"
+                    "explain select * from x where ts <= (select '2014-09-03'::string)"
             );
 
             assertSql(
@@ -247,8 +261,20 @@ public class GtTimestampCursorFunctionFactoryTest extends AbstractCairoTest {
                     "explain select * from x where ts > (select '2020-02-21'::varchar)"
             );
 
-            // non-thread-safe
+            assertSql(
+                    "QUERY PLAN\n" +
+                            "Async Filter workers: 1\n" +
+                            "  filter: ts [thread-safe] <= cursor \n" +
+                            "    VirtualRecord\n" +
+                            "      functions: ['2020-02-21']\n" +
+                            "        long_sequence count: 1\n" +
+                            "    PageFrame\n" +
+                            "        Row forward scan\n" +
+                            "        Frame forward scan on: x\n",
+                    "explain select * from x where ts <= (select '2020-02-21'::varchar)"
+            );
 
+            // non-thread-safe
             assertSql(
                     "QUERY PLAN\n" +
                             "Async Filter workers: 1\n" +


### PR DESCRIPTION
Replaces single-threaded `distinct` execution with multi-threaded group-by.

rewrites SQL such as:

```sql
select distinct a, b, c from tab
```

to effectively:
```sql
select a, b, c from (select a, b, c, count() from tab)
```

Perf:

```
select distinct symbol from trades;

before: 300ms
after: 15ms
(32-core)
```

There are notable side-effects:

- there was reliance on perceived order of rows in tests from `distinct` queries, there order was there due to single-threaded nature of things. Now with multi-threaded execution the order is just random. I added `order by` clause to few tests.
- `distinct` was not able to compute its `size()`, now it can
- fixed generateOrderBy() to set timestamp when sort is descending
- i added extra size() checks to `assertQuery`. The logic now is that `size()` must be either correct size or -1 before cursor fetch. After cursor fetch must be also correct size or -1. If cursor size wasn't -1 before cursor fetch, it must match size after cursor fetch. Some cursors were returning 0 before cursor fetch and correct size after cursor fetch. Some factories were not returning correct cursor size at all, for example for 2 rows fetched size 9 was reported. These all have been fixed.
- i deleted `testMemoryRestrictionsWithDistinct` test. This test was testing memory pressure handling by `distinct`. Now `distinct` factory will only execute on top of either `group-by` or `window`. Testing memory pressure in these conditions is tricky. First the underlying factory will experience memory pressure, then distinct. May be i can think of a way, but for now test is gone in its current form anyway.

This PR goes to a branch, which improves performance of `symbol-in-sub-query` queries as well as fixing memory leaks.


One test still fails, it is on my to-do. This test failing not because of this PR, most likely async group-by doesn't 