### PR TITLE
test(pgwire): fix racy test with thread-local memory leak

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PreparedStatementInvalidationTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PreparedStatementInvalidationTest.java
@@ -460,12 +460,15 @@ public class PreparedStatementInvalidationTest extends BasePGTest {
                 } catch (SQLException e) {
                     exception.set(e);
                 } finally {
+                    // We have to clear thread locals *before* awaiting on the barrier.
+                    // Otherwise, the main test thread might be unblocked before we
+                    // clean up the thread locals and we get a false memory leak failure.
+                    Path.clearThreadLocals();
                     try {
                         barrier.await();
                     } catch (InterruptedException | BrokenBarrierException e) {
                         exception.compareAndSet(null, e);
                     }
-                    Path.clearThreadLocals();
                 }
             }).start();
 


### PR DESCRIPTION
Fix a test that was causing spurious failures due to a race condition. The test starts an auxiliary thread that allocates a thread-local Path instance. Ensure this thread-local is properly cleared before the main test thread completes to prevent spurious memory leak failures.