### PR TITLE
chore(core): refactoring for explain create table/mat view ent fixes

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -1690,8 +1690,7 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     protected SqlExecutionContext createRootExecutionContext() {
-        return new SqlExecutionContextImpl(this, 1)
-                .with(AllowAllSecurityContext.INSTANCE);
+        return new SqlExecutionContextImpl(this, 1).with(AllowAllSecurityContext.INSTANCE);
     }
 
     protected @NotNull <T extends AbstractTelemetryTask> Telemetry<T> createTelemetry(

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -192,8 +192,7 @@ public class CairoEngine implements Closeable, WriterSource {
             this.tableIdGenerator = IDGeneratorFactory.newIDGenerator(configuration, TableUtils.TAB_INDEX_FILE_NAME, 1);
             this.checkpointAgent = new DatabaseCheckpointAgent(this);
             this.queryRegistry = new QueryRegistry(configuration);
-            this.rootExecutionContext = new SqlExecutionContextImpl(this, 1)
-                    .with(AllowAllSecurityContext.INSTANCE);
+            this.rootExecutionContext = createRootExecutionContext();
 
             tableIdGenerator.open();
             checkpointRecover();
@@ -1688,6 +1687,11 @@ public class CairoEngine implements Closeable, WriterSource {
             throw CairoException.tableDoesNotExist(tableName);
         }
         return token;
+    }
+
+    protected SqlExecutionContext createRootExecutionContext() {
+        return new SqlExecutionContextImpl(this, 1)
+                .with(AllowAllSecurityContext.INSTANCE);
     }
 
     protected @NotNull <T extends AbstractTelemetryTask> Telemetry<T> createTelemetry(

--- a/core/src/main/java/io/questdb/griffin/SqlParserCallback.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParserCallback.java
@@ -37,26 +37,34 @@ import io.questdb.griffin.model.QueryModel;
 import io.questdb.std.GenericLexer;
 import io.questdb.std.ObjectPool;
 import io.questdb.std.str.Path;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface SqlParserCallback {
 
-    default RecordCursorFactory generateShowCreateMatViewFactory(QueryModel model, SqlExecutionContext executionContext, Path path) throws SqlException {
-        TableToken viewToken = executionContext.getTableTokenIfExists(model.getTableNameExpr().token);
-        if (executionContext.getTableStatus(path, viewToken) != TableUtils.TABLE_EXISTS) {
-            throw SqlException.tableDoesNotExist(model.getTableNameExpr().position, model.getTableNameExpr().token);
-        }
+    static @NotNull TableToken getMatViewToken(ExpressionNode tableNameExpr, SqlExecutionContext executionContext, Path path) throws SqlException {
+        final TableToken viewToken = getTableToken(tableNameExpr, executionContext, path);
         if (!viewToken.isMatView()) {
-            throw SqlException.$(model.getTableNameExpr().position, "materialized view name expected, got table name");
+            throw SqlException.$(tableNameExpr.position, "materialized view name expected, got table name");
         }
+        return viewToken;
+    }
+
+    static TableToken getTableToken(ExpressionNode tableNameExpr, SqlExecutionContext executionContext, Path path) throws SqlException {
+        final TableToken tableToken = executionContext.getTableTokenIfExists(tableNameExpr.token);
+        if (executionContext.getTableStatus(path, tableToken) != TableUtils.TABLE_EXISTS) {
+            throw SqlException.tableDoesNotExist(tableNameExpr.position, tableNameExpr.token);
+        }
+        return tableToken;
+    }
+
+    default RecordCursorFactory generateShowCreateMatViewFactory(QueryModel model, SqlExecutionContext executionContext, Path path) throws SqlException {
+        final TableToken viewToken = getMatViewToken(model.getTableNameExpr(), executionContext, path);
         return new ShowCreateMatViewRecordCursorFactory(viewToken, model.getTableNameExpr().position);
     }
 
     default RecordCursorFactory generateShowCreateTableFactory(QueryModel model, SqlExecutionContext executionContext, Path path) throws SqlException {
-        TableToken tableToken = executionContext.getTableTokenIfExists(model.getTableNameExpr().token);
-        if (executionContext.getTableStatus(path, tableToken) != TableUtils.TABLE_EXISTS) {
-            throw SqlException.tableDoesNotExist(model.getTableNameExpr().position, model.getTableNameExpr().token);
-        }
+        final TableToken tableToken = getTableToken(model.getTableNameExpr(), executionContext, path);
         return new ShowCreateTableRecordCursorFactory(tableToken, model.getTableNameExpr().position);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationBuilderImpl.java
@@ -29,6 +29,7 @@ import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.model.CreateTableColumnModel;
+import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.QueryModel;
 import io.questdb.std.Chars;
 import io.questdb.std.Mutable;
@@ -81,6 +82,11 @@ public class CreateMatViewOperationBuilderImpl implements CreateMatViewOperation
     @Override
     public CharSequence getTableName() {
         return createTableOperationBuilder.getTableName();
+    }
+
+    @Override
+    public ExpressionNode getTableNameExpr() {
+        return createTableOperationBuilder.getTableNameExpr();
     }
 
     public void setBaseTableName(String baseTableName) {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
@@ -192,6 +192,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
         return tableNameExpr.token;
     }
 
+    @Override
     public ExpressionNode getTableNameExpr() {
         return tableNameExpr;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
@@ -348,14 +348,6 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         return tableNamePosition;
     }
 
-    public String getTimestampColumnName() {
-        return timestampColumnName;
-    }
-
-    public int getTimestampColumnNamePosition() {
-        return timestampColumnNamePosition;
-    }
-
     @Override
     public int getTimestampIndex() {
         return timestampIndex;
@@ -632,5 +624,13 @@ public class CreateTableOperationImpl implements CreateTableOperation {
 
     private int getLowAt(int index) {
         return Numbers.decodeLowInt(columnBits.getQuick(index));
+    }
+
+    String getTimestampColumnName() {
+        return timestampColumnName;
+    }
+
+    int getTimestampColumnNamePosition() {
+        return timestampColumnNamePosition;
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -1046,58 +1046,56 @@ public class CreateMatViewTest extends AbstractCairoTest {
     @Test
     public void testMatViewDefinitionInvalidTz() throws Exception {
         assertMemoryLeak(() -> {
-            try (Path path = new Path()) {
-                createTable(TABLE1);
-                final String query = "select ts, v+v doubleV, avg(v) from " + TABLE1 + " sample by 30s";
-                execute("create materialized view test as (" + query + ") partition by day");
-                final TableToken matViewToken = engine.getTableTokenIfExists("test");
-                MatViewDefinition def = new MatViewDefinition();
-                try {
-                    def.init(
-                            MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
-                            matViewToken,
-                            query,
-                            TABLE1,
-                            30,
-                            'K',
-                            "Europe/Berlin",
-                            "00:00"
-                    );
-                    Assert.fail("exception expected");
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "invalid sampling interval and/or unit: 30, K");
-                }
+            createTable(TABLE1);
+            final String query = "select ts, v+v doubleV, avg(v) from " + TABLE1 + " sample by 30s";
+            execute("create materialized view test as (" + query + ") partition by day");
+            final TableToken matViewToken = engine.getTableTokenIfExists("test");
+            MatViewDefinition def = new MatViewDefinition();
+            try {
+                def.init(
+                        MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
+                        matViewToken,
+                        query,
+                        TABLE1,
+                        30,
+                        'K',
+                        "Europe/Berlin",
+                        "00:00"
+                );
+                Assert.fail("exception expected");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid sampling interval and/or unit: 30, K");
+            }
 
-                try {
-                    def.init(
-                            MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
-                            matViewToken,
-                            query,
-                            TABLE1,
-                            30,
-                            's',
-                            "Oceania",
-                            "00:00"
-                    );
-                    Assert.fail("exception expected");
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone: Oceania");
-                }
-                try {
-                    def.init(
-                            MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
-                            matViewToken,
-                            query,
-                            TABLE1,
-                            30,
-                            's',
-                            "Europe/Berlin",
-                            "T00:00"
-                    );
-                    Assert.fail("exception expected");
-                } catch (CairoException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "invalid offset: T00:00");
-                }
+            try {
+                def.init(
+                        MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
+                        matViewToken,
+                        query,
+                        TABLE1,
+                        30,
+                        's',
+                        "Oceania",
+                        "00:00"
+                );
+                Assert.fail("exception expected");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid timezone: Oceania");
+            }
+            try {
+                def.init(
+                        MatViewDefinition.INCREMENTAL_REFRESH_TYPE,
+                        matViewToken,
+                        query,
+                        TABLE1,
+                        30,
+                        's',
+                        "Europe/Berlin",
+                        "T00:00"
+                );
+                Assert.fail("exception expected");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "invalid offset: T00:00");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -1211,7 +1211,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
         assertException(
                 "show create materialized view 'test';",
                 30,
-                "table does not exist [table=test]"
+                "materialized view does not exist [view=test]"
         );
     }
 


### PR DESCRIPTION
Allows EntCairoEngine to use EntAllowAllSecurityContext instead of AllowAllSecurityContext.

Gets rid of SHOW CREATE TABLE/MAT VIEW related code duplication, and allows ent to reuse this code too.

required by https://github.com/questdb/questdb-enterprise/pull/582