### PR TITLE
chore(sql): fix startup errors migrating telemetry_config

### DIFF
--- a/core/src/main/java/io/questdb/TelemetryConfigLogger.java
+++ b/core/src/main/java/io/questdb/TelemetryConfigLogger.java
@@ -96,7 +96,7 @@ public class TelemetryConfigLogger implements Closeable {
 
     private void tryAddColumn(SqlCompiler compiler, SqlExecutionContext executionContext, CharSequence columnDetails) {
         try {
-            CompiledQuery cc = compiler.query().$("ALTER TABLE ").$(TELEMETRY_CONFIG_TABLE_NAME).$(" ADD COLUMN ").$(columnDetails).compile(executionContext);
+            CompiledQuery cc = compiler.query().$("ALTER TABLE ").$(TELEMETRY_CONFIG_TABLE_NAME).$(" ADD COLUMN IF NOT EXISTS ").$(columnDetails).compile(executionContext);
             try (OperationFuture fut = cc.execute(tempSequence)) {
                 fut.await();
             }


### PR DESCRIPTION
`TelemetryConfigLogger` used `ADD COLUMN` instead of `ADD COLUMN IF NOT EXISTS`.

That meant the log would be spammed with errors on startup:

```
2025-04-11T11:28:53.524232Z E i.q.g.e.QueryProgress err [id=-1, sql=`ALTER TABLE telemetry_config ADD COLUMN version symbol`, principal=admin, cache=false, jit=true, time=12798000, msg=column 'version' already exists, errno=0, pos=40]
2025-04-11T11:28:53.524718Z E i.q.g.e.QueryProgress err [id=-1, sql=`ALTER TABLE telemetry_config ADD COLUMN os symbol`, principal=admin, cache=false, jit=true, time=336300, msg=column 'os' already exists, errno=0, pos=40]
2025-04-11T11:28:53.524951Z E i.q.g.e.QueryProgress err [id=-1, sql=`ALTER TABLE telemetry_config ADD COLUMN package symbol`, principal=admin, cache=false, jit=true, time=101800, msg=column 'package' already exists, errno=0, pos=40]
```