### PR TITLE
fix(core): fix incorrectly reported SQL error position in CREATE MATERIALIZED VIEW statements

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1984,6 +1984,10 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             compiledQuery.ofSelect(
                     generateSelectWithRetries(queryModel, executionContext, false)
             );
+        } catch (SqlException e) {
+            e.setPosition(e.getPosition() + createTableOp.getSelectTextPosition());
+            QueryProgress.logError(e, -1, sqlText, executionContext, beginNanos);
+            throw e;
         } catch (Throwable th) {
             QueryProgress.logError(th, -1, sqlText, executionContext, beginNanos);
             throw th;

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -850,7 +850,7 @@ public class SqlParser {
             }
 
             final String matViewSql = Chars.toString(lexer.getContent(), startOfQuery, endOfQuery);
-            tableOpBuilder.setSelectText(matViewSql);
+            tableOpBuilder.setSelectText(matViewSql, startOfQuery);
             tableOpBuilder.setSelectModel(queryModel); // transient model, for toSink() purposes only
 
             expectTok(lexer, ')');
@@ -1204,7 +1204,8 @@ public class SqlParser {
         // It'll be compiled and optimized later, at the execution phase.
         final QueryModel selectModel = parseDml(lexer, null, startOfSelect, true, sqlParserCallback, null);
         final int endOfSelect = lexer.getPosition() - 1;
-        createTableOperationBuilder.setSelectText(lexer.getContent().subSequence(startOfSelect, endOfSelect));
+        final String selectText = Chars.toString(lexer.getContent(), startOfSelect, endOfSelect);
+        createTableOperationBuilder.setSelectText(selectText, startOfSelect);
         createTableOperationBuilder.setSelectModel(selectModel); // transient model, for toSink() purposes only
         expectTok(lexer, ')');
     }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperation.java
@@ -38,13 +38,16 @@ public interface CreateTableOperation extends TableStructure, Operation {
 
     long getBatchSize();
 
-    @Nullable CharSequence getLikeTableName();
+    @Nullable
+    CharSequence getLikeTableName();
 
     int getLikeTableNamePosition();
 
     OperationFuture getOperationFuture();
 
     CharSequence getSelectText();
+
+    int getSelectTextPosition();
 
     CharSequence getSqlText();
 

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
@@ -64,6 +64,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
     // transient field, unoptimized AS SELECT model, used in toSink()
     private QueryModel selectModel;
     private CharSequence selectText;
+    private int selectTextPosition;
     private ExpressionNode tableNameExpr;
     private ExpressionNode timestampExpr;
     private int ttlHoursOrMonths;
@@ -86,6 +87,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
                     Chars.toString(sqlText),
                     Chars.toString(tableNameExpr.token),
                     Chars.toString(selectText),
+                    selectTextPosition,
                     tableNameExpr.position,
                     ignoreIfExists,
                     getPartitionByFromExpr(),
@@ -258,8 +260,9 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
         this.selectModel = selectModel;
     }
 
-    public void setSelectText(CharSequence selectText) {
+    public void setSelectText(CharSequence selectText, int selectTextPosition) {
         this.selectText = selectText;
+        this.selectTextPosition = selectTextPosition;
     }
 
     public void setTableNameExpr(ExpressionNode expr) {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
@@ -75,6 +75,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
     // position of the "like" table name in the SQL text, for error reporting
     private final int likeTableNamePosition;
     private final String selectText;
+    private final int selectTextPosition;
     private final String sqlText;
     private final String tableName;
     private final int tableNamePosition;
@@ -108,6 +109,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.likeTableNamePosition = likeTableNamePosition;
         this.ignoreIfExists = ignoreIfExists;
         this.selectText = null;
+        this.selectTextPosition = -1;
         this.timestampColumnName = null;
         this.timestampColumnNamePosition = 0;
         this.batchSize = 0;
@@ -158,6 +160,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.walEnabled = walEnabled;
 
         this.selectText = null;
+        this.selectTextPosition = -1;
         this.likeTableName = null;
         this.likeTableNamePosition = -1;
         this.batchSize = 0;
@@ -192,6 +195,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
             String sqlText,
             @NotNull String tableName,
             @NotNull String selectText,
+            int selectTextPosition,
             int tableNamePosition,
             boolean ignoreIfExists,
             int partitionBy,
@@ -210,6 +214,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.sqlText = sqlText;
         this.tableName = tableName;
         this.selectText = selectText;
+        this.selectTextPosition = selectTextPosition;
         this.tableNamePosition = tableNamePosition;
         this.partitionBy = partitionBy;
         this.volumeAlias = volumeAlias;
@@ -319,6 +324,11 @@ public class CreateTableOperationImpl implements CreateTableOperation {
     @Override
     public String getSelectText() {
         return selectText;
+    }
+
+    @Override
+    public int getSelectTextPosition() {
+        return selectTextPosition;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -244,6 +244,23 @@ public class CreateMatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateMatViewInvalidColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+
+            final String createSql = "create materialized view test as (select ts, avg(no_col_like_this) from " + TABLE1 + " sample by 30s) partition by DAY";
+            try {
+                execute(createSql);
+                fail("Expected SqlException missing");
+            } catch (SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "Invalid column: no_col_like_this");
+                assertEquals(createSql.indexOf("no_col_like_this"), e.getPosition());
+            }
+            assertNull(getMatViewDefinition("test"));
+        });
+    }
+
+    @Test
     public void testCreateMatViewInvalidTimestamp() throws Exception {
         assertMemoryLeak(() -> {
             createTable(TABLE1);

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3064,7 +3064,8 @@ if __name__ == "__main__":
                 try (ResultSet rs = stmt.executeQuery("tables();")) {
                     assertResultSet("id[INTEGER],table_name[VARCHAR],designatedTimestamp[VARCHAR],partitionBy[VARCHAR],maxUncommittedRows[INTEGER],o3MaxLag[BIGINT],walEnabled[BIT],directoryName[VARCHAR],dedup[BIT],ttlValue[INTEGER],ttlUnit[VARCHAR],matView[BIT]\n" +
                                     "2,x,ts,NONE,1000,300000000,false,x~,false,0,HOUR,false\n",
-                            sink, rs);
+                            sink, rs
+                    );
                 }
 
                 stmt.execute("drop table x");
@@ -3074,7 +3075,8 @@ if __name__ == "__main__":
                 try (ResultSet rs = stmt.executeQuery("tables();")) {
                     assertResultSet("id[INTEGER],table_name[VARCHAR],designatedTimestamp[VARCHAR],partitionBy[VARCHAR],maxUncommittedRows[INTEGER],o3MaxLag[BIGINT],walEnabled[BIT],directoryName[VARCHAR],dedup[BIT],ttlValue[INTEGER],ttlUnit[VARCHAR],matView[BIT]\n" +
                                     "3,x,ts,NONE,1000,300000000,false,x~,false,0,HOUR,false\n",
-                            sink, rs);
+                            sink, rs
+                    );
                 }
             }
         });
@@ -3182,17 +3184,21 @@ if __name__ == "__main__":
     @Test
     public void testCreateTableDuplicateColumnName() throws Exception {
         skipOnWalRun(); // non-partitioned table
+
+        final String sql = "create table tab as (\n" +
+                "            select\n" +
+                "                rnd_byte() b,\n" +
+                "                rnd_boolean() B\n" +
+                "            from long_sequence(1)\n" +
+                "        )";
+
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             try {
-                connection.prepareStatement("create table tab as (\n" +
-                        "            select\n" +
-                        "                rnd_byte() b,\n" +
-                        "                rnd_boolean() B\n" +
-                        "            from long_sequence(1)\n" +
-                        "        )").execute();
+                connection.prepareStatement(sql).execute();
                 Assert.fail();
             } catch (PSQLException e) {
-                assertContains(e.getMessage(), "Duplicate column [name=B]");
+                assertContains(e.getMessage(), "ERROR: Duplicate column [name=B]\n" +
+                        "  Position: " + sql.indexOf("B"));
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -1575,9 +1575,10 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testCreateAsSelectDuplicateColumn1() throws Exception {
+        final String sql = "create table tab as (select rnd_byte() b, rnd_boolean() \"B\" from long_sequence(1))";
         assertSyntaxError(
-                "create table tab as (select rnd_byte() b, rnd_boolean() \"B\" from long_sequence(1))",
-                56,
+                sql,
+                sql.indexOf("\"B\""),
                 "Duplicate column [name=B]",
                 modelOf("tab")
                         .col("b", ColumnType.BYTE)


### PR DESCRIPTION
If the SELECT statement used to create the view fails to compile, the error position is reported as within the SELECT statement, and not within the CREATE MATERIALIZED VIEW statement.
This change fixes the problem by adding an offset to the error position, the offset is the start os the mat view SELECT statement.

For example, in the below scenario error position would be reported as 15 instead of 50:
```
create table x (a int, ts timestamp) timestamp(ts) partition by day wal;
create materialized view test as (select ts, avg(no_col_like_this) from x sample by 30s) partition by DAY;
```