### PR TITLE
fix(sql): fix sample by issue when design a timestamp column in projection columns.

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -4965,7 +4965,9 @@ public class SqlOptimiser implements Mutable {
                 for (int i = 0, k = 0, n = model.getBottomUpColumns().size(); i < n; k++) {
                     QueryColumn qc = model.getBottomUpColumns().getQuick(i);
                     boolean isAFunctionUsingTimestampColumn = (qc.getAst().type == FUNCTION || qc.getAst().type == OPERATION)
-                            && nonAggregateFunctionDependsOn(qc.getAst(), nested.getTimestamp());
+                            && nonAggregateFunctionDependsOn(qc.getAst(), nested.getTimestamp())
+                            // exclude timestamp column itself
+                            && !Chars.equalsIgnoreCase(qc.getAst().token, timestamp.token);
 
                     if (
                             isAFunctionUsingTimestampColumn ||


### PR DESCRIPTION
close https://github.com/questdb/questdb/issues/5508
Run query in [demo](https://demo.questdb.io/index.html)
```
SELECT
    min(price) AS min_price,
    max(price) AS max_price,
    timestamp (timestamp + 100000) AS new_timestamp,
FROM trades
WHERE timestamp > '2021-03-21' and symbol='ETH-USD'
SAMPLE BY 1h
order by new_timestamp asc
```
The root case is there is a new designed timestamp column in projection. 