### PR TITLE
chore(build): fix Azure Pipelines

### DIFF
--- a/ci/github-release-pipeline.yml
+++ b/ci/github-release-pipeline.yml
@@ -61,7 +61,7 @@ stages:
     jobs:
       - job: Release
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: 'ubuntu-24.04'
         steps:
           - checkout: self
             fetchDepth: 1
@@ -94,7 +94,6 @@ stages:
 
           - script: |
               sudo apt-get update
-              sudo apt-get install awscli
               cd "$(Build.SourcesDirectory)"/pkg/ami/marketplace
               make install_aws_plugin
               make build_release

--- a/ci/templates/self-hosted-jobs.yml
+++ b/ci/templates/self-hosted-jobs.yml
@@ -3,7 +3,6 @@ jobs:
     displayName: "on linux-arm64"
     pool:
       name: "arm64"
-      vmImage:
       demands:
         - Agent.Name -equals arm64-$(System.StageName)$(Build.BuildId)
     dependsOn:
@@ -28,7 +27,6 @@ jobs:
     displayName: "on linux-x64-zfs"
     pool:
       name: "amd64-zfs"
-      vmImage:
       demands:
         - Agent.Name -equals amd64-zfs-$(System.StageName)$(Build.BuildId)
     dependsOn:


### PR DESCRIPTION
We're running ubuntu-latest, which can toggle between 22.04 and 24.04. The aws package is not included in ubuntu 24.04, and even the one in 22.04 is an old cli version.

By pinning to MSFT's ubuntu 24.04 build, they include aws cli v2 so we don't run into these issues in the future.

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools

Our syntax for self-hosted runners is no longer valid, so we update that as well