### PR TITLE
fix(core): return sensible error when mat view query has no designated timestamp

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -851,6 +851,7 @@ public class SqlParser {
 
             final String matViewSql = Chars.toString(lexer.getContent(), startOfQuery, endOfQuery);
             tableOpBuilder.setSelectText(matViewSql);
+            tableOpBuilder.setSelectTextPosition(startOfQuery);
             tableOpBuilder.setSelectModel(queryModel); // transient model, for toSink() purposes only
 
             expectTok(lexer, ')');

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
@@ -404,6 +404,12 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
     @Override
     public void validateAndUpdateMetadataFromSelect(RecordMetadata selectMetadata, TableReaderMetadata baseTableMetadata) throws SqlException {
         // SELECT validation
+        if (createTableOperation.getTimestampColumnName() == null) {
+            if (selectMetadata.getTimestampIndex() == -1) {
+                throw SqlException.position(createTableOperation.getSelectTextPosition())
+                        .put("materialized view query is required to have designated timestamp");
+            }
+        }
         createTableOperation.validateAndUpdateMetadataFromSelect(selectMetadata);
         // Key column validation (best effort):
         // Option 1. Base table has no dedup.

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
@@ -64,6 +64,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
     // transient field, unoptimized AS SELECT model, used in toSink()
     private QueryModel selectModel;
     private CharSequence selectText;
+    private int selectTextPosition;
     private ExpressionNode tableNameExpr;
     private ExpressionNode timestampExpr;
     private int ttlHoursOrMonths;
@@ -87,6 +88,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
                     Chars.toString(tableNameExpr.token),
                     Chars.toString(selectText),
                     tableNameExpr.position,
+                    selectTextPosition,
                     ignoreIfExists,
                     getPartitionByFromExpr(),
                     timestampExpr != null ? Chars.toString(timestampExpr.token) : null,
@@ -152,6 +154,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
         tableNameExpr = null;
         timestampExpr = null;
         selectText = null;
+        selectTextPosition = 0;
         selectModel = null;
         volumeAlias = null;
         ttlHoursOrMonths = 0;
@@ -260,6 +263,10 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
 
     public void setSelectText(CharSequence selectText) {
         this.selectText = selectText;
+    }
+
+    public void setSelectTextPosition(int selectTextPosition) {
+        this.selectTextPosition = selectTextPosition;
     }
 
     public void setTableNameExpr(ExpressionNode expr) {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
@@ -75,6 +75,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
     // position of the "like" table name in the SQL text, for error reporting
     private final int likeTableNamePosition;
     private final String selectText;
+    private final int selectTextPosition;
     private final String sqlText;
     private final String tableName;
     private final int tableNamePosition;
@@ -108,6 +109,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.likeTableNamePosition = likeTableNamePosition;
         this.ignoreIfExists = ignoreIfExists;
         this.selectText = null;
+        this.selectTextPosition = 0;
         this.timestampColumnName = null;
         this.timestampColumnNamePosition = 0;
         this.batchSize = 0;
@@ -158,6 +160,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.walEnabled = walEnabled;
 
         this.selectText = null;
+        this.selectTextPosition = 0;
         this.likeTableName = null;
         this.likeTableNamePosition = -1;
         this.batchSize = 0;
@@ -174,6 +177,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
      * @param tableName                   name of the table to be created
      * @param selectText                  text of the nested AS SELECT statement
      * @param tableNamePosition           the position of table name in user's input, it is used for error reporting
+     * @param selectTextPosition          the position of the nested AS SELECT statement, it is used for error reporting
      * @param ignoreIfExists              "if exists" flag, table won't be created silently if it exists already
      * @param partitionBy                 partition type
      * @param timestampColumnName         designated timestamp column name
@@ -193,6 +197,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
             @NotNull String tableName,
             @NotNull String selectText,
             int tableNamePosition,
+            int selectTextPosition,
             boolean ignoreIfExists,
             int partitionBy,
             @Nullable String timestampColumnName,
@@ -211,6 +216,7 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         this.tableName = tableName;
         this.selectText = selectText;
         this.tableNamePosition = tableNamePosition;
+        this.selectTextPosition = selectTextPosition;
         this.partitionBy = partitionBy;
         this.volumeAlias = volumeAlias;
         this.ignoreIfExists = ignoreIfExists;
@@ -624,6 +630,10 @@ public class CreateTableOperationImpl implements CreateTableOperation {
 
     private int getLowAt(int index) {
         return Numbers.decodeLowInt(columnBits.getQuick(index));
+    }
+
+    int getSelectTextPosition() {
+        return selectTextPosition;
     }
 
     String getTimestampColumnName() {

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -358,6 +358,32 @@ public class CreateMatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateMatViewNoDesignatedTimestamp() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table stocks_d1_ohlcv (" +
+                    "ts timestamp, ticker symbol, close double" +
+                    ") timestamp(ts) partition by day WAL");
+
+            try {
+                final String query =
+                        "  WITH t1 AS (\n" +
+                                "    SELECT ts, ticker, greatest(close, close + 1) as close\n" +
+                                "    FROM stocks_d1_ohlcv\n" +
+                                "  )\n" +
+                                "  SELECT ts, ticker, avg(close)\n" +
+                                "  FROM t1\n" +
+                                "  SAMPLE BY 1d\n" +
+                                "  ORDER BY ticker, ts\n";
+                execute("create materialized view test_view as (" + query + ") partition by month");
+                fail("Expected SqlException missing");
+            } catch (SqlException e) {
+                TestUtils.assertContains(e.getMessage(), "[39] materialized view query is required to have designated timestamp");
+            }
+            assertNull(getMatViewDefinition("testView"));
+        });
+    }
+
+    @Test
     public void testCreateMatViewNoPartitionBy() throws Exception {
         assertMemoryLeak(() -> {
             createTable(TABLE1);


### PR DESCRIPTION
When a mat view is created, the resulting dataset of the query used to create the materialized view must contain a designated timestamp.
This timestamp column also has to be part of the dedup keys set on the view.
Some queries can end up generating data without a designated timestamp, and the user gets an error that the `deduplicate key list must include the designated timestamp column`.
This message is not clear to the user, because dedup keys are automatically set by the database on mat views.
Instead, we should let the user know that the query used to create the mat view should result in a designated timestamp.