### PR TITLE
chore(sql):  add last_refresh_started_timestamp to materialized_views() output

### DIFF
--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshExecutionContext.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshExecutionContext.java
@@ -139,10 +139,10 @@ public class MatViewRefreshExecutionContext extends SqlExecutionContextImpl {
     }
 
     private long getTimestamp(int index) {
-        Function fn = getBindVariableService().getFunction(index);
-        if (fn == null || fn.getType() != ColumnType.TIMESTAMP) {
+        final Function func = getBindVariableService().getFunction(index);
+        if (func == null || func.getType() != ColumnType.TIMESTAMP) {
             return Numbers.LONG_NULL;
         }
-        return fn.getTimestamp(null);
+        return func.getTimestamp(null);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshExecutionContext.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshExecutionContext.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.security.ReadOnlySecurityContext;
+import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.griffin.SqlException;
@@ -37,6 +38,8 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.griffin.engine.functions.bind.BindVariableServiceImpl;
 import io.questdb.griffin.engine.functions.bind.IndexedParameterLinkFunction;
 import io.questdb.griffin.model.IntrinsicModel;
+import io.questdb.std.Numbers;
+import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 
 public class MatViewRefreshExecutionContext extends SqlExecutionContextImpl {
@@ -126,5 +129,20 @@ public class MatViewRefreshExecutionContext extends SqlExecutionContextImpl {
     public void setRange(long tsLo, long tsHi) throws SqlException {
         getBindVariableService().setTimestamp(1, tsLo);
         getBindVariableService().setTimestamp(2, tsHi - 1);
+    }
+
+    @Override
+    public void toSink(@NotNull CharSink<?> sink) {
+        super.toSink(sink);
+        sink.putAscii(", refreshMinTs=").putISODate(getTimestamp(1));
+        sink.putAscii(", refreshMaxTs=").putISODate(getTimestamp(2));
+    }
+
+    private long getTimestamp(int index) {
+        Function fn = getBindVariableService().getFunction(index);
+        if (fn == null || fn.getType() != ColumnType.TIMESTAMP) {
+            return Numbers.LONG_NULL;
+        }
+        return fn.getTimestamp(null);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -780,6 +780,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private void setInvalidState(MatViewState state, WalWriter walWriter, CharSequence invalidationReason, long invalidationTimestamp) {
         state.markAsInvalid(invalidationReason);
         state.setLastRefreshTimestamp(invalidationTimestamp);
+        state.setLastRefreshStartTimestamp(invalidationTimestamp);
         walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishTimestamp(), true, invalidationReason);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -259,7 +259,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private boolean fullRefresh(MatViewRefreshTask refreshTask) {
         final TableToken viewToken = refreshTask.matViewToken;
         assert viewToken != null;
-        final long refreshTriggeredTimestamp = refreshTask.refreshTriggeredTimestamp;
+        final long refreshTriggerTimestamp = refreshTask.refreshTriggerTimestamp;
 
         final MatViewState state = stateStore.getViewState(viewToken);
         if (state == null || state.isDropped()) {
@@ -286,12 +286,12 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                         .$(", errno=").$(e.getErrno())
                         .$(", errorMsg=").$(e.getFlyweightMessage())
                         .I$();
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), e);
+                refreshFailState(state, walWriter, e);
                 return false;
             }
 
             if (!baseTableToken.isWal()) {
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), "base table is not a WAL table");
+                refreshFailState(state, walWriter, "base table is not a WAL table");
                 return false;
             }
 
@@ -316,7 +316,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     // Specify -1 as the last refresh txn, so that we scan all partitions.
                     final SampleByIntervalIterator intervalIterator = findSampleByIntervals(baseTableReader, viewDef, -1);
                     if (intervalIterator != null) {
-                        insertAsSelect(state, viewDef, walWriter, intervalIterator, toBaseTxn, refreshTriggeredTimestamp);
+                        insertAsSelect(state, viewDef, walWriter, intervalIterator, toBaseTxn, refreshTriggerTimestamp);
                     }
                 } finally {
                     refreshExecutionContext.clearReader();
@@ -328,7 +328,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                         .$(", baseTable=").$(baseTableToken)
                         .$(", ex=").$(th)
                         .I$();
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), th);
+                refreshFailState(state, walWriter, th);
                 return false;
             }
         } catch (Throwable th) {
@@ -338,7 +338,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     .$("could not perform incremental refresh, unexpected error [view=").$(viewToken)
                     .$(", ex=").$(th)
                     .I$();
-            refreshFailState(state, null, microsecondClock.getTicks(), th);
+            refreshFailState(state, null, th);
             return false;
         } finally {
             state.unlock();
@@ -363,11 +363,11 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private boolean incrementalRefresh(MatViewRefreshTask refreshTask) {
         final TableToken baseTableToken = refreshTask.baseTableToken;
         final TableToken matViewToken = refreshTask.matViewToken;
-        final long refreshTriggeredTimestamp = refreshTask.refreshTriggeredTimestamp;
+        final long refreshTriggerTimestamp = refreshTask.refreshTriggerTimestamp;
         if (matViewToken == null) {
-            return refreshDependentViewsIncremental(baseTableToken, graph, stateStore, refreshTriggeredTimestamp);
+            return refreshDependentViewsIncremental(baseTableToken, graph, stateStore, refreshTriggerTimestamp);
         } else {
-            return refreshIncremental(matViewToken, stateStore, refreshTriggeredTimestamp);
+            return refreshIncremental(matViewToken, stateStore, refreshTriggerTimestamp);
         }
     }
 
@@ -377,7 +377,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             WalWriter walWriter,
             SampleByIntervalIterator intervalIterator,
             long baseTableTxn,
-            long refreshTriggeredTimestamp
+            long refreshTriggerTimestamp
     ) {
         assert state.isLocked();
 
@@ -388,8 +388,8 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         RecordCursorFactory factory = null;
         RecordToRowCopier copier;
         int intervalStep = intervalIterator.getStep();
-        final long refreshStartedTimestamp = microsecondClock.getTicks();
-        state.setLastRefreshStartedTimestamp(refreshStartedTimestamp);
+        final long refreshStartTimestamp = microsecondClock.getTicks();
+        state.setLastRefreshStartTimestamp(refreshStartTimestamp);
         final TableToken viewTableToken = viewDef.getMatViewToken();
         try {
             factory = state.acquireRecordFactory();
@@ -415,7 +415,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                                     .$(", attempt=").$(i)
                                     .$(", error=").$(e.getFlyweightMessage())
                                     .I$();
-                            refreshFailState(state, walWriter, microsecondClock.getTicks(), e);
+                            refreshFailState(state, walWriter, e);
                             return false;
                         }
                     }
@@ -472,9 +472,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 }
             }
 
-            long refreshFinishedTimestamp = microsecondClock.getTicks();
-            walWriter.commitMatView(baseTableTxn, refreshFinishedTimestamp);
-            state.refreshSuccess(factory, copier, walWriter.getMetadata().getMetadataVersion(), refreshFinishedTimestamp, refreshTriggeredTimestamp, baseTableTxn);
+            final long refreshFinishTimestamp = microsecondClock.getTicks();
+            walWriter.commitMatView(baseTableTxn, refreshFinishTimestamp);
+            state.refreshSuccess(factory, copier, walWriter.getMetadata().getMetadataVersion(), refreshFinishTimestamp, refreshTriggerTimestamp, baseTableTxn);
             state.setLastRefreshBaseTableTxn(baseTableTxn);
         } catch (Throwable th) {
             Misc.free(factory);
@@ -482,7 +482,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     .$("could not refresh materialized view [view=").$(viewTableToken)
                     .$(", ex=").$(th)
                     .I$();
-            refreshFailState(state, walWriter, microsecondClock.getTicks(), th);
+            refreshFailState(state, walWriter, th);
             return false;
         }
 
@@ -599,7 +599,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             TableToken baseTableToken,
             MatViewGraph graph,
             MatViewStateStore stateStore,
-            long refreshTriggeredTimestamp
+            long refreshTriggerTimestamp
     ) {
         assert baseTableToken.isWal();
 
@@ -620,9 +620,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 }
                 try (WalWriter walWriter = engine.getWalWriter(viewToken)) {
                     try {
-                        refreshed |= refreshIncremental0(state, baseTableToken, walWriter, refreshTriggeredTimestamp);
+                        refreshed |= refreshIncremental0(state, baseTableToken, walWriter, refreshTriggerTimestamp);
                     } catch (Throwable th) {
-                        refreshFailState(state, walWriter, microsecondClock.getTicks(), th);
+                        refreshFailState(state, walWriter, th);
                     }
                 } catch (Throwable th) {
                     // If we're here, we either couldn't obtain the WAL writer or the writer couldn't write
@@ -631,7 +631,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                             .$("could not get table writer for view [view=").$(viewToken)
                             .$(", ex=").$(th)
                             .I$();
-                    refreshFailState(state, null, microsecondClock.getTicks(), th);
+                    refreshFailState(state, null, th);
                 } finally {
                     state.unlock();
                     state.tryCloseIfDropped();
@@ -649,26 +649,26 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         return refreshed;
     }
 
-    private void refreshFailState(MatViewState state, @Nullable WalWriter walWriter, long refreshTimestamp, CharSequence errorMessage) {
-        state.refreshFail(refreshTimestamp, errorMessage);
+    private void refreshFailState(MatViewState state, @Nullable WalWriter walWriter, CharSequence errorMessage) {
+        state.refreshFail(microsecondClock.getTicks(), errorMessage);
         if (walWriter != null) {
-            walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishedTimestamp(), true, errorMessage);
+            walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishTimestamp(), true, errorMessage);
         }
         // Invalidate dependent views recursively.
         enqueueInvalidateDependentViews(state.getViewDefinition().getMatViewToken(), "base materialized view refresh failed");
     }
 
-    private void refreshFailState(MatViewState state, @Nullable WalWriter walWriter, long refreshTimestamp, Throwable th) {
+    private void refreshFailState(MatViewState state, @Nullable WalWriter walWriter, Throwable th) {
         errorMsgSink.clear();
         if (th instanceof Sinkable) {
             ((Sinkable) th).toSink(errorMsgSink);
         } else {
             errorMsgSink.put(th.getMessage());
         }
-        refreshFailState(state, walWriter, refreshTimestamp, errorMsgSink);
+        refreshFailState(state, walWriter, errorMsgSink);
     }
 
-    private boolean refreshIncremental(@NotNull TableToken viewToken, MatViewStateStore stateStore, long refreshTriggeredTimestamp) {
+    private boolean refreshIncremental(@NotNull TableToken viewToken, MatViewStateStore stateStore, long refreshTriggerTimestamp) {
         final MatViewState state = stateStore.getViewState(viewToken);
         if (state == null || state.isPendingInvalidation() || state.isInvalid() || state.isDropped()) {
             return false;
@@ -692,24 +692,24 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                         .$(", errno=").$(e.getErrno())
                         .$(", errorMsg=").$(e.getFlyweightMessage())
                         .I$();
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), e);
+                refreshFailState(state, walWriter, e);
                 return false;
             }
 
             if (!baseTableToken.isWal()) {
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), "base table is not a WAL table");
+                refreshFailState(state, walWriter, "base table is not a WAL table");
                 return false;
             }
 
             try {
-                return refreshIncremental0(state, baseTableToken, walWriter, refreshTriggeredTimestamp);
+                return refreshIncremental0(state, baseTableToken, walWriter, refreshTriggerTimestamp);
             } catch (Throwable th) {
                 LOG.error()
                         .$("could not perform incremental refresh [view=").$(viewToken)
                         .$(", baseTableToken=").$(baseTableToken)
                         .$(", ex=").$(th)
                         .I$();
-                refreshFailState(state, walWriter, microsecondClock.getTicks(), th);
+                refreshFailState(state, walWriter, th);
                 return false;
             }
         } catch (Throwable th) {
@@ -719,7 +719,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     .$("could not perform incremental refresh, unexpected error [view=").$(viewToken)
                     .$(", ex=").$(th)
                     .I$();
-            refreshFailState(state, null, microsecondClock.getTicks(), th);
+            refreshFailState(state, null, th);
             return false;
         } finally {
             state.unlock();
@@ -731,7 +731,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             @NotNull MatViewState state,
             @NotNull TableToken baseTableToken,
             @NotNull WalWriter walWriter,
-            long refreshTriggeredTimestamp
+            long refreshTriggerTimestamp
     ) throws SqlException {
         assert state.isLocked();
 
@@ -760,7 +760,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 final MatViewDefinition viewDef = state.getViewDefinition();
                 final SampleByIntervalIterator intervalIterator = findSampleByIntervals(baseTableReader, viewDef, fromBaseTxn);
                 if (intervalIterator != null) {
-                    return insertAsSelect(state, viewDef, walWriter, intervalIterator, baseTableReader.getSeqTxn(), refreshTriggeredTimestamp);
+                    return insertAsSelect(state, viewDef, walWriter, intervalIterator, baseTableReader.getSeqTxn(), refreshTriggerTimestamp);
                 }
             } finally {
                 refreshExecutionContext.clearReader();
@@ -774,12 +774,12 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         state.markAsValid();
         state.setLastRefreshBaseTableTxn(-1);
         state.setLastRefreshTimestamp(Numbers.LONG_NULL);
-        walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishedTimestamp(), false, null);
+        walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishTimestamp(), false, null);
     }
 
     private void setInvalidState(MatViewState state, WalWriter walWriter, CharSequence invalidationReason, long invalidationTimestamp) {
         state.markAsInvalid(invalidationReason);
         state.setLastRefreshTimestamp(invalidationTimestamp);
-        walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishedTimestamp(), true, invalidationReason);
+        walWriter.invalidateMatView(state.getLastRefreshBaseTxn(), state.getLastRefreshFinishTimestamp(), true, invalidationReason);
     }
 }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshTask.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshTask.java
@@ -36,7 +36,7 @@ public class MatViewRefreshTask implements ValueHolder<MatViewRefreshTask> {
     public String invalidationReason;
     public TableToken matViewToken;
     public int operation = UNDEFINED;
-    public long refreshTriggeredTimestamp = -1;
+    public long refreshTriggerTimestamp = -1;
 
     @Override
     public void clear() {
@@ -44,7 +44,7 @@ public class MatViewRefreshTask implements ValueHolder<MatViewRefreshTask> {
         baseTableToken = null;
         matViewToken = null;
         invalidationReason = null;
-        refreshTriggeredTimestamp = -1;
+        refreshTriggerTimestamp = -1;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class MatViewRefreshTask implements ValueHolder<MatViewRefreshTask> {
         anotherHolder.baseTableToken = baseTableToken;
         anotherHolder.matViewToken = matViewToken;
         anotherHolder.invalidationReason = invalidationReason;
-        anotherHolder.refreshTriggeredTimestamp = refreshTriggeredTimestamp;
+        anotherHolder.refreshTriggerTimestamp = refreshTriggerTimestamp;
     }
 
     public boolean isBaseTableTask() {

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
@@ -57,7 +57,8 @@ public class MatViewState implements QuietCloseable {
     private volatile boolean dropped;
     private volatile boolean invalid;
     private volatile long lastRefreshBaseTxn = -1;
-    private volatile long lastRefreshTimestamp = Numbers.LONG_NULL;
+    private volatile long lastRefreshFinishedTimestamp = Numbers.LONG_NULL;
+    private volatile long lastRefreshStartedTimestamp = Numbers.LONG_NULL;
     private volatile boolean pendingInvalidation;
     private long recordRowCopierMetadataVersion;
     private RecordToRowCopier recordToRowCopier;
@@ -140,8 +141,12 @@ public class MatViewState implements QuietCloseable {
         return lastRefreshBaseTxn;
     }
 
-    public long getLastRefreshTimestamp() {
-        return lastRefreshTimestamp;
+    public long getLastRefreshFinishedTimestamp() {
+        return lastRefreshFinishedTimestamp;
+    }
+
+    public long getLastRefreshStartedTimestamp() {
+        return lastRefreshStartedTimestamp;
     }
 
     public long getRecordRowCopierMetadataVersion() {
@@ -163,7 +168,7 @@ public class MatViewState implements QuietCloseable {
     public void initFromReader(MatViewStateReader reader) {
         this.invalid = reader.isInvalid();
         this.lastRefreshBaseTxn = reader.getLastRefreshBaseTxn();
-        this.lastRefreshTimestamp = reader.getLastRefreshTimestamp();
+        this.lastRefreshFinishedTimestamp = reader.getLastRefreshTimestamp();
     }
 
     public boolean isDropped() {
@@ -205,7 +210,7 @@ public class MatViewState implements QuietCloseable {
 
     public void refreshFail(long refreshTimestamp, CharSequence errorMessage) {
         assert latch.get();
-        this.lastRefreshTimestamp = refreshTimestamp;
+        this.lastRefreshFinishedTimestamp = refreshTimestamp;
         markAsInvalid(errorMessage);
         telemetryFacade.store(MAT_VIEW_REFRESH_FAIL, viewDefinition.getMatViewToken(), Numbers.LONG_NULL, errorMessage, 0);
     }
@@ -214,7 +219,7 @@ public class MatViewState implements QuietCloseable {
             RecordCursorFactory factory,
             RecordToRowCopier copier,
             long recordRowCopierMetadataVersion,
-            long refreshTimestamp,
+            long refreshFinishedTimestamp,
             long refreshTriggeredTimestamp,
             long baseTableTxn
     ) {
@@ -222,13 +227,13 @@ public class MatViewState implements QuietCloseable {
         this.cursorFactory = factory;
         this.recordToRowCopier = copier;
         this.recordRowCopierMetadataVersion = recordRowCopierMetadataVersion;
-        this.lastRefreshTimestamp = refreshTimestamp;
+        this.lastRefreshFinishedTimestamp = refreshFinishedTimestamp;
         telemetryFacade.store(
                 MAT_VIEW_REFRESH_SUCCESS,
                 viewDefinition.getMatViewToken(),
                 baseTableTxn,
                 null,
-                refreshTimestamp - refreshTriggeredTimestamp
+                refreshFinishedTimestamp - refreshTriggeredTimestamp
         );
     }
 
@@ -236,8 +241,12 @@ public class MatViewState implements QuietCloseable {
         lastRefreshBaseTxn = txn;
     }
 
+    public void setLastRefreshStartedTimestamp(long ts) {
+        lastRefreshStartedTimestamp = ts;
+    }
+
     public void setLastRefreshTimestamp(long ts) {
-        this.lastRefreshTimestamp = ts;
+        this.lastRefreshFinishedTimestamp = ts;
     }
 
     public void tryCloseIfDropped() {

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
@@ -57,8 +57,8 @@ public class MatViewState implements QuietCloseable {
     private volatile boolean dropped;
     private volatile boolean invalid;
     private volatile long lastRefreshBaseTxn = -1;
-    private volatile long lastRefreshFinishedTimestamp = Numbers.LONG_NULL;
-    private volatile long lastRefreshStartedTimestamp = Numbers.LONG_NULL;
+    private volatile long lastRefreshFinishTimestamp = Numbers.LONG_NULL;
+    private volatile long lastRefreshStartTimestamp = Numbers.LONG_NULL;
     private volatile boolean pendingInvalidation;
     private long recordRowCopierMetadataVersion;
     private RecordToRowCopier recordToRowCopier;
@@ -141,12 +141,12 @@ public class MatViewState implements QuietCloseable {
         return lastRefreshBaseTxn;
     }
 
-    public long getLastRefreshFinishedTimestamp() {
-        return lastRefreshFinishedTimestamp;
+    public long getLastRefreshFinishTimestamp() {
+        return lastRefreshFinishTimestamp;
     }
 
-    public long getLastRefreshStartedTimestamp() {
-        return lastRefreshStartedTimestamp;
+    public long getLastRefreshStartTimestamp() {
+        return lastRefreshStartTimestamp;
     }
 
     public long getRecordRowCopierMetadataVersion() {
@@ -168,7 +168,7 @@ public class MatViewState implements QuietCloseable {
     public void initFromReader(MatViewStateReader reader) {
         this.invalid = reader.isInvalid();
         this.lastRefreshBaseTxn = reader.getLastRefreshBaseTxn();
-        this.lastRefreshFinishedTimestamp = reader.getLastRefreshTimestamp();
+        this.lastRefreshFinishTimestamp = reader.getLastRefreshTimestamp();
     }
 
     public boolean isDropped() {
@@ -210,7 +210,7 @@ public class MatViewState implements QuietCloseable {
 
     public void refreshFail(long refreshTimestamp, CharSequence errorMessage) {
         assert latch.get();
-        this.lastRefreshFinishedTimestamp = refreshTimestamp;
+        this.lastRefreshFinishTimestamp = refreshTimestamp;
         markAsInvalid(errorMessage);
         telemetryFacade.store(MAT_VIEW_REFRESH_FAIL, viewDefinition.getMatViewToken(), Numbers.LONG_NULL, errorMessage, 0);
     }
@@ -227,7 +227,7 @@ public class MatViewState implements QuietCloseable {
         this.cursorFactory = factory;
         this.recordToRowCopier = copier;
         this.recordRowCopierMetadataVersion = recordRowCopierMetadataVersion;
-        this.lastRefreshFinishedTimestamp = refreshFinishedTimestamp;
+        this.lastRefreshFinishTimestamp = refreshFinishedTimestamp;
         telemetryFacade.store(
                 MAT_VIEW_REFRESH_SUCCESS,
                 viewDefinition.getMatViewToken(),
@@ -241,12 +241,12 @@ public class MatViewState implements QuietCloseable {
         lastRefreshBaseTxn = txn;
     }
 
-    public void setLastRefreshStartedTimestamp(long ts) {
-        lastRefreshStartedTimestamp = ts;
+    public void setLastRefreshStartTimestamp(long ts) {
+        lastRefreshStartTimestamp = ts;
     }
 
     public void setLastRefreshTimestamp(long ts) {
-        this.lastRefreshFinishedTimestamp = ts;
+        this.lastRefreshFinishTimestamp = ts;
     }
 
     public void tryCloseIfDropped() {

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
@@ -171,7 +171,7 @@ public class MatViewStateStoreImpl implements MatViewStateStore {
         final AtomicLong lastNotifiedTxn = lastNotifiedTxnByTableName.get(task.baseTableToken.getTableName());
         if (lastNotifiedTxn != null && notifyOnBaseTableRefreshed(lastNotifiedTxn, seqTxn)) {
             // While refreshing more txn were committed. Refresh will need to re-run.
-            task.refreshTriggeredTimestamp = microsecondClock.getTicks();
+            task.refreshTriggerTimestamp = microsecondClock.getTicks();
             taskQueue.enqueue(task);
         }
     }
@@ -184,7 +184,7 @@ public class MatViewStateStoreImpl implements MatViewStateStore {
             // Always notify refresh job in case of mat view invalidation or full refresh.
             // For incremental refresh we check if we haven't already notified on the given txn.
             if (task.operation != MatViewRefreshTask.INCREMENTAL_REFRESH || notifyBaseTableCommit(lastNotifiedBaseTableTxn, seqTxn)) {
-                task.refreshTriggeredTimestamp = microsecondClock.getTicks();
+                task.refreshTriggerTimestamp = microsecondClock.getTicks();
                 taskQueue.enqueue(task);
                 if (task.operation == MatViewRefreshTask.INVALIDATE) {
                     LOG.error()
@@ -223,7 +223,7 @@ public class MatViewStateStoreImpl implements MatViewStateStore {
         task.operation = operation;
         task.invalidationReason = invalidationReason;
         if (operation == MatViewRefreshTask.INCREMENTAL_REFRESH || operation == MatViewRefreshTask.FULL_REFRESH) {
-            task.refreshTriggeredTimestamp = microsecondClock.getTicks();
+            task.refreshTriggerTimestamp = microsecondClock.getTicks();
         }
         taskQueue.enqueue(task);
     }

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
@@ -41,14 +41,16 @@ import io.questdb.griffin.engine.window.WindowContext;
 import io.questdb.griffin.model.IntrinsicModel;
 import io.questdb.std.Rnd;
 import io.questdb.std.Transient;
+import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Path;
+import io.questdb.std.str.Sinkable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public interface SqlExecutionContext extends Closeable {
+public interface SqlExecutionContext extends Sinkable, Closeable {
 
     void clearWindowContext();
 
@@ -232,5 +234,8 @@ public interface SqlExecutionContext extends Closeable {
     void setUseSimpleCircuitBreaker(boolean value);
 
     default void storeTelemetry(short event, short origin) {
+    }
+
+    default void toSink(@NotNull CharSink<?> sink) {
     }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContextImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContextImpl.java
@@ -42,6 +42,7 @@ import io.questdb.std.IntStack;
 import io.questdb.std.Rnd;
 import io.questdb.std.Transient;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
+import io.questdb.std.str.CharSink;
 import io.questdb.tasks.TelemetryTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -365,6 +366,11 @@ public class SqlExecutionContextImpl implements SqlExecutionContext {
     @Override
     public void storeTelemetry(short event, short origin) {
         telemetryFacade.store(event, origin);
+    }
+
+    @Override
+    public void toSink(@NotNull CharSink<?> sink) {
+        sink.putAscii("principal=").put(securityContext.getPrincipal()).putAscii(", cache=").put(isCacheHit());
     }
 
     public SqlExecutionContextImpl with(@NotNull SecurityContext securityContext, @Nullable BindVariableService bindVariableService, @Nullable Rnd rnd) {

--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -117,9 +117,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
                 log.$("fin");
             }
             log.$(" [id=").$(sqlId)
-                    .$(", sql=`").utf8(sqlText).$('`')
-                    .$(", ")
-                    .$(executionContext)
+                    .$(", sql=`").utf8(sqlText)
+                    .$("`, ").$(executionContext)
                     .$(", jit=").$(isJit)
                     .$(", time=").$(durationNanos);
 
@@ -171,8 +170,6 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             // causing log sequence leaks.
             long durationNanos =
                     executionContext.getCairoEngine().getConfiguration().getNanosecondClock().getTicks() - beginNanos;
-            CharSequence principal = executionContext.getSecurityContext().getPrincipal();
-            boolean cacheHit = executionContext.isCacheHit();
             log = LOG.errorW();
             if (leakedReadersCount > 0) {
                 log.$("brk");
@@ -187,9 +184,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
                 // We need guaranteed logging for errors, hence errorW() call.
 
                 log.$(" [id=").$(sqlId)
-                        .$(", sql=`").utf8(sqlText).$('`')
-                        .$(", ")
-                        .$(executionContext)
+                        .$(", sql=`").utf8(sqlText)
+                        .$("`, ").$(executionContext)
                         .$(", jit=").$(executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED)
                         .$(", time=").$(durationNanos)
                         .$(", msg=").$(message)
@@ -198,9 +194,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             } else {
                 // This is unknown exception, can be OOM that can cause exception in logging.
                 log.$(" [id=").$(sqlId)
-                        .$(", sql=`").utf8(sqlText).$('`')
-                        .$(", ")
-                        .$(executionContext)
+                        .$(", sql=`").utf8(sqlText)
+                        .$("`, ").$(executionContext)
                         .$(", jit=").$(executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED)
                         .$(", time=").$(durationNanos)
                         .$(", exception=").$(e);
@@ -228,9 +223,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             LOG.info()
                     .$("exe")
                     .$(" [id=").$(sqlId)
-                    .$(", sql=`").utf8(sqlText).$('`')
-                    .$(", ")
-                    .$(executionContext)
+                    .$(", sql=`").utf8(sqlText)
+                    .$("`, ").$(executionContext)
                     .$(", jit=").$(jit)
                     .I$();
         }

--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -118,8 +118,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             }
             log.$(" [id=").$(sqlId)
                     .$(", sql=`").utf8(sqlText).$('`')
-                    .$(", principal=").$(principal)
-                    .$(", cache=").$(executionContext.isCacheHit())
+                    .$(", ")
+                    .$(executionContext)
                     .$(", jit=").$(isJit)
                     .$(", time=").$(durationNanos);
 
@@ -188,8 +188,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
 
                 log.$(" [id=").$(sqlId)
                         .$(", sql=`").utf8(sqlText).$('`')
-                        .$(", principal=").$(principal)
-                        .$(", cache=").$(cacheHit)
+                        .$(", ")
+                        .$(executionContext)
                         .$(", jit=").$(executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED)
                         .$(", time=").$(durationNanos)
                         .$(", msg=").$(message)
@@ -199,8 +199,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
                 // This is unknown exception, can be OOM that can cause exception in logging.
                 log.$(" [id=").$(sqlId)
                         .$(", sql=`").utf8(sqlText).$('`')
-                        .$(", principal=").$(principal)
-                        .$(", cache=").$(cacheHit)
+                        .$(", ")
+                        .$(executionContext)
                         .$(", jit=").$(executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED)
                         .$(", time=").$(durationNanos)
                         .$(", exception=").$(e);
@@ -229,8 +229,8 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
                     .$("exe")
                     .$(" [id=").$(sqlId)
                     .$(", sql=`").utf8(sqlText).$('`')
-                    .$(", principal=").$(executionContext.getSecurityContext().getPrincipal())
-                    .$(", cache=").$(executionContext.isCacheHit())
+                    .$(", ")
+                    .$(executionContext)
                     .$(", jit=").$(jit)
                     .I$();
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -84,14 +84,14 @@ public class MatViewsFunctionFactory implements FunctionFactory {
         private static final int COLUMN_VIEW_NAME = 0;
         private static final int COLUMN_REFRESH_TYPE = COLUMN_VIEW_NAME + 1;
         private static final int COLUMN_BASE_TABLE_NAME = COLUMN_REFRESH_TYPE + 1;
-        private static final int COLUMN_LAST_REFRESH_FINISHED_TIMESTAMP = COLUMN_BASE_TABLE_NAME + 1;
-        private static final int COLUMN_VIEW_SQL = COLUMN_LAST_REFRESH_FINISHED_TIMESTAMP + 1;
+        private static final int COLUMN_LAST_REFRESH_START_TIMESTAMP = COLUMN_BASE_TABLE_NAME + 1;
+        private static final int COLUMN_LAST_REFRESH_FINISH_TIMESTAMP = COLUMN_LAST_REFRESH_START_TIMESTAMP + 1;
+        private static final int COLUMN_VIEW_SQL = COLUMN_LAST_REFRESH_FINISH_TIMESTAMP + 1;
         private static final int COLUMN_TABLE_DIR_NAME = COLUMN_VIEW_SQL + 1;
         private static final int COLUMN_INVALIDATION_REASON = COLUMN_TABLE_DIR_NAME + 1;
         private static final int COLUMN_VIEW_STATUS = COLUMN_INVALIDATION_REASON + 1;
         private static final int COLUMN_LAST_REFRESH_BASE_TABLE_TXN = COLUMN_VIEW_STATUS + 1;
         private static final int COLUMN_LAST_APPLIED_BASE_TABLE_TXN = COLUMN_LAST_REFRESH_BASE_TABLE_TXN + 1;
-        private static final int COLUMN_LAST_REFRESH_STARTED_TIMESTAMP = COLUMN_LAST_APPLIED_BASE_TABLE_TXN + 1;
         private static final RecordMetadata METADATA;
         private final ViewsListCursor cursor = new ViewsListCursor();
 
@@ -222,13 +222,13 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                 @Override
                 public long getLong(int col) {
                     switch (col) {
-                        case COLUMN_LAST_REFRESH_FINISHED_TIMESTAMP:
+                        case COLUMN_LAST_REFRESH_FINISH_TIMESTAMP:
                             return lastRefreshFinishedTimestamp;
                         case COLUMN_LAST_REFRESH_BASE_TABLE_TXN:
                             return lastRefreshTxn;
                         case COLUMN_LAST_APPLIED_BASE_TABLE_TXN:
                             return lastAppliedBaseTxn;
-                        case COLUMN_LAST_REFRESH_STARTED_TIMESTAMP:
+                        case COLUMN_LAST_REFRESH_START_TIMESTAMP:
                             return lastRefreshStartedTimestamp;
                         default:
                             return 0;
@@ -297,14 +297,14 @@ public class MatViewsFunctionFactory implements FunctionFactory {
             metadata.add(new TableColumnMetadata("view_name", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("refresh_type", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("base_table_name", ColumnType.STRING));
-            metadata.add(new TableColumnMetadata("last_refresh_finished_timestamp", ColumnType.TIMESTAMP));
+            metadata.add(new TableColumnMetadata("last_refresh_start_timestamp", ColumnType.TIMESTAMP));
+            metadata.add(new TableColumnMetadata("last_refresh_finish_timestamp", ColumnType.TIMESTAMP));
             metadata.add(new TableColumnMetadata("view_sql", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("view_table_dir_name", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("invalidation_reason", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("view_status", ColumnType.STRING));
             metadata.add(new TableColumnMetadata("refresh_base_table_txn", ColumnType.LONG));
             metadata.add(new TableColumnMetadata("base_table_txn", ColumnType.LONG));
-            metadata.add(new TableColumnMetadata("last_refresh_started_timestamp", ColumnType.TIMESTAMP));
             METADATA = metadata;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -253,7 +253,7 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                         case COLUMN_TABLE_DIR_NAME:
                             return viewDefinition.getMatViewToken().getDirName();
                         case COLUMN_VIEW_STATUS:
-                            return lastRefreshStartTimestamp > lastRefreshFinishTimestamp ? "refreshing" : invalid ? "invalid" : "valid";
+                            return getViewStatus();
                         case COLUMN_INVALIDATION_REASON:
                             return invalidationReason.length() > 0 ? invalidationReason : null;
                         default:
@@ -288,6 +288,15 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                     this.invalidationReason.clear();
                     this.invalidationReason.put(invalidationReason);
                     this.invalid = invalid;
+                }
+
+                private CharSequence getViewStatus() {
+                    if (invalid) {
+                        return "invalid";
+                    }
+                    return (lastRefreshFinishTimestamp != Numbers.LONG_NULL && lastRefreshStartTimestamp > lastRefreshFinishTimestamp)
+                            ? "refreshing"
+                            : "valid";
                 }
             }
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -175,10 +175,10 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                             final long lastAppliedBaseTxn = baseTableToken != null
                                     ? engine.getTableSequencerAPI().getTxnTracker(baseTableToken).getWriterTxn() : -1;
                             final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
-                            final long lastRefreshStartedTimestamp = state != null ? state.getLastRefreshStartTimestamp() : Numbers.LONG_NULL;
+                            final long lastRefreshStartTimestamp = state != null ? state.getLastRefreshStartTimestamp() : Numbers.LONG_NULL;
                             record.of(
                                     matViewDefinition,
-                                    lastRefreshStartedTimestamp,
+                                    lastRefreshStartTimestamp,
                                     lastRefreshTimestamp,
                                     lastRefreshedBaseTxn,
                                     lastAppliedBaseTxn,
@@ -214,22 +214,22 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                 private final StringSink invalidationReason = new StringSink();
                 private boolean invalid;
                 private long lastAppliedBaseTxn;
-                private long lastRefreshFinishedTimestamp;
-                private long lastRefreshStartedTimestamp;
+                private long lastRefreshFinishTimestamp;
+                private long lastRefreshStartTimestamp;
                 private long lastRefreshTxn;
                 private MatViewDefinition viewDefinition;
 
                 @Override
                 public long getLong(int col) {
                     switch (col) {
+                        case COLUMN_LAST_REFRESH_START_TIMESTAMP:
+                            return lastRefreshStartTimestamp;
                         case COLUMN_LAST_REFRESH_FINISH_TIMESTAMP:
-                            return lastRefreshFinishedTimestamp;
+                            return lastRefreshFinishTimestamp;
                         case COLUMN_LAST_REFRESH_BASE_TABLE_TXN:
                             return lastRefreshTxn;
                         case COLUMN_LAST_APPLIED_BASE_TABLE_TXN:
                             return lastAppliedBaseTxn;
-                        case COLUMN_LAST_REFRESH_START_TIMESTAMP:
-                            return lastRefreshStartedTimestamp;
                         default:
                             return 0;
                     }
@@ -253,7 +253,7 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                         case COLUMN_TABLE_DIR_NAME:
                             return viewDefinition.getMatViewToken().getDirName();
                         case COLUMN_VIEW_STATUS:
-                            return invalid ? "invalid" : "valid";
+                            return lastRefreshStartTimestamp > lastRefreshFinishTimestamp ? "refreshing" : invalid ? "invalid" : "valid";
                         case COLUMN_INVALIDATION_REASON:
                             return invalidationReason.length() > 0 ? invalidationReason : null;
                         default:
@@ -273,16 +273,16 @@ public class MatViewsFunctionFactory implements FunctionFactory {
 
                 public void of(
                         MatViewDefinition viewDefinition,
-                        long lastRefreshStartedTimestamp,
-                        long lastRefreshFinishedTimestamp,
+                        long lastRefreshStartTimestamp,
+                        long lastRefreshFinishTimestamp,
                         long lastRefreshTxn,
                         long lastAppliedBaseTxn,
                         CharSequence invalidationReason,
                         boolean invalid
                 ) {
                     this.viewDefinition = viewDefinition;
-                    this.lastRefreshStartedTimestamp = lastRefreshStartedTimestamp;
-                    this.lastRefreshFinishedTimestamp = lastRefreshFinishedTimestamp;
+                    this.lastRefreshStartTimestamp = lastRefreshStartTimestamp;
+                    this.lastRefreshFinishTimestamp = lastRefreshFinishTimestamp;
                     this.lastRefreshTxn = lastRefreshTxn;
                     this.lastAppliedBaseTxn = lastAppliedBaseTxn;
                     this.invalidationReason.clear();

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -175,7 +175,7 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                             final long lastAppliedBaseTxn = baseTableToken != null
                                     ? engine.getTableSequencerAPI().getTxnTracker(baseTableToken).getWriterTxn() : -1;
                             final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
-                            final long lastRefreshStartedTimestamp = state != null ? state.getLastRefreshStartedTimestamp() : Numbers.LONG_NULL;
+                            final long lastRefreshStartedTimestamp = state != null ? state.getLastRefreshStartTimestamp() : Numbers.LONG_NULL;
                             record.of(
                                     matViewDefinition,
                                     lastRefreshStartedTimestamp,

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -1399,7 +1399,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
                     );
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_MSG_TYPE);
                     block = writer.append();
-                    MatViewState.appendTs(matViewState.getLastRefreshFinishedTimestamp(), block);
+                    MatViewState.appendTs(matViewState.getLastRefreshFinishTimestamp(), block);
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_EXTRA_TS_MSG_TYPE);
                     writer.commit();
                 }
@@ -1411,7 +1411,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
 
                     assertEquals(matViewState.isInvalid(), actualState.isInvalid());
                     assertEquals(matViewState.getLastRefreshBaseTxn(), actualState.getLastRefreshBaseTxn());
-                    assertEquals(matViewState.getLastRefreshFinishedTimestamp(), actualState.getLastRefreshTimestamp());
+                    assertEquals(matViewState.getLastRefreshFinishTimestamp(), actualState.getLastRefreshTimestamp());
                     TestUtils.assertEquals(invalidationReason, actualState.getInvalidationReason());
                 }
             }
@@ -1542,7 +1542,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_MSG_TYPE);
 
                     block = writer.append();
-                    MatViewState.appendTs(matViewState.getLastRefreshFinishedTimestamp(), block);
+                    MatViewState.appendTs(matViewState.getLastRefreshFinishTimestamp(), block);
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_EXTRA_TS_MSG_TYPE);
                     writer.commit();
                 }
@@ -1554,7 +1554,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
 
                     assertEquals(matViewState.isInvalid(), actualState.isInvalid());
                     assertEquals(matViewState.getLastRefreshBaseTxn(), actualState.getLastRefreshBaseTxn());
-                    assertEquals(matViewState.getLastRefreshFinishedTimestamp(), actualState.getLastRefreshTimestamp());
+                    assertEquals(matViewState.getLastRefreshFinishTimestamp(), actualState.getLastRefreshTimestamp());
                     TestUtils.assertEquals(invalidationReason, actualState.getInvalidationReason());
                 }
             }

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -1399,7 +1399,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
                     );
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_MSG_TYPE);
                     block = writer.append();
-                    MatViewState.appendTs(matViewState.getLastRefreshTimestamp(), block);
+                    MatViewState.appendTs(matViewState.getLastRefreshFinishedTimestamp(), block);
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_EXTRA_TS_MSG_TYPE);
                     writer.commit();
                 }
@@ -1411,7 +1411,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
 
                     assertEquals(matViewState.isInvalid(), actualState.isInvalid());
                     assertEquals(matViewState.getLastRefreshBaseTxn(), actualState.getLastRefreshBaseTxn());
-                    assertEquals(matViewState.getLastRefreshTimestamp(), actualState.getLastRefreshTimestamp());
+                    assertEquals(matViewState.getLastRefreshFinishedTimestamp(), actualState.getLastRefreshTimestamp());
                     TestUtils.assertEquals(invalidationReason, actualState.getInvalidationReason());
                 }
             }
@@ -1542,7 +1542,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_MSG_TYPE);
 
                     block = writer.append();
-                    MatViewState.appendTs(matViewState.getLastRefreshTimestamp(), block);
+                    MatViewState.appendTs(matViewState.getLastRefreshFinishedTimestamp(), block);
                     block.commit(MatViewState.MAT_VIEW_STATE_FORMAT_EXTRA_TS_MSG_TYPE);
                     writer.commit();
                 }
@@ -1554,7 +1554,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
 
                     assertEquals(matViewState.isInvalid(), actualState.isInvalid());
                     assertEquals(matViewState.getLastRefreshBaseTxn(), actualState.getLastRefreshBaseTxn());
-                    assertEquals(matViewState.getLastRefreshTimestamp(), actualState.getLastRefreshTimestamp());
+                    assertEquals(matViewState.getLastRefreshFinishedTimestamp(), actualState.getLastRefreshTimestamp());
                     TestUtils.assertEquals(invalidationReason, actualState.getInvalidationReason());
                 }
             }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewStateTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewStateTest.java
@@ -59,8 +59,8 @@ public class MatViewStateTest extends AbstractCairoTest {
                 path.of(configuration.getDbRoot()).concat(tableToken).concat(MatViewState.MAT_VIEW_STATE_FILE_NAME).$();
                 assertFalse(configuration.getFilesFacade().exists(path.$()));
                 assertSql(
-                        "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                                "price_1h\tincremental\tbase_price\t\tselect sym0, last(price0) price, ts0 from (select ts as ts0, sym as sym0, price as price0 from base_price) sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
+                        "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                                "price_1h\tincremental\tbase_price\t\t\tselect sym0, last(price0) price, ts0 from (select ts as ts0, sym as sym0, price as price0 from base_price) sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
                         "select * from materialized_views()"
                 );
             }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewStateTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewStateTest.java
@@ -59,8 +59,8 @@ public class MatViewStateTest extends AbstractCairoTest {
                 path.of(configuration.getDbRoot()).concat(tableToken).concat(MatViewState.MAT_VIEW_STATE_FILE_NAME).$();
                 assertFalse(configuration.getFilesFacade().exists(path.$()));
                 assertSql(
-                        "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                                "price_1h\tincremental\tbase_price\t\tselect sym0, last(price0) price, ts0 from (select ts as ts0, sym as sym0, price as price0 from base_price) sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
+                        "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                                "price_1h\tincremental\tbase_price\t\tselect sym0, last(price0) price, ts0 from (select ts as ts0, sym as sym0, price as price0 from base_price) sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
                         "select * from materialized_views()"
                 );
             }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -511,7 +511,7 @@ public class MatViewTest extends AbstractCairoTest {
 
             assertQueryNoLeakCheck(
                     "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\n",
+                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -134,8 +134,8 @@ public class MatViewTest extends AbstractCairoTest {
             );
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -239,8 +239,8 @@ public class MatViewTest extends AbstractCairoTest {
             );
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
                     "materialized_views",
                     null,
                     false
@@ -417,8 +417,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -430,8 +430,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[-105]: table does not exist [table=base_price]\tinvalid\t1\t-1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[-105]: table does not exist [table=base_price]\tinvalid\t1\t-1\t2024-10-24T17:22:09.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -449,8 +449,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tbase table is not a WAL table\tinvalid\t1\t-1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tbase table is not a WAL table\tinvalid\t1\t-1\t2024-10-24T17:22:09.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -495,8 +495,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\t\tvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -510,8 +510,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -948,8 +948,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -965,8 +965,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -976,8 +976,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t2\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t2\t2\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1008,8 +1008,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1025,8 +1025,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1036,8 +1036,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[7]: Invalid column: sym\tinvalid\t-1\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[7]: Invalid column: sym\tinvalid\t-1\t2\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1068,8 +1068,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be invalid due to npe() in where clause.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\t2001-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1080,8 +1080,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be still invalid.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\t2001-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1104,8 +1104,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2001-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1115,8 +1115,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2001-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1127,8 +1127,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be still invalid.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[17]: Invalid column: price\tinvalid\t-1\t2\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[17]: Invalid column: price\tinvalid\t-1\t2\t2001-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1180,8 +1180,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
                     "materialized_views",
                     null,
                     false
@@ -1219,8 +1219,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -1970,8 +1970,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
                     "materialized_views",
                     null,
                     false
@@ -2531,6 +2531,8 @@ public class MatViewTest extends AbstractCairoTest {
     @Test
     public void testTimestampGetsRefreshedOnInvalidation() throws Exception {
         assertMemoryLeak(() -> {
+
+            currentMicros = parseFloorPartialTimestamp("2020-01-01T01:01:01.000000Z");
             execute(
                     "create table base_price (" +
                             "sym varchar, price double, amount int, ts timestamp" +
@@ -2554,13 +2556,12 @@ public class MatViewTest extends AbstractCairoTest {
             assertQueryNoLeakCheck(expected, viewQuery, "ts", true, true);
             assertQueryNoLeakCheck(expected, "price_1h", "ts", true, true);
 
-            currentMicros = parseFloorPartialTimestamp("2020-01-01T01:01:01.000000Z");
             execute("drop table base_price;");
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2020-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1d\tprice_1h~2\tbase table is dropped or renamed\tinvalid\t1\t-1\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2020-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1d\tprice_1h~2\tbase table is dropped or renamed\tinvalid\t1\t-1\t2020-01-01T01:01:01.000000Z\n",
                     "materialized_views",
                     null,
                     false
@@ -2764,8 +2765,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\ttable rename operation\tinvalid\t1\t3\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\ttable rename operation\tinvalid\t1\t3\t2024-10-24T19:00:00.000000Z\n",
                     "materialized_views",
                     null,
                     false

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -134,8 +134,8 @@ public class MatViewTest extends AbstractCairoTest {
             );
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -239,8 +239,8 @@ public class MatViewTest extends AbstractCairoTest {
             );
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
                     "materialized_views",
                     null,
                     false
@@ -417,8 +417,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -430,8 +430,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[-105]: table does not exist [table=base_price]\tinvalid\t1\t-1\t2024-10-24T17:22:09.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[-105]: table does not exist [table=base_price]\tinvalid\t1\t-1\n",
                     "materialized_views",
                     null,
                     false
@@ -449,8 +449,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tbase table is not a WAL table\tinvalid\t1\t-1\t2024-10-24T17:22:09.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tbase table is not a WAL table\tinvalid\t1\t-1\n",
                     "materialized_views",
                     null,
                     false
@@ -495,8 +495,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\t\tvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T17:22:09.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -510,8 +510,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\t2024-10-24T17:22:09.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T17:22:09.842574Z\t2024-10-24T18:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~3\ttable rename operation\tinvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -948,8 +948,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -965,8 +965,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -976,8 +976,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t2\t2\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t2\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -1008,8 +1008,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -1025,8 +1025,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -1036,8 +1036,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[7]: Invalid column: sym\tinvalid\t-1\t2\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[7]: Invalid column: sym\tinvalid\t-1\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -1068,8 +1068,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be invalid due to npe() in where clause.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\t2001-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -1080,8 +1080,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be still invalid.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\t2001-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price where npe() sample by 1h\tprice_1h~2\t[-1]: unexpected filter error\tinvalid\t-1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -1104,8 +1104,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2001-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -1115,8 +1115,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\t2001-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\tdrop column operation\tinvalid\t1\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -1127,8 +1127,8 @@ public class MatViewTest extends AbstractCairoTest {
 
             // The view is expected to be still invalid.
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[17]: Invalid column: price\tinvalid\t-1\t2\t2001-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2001-01-01T01:01:01.000000Z\t2001-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t[17]: Invalid column: price\tinvalid\t-1\t2\n",
                     "materialized_views",
                     null,
                     false
@@ -1180,8 +1180,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\t\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t\t\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t-1\t0\n",
                     "materialized_views",
                     null,
                     false
@@ -1219,8 +1219,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -1970,8 +1970,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\t2024-01-01T01:01:01.842574Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-01-01T01:01:01.842574Z\t2024-01-01T01:01:01.842574Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\t\tvalid\t1\t1\n",
                     "materialized_views",
                     null,
                     false
@@ -2560,8 +2560,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2020-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1d\tprice_1h~2\tbase table is dropped or renamed\tinvalid\t1\t-1\t2020-01-01T01:01:01.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2020-01-01T01:01:01.000000Z\t2020-01-01T01:01:01.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1d\tprice_1h~2\tbase table is dropped or renamed\tinvalid\t1\t-1\n",
                     "materialized_views",
                     null,
                     false
@@ -2765,8 +2765,8 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             assertQueryNoLeakCheck(
-                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_finished_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\tlast_refresh_started_timestamp\n" +
-                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\ttable rename operation\tinvalid\t1\t3\t2024-10-24T19:00:00.000000Z\n",
+                    "view_name\trefresh_type\tbase_table_name\tlast_refresh_start_timestamp\tlast_refresh_finish_timestamp\tview_sql\tview_table_dir_name\tinvalidation_reason\tview_status\trefresh_base_table_txn\tbase_table_txn\n" +
+                            "price_1h\tincremental\tbase_price\t2024-10-24T19:00:00.000000Z\t2024-10-24T19:00:00.000000Z\tselect sym, last(price) as price, ts from base_price sample by 1h\tprice_1h~2\ttable rename operation\tinvalid\t1\t3\n",
                     "materialized_views",
                     null,
                     false

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilteredRecordCursorFactoryTest.java
@@ -203,7 +203,7 @@ public class AsyncFilteredRecordCursorFactoryTest extends AbstractCairoTest {
                         String stringType = ColumnType.nameOf(ColumnType.STRING);
                         TestUtils.assertContains(e.getMessage(), "inconvertible value: `2022-03-08T18:03:57.609765Z` [" + stringType + " -> DOUBLE]");
                     }
-                }, 4, 4
+                }, 3, 3
         );
     }
 


### PR DESCRIPTION
- Add `last_refresh_started_timestamp` to the` materialized_views()` output.
- When a refresh is running, the `view_status` column in the` materialized_views()` output is set to "refreshing".
- Include `refreshMinTs` and `refreshMaxTs` from materialized view refreshes in `QueryProgress` logging.