### PR TITLE
chore(ui): upgrade web console to 0.7.9

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.7.8</web.console.version>
+        <web.console.version>0.7.9</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 


### PR DESCRIPTION
### Added
- array type support [#391](https://github.com/questdb/ui/pull/391)

### Fixed
- minor improvements to tests and performance [#406](https://github.com/questdb/ui/pull/406)
- show JSON parsing error in case of an invalid query result [#411](https://github.com/questdb/ui/pull/411)
- open a new tab when query param exists and metrics tab is open [#415](https://github.com/questdb/ui/pull/415)
- fix incorrect unit normalisation for wal row throughput [#414](https://github.com/questdb/ui/pull/414)
- don't use navigator.clipboard in insecure context [#417](https://github.com/questdb/ui/pull/417)
- workaround for broken safari copy schema mechanism [#418](https://github.com/questdb/ui/pull/418)