### PR TITLE
chore(core): fix rare table rename failure on replica on after restart

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -135,7 +135,7 @@ public class MetadataCache implements QuietCloseable {
         return cacheWriter;
     }
 
-    private ColumnVersionReader getColumnVersionReader() {
+    private @NotNull ColumnVersionReader getColumnVersionReader() {
         if (columnVersionReader != null) {
             return columnVersionReader;
         }
@@ -595,9 +595,13 @@ public class MetadataCache implements QuietCloseable {
         public void renameTable(@NotNull TableToken fromTableToken, @NotNull TableToken toTableToken) {
             String tableName = fromTableToken.getTableName();
             final int index = tableMap.keyIndex(tableName);
-            CairoTable fromTab = tableMap.valueAt(index);
-            tableMap.removeAt(index);
-            tableMap.put(toTableToken.getTableName(), new CairoTable(toTableToken, fromTab));
+
+            // Metadata may not be hydrated at this point, handle this case
+            if (index < 0) {
+                CairoTable fromTab = tableMap.valueAt(index);
+                tableMap.removeAt(index);
+                tableMap.put(toTableToken.getTableName(), new CairoTable(toTableToken, fromTab));
+            }
         }
     }
 }


### PR DESCRIPTION
Fix replication failure to rename the table on the replica

```
2025-03-19T09:53:43.8653242Z java.lang.NullPointerException: Cannot read field "columnOrderMap" because "fromTab" is null
2025-03-19T09:53:43.8653837Z 	at io.questdb.cairo.CairoTable.<init>(CairoTable.java:57)
2025-03-19T09:53:43.8654443Z 	at io.questdb.cairo.MetadataCache$MetadataCacheWriterImpl.renameTable(MetadataCache.java:600)
2025-03-19T09:53:43.8655065Z 	at io.questdb.cairo.TableNameRegistryRW.renameToNew(TableNameRegistryRW.java:175)
2025-03-19T09:53:43.8655745Z 	at io.questdb.cairo.TableNameRegistryRW.rename(TableNameRegistryRW.java:143)
2025-03-19T09:53:43.8656803Z 	at io.questdb.cairo.CairoEngine.applyTableRename(CairoEngine.java:295)
2025-03-19T09:53:43.8657675Z 	at com.questdb.cairo.wal.transfer.WalEvents.reconstructMetadata(WalEvents.java:415)
2025-03-19T09:53:43.8678922Z 	at com.questdb.cairo.wal.transfer.WalEvents.registerTable(WalEvents.java:94)
2025-03-19T09:53:43.8684019Z 	at com.questdb.cairo.wal.transfer.WalEvents.registerTable(WalEvents.java:88)
2025-03-19T09:53:43.8684621Z 	at com.questdb.EntServerMain$1.tableUpdated(EntServerMain.java:162)
2025-03-19T09:53:43.8685323Z 	at com.questdb.cairo.wal.transfer.WalDownloader$Listener.tableUpdated(WalDownloader.java:238)
```