### PR TITLE
chore(core): disable Nagle's algorithm in HttpClient (set TCP_NODELAY flag)

### DIFF
--- a/core/rust/qdb-core/src/col_driver/varchar.rs
+++ b/core/rust/qdb-core/src/col_driver/varchar.rs
@@ -33,7 +33,7 @@ use crate::error::{CoreErrorExt, CoreResult};
 ///
 /// The `varchar` column type is implemented using two files:
 /// - **Aux file:** Contains fixed-size records—one per row—that store metadata about each UTF-8 string.
-///    Strings up to 9 bytes are also inlined.
+///   Strings up to 9 bytes are also inlined.
 /// - **Data file:** Stores the actual UTF-8 string bytes for values that are too long to be stored directly in the aux record
 ///   for any strings larger than 9 bytes.
 ///

--- a/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
+++ b/core/src/main/java/io/questdb/cutlass/http/client/HttpClient.java
@@ -529,6 +529,10 @@ public abstract class HttpClient implements QuietCloseable {
             if (fd < 0) {
                 throw new HttpClientException("could not allocate a file descriptor").errno(nf.errno());
             }
+            if (nf.setTcpNoDelay(fd, true) < 0) {
+                LOG.info().$("could not turn off Nagle's algorithm [fd=").$(fd)
+                        .$(", errno=").$(nf.errno()).I$();
+            }
             socket.of(fd);
 
             nf.configureKeepAlive(fd);


### PR DESCRIPTION
While benchmarking ILP over HTTP with small batch sizes, we found the performance to be very poor (16 request per second). We tracked it down to Nagle's algorithm being on by default, causing the TCP client socket to wait for some time before sending the data after it got it from the application.

This change sets the `TCP_NODELAY` flag on the TCP connection used in `HttpClient`.