### PR TITLE
feat(sql): alter materialized view symbol capacity

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -2088,7 +2088,7 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exist");
             }
         }
 
@@ -2150,7 +2150,7 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exist");
             }
         }
 
@@ -2204,7 +2204,7 @@ public class WalWriter implements TableWriterAPI {
                     }
                 }
             } else {
-                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exists");
+                throw CairoException.nonCritical().put("column '").put(columnNameSeq).put("' does not exist");
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -813,7 +813,6 @@ public class ExpressionParser {
                                 }
                                 processDefaultBranch = true;
                             }
-
                         } else {
                             processDefaultBranch = true;
                         }

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -523,8 +523,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
     private int addColumnWithType(
             AlterOperationBuilder addColumn,
             CharSequence columnName,
-            int columnNamePosition,
-            boolean symbolsCanHaveIndex
+            int columnNamePosition
     ) throws SqlException {
         CharSequence tok;
         tok = expectToken(lexer, "column type");
@@ -612,9 +611,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
 
             indexed = Chars.equalsLowerCaseAsciiNc("index", tok);
             if (indexed) {
-                if (!symbolsCanHaveIndex) {
-                    throw SqlException.$(lexer.lastTokenPosition(), "INDEX is not supported when changing SYMBOL capacity");
-                }
                 tok = SqlUtil.fetchNext(lexer);
             }
 
@@ -631,7 +627,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 indexValueBlockCapacity = configuration.getIndexValueBlockSize();
             }
         } else { // set defaults
-
             // ignore `NULL` and `NOT NULL`
             if (tok != null && isNotKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
@@ -722,7 +717,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 throw SqlException.$(lexer.lastTokenPosition(), " new column name contains invalid characters");
             }
 
-            addColumnWithType(addColumn, columnName, columnNamePosition, true);
+            addColumnWithType(addColumn, columnName, columnNamePosition);
             tok = SqlUtil.fetchNext(lexer);
 
             if (tok == null || (!isSingleQueryMode && isSemicolon(tok))) {
@@ -756,7 +751,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 tableMetadata.getTableId()
         );
         int existingColumnType = tableMetadata.getColumnType(columnIndex);
-        int newColumnType = addColumnWithType(changeColumn, columnName, columnNamePosition, true);
+        int newColumnType = addColumnWithType(changeColumn, columnName, columnNamePosition);
         CharSequence tok = SqlUtil.fetchNext(lexer);
         if (tok != null && !isSemicolon(tok)) {
             throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [").put(tok).put("] while trying to change column type");
@@ -786,21 +781,55 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             TableRecordMetadata tableMetadata,
             int columnIndex
     ) throws SqlException {
-        AlterOperationBuilder changeColumn = alterOperationBuilder.ofSymbolCapacityChange(
+        final AlterOperationBuilder changeColumn = alterOperationBuilder.ofSymbolCapacityChange(
                 tableNamePosition,
                 tableToken,
                 tableMetadata.getTableId()
         );
-        int existingColumnType = tableMetadata.getColumnType(columnIndex);
+        final int existingColumnType = tableMetadata.getColumnType(columnIndex);
         if (!ColumnType.isSymbol(existingColumnType)) {
             throw SqlException.walRecoverable(columnNamePosition).put("column '").put(columnName).put("' is not of symbol type");
         }
-        lexer.unparseLast();
-        addColumnWithType(changeColumn, columnName, columnNamePosition, false);
+        expectKeyword(lexer, "capacity");
 
-        CharSequence tok = SqlUtil.fetchNext(lexer);
+        CharSequence tok = expectToken(lexer, "symbol capacity");
+
+        final boolean negative;
+        final int errorPos = lexer.lastTokenPosition();
+        if (Chars.equals(tok, '-')) {
+            negative = true;
+            tok = expectToken(lexer, "symbol capacity");
+        } else {
+            negative = false;
+        }
+
+        int symbolCapacity;
+        try {
+            symbolCapacity = Numbers.parseInt(tok);
+        } catch (NumericException e) {
+            throw SqlException.$(lexer.lastTokenPosition(), "numeric capacity expected");
+        }
+
+        if (negative) {
+            symbolCapacity = -symbolCapacity;
+        }
+
+        TableUtils.validateSymbolCapacity(errorPos, symbolCapacity);
+
+        changeColumn.addColumnToList(
+                columnName,
+                columnNamePosition,
+                ColumnType.SYMBOL,
+                Numbers.ceilPow2(symbolCapacity),
+                configuration.getDefaultSymbolCacheFlag(),
+                false,
+                Numbers.ceilPow2(configuration.getIndexValueBlockSize()),
+                false
+        );
+
+        tok = SqlUtil.fetchNext(lexer);
         if (tok != null && !isSemicolon(tok)) {
-            throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [").put(tok).put("] while trying to change column type");
+            throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [").put(tok).put("] while trying to change symbol capacity");
         }
 
         securityContext.authorizeAlterTableAlterColumnType(tableToken, alterOperationBuilder.getExtraStrInfo());
@@ -1365,15 +1394,37 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         tok = expectToken(lexer, "materialized view name");
         assertTableNameIsQuotedOrNotAKeyword(tok, matViewNamePosition);
         final TableToken matViewToken = tableExistsOrFail(matViewNamePosition, GenericLexer.unquote(tok), executionContext);
+        final SecurityContext securityContext = executionContext.getSecurityContext();
 
-        try {
-            tok = expectToken(lexer, "'resume' or 'suspend'");
-            if (isResumeKeyword(tok)) {
+        try (TableRecordMetadata tableMetadata = executionContext.getMetadataForWrite(matViewToken)) {
+            tok = expectToken(lexer, "'alter' or 'resume' or 'suspend'");
+            if (isAlterKeyword(tok)) {
+                expectKeyword(lexer, "column");
+                final int columnNamePosition = lexer.getPosition();
+                tok = expectToken(lexer, "column name");
+                final CharSequence columnName = GenericLexer.immutableOf(tok);
+                final int columnIndex = tableMetadata.getColumnIndexQuiet(columnName);
+                if (columnIndex == -1) {
+                    throw SqlException.walRecoverable(columnNamePosition).put("column '").put(columnName)
+                            .put("' does not exist in materialized view '").put(matViewToken.getTableName()).put('\'');
+                }
+
+                expectKeyword(lexer, "symbol");
+                alterTableChangeSymbolCapacity(
+                        securityContext,
+                        matViewNamePosition,
+                        matViewToken,
+                        columnNamePosition,
+                        columnName,
+                        tableMetadata,
+                        columnIndex
+                );
+            } else if (isResumeKeyword(tok)) {
                 parseResumeWal(matViewToken, matViewNamePosition, executionContext);
             } else if (isSuspendKeyword(tok)) {
                 parseSuspendWal(matViewToken, matViewNamePosition, executionContext);
             } else {
-                throw SqlException.$(lexer.lastTokenPosition(), "'resume' or 'suspend'").put(" expected");
+                throw SqlException.$(lexer.lastTokenPosition(), "'alter' or 'resume' or 'suspend' expected");
             }
         } catch (CairoException e) {
             LOG.info().$("could not alter materialized view [view=").$(matViewToken.getTableName())
@@ -1480,10 +1531,10 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                     final int columnIndex = tableMetadata.getColumnIndexQuiet(columnName);
                     if (columnIndex == -1) {
                         throw SqlException.walRecoverable(columnNamePosition).put("column '").put(columnName)
-                                .put("' does not exists in table '").put(tableToken.getTableName()).put('\'');
+                                .put("' does not exist in table '").put(tableToken.getTableName()).put('\'');
                     }
 
-                    tok = expectToken(lexer, "'add index' or 'drop index' or 'type' or 'cache' or 'nocache'");
+                    tok = expectToken(lexer, "'add index' or 'drop index' or 'type' or 'cache' or 'nocache' or 'symbol'");
                     if (isAddKeyword(tok)) {
                         expectKeyword(lexer, "index");
                         tok = SqlUtil.fetchNext(lexer);

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -821,10 +821,10 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 columnNamePosition,
                 ColumnType.SYMBOL,
                 Numbers.ceilPow2(symbolCapacity),
-                configuration.getDefaultSymbolCacheFlag(),
-                false,
-                Numbers.ceilPow2(configuration.getIndexValueBlockSize()),
-                false
+                configuration.getDefaultSymbolCacheFlag(), // ignored
+                false, // ignored
+                Numbers.ceilPow2(configuration.getIndexValueBlockSize()), // ignored
+                false // ignored
         );
 
         tok = SqlUtil.fetchNext(lexer);

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
@@ -88,9 +88,9 @@ public class AlterOperation extends AbstractOperation implements Mutable {
         this(new LongList(), new ObjList<>());
     }
 
-    public AlterOperation(LongList extraInfo, ObjList<CharSequence> charSequenceObjList) {
+    public AlterOperation(LongList extraInfo, ObjList<CharSequence> extraStrInfo) {
         this.extraInfo = extraInfo;
-        this.extraStrInfo = new ObjCharSequenceList(charSequenceObjList);
+        this.extraStrInfo = new ObjCharSequenceList(extraStrInfo);
         this.command = DO_NOTHING;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperationBuilder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperationBuilder.java
@@ -40,12 +40,21 @@ public class AlterOperationBuilder implements Mutable {
     private int tableNamePosition = -1;
     private TableToken tableToken;
 
-    // builder and the operation it is building share two lists.
+    // the builder and the operation it builds share the extraInfo list
     public AlterOperationBuilder() {
         this.op = new AlterOperation(extraInfo, extraStrInfo);
     }
 
-    public void addColumnToList(CharSequence columnName, int columnNamePosition, int type, int symbolCapacity, boolean cache, boolean indexed, int indexValueBlockCapacity, boolean dedupKey) {
+    public void addColumnToList(
+            CharSequence columnName,
+            int columnNamePosition,
+            int type,
+            int symbolCapacity,
+            boolean cache,
+            boolean indexed,
+            int indexValueBlockCapacity,
+            boolean dedupKey
+    ) {
         assert columnName != null && columnName.length() > 0;
         extraStrInfo.add(columnName);
         extraInfo.add(type);
@@ -128,14 +137,6 @@ public class AlterOperationBuilder implements Mutable {
 
     public AlterOperationBuilder ofColumnChangeType(int tableNamePosition, TableToken tableToken, int tableId) {
         this.command = CHANGE_COLUMN_TYPE;
-        this.tableNamePosition = tableNamePosition;
-        this.tableToken = tableToken;
-        this.tableId = tableId;
-        return this;
-    }
-
-    public AlterOperationBuilder ofSymbolCapacityChange(int tableNamePosition, TableToken tableToken, int tableId) {
-        this.command = CHANGE_SYMBOL_CAPACITY;
         this.tableNamePosition = tableNamePosition;
         this.tableToken = tableToken;
         this.tableId = tableId;
@@ -267,6 +268,14 @@ public class AlterOperationBuilder implements Mutable {
         this.tableNamePosition = tableNamePosition;
         this.tableToken = tableToken;
         this.tableId = tableToken.getTableId();
+        return this;
+    }
+
+    public AlterOperationBuilder ofSymbolCapacityChange(int tableNamePosition, TableToken tableToken, int tableId) {
+        this.command = CHANGE_SYMBOL_CAPACITY;
+        this.tableNamePosition = tableNamePosition;
+        this.tableToken = tableToken;
+        this.tableId = tableId;
         return this;
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -228,6 +228,11 @@ public class MatViewTest extends AbstractCairoTest {
                     "min symbol capacity is 2"
             );
             assertExceptionNoLeakCheck(
+                    "alter materialized view price_1h alter column sym symbol capacity 1073741825;",
+                    66,
+                    "max symbol capacity is 1073741824"
+            );
+            assertExceptionNoLeakCheck(
                     "ALTER MATERIALIZED VIEW price_1h ALTER COLUMN sym SYMBOL CAPACITY 42 foobar;",
                     69,
                     "unexpected token [foobar] while trying to change symbol capacity"

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -223,6 +223,11 @@ public class MatViewTest extends AbstractCairoTest {
                     "numeric capacity expected"
             );
             assertExceptionNoLeakCheck(
+                    "alter materialized view price_1h alter column sym symbol capacity -42;",
+                    66,
+                    "min symbol capacity is 2"
+            );
+            assertExceptionNoLeakCheck(
                     "ALTER MATERIALIZED VIEW price_1h ALTER COLUMN sym SYMBOL CAPACITY 42 foobar;",
                     69,
                     "unexpected token [foobar] while trying to change symbol capacity"

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -4101,7 +4101,7 @@ public class WalWriterTest extends AbstractCairoTest {
         try {
             path = constructPath(path, tableName, walName, segment, fileName);
             if (!Files.exists(path.$())) {
-                throw new AssertionError("Path " + path + " does not exists!");
+                throw new AssertionError("Path " + path + " does not exist!");
             }
         } finally {
             path.trimTo(pathLen);

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAlterColumnTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAlterColumnTest.java
@@ -174,7 +174,7 @@ public class AlterTableAlterColumnTest extends AbstractCairoTest {
 
     @Test
     public void testInvalidColumnName() throws Exception {
-        assertFailure("alter table x alter column y add index", 27, "column 'y' does not exists in table 'x'");
+        assertFailure("alter table x alter column y add index", 27, "column 'y' does not exist in table 'x'");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAlterSymbolColumnCacheFlagTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAlterSymbolColumnCacheFlagTest.java
@@ -159,7 +159,7 @@ public class AlterTableAlterSymbolColumnCacheFlagTest extends AbstractCairoTest 
 
     @Test
     public void testBadSyntax() throws Exception {
-        assertFailure("alter table x alter column c", 28, "'add index' or 'drop index' or 'type' or 'cache' or 'nocache' expected");
+        assertFailure("alter table x alter column c", 28, "'add index' or 'drop index' or 'type' or 'cache' or 'nocache' or 'symbol' expected");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableAlterSymbolColumnCacheFlagTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableAlterSymbolColumnCacheFlagTest.java
@@ -164,7 +164,7 @@ public class AlterTableAlterSymbolColumnCacheFlagTest extends AbstractCairoTest 
 
     @Test
     public void testInvalidColumn() throws Exception {
-        assertFailure("alter table x alter column y cache", 27, "column 'y' does not exists in table 'x'");
+        assertFailure("alter table x alter column y cache", 27, "column 'y' does not exist in table 'x'");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
@@ -509,7 +509,7 @@ public class AlterTableChangeColumnTypeTest extends AbstractCairoTest {
     @Test
     public void testColumnDoesNotExist() throws Exception {
         Assume.assumeTrue(!walEnabled && partitioned);
-        assertFailure("alter table x alter column non_existing", 27, "column 'non_existing' does not exists in table 'x'");
+        assertFailure("alter table x alter column non_existing", 27, "column 'non_existing' does not exist in table 'x'");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableChangeColumnTypeTest.java
@@ -310,7 +310,7 @@ public class AlterTableChangeColumnTypeTest extends AbstractCairoTest {
                 execute("alter table x alter column ik symbol capacity 512 index", sqlExecutionContext);
                 Assert.fail("index syntax not supported when changing SYMBOL capacity");
             } catch (SqlException ex) {
-                TestUtils.assertContains(ex.getFlyweightMessage(), "INDEX is not supported when changing SYMBOL capacity");
+                TestUtils.assertContains(ex.getFlyweightMessage(), "unexpected token [index] while trying to change symbol capacity");
             }
             drainWalQueue();
         });

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1102,7 +1102,7 @@ public class CheckpointTest extends AbstractCairoTest {
                 Assert.assertTrue(TestFilesFacadeImpl.INSTANCE.exists(
                         path.of(configuration.getLegacyCheckpointRoot()).concat(configuration.getDbDirectory()).slash$()
                 ));
-                // Assert .checkpint folder DOES NOT exists
+                // Assert .checkpoint folder DOES NOT exist
                 Assert.assertFalse(TestFilesFacadeImpl.INSTANCE.exists(
                         path.of(configuration.getCheckpointRoot()).slash$()
                 ));


### PR DESCRIPTION
Also fixes insufficient validation in ALTER TABLE SYMBOL CAPACITY. Statements like `alter table x alter column sym symbol capacity;` or `alter materialized view x alter column sym symbol cache;` were accepted and led to default capacity being used as the new value.