### PR TITLE
fix(core): fix table not being readable with _txn open error on Windows

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -243,7 +243,9 @@ public final class TableUtils {
     }
 
     public static int calculateTxRecordSize(int bytesSymbols, int bytesPartitions) {
-        return TX_RECORD_HEADER_SIZE + Integer.BYTES + bytesSymbols + Integer.BYTES + bytesPartitions;
+        // Note that 32 bit symbol length is included in TX_RECORD_HEADER_SIZE,
+        // hence the record size is head + symbol sizes + 32bit partition count + bytes to store partitions
+        return TX_RECORD_HEADER_SIZE + bytesSymbols + Integer.BYTES + bytesPartitions;
     }
 
     public static int calculateTxnLagChecksum(long txn, long seqTxn, int lagRowCount, long lagMinTimestamp, long lagMaxTimestamp, int lagTxnCount) {

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -600,6 +600,8 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
 
         readRecordSize = calculateTxRecordSize(bytesSymbols, bytesPartitions);
         readBaseOffset = areaOffset;
+
+        assert readBaseOffset + readRecordSize <= txMemBase.size();
         super.switchRecord(readBaseOffset, readRecordSize);
 
         if (commitMode != CommitMode.NOSYNC) {

--- a/core/src/test/java/io/questdb/test/cairo/TxnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TxnTest.java
@@ -268,8 +268,8 @@ public class TxnTest extends AbstractCairoTest {
                     partitionCountCheck,
                     truncateIteration
             );
-            Rnd readerRnd = TestUtils.generateRandom(LOG);
 
+            Rnd readerRnd = new Rnd(rnd.nextLong(), rnd.nextLong());
             Thread[] readers = new Thread[readerThreads];
             for (int th = 0; th < readerThreads; th++) {
                 Thread readerThread = new Thread(() -> {


### PR DESCRIPTION
Fixes #5574

The culprit is a bug in the calculation of `_txn` record size that results in saving the records size 4 bytes bigger than it should be. When Windows tries to map such `_txn` file and 4 bytes stick beyond the Windows mapping page granularity of 64k mapping of such file fails and _txn file cannot be read. 