### PR TITLE
chore(core): fix potential crash/leak in scoreboard v2 courtesy of the column purge job

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -261,7 +261,7 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     if (ts != lastTs || task == null) {
                         if (task != null) {
                             if (taskInitialized) {
-                                columnPurgeOperator.purgeExclusive(task);
+                                columnPurgeOperator.purge(task);
                                 taskInitialized = false;
                             }
                         } else {
@@ -303,7 +303,7 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                 }
                 if (task != null) {
                     if (taskInitialized) {
-                        columnPurgeOperator.purgeExclusive(task);
+                        columnPurgeOperator.purge(task);
                     }
                     taskPool.push(task);
                 }

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeJob.java
@@ -119,7 +119,12 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
             }
 
             this.writer = engine.getWriter(tableToken, "QuestDB system");
-            this.columnPurgeOperator = new ColumnPurgeOperator(engine, this.writer, "completed");
+            this.columnPurgeOperator = new ColumnPurgeOperator(
+                    engine,
+                    this.writer,
+                    "completed",
+                    ColumnPurgeOperator.ScoreboardUseMode.BAU_QUEUE_PROCESSING
+            );
             this.checkpointStatus = engine.getCheckpointStatus();
             processTableRecords(engine);
         } catch (Throwable th) {
@@ -221,8 +226,8 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
                     .$(tableToken.getTableName())
                     .$("\" WHERE completed = null")
                     .compile(sqlExecutionContext).getRecordCursorFactory();
-        } catch (SqlException e) {
-            LOG.error().$("failed to reload column version purge tasks").$((Throwable) e).$();
+        } catch (Throwable e) {
+            LOG.error().$("failed to reload column version purge tasks").$(e).$();
             return;
         }
 
@@ -231,7 +236,18 @@ public class ColumnPurgeJob extends SynchronizedJob implements Closeable {
             assert recordCursorFactory.supportsUpdateRowId(tableToken);
             int count = 0;
 
-            try (RecordCursor records = recordCursorFactory.getCursor(sqlExecutionContext)) {
+            try (
+                    RecordCursor records = recordCursorFactory.getCursor(sqlExecutionContext);
+                    // this is a startup-only activity where we purge columns from the log table
+                    // to ensure purge operator does not have to deal with the complexity of switching operating
+                    // modes dynamically, we create a new instance specifically for startup.
+                    ColumnPurgeOperator columnPurgeOperator = new ColumnPurgeOperator(
+                            engine,
+                            this.writer,
+                            "completed",
+                            ColumnPurgeOperator.ScoreboardUseMode.STARTUP_ONLY
+                    )
+            ) {
                 Record rec = records.getRecord();
                 long lastTs = 0;
                 ColumnPurgeRetryTask task = null;

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
@@ -188,7 +188,7 @@ public class ColumnPurgeOperator implements Closeable {
 
     private boolean openScoreboardAndTxn(ColumnPurgeTask task, ScoreboardUseMode scoreboardUseMode) {
         if (scoreboardUseMode == ScoreboardUseMode.INTERNAL) {
-            Misc.free(txnScoreboard);
+            txnScoreboard = Misc.free(txnScoreboard);
             txnScoreboard = engine.getTxnScoreboard(task.getTableName());
         }
 
@@ -370,7 +370,11 @@ public class ColumnPurgeOperator implements Closeable {
         } finally {
             if (scoreboardMode != ScoreboardUseMode.EXTERNAL) {
                 txnScoreboard = Misc.free(txnScoreboard);
-                Misc.free(txReader);
+                txReader = Misc.free(txReader);
+            } else {
+                // even though we take these things from the reader, we must not re-use them on the next run
+                txnScoreboard = null;
+                txReader = null;
             }
         }
 

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
@@ -37,6 +37,7 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
 import io.questdb.tasks.ColumnPurgeTask;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.Closeable;
 
@@ -115,41 +116,22 @@ public class ColumnPurgeOperator implements Closeable {
         txnScoreboard = Misc.free(txnScoreboard);
     }
 
-    public boolean purge(ColumnPurgeTask task) {
+    public boolean purge(@NotNull ColumnPurgeTask task) {
         assert task.getTableName() != null;
-        try {
-            boolean done = purge0(task);
+        assert scoreboardUseMode != ScoreboardUseMode.VACUUM_TABLE;
+        boolean done = purge0(task);
+        if (done && scoreboardUseMode == ScoreboardUseMode.BAU_QUEUE_PROCESSING) {
             setCompletionTimestamp(completedRowIds, microClock.getTicks());
-            return done;
-        } catch (Throwable ex) {
-            // Can be some IO exception
-            LOG.error().$("could not purge").$(ex).$();
-            return false;
         }
+        return done;
     }
 
-    public boolean purge(ColumnPurgeTask task, TableReader tableReader) {
+    public boolean purge(@NotNull ColumnPurgeTask task, @NotNull TableReader tableReader) {
         assert task.getTableName() != null;
         assert scoreboardUseMode == ScoreboardUseMode.VACUUM_TABLE;
-        try {
-            txReader = tableReader.getTxFile();
-            txnScoreboard = tableReader.getTxnScoreboard();
-            return purge0(task);
-        } catch (Throwable ex) {
-            // Can be some IO exception
-            LOG.error().$("could not purge").$(ex).$();
-            return false;
-        }
-    }
-
-    public void purgeExclusive(ColumnPurgeTask task) {
-        assert task.getTableName() != null;
-        try {
-            purge0(task);
-        } catch (Throwable ex) {
-            // Can be some IO exception
-            LOG.error().$("could not purge").$(ex).$();
-        }
+        txReader = tableReader.getTxFile();
+        txnScoreboard = tableReader.getTxnScoreboard();
+        return purge0(task);
     }
 
     private static boolean couldNotRemove(FilesFacade ff, LPSZ path) {
@@ -217,171 +199,177 @@ public class ColumnPurgeOperator implements Closeable {
     }
 
     private boolean purge0(ColumnPurgeTask task) {
-        setTablePath(task.getTableName());
-        final LongList updatedColumnInfo = task.getUpdatedColumnInfo();
-        long minUnlockedTxnRangeStarts = Long.MAX_VALUE;
-        boolean allDone = true;
-        boolean setupScoreboard = scoreboardUseMode != ScoreboardUseMode.VACUUM_TABLE;
-
         try {
-            completedRowIds.clear();
-            for (int i = 0, n = updatedColumnInfo.size(); i < n; i += ColumnPurgeTask.BLOCK_SIZE) {
-                final long columnVersion = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_COLUMN_VERSION);
-                final long partitionTimestamp = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_PARTITION_TIMESTAMP);
-                final long partitionTxnName = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_PARTITION_NAME_TXN);
-                final long updateRowId = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_UPDATE_ROW_ID);
-                int columnTypeRaw = task.getColumnType();
-                int columnType = Math.abs(columnTypeRaw);
-                // We don't know the type of the column, the files are found on the disk, but column
-                // does not exist in the table metadata (e.g., column was dropped)
-                boolean columnTypeRogue = columnTypeRaw == ColumnType.UNDEFINED;
-                boolean isSymbolRootFiles = (ColumnType.isSymbol(columnType) || columnTypeRogue)
-                        && partitionTimestamp == PurgingOperator.TABLE_ROOT_PARTITION;
+            setTablePath(task.getTableName());
+            final LongList updatedColumnInfo = task.getUpdatedColumnInfo();
+            long minUnlockedTxnRangeStarts = Long.MAX_VALUE;
+            boolean allDone = true;
+            boolean setupScoreboard = scoreboardUseMode != ScoreboardUseMode.VACUUM_TABLE;
 
-                int pathTrimToPartition;
-                CharSequence columnName = task.getColumnName();
-                if (!isSymbolRootFiles) {
-                    setUpPartitionPath(task.getPartitionBy(), partitionTimestamp, partitionTxnName);
-                    pathTrimToPartition = path.size();
-                    TableUtils.dFile(path, columnName, columnVersion);
-                } else {
-                    path.trimTo(pathTableLen);
-                    pathTrimToPartition = path.size();
-                    TableUtils.charFileName(path, columnName, columnVersion);
-                }
+            try {
+                completedRowIds.clear();
+                for (int i = 0, n = updatedColumnInfo.size(); i < n; i += ColumnPurgeTask.BLOCK_SIZE) {
+                    final long columnVersion = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_COLUMN_VERSION);
+                    final long partitionTimestamp = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_PARTITION_TIMESTAMP);
+                    final long partitionTxnName = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_PARTITION_NAME_TXN);
+                    final long updateRowId = updatedColumnInfo.getQuick(i + ColumnPurgeTask.OFFSET_UPDATE_ROW_ID);
+                    int columnTypeRaw = task.getColumnType();
+                    int columnType = Math.abs(columnTypeRaw);
+                    // We don't know the type of the column, the files are found on the disk, but column
+                    // does not exist in the table metadata (e.g., column was dropped)
+                    boolean columnTypeRogue = columnTypeRaw == ColumnType.UNDEFINED;
+                    boolean isSymbolRootFiles = (ColumnType.isSymbol(columnType) || columnTypeRogue)
+                            && partitionTimestamp == PurgingOperator.TABLE_ROOT_PARTITION;
 
-                // perform existence check ahead of trying to remove files
-                if (!ff.exists(path.$()) && !columnTypeRogue) {
-                    if (ColumnType.isVarSize(columnType)) {
-                        path.trimTo(pathTrimToPartition);
-                        if (!ff.exists(TableUtils.iFile(path, columnName, columnVersion))) {
+                    int pathTrimToPartition;
+                    CharSequence columnName = task.getColumnName();
+                    if (!isSymbolRootFiles) {
+                        setUpPartitionPath(task.getPartitionBy(), partitionTimestamp, partitionTxnName);
+                        pathTrimToPartition = path.size();
+                        TableUtils.dFile(path, columnName, columnVersion);
+                    } else {
+                        path.trimTo(pathTableLen);
+                        pathTrimToPartition = path.size();
+                        TableUtils.charFileName(path, columnName, columnVersion);
+                    }
+
+                    // perform existence check ahead of trying to remove files
+                    if (!ff.exists(path.$()) && !columnTypeRogue) {
+                        if (ColumnType.isVarSize(columnType)) {
+                            path.trimTo(pathTrimToPartition);
+                            if (!ff.exists(TableUtils.iFile(path, columnName, columnVersion))) {
+                                completedRowIds.add(updateRowId);
+                                continue;
+                            }
+                        } else if (ColumnType.isSymbol(columnType)) {
+                            // In the case of symbol root files, we need to check if .k and .v files exist in table root.
+                            // In the case of symbol files in partition, we need to check if .k and .v files exist in partition
+                            // that can be index files after index drop SQL.
+                            if (!ff.exists(TableUtils.offsetFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
+                                if (!ff.exists(BitmapIndexUtils.keyFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
+                                    if (!ff.exists(BitmapIndexUtils.valueFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
+                                        completedRowIds.add(updateRowId);
+                                        continue;
+                                    }
+                                }
+                            }
+                        } else {
+                            // Files already deleted, move to the next partition
                             completedRowIds.add(updateRowId);
                             continue;
                         }
-                    } else if (ColumnType.isSymbol(columnType)) {
-                        // In the case of symbol root files, we need to check if .k and .v files exist in table root.
-                        // In the case of symbol files in partition, we need to check if .k and .v files exist in partition
-                        // that can be index files after index drop SQL.
-                        if (!ff.exists(TableUtils.offsetFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
-                            if (!ff.exists(BitmapIndexUtils.keyFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
-                                if (!ff.exists(BitmapIndexUtils.valueFileName(path.trimTo(pathTrimToPartition), columnName, columnVersion))) {
-                                    completedRowIds.add(updateRowId);
-                                    continue;
-                                }
-                            }
+                    }
+
+                    if (setupScoreboard) {
+                        // Setup scoreboard lazily because columns we're purging
+                        // may not exist, including the entire table. Setting up
+                        // scoreboard ahead of checking file existence would fail in those
+                        // cases.
+                        if (!openScoreboardAndTxn(task)) {
+                            // the current table state precludes us from purging its columns
+                            // nothing to do here
+                            completedRowIds.add(updateRowId);
+                            continue;
                         }
-                    } else {
-                        // Files already deleted, move to the next partition
+                        // we would have mutated the path by checking the state of the table
+                        // we will have to re-set up that
+                        if (!isSymbolRootFiles) {
+                            setUpPartitionPath(task.getPartitionBy(), partitionTimestamp, partitionTxnName);
+                        } else {
+                            path.trimTo(pathTableLen);
+                        }
+                        pathTrimToPartition = path.size();
+                        TableUtils.dFile(path, columnName, columnVersion);
+                        setupScoreboard = false;
+                    }
+
+                    if (txReader.isPartitionReadOnlyByPartitionTimestamp(partitionTimestamp)) {
+                        // txReader is either open because scoreboardMode == ScoreboardUseMode.EXTERNAL,
+                        // or it was open by openScoreboardAndTxn
+                        LOG.info().$("skipping purge of read-only partition [path=").$(path.$())
+                                .$(", column=").utf8(columnName)
+                                .I$();
                         completedRowIds.add(updateRowId);
                         continue;
                     }
-                }
 
-                if (setupScoreboard) {
-                    // Setup scoreboard lazily because columns we're purging
-                    // may not exist, including the entire table. Setting up
-                    // scoreboard ahead of checking file existence would fail in those
-                    // cases.
-                    if (!openScoreboardAndTxn(task)) {
-                        // the current table state precludes us from purging its columns
-                        // nothing to do here
-                        completedRowIds.add(updateRowId);
-                        continue;
+                    if (columnVersion < minUnlockedTxnRangeStarts) {
+                        if (scoreboardUseMode != ScoreboardUseMode.STARTUP_ONLY && checkScoreboardHasReadersBeforeUpdate(columnVersion, task)) {
+                            // Reader lock still exists
+                            allDone = false;
+                            LOG.debug().$("cannot purge, version is in use [path=").$(path).I$();
+                            continue;
+                        } else {
+                            minUnlockedTxnRangeStarts = columnVersion;
+                        }
                     }
-                    // we would have mutated the path by checking the state of the table
-                    // we will have to re-set up that
-                    if (!isSymbolRootFiles) {
-                        setUpPartitionPath(task.getPartitionBy(), partitionTimestamp, partitionTxnName);
-                    } else {
-                        path.trimTo(pathTableLen);
-                    }
-                    pathTrimToPartition = path.size();
-                    TableUtils.dFile(path, columnName, columnVersion);
-                    setupScoreboard = false;
-                }
 
-                if (txReader.isPartitionReadOnlyByPartitionTimestamp(partitionTimestamp)) {
-                    // txReader is either open because scoreboardMode == ScoreboardUseMode.EXTERNAL,
-                    // or it was open by openScoreboardAndTxn
-                    LOG.info().$("skipping purge of read-only partition [path=").$(path.$())
-                            .$(", column=").utf8(columnName)
-                            .I$();
-                    completedRowIds.add(updateRowId);
-                    continue;
-                }
+                    LOG.info().$("purging [path=").$(path).I$();
 
-                if (columnVersion < minUnlockedTxnRangeStarts) {
-                    if (scoreboardUseMode != ScoreboardUseMode.STARTUP_ONLY && checkScoreboardHasReadersBeforeUpdate(columnVersion, task)) {
-                        // Reader lock still exists
-                        allDone = false;
-                        LOG.debug().$("cannot purge, version is in use [path=").$(path).I$();
-                        continue;
-                    } else {
-                        minUnlockedTxnRangeStarts = columnVersion;
-                    }
-                }
-
-                LOG.info().$("purging [path=").$(path).I$();
-
-                // No readers looking at the column version, files can be deleted
-                if (couldNotRemove(ff, path.$())) {
-                    allDone = false;
-                    continue;
-                }
-
-                if (ColumnType.isVarSize(columnType) || columnTypeRogue) {
-                    path.trimTo(pathTrimToPartition);
-                    TableUtils.iFile(path, columnName, columnVersion);
-
+                    // No readers looking at the column version, files can be deleted
                     if (couldNotRemove(ff, path.$())) {
                         allDone = false;
                         continue;
                     }
-                }
 
-                // Check if it's a symbol, try to remove .k and .v files in the partition
-                if (ColumnType.isSymbol(columnType) || columnTypeRogue) {
-                    if (isSymbolRootFiles) {
+                    if (ColumnType.isVarSize(columnType) || columnTypeRogue) {
                         path.trimTo(pathTrimToPartition);
-                        if (couldNotRemove(ff, TableUtils.charFileName(path, columnName, columnVersion))) {
-                            allDone = false;
-                            continue;
-                        }
+                        TableUtils.iFile(path, columnName, columnVersion);
 
-                        path.trimTo(pathTrimToPartition);
-                        if (couldNotRemove(ff, TableUtils.offsetFileName(path, columnName, columnVersion))) {
+                        if (couldNotRemove(ff, path.$())) {
                             allDone = false;
                             continue;
                         }
                     }
 
-                    path.trimTo(pathTrimToPartition);
-                    if (couldNotRemove(ff, BitmapIndexUtils.keyFileName(path, columnName, columnVersion))) {
-                        allDone = false;
-                        continue;
-                    }
+                    // Check if it's a symbol, try to remove .k and .v files in the partition
+                    if (ColumnType.isSymbol(columnType) || columnTypeRogue) {
+                        if (isSymbolRootFiles) {
+                            path.trimTo(pathTrimToPartition);
+                            if (couldNotRemove(ff, TableUtils.charFileName(path, columnName, columnVersion))) {
+                                allDone = false;
+                                continue;
+                            }
 
-                    path.trimTo(pathTrimToPartition);
-                    if (couldNotRemove(ff, BitmapIndexUtils.valueFileName(path, columnName, columnVersion))) {
-                        allDone = false;
-                        continue;
+                            path.trimTo(pathTrimToPartition);
+                            if (couldNotRemove(ff, TableUtils.offsetFileName(path, columnName, columnVersion))) {
+                                allDone = false;
+                                continue;
+                            }
+                        }
+
+                        path.trimTo(pathTrimToPartition);
+                        if (couldNotRemove(ff, BitmapIndexUtils.keyFileName(path, columnName, columnVersion))) {
+                            allDone = false;
+                            continue;
+                        }
+
+                        path.trimTo(pathTrimToPartition);
+                        if (couldNotRemove(ff, BitmapIndexUtils.valueFileName(path, columnName, columnVersion))) {
+                            allDone = false;
+                            continue;
+                        }
                     }
+                    completedRowIds.add(updateRowId);
                 }
-                completedRowIds.add(updateRowId);
+            } finally {
+                if (scoreboardUseMode != ScoreboardUseMode.VACUUM_TABLE) {
+                    txnScoreboard = Misc.free(txnScoreboard);
+                    // txReader is a reusable object, do not NULL it
+                    Misc.free(txReader);
+                } else {
+                    // even though we take these things from the reader, we must not re-use them on the next run
+                    txnScoreboard = null;
+                    txReader = null;
+                }
             }
-        } finally {
-            if (scoreboardUseMode != ScoreboardUseMode.VACUUM_TABLE) {
-                txnScoreboard = Misc.free(txnScoreboard);
-                // txReader is a reusable object, do not NULL it
-                Misc.free(txReader);
-            } else {
-                // even though we take these things from the reader, we must not re-use them on the next run
-                txnScoreboard = null;
-                txReader = null;
-            }
+
+            return allDone;
+        } catch (Throwable e) {
+            // Can be some IO exception
+            LOG.error().$("could not purge [ex=`").$(e).$("`]").$();
+            return false;
         }
-
-        return allDone;
     }
 
     private int readTableId(Path path) {

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -56,7 +56,6 @@ import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
 import io.questdb.cairo.wal.ApplyWal2TableJob;
-import io.questdb.cairo.wal.WalPurgeJob;
 import io.questdb.cairo.wal.WalUtils;
 import io.questdb.cairo.wal.WalWriter;
 import io.questdb.griffin.CompiledQuery;
@@ -1348,6 +1347,10 @@ public abstract class AbstractCairoTest extends AbstractTest {
         return createWalApplyJob(engine);
     }
 
+    protected static void drainPurgeJob() {
+        TestUtils.drainPurgeJob(engine);
+    }
+
     protected static void drainWalAndMatViewQueues() {
         drainWalAndMatViewQueues(engine);
     }
@@ -1582,17 +1585,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
             replicate(tableName, walName, node1, node);
             drainWalQueue(node);
         }
-    }
-
-    protected static void runWalPurgeJob(FilesFacade ff) {
-        try (WalPurgeJob job = new WalPurgeJob(engine, ff, engine.getConfiguration().getMicrosecondClock())) {
-            engine.setWalPurgeJobRunLock(job.getRunLock());
-            job.drain(0);
-        }
-    }
-
-    protected static void runWalPurgeJob() {
-        runWalPurgeJob(engine.getConfiguration().getFilesFacade());
     }
 
     protected static RecordCursorFactory select(CharSequence selectSql, SqlExecutionContext sqlExecutionContext) throws SqlException {

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -303,7 +303,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             drainWalQueue();
 
             engine.releaseInactive();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             drainWalQueue();
 
@@ -665,7 +665,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             engine.reconcileTableNameRegistryState();
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             createTableWal("tab1");
 

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
@@ -137,7 +137,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
             execute("insert batch 2 into chunk_seq \n" +
                     "  select x, timestamp_sequence('2024-01-01', 312312) from long_sequence(1000)");
 
-            runWalPurgeJob();
+            drainPurgeJob();
 
             int expectedTxnCount = 500;
             assertSql("count\n" +
@@ -148,7 +148,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
             assertSql("count\n" +
                     expectedTxnCount + "\n", "select count(*) from wal_transactions('chunk_seq')");
 
-            runWalPurgeJob();
+            drainPurgeJob();
 
             assertSql("count\n" +
                     (expectedTxnCount - (expectedTxnCount - 1) / chunkSize * chunkSize) + "\n", "select count(*) from wal_transactions('chunk_seq')");

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -1843,7 +1843,7 @@ public class CreateMatViewTest extends AbstractCairoTest {
         drainWalAndMatViewQueues();
         // purge job may create MatViewRefreshList for existing tables by calling engine.getDependentMatViews();
         // this affects refresh logic in some scenarios, so make sure to run it
-        runWalPurgeJob();
+        drainPurgeJob();
     }
 
     private void testCreateMatViewNoPartitionBy(boolean useParentheses) throws Exception {

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -592,7 +592,7 @@ public class MatViewTest extends AbstractCairoTest {
                 Assert.assertTrue(Utf8s.toString(path), Files.exists(path.$()));
 
                 engine.releaseInactiveTableSequencers();
-                runWalPurgeJob();
+                drainPurgeJob();
 
                 Assert.assertFalse(Utf8s.toString(path), Files.exists(path.$()));
             }
@@ -2644,7 +2644,7 @@ public class MatViewTest extends AbstractCairoTest {
         drainWalAndMatViewQueues();
         // purge job may create MatViewRefreshList for existing tables by calling engine.getDependentMatViews();
         // this affects refresh logic in some scenarios, so make sure to run it
-        runWalPurgeJob();
+        drainPurgeJob();
     }
 
     private void dropMatView() throws SqlException {

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
@@ -1160,12 +1160,12 @@ public class WalTableSqlTest extends AbstractCairoTest {
             engine.reloadTableNames(convertedTables);
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             engine.releaseInactive();
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             checkTableFilesExist(sysTableName1, "2022-02-24", "sym.d", false);
         });
@@ -1201,12 +1201,12 @@ public class WalTableSqlTest extends AbstractCairoTest {
             pretendNotExist.set(Path.getThreadLocal(root).concat(sysTableName1).toString());
             engine.reloadTableNames();
 
-            runWalPurgeJob();
+            drainPurgeJob();
 
             engine.reloadTableNames();
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             checkTableFilesExist(sysTableName1, "2022-02-24", "sym.d", false);
         });
@@ -1243,10 +1243,10 @@ public class WalTableSqlTest extends AbstractCairoTest {
             pretendNotExist.set(Path.getThreadLocal(root).concat(sysTableName1).slash$().toString());
             engine.reloadTableNames();
 
-            runWalPurgeJob();
+            drainPurgeJob();
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             checkTableFilesExist(sysTableName1, "2022-02-24", "sym.d", false);
         });
@@ -2164,7 +2164,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
             execute("drop table " + tableName + "2");
             engine.releaseInactive();
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
             checkTableFilesExist(sysTableName2, "2022-02-24", "sym.d", false);
 
             // Mark table1 as deleted
@@ -2187,7 +2187,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
             engine.releaseInactive();
 
             drainWalQueue();
-            runWalPurgeJob();
+            drainPurgeJob();
 
             checkTableFilesExist(sysTableName1, "2022-02-24", "sym.d", false);
         });

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -1879,7 +1879,7 @@ public class WalWriterTest extends AbstractCairoTest {
                 assertSegmentLockEngagement(false, tableName, 1, 0);
 
                 drainWalQueue();
-                runWalPurgeJob();
+                drainPurgeJob();
 
                 assertSegmentExistence(false, tableName, 1, 0);
             }
@@ -2339,16 +2339,12 @@ public class WalWriterTest extends AbstractCairoTest {
 
     @Test
     public void testReadMatViewStateV1() throws Exception {
-        assertMemoryLeak(() -> {
-            testReadMatViewState(0);
-        });
+        assertMemoryLeak(() -> testReadMatViewState(0));
     }
 
     @Test
     public void testReadMatViewStateV2() throws Exception {
-        assertMemoryLeak(() -> {
-            testReadMatViewState(2);
-        });
+        assertMemoryLeak(() -> testReadMatViewState(2));
     }
 
     @Test
@@ -3856,6 +3852,7 @@ public class WalWriterTest extends AbstractCairoTest {
                         return true;
                     }
 
+                    @SuppressWarnings("ResultOfMethodCallIgnored")
                     @Override
                     public void rollbackDirectory(Path path) {
                         final File segmentDirFile = new File(path.toString());

--- a/core/src/test/java/io/questdb/test/cutlass/http/ScoreboardHandlingTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ScoreboardHandlingTest.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.http;
+
+import io.questdb.PropertyKey;
+import io.questdb.ServerMain;
+import io.questdb.std.Files;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractBootstrapTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static io.questdb.test.tools.TestUtils.*;
+
+public class ScoreboardHandlingTest extends AbstractBootstrapTest {
+
+    static String backupRoot;
+
+    @BeforeClass
+    public static void setUpStatic() throws Exception {
+        AbstractBootstrapTest.setUpStatic();
+        unchecked(() -> {
+            backupRoot = temp.newFolder("backups").getAbsolutePath();
+        });
+    }
+
+    @Test
+    public void testPermissionsAreUpdatedWhenColumnIsRenamed() throws Exception {
+
+        createDummyConfiguration();
+        assertMemoryLeak(() -> {
+            try (
+                    ServerMain main = startWithEnvVariables(
+                            PropertyKey.DEV_MODE_ENABLED.getEnvVarName(), "true",
+                            PropertyKey.CAIRO_SQL_BACKUP_ROOT.getEnvVarName(), backupRoot
+
+                    );
+                    TestHttpClient httpClient = new TestHttpClient()
+            ) {
+                TestUtils.executeSQLViaPostgres(
+                        main.getConfiguration().getPGWireConfiguration().getDefaultUsername(),
+                        main.getConfiguration().getPGWireConfiguration().getDefaultPassword(),
+                        main.getPgWireServerPort(),
+                        "create table trades(ts timestamp, ticker symbol index, value double) timestamp(ts) partition by day wal"
+                );
+
+                exec(
+                        httpClient,
+                        main,
+                        "{\"query\":\"select ticker from trades\",\"columns\":[{\"name\":\"ticker\",\"type\":\"SYMBOL\"}],\"timestamp\":-1,\"dataset\":[],\"count\":0}",
+                        "select ticker from trades"
+                );
+
+                dml(httpClient, main, "insert into trades values ('2023-07-01T00:00:00.000000', 'ABC', 1.0)");
+                dml(httpClient, main, "insert into trades values ('2023-07-02T00:00:00.000000', 'DEF', 2.0)");
+
+                // this is a bad naming schema: "updated" is a txn, not the number of updated rows
+                exec(
+                        httpClient,
+                        main,
+                        "{\"dml\":\"OK\",\"updated\":3}",
+                        "update trades set value = value + 1 where ticker = 'ABC'"
+                );
+
+                ddl(httpClient, main, "rename table trades to old_trades");
+                ddl(httpClient, main, "alter table old_trades set param maxUncommittedRows =  100000");
+                ddl(httpClient, main, "alter table old_trades set type wal");
+                ddl(httpClient, main, "alter table old_trades set type bypass wal");
+                ddl(httpClient, main, "alter table old_trades set type wal");
+                ddl(httpClient, main, "alter table old_trades suspend wal");
+                ddl(httpClient, main, "alter table old_trades resume wal");
+                ddl(httpClient, main, "alter table old_trades detach partition list '2023-07-01'");
+
+                Files.rename(
+                        Path.getThreadLocal(root).concat("db").concat("old_trades").concat("2023-07-01.detached").$(),
+                        Path.getThreadLocal2(root).concat("db").concat("old_trades").concat("2023-07-01.attachable").$()
+                );
+
+                ddl(httpClient, main, "alter table old_trades attach partition list '2023-07-01'");
+                ddl(httpClient, main, "alter table old_trades drop partition list '2023-07-01'");
+                ddl(httpClient, main, "backup table old_trades");
+
+                exec(
+                        httpClient,
+                        main,
+                        "{\"query\":\"select * from old_trades where ts in '2022'\",\"columns\":[{\"name\":\"ts\",\"type\":\"TIMESTAMP\"},{\"name\":\"ticker\",\"type\":\"SYMBOL\"},{\"name\":\"value\",\"type\":\"DOUBLE\"}],\"timestamp\":0,\"dataset\":[],\"count\":0}",
+                        "select * from old_trades where ts in '2022'"
+                );
+
+                dml(httpClient, main, "insert into old_trades values ('2023-07-09T00:00:00.000000', 'ABC', 1.0)");
+                exec(httpClient, main, "{\"dml\":\"OK\",\"updated\":10}", "update old_trades set value = value + 1 where ticker = 'ABC'");
+                ddl(httpClient, main, "truncate table old_trades");
+                ddl(httpClient, main, "vacuum table old_trades");
+                ddl(httpClient, main, "alter table old_trades alter column ticker drop index");
+                ddl(httpClient, main, "alter table old_trades alter column ticker add index");
+                ddl(httpClient, main, "alter table old_trades alter column ticker nocache");
+                ddl(httpClient, main, "alter table old_trades alter column ticker cache");
+                ddl(httpClient, main, "alter table old_trades rename column ticker to sym");
+                ddl(httpClient, main, "alter table old_trades drop column sym");
+                ddl(httpClient, main, "alter table old_trades add column currency symbol");
+                assertEventually(() -> ddl(httpClient, main, "rename table old_trades to older_trades"));
+                ddl(httpClient, main, "drop table older_trades");
+                TestUtils.executeSQLViaPostgres(
+                        main.getConfiguration().getPGWireConfiguration().getDefaultUsername(),
+                        main.getConfiguration().getPGWireConfiguration().getDefaultPassword(),
+                        main.getPgWireServerPort(),
+                        "create table trades (ticker symbol)"
+                );
+            }
+        });
+    }
+
+    private static void ddl(TestHttpClient httpClient, ServerMain main, String sql) {
+        httpClient.assertGet(
+                "/exec",
+                "{\"ddl\":\"OK\"}",
+                sql,
+                "localhost",
+                main.getHttpServerPort(),
+                null,
+                null,
+                null
+        );
+    }
+
+    private static void dml(TestHttpClient httpClient, ServerMain main, String sql) {
+        httpClient.assertGet(
+                "/exec",
+                "{\"dml\":\"OK\"}",
+                sql,
+                "localhost",
+                main.getHttpServerPort(),
+                null,
+                null,
+                null
+        );
+    }
+
+    private static void exec(TestHttpClient httpClient, ServerMain main, String expectedResponse, String sql) {
+        httpClient.assertGet(
+                "/exec",
+                expectedResponse,
+                sql,
+                "localhost",
+                main.getHttpServerPort(),
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/http/ScoreboardHandlingTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ScoreboardHandlingTest.java
@@ -48,8 +48,7 @@ public class ScoreboardHandlingTest extends AbstractBootstrapTest {
     }
 
     @Test
-    public void testPermissionsAreUpdatedWhenColumnIsRenamed() throws Exception {
-
+    public void testVacuumRerunOnWindows() throws Exception {
         createDummyConfiguration();
         assertMemoryLeak(() -> {
             try (

--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -116,10 +116,15 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -1214,9 +1219,13 @@ public final class TestUtils {
     }
 
     public static void drainPurgeJob(CairoEngine engine) {
+        drainPurgeJob(engine, engine.getConfiguration().getFilesFacade());
+    }
+
+    public static void drainPurgeJob(CairoEngine engine, FilesFacade filesFacade) {
         try (WalPurgeJob job = new WalPurgeJob(
                 engine,
-                engine.getConfiguration().getFilesFacade(),
+                filesFacade,
                 engine.getConfiguration().getMicrosecondClock()
         )) {
             engine.setWalPurgeJobRunLock(job.getRunLock());
@@ -1298,6 +1307,23 @@ public final class TestUtils {
         }
     }
 
+    public static void execute(Connection conn, String sql, String... bindVars) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            for (int i = 0; i < bindVars.length; i++) {
+                stmt.setString(i + 1, bindVars[i]);
+            }
+            stmt.execute();
+        }
+    }
+
+    public static void executeSQLViaPostgres(String username, String password, int pgPort, String... sqls) throws SQLException {
+        try (final Connection connection = getConnectionForUser(username, password, pgPort)) {
+            for (String sql : sqls) {
+                execute(connection, sql);
+            }
+        }
+    }
+
     @NotNull
     public static Rnd generateRandom(Log log) {
         return generateRandom(log, System.nanoTime(), System.currentTimeMillis());
@@ -1332,6 +1358,10 @@ public final class TestUtils {
             }
         }
         return Integer.parseInt(version);
+    }
+
+    public static String getPgConnectionUri(int pgPort) {
+        return "jdbc:postgresql://127.0.0.1:" + pgPort + "/qdb";
     }
 
     public static String getResourcePath(String resourceName) {
@@ -2137,6 +2167,13 @@ public final class TestUtils {
                     return i + 1;
                 }
         );
+    }
+
+    static Connection getConnectionForUser(String username, String password, int pgPort) throws SQLException {
+        Properties properties = new Properties();
+        properties.setProperty("user", username);
+        properties.setProperty("password", password);
+        return DriverManager.getConnection(getPgConnectionUri(pgPort), properties);
     }
 
     public interface CheckedIntFunction {


### PR DESCRIPTION
The test I added would reproduce the problem only occasionally. The problem emanates out of the async column purge job.

Refactored purge operator to have fixed, final scoreboard usage mode. This avoids the code to deal possible mode switches. E.g. what and when should or should not be null. Mode switching is disallowed and mode is a final value in the constructor.