### PR TITLE
fix(core): adjust query cache scaling to prevent memory exhaustion

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -1610,12 +1610,12 @@ public class PropServerConfiguration implements ServerConfiguration {
             if (pgEnabled) {
                 this.pgSelectCacheEnabled = getBoolean(properties, env, PropertyKey.PG_SELECT_CACHE_ENABLED, true);
                 final int effectivePGWorkerCount = pgWorkerCount > 0 ? pgWorkerCount : sharedWorkerCount;
-                this.pgSelectCacheBlockCount = getInt(properties, env, PropertyKey.PG_SELECT_CACHE_BLOCK_COUNT, 8 * effectivePGWorkerCount);
+                this.pgSelectCacheBlockCount = getInt(properties, env, PropertyKey.PG_SELECT_CACHE_BLOCK_COUNT, 32);
                 this.pgSelectCacheRowCount = getInt(properties, env, PropertyKey.PG_SELECT_CACHE_ROW_COUNT, 2 * effectivePGWorkerCount);
             }
             final int effectiveHttpWorkerCount = httpWorkerCount > 0 ? httpWorkerCount : sharedWorkerCount;
             this.httpSqlCacheEnabled = getBoolean(properties, env, PropertyKey.HTTP_QUERY_CACHE_ENABLED, true);
-            this.httpSqlCacheBlockCount = getInt(properties, env, PropertyKey.HTTP_QUERY_CACHE_BLOCK_COUNT, 8 * effectiveHttpWorkerCount);
+            this.httpSqlCacheBlockCount = getInt(properties, env, PropertyKey.HTTP_QUERY_CACHE_BLOCK_COUNT, 32);
             this.httpSqlCacheRowCount = getInt(properties, env, PropertyKey.HTTP_QUERY_CACHE_ROW_COUNT, 2 * effectiveHttpWorkerCount);
             this.queryCacheEventQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_QUERY_CACHE_EVENT_QUEUE_CAPACITY, 4));
 


### PR DESCRIPTION
The previous default query cache sizing algorithm scaled quadratically with CPU count, potentially causing memory exhaustion on machines with high core counts. This change modifies the scaling behavior to be more conservative while maintaining performance.

Only the default sizing is adjusted - explicit cache size settings are unaffected.

Implementation details:
- Previously: Both block count and row count scaled with CPU count, resulting in quadratic memory growth (blocks × rows)
- Now: Only row count scales with CPU count, while block count remains constant
- This provides linear scaling, as rows are the fundamental unit of parallelism