### PR TITLE
fix(sql): crash when GROUP BY key includes timestamp

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByUtils.java
@@ -188,7 +188,7 @@ public class GroupByUtils {
                         throw SqlException.invalidColumn(node.position, node.token);
                     }
 
-                    if (index != timestampIndex) {
+                    if (index != timestampIndex || timestampUnimportant) {
                         // when we have same column several times in a row
                         // we only add it once to map keys
                         if (lastIndex != index) {

--- a/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupByTest.java
@@ -33,6 +33,31 @@ import java.util.Arrays;
 public class GroupByTest extends AbstractCairoTest {
 
     @Test
+    public void testGroupByWithTimestampKey() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE foo (\n" +
+                    "  timestamp TIMESTAMP,\n" +
+                    "  bar INT\n" +
+                    ") TIMESTAMP (timestamp)\n" +
+                    "PARTITION BY DAY;");
+            execute("INSERT INTO foo VALUES ('2020', 0);");
+            String query = "SELECT\n" +
+                    "  timestamp AS time,\n" +
+                    "  TO_STR(timestamp, 'yyyy-MM-dd'),\n" +
+                    "  SUM(1) \n" +
+                    "FROM foo;";
+            assertQueryNoLeakCheck(
+                    "time\tTO_STR\tSUM\n" +
+                            "2020-01-01T00:00:00.000000Z\t2020-01-01\t1\n",
+                    query,
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void test1GroupByWithoutAggregateFunctionsReturnsUniqueKeys() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table t as (" +


### PR DESCRIPTION
When `assembleGroupByFunctions()` processes columns, it incorrectly excludes timestamps from the grouping keys in `outKeyType`s. While the function doesn't consider timestamp to be a grouping key, the downstream RecordSink still attempts to write to this non-existent column.

fixes #5526