### PR TITLE
fix(core): fix for emoji in instance name breaking web console

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -114,6 +114,7 @@ import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
+import io.questdb.std.str.Utf8StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -2186,15 +2187,15 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public static class JsonPropertyValueFormatter {
-        public static void bool(CharSequence key, boolean value, StringSink sink) {
+        public static void bool(CharSequence key, boolean value, Utf8StringSink sink) {
             sink.putQuoted(key).putAscii(':').put(value).putAscii(',');
         }
 
-        public static void integer(CharSequence key, long value, StringSink sink) {
+        public static void integer(CharSequence key, long value, Utf8StringSink sink) {
             sink.putQuoted(key).putAscii(':').put(value).putAscii(',');
         }
 
-        public static void str(CharSequence key, CharSequence value, StringSink sink) {
+        public static void str(CharSequence key, CharSequence value, Utf8StringSink sink) {
             sink.putQuoted(key).putAscii(':');
             if (value != null) {
                 sink.putQuoted(value);
@@ -2550,7 +2551,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean exportConfiguration(StringSink sink) {
+        public boolean exportConfiguration(Utf8StringSink sink) {
             str(RELEASE_TYPE, getReleaseType(), sink);
             str(RELEASE_VERSION, getBuildInformation().getSwVersion(), sink);
             if (!Chars.empty(httpUsername)) {
@@ -5233,7 +5234,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     class PropPublicPassthroughConfiguration implements PublicPassthroughConfiguration {
         @Override
-        public boolean exportConfiguration(StringSink sink) {
+        public boolean exportConfiguration(Utf8StringSink sink) {
             bool(PropertyKey.POSTHOG_ENABLED.getPropertyPath(), isPosthogEnabled(), sink);
             str(PropertyKey.POSTHOG_API_KEY.getPropertyPath(), getPosthogApiKey(), sink);
             return true;

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -110,11 +110,11 @@ import io.questdb.std.datetime.millitime.DateFormatFactory;
 import io.questdb.std.datetime.millitime.Dates;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
+import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
-import io.questdb.std.str.Utf8StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -2187,15 +2187,15 @@ public class PropServerConfiguration implements ServerConfiguration {
     }
 
     public static class JsonPropertyValueFormatter {
-        public static void bool(CharSequence key, boolean value, Utf8StringSink sink) {
+        public static void bool(CharSequence key, boolean value, CharSink<?> sink) {
             sink.putQuoted(key).putAscii(':').put(value).putAscii(',');
         }
 
-        public static void integer(CharSequence key, long value, Utf8StringSink sink) {
+        public static void integer(CharSequence key, long value, CharSink<?> sink) {
             sink.putQuoted(key).putAscii(':').put(value).putAscii(',');
         }
 
-        public static void str(CharSequence key, CharSequence value, Utf8StringSink sink) {
+        public static void str(CharSequence key, CharSequence value, CharSink<?> sink) {
             sink.putQuoted(key).putAscii(':');
             if (value != null) {
                 sink.putQuoted(value);
@@ -2551,7 +2551,7 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean exportConfiguration(Utf8StringSink sink) {
+        public boolean exportConfiguration(CharSink<?> sink) {
             str(RELEASE_TYPE, getReleaseType(), sink);
             str(RELEASE_VERSION, getBuildInformation().getSwVersion(), sink);
             if (!Chars.empty(httpUsername)) {
@@ -5234,7 +5234,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
     class PropPublicPassthroughConfiguration implements PublicPassthroughConfiguration {
         @Override
-        public boolean exportConfiguration(Utf8StringSink sink) {
+        public boolean exportConfiguration(CharSink<?> sink) {
             bool(PropertyKey.POSTHOG_ENABLED.getPropertyPath(), isPosthogEnabled(), sink);
             str(PropertyKey.POSTHOG_API_KEY.getPropertyPath(), getPosthogApiKey(), sink);
             return true;

--- a/core/src/main/java/io/questdb/PublicPassthroughConfiguration.java
+++ b/core/src/main/java/io/questdb/PublicPassthroughConfiguration.java
@@ -24,7 +24,7 @@
 
 package io.questdb;
 
-import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 
 public interface PublicPassthroughConfiguration {
 
@@ -34,7 +34,7 @@ public interface PublicPassthroughConfiguration {
      *
      * @return true if anything was exported
      */
-    default boolean exportConfiguration(StringSink sink) {
+    default boolean exportConfiguration(Utf8StringSink sink) {
         return false;
     }
 

--- a/core/src/main/java/io/questdb/PublicPassthroughConfiguration.java
+++ b/core/src/main/java/io/questdb/PublicPassthroughConfiguration.java
@@ -24,7 +24,7 @@
 
 package io.questdb;
 
-import io.questdb.std.str.Utf8StringSink;
+import io.questdb.std.str.CharSink;
 
 public interface PublicPassthroughConfiguration {
 
@@ -34,7 +34,7 @@ public interface PublicPassthroughConfiguration {
      *
      * @return true if anything was exported
      */
-    default boolean exportConfiguration(Utf8StringSink sink) {
+    default boolean exportConfiguration(CharSink<?> sink) {
         return false;
     }
 

--- a/core/src/main/java/io/questdb/ServerConfiguration.java
+++ b/core/src/main/java/io/questdb/ServerConfiguration.java
@@ -33,7 +33,7 @@ import io.questdb.cutlass.line.udp.LineUdpReceiverConfiguration;
 import io.questdb.cutlass.pgwire.PGWireConfiguration;
 import io.questdb.metrics.MetricsConfiguration;
 import io.questdb.mp.WorkerPoolConfiguration;
-import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 
 public interface ServerConfiguration {
     String OSS = "OSS";
@@ -44,14 +44,14 @@ public interface ServerConfiguration {
      *
      * @param sink the target sink
      */
-    default void exportConfiguration(StringSink sink) {
+    default void exportConfiguration(Utf8StringSink sink) {
         sink.putAscii("\"config\":{");
         // bitwise OR below is intentional, always want to append passthrough config
         if (
                 getCairoConfiguration().exportConfiguration(sink)
                         | getPublicPassthroughConfiguration().exportConfiguration(sink)
         ) {
-            sink.clear(sink.length() - 1);
+            sink.clear(sink.size() - 1);
         }
         sink.putAscii("},");
     }

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -49,7 +49,7 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
-import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,7 +78,7 @@ public interface CairoConfiguration {
      *
      * @return true if anything was exported
      */
-    default boolean exportConfiguration(StringSink sink) {
+    default boolean exportConfiguration(Utf8StringSink sink) {
         return false;
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -49,7 +49,7 @@ import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.MicrosecondClockImpl;
 import io.questdb.std.datetime.millitime.MillisecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClockImpl;
-import io.questdb.std.str.Utf8StringSink;
+import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,7 +78,7 @@ public interface CairoConfiguration {
      *
      * @return true if anything was exported
      */
-    default boolean exportConfiguration(Utf8StringSink sink) {
+    default boolean exportConfiguration(CharSink<?> sink) {
         return false;
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -40,7 +40,7 @@ import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.TimeZoneRules;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
-import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -72,7 +72,7 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public boolean exportConfiguration(StringSink sink) {
+    public boolean exportConfiguration(Utf8StringSink sink) {
         return getDelegate().exportConfiguration(sink);
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -40,7 +40,7 @@ import io.questdb.std.datetime.DateLocale;
 import io.questdb.std.datetime.TimeZoneRules;
 import io.questdb.std.datetime.microtime.MicrosecondClock;
 import io.questdb.std.datetime.millitime.MillisecondClock;
-import io.questdb.std.str.Utf8StringSink;
+import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -72,7 +72,7 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public boolean exportConfiguration(Utf8StringSink sink) {
+    public boolean exportConfiguration(CharSink<?> sink) {
         return getDelegate().exportConfiguration(sink);
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -63,7 +63,6 @@ import io.questdb.std.Vect;
 import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.DirectUtf8String;
 import io.questdb.std.str.StdoutSink;
-import io.questdb.std.str.Utf16Sink;
 import io.questdb.std.str.Utf8s;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -472,8 +471,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
             connectionCountGauge = processor.connectionCountGauge(metrics);
             final long numOfConnections = connectionCountGauge.incrementAndGet();
             if (numOfConnections > connectionLimit) {
-                Utf16Sink utf16Sink = rejectProcessor.getMessageSink();
-                utf16Sink
+                rejectProcessor.getMessageSink()
                         .put("exceeded connection limit [name=").put(connectionCountGauge.getName())
                         .put(", numOfConnections=").put(numOfConnections)
                         .put(", connectionLimit=").put(connectionLimit)
@@ -481,8 +479,8 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
                 return rejectProcessor.withShutdownWrite().reject(HTTP_BAD_REQUEST);
             }
             if (numOfConnections == connectionLimit && !securityContext.isSystemAdmin()) {
-                Utf16Sink utf16Sink = rejectProcessor.getMessageSink();
-                utf16Sink.put("non-admin user reached connection limit [name=").put(connectionCountGauge.getName())
+                rejectProcessor.getMessageSink()
+                        .put("non-admin user reached connection limit [name=").put(connectionCountGauge.getName())
                         .put(", numOfConnections=").put(numOfConnections)
                         .put(", connectionLimit=").put(connectionLimit)
                         .put(']');

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseHeader.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseHeader.java
@@ -39,5 +39,5 @@ public interface HttpResponseHeader extends Utf8Sink {
         }
     }
 
-    String status(CharSequence httpProtocolVersion, int code, CharSequence contentType, long contentLength);
+    void status(CharSequence httpProtocolVersion, int code, CharSequence contentType, long contentLength);
 }

--- a/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessor.java
@@ -31,7 +31,7 @@ import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.network.QueryPausedException;
 import io.questdb.network.ServerDisconnectException;
-import io.questdb.std.str.Utf16Sink;
+import io.questdb.std.str.Utf8Sink;
 
 import static io.questdb.cutlass.http.HttpRequestValidator.ALL;
 import static io.questdb.cutlass.http.HttpRequestValidator.INVALID;
@@ -40,7 +40,7 @@ public interface RejectProcessor extends HttpMultipartContentProcessor {
 
     void clear();
 
-    Utf16Sink getMessageSink();
+    Utf8Sink getMessageSink();
 
     @Override
     default short getSupportedRequestTypes() {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessor.java
@@ -31,7 +31,7 @@ import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.network.QueryPausedException;
 import io.questdb.network.ServerDisconnectException;
-import io.questdb.std.str.Utf8Sink;
+import io.questdb.std.str.CharSink;
 
 import static io.questdb.cutlass.http.HttpRequestValidator.ALL;
 import static io.questdb.cutlass.http.HttpRequestValidator.INVALID;
@@ -40,7 +40,7 @@ public interface RejectProcessor extends HttpMultipartContentProcessor {
 
     void clear();
 
-    Utf8Sink getMessageSink();
+    CharSink<?> getMessageSink();
 
     @Override
     default short getSupportedRequestTypes() {

--- a/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessorImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessorImpl.java
@@ -30,8 +30,8 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
-import io.questdb.std.str.StringSink;
-import io.questdb.std.str.Utf16Sink;
+import io.questdb.std.str.Utf8Sink;
+import io.questdb.std.str.Utf8StringSink;
 
 import static io.questdb.cairo.SecurityContext.AUTH_TYPE_NONE;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -39,7 +39,7 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 public class RejectProcessorImpl implements RejectProcessor {
     private static final Log LOG = LogFactory.getLog(RejectProcessorImpl.class);
     protected final HttpConnectionContext httpConnectionContext;
-    private final StringSink rejectMessage = new StringSink();
+    private final Utf8StringSink rejectMessage = new Utf8StringSink();
     protected byte authenticationType = AUTH_TYPE_NONE;
     protected int rejectCode = 0;
     protected CharSequence rejectCookieName = null;
@@ -61,7 +61,7 @@ public class RejectProcessorImpl implements RejectProcessor {
     }
 
     @Override
-    public Utf16Sink getMessageSink() {
+    public Utf8Sink getMessageSink() {
         return rejectMessage;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessorImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/RejectProcessorImpl.java
@@ -30,7 +30,7 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
-import io.questdb.std.str.Utf8Sink;
+import io.questdb.std.str.CharSink;
 import io.questdb.std.str.Utf8StringSink;
 
 import static io.questdb.cairo.SecurityContext.AUTH_TYPE_NONE;
@@ -61,7 +61,7 @@ public class RejectProcessorImpl implements RejectProcessor {
     }
 
     @Override
-    public Utf8Sink getMessageSink() {
+    public CharSink<?> getMessageSink() {
         return rejectMessage;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/SettingsProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/SettingsProcessorState.java
@@ -24,28 +24,21 @@
 
 package io.questdb.cutlass.http.processors;
 
-import io.questdb.preferences.SettingsStore;
 import io.questdb.std.Mutable;
 import io.questdb.std.str.DirectUtf8Sink;
-import io.questdb.std.str.StringSink;
 
 import java.io.Closeable;
 
 class SettingsProcessorState implements Mutable, Closeable {
-    final StringSink utf16Sink;
     final DirectUtf8Sink utf8Sink;
-    SettingsStore.Mode mode;
 
     SettingsProcessorState(int size) {
         utf8Sink = new DirectUtf8Sink(size);
-        utf16Sink = new StringSink();
     }
 
     @Override
     public void clear() {
         utf8Sink.clear();
-        utf16Sink.clear();
-        mode = null;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/preferences/SettingsStore.java
+++ b/core/src/main/java/io/questdb/preferences/SettingsStore.java
@@ -12,8 +12,8 @@ import io.questdb.std.ObjList;
 import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
-import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8StringSink;
 import io.questdb.std.str.Utf8s;
 import org.jetbrains.annotations.NotNull;
 
@@ -58,7 +58,7 @@ public class SettingsStore implements Closeable {
         Misc.free(path);
     }
 
-    public synchronized void exportPreferences(StringSink settings) {
+    public synchronized void exportPreferences(Utf8StringSink settings) {
         settings.putAscii("\"preferences\":{");
         final ObjList<CharSequence> keys = preferencesMap.keys();
         for (int i = 0, n = keys.size(); i < n; i++) {
@@ -67,7 +67,7 @@ public class SettingsStore implements Closeable {
             str(key, value, settings);
         }
         if (keys.size() > 0) {
-            settings.clear(settings.length() - 1);
+            settings.clear(settings.size() - 1);
         }
         settings.putAscii('}');
     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
@@ -42,6 +42,7 @@ import io.questdb.preferences.PreferencesMap;
 import io.questdb.preferences.PreferencesUpdateListener;
 import io.questdb.preferences.SettingsStore;
 import io.questdb.std.FilesFacadeImpl;
+import io.questdb.std.str.CharSink;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8StringSink;
 import io.questdb.test.AbstractBootstrapTest;
@@ -585,7 +586,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
                             public CairoConfiguration getCairoConfiguration() {
                                 return new DefaultCairoConfiguration(bootstrap.getRootDirectory()) {
                                     @Override
-                                    public boolean exportConfiguration(Utf8StringSink sink) {
+                                    public boolean exportConfiguration(CharSink<?> sink) {
                                         final CairoConfiguration config = getCairoConfiguration();
                                         str(PropertyKey.CAIRO_LEGACY_SNAPSHOT_INSTANCE_ID.getPropertyPath(), config.getDbDirectory(), sink);
                                         integer(PropertyKey.CAIRO_MAX_FILE_NAME_LENGTH.getPropertyPath(), config.getMaxFileNameLength(), sink);
@@ -599,7 +600,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
                             public PublicPassthroughConfiguration getPublicPassthroughConfiguration() {
                                 return new DefaultPublicPassthroughConfiguration() {
                                     @Override
-                                    public boolean exportConfiguration(Utf8StringSink sink) {
+                                    public boolean exportConfiguration(CharSink<?> sink) {
                                         final PublicPassthroughConfiguration config = getPublicPassthroughConfiguration();
                                         bool(PropertyKey.POSTHOG_ENABLED.getPropertyPath(), config.isPosthogEnabled(), sink);
                                         str(PropertyKey.POSTHOG_API_KEY.getPropertyPath(), config.getPosthogApiKey(), sink);

--- a/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
@@ -43,6 +43,7 @@ import io.questdb.preferences.PreferencesUpdateListener;
 import io.questdb.preferences.SettingsStore;
 import io.questdb.std.FilesFacadeImpl;
 import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 import io.questdb.test.AbstractBootstrapTest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -92,7 +93,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
             "}" +
             "}";
 
-    private final StringSink sink = new StringSink();
+    private final Utf8StringSink sink = new Utf8StringSink();
 
     public static void assertSettingsRequest(HttpClient httpClient, String expectedHttpResponse) {
         final HttpClient.Request request = httpClient.newRequest("localhost", HTTP_PORT);
@@ -105,6 +106,52 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
         super.setUp();
         unchecked(() -> createDummyConfiguration());
         dbPath.parent().$();
+    }
+
+    @Test
+    public void testEmojiPreferences() throws Exception {
+        assertMemoryLeak(() -> {
+            try (final ServerMain serverMain = ServerMain.create(root)) {
+                serverMain.start();
+
+                final SettingsStore settingsStore = serverMain.getEngine().getSettingsStore();
+                try (HttpClient httpClient = HttpClientFactory.newPlainTextInstance(new DefaultHttpClientConfiguration())) {
+                    savePreferences(httpClient, "{\"instance_name\":\"instance ❤️\",\"instance_desc\":\"desc\"}", OVERWRITE, 0L);
+                    assertPreferencesStore(settingsStore, 1, "\"preferences\":{\"instance_name\":\"instance ❤️\",\"instance_desc\":\"desc\"}");
+
+                    assertSettingsRequest(httpClient, "{" +
+                            "\"config\":{" +
+                            "\"release.type\":\"OSS\"," +
+                            "\"release.version\":\"[DEVELOPMENT]\"," +
+                            "\"posthog.enabled\":false," +
+                            "\"posthog.api.key\":null" +
+                            "}," +
+                            "\"preferences.version\":1," +
+                            "\"preferences\":{" +
+                            "\"instance_name\":\"instance ❤️\"," +
+                            "\"instance_desc\":\"desc\"" +
+                            "}" +
+                            "}");
+
+                    savePreferences(httpClient, "{\"instance_name\":\"instance ❤️\",\"instance_desc\":\"desc \uD83D\uDE02\"}", OVERWRITE, 1L);
+                    assertPreferencesStore(settingsStore, 2, "\"preferences\":{\"instance_name\":\"instance ❤️\",\"instance_desc\":\"desc \uD83D\uDE02\"}");
+
+                    assertSettingsRequest(httpClient, "{" +
+                            "\"config\":{" +
+                            "\"release.type\":\"OSS\"," +
+                            "\"release.version\":\"[DEVELOPMENT]\"," +
+                            "\"posthog.enabled\":false," +
+                            "\"posthog.api.key\":null" +
+                            "}," +
+                            "\"preferences.version\":2," +
+                            "\"preferences\":{" +
+                            "\"instance_name\":\"instance ❤️\"," +
+                            "\"instance_desc\":\"desc \uD83D\uDE02\"" +
+                            "}" +
+                            "}");
+                }
+            }
+        });
     }
 
     @Test
@@ -197,6 +244,52 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
                             "\"instance_name\":\"instance1\"," +
                             "\"instance_desc\":\"desc222\"," +
                             "\"key1\":\"value1\"" +
+                            "}" +
+                            "}");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testNonASCIIPreferences() throws Exception {
+        assertMemoryLeak(() -> {
+            try (final ServerMain serverMain = ServerMain.create(root)) {
+                serverMain.start();
+
+                final SettingsStore settingsStore = serverMain.getEngine().getSettingsStore();
+                try (HttpClient httpClient = HttpClientFactory.newPlainTextInstance(new DefaultHttpClientConfiguration())) {
+                    savePreferences(httpClient, "{\"instance_name\":\"ветер\",\"instance_desc\":\"HŐMÉRSÉKLET\"}", OVERWRITE, 0L);
+                    assertPreferencesStore(settingsStore, 1, "\"preferences\":{\"instance_name\":\"ветер\",\"instance_desc\":\"HŐMÉRSÉKLET\"}");
+
+                    assertSettingsRequest(httpClient, "{" +
+                            "\"config\":{" +
+                            "\"release.type\":\"OSS\"," +
+                            "\"release.version\":\"[DEVELOPMENT]\"," +
+                            "\"posthog.enabled\":false," +
+                            "\"posthog.api.key\":null" +
+                            "}," +
+                            "\"preferences.version\":1," +
+                            "\"preferences\":{" +
+                            "\"instance_name\":\"ветер\"," +
+                            "\"instance_desc\":\"HŐMÉRSÉKLET\"" +
+                            "}" +
+                            "}");
+
+                    savePreferences(httpClient, "{\"instance_name\":\"金融\",\"instance_desc\":\"ファイナンス\"}", OVERWRITE, 1L);
+                    assertPreferencesStore(settingsStore, 2, "\"preferences\":{\"instance_name\":\"金融\",\"instance_desc\":\"ファイナンス\"}");
+
+                    assertSettingsRequest(httpClient, "{" +
+                            "\"config\":{" +
+                            "\"release.type\":\"OSS\"," +
+                            "\"release.version\":\"[DEVELOPMENT]\"," +
+                            "\"posthog.enabled\":false," +
+                            "\"posthog.api.key\":null" +
+                            "}," +
+                            "\"preferences.version\":2," +
+                            "\"preferences\":{" +
+                            "\"instance_name\":\"金融\"," +
+                            "\"instance_desc\":\"ファイナンス\"" +
                             "}" +
                             "}");
                 }
@@ -492,7 +585,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
                             public CairoConfiguration getCairoConfiguration() {
                                 return new DefaultCairoConfiguration(bootstrap.getRootDirectory()) {
                                     @Override
-                                    public boolean exportConfiguration(StringSink sink) {
+                                    public boolean exportConfiguration(Utf8StringSink sink) {
                                         final CairoConfiguration config = getCairoConfiguration();
                                         str(PropertyKey.CAIRO_LEGACY_SNAPSHOT_INSTANCE_ID.getPropertyPath(), config.getDbDirectory(), sink);
                                         integer(PropertyKey.CAIRO_MAX_FILE_NAME_LENGTH.getPropertyPath(), config.getMaxFileNameLength(), sink);
@@ -506,7 +599,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
                             public PublicPassthroughConfiguration getPublicPassthroughConfiguration() {
                                 return new DefaultPublicPassthroughConfiguration() {
                                     @Override
-                                    public boolean exportConfiguration(StringSink sink) {
+                                    public boolean exportConfiguration(Utf8StringSink sink) {
                                         final PublicPassthroughConfiguration config = getPublicPassthroughConfiguration();
                                         bool(PropertyKey.POSTHOG_ENABLED.getPropertyPath(), config.isPosthogEnabled(), sink);
                                         str(PropertyKey.POSTHOG_API_KEY.getPropertyPath(), config.getPosthogApiKey(), sink);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/json/JsonExtractVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/json/JsonExtractVarcharFunctionFactoryTest.java
@@ -124,72 +124,6 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testString() throws Exception {
-        assertMemoryLeak(
-                () -> {
-                    execute("create table json_test as (" +
-                            "select rnd_str('{\n" +
-                            "    \"hello\": \"world\",\n" +
-                            "    \"list\": [\n" +
-                            "        1,\n" +
-                            "        2,\n" +
-                            "        3\n" +
-                            "     ],\n" +
-                            "     \"dicts\": [\n" +
-                            "         {\"hello\": \"world\"},\n" +
-                            "         {\"hello\": \"bob\"}\n" +
-                            "     ]\n" +
-                            "}', \n" +
-                            "'{\n" +
-                            "    \"hello\": \"world\",\n" +
-                            "    \"list\": [\n" +
-                            "        1,\n" +
-                            "        2,\n" +
-                            "        3\n" +
-                            "     ],\n" +
-                            "     \"dicts\": [\n" +
-                            "         {\"hello\": \"world\"},\n" +
-                            "         {\"hello\": \"bob\"},\n" +
-                            "         {\"hello\": \"alice\"}\n" +
-                            "     ]\n" +
-                            "}',\n" +
-                            "'{\n" +
-                            "    \"hello\": \"world\",\n" +
-                            "    \"list\": [\n" +
-                            "        1,\n" +
-                            "        2,\n" +
-                            "        3\n" +
-                            "     ],\n" +
-                            "     \"dicts\": [\n" +
-                            "         {\"hello\": \"world\"},\n" +
-                            "         {\"hello\": \"bob\"},\n" +
-                            "         {\"hello\": \"запросила\"}\n" +
-                            "     ]\n" +
-                            "}',\n" +
-                            "null\n" +
-                            ")::varchar text from long_sequence(10)\n" +
-                            ")");
-
-                    assertQuery(
-                            "k\n" +
-                                    "\n" +
-                                    "{\"hello\": \"запросила\"}\n" +
-                                    "{\"hello\": \"alice\"}\n" +
-                                    "\n" +
-                                    "{\"hello\": \"alice\"}\n" +
-                                    "\n" +
-                                    "{\"hello\": \"запросила\"}\n" +
-                                    "\n" +
-                                    "{\"hello\": \"запросила\"}\n" +
-                                    "\n",
-                            "select json_extract(text, '.dicts[2]')::string k from json_test",
-                            true
-                    );
-                }
-        );
-    }
-
-    @Test
     public void testEmptyJson() throws Exception {
         assertMemoryLeak(() -> {
             final String json = "'{}'";
@@ -223,27 +157,6 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testExtractSymbol() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table json_test (text varchar)");
-            execute("insert into json_test values ('{\"path\": \"blue\"}')");
-            execute("insert into json_test values ('{\"path\": \"klll\"}')");
-            execute("insert into json_test values ('{\"path\": \"appl\"}')");
-            execute("insert into json_test values ('{\"path2\": \"4\"}')");
-            execute("insert into json_test values ('{\"path\": \"1on1\"}')");
-            assertSqlWithTypes(
-                    "x\n" +
-                            "klll:SYMBOL\n" +
-                            "blue:SYMBOL\n" +
-                            "appl:SYMBOL\n" +
-                            "1on1:SYMBOL\n" +
-                            ":SYMBOL\n",
-                    "select json_extract(text, '.path')::symbol x from json_test order by 1 desc"
-            );
-        });
-    }
-
-    @Test
     public void testExtractString() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table json_test (text varchar)");
@@ -265,22 +178,22 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testGeoHash() throws Exception {
+    public void testExtractSymbol() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table json_test (text varchar)");
-            execute("insert into json_test values ('{\"path\": \"sp052w9\"}')");
-            execute("insert into json_test values ('{\"path\": \"gbsuv7z\"}')");
-            execute("insert into json_test values ('{\"path\": null}')");
+            execute("insert into json_test values ('{\"path\": \"blue\"}')");
+            execute("insert into json_test values ('{\"path\": \"klll\"}')");
+            execute("insert into json_test values ('{\"path\": \"appl\"}')");
             execute("insert into json_test values ('{\"path2\": \"4\"}')");
             execute("insert into json_test values ('{\"path\": \"1on1\"}')");
             assertSqlWithTypes(
                     "x\n" +
-                            "sp052w9:GEOHASH(7c)\n" +
-                            "gbsuv7z:GEOHASH(7c)\n" +
-                            ":GEOHASH(7c)\n" +
-                            ":GEOHASH(7c)\n" +
-                            ":GEOHASH(7c)\n",
-                    "select cast(json_extract(text, '.path') as geohash(7c)) x from json_test order by 1 desc"
+                            "klll:SYMBOL\n" +
+                            "blue:SYMBOL\n" +
+                            "appl:SYMBOL\n" +
+                            "1on1:SYMBOL\n" +
+                            ":SYMBOL\n",
+                    "select json_extract(text, '.path')::symbol x from json_test order by 1 desc"
             );
         });
     }
@@ -298,6 +211,27 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
                             "6e18f80d-8b8f-4561-a9c8-703b73d5560d\n" +
                             "58e9a7c6-6112-4c48-8723-8765c706773a\n",
                     "select json_extract(text, '.path')::uuid x from json_test order by 1 desc"
+            );
+        });
+    }
+
+    @Test
+    public void testGeoHash() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table json_test (text varchar)");
+            execute("insert into json_test values ('{\"path\": \"sp052w9\"}')");
+            execute("insert into json_test values ('{\"path\": \"gbsuv7z\"}')");
+            execute("insert into json_test values ('{\"path\": null}')");
+            execute("insert into json_test values ('{\"path2\": \"4\"}')");
+            execute("insert into json_test values ('{\"path\": \"1on1\"}')");
+            assertSqlWithTypes(
+                    "x\n" +
+                            "sp052w9:GEOHASH(7c)\n" +
+                            "gbsuv7z:GEOHASH(7c)\n" +
+                            ":GEOHASH(7c)\n" +
+                            ":GEOHASH(7c)\n" +
+                            ":GEOHASH(7c)\n",
+                    "select cast(json_extract(text, '.path') as geohash(7c)) x from json_test order by 1 desc"
             );
         });
     }
@@ -553,15 +487,69 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testVarcharVanilla() throws Exception {
-        assertMemoryLeak(() -> {
-            final String json = "'{\"path\": \"abc\"}'";
-            final String expected = "json_extract\n" +
-                    "abc\n";
-            execute("create table json_test as (select " + json + "::varchar text)");
-            assertSql(expected, "select json_extract(" + json + ", '.path')");
-            assertSql(expected, "select json_extract(text, '.path') from json_test");
-        });
+    public void testString() throws Exception {
+        assertMemoryLeak(
+                () -> {
+                    execute("create table json_test as (" +
+                            "select rnd_str('{\n" +
+                            "    \"hello\": \"world\",\n" +
+                            "    \"list\": [\n" +
+                            "        1,\n" +
+                            "        2,\n" +
+                            "        3\n" +
+                            "     ],\n" +
+                            "     \"dicts\": [\n" +
+                            "         {\"hello\": \"world\"},\n" +
+                            "         {\"hello\": \"bob\"}\n" +
+                            "     ]\n" +
+                            "}', \n" +
+                            "'{\n" +
+                            "    \"hello\": \"world\",\n" +
+                            "    \"list\": [\n" +
+                            "        1,\n" +
+                            "        2,\n" +
+                            "        3\n" +
+                            "     ],\n" +
+                            "     \"dicts\": [\n" +
+                            "         {\"hello\": \"world\"},\n" +
+                            "         {\"hello\": \"bob\"},\n" +
+                            "         {\"hello\": \"alice\"}\n" +
+                            "     ]\n" +
+                            "}',\n" +
+                            "'{\n" +
+                            "    \"hello\": \"world\",\n" +
+                            "    \"list\": [\n" +
+                            "        1,\n" +
+                            "        2,\n" +
+                            "        3\n" +
+                            "     ],\n" +
+                            "     \"dicts\": [\n" +
+                            "         {\"hello\": \"world\"},\n" +
+                            "         {\"hello\": \"bob\"},\n" +
+                            "         {\"hello\": \"запросила\"}\n" +
+                            "     ]\n" +
+                            "}',\n" +
+                            "null\n" +
+                            ")::varchar text from long_sequence(10)\n" +
+                            ")");
+
+                    assertQuery(
+                            "k\n" +
+                                    "\n" +
+                                    "{\"hello\": \"запросила\"}\n" +
+                                    "{\"hello\": \"alice\"}\n" +
+                                    "\n" +
+                                    "{\"hello\": \"alice\"}\n" +
+                                    "\n" +
+                                    "{\"hello\": \"запросила\"}\n" +
+                                    "\n" +
+                                    "{\"hello\": \"запросила\"}\n" +
+                                    "\n",
+                            "select json_extract(text, '.dicts[2]')::string k from json_test",
+                            true
+                    );
+                }
+        );
     }
 
     @Test
@@ -570,6 +558,18 @@ public class JsonExtractVarcharFunctionFactoryTest extends AbstractCairoTest {
             final String json = "'{\"path\": 9999999999999999999}'";
             final String expected = "json_extract\n" +
                     "9999999999999999999\n";
+            execute("create table json_test as (select " + json + "::varchar text)");
+            assertSql(expected, "select json_extract(" + json + ", '.path')");
+            assertSql(expected, "select json_extract(text, '.path') from json_test");
+        });
+    }
+
+    @Test
+    public void testVarcharVanilla() throws Exception {
+        assertMemoryLeak(() -> {
+            final String json = "'{\"path\": \"abc\"}'";
+            final String expected = "json_extract\n" +
+                    "abc\n";
             execute("create table json_test as (select " + json + "::varchar text)");
             assertSql(expected, "select json_extract(" + json + ", '.path')");
             assertSql(expected, "select json_extract(text, '.path') from json_test");

--- a/core/src/test/java/io/questdb/test/preferences/SettingsStoreConcurrentTest.java
+++ b/core/src/test/java/io/questdb/test/preferences/SettingsStoreConcurrentTest.java
@@ -28,7 +28,7 @@ import io.questdb.cairo.CairoException;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.preferences.SettingsStore;
 import io.questdb.std.str.DirectUtf8Sink;
-import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8StringSink;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -92,7 +92,7 @@ public class SettingsStoreConcurrentTest extends AbstractCairoTest {
                     new Thread(() -> {
                         await(start);
                         try {
-                            final StringSink sink = new StringSink();
+                            final Utf8StringSink sink = new Utf8StringSink();
                             for (int j = 0; j < numOfReads; j++) {
                                 sink.clear();
                                 settingsStore.exportPreferences(sink);


### PR DESCRIPTION
Content length was calculated incorrectly for non-ASCII content in `HttpResponseSink.sendStatus...()` methods.
Because of the incorrect content length the browser stopped reading the HTTP body early, resulting in malformed JSON messages which subsequently broke the web console.

Changed all `HttpResponseSink.sendStatus...()` methods to take `Utf8Sequence` as a message, and content length is calculated by calling `Utf8Sequence.size()`. 

fixes https://github.com/questdb/questdb/issues/5698

required by https://github.com/questdb/questdb-enterprise/pull/621

 