### PR TITLE
chore(ilp): make ilp concurrent add column log info level

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -229,7 +229,7 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public boolean isMetadataValidation() {
-        return errno == METADATA_VALIDATION;
+        return errno == METADATA_VALIDATION || errno == METADATA_VALIDATION_RECOVERABLE;
     }
 
     public boolean isOutOfMemory() {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
@@ -226,7 +226,7 @@ public class AlterOperation extends AbstractOperation implements Mutable {
             // "duplicate column name:" is BAU when column is added from ILP, don't log it as an error
             boolean isInfo = command == ADD_COLUMN && e.isMetadataValidation();
 
-            final LogRecord log = isCritical ? LOG.critical() : (isInfo ? LOG.info() : LOG.error());
+            final LogRecord log = isInfo ? LOG.info() : (isCritical ? LOG.critical() : LOG.error());
             log.$("could not alter table [table=").$(svc.getTableToken())
                     .$(", command=").$(command)
                     .$(", msg=").$(e.getFlyweightMessage())

--- a/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/DynamicPropServerConfigurationTest.java
@@ -41,6 +41,7 @@ import io.questdb.cutlass.http.client.HttpClientFactory;
 import io.questdb.metrics.QueryTracingJob;
 import io.questdb.std.Chars;
 import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.Os;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.cutlass.http.TestHttpClient;
 import io.questdb.test.tools.TestUtils;
@@ -584,7 +585,7 @@ public class DynamicPropServerConfigurationTest extends AbstractTest {
 
                     int sleepMillis = 100;
                     while (true) {
-                        Thread.sleep(sleepMillis);
+                        Os.sleep(sleepMillis);
                         try (ResultSet rs = queryTraceStmt.executeQuery()) {
                             Assert.assertTrue(rs.next());
                             break;

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/AbstractLineHttpFuzzTest.java
@@ -224,6 +224,7 @@ abstract class AbstractLineHttpFuzzTest extends AbstractBootstrapTest {
                         PropertyKey.PG_ENABLED.getEnvVarName(), "false",
                         PropertyKey.PG_LEGACY_MODE_ENABLED.getEnvVarName(), "false",
                         PropertyKey.LINE_TCP_ENABLED.getEnvVarName(), "false",
+                        PropertyKey.HTTP_NET_CONNECTION_LIMIT.getEnvVarName(), String.valueOf(2 * numOfThreads),
                         PropertyKey.HTTP_BIND_TO.getEnvVarName(), "127.0.0.1:" + httpPortRandom
                 )) {
                     Assert.assertEquals(0, tables.size());
@@ -550,6 +551,7 @@ abstract class AbstractLineHttpFuzzTest extends AbstractBootstrapTest {
                             .address("localhost:" + port)
                             .httpUsernamePassword(username, password)
                             .retryTimeoutMillis(0)
+                            .httpTimeoutMillis(60000)
                             .build()
             ) {
                 LineHttpSender httpSender = (LineHttpSender) sender;


### PR DESCRIPTION
Before

```
2025-03-19T18:40:36.224663Z C i.q.g.e.o.AlterOperation could not alter table [table=WEATHER0~4, command=1, msg=duplicate column [name=location], errno=-100]
2025-03-19T18:40:36.224721Z C i.q.g.e.o.AlterOperation could not alter table [table=WEATHER0~4, command=1, msg=duplicate column [name=location], errno=-100]
```

After

```
2025-03-19T18:41:14.297188Z I i.q.g.e.o.AlterOperation could not alter table [table=weather1~4, command=1, msg=duplicate column [name=humidity1], errno=-100]
2025-03-19T18:41:14.297238Z I i.q.g.e.o.AlterOperation could not alter table [table=weather1~4, command=1, msg=duplicate column [name=humidity1], errno=-100]
```

Change is in the logging level.

Also fixed few flaky tests:

- `ServerMainCleanStartupTest.testServerMainCleanStart`
- `DynamicPropServerConfigurationTest.testQueryTracingReload`
- timeouts in `LineHttpReceiverFuzzTest.*`