### PR TITLE
fix(pgwire): prevent stale results in LATEST ON queries with bind variables

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/AbstractDeferredValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AbstractDeferredValueRecordCursorFactory.java
@@ -98,6 +98,8 @@ abstract class AbstractDeferredValueRecordCursorFactory extends AbstractPageFram
             PageFrameCursor pageFrameCursor,
             SqlExecutionContext executionContext
     ) throws SqlException {
+        symbolFunc.init(pageFrameCursor, executionContext);
+
         if (lookupDeferredSymbol(pageFrameCursor)) {
             if (recordCursorSupportsRandomAccess()) {
                 return EmptyTableRandomRecordCursor.INSTANCE;

--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -1645,7 +1645,7 @@ public abstract class AbstractCairoTest extends AbstractTest {
         }
     }
 
-    void assertFactoryCursor(
+    protected void assertFactoryCursor(
             String expected,
             String expectedTimestamp,
             RecordCursorFactory factory,


### PR DESCRIPTION
When executing `LATEST ON` queries that use a bind variable in a predicate (e.g., `SELECT * FROM table LATEST ON timestamp PARTITION BY symbol_column WHERE symbol_column = $1`) via the PostgreSQL wire protocol, an internal state management issue could lead to incorrect results. Specifically, a filter associated with the bind variable was not being correctly re-initialized upon repeated executions of a cached query plan.

This could, in certain sequences of operations, cause the query to return data corresponding to a parameter value used in a *previous execution*, rather than the currently bound parameter, because the filter retained stale criteria.