### PR TITLE
chore(utils): include pg driver into utils jar

### DIFF
--- a/ci/validate-pr-title/validate.js
+++ b/ci/validate-pr-title/validate.js
@@ -24,6 +24,7 @@ const allowedSubTypes = [
   "ui",
   "wal",
   "parquet",
+    "utils"
 ];
 
 const errorMessage = `

--- a/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
+++ b/core/src/main/java/io/questdb/cutlass/http/DefaultHttpServerConfiguration.java
@@ -26,6 +26,8 @@ package io.questdb.cutlass.http;
 
 import io.questdb.DefaultFactoryProvider;
 import io.questdb.FactoryProvider;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.cutlass.http.processors.JsonQueryProcessorConfiguration;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
@@ -39,6 +41,7 @@ import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.NanosecondClock;
 import io.questdb.std.Numbers;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
+import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
 
@@ -239,31 +242,31 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
         }
     }
 
-    public class DefaultLineHttpProcessorConfiguration implements LineHttpProcessorConfiguration {
+    public static class DefaultLineHttpProcessorConfiguration implements LineHttpProcessorConfiguration {
 
         @Override
         public boolean autoCreateNewColumns() {
-            return lineHttpProcessorConfiguration.autoCreateNewColumns();
+            return true;
         }
 
         @Override
         public boolean autoCreateNewTables() {
-            return lineHttpProcessorConfiguration.autoCreateNewTables();
+            return true;
         }
 
         @Override
         public short getDefaultColumnTypeForFloat() {
-            return lineHttpProcessorConfiguration.getDefaultColumnTypeForInteger();
+            return ColumnType.DOUBLE;
         }
 
         @Override
         public short getDefaultColumnTypeForInteger() {
-            return lineHttpProcessorConfiguration.getDefaultColumnTypeForInteger();
+            return ColumnType.LONG;
         }
 
         @Override
         public int getDefaultPartitionBy() {
-            return lineHttpProcessorConfiguration.getDefaultPartitionBy();
+            return PartitionBy.DAY;
         }
 
         @Override
@@ -273,17 +276,17 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
 
         @Override
         public MicrosecondClock getMicrosecondClock() {
-            return lineHttpProcessorConfiguration.getMicrosecondClock();
+            return MicrosecondClockImpl.INSTANCE;
         }
 
         @Override
         public long getSymbolCacheWaitUsBeforeReload() {
-            return lineHttpProcessorConfiguration.getSymbolCacheWaitUsBeforeReload();
+            return 500_000;
         }
 
         @Override
         public LineTcpTimestampAdapter getTimestampAdapter() {
-            return lineHttpProcessorConfiguration.getTimestampAdapter();
+            return LineTcpTimestampAdapter.DEFAULT_TS_INSTANCE;
         }
 
         @Override
@@ -293,7 +296,7 @@ public class DefaultHttpServerConfiguration extends DefaultIODispatcherConfigura
 
         @Override
         public boolean isStringToCharCastAllowed() {
-            return lineHttpProcessorConfiguration.isStringToCharCastAllowed();
+            return false;
         }
 
         @Override

--- a/utils/README.md
+++ b/utils/README.md
@@ -89,18 +89,16 @@ io.questdb.cliutil.Table2Ilp -d <destination_table_name> -dc <destination_ilp_ho
 ```
 
 - `-d` destination table name
-- `-dc` destination ILP host and port, e.g. `localhost:9009`
+- `-dilp` destination ILP connection string, e.g. `http::addr=localhost:9000;`
 - `-s` source select query, e.g. `trades` or `trades WHERE timestamp in '2021-01'`
 - `-sc` source connection string, e.g. `jdbc:pgsql://localhost:8812/qdb`
 - `-sts` source designated timestamp column name, defaults to `timestamp`
 - `-sym` comma separated list of symbol columns, e.g. `symbol,exchange`
-- `-dauth` ILP key and authentication token. e.g. `admin:GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0`
-- `-dtls` specify to use TLS for ILP connection. False by default.
 
 #### Examples
 
 ```bash
-java -cp utils.jar io.questdb.cliutil.Table2Ilp -d trades -dc localhost:9009 -s "trades WHERE start_time in '2022-06'" \ 
+java -cp utils.jar io.questdb.cliutil.Table2Ilp -d trades -dilp "http::addr=localhost:9000;" -s "trades WHERE start_time in '2022-06'" \ 
      -sc "jdbc:postgresql://localhost:9812/qdb?user=account&password=secret&ssl=false" \
      -sym "ticker,exchagne" -sts start_time
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -89,7 +89,7 @@ io.questdb.cliutil.Table2Ilp -d <destination_table_name> -dc <destination_ilp_ho
 ```
 
 - `-d` destination table name
-- `-dilp` destination ILP connection string, e.g. `http::addr=localhost:9000;`
+- `-dilp` destination ILP connection string, e.g. `https::addr=localhost:9000;username=admin;password=quest;`
 - `-s` source select query, e.g. `trades` or `trades WHERE timestamp in '2021-01'`
 - `-sc` source connection string, e.g. `jdbc:pgsql://localhost:8812/qdb`
 - `-sts` source designated timestamp column name, defaults to `timestamp`
@@ -98,7 +98,7 @@ io.questdb.cliutil.Table2Ilp -d <destination_table_name> -dc <destination_ilp_ho
 #### Examples
 
 ```bash
-java -cp utils.jar io.questdb.cliutil.Table2Ilp -d trades -dilp "http::addr=localhost:9000;" -s "trades WHERE start_time in '2022-06'" \ 
+java -cp utils.jar io.questdb.cliutil.Table2Ilp -d trades -dilp "https::addr=localhost:9000;username=admin;password=quest;" -s "trades WHERE start_time in '2022-06'" \ 
      -sc "jdbc:postgresql://localhost:9812/qdb?user=account&password=secret&ssl=false" \
      -sym "ticker,exchagne" -sts start_time
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -62,7 +62,6 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/utils/src/main/java/io/questdb/cliutil/Table2Ilp.java
+++ b/utils/src/main/java/io/questdb/cliutil/Table2Ilp.java
@@ -50,8 +50,8 @@ public class Table2Ilp {
     }
 
     private static void printUsage() {
-        System.out.println("usage: " + Table2Ilp.class.getName() + " -d <destination_table_name> -dc <destination_ilp_host_port> -s <source_select_query> -sc <source_pg_connection_string> \\ " +
-                "\n [-sts <timestamp_column>] [-sym <symbol_columns>] [-dauth <ilp_auth_key:ilp_auth_token>] [-dtls]");
+        System.out.println("usage: " + Table2Ilp.class.getName() + " -d <destination_table_name> -dilp <destination_ilp_connection_string> -s <source_select_query> -sc <source_pg_connection_string> \\ " +
+                "\n [-sts <timestamp_column>] [-sym <symbol_columns>]");
     }
 
     static class Table2IlpParams {

--- a/utils/src/main/java/io/questdb/cliutil/Table2Ilp.java
+++ b/utils/src/main/java/io/questdb/cliutil/Table2Ilp.java
@@ -59,6 +59,7 @@ public class Table2Ilp {
         private String destinationAuthToken;
         private boolean destinationEnableTls;
         private String destinationIlpHost;
+        private String destinationIlpConnection;
         private int destinationIlpPort;
         private String destinationTableName;
         private String sourcePgConnectionString;
@@ -102,6 +103,9 @@ public class Table2Ilp {
                     case "-sts":
                         params.sourceTimestampColumnName = args[++i].trim();
                         break;
+                    case "-dilp":
+                        params.destinationIlpConnection = args[++i].trim();
+                        break;
                     default:
                         System.err.println("Error: invalid token: " + arg);
                         break;
@@ -118,24 +122,26 @@ public class Table2Ilp {
                 return params;
             }
 
-            if (destinationIlpHostPort != null) {
-                String[] parts = destinationIlpHostPort.split("\\s*:\\s*");
+            if (params.destinationIlpConnection == null) {
+                if (destinationIlpHostPort != null) {
+                    String[] parts = destinationIlpHostPort.split("\\s*:\\s*");
 
-                if (parts.length != 2) {
-                    System.err.println("Error: invalid destination ILP host:port '" + destinationIlpHostPort + "'");
+                    if (parts.length != 2) {
+                        System.err.println("Error: invalid destination ILP host:port '" + destinationIlpHostPort + "'");
+                        return params;
+                    }
+
+                    params.destinationIlpHost = parts[0];
+                    try {
+                        params.destinationIlpPort = Numbers.parseInt(parts[1]);
+                    } catch (NumericException e) {
+                        System.err.println("Error: invalid destination ILP port: " + destinationIlpHostPort);
+                        return params;
+                    }
+                } else {
+                    System.err.println("error: destination ILP host:port not specified");
                     return params;
                 }
-
-                params.destinationIlpHost = parts[0];
-                try {
-                    params.destinationIlpPort = Numbers.parseInt(parts[1]);
-                } catch (NumericException e) {
-                    System.err.println("Error: invalid destination ILP port: " + destinationIlpHostPort);
-                    return params;
-                }
-            } else {
-                System.err.println("error: destination ILP host:port not specified");
-                return params;
             }
 
             if (params.sourcePgConnectionString == null) {
@@ -191,6 +197,10 @@ public class Table2Ilp {
 
         public int getDestinationIlpPort() {
             return destinationIlpPort;
+        }
+
+        public String getDestinationIlpConnection() {
+            return destinationIlpConnection;
         }
 
         public String getDestinationTableName() {

--- a/utils/src/main/java/io/questdb/cliutil/Table2IlpCopier.java
+++ b/utils/src/main/java/io/questdb/cliutil/Table2IlpCopier.java
@@ -61,7 +61,7 @@ public class Table2IlpCopier {
                     }
                     int timestampIndex = getTimestampIndex(columnNames, columnTypes, params.getSourceTimestampColumnName());
 
-                    try (Sender sender = buildLineTcpSender(params)) {
+                    try (Sender sender = buildSender(params)) {
                         String tableName = params.getDestinationTableName();
 
                         try {
@@ -97,7 +97,11 @@ public class Table2IlpCopier {
         return totalSentLines;
     }
 
-    private static Sender buildLineTcpSender(Table2Ilp.Table2IlpParams params) {
+    private static Sender buildSender(Table2Ilp.Table2IlpParams params) {
+        if (params.getDestinationIlpConnection() != null) {
+            return Sender.builder(params.getDestinationIlpConnection()).build();
+        }
+
         Sender.LineSenderBuilder senderBuilder = Sender.builder(Sender.Transport.TCP);
         senderBuilder.address(params.getDestinationIlpHost() + ":" + params.getDestinationIlpPort());
         if (params.enableDestinationTls()) {
@@ -218,6 +222,7 @@ public class Table2IlpCopier {
                     case Types.CHAR:
                     case Types.VARCHAR:
                     case Types.LONGVARCHAR:
+                    case Types.OTHER:
                         String value = resultSet.getString(i + 1);
                         if (value != null && !resultSet.wasNull()) {
                             sender.stringColumn(columnName, resultSet.getString(i + 1));

--- a/utils/src/main/java/io/questdb/cliutil/Table2IlpCopier.java
+++ b/utils/src/main/java/io/questdb/cliutil/Table2IlpCopier.java
@@ -76,6 +76,7 @@ public class Table2IlpCopier {
                                     start = microsecondClock.getTicks();
                                 }
                             }
+                            sender.flush();
                         } catch (Exception th) {
                             try {
                                 sender.flush();


### PR DESCRIPTION
1. Fix the exception of missing pg driver when running utils.jar

```
java.sql.SQLException: No suitable driver found for jdbc:postgresql://localhost:8812/qdb
        at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:708)
        at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:191)
        at io.questdb.cliutil.Table2IlpCopier.getConnection(Table2IlpCopier.java:132)
        at io.questdb.cliutil.Table2IlpCopier.copyTable(Table2IlpCopier.java:47)
        at io.questdb.cliutil.Table2Ilp.main(Table2Ilp.java:49)
Failed to connect to the source
Total sent lines: 0
```

2. Support UUID column type
3. Allow to specify ILP destination connection string instead of host/port/keys. Connectoin strings can be used to write using ILP HTTP