### PR TITLE
fix(core): fixed table metadata commands, incorrectly displayed which column is the designated timestamp

### DIFF
--- a/core/rust/qdb-core/src/error.rs
+++ b/core/rust/qdb-core/src/error.rs
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     pub fn test_io_error() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let mut err = CoreErrorReason::Io(Arc::new(io_err)).into_err();
         err.add_context("context_msg");
         let result: Result<(), _> = Err(err);
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn io_err_into_coreerror() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let err: CoreError = io_err.into();
         assert_eq!(err.to_string(), "io_error");
     }
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     pub fn test_no_context() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io_error");
+        let io_err = std::io::Error::other("io_error");
         let err = CoreErrorReason::Io(Arc::new(io_err)).into_err();
         assert_eq!(err.to_string(), "io_error");
     }

--- a/core/src/main/java/io/questdb/cairo/CairoColumn.java
+++ b/core/src/main/java/io/questdb/cairo/CairoColumn.java
@@ -32,16 +32,16 @@ import org.jetbrains.annotations.NotNull;
 
 public class CairoColumn implements Sinkable {
     public static final Log LOG = LogFactory.getLog(CairoEngine.class);
+    private boolean dedupKey;
+    private boolean designated;
     private int indexBlockCapacity;
-    private boolean isDedupKey;
-    private boolean isDesignated;
-    private boolean isIndexed;
-    private boolean isSymbolTableStatic;
+    private boolean indexed;
     private long metadataVersion;
     private CharSequence name;
     private int position;
     private boolean symbolCached;
     private int symbolCapacity;
+    private boolean symbolTableStatic;
     private int type;
     private int writerIndex;
 
@@ -49,11 +49,11 @@ public class CairoColumn implements Sinkable {
     }
 
     public void copyTo(@NotNull CairoColumn target) {
-        target.isDesignated = this.isDesignated;
+        target.designated = this.designated;
         target.indexBlockCapacity = this.indexBlockCapacity;
-        target.isDedupKey = this.isDedupKey;
-        target.isIndexed = this.isIndexed;
-        target.isSymbolTableStatic = this.isSymbolTableStatic;
+        target.dedupKey = this.dedupKey;
+        target.indexed = this.indexed;
+        target.symbolTableStatic = this.symbolTableStatic;
         target.name = this.name;
         target.position = this.position;
         target.symbolCached = this.symbolCached;
@@ -67,32 +67,12 @@ public class CairoColumn implements Sinkable {
         return indexBlockCapacity;
     }
 
-    public boolean getIsDedupKey() {
-        return isDedupKey;
-    }
-
-    public boolean getIsDesignated() {
-        return isDesignated;
-    }
-
-    public boolean getIsIndexed() {
-        return isIndexed;
-    }
-
-    public boolean getIsSymbolTableStatic() {
-        return isSymbolTableStatic;
-    }
-
     public CharSequence getName() {
         return name;
     }
 
     public int getPosition() {
         return position;
-    }
-
-    public boolean getSymbolCached() {
-        return symbolCached;
     }
 
     public int getSymbolCapacity() {
@@ -107,24 +87,40 @@ public class CairoColumn implements Sinkable {
         return writerIndex;
     }
 
+    public boolean isDedupKey() {
+        return dedupKey;
+    }
+
+    public boolean isDesignated() {
+        return designated;
+    }
+
+    public boolean isIndexed() {
+        return indexed;
+    }
+
+    public boolean isSymbolCached() {
+        return symbolCached;
+    }
+
+    public boolean isSymbolTableStatic() {
+        return symbolTableStatic;
+    }
+
+    public void setDedupKeyFlag(boolean dedupKey) {
+        this.dedupKey = dedupKey;
+    }
+
+    public void setDesignatedFlag(boolean designated) {
+        this.designated = designated;
+    }
+
     public void setIndexBlockCapacity(int indexBlockCapacity) {
         this.indexBlockCapacity = indexBlockCapacity;
     }
 
-    public void setIsDedupKey(boolean isDedupKey) {
-        this.isDedupKey = isDedupKey;
-    }
-
-    public void setIsDesignated(boolean isDesignated) {
-        this.isDesignated = isDesignated;
-    }
-
-    public void setIsIndexed(boolean isIndexed) {
-        this.isIndexed = isIndexed;
-    }
-
-    public void setIsSymbolTableStatic(boolean symbolTableStatic) {
-        isSymbolTableStatic = symbolTableStatic;
+    public void setIndexedFlag(boolean indexed) {
+        this.indexed = indexed;
     }
 
     public void setName(CharSequence name) {
@@ -143,6 +139,10 @@ public class CairoColumn implements Sinkable {
         this.symbolCapacity = symbolCapacity;
     }
 
+    public void setSymbolTableStaticFlag(boolean symbolTableStatic) {
+        this.symbolTableStatic = symbolTableStatic;
+    }
+
     public void setType(int type) {
         this.type = type;
     }
@@ -157,14 +157,13 @@ public class CairoColumn implements Sinkable {
         sink.put("name=").put(getName()).put(", ");
         sink.put("position=").put(getPosition()).put(", ");
         sink.put("type=").put(ColumnType.nameOf(getType())).put(", ");
-        sink.put("isDedupKey=").put(getIsDedupKey()).put(", ");
-        sink.put("isDesignated=").put(getIsDesignated()).put(", ");
-        sink.put("isSymbolTableStatic=").put(getIsSymbolTableStatic()).put(", ");
-        sink.put("symbolCached=").put(getSymbolCached()).put(", ");
+        sink.put("isDedupKey=").put(isDedupKey()).put(", ");
+        sink.put("isDesignated=").put(isDesignated()).put(", ");
+        sink.put("isSymbolTableStatic=").put(isSymbolTableStatic()).put(", ");
+        sink.put("symbolCached=").put(isSymbolCached()).put(", ");
         sink.put("symbolCapacity=").put(getSymbolCapacity()).put(", ");
-        sink.put("isIndexed=").put(getIsIndexed()).put(", ");
+        sink.put("isIndexed=").put(isIndexed()).put(", ");
         sink.put("indexBlockCapacity=").put(getIndexBlockCapacity()).put(", ");
         sink.put("writerIndex=").put(getWriterIndex()).put("]");
     }
-
 }

--- a/core/src/main/java/io/questdb/cairo/CairoTable.java
+++ b/core/src/main/java/io/questdb/cairo/CairoTable.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class CairoTable implements Sinkable {
     public final LowerCaseCharSequenceIntHashMap columnNameIndexMap;
-    public final IntList columnOrderMap;
+    public final IntList columnOrderList;
     public final ObjList<CairoColumn> columns;
     private boolean dedup;
     private int matViewRefreshLimitHoursOrMonths;
@@ -50,14 +50,14 @@ public class CairoTable implements Sinkable {
         this.token = token;
 
         columnNameIndexMap = new LowerCaseCharSequenceIntHashMap();
-        columnOrderMap = new IntList();
+        columnOrderList = new IntList();
         columns = new ObjList<>();
     }
 
     public CairoTable(@NotNull TableToken token, CairoTable fromTab) {
         this.token = token;
 
-        columnOrderMap = fromTab.columnOrderMap;
+        columnOrderList = fromTab.columnOrderList;
         columns = fromTab.columns;
         columnNameIndexMap = fromTab.columnNameIndexMap;
 

--- a/core/src/main/java/io/questdb/cairo/CairoTable.java
+++ b/core/src/main/java/io/questdb/cairo/CairoTable.java
@@ -35,46 +35,49 @@ public class CairoTable implements Sinkable {
     public final LowerCaseCharSequenceIntHashMap columnNameIndexMap;
     public final IntList columnOrderMap;
     public final ObjList<CairoColumn> columns;
-    private boolean isDedup;
-    private boolean isSoftLink;
+    private boolean dedup;
     private int matViewRefreshLimitHoursOrMonths;
     private int maxUncommittedRows;
     private long metadataVersion = -1;
     private long o3MaxLag;
     private int partitionBy;
+    private boolean softLink;
     private int timestampIndex;
     private TableToken token;
     private int ttlHoursOrMonths;
 
     public CairoTable(@NotNull TableToken token) {
         this.token = token;
-        this.columnNameIndexMap = new LowerCaseCharSequenceIntHashMap();
-        this.columnOrderMap = new IntList();
-        this.columns = new ObjList<>();
+
+        columnNameIndexMap = new LowerCaseCharSequenceIntHashMap();
+        columnOrderMap = new IntList();
+        columns = new ObjList<>();
     }
 
     public CairoTable(@NotNull TableToken token, CairoTable fromTab) {
         this.token = token;
-        this.columnOrderMap = fromTab.columnOrderMap;
-        this.columns = fromTab.columns;
-        this.columnNameIndexMap = fromTab.columnNameIndexMap;
-        this.metadataVersion = fromTab.getMetadataVersion();
-        this.partitionBy = fromTab.getPartitionBy();
-        this.maxUncommittedRows = fromTab.getMaxUncommittedRows();
-        this.o3MaxLag = fromTab.getO3MaxLag();
-        this.timestampIndex = fromTab.getTimestampIndex();
-        this.ttlHoursOrMonths = fromTab.getTtlHoursOrMonths();
-        this.isSoftLink = fromTab.getIsSoftLink();
-        this.isDedup = fromTab.getIsDedup();
-        this.matViewRefreshLimitHoursOrMonths = fromTab.getMatViewRefreshLimitHoursOrMonths();
+
+        columnOrderMap = fromTab.columnOrderMap;
+        columns = fromTab.columns;
+        columnNameIndexMap = fromTab.columnNameIndexMap;
+
+        metadataVersion = fromTab.getMetadataVersion();
+        partitionBy = fromTab.getPartitionBy();
+        maxUncommittedRows = fromTab.getMaxUncommittedRows();
+        o3MaxLag = fromTab.getO3MaxLag();
+        timestampIndex = fromTab.getTimestampIndex();
+        ttlHoursOrMonths = fromTab.getTtlHoursOrMonths();
+        softLink = fromTab.isSoftLink();
+        dedup = fromTab.hasDedup();
+        matViewRefreshLimitHoursOrMonths = fromTab.getMatViewRefreshLimitHoursOrMonths();
     }
 
     public int getColumnCount() {
-        return this.columns.size();
+        return columns.size();
     }
 
     public ObjList<CharSequence> getColumnNames() {
-        return this.columnNameIndexMap.keys();
+        return columnNameIndexMap.keys();
     }
 
     public CairoColumn getColumnQuiet(@NotNull CharSequence columnName) {
@@ -91,19 +94,11 @@ public class CairoTable implements Sinkable {
     }
 
     public String getDirectoryName() {
-        return getTableToken().getDirName();
+        return token.getDirName();
     }
 
     public int getId() {
-        return getTableToken().getTableId();
-    }
-
-    public boolean getIsDedup() {
-        return isDedup;
-    }
-
-    public boolean getIsSoftLink() {
-        return isSoftLink;
+        return token.getTableId();
     }
 
     public int getMatViewRefreshLimitHoursOrMonths() {
@@ -131,7 +126,7 @@ public class CairoTable implements Sinkable {
     }
 
     public @NotNull String getTableName() {
-        return getTableToken().getTableName();
+        return token.getTableName();
     }
 
     public TableToken getTableToken() {
@@ -160,16 +155,20 @@ public class CairoTable implements Sinkable {
         return ttlHoursOrMonths;
     }
 
-    public boolean getWalEnabled() {
-        return getTableToken().isWal();
+    public boolean hasDedup() {
+        return dedup;
     }
 
-    public void setIsDedup(boolean isDedup) {
-        this.isDedup = isDedup;
+    public boolean isSoftLink() {
+        return softLink;
     }
 
-    public void setIsSoftLink(boolean isSoftLink) {
-        this.isSoftLink = isSoftLink;
+    public boolean isWalEnabled() {
+        return token.isWal();
+    }
+
+    public void setDedupFlag(boolean dedup) {
+        this.dedup = dedup;
     }
 
     public void setMatViewRefreshLimitHoursOrMonths(int matViewRefreshLimitHoursOrMonths) {
@@ -192,6 +191,10 @@ public class CairoTable implements Sinkable {
         this.partitionBy = partitionBy;
     }
 
+    public void setSoftLinkFlag(boolean softLink) {
+        this.softLink = softLink;
+    }
+
     public void setTableToken(TableToken token) {
         this.token = token;
     }
@@ -210,8 +213,8 @@ public class CairoTable implements Sinkable {
         sink.put("name=").put(getTableName()).put(", ");
         sink.put("id=").put(getId()).put(", ");
         sink.put("directoryName=").put(getDirectoryName()).put(", ");
-        sink.put("isDedup=").put(getIsDedup()).put(", ");
-        sink.put("isSoftLink=").put(getIsSoftLink()).put(", ");
+        sink.put("hasDedup=").put(hasDedup()).put(", ");
+        sink.put("isSoftLink=").put(isSoftLink()).put(", ");
         sink.put("metadataVersion=").put(getMetadataVersion()).put(", ");
         sink.put("maxUncommittedRows=").put(getMaxUncommittedRows()).put(", ");
         sink.put("o3MaxLag=").put(getO3MaxLag()).put(", ");
@@ -224,7 +227,7 @@ public class CairoTable implements Sinkable {
         } else {
             sink.put("ttlMonths=").put(-ttlHoursOrMonths).put(", ");
         }
-        sink.put("walEnabled=").put(getWalEnabled()).put(", ");
+        sink.put("walEnabled=").put(isWalEnabled()).put(", ");
         sink.put("columnCount=").put(getColumnCount()).put("]");
         sink.put('\n');
         for (int i = 0, n = columns.size(); i < n; i++) {

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -157,8 +157,7 @@ public class MetadataCache implements QuietCloseable {
         boolean isSoftLink = Files.isSoftLink(path.$());
 
         // set up table path
-        path.concat(TableUtils.META_FILE_NAME)
-                .trimTo(path.size());
+        path.concat(TableUtils.META_FILE_NAME).trimTo(path.size());
 
         // create table to work with
         CairoTable table = new CairoTable(token);
@@ -201,7 +200,7 @@ public class MetadataCache implements QuietCloseable {
             table.setTimestampIndex(-1);
             table.setTtlHoursOrMonths(TableUtils.getTtlHoursOrMonths(metaMem));
             table.setMatViewRefreshLimitHoursOrMonths(TableUtils.getMatViewRefreshLimitHoursOrMonths(metaMem));
-            table.setIsSoftLink(isSoftLink);
+            table.setSoftLinkFlag(isSoftLink);
 
             TableUtils.buildWriterOrderMap(metaMem, table.columnOrderMap, columnCount);
             boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(metaMem);
@@ -231,20 +230,20 @@ public class MetadataCache implements QuietCloseable {
                 column.setPosition(table.getColumnCount());
                 column.setType(columnType);
 
-                column.setIsIndexed(TableUtils.isColumnIndexed(metaMem, writerIndex));
+                column.setIndexedFlag(TableUtils.isColumnIndexed(metaMem, writerIndex));
                 column.setIndexBlockCapacity(TableUtils.getIndexBlockCapacity(metaMem, writerIndex));
-                column.setIsSymbolTableStatic(true);
-                column.setIsDedupKey(TableUtils.isColumnDedupKey(metaMem, writerIndex));
+                column.setSymbolTableStaticFlag(true);
+                column.setDedupKeyFlag(TableUtils.isColumnDedupKey(metaMem, writerIndex));
                 column.setWriterIndex(writerIndex);
 
                 boolean isDesignated = writerIndex == timestampWriterIndex;
-                column.setIsDesignated(isDesignated);
+                column.setDesignatedFlag(isDesignated);
                 if (isDesignated) {
                     table.setTimestampIndex(table.getColumnCount());
                 }
 
-                if (column.getIsDedupKey()) {
-                    table.setIsDedup(true);
+                if (column.isDedupKey()) {
+                    table.setDedupFlag(true);
                 }
 
                 if (columnType == ColumnType.SYMBOL) {
@@ -539,7 +538,7 @@ public class MetadataCache implements QuietCloseable {
             table.setTtlHoursOrMonths(tableMetadata.getTtlHoursOrMonths());
             table.setMatViewRefreshLimitHoursOrMonths(tableMetadata.getMatViewRefreshLimitHoursOrMonths());
             Path tempPath = Path.getThreadLocal(engine.getConfiguration().getDbRoot());
-            table.setIsSoftLink(engine.getConfiguration().getFilesFacade().isSoftLink(tempPath.concat(tableToken.getDirNameUtf8()).$()));
+            table.setSoftLinkFlag(Files.isSoftLink(tempPath.concat(tableToken.getDirNameUtf8()).$()));
 
             for (int i = 0; i < columnCount; i++) {
                 final TableColumnMetadata columnMetadata = tableMetadata.getColumnMetadata(i);
@@ -558,22 +557,22 @@ public class MetadataCache implements QuietCloseable {
                 column.setType(columnType);
                 int replacingIndex = columnMetadata.getReplacingIndex();
                 column.setPosition(replacingIndex > -1 ? replacingIndex : i);
-                column.setIsIndexed(columnMetadata.isSymbolIndexFlag());
+                column.setIndexedFlag(columnMetadata.isSymbolIndexFlag());
                 column.setIndexBlockCapacity(columnMetadata.getIndexValueBlockCapacity());
-                column.setIsSymbolTableStatic(columnMetadata.isSymbolTableStatic());
-                column.setIsDedupKey(columnMetadata.isDedupKeyFlag());
+                column.setSymbolTableStaticFlag(columnMetadata.isSymbolTableStatic());
+                column.setDedupKeyFlag(columnMetadata.isDedupKeyFlag());
 
                 int writerIndex = columnMetadata.getWriterIndex();
                 column.setWriterIndex(writerIndex);
 
                 boolean isDesignated = writerIndex == timestampWriterIndex;
-                column.setIsDesignated(isDesignated);
+                column.setDesignatedFlag(isDesignated);
                 if (isDesignated) {
                     table.setTimestampIndex(table.getColumnCount());
                 }
 
-                if (column.getIsDedupKey()) {
-                    table.setIsDedup(true);
+                if (column.isDedupKey()) {
+                    table.setDedupFlag(true);
                 }
 
                 if (ColumnType.isSymbol(column.getType())) {

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -46,7 +46,7 @@ import static io.questdb.cairo.TableUtils.validationException;
 
 public class TableReaderMetadata extends AbstractRecordMetadata implements TableMetadata, Mutable {
     protected final CairoConfiguration configuration;
-    private final IntList columnOrderMap = new IntList();
+    private final IntList columnOrderList = new IntList();
     private final FilesFacade ff;
     private final LowerCaseCharSequenceIntHashMap tmpValidationMap = new LowerCaseCharSequenceIntHashMap();
     private boolean isCopy;
@@ -307,17 +307,17 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         this.columnMetadata.clear();
         this.timestampIndex = -1;
 
-        buildWriterOrderMap(mem, columnCount);
+        TableUtils.buildColumnListFromMetadataFile(mem, columnCount, columnOrderList);
         this.columnNameIndexMap.clear();
 
-        for (int i = 0, n = columnOrderMap.size(); i < n; i += 3) {
-            int writerIndex = columnOrderMap.get(i);
+        for (int i = 0, n = columnOrderList.size(); i < n; i += 3) {
+            int writerIndex = columnOrderList.get(i);
             if (writerIndex < 0) {
                 continue;
             }
             int stableIndex = i / 3;
-            CharSequence name = mem.getStrA(columnOrderMap.get(i + 1));
-            int denseSymbolIndex = columnOrderMap.get(i + 2);
+            CharSequence name = mem.getStrA(columnOrderList.get(i + 1));
+            int denseSymbolIndex = columnOrderList.get(i + 2);
 
             assert name != null;
             int columnType = TableUtils.getColumnType(mem, writerIndex);
@@ -356,24 +356,24 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         this.tableToken = tableToken;
     }
 
-    private TableReaderMetadataTransitionIndex applyTransition0(MemoryR metaMem, int existingColumnCount) {
+    private TableReaderMetadataTransitionIndex applyTransition0(MemoryR newMetaMem, int existingColumnCount) {
         columnNameIndexMap.clear();
 
-        int columnCount = metaMem.getInt(TableUtils.META_OFFSET_COUNT);
+        int columnCount = newMetaMem.getInt(TableUtils.META_OFFSET_COUNT);
         assert columnCount >= existingColumnCount;
         columnMetadata.setPos(columnCount);
-        int timestampIndex = metaMem.getInt(TableUtils.META_OFFSET_TIMESTAMP_INDEX);
-        this.tableId = metaMem.getInt(TableUtils.META_OFFSET_TABLE_ID);
-        this.metadataVersion = metaMem.getLong(TableUtils.META_OFFSET_METADATA_VERSION);
-        this.maxUncommittedRows = metaMem.getInt(TableUtils.META_OFFSET_MAX_UNCOMMITTED_ROWS);
-        this.o3MaxLag = metaMem.getLong(TableUtils.META_OFFSET_O3_MAX_LAG);
-        this.walEnabled = metaMem.getBool(TableUtils.META_OFFSET_WAL_ENABLED);
-        this.ttlHoursOrMonths = TableUtils.getTtlHoursOrMonths(metaMem);
-        this.matViewRefreshLimitHoursOrMonths = TableUtils.getMatViewRefreshLimitHoursOrMonths(metaMem);
+        int timestampIndex = newMetaMem.getInt(TableUtils.META_OFFSET_TIMESTAMP_INDEX);
+        this.tableId = newMetaMem.getInt(TableUtils.META_OFFSET_TABLE_ID);
+        this.metadataVersion = newMetaMem.getLong(TableUtils.META_OFFSET_METADATA_VERSION);
+        this.maxUncommittedRows = newMetaMem.getInt(TableUtils.META_OFFSET_MAX_UNCOMMITTED_ROWS);
+        this.o3MaxLag = newMetaMem.getLong(TableUtils.META_OFFSET_O3_MAX_LAG);
+        this.walEnabled = newMetaMem.getBool(TableUtils.META_OFFSET_WAL_ENABLED);
+        this.ttlHoursOrMonths = TableUtils.getTtlHoursOrMonths(newMetaMem);
+        this.matViewRefreshLimitHoursOrMonths = TableUtils.getMatViewRefreshLimitHoursOrMonths(newMetaMem);
 
         int shiftLeft = 0, existingIndex = 0;
-        buildWriterOrderMap(metaMem, columnCount);
-        int newColumnCount = metaMem.getInt(TableUtils.META_OFFSET_COUNT);
+        TableUtils.buildColumnListFromMetadataFile(newMetaMem, columnCount, columnOrderList);
+        int newColumnCount = newMetaMem.getInt(TableUtils.META_OFFSET_COUNT);
 
         if (transitionIndex == null) {
             transitionIndex = new TableReaderMetadataTransitionIndex();
@@ -381,23 +381,23 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
             transitionIndex.clear();
         }
 
-        buildWriterOrderMap(metaMem, newColumnCount);
-        for (int i = 0, n = columnOrderMap.size(); i < n; i += 3) {
+        TableUtils.buildColumnListFromMetadataFile(newMetaMem, newColumnCount, columnOrderList);
+        for (int i = 0, n = columnOrderList.size(); i < n; i += 3) {
             int stableIndex = i / 3;
-            int writerIndex = columnOrderMap.get(i);
+            int writerIndex = columnOrderList.get(i);
             if (writerIndex < 0) {
                 continue;
             }
-            CharSequence name = metaMem.getStrA(columnOrderMap.get(i + 1));
+            CharSequence name = newMetaMem.getStrA(columnOrderList.get(i + 1));
             assert name != null;
-            int denseSymbolIndex = columnOrderMap.get(i + 2);
-            int newColumnType = TableUtils.getColumnType(metaMem, writerIndex);
-            int columnType = TableUtils.getColumnType(metaMem, writerIndex);
-            boolean isIndexed = TableUtils.isColumnIndexed(metaMem, writerIndex);
-            boolean isDedupKey = TableUtils.isColumnDedupKey(metaMem, writerIndex);
-            int indexBlockCapacity = TableUtils.getIndexBlockCapacity(metaMem, writerIndex);
-            boolean symbolIsCached = TableUtils.isSymbolCached(metaMem, writerIndex);
-            int symbolCapacity = TableUtils.getSymbolCapacity(metaMem, writerIndex);
+            int denseSymbolIndex = columnOrderList.get(i + 2);
+            int newColumnType = TableUtils.getColumnType(newMetaMem, writerIndex);
+            int columnType = TableUtils.getColumnType(newMetaMem, writerIndex);
+            boolean isIndexed = TableUtils.isColumnIndexed(newMetaMem, writerIndex);
+            boolean isDedupKey = TableUtils.isColumnDedupKey(newMetaMem, writerIndex);
+            int indexBlockCapacity = TableUtils.getIndexBlockCapacity(newMetaMem, writerIndex);
+            boolean symbolIsCached = TableUtils.isSymbolCached(newMetaMem, writerIndex);
+            int symbolCapacity = TableUtils.getSymbolCapacity(newMetaMem, writerIndex);
             TableReaderMetadataColumn existing = null;
             String newName;
 
@@ -483,10 +483,6 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         }
 
         return transitionIndex;
-    }
-
-    private void buildWriterOrderMap(MemoryR newMetaMem, int newColumnCount) {
-        TableUtils.buildWriterOrderMap(newMetaMem, columnOrderMap, newColumnCount);
     }
 
     private void copyMemFrom(TableReaderMetadata srcMeta) {

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -83,8 +83,7 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
     }
 
     public int getReplacingColumnIndex(int columnIndex) {
-        WriterTableColumnMetadata columnMeta = (WriterTableColumnMetadata) columnMetadata.get(columnIndex);
-        return columnMeta.getReplacingIndex();
+        return columnMetadata.get(columnIndex).getReplacingIndex();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
@@ -200,9 +200,9 @@ public class TablesFunctionFactory implements FunctionFactory {
                 public boolean getBool(int col) {
                     switch (col) {
                         case WAL_ENABLED_COLUMN:
-                            return table.getWalEnabled();
+                            return table.isWalEnabled();
                         case DEDUP_NAME_COLUMN:
-                            return table.getIsDedup();
+                            return table.hasDedup();
                         case IS_MAT_VIEW_COLUMN:
                             return table.getTableToken().isMatView();
                         default:
@@ -240,7 +240,7 @@ public class TablesFunctionFactory implements FunctionFactory {
                         case DESIGNATED_TIMESTAMP_COLUMN:
                             return table.getTimestampName();
                         case DIRECTORY_NAME_COLUMN:
-                            if (table.getIsSoftLink()) {
+                            if (table.isSoftLink()) {
                                 if (lazyStringSink == null) {
                                     lazyStringSink = new StringSink();
                                 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
@@ -142,16 +142,16 @@ public class ShowColumnsRecordCursorFactory extends AbstractRecordCursorFactory 
             @Override
             public boolean getBool(int col) {
                 if (col == N_INDEXED_COL) {
-                    return cairoColumn.getIsIndexed();
+                    return cairoColumn.isIndexed();
                 }
                 if (col == N_SYMBOL_CACHED_COL) {
-                    return cairoColumn.getSymbolCached();
+                    return cairoColumn.isSymbolCached();
                 }
                 if (col == N_DESIGNATED_COL) {
-                    return cairoColumn.getIsDesignated();
+                    return cairoColumn.isDesignated();
                 }
                 if (col == N_UPSERT_KEY_COL) {
-                    return cairoColumn.getIsDedupKey();
+                    return cairoColumn.isDedupKey();
                 }
                 throw new UnsupportedOperationException();
             }

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
@@ -62,7 +62,7 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
     }
 
     public static void inVolumeToSink(CairoConfiguration configuration, CairoTable table, CharSink<?> sink) {
-        if (table.getIsSoftLink()) {
+        if (table.isSoftLink()) {
             sink.putAscii(", IN VOLUME ");
 
             Path.clearThreadLocals();
@@ -250,9 +250,9 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
                 }
 
                 sink.putAscii(" CAPACITY ").put(symbolCapacity);
-                sink.putAscii(column.getSymbolCached() ? " CACHE" : " NOCACHE");
+                sink.putAscii(column.isSymbolCached() ? " CACHE" : " NOCACHE");
 
-                if (column.getIsIndexed()) {
+                if (column.isIndexed()) {
                     // INDEX CAPACITY value
                     sink.putAscii(" INDEX CAPACITY ").put(column.getIndexBlockCapacity());
                 }
@@ -278,13 +278,13 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
         }
 
         protected void putDedup() {
-            if (table.getIsDedup()) {
+            if (table.hasDedup()) {
                 boolean afterFirst = false;
                 sink.putAscii('\n');
                 sink.putAscii("DEDUP UPSERT KEYS(");
                 for (int i = 0, n = table.getColumnCount(); i < n; i++) {
                     final CairoColumn column = table.getColumnQuiet(i);
-                    if (column.getIsDedupKey()) {
+                    if (column.isDedupKey()) {
                         if (afterFirst) {
                             sink.putAscii(',');
                         } else {
@@ -312,7 +312,7 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
         }
 
         protected void putWal() {
-            if (!table.getWalEnabled()) {
+            if (!table.isWalEnabled()) {
                 sink.putAscii(" BYPASS");
             }
             sink.putAscii(" WAL");

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 
 public class MetadataCacheTest extends AbstractCairoTest {
-    private static final String xMetaStringSansHeader = "CairoTable [name=x, id=1, directoryName=x~, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=false, columnCount=16]\n" +
+    private static final String xMetaStringSansHeader = "CairoTable [name=x, id=1, directoryName=x~, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=false, columnCount=16]\n" +
             "\t\tCairoColumn [name=i, position=0, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
             "\t\tCairoColumn [name=sym, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
             "\t\tCairoColumn [name=amt, position=2, type=DOUBLE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -71,10 +71,10 @@ public class MetadataCacheTest extends AbstractCairoTest {
     private static final String xMetaStringId2SansHeader = xMetaStringSansHeader.replace("id=1", "id=2");
 
     private static final String yMetaString = "MetadataCache [tableCount=1]\n" +
-            "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
+            "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
             "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n";
     private static final String zMetaString = "MetadataCache [tableCount=1]\n" +
-            "\tCairoTable [name=z, id=1, directoryName=z~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=true, columnCount=16]\n" +
+            "\tCairoTable [name=z, id=1, directoryName=z~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=true, columnCount=16]\n" +
             "\t\tCairoColumn [name=i, position=0, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
             "\t\tCairoColumn [name=sym, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
             "\t\tCairoColumn [name=amt, position=2, type=DOUBLE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -364,7 +364,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=VARCHAR, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -372,7 +372,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=VARCHAR, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n" +
                     "\t\tCairoColumn [name=bah, position=2, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=2]\n");
@@ -381,7 +381,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=3, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=3, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=STRING, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=256, writerIndex=3]\n" +
                     "\t\tCairoColumn [name=bah, position=2, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=2]\n");
@@ -397,7 +397,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -405,7 +405,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=true, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -421,7 +421,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -429,7 +429,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -437,7 +437,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -453,7 +453,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=true, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -461,7 +461,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=1]\n");
 
@@ -476,7 +476,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=VARCHAR, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -484,7 +484,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=2]\n");
         });
@@ -499,7 +499,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=true, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=true, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=true, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=INT, isDedupKey=true, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -507,7 +507,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=foo, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
         });
@@ -526,7 +526,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=z, id=1, directoryName=z~1, isDedup=true, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=true, columnCount=16]\n" +
+                    "\tCairoTable [name=z, id=1, directoryName=z~1, hasDedup=true, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=3, timestampName=timestamp, ttlHours=0, walEnabled=true, columnCount=16]\n" +
                     "\t\tCairoColumn [name=i, position=0, type=INT, isDedupKey=true, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=sym, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
                     "\t\tCairoColumn [name=amt, position=2, type=DOUBLE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -555,7 +555,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=true, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=1, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=true, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=1, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=3]\n" +
                     "\t\tCairoColumn [name=bar, position=0, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=ts, position=1, type=TIMESTAMP, isDedupKey=true, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
                     "\t\tCairoColumn [name=foo, position=2, type=INT, isDedupKey=true, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n");
@@ -565,7 +565,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=true, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=1, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=true, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=1, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=bar, position=0, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=false, indexBlockCapacity=256, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=ts, position=1, type=TIMESTAMP, isDedupKey=true, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -574,7 +574,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=true, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=true, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=true, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
         });
     }
@@ -588,7 +588,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -596,7 +596,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x2, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
         });
@@ -611,7 +611,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -619,7 +619,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=42, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=42, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -627,7 +627,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=42, o3MaxLag=42000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=42, o3MaxLag=42000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -707,7 +707,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -766,7 +766,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y2, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
+                    "\tCairoTable [name=y2, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=1]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n");
 
         });
@@ -781,7 +781,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
 
@@ -789,7 +789,7 @@ public class MetadataCacheTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertCairoMetadata("MetadataCache [tableCount=1]\n" +
-                    "\tCairoTable [name=y, id=1, directoryName=y~1, isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
+                    "\tCairoTable [name=y, id=1, directoryName=y~1, hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=DAY, timestampIndex=0, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=2]\n" +
                     "\t\tCairoColumn [name=ts, position=0, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                     "\t\tCairoColumn [name=x, position=1, type=INT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n");
         });

--- a/core/src/test/java/io/questdb/test/cairo/mig/EngineMigrationTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mig/EngineMigrationTest.java
@@ -294,7 +294,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
             String tableName = params[i];
             String partitionBy = params[i + 1];
             assertCairoMetadata(
-                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", isDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=5]\n" +
+                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", hasDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=5]\n" +
                             "\t\tCairoColumn [name=x, position=0, type=LONG, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                             "\t\tCairoColumn [name=m, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=true, indexBlockCapacity=256, writerIndex=1]\n" +
                             "\t\tCairoColumn [name=ts, position=2, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -311,7 +311,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
             String tableName = params[i];
             String partitionBy = params[i + 1];
             assertCairoMetadata(
-                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", isDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=4]\n" +
+                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", hasDedup=false, isSoftLink=false, metadataVersion=1, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=4]\n" +
                             "\t\tCairoColumn [name=x, position=0, type=LONG, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                             "\t\tCairoColumn [name=m, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=true, indexBlockCapacity=256, writerIndex=1]\n" +
                             "\t\tCairoColumn [name=ts, position=2, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -327,7 +327,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
             String tableName = params[i];
             String partitionBy = params[i + 1];
             assertCairoMetadata(
-                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + "~14, isDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=5]\n" +
+                    "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + "~14, hasDedup=false, isSoftLink=false, metadataVersion=2, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=2, timestampName=ts, ttlHours=0, walEnabled=true, columnCount=5]\n" +
                             "\t\tCairoColumn [name=x, position=0, type=LONG, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                             "\t\tCairoColumn [name=m, position=1, type=SYMBOL, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=true, symbolCapacity=128, isIndexed=true, indexBlockCapacity=256, writerIndex=1]\n" +
                             "\t\tCairoColumn [name=ts, position=2, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +
@@ -358,7 +358,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
                 "\t\tCairoColumn [name=ts, position=15, type=TIMESTAMP, isDedupKey=false, isDesignated=true, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=15]";
 
         assertCairoMetadata(
-                "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=15, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=16]\n" +
+                "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=" + partitionBy + ", timestampIndex=15, timestampName=ts, ttlHours=0, walEnabled=false, columnCount=16]\n" +
                         columns,
                 tableName,
                 ignoreMaxLag
@@ -371,7 +371,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
             String partitionBy = params[i + 1];
             if (partitionBy.equals("NONE_NTS")) {
                 assertCairoMetadata(
-                        "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", isDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=-1, timestampName=, ttlHours=0, walEnabled=false, columnCount=15]\n" +
+                        "CairoTable [name=" + tableName + ", id=1, directoryName=" + tableName + ", hasDedup=false, isSoftLink=false, metadataVersion=0, maxUncommittedRows=1000, o3MaxLag=300000000, partitionBy=NONE, timestampIndex=-1, timestampName=, ttlHours=0, walEnabled=false, columnCount=15]\n" +
                                 "\t\tCairoColumn [name=a, position=0, type=BYTE, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=0]\n" +
                                 "\t\tCairoColumn [name=b, position=1, type=CHAR, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=1]\n" +
                                 "\t\tCairoColumn [name=c, position=2, type=SHORT, isDedupKey=false, isDesignated=false, isSymbolTableStatic=true, symbolCached=false, symbolCapacity=0, isIndexed=false, indexBlockCapacity=0, writerIndex=2]\n" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TablesBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TablesBootstrapTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.catalogue;
+
+import io.questdb.test.AbstractBootstrapTest;
+import io.questdb.test.TestServerMain;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TablesBootstrapTest extends AbstractBootstrapTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        TestUtils.unchecked(() -> createDummyConfiguration());
+        dbPath.parent().$();
+    }
+
+    @Test
+    public void testDesignatedTimestampAfterDropColumnAndRestart() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (final TestServerMain serverMain = startWithEnvVariables()) {
+                serverMain.start();
+
+                serverMain.ddl("CREATE TABLE tab (sym SYMBOL, bar VARCHAR, ts TIMESTAMP, foo INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                assertTables(serverMain);
+
+                serverMain.ddl("ALTER TABLE tab DROP COLUMN foo");
+                assertTables(serverMain);
+
+                serverMain.ddl("ALTER TABLE tab DROP COLUMN bar");
+                assertTables(serverMain);
+            }
+
+            // restart
+            try (final TestServerMain serverMain = startWithEnvVariables()) {
+                serverMain.start();
+
+                assertTables(serverMain);
+
+                serverMain.ddl("ALTER TABLE tab DROP COLUMN sym");
+                assertTables(serverMain);
+            }
+        });
+    }
+
+    private static void assertTables(TestServerMain serverMain) {
+        serverMain.assertSql(
+                "tables()",
+                "id\ttable_name\tdesignatedTimestamp\tpartitionBy\tmaxUncommittedRows\to3MaxLag\twalEnabled\tdirectoryName\tdedup\tttlValue\tttlUnit\tmatView\n" +
+                        "4\ttab\tts\tDAY\t500000\t600000000\ttrue\ttab~4\tfalse\t0\tHOUR\tfalse\n"
+        );
+    }
+}


### PR DESCRIPTION
Table metadata commands, such as `tables()` and `SHOW CREATE TABLE...`, incorrectly displayed which column is the designated timestamp because of a bug in metadata cache.

When a column positioned before the designated timestamp was dropped, the index of the designated timestamp column did not get adjusted.
This meant that the index pointed to the column behind the actual timestamp, and we displayed incorrect information.
Restart did not help either, because we never remove columns from the metadata files, just mark them as dropped.
On startup the cache does not load the dropped columns, and the timestamp index was just taken from the file as is without accounting for the dropped columns.

Fix is to use the writer index of the timestamp column to mark the designated timestamp column, the writer index never changes