### PR TITLE
fix(sql): NullPointerException when calling vararg functions with no arguments

### DIFF
--- a/core/rust/qdb-core/src/error.rs
+++ b/core/rust/qdb-core/src/error.rs
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     pub fn test_io_error() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let mut err = CoreErrorReason::Io(Arc::new(io_err)).into_err();
         err.add_context("context_msg");
         let result: Result<(), _> = Err(err);
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn io_err_into_coreerror() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let err: CoreError = io_err.into();
         assert_eq!(err.to_string(), "io_error");
     }
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     pub fn test_no_context() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let err = CoreErrorReason::Io(Arc::new(io_err)).into_err();
         assert_eq!(err.to_string(), "io_error");
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CaseFunctionFactory.java
@@ -36,6 +36,7 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Transient;
 
 public class CaseFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
         return "case(V)";

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/CoalesceFunctionFactory.java
@@ -48,12 +48,14 @@ import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Utf8Sequence;
 
 import static io.questdb.cairo.ColumnType.*;
 
 public class CoalesceFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
         return "coalesce(V)";
@@ -62,12 +64,12 @@ public class CoalesceFunctionFactory implements FunctionFactory {
     @Override
     public Function newInstance(
             int position,
-            ObjList<Function> args,
-            IntList argPositions,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-        if (args.size() < 2) {
+        if (args == null || args.size() < 2) {
             throw SqlException.$(position, "coalesce can be used with 2 or more arguments");
         }
         if (args.size() > 2) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/conditional/SwitchFunctionFactory.java
@@ -32,10 +32,13 @@ import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.constants.Constants;
-import io.questdb.std.*;
+import io.questdb.std.CharSequenceObjHashMap;
+import io.questdb.std.IntList;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.LongObjHashMap;
+import io.questdb.std.ObjList;
 
 public class SwitchFunctionFactory implements FunctionFactory {
-
     private static final IntMethod GET_BYTE = SwitchFunctionFactory::getByte;
     private static final IntMethod GET_CHAR = SwitchFunctionFactory::getChar;
     private static final LongMethod GET_DATE = SwitchFunctionFactory::getDate;
@@ -167,7 +170,6 @@ public class SwitchFunctionFactory implements FunctionFactory {
         } else {
             throw SqlException.$(sqlPos, "CASE values cannot be bind variables");
         }
-
     }
 
     private static byte getByte(Function function, Record record) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/ListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/ListFunctionFactory.java
@@ -36,9 +36,11 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
 import io.questdb.std.str.Sinkable;
 
 public class ListFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
         return "list(V)";
@@ -47,11 +49,14 @@ public class ListFunctionFactory implements FunctionFactory {
     @Override
     public Function newInstance(
             int position,
-            ObjList<Function> args,
-            IntList argPositions,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
+        if (args == null || args.size() == 0) {
+            throw SqlException.$(position, "no arguments provided");
+        }
         final ObjList<String> symbols = new ObjList<>(args.size());
         RndStringListFunctionFactory.copyConstants(args, argPositions, symbols);
         return new Func(symbols);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/LongSequenceFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/LongSequenceFunctionFactory.java
@@ -24,7 +24,11 @@
 
 package io.questdb.griffin.engine.functions.rnd;
 
-import io.questdb.cairo.*;
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
@@ -37,6 +41,7 @@ import io.questdb.griffin.engine.functions.CursorFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
 
 public class LongSequenceFunctionFactory implements FunctionFactory {
     private static final RecordMetadata METADATA;
@@ -47,7 +52,13 @@ public class LongSequenceFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         Function countFunc;
         final Function seedLoFunc;
         final Function seedHiFunc;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndStringListFunctionFactory.java
@@ -38,6 +38,7 @@ import io.questdb.std.Chars;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
 import io.questdb.std.str.Sinkable;
 
 public class RndStringListFunctionFactory implements FunctionFactory {
@@ -47,7 +48,13 @@ public class RndStringListFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         if (args == null) {
             return new RndStrFunction(3, 10, 1);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolListFunctionFactory.java
@@ -36,6 +36,7 @@ import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
 import io.questdb.std.str.Sinkable;
 
 public class RndSymbolListFunctionFactory implements FunctionFactory {
@@ -47,17 +48,16 @@ public class RndSymbolListFunctionFactory implements FunctionFactory {
     @Override
     public Function newInstance(
             int position,
-            ObjList<Function> args,
-            IntList argPositions,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
         if (args == null || args.size() == 0) {
-            throw SqlException.$(position, "function rnd_symbol expects arguments but has none");
+            throw SqlException.$(position, "no arguments provided");
         }
         final ObjList<String> symbols = new ObjList<>(args.size());
         RndStringListFunctionFactory.copyConstants(args, argPositions, symbols);
-
         return new Func(symbols);
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndVarcharListFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndVarcharListFunctionFactory.java
@@ -37,6 +37,7 @@ import io.questdb.griffin.engine.functions.VarcharFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
 import io.questdb.std.str.Sinkable;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
@@ -48,7 +49,13 @@ public class RndVarcharListFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) throws SqlException {
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
         if (args == null) {
             return new RndVarcharFunction(3, 10, 1);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ConcatFunctionFactory.java
@@ -28,7 +28,11 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.SymbolTableSource;
-import io.questdb.griffin.*;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlUtil;
 import io.questdb.griffin.engine.functions.MultiArgFunction;
 import io.questdb.griffin.engine.functions.StrFunction;
 import io.questdb.griffin.engine.functions.constants.ConstantFunction;
@@ -53,10 +57,14 @@ public class ConcatFunctionFactory implements FunctionFactory {
     public Function newInstance(
             int position,
             @Transient ObjList<Function> args,
-            IntList argPositions,
+            @Transient IntList argPositions,
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
+        if (args == null || args.size() == 0) {
+            throw SqlException.$(position, "no arguments provided");
+        }
+
         final int n = args.size();
 
         boolean allConst = true;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/HydrateTableMetadataFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/HydrateTableMetadataFunctionFactory.java
@@ -68,13 +68,13 @@ public class HydrateTableMetadataFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
-        final CairoEngine engine = sqlExecutionContext.getCairoEngine();
-        ObjList<TableToken> tableTokens = new ObjList<>();
-
         // check if there are no args
         if (args == null || args.size() == 0) {
             throw SqlException.$(position, "no arguments provided");
         }
+
+        final CairoEngine engine = sqlExecutionContext.getCairoEngine();
+        ObjList<TableToken> tableTokens = new ObjList<>();
 
         // check for hydrate_table_metadata('*') case
         if (args.size() == 1) {

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -5472,6 +5472,15 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testListEmptyArgs() throws Exception {
+        assertException(
+                "select list() from long_sequence(1)",
+                7,
+                "no arguments provided"
+        );
+    }
+
+    @Test
     public void testNonEqualityJoinCondition() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table tab ( created timestamp, value long ) timestamp(created) ");
@@ -5887,7 +5896,11 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
 
     @Test
     public void testRndSymbolEmptyArgs() throws Exception {
-        assertMemoryLeak(() -> assertExceptionNoLeakCheck("select rnd_symbol() from long_sequence(1)", 7, "function rnd_symbol expects arguments but has none"));
+        assertException(
+                "select rnd_symbol() from long_sequence(1)",
+                7,
+                "no arguments provided"
+        );
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CaseFunctionFactoryTest.java
@@ -1440,6 +1440,18 @@ public class CaseFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testNoArgs() throws Exception {
+        assertException(
+                "select " +
+                        "    x " +
+                        "    case end c " +
+                        "from long_sequence(1);",
+                17,
+                "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"case\""
+        );
+    }
+
+    @Test
     public void testNonBooleanWhen() throws Exception {
         assertException(
                 "select \n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/conditional/CoalesceFunctionFactoryTest.java
@@ -328,22 +328,20 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testFailsWithSingleArg() throws Exception {
         assertMemoryLeak(() -> {
-            execute("create table alex as (" +
-                    "select CASE WHEN x % 2 = 0 THEN CAST(NULL as long) ELSE x END as x," +
-                    " CASE WHEN x % 3 = 0 THEN x * 2 ELSE CAST(NULL as long) END as a," +
-                    " CASE WHEN x % 3 = 1 THEN x * 3 ELSE CAST(NULL as long) END as b" +
-                    " from long_sequence(6)" +
-                    ")");
+            execute(
+                    "create table alex as (" +
+                            "select CASE WHEN x % 2 = 0 THEN CAST(NULL as long) ELSE x END as x," +
+                            " CASE WHEN x % 3 = 0 THEN x * 2 ELSE CAST(NULL as long) END as a," +
+                            " CASE WHEN x % 3 = 1 THEN x * 3 ELSE CAST(NULL as long) END as b" +
+                            " from long_sequence(6)" +
+                            ")"
+            );
 
-            try {
-                execute(
-                        "select coalesce(b)\n" +
-                                "from alex"
-                );
-                Assert.fail("SqlException expected");
-            } catch (SqlException ex) {
-                Assert.assertTrue(ex.getMessage().contains("coalesce"));
-            }
+            assertExceptionNoLeakCheck(
+                    "select coalesce(b) from alex",
+                    7,
+                    "coalesce can be used with 2 or more arguments"
+            );
         });
     }
 
@@ -481,6 +479,15 @@ public class CoalesceFunctionFactoryTest extends AbstractCairoTest {
                 null,
                 true,
                 true
+        );
+    }
+
+    @Test
+    public void testNoArgs() throws Exception {
+        assertException(
+                "select coalesce();",
+                7,
+                "coalesce can be used with 2 or more arguments"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ConcatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ConcatFunctionFactoryTest.java
@@ -156,6 +156,15 @@ public class ConcatFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testNoArgs() throws Exception {
+        assertException(
+                "select concat();",
+                7,
+                "no arguments provided"
+        );
+    }
+
+    @Test
     public void testNull() throws Exception {
         assertSql(
                 "concat\n" +


### PR DESCRIPTION
`greatest()` and `least()` are fixed in #5669