### PR TITLE
test(core): clean up test infastructure

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
@@ -47,7 +47,6 @@ import io.questdb.cutlass.http.processors.TextQueryProcessor;
 import io.questdb.cutlass.text.CopyRequestJob;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.griffin.QueryFutureUpdateListener;
-import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.log.Log;
@@ -65,7 +64,6 @@ import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.BrokenBarrierException;
 import java.util.function.LongSupplier;
 
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
@@ -386,7 +384,7 @@ public class HttpQueryTestBuilder {
 
     @FunctionalInterface
     public interface HttpClientCode {
-        void run(CairoEngine engine, SqlExecutionContext sqlExecutionContext) throws InterruptedException, SqlException, BrokenBarrierException;
+        void run(CairoEngine engine, SqlExecutionContext sqlExecutionContext) throws Exception;
     }
 
     @FunctionalInterface

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderFailureTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderFailureTest.java
@@ -103,7 +103,7 @@ public class LineHttpSenderFailureTest extends AbstractBootstrapTest {
     public static class ServerController implements Closeable {
         private TestServerMain serverMain;
 
-        public void assertSqlEventually(String sql, String expected) {
+        public void assertSqlEventually(String sql, String expected) throws Exception {
             TestUtils.assertEventually(() -> serverMain.assertSql(sql, expected));
         }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpsSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpsSenderTest.java
@@ -282,7 +282,7 @@ public class LineHttpsSenderTest extends AbstractBootstrapTest {
         }
     }
 
-    private static void assertTableSizeEventually(CairoEngine engine, CharSequence tableName, long expectedSize) {
+    private static void assertTableSizeEventually(CairoEngine engine, CharSequence tableName, long expectedSize) throws Exception {
         TestUtils.assertEventually(() -> {
             assertTableExists(engine, tableName);
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AbstractLineTcpReceiverTest.java
@@ -213,11 +213,11 @@ public class AbstractLineTcpReceiverTest extends AbstractCairoTest {
         }
     }
 
-    public static void assertTableExistsEventually(CairoEngine engine, CharSequence tableName) {
+    public static void assertTableExistsEventually(CairoEngine engine, CharSequence tableName) throws Exception {
         assertEventually(() -> assertTableExists(engine, tableName));
     }
 
-    public static void assertTableSizeEventually(CairoEngine engine, CharSequence tableName, long expectedSize) {
+    public static void assertTableSizeEventually(CairoEngine engine, CharSequence tableName, long expectedSize) throws Exception {
         TestUtils.assertEventually(() -> {
             assertTableExists(engine, tableName);
 

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/AlterWalTableLineTcpReceiverTest.java
@@ -869,7 +869,7 @@ public class AlterWalTableLineTcpReceiverTest extends AbstractLineTcpReceiverTes
         }
     }
 
-    protected void assertTableSize(int expected) {
+    protected void assertTableSize(int expected) throws Exception {
         try (TableReader reader = getReader("plug")) {
             TestUtils.assertEventually(() -> {
                 drainWalQueue();

--- a/core/src/test/java/io/questdb/test/log/LogFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/log/LogFactoryTest.java
@@ -236,13 +236,13 @@ public class LogFactoryTest {
             factory.bind();
             factory.startThread();
 
-            Assert.assertEquals(Logger.class, getLogger(QueryProgress.class).getClass());
+            Assert.assertEquals(Logger.class, getLogger().getClass());
 
             LogFactory.enableGuaranteedLogging(QueryProgress.class);
-            Assert.assertEquals(GuaranteedLogger.class, getLogger(QueryProgress.class).getClass());
+            Assert.assertEquals(GuaranteedLogger.class, getLogger().getClass());
 
             LogFactory.disableGuaranteedLogging(QueryProgress.class);
-            Assert.assertEquals(Logger.class, getLogger(QueryProgress.class).getClass());
+            Assert.assertEquals(Logger.class, getLogger().getClass());
         }
     }
 
@@ -998,8 +998,8 @@ public class LogFactoryTest {
             writer.setRollEvery("day  ");
             writer.bindProperties(LogFactory.getInstance());
 
-            Assert.assertNotEquals(writer.getRollDeadlineFunction().getDeadline(), Long.MAX_VALUE);
-            Assert.assertEquals(writer.getRollDeadlineFunction().getDeadline(), 1430697600000000L);
+            Assert.assertNotEquals(Long.MAX_VALUE, writer.getRollDeadlineFunction().getDeadline());
+            Assert.assertEquals(1430697600000000L, writer.getRollDeadlineFunction().getDeadline());
         }
 
         try (final LogRollingFileWriter writer = new LogRollingFileWriter(
@@ -1013,8 +1013,8 @@ public class LogFactoryTest {
             writer.setRollEvery(" minute ");
             writer.bindProperties(LogFactory.getInstance());
 
-            Assert.assertNotEquals(writer.getRollDeadlineFunction().getDeadline(), Long.MAX_VALUE);
-            Assert.assertEquals(writer.getRollDeadlineFunction().getDeadline(), 1430649360000000L);
+            Assert.assertNotEquals(Long.MAX_VALUE, writer.getRollDeadlineFunction().getDeadline());
+            Assert.assertEquals(1430649360000000L, writer.getRollDeadlineFunction().getDeadline());
         }
     }
 
@@ -1084,9 +1084,9 @@ public class LogFactoryTest {
         r.$();
     }
 
-    private static Log getLogger(Class<?> clazz) {
+    private static Log getLogger() {
         try {
-            final Field field = clazz.getDeclaredField("LOG");
+            final Field field = QueryProgress.class.getDeclaredField("LOG");
             field.setAccessible(true);
             return (Log) field.get(null);
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -1099,7 +1099,7 @@ public class LogFactoryTest {
         Assert.assertTrue("oops: " + len, len > 0L && len < 1073741824L);
     }
 
-    private void testAutoDelete(String sizeLimit, String lifeDuration, String rollSize) throws NumericException {
+    private void testAutoDelete(String sizeLimit, String lifeDuration, String rollSize) throws Exception {
         final int extraFiles = 2;
         String fileTemplate = "mylog-${date:yyyy-MM-dd}.log";
         String extraFilePrefix = "mylog-test";

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -627,11 +627,15 @@ public final class TestUtils {
         }
     }
 
-    public static void assertEventually(Runnable assertion) {
+    public static void assertEventually(EventualCode assertion) throws Exception {
         assertEventually(assertion, 30);
     }
 
-    public static void assertEventually(Runnable assertion, int timeoutSeconds) {
+    public interface EventualCode {
+        void run() throws Exception;
+    }
+
+    public static void assertEventually(EventualCode assertion, int timeoutSeconds) throws Exception {
         long maxSleepingTimeMillis = 1000;
         long nextSleepingTimeMillis = 10;
         long startTime = System.nanoTime();


### PR DESCRIPTION
- inlined constant args (please don't proleferate those)
- added exception to `assertEventually()` so that we don't need to have wrappers all over
- inlined lambdas and removed IntelliJ warnings 

Majority of the clean up is in Ent tandem: https://github.com/questdb/questdb-enterprise/pull/592