### PR TITLE
fix(sql): fix string constant unescaping in JIT

### DIFF
--- a/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
+++ b/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
@@ -39,6 +39,7 @@ import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.IntervalUtils;
 import io.questdb.std.*;
 import io.questdb.std.datetime.microtime.Timestamps;
+import io.questdb.std.str.StringSink;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -105,6 +106,7 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
     private MemoryCARW memory;
     private RecordMetadata metadata;
     private PageFrameCursor pageFrameCursor;
+    private StringSink sink = new StringSink();
 
     @Override
     public void clear() {
@@ -1040,7 +1042,9 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
             if (len < 3) {
                 throw SqlException.position(position).put("unsupported symbol constant: ").put(token);
             }
-            symbol = symbol.subSequence(1, len - 1);
+            sink.clear();
+            Chars.unescape(symbol, 1, len - 1, '\'', sink);
+            symbol = sink;
         }
 
         if (predicateContext.symbolTable == null || predicateContext.symbolColumnIndex == -1) {

--- a/core/src/main/java/io/questdb/std/Chars.java
+++ b/core/src/main/java/io/questdb/std/Chars.java
@@ -675,6 +675,37 @@ public final class Chars {
         return -1;
     }
 
+    public static int indexOfIgnoreCase(@NotNull CharSequence seq, int seqLo, int seqHi, @NotNull CharSequence term) {
+        int termLen = term.length();
+        if (termLen == 0) {
+            return 0;
+        }
+
+        char first = Character.toLowerCase(term.charAt(0));
+        int max = seqHi - termLen;
+
+        for (int i = seqLo; i <= max; ++i) {
+            if (Character.toLowerCase(seq.charAt(i)) != first) {
+                do {
+                    ++i;
+                } while (i <= max && Character.toLowerCase(seq.charAt(i)) != first);
+            }
+
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + termLen - 1;
+                for (int k = 1; j < end && Character.toLowerCase(seq.charAt(j)) == Character.toLowerCase(term.charAt(k)); ++k) {
+                    ++j;
+                }
+                if (j == end) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
     // Term has to be lower-case.
     public static int indexOfLowerCase(@NotNull CharSequence seq, int seqLo, int seqHi, @NotNull CharSequence termLC) {
         int termLen = termLC.length();
@@ -696,37 +727,6 @@ public final class Chars {
                 int j = i + 1;
                 int end = j + termLen - 1;
                 for (int k = 1; j < end && Character.toLowerCase(seq.charAt(j)) == termLC.charAt(k); ++k) {
-                    ++j;
-                }
-                if (j == end) {
-                    return i;
-                }
-            }
-        }
-
-        return -1;
-    }
-
-    public static int indexOfIgnoreCase(@NotNull CharSequence seq, int seqLo, int seqHi, @NotNull CharSequence term) {
-        int termLen = term.length();
-        if (termLen == 0) {
-            return 0;
-        }
-
-        char first = Character.toLowerCase(term.charAt(0));
-        int max = seqHi - termLen;
-
-        for (int i = seqLo; i <= max; ++i) {
-            if (Character.toLowerCase(seq.charAt(i)) != first) {
-                do {
-                    ++i;
-                } while (i <= max && Character.toLowerCase(seq.charAt(i)) != first);
-            }
-
-            if (i <= max) {
-                int j = i + 1;
-                int end = j + termLen - 1;
-                for (int k = 1; j < end && Character.toLowerCase(seq.charAt(j)) == Character.toLowerCase(term.charAt(k)); ++k) {
                     ++j;
                 }
                 if (j == end) {
@@ -1145,14 +1145,7 @@ public final class Chars {
 
     public static String toString(@NotNull CharSequence cs, int start, int end, char unescape) {
         final Utf16Sink b = Misc.getThreadLocalSink();
-        final int lastChar = end - 1;
-        for (int i = start; i < end; i++) {
-            char c = cs.charAt(i);
-            b.put(c);
-            if (c == unescape && i < lastChar && cs.charAt(i + 1) == unescape) {
-                i++;
-            }
-        }
+        unescape(cs, start, end, unescape, b);
         return b.toString();
     }
 
@@ -1184,6 +1177,17 @@ public final class Chars {
         sink.clear();
         if (startIdx != endIdx) {
             sink.put(str, startIdx, endIdx + 1);
+        }
+    }
+
+    public static void unescape(@NotNull CharSequence cs, int start, int end, char unescape, @NotNull Utf16Sink sink) {
+        final int lastChar = end - 1;
+        for (int i = start; i < end; i++) {
+            char c = cs.charAt(i);
+            sink.put(c);
+            if (c == unescape && i < lastChar && cs.charAt(i + 1) == unescape) {
+                i++;
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/InTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/InTest.java
@@ -210,6 +210,23 @@ public class InTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testInSymbol_escapedConstant() throws Exception {
+        assertQuery(
+                "ts\ts\n" +
+                        "2020-01-01T00:00:00.000000Z\t1'suffix\n" +
+                        "2020-01-01T00:10:00.000000Z\t2'suffix\n" +
+                        "2020-01-01T00:20:00.000000Z\t3'suffix\n" +
+                        "2020-01-01T00:30:00.000000Z\t4'suffix\n",
+                "select * from tab WHERE s in ('1''suffix', '2''suffix', '3''suffix', '4''suffix')",
+                "create table tab as (select timestamp_sequence('2020-01-01', 10 * 60 * 1000000L) ts, concat(x::symbol, '''', 'suffix')::symbol s from long_sequence(20))" +
+                        " timestamp(ts) PARTITION BY MONTH",
+                "ts",
+                true,
+                false
+        );
+    }
+
+    @Test
     public void testInUuid_const() throws Exception {
         assertQuery(
                 "ts\tu\n" +

--- a/core/src/test/java/io/questdb/test/std/str/CharsTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/CharsTest.java
@@ -388,19 +388,6 @@ public class CharsTest {
     }
 
     @Test
-    public void testIndexOfLowerCase() {
-        Assert.assertEquals(4, Chars.indexOfLowerCase("foo bar baz", 0, 11, "bar"));
-        Assert.assertEquals(4, Chars.indexOfLowerCase("FOO BAR BAZ", 0, 11, "bar"));
-        Assert.assertEquals(4, Chars.indexOfLowerCase("foo bar baz", 0, 11, "ba"));
-        Assert.assertEquals(8, Chars.indexOfLowerCase("foo BAr BAz", 6, 11, "ba"));
-        Assert.assertEquals(1, Chars.indexOfLowerCase("foo bar baz", 0, 7, "oo"));
-        Assert.assertEquals(0, Chars.indexOfLowerCase("foo bar baz", 2, 4, ""));
-        Assert.assertEquals(-1, Chars.indexOfLowerCase("foo bar baz", 2, 4, "y"));
-        Assert.assertEquals(-1, Chars.indexOfLowerCase("", 0, 0, "oo"));
-        Assert.assertEquals(-1, Chars.indexOfLowerCase("", 0, 0, "y"));
-    }
-
-    @Test
     public void testIndexOfIgnoreCase() {
         Assert.assertEquals(4, Chars.indexOfIgnoreCase("foo bar baz", 0, 11, "bar"));
         Assert.assertEquals(4, Chars.indexOfIgnoreCase("foo bar baz", 0, 11, "BAR"));
@@ -424,6 +411,19 @@ public class CharsTest {
         Assert.assertEquals(-1, Chars.indexOfIgnoreCase("", 0, 0, "OO"));
         Assert.assertEquals(-1, Chars.indexOfIgnoreCase("", 0, 0, "y"));
         Assert.assertEquals(-1, Chars.indexOfIgnoreCase("", 0, 0, "y"));
+    }
+
+    @Test
+    public void testIndexOfLowerCase() {
+        Assert.assertEquals(4, Chars.indexOfLowerCase("foo bar baz", 0, 11, "bar"));
+        Assert.assertEquals(4, Chars.indexOfLowerCase("FOO BAR BAZ", 0, 11, "bar"));
+        Assert.assertEquals(4, Chars.indexOfLowerCase("foo bar baz", 0, 11, "ba"));
+        Assert.assertEquals(8, Chars.indexOfLowerCase("foo BAr BAz", 6, 11, "ba"));
+        Assert.assertEquals(1, Chars.indexOfLowerCase("foo bar baz", 0, 7, "oo"));
+        Assert.assertEquals(0, Chars.indexOfLowerCase("foo bar baz", 2, 4, ""));
+        Assert.assertEquals(-1, Chars.indexOfLowerCase("foo bar baz", 2, 4, "y"));
+        Assert.assertEquals(-1, Chars.indexOfLowerCase("", 0, 0, "oo"));
+        Assert.assertEquals(-1, Chars.indexOfLowerCase("", 0, 0, "y"));
     }
 
     @Test
@@ -534,6 +534,122 @@ public class CharsTest {
         // The pattern has to be lower-case.
         Assert.assertFalse(Chars.startsWithLowerCase("abc", "ABC"));
         Assert.assertFalse(Chars.startsWithLowerCase("ABC", "ABC"));
+    }
+
+    @Test
+    public void testUnescape() {
+        final StringSink sink = new StringSink();
+        final char escapeChar = '\'';
+
+        // double escape in the middle
+        final String input1 = "prefix''suffix";
+        final String expected1 = "prefix'suffix";
+        sink.clear();
+        Chars.unescape(input1, 0, input1.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 1 Failed: Double escape in middle",
+                expected1,
+                sink.toString()
+        );
+
+        // double escape at the start
+        final String input2 = "''suffix";
+        final String expected2 = "'suffix";
+        sink.clear();
+        Chars.unescape(input2, 0, input2.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 2 Failed: Double escape at start",
+                expected2,
+                sink.toString()
+        );
+
+        // double escape at the end
+        final String input3 = "prefix''";
+        final String expected3 = "prefix'";
+        sink.clear();
+        Chars.unescape(input3, 0, input3.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 3 Failed: Double escape at end",
+                expected3,
+                sink.toString()
+        );
+
+        // multiple double escapes
+        final String input4 = "a''b''c''";
+        final String expected4 = "a'b'c'";
+        sink.clear();
+        Chars.unescape(input4, 0, input4.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 4 Failed: Multiple double escapes",
+                expected4,
+                sink.toString()
+        );
+
+        // mix of single and double escapes
+        final String input5 = "a'b''c'd";
+        final String expected5 = "a'b'c'd";
+        sink.clear();
+        Chars.unescape(input5, 0, input5.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 5 Failed: Mixed single and double escapes",
+                expected5,
+                sink.toString()
+        );
+
+        // only a double escape
+        final String input6 = "''";
+        final String expected6 = "'";
+        sink.clear();
+        Chars.unescape(input6, 0, input6.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 6 Failed: Only double escape",
+                expected6,
+                sink.toString()
+        );
+
+        // no escapes
+        final String input7 = "plain string";
+        final String expected7 = "plain string";
+        sink.clear();
+        Chars.unescape(input7, 0, input7.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 7 Failed: No escapes",
+                expected7,
+                sink.toString()
+        );
+
+        // single escape not at end
+        final String input8 = "single'escape";
+        final String expected8 = "single'escape";
+        sink.clear();
+        Chars.unescape(input8, 0, input8.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 8 Failed: Single escape internal",
+                expected8,
+                sink.toString()
+        );
+
+        // single escape at end
+        final String input9 = "single'";
+        final String expected9 = "single'";
+        sink.clear();
+        Chars.unescape(input9, 0, input9.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 9 Failed: Single escape at end",
+                expected9,
+                sink.toString()
+        );
+
+        // empty input
+        final String input10 = "";
+        final String expected10 = "";
+        sink.clear();
+        Chars.unescape(input10, 0, input10.length(), escapeChar, sink);
+        Assert.assertEquals(
+                "Test Case 10 Failed: Empty input",
+                expected10,
+                sink.toString()
+        );
     }
 
     private void assertThat(String expected, ObjList<Path> list) {


### PR DESCRIPTION
resolves #5648

A note for reviewers:
I was considering using the thread-local sink, but I deemed as too risky. There is one instance of the IRSerializer per SQLCompiler, so having a separate sink is IMHO acceptable.