### PR TITLE
fix: "unsupported cast" exception msg  for 'DOUBLE PRECISION'

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1444,9 +1444,13 @@ public class ExpressionParser {
                                         }
                                     }
                                 }
-                            } else if (SqlKeywords.isDoubleKeyword(last.token) && SqlKeywords.isPrecisionKeyword(tok)) {
-                                // ignore 'precision' keyword after 'double'
-                                continue;
+                            } else if (SqlKeywords.isDoubleKeyword(last.token)) {
+                                if (!SqlKeywords.isPrecisionKeyword(tok)) {
+                                    // no more ignore 'precision' keyword after 'double'
+                                    continue;
+                                } else {
+                                    throw SqlException.$(lastPos, "unsupported cast");
+                                }
                             }
                         }
                         // literal can be at start of input, after a bracket or part of an operator

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -1332,4 +1332,13 @@ public class ExpressionParserTest extends AbstractCairoTest {
         }
         TestUtils.assertEquals(expectedRpn, rpnBuilder.rpn());
     }
+
+    @Test
+    public void testUnsupportedCastDoublePrecision() {
+        assertFail("cast(1 as DOUBLE PRECISION)",
+                17,
+                "unsupported cast"
+        );
+    }
+
 }


### PR DESCRIPTION
fix: "unsupported cast" exception msg instead of response code 500 on invalid query which has 'DOUBLE PRECISION' ( not supported)

Ref : #5609
