### PR TITLE
chore(wal): add stub code for future WAL-E format handling

### DIFF
--- a/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
+++ b/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
@@ -35,7 +35,8 @@ import io.questdb.std.FilesFacade;
 import io.questdb.std.IntList;
 import io.questdb.std.str.Path;
 
-import static io.questdb.cairo.wal.WalUtils.*;
+import static io.questdb.cairo.wal.WalUtils.WAL_NAME_BASE;
+import static io.questdb.cairo.wal.WalUtils.WAL_SEQUENCER_FORMAT_VERSION_V1;
 
 public class WalTxnRangeLoader {
     private final IntList txnDetails = new IntList();
@@ -70,7 +71,7 @@ public class WalTxnRangeLoader {
     private static WalEventCursor openWalEFile(Path tempPath, WalEventReader eventReader, int segmentTxn) {
         WalEventCursor walEventCursor;
         try {
-            walEventCursor = eventReader.of(tempPath, WAL_FORMAT_VERSION, segmentTxn);
+            walEventCursor = eventReader.of(tempPath, segmentTxn);
         } catch (CairoException ex) {
             throw CairoException.critical(ex.getErrno()).put("cannot read WAL even file:").put(tempPath)
                     .put(", ").put(ex.getFlyweightMessage());

--- a/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
+++ b/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
@@ -122,7 +122,7 @@ public class WalTxnRangeLoader {
                     lastSegmentTxn = segmentTxn;
                 }
 
-                if (walEventCursor.getType() != WalTxnType.DATA) {
+                if (!WalTxnType.isDataType(walEventCursor.getType())) {
                     // Skip non-inserts
                     continue;
                 }

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -548,7 +548,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
 
             case SQL:
                 try (WalEventReader eventReader = walEventReader) {
-                    final WalEventCursor walEventCursor = eventReader.of(walPath, WAL_FORMAT_VERSION, segmentTxn);
+                    final WalEventCursor walEventCursor = eventReader.of(walPath, segmentTxn);
                     final WalEventCursor.SqlInfo sqlInfo = walEventCursor.getSqlInfo();
                     walTelemetryFacade.store(WAL_TXN_APPLY_START, writer.getTableToken(), walId, seqTxn, -1L, -1L, start - commitTimestamp);
                     processWalSql(writer, sqlInfo, operationExecutor, seqTxn);
@@ -571,11 +571,8 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 mvRefreshTask.invalidationReason = "truncate operation";
                 return 1;
             case MAT_VIEW_INVALIDATE:
-                long txn_old = writer.getTxn();
                 writer.setSeqTxn(seqTxn);
-                if (writer.getTxn() == txn_old) {
-                    writer.markSeqTxnCommitted(seqTxn);
-                }
+                writer.markSeqTxnCommitted(seqTxn);
                 lastCommittedRows = 0;
                 return 1;
             default:

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventCursor.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventCursor.java
@@ -43,7 +43,9 @@ public class WalEventCursor {
     public static final long END_OF_EVENTS = -1L;
 
     private final DataInfo dataInfo = new DataInfo();
+    private final DataInfoExt dataInfoExt = new DataInfoExt();
     private final MemoryCMR eventMem;
+    private final InvalidationInfo invalidationInfo = new InvalidationInfo();
     private final SqlInfo sqlInfo = new SqlInfo();
     private long memSize;
     private long nextOffset = Integer.BYTES;
@@ -77,10 +79,24 @@ public class WalEventCursor {
     }
 
     public DataInfo getDataInfo() {
-        if (type != DATA) {
+        if (!WalTxnType.isDataType(type)) {
             throw CairoException.critical(CairoException.ILLEGAL_OPERATION).put("WAL event type is not DATA, type=").put(type);
         }
-        return dataInfo;
+        return (type == DATA) ? dataInfo : dataInfoExt;
+    }
+
+    public DataInfoExt getDataInfoExt() {
+        if (type != MAT_VIEW_DATA) {
+            throw CairoException.critical(CairoException.ILLEGAL_OPERATION).put("WAL event type is not MAT_VIEW_DATA, type=").put(type);
+        }
+        return dataInfoExt;
+    }
+
+    public InvalidationInfo getInvalidationInfo() {
+        if (type != MAT_VIEW_INVALIDATE) {
+            throw CairoException.critical(CairoException.ILLEGAL_OPERATION).put("WAL event type is not MAT_VIEW_INVALIDATION, type=").put(type);
+        }
+        return invalidationInfo;
     }
 
     public SqlInfo getSqlInfo() {
@@ -198,10 +214,16 @@ public class WalEventCursor {
             case DATA:
                 dataInfo.read();
                 break;
+            case MAT_VIEW_DATA:
+                dataInfoExt.read();
+                break;
             case SQL:
                 sqlInfo.read();
                 break;
             case TRUNCATE:
+                break;
+            case MAT_VIEW_INVALIDATE:
+                invalidationInfo.read();
                 break;
             default:
                 throw CairoException.critical(CairoException.METADATA_VALIDATION).put("Unsupported WAL event type: ").put(type);
@@ -317,12 +339,53 @@ public class WalEventCursor {
             return readNextSymbolMapDiff(symbolMapDiff);
         }
 
-        private void read() {
+        protected void read() {
             startRowID = readLong();
             endRowID = readLong();
             minTimestamp = readLong();
             maxTimestamp = readLong();
             outOfOrder = readBool();
+        }
+    }
+
+    public class DataInfoExt extends DataInfo {
+        private long lastRefreshBaseTableTxn;
+        private long lastRefreshTimestamp;
+
+        public long getLastRefreshBaseTableTxn() {
+            return lastRefreshBaseTableTxn;
+        }
+
+        public long getLastRefreshTimestamp() {
+            return lastRefreshTimestamp;
+        }
+
+        @Override
+        protected void read() {
+            super.read();
+            // read the extra fields in the fixed part
+            // symbol map will start after this
+            lastRefreshBaseTableTxn = readLong();
+            lastRefreshTimestamp = readLong();
+        }
+    }
+
+    public class InvalidationInfo {
+        private final StringSink error = new StringSink();
+        private boolean invalid;
+
+        public CharSequence getInvalidationReason() {
+            return error;
+        }
+
+        public boolean isInvalid() {
+            return invalid;
+        }
+
+        private void read() {
+            invalid = readBool();
+            error.clear();
+            error.put(readStr());
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventReader.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventReader.java
@@ -26,9 +26,9 @@ package io.questdb.cairo.wal;
 
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCMR;
-import io.questdb.cairo.vm.api.MemoryMR;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.FilesFacade;
@@ -39,7 +39,6 @@ import io.questdb.std.str.Path;
 import java.io.Closeable;
 
 import static io.questdb.cairo.TableUtils.openRO;
-import static io.questdb.cairo.TableUtils.validateMetaVersion;
 import static io.questdb.cairo.wal.WalUtils.*;
 
 public class WalEventReader implements Closeable {
@@ -60,7 +59,7 @@ public class WalEventReader implements Closeable {
         Misc.free(eventMem);
     }
 
-    public WalEventCursor of(Path path, int expectedVersion, long segmentTxn) {
+    public WalEventCursor of(Path path, long segmentTxn) {
         int trimTo = path.size();
         try {
             final int pathLen = path.size();
@@ -113,7 +112,14 @@ public class WalEventReader implements Closeable {
                 eventCursor.openOffset(-1);
             }
 
-            validateMetaVersion(eventMem, WAL_FORMAT_OFFSET_32, expectedVersion);
+            final int formatVersion = eventMem.getInt(WAL_FORMAT_OFFSET_32);
+            if (WALE_FORMAT_VERSION != formatVersion && WALE_MAT_VIEW_FORMAT_VERSION != formatVersion) {
+                throw TableUtils.validationException(eventMem)
+                        .put("Wal events file version does not match runtime version [expected=")
+                        .put(WALE_FORMAT_VERSION).put(" or ").put(WALE_MAT_VIEW_FORMAT_VERSION)
+                        .put(", actual=").put(formatVersion)
+                        .put(']');
+            }
             return eventCursor;
         } catch (Throwable e) {
             close();

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -134,6 +134,9 @@ class WalEventWriter implements Closeable {
 
         appendIndex(eventMem.getAppendOffset() - Integer.BYTES);
         eventMem.putInt(WALE_MAX_TXN_OFFSET_32, txn);
+        if (txnType == WalTxnType.MAT_VIEW_DATA) {
+            eventMem.putInt(WAL_FORMAT_OFFSET_32, WALE_MAT_VIEW_FORMAT_VERSION);
+        }
         return txn++;
     }
 
@@ -213,7 +216,7 @@ class WalEventWriter implements Closeable {
 
     private void init() {
         eventMem.putInt(0);
-        eventMem.putInt(WAL_FORMAT_VERSION);
+        eventMem.putInt(WALE_FORMAT_VERSION);
         eventMem.putInt(-1);
 
         appendIndex(WALE_HEADER_SIZE);
@@ -307,6 +310,7 @@ class WalEventWriter implements Closeable {
 
         appendIndex(eventMem.getAppendOffset() - Integer.BYTES);
         eventMem.putInt(WALE_MAX_TXN_OFFSET_32, txn);
+        eventMem.putInt(WAL_FORMAT_OFFSET_32, WALE_MAT_VIEW_FORMAT_VERSION);
         return txn++;
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalEventWriter.java
@@ -34,9 +34,19 @@ import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.std.*;
+import io.questdb.std.AtomicIntList;
+import io.questdb.std.BoolList;
+import io.questdb.std.CharSequenceIntHashMap;
+import io.questdb.std.Files;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.Unsafe;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 
@@ -102,6 +112,29 @@ class WalEventWriter implements Closeable {
                 appendFunctionValue(bindVariableService.getFunction(sink));
             }
         }
+    }
+
+    private int appendData(byte txnType, long startRowID, long endRowID, long minTimestamp, long maxTimestamp, boolean outOfOrder, long lastRefreshBaseTxn, long lastRefreshTimestamp) {
+        startOffset = eventMem.getAppendOffset() - Integer.BYTES;
+        eventMem.putLong(txn);
+        eventMem.putByte(txnType);
+        eventMem.putLong(startRowID);
+        eventMem.putLong(endRowID);
+        eventMem.putLong(minTimestamp);
+        eventMem.putLong(maxTimestamp);
+        eventMem.putBool(outOfOrder);
+        if (txnType == WalTxnType.MAT_VIEW_DATA) {
+            assert lastRefreshBaseTxn != Numbers.LONG_NULL;
+            eventMem.putLong(lastRefreshBaseTxn);
+            eventMem.putLong(lastRefreshTimestamp);
+        }
+        writeSymbolMapDiffs();
+        eventMem.putInt(startOffset, (int) (eventMem.getAppendOffset() - startOffset));
+        eventMem.putInt(-1);
+
+        appendIndex(eventMem.getAppendOffset() - Integer.BYTES);
+        eventMem.putInt(WALE_MAX_TXN_OFFSET_32, txn);
+        return txn++;
     }
 
     private void appendFunctionValue(Function function) {
@@ -227,22 +260,20 @@ class WalEventWriter implements Closeable {
     }
 
     int appendData(long startRowID, long endRowID, long minTimestamp, long maxTimestamp, boolean outOfOrder) {
-        startOffset = eventMem.getAppendOffset() - Integer.BYTES;
-        eventMem.putLong(txn);
-        eventMem.putByte(WalTxnType.DATA);
-        eventMem.putLong(startRowID);
-        eventMem.putLong(endRowID);
-        eventMem.putLong(minTimestamp);
-        eventMem.putLong(maxTimestamp);
-        eventMem.putBool(outOfOrder);
-        writeSymbolMapDiffs();
-        eventMem.putInt(startOffset, (int) (eventMem.getAppendOffset() - startOffset));
-        eventMem.putInt(-1);
+        return appendData(
+                startRowID,
+                endRowID,
+                minTimestamp,
+                maxTimestamp,
+                outOfOrder,
+                Numbers.LONG_NULL,
+                Numbers.LONG_NULL
+        );
+    }
 
-        appendIndex(eventMem.getAppendOffset() - Integer.BYTES);
-
-        eventMem.putInt(WALE_MAX_TXN_OFFSET_32, txn);
-        return txn++;
+    int appendData(long startRowID, long endRowID, long minTimestamp, long maxTimestamp, boolean outOfOrder, long lastRefreshBaseTxn, long lastRefreshTimestamp) {
+        byte msgType = lastRefreshBaseTxn != Numbers.LONG_NULL ? WalTxnType.MAT_VIEW_DATA : WalTxnType.DATA;
+        return appendData(msgType, startRowID, endRowID, minTimestamp, maxTimestamp, outOfOrder, lastRefreshBaseTxn, lastRefreshTimestamp);
     }
 
     int appendSql(int cmdType, CharSequence sqlText, SqlExecutionContext sqlExecutionContext) {
@@ -257,6 +288,20 @@ class WalEventWriter implements Closeable {
         final BindVariableService bindVariableService = sqlExecutionContext.getBindVariableService();
         appendBindVariableValuesByIndex(bindVariableService);
         appendBindVariableValuesByName(bindVariableService);
+        eventMem.putInt(startOffset, (int) (eventMem.getAppendOffset() - startOffset));
+        eventMem.putInt(-1);
+
+        appendIndex(eventMem.getAppendOffset() - Integer.BYTES);
+        eventMem.putInt(WALE_MAX_TXN_OFFSET_32, txn);
+        return txn++;
+    }
+
+    int invalidate(boolean invalid, @Nullable CharSequence invalidationReason) {
+        startOffset = eventMem.getAppendOffset() - Integer.BYTES;
+        eventMem.putLong(txn);
+        eventMem.putByte(WalTxnType.MAT_VIEW_INVALIDATE);
+        eventMem.putBool(invalid);
+        eventMem.putStr(invalidationReason);
         eventMem.putInt(startOffset, (int) (eventMem.getAppendOffset() - startOffset));
         eventMem.putInt(-1);
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalReader.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalReader.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Closeable;
 
 import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
-import static io.questdb.cairo.wal.WalTxnType.DATA;
 import static io.questdb.cairo.wal.WalUtils.WAL_FORMAT_VERSION;
 
 public class WalReader implements Closeable {
@@ -241,7 +240,7 @@ public class WalReader implements Closeable {
 
     private void openSymbolMaps(WalEventCursor eventCursor, CairoConfiguration configuration) {
         while (eventCursor.hasNext()) {
-            if (eventCursor.getType() == DATA) {
+            if (WalTxnType.isDataType(eventCursor.getType())) {
                 WalEventCursor.DataInfo dataInfo = eventCursor.getDataInfo();
                 SymbolMapDiff symbolDiff = dataInfo.nextSymbolMapDiff();
                 while (symbolDiff != null) {

--- a/core/src/main/java/io/questdb/cairo/wal/WalReader.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalReader.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Closeable;
 
 import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
-import static io.questdb.cairo.wal.WalUtils.WAL_FORMAT_VERSION;
 
 public class WalReader implements Closeable {
     private static final Log LOG = LogFactory.getLog(WalReader.class);
@@ -85,7 +84,7 @@ public class WalReader implements Closeable {
             events = new WalEventReader(ff);
             LOG.debug().$("open [table=").$(tableName).I$();
             int pathLen = path.size();
-            eventCursor = events.of(path.slash().put(segmentId), WAL_FORMAT_VERSION, -1L);
+            eventCursor = events.of(path.slash().put(segmentId), -1L);
             path.trimTo(pathLen);
             openSymbolMaps(eventCursor, configuration);
             path.slash().put(segmentId);

--- a/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
@@ -46,7 +46,6 @@ import io.questdb.std.str.DirectString;
 import io.questdb.std.str.Path;
 import org.jetbrains.annotations.Nullable;
 
-import static io.questdb.cairo.wal.WalTxnType.DATA;
 import static io.questdb.cairo.wal.WalTxnType.NONE;
 import static io.questdb.cairo.wal.WalUtils.*;
 
@@ -648,7 +647,7 @@ public class WalTxnDetails implements QuietCloseable {
                         }
 
                         walTxnType = walEventCursor.getType();
-                        if (walTxnType == DATA) {
+                        if (WalTxnType.isDataType(walTxnType)) {
                             WalEventCursor.DataInfo commitInfo = walEventCursor.getDataInfo();
                             transactionMeta.set(txnMetaOffset + SEQ_TXN_OFFSET, seqTxn);
                             transactionMeta.set(txnMetaOffset + COMMIT_TO_TIMESTAMP_OFFSET, -1); // commit to timestamp

--- a/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
@@ -47,7 +47,8 @@ import io.questdb.std.str.Path;
 import org.jetbrains.annotations.Nullable;
 
 import static io.questdb.cairo.wal.WalTxnType.NONE;
-import static io.questdb.cairo.wal.WalUtils.*;
+import static io.questdb.cairo.wal.WalUtils.MIN_WAL_ID;
+import static io.questdb.cairo.wal.WalUtils.WAL_NAME_BASE;
 
 public class WalTxnDetails implements QuietCloseable {
     public static final long FORCE_FULL_COMMIT = Long.MAX_VALUE;
@@ -518,7 +519,7 @@ public class WalTxnDetails implements QuietCloseable {
     private static WalEventCursor openWalEFile(Path tempPath, WalEventReader eventReader, int segmentTxn, long seqTxn) {
         WalEventCursor walEventCursor;
         try {
-            walEventCursor = eventReader.of(tempPath, WAL_FORMAT_VERSION, segmentTxn);
+            walEventCursor = eventReader.of(tempPath, segmentTxn);
         } catch (CairoException ex) {
             throw CairoException.critical(ex.getErrno()).put("cannot read WAL even file for seqTxn=").put(seqTxn)
                     .put(", ").put(ex.getFlyweightMessage()).put(']');

--- a/core/src/main/java/io/questdb/cairo/wal/WalTxnType.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalTxnType.java
@@ -26,7 +26,13 @@ package io.questdb.cairo.wal;
 
 public class WalTxnType {
     public static final byte DATA = 0;
+    public static final byte MAT_VIEW_DATA = 3;
+    public static final byte MAT_VIEW_INVALIDATE = 4;
     public static final byte NONE = -1;
     public static final byte SQL = 1;
     public static final byte TRUNCATE = 2;
+
+    public static boolean isDataType(byte type) {
+        return type == DATA || type == MAT_VIEW_DATA;
+    }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/WalUtils.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalUtils.java
@@ -61,6 +61,8 @@ public class WalUtils {
     public static final long WALE_MAX_TXN_OFFSET_32 = 0L;
     public static final int WAL_FORMAT_OFFSET_32 = Integer.BYTES;
     public static final int WAL_FORMAT_VERSION = 0;
+    public static final int WALE_FORMAT_VERSION = WAL_FORMAT_VERSION;
+    public static final int WALE_MAT_VIEW_FORMAT_VERSION = WALE_FORMAT_VERSION + 1;
     public static final String WAL_INDEX_FILE_NAME = "_wal_index.d";
     public static final String WAL_NAME_BASE = "wal";
     public static final String WAL_PENDING_FS_MARKER = ".pending";

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -92,6 +92,7 @@ import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8StringSink;
 import io.questdb.std.str.Utf8s;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static io.questdb.cairo.TableUtils.*;
 import static io.questdb.cairo.wal.WalUtils.WAL_NAME_BASE;
@@ -303,36 +304,13 @@ public class WalWriter implements TableWriterAPI {
 
     @Override
     public void commit() {
-        checkDistressed();
-        try {
-            if (inTransaction()) {
-                isCommittingData = true;
-                final long rowsToCommit = getUncommittedRowCount();
-                lastSegmentTxn = events.appendData(currentTxnStartRowNum, segmentRowCount, txnMinTimestamp, txnMaxTimestamp, txnOutOfOrder);
-                // flush disk before getting next txn
-                syncIfRequired();
-                final long seqTxn = getSequencerTxn();
-                LOG.info().$("commit [wal=").$substr(pathRootSize, path).$(Files.SEPARATOR).$(segmentId)
-                        .$(", segTxn=").$(lastSegmentTxn)
-                        .$(", seqTxn=").$(seqTxn)
-                        .$(", rowLo=").$(currentTxnStartRowNum).$(", rowHi=").$(segmentRowCount)
-                        .$(", minTs=").$ts(txnMinTimestamp).$(", maxTs=").$ts(txnMaxTimestamp).I$();
-                resetDataTxnProperties();
-                mayRollSegmentOnNextRow();
-                metrics.walMetrics().addRowsWritten(rowsToCommit);
-            }
-        } catch (CairoException ex) {
-            distressed = true;
-            throw ex;
-        } catch (Throwable th) {
-            // If distressed, no need to rollback, WalWriter will not be used anymore
-            if (!isDistressed()) {
-                rollback();
-            }
-            throw th;
-        } finally {
-            isCommittingData = false;
-        }
+        // plain old commit
+        commit0(Long.MIN_VALUE, Long.MIN_VALUE);
+    }
+
+    public void commitWithExtra(long lastRefreshBaseTxn, long lastRefreshTimestamp) {
+        assert lastRefreshBaseTxn != Numbers.LONG_NULL;
+        commit0(lastRefreshBaseTxn, lastRefreshTimestamp);
     }
 
     public void doClose(boolean truncate) {
@@ -433,6 +411,16 @@ public class WalWriter implements TableWriterAPI {
 
     public boolean inTransaction() {
         return segmentRowCount > currentTxnStartRowNum;
+    }
+
+    public void invalidate(boolean invalid, @Nullable CharSequence invalidationReason) {
+        try {
+            lastSegmentTxn = events.invalidate(invalid, invalidationReason);
+            getSequencerTxn();
+        } catch (Throwable th) {
+            rollback();
+            throw th;
+        }
     }
 
     public boolean isDistressed() {
@@ -936,6 +924,47 @@ public class WalWriter implements TableWriterAPI {
             } else {
                 ff.close(secondaryFd);
             }
+        }
+    }
+
+    private void commit0(long lastRefreshBaseTxn, long lastRefreshTimestamp) {
+        checkDistressed();
+        try {
+            if (inTransaction()) {
+                isCommittingData = true;
+                final long rowsToCommit = getUncommittedRowCount();
+                lastSegmentTxn = events.appendData(
+                        currentTxnStartRowNum,
+                        segmentRowCount,
+                        txnMinTimestamp,
+                        txnMaxTimestamp,
+                        txnOutOfOrder,
+                        lastRefreshBaseTxn,
+                        lastRefreshTimestamp
+                );
+                // flush disk before getting next txn
+                syncIfRequired();
+                final long seqTxn = getSequencerTxn();
+                LOG.info().$("commit [wal=").$substr(pathRootSize, path).$(Files.SEPARATOR).$(segmentId)
+                        .$(", segTxn=").$(lastSegmentTxn)
+                        .$(", seqTxn=").$(seqTxn)
+                        .$(", rowLo=").$(currentTxnStartRowNum).$(", rowHi=").$(segmentRowCount)
+                        .$(", minTs=").$ts(txnMinTimestamp).$(", maxTs=").$ts(txnMaxTimestamp).I$();
+                resetDataTxnProperties();
+                mayRollSegmentOnNextRow();
+                metrics.walMetrics().addRowsWritten(rowsToCommit);
+            }
+        } catch (CairoException ex) {
+            distressed = true;
+            throw ex;
+        } catch (Throwable th) {
+            // If distressed, no need to rollback, WalWriter will not be used anymore
+            if (!isDistressed()) {
+                rollback();
+            }
+            throw th;
+        } finally {
+            isCommittingData = false;
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -3751,7 +3751,7 @@ public class WalWriterTest extends AbstractCairoTest {
                 row.putByte(0, (byte) i);
                 row.putSym(1, "sym" + i);
                 row.append();
-                walWriter.commit();
+
                 if (i % 2 == 0) {
                     walWriter.commit();
                 } else {

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -40,9 +40,12 @@ import io.questdb.cairo.wal.SymbolMapDiffEntry;
 import io.questdb.cairo.wal.WalDataRecord;
 import io.questdb.cairo.wal.WalDirectoryPolicy;
 import io.questdb.cairo.wal.WalEventCursor;
+import io.questdb.cairo.wal.WalEventReader;
 import io.questdb.cairo.wal.WalReader;
 import io.questdb.cairo.wal.WalTxnType;
 import io.questdb.cairo.wal.WalWriter;
+import io.questdb.cairo.wal.seq.TransactionLogCursor;
+import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlUtil;
 import io.questdb.griffin.engine.ops.AlterOperationBuilder;
 import io.questdb.griffin.model.IntervalUtils;
@@ -879,8 +882,10 @@ public class WalWriterTest extends AbstractCairoTest {
 
             drainWalQueue();
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
-            assertSql("a\tb\tts\ti2\n" +
-                    "0\t\t2022-02-24T00:00:00.000000Z\t2\n", tableToken.getTableName());
+            assertSql(
+                    "a\tb\tts\ti2\n" +
+                            "0\t\t2022-02-24T00:00:00.000000Z\t2\n", tableToken.getTableName()
+            );
         });
     }
 
@@ -894,8 +899,10 @@ public class WalWriterTest extends AbstractCairoTest {
 
             drainWalQueue();
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
-            assertSql("a\tb\tts\ti2\n" +
-                    "0\t\t2022-02-24T00:00:00.000000Z\t2\n", tableToken.getTableName());
+            assertSql(
+                    "a\tb\tts\ti2\n" +
+                            "0\t\t2022-02-24T00:00:00.000000Z\t2\n", tableToken.getTableName()
+            );
         });
     }
 
@@ -914,8 +921,10 @@ public class WalWriterTest extends AbstractCairoTest {
 
             drainWalQueue();
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
-            assertSql("a\tb\tts\tsym2\ti2\n" +
-                    "0\t\t2022-02-24T00:00:00.000000Z\t\t2\n", tableToken.getTableName());
+            assertSql(
+                    "a\tb\tts\tsym2\ti2\n" +
+                            "0\t\t2022-02-24T00:00:00.000000Z\t\t2\n", tableToken.getTableName()
+            );
         });
     }
 
@@ -936,8 +945,10 @@ public class WalWriterTest extends AbstractCairoTest {
             drainWalQueue();
 
 
-            assertSql("a\tb\tts\tc\n" +
-                    "1\t\t1970-01-01T00:00:00.000000Z\tnull\n", tableToken.getTableName());
+            assertSql(
+                    "a\tb\tts\tc\n" +
+                            "1\t\t1970-01-01T00:00:00.000000Z\tnull\n", tableToken.getTableName()
+            );
         });
     }
 
@@ -998,8 +1009,10 @@ public class WalWriterTest extends AbstractCairoTest {
 
                     drainWalQueue();
                     Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
-                    assertSql("count\tmin\tmax\n" +
-                            (c + 1) * totalRows + "\t2022-02-24T00:00:00.000000Z\t" + Timestamps.toUSecString(ts - tsIncrement) + "\n", "select count(*), min(ts), max(ts) from sm");
+                    assertSql(
+                            "count\tmin\tmax\n" +
+                                    (c + 1) * totalRows + "\t2022-02-24T00:00:00.000000Z\t" + Timestamps.toUSecString(ts - tsIncrement) + "\n", "select count(*), min(ts), max(ts) from sm"
+                    );
                     assertSqlCursors("sm", "select * from sm order by id");
                     assertSql("id\tts\ty\ts\tv\tm\n", "select * from sm WHERE id <> cast(s as int)");
                     assertSql("id\tts\ty\ts\tv\tm\n", "select * from sm WHERE id <> cast(v as int)");
@@ -1531,15 +1544,17 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            try {
-                createTable(testName.getMethodName());
-                assertExceptionNoLeakCheck("Exception expected");
-            } catch (Exception e) {
-                // this exception will be handled in ILP/PG/HTTP
-                assertEquals("Test failure", e.getMessage());
-            }
-        });
+        assertMemoryLeak(
+                ff, () -> {
+                    try {
+                        createTable(testName.getMethodName());
+                        assertExceptionNoLeakCheck("Exception expected");
+                    } catch (Exception e) {
+                        // this exception will be handled in ILP/PG/HTTP
+                        assertEquals("Test failure", e.getMessage());
+                    }
+                }
+        );
     }
 
     @Test
@@ -1564,14 +1579,100 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            try {
-                createTable(testName.getMethodName());
-                assertExceptionNoLeakCheck("Exception expected");
-            } catch (Exception e) {
-                // this exception will be handled in ILP/PG/HTTP
-                assertTrue(e.getMessage().startsWith("[999] Cannot create sequencer directory:"));
+        assertMemoryLeak(
+                ff, () -> {
+                    try {
+                        createTable(testName.getMethodName());
+                        assertExceptionNoLeakCheck("Exception expected");
+                    } catch (Exception e) {
+                        // this exception will be handled in ILP/PG/HTTP
+                        assertTrue(e.getMessage().startsWith("[999] Cannot create sequencer directory:"));
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testExtractNewWalEvents() throws Exception {
+        assertMemoryLeak(() -> {
+            final String tableName = "testExtractNewWalEvents";
+            TableToken tableToken;
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
+                    .col("a", ColumnType.BYTE)
+                    .col("b", ColumnType.SYMBOL)
+                    .timestamp("ts")
+                    .wal();
+            tableToken = createTable(model);
+            final long refreshTxn = 42;
+            try (WalWriter walWriter = engine.getWalWriter(tableToken)) {
+                walWriter.invalidate(true, "test_invalidate0");
+                for (int i = 0; i < 10; i++) {
+                    TableWriter.Row row = walWriter.newRow(0);
+                    row.putByte(0, (byte) i);
+                    row.putSym(1, "sym" + i);
+                    row.append();
+                    if (i % 2 == 0) {
+                        walWriter.commit();
+                    } else {
+                        walWriter.commitWithExtra(refreshTxn + i, i);
+                    }
+                }
+                walWriter.invalidate(false, "test_invalidate1");
             }
+
+            try (Path path = new Path();
+                 WalEventReader walEventReader = new WalEventReader(configuration.getFilesFacade());
+                 TransactionLogCursor transactionLogCursor = engine.getTableSequencerAPI().getCursor(tableToken, 0)) {
+                path.of(configuration.getDbRoot()).concat(tableToken.getDirName());
+                int pathLen = path.size();
+                int i = 0;
+                while (transactionLogCursor.hasNext()) {
+                    final int walId = transactionLogCursor.getWalId();
+                    final int segmentId = transactionLogCursor.getSegmentId();
+                    final int segmentTxn = transactionLogCursor.getSegmentTxn();
+                    path.trimTo(pathLen).concat(WAL_NAME_BASE).put(walId).slash().put(segmentId);
+                    WalEventCursor walEventCursor = walEventReader.of(path, WAL_FORMAT_VERSION, segmentTxn);
+                    if (walEventCursor.getType() == WalTxnType.MAT_VIEW_INVALIDATE) {
+                        WalEventCursor.InvalidationInfo info = walEventCursor.getInvalidationInfo();
+                        if (i == 0) {
+                            assertTrue(info.isInvalid());
+                            assertEquals("test_invalidate0", info.getInvalidationReason().toString());
+                        } else {
+                            assertFalse(info.isInvalid());
+                            assertEquals("test_invalidate1", info.getInvalidationReason().toString());
+                        }
+                    }
+                    if (WalTxnType.isDataType(walEventCursor.getType())) {
+                        WalEventCursor.DataInfo info = walEventCursor.getDataInfo();
+                        assertEquals(segmentTxn - 1, info.getStartRowID());
+                        assertEquals(segmentTxn, info.getEndRowID());
+                    }
+                    if (walEventCursor.getType() == WalTxnType.MAT_VIEW_DATA) {
+                        WalEventCursor.DataInfoExt info = walEventCursor.getDataInfoExt();
+                        assertEquals(segmentTxn - 1, info.getStartRowID());
+                        assertEquals(segmentTxn, info.getEndRowID());
+                        assertEquals(refreshTxn + segmentTxn - 1, info.getLastRefreshBaseTableTxn());
+                        assertEquals(segmentTxn - 1, info.getLastRefreshTimestamp());
+                    }
+                    i++;
+                }
+            }
+
+            drainWalQueue();
+            Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
+            assertSql(
+                    "a\tb\n" +
+                            "0\tsym0\n" +
+                            "1\tsym1\n" +
+                            "2\tsym2\n" +
+                            "3\tsym3\n" +
+                            "4\tsym4\n" +
+                            "5\tsym5\n" +
+                            "6\tsym6\n" +
+                            "7\tsym7\n" +
+                            "8\tsym8\n" +
+                            "9\tsym9\n", "select a,b from " + tableName
+            );
         });
     }
 
@@ -1592,6 +1693,61 @@ public class WalWriterTest extends AbstractCairoTest {
                 // The table is not dropped in the table registry, the exception should not be table dropped exception
                 Assert.assertFalse(e.isTableDropped());
                 TestUtils.assertContains(e.getFlyweightMessage(), "could not open read-write");
+            }
+        });
+    }
+
+    @Test
+    public void testIgnoreNewWalEvents() throws Exception {
+        assertMemoryLeak(() -> {
+            final String tableName = "new_wal_events";
+            final String tableCopyName = tableName + "_copy";
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.YEAR)
+                    .col("a", ColumnType.INT)
+                    .col("b", ColumnType.SYMBOL)
+                    .timestamp("ts").wal();
+            TableModel copyModel = new TableModel(configuration, tableCopyName, PartitionBy.YEAR)
+                    .col("a", ColumnType.INT)
+                    .col("b", ColumnType.SYMBOL)
+                    .timestamp("ts").noWal();
+            TableToken tableToken = createTable(model);
+            TableToken _unused = createTable(copyModel);
+
+            final int rowsToInsertTotal = 100;
+            Rnd rnd = new Rnd();
+            try (
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    WalWriter walWriter = engine.getWalWriter(tableToken);
+                    TableWriter copyWriter = getWriter(tableCopyName);
+            ) {
+                for (int i = 0; i < rowsToInsertTotal; i++) {
+                    boolean invalidate = rnd.nextBoolean();
+                    if (invalidate) {
+                        walWriter.invalidate(invalidate, "Invalidating " + i);
+                    }
+                    String symbol = rnd.nextInt(10) == 5 ? null : rnd.nextString(rnd.nextInt(9) + 1);
+                    int v = rnd.nextInt(rowsToInsertTotal);
+
+                    TableWriter.Row row = walWriter.newRow(0);
+                    row.putInt(0, v);
+                    row.putSym(1, symbol);
+                    row.append();
+
+                    TableWriter.Row rowc = copyWriter.newRow(0);
+                    rowc.putInt(0, v);
+                    rowc.putSym(1, symbol);
+                    rowc.append();
+                }
+
+                copyWriter.commit();
+                if (rnd.nextBoolean()) {
+                    walWriter.commit();
+                } else {
+                    walWriter.commitWithExtra(0, 0);
+                }
+
+                drainWalQueue();
+                TestUtils.assertSqlCursors(compiler, sqlExecutionContext, tableCopyName, tableName, LOG);
             }
         });
     }
@@ -1733,20 +1889,22 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            TableToken tableToken = createTable(testName.getMethodName());
+        assertMemoryLeak(
+                ff, () -> {
+                    TableToken tableToken = createTable(testName.getMethodName());
 
-            try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
-                try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
-                    addColumn(walWriter1, "c", ColumnType.INT);
-                    addColumn(walWriter2, "d", ColumnType.INT);
-                    assertExceptionNoLeakCheck("Exception expected");
-                } catch (CairoException e) {
-                    // this exception will be handled in ILP/PG/HTTP
-                    TestUtils.assertContains(e.getFlyweightMessage(), "could not open read-write");
+                    try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
+                        try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
+                            addColumn(walWriter1, "c", ColumnType.INT);
+                            addColumn(walWriter2, "d", ColumnType.INT);
+                            assertExceptionNoLeakCheck("Exception expected");
+                        } catch (CairoException e) {
+                            // this exception will be handled in ILP/PG/HTTP
+                            TestUtils.assertContains(e.getFlyweightMessage(), "could not open read-write");
+                        }
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -1761,20 +1919,22 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            final TableToken tableToken = createTable(testName.getMethodName());
+        assertMemoryLeak(
+                ff, () -> {
+                    final TableToken tableToken = createTable(testName.getMethodName());
 
-            try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
-                try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
-                    addColumn(walWriter1, "c", ColumnType.INT);
-                    addColumn(walWriter2, "d", ColumnType.INT);
-                    Assert.fail("Exception expected");
-                } catch (Exception e) {
-                    // this exception will be handled in ILP/PG/HTTP
-                    assertTrue(e.getMessage().contains("could not open"));
+                    try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
+                        try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
+                            addColumn(walWriter1, "c", ColumnType.INT);
+                            addColumn(walWriter2, "d", ColumnType.INT);
+                            Assert.fail("Exception expected");
+                        } catch (Exception e) {
+                            // this exception will be handled in ILP/PG/HTTP
+                            assertTrue(e.getMessage().contains("could not open"));
+                        }
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -1794,20 +1954,22 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            TableToken tableToken = createTable(testName.getMethodName());
+        assertMemoryLeak(
+                ff, () -> {
+                    TableToken tableToken = createTable(testName.getMethodName());
 
-            try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
-                try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
-                    addColumn(walWriter1, "c", ColumnType.INT);
-                    addColumn(walWriter2, "d", ColumnType.INT);
-                    assertExceptionNoLeakCheck("Exception expected");
-                } catch (Exception e) {
-                    // this exception will be handled in ILP/PG/HTTP
-                    assertEquals("[0] expected to read table structure changes but there is no saved in the sequencer [structureVersionLo=0]", e.getMessage());
+                    try (WalWriter walWriter1 = engine.getWalWriter(tableToken)) {
+                        try (WalWriter walWriter2 = engine.getWalWriter(tableToken)) {
+                            addColumn(walWriter1, "c", ColumnType.INT);
+                            addColumn(walWriter2, "d", ColumnType.INT);
+                            assertExceptionNoLeakCheck("Exception expected");
+                        } catch (Exception e) {
+                            // this exception will be handled in ILP/PG/HTTP
+                            assertEquals("[0] expected to read table structure changes but there is no saved in the sequencer [structureVersionLo=0]", e.getMessage());
+                        }
+                    }
                 }
-            }
-        });
+        );
     }
 
     @Test
@@ -2261,11 +2423,13 @@ public class WalWriterTest extends AbstractCairoTest {
                 engine.getWalReader(sqlExecutionContext.getSecurityContext(), tableToken, walName, 1, 0);
                 assertExceptionNoLeakCheck("Segment 1 should not exist");
             } catch (CairoException e) {
-                TestUtils.assertContains(e.getFlyweightMessage(), "could not open, file does not exist: " + engine.getConfiguration().getDbRoot() +
-                        File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
-                        File.separatorChar + walName +
-                        File.separatorChar + "1" +
-                        File.separatorChar + TableUtils.META_FILE_NAME + "]");
+                TestUtils.assertContains(
+                        e.getFlyweightMessage(), "could not open, file does not exist: " + engine.getConfiguration().getDbRoot() +
+                                File.separatorChar + tableName + TableUtils.SYSTEM_TABLE_NAME_SUFFIX + "1" +
+                                File.separatorChar + walName +
+                                File.separatorChar + "1" +
+                                File.separatorChar + TableUtils.META_FILE_NAME + "]"
+                );
             }
         });
     }
@@ -2870,10 +3034,12 @@ public class WalWriterTest extends AbstractCairoTest {
         //   * 16 bytes for timestamp (8 bytes index + 8 bytes timestamp).
         final long bytesPerRow = 8 + 10 + 16;
         final AtomicInteger value = new AtomicInteger();
-        testRolloverSegmentSize(ColumnType.STRING, true, bytesPerRow, 0, (row) -> {
-            final String formatted = String.format("%03d", value.getAndIncrement());
-            row.putStr(0, formatted);
-        });
+        testRolloverSegmentSize(
+                ColumnType.STRING, true, bytesPerRow, 0, (row) -> {
+                    final String formatted = String.format("%03d", value.getAndIncrement());
+                    row.putStr(0, formatted);
+                }
+        );
     }
 
     @Test
@@ -2891,10 +3057,12 @@ public class WalWriterTest extends AbstractCairoTest {
         // Overhead to track symbols per txn (per symbol column, in actual fact - but we only have one).
         final long additionalBytesPerTxn = 17;
         final AtomicInteger value = new AtomicInteger();
-        testRolloverSegmentSize(ColumnType.SYMBOL, false, bytesPerRow, additionalBytesPerTxn, (row) -> {
-            final String formatted = String.format("%03d", value.getAndIncrement());
-            row.putSym(0, formatted);
-        });
+        testRolloverSegmentSize(
+                ColumnType.SYMBOL, false, bytesPerRow, additionalBytesPerTxn, (row) -> {
+                    final String formatted = String.format("%03d", value.getAndIncrement());
+                    row.putSym(0, formatted);
+                }
+        );
     }
 
     @Test
@@ -3405,35 +3573,39 @@ public class WalWriterTest extends AbstractCairoTest {
             }
         };
 
-        assertMemoryLeak(ff, () -> {
-            final String tableName = testName.getMethodName();
-            TableToken tableToken;
-            TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
-                    .col("a", ColumnType.INT)
-                    .col("b", ColumnType.SYMBOL)
-                    .timestamp("ts")
-                    .wal();
-            tableToken = createTable(model);
+        assertMemoryLeak(
+                ff, () -> {
+                    final String tableName = testName.getMethodName();
+                    TableToken tableToken;
+                    TableModel model = new TableModel(configuration, tableName, PartitionBy.HOUR)
+                            .col("a", ColumnType.INT)
+                            .col("b", ColumnType.SYMBOL)
+                            .timestamp("ts")
+                            .wal();
+                    tableToken = createTable(model);
 
-            WalWriter walWriter = engine.getWalWriter(tableToken);
-            TableWriter.Row row = walWriter.newRow(0);
-            row.putInt(0, 1);
-            row.append();
+                    WalWriter walWriter = engine.getWalWriter(tableToken);
+                    TableWriter.Row row = walWriter.newRow(0);
+                    row.putInt(0, 1);
+                    row.append();
 
-            walWriter.commit();
+                    walWriter.commit();
 
-            evenFileLengthCallBack.set(() -> {
-                // Close wal segments after the moment when _even file length is taken
-                // but before it's mapped to memory
-                walWriter.close();
-                engine.releaseInactive();
-            });
+                    evenFileLengthCallBack.set(() -> {
+                        // Close wal segments after the moment when _even file length is taken
+                        // but before it's mapped to memory
+                        walWriter.close();
+                        engine.releaseInactive();
+                    });
 
-            drainWalQueue();
+                    drainWalQueue();
 
-            assertSql("a\tb\tts\n" +
-                    "1\t\t1970-01-01T00:00:00.000000Z\n", tableName);
-        });
+                    assertSql(
+                            "a\tb\tts\n" +
+                                    "1\t\t1970-01-01T00:00:00.000000Z\n", tableName
+                    );
+                }
+        );
     }
 
     @Test
@@ -3661,8 +3833,10 @@ public class WalWriterTest extends AbstractCairoTest {
             }
 
             Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tableToken));
-            assertSql("count\tmin\tmax\n" +
-                    totalRows + "\t2022-02-24T00:00:00.000000Z\t" + Timestamps.toUSecString(ts - MAX_VALUE) + "\n", "select count(*), min(ts), max(ts) from sm");
+            assertSql(
+                    "count\tmin\tmax\n" +
+                            totalRows + "\t2022-02-24T00:00:00.000000Z\t" + Timestamps.toUSecString(ts - MAX_VALUE) + "\n", "select count(*), min(ts), max(ts) from sm"
+            );
             assertSqlCursors("sm", "select * from sm order by id");
             assertSql("id\tts\ty\ts\tv\tm\n", "select * from sm WHERE id <> cast(s as int)");
             assertSql("id\tts\ty\ts\tv\tm\n", "select * from sm WHERE id <> cast(v as int)");
@@ -3751,7 +3925,8 @@ public class WalWriterTest extends AbstractCairoTest {
         for (int i = 0; i < expected.length(); i++) {
             byte expectedByte = expected.byteAt(i);
             byte actualByte = actual.byteAt(i);
-            assertEquals("Binary sequences not equals at offset " + i
+            assertEquals(
+                    "Binary sequences not equals at offset " + i
                             + ". Expected byte: " + expectedByte + ", actual byte: " + actualByte + ".",
                     expectedByte, actualByte
             );


### PR DESCRIPTION
This PR adds some stub code to handle a new WAL-E records (`MAT_VIEW_DATA` and `MAT_VIEW_INVALIDATION`) .
The current file format is **not** changed, and the code doesn't add any new features yet.