### PR TITLE
fix(sql): unreliable out-of-memory error propagation in parallel SQL

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
@@ -55,6 +55,7 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
     private PageFrameSequence<?> frameSequence;
     private long frameSequenceId;
     private boolean isCancelled;
+    private boolean isOutOfMemory;
     private byte type;
 
     public PageFrameReduceTask(CairoConfiguration configuration, int memoryTag) {
@@ -151,6 +152,10 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
         return isCancelled;
     }
 
+    public boolean isOutOfMemory() {
+        return isOutOfMemory;
+    }
+
     public void of(PageFrameSequence<?> frameSequence, int frameIndex) {
         this.frameSequence = frameSequence;
         this.frameMemoryPool.of(frameSequence.getPageFrameAddressCache());
@@ -159,6 +164,7 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
         this.frameIndex = frameIndex;
         errorMsg.clear();
         isCancelled = false;
+        isOutOfMemory = false;
         frameMemory = null;
         filteredRows.clear();
     }
@@ -216,8 +222,10 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
         }
 
         if (th instanceof CairoException) {
-            isCancelled = ((CairoException) th).isCancellation();
-            errorMessagePosition = ((CairoException) th).getPosition();
+            final CairoException ce = (CairoException) th;
+            isCancelled = ce.isCancellation();
+            isOutOfMemory = ce.isOutOfMemory();
+            errorMessagePosition = ce.getPosition();
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/vect/GroupByRecordCursorFactory.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.groupby.vect;
 import io.questdb.MessageBus;
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.DataUnavailableException;
@@ -134,7 +135,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                         raf.free(pRosti[k]);
                         pRosti[k] = 0;
                     }
-                    throw new OutOfMemoryError();
+                    throw CairoException.nonCritical()
+                            .put("could not allocate rosti hash table")
+                            .setOutOfMemory(true);
                 }
                 pRosti[i] = ptr;
 
@@ -261,7 +264,7 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
     private void resetRostiMemorySize() {
         for (int i = 0, n = pRosti.length; i < n; i++) {
             if (!raf.reset(pRosti[i], ROSTI_MINIMIZED_SIZE)) {
-                LOG.debug().$("Couldn't minimize rosti memory [i=").$(i).$(",current_size=").$(Rosti.getSize(pRosti[i])).I$();
+                LOG.debug().$("could not minimize rosti memory [i=").$(i).$(", currentSize=").$(Rosti.getSize(pRosti[i])).I$();
             }
         }
     }
@@ -538,7 +541,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
 
             if (oomCounter.get() > 0) {
                 resetRostiMemorySize();
-                throw new OutOfMemoryError();
+                throw CairoException.nonCritical()
+                        .put("could not resize rosti hash table")
+                        .setOutOfMemory(true);
             }
 
             // merge maps only when cursor was fetched successfully
@@ -568,7 +573,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                             long oldSize = Rosti.getAllocMemory(pRostiBig);
                             if (!vaf.merge(pRostiBig, pRosti[i])) {
                                 resetRostiMemorySize();
-                                throw new OutOfMemoryError();
+                                throw CairoException.nonCritical()
+                                        .put("could not merge rosti hash table")
+                                        .setOutOfMemory(true);
                             }
                             raf.updateMemoryUsage(pRostiBig, oldSize);
                         }
@@ -579,7 +586,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                         long oldSize = Rosti.getAllocMemory(pRostiBig);
                         if (!vaf.wrapUp(pRostiBig)) {
                             resetRostiMemorySize();
-                            throw new OutOfMemoryError();
+                            throw CairoException.nonCritical()
+                                    .put("could not wrap up rosti hash table")
+                                    .setOutOfMemory(true);
                         }
                         raf.updateMemoryUsage(pRostiBig, oldSize);
                     }
@@ -598,7 +607,9 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
                     for (int j = 0; j < vafCount; j++) {
                         if (!vafList.getQuick(j).wrapUp(pRostiBig)) {
                             resetRostiMemorySize();
-                            throw new OutOfMemoryError();
+                            throw CairoException.nonCritical()
+                                    .put("could not wrap up rosti hash table")
+                                    .setOutOfMemory(true);
                         }
                     }
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredNegativeLimitRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredNegativeLimitRecordCursor.java
@@ -187,7 +187,10 @@ class AsyncFilteredNegativeLimitRecordCursor implements RecordCursor {
                     if (task.hasError()) {
                         throw CairoException.nonCritical()
                                 .position(task.getErrorMessagePosition())
-                                .put(task.getErrorMsg());
+                                .put(task.getErrorMsg())
+                                .setCancellation(task.isCancelled())
+                                .setInterruption(task.isCancelled())
+                                .setOutOfMemory(task.isOutOfMemory());
                     }
 
                     // Consider frame sequence status only if we haven't accumulated enough rows.

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursor.java
@@ -337,7 +337,8 @@ class AsyncFilteredRecordCursor implements RecordCursor {
                                 .position(task.getErrorMessagePosition())
                                 .put(task.getErrorMsg())
                                 .setCancellation(task.isCancelled())
-                                .setInterruption(task.isCancelled());
+                                .setInterruption(task.isCancelled())
+                                .setOutOfMemory(task.isOutOfMemory());
                     }
 
                     allFramesActive &= frameSequence.isActive();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
@@ -25,8 +25,12 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.*;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.sql.VirtualRecord;
 import io.questdb.cairo.sql.async.PageFrameReduceTask;
 import io.questdb.cairo.sql.async.PageFrameSequence;
 import io.questdb.griffin.SqlException;
@@ -146,7 +150,10 @@ class AsyncGroupByNotKeyedRecordCursor implements NoRandomAccessRecordCursor {
                     if (task.hasError()) {
                         throw CairoException.nonCritical()
                                 .position(task.getErrorMessagePosition())
-                                .put(task.getErrorMsg());
+                                .put(task.getErrorMsg())
+                                .setCancellation(task.isCancelled())
+                                .setInterruption(task.isCancelled())
+                                .setOutOfMemory(task.isOutOfMemory());
                     }
 
                     allFramesActive &= frameSequence.isActive();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -197,7 +197,10 @@ class AsyncGroupByRecordCursor implements RecordCursor {
                     if (task.hasError()) {
                         throw CairoException.nonCritical()
                                 .position(task.getErrorMessagePosition())
-                                .put(task.getErrorMsg());
+                                .put(task.getErrorMsg())
+                                .setCancellation(task.isCancelled())
+                                .setInterruption(task.isCancelled())
+                                .setOutOfMemory(task.isOutOfMemory());
                     }
 
                     allFramesActive &= frameSequence.isActive();

--- a/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AggregateTest.java
@@ -27,6 +27,7 @@ package io.questdb.test.griffin;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.PartitionBy;
@@ -1318,7 +1319,8 @@ public class AggregateTest extends AbstractCairoTest {
                                 true
                         );
                         Assert.fail();
-                    } catch (OutOfMemoryError oome) {
+                    } catch (CairoException e) {
+                        Assert.assertTrue(e.isOutOfMemory());
                         long memAfter = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_ROSTI);
                         Assert.assertEquals(memBefore, memAfter);
                     }
@@ -1975,7 +1977,8 @@ public class AggregateTest extends AbstractCairoTest {
                     cursor.hasNext();
                 }
                 Assert.fail("Cursor should throw OOM for " + query + " !");
-            } catch (OutOfMemoryError oome) {
+            } catch (CairoException e) {
+                Assert.assertTrue(e.isOutOfMemory());
                 long memAfter = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_ROSTI);
                 // rostis are minimized on OOM
                 Assert.assertTrue(memAfter < memBefore + 10 * 1024);

--- a/core/src/test/java/io/questdb/test/griffin/DistinctIntKeyTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctIntKeyTest.java
@@ -69,8 +69,8 @@ public class DistinctIntKeyTest extends AbstractCairoTest {
 
             try {
                 assertExceptionNoLeakCheck("select DISTINCT i from tab order by 1 LIMIT 3", sqlExecutionContext);
-            } catch (OutOfMemoryError e) {
-                // ignore
+            } catch (CairoException e) {
+                Assert.assertTrue(e.isOutOfMemory());
             }
         });
     }


### PR DESCRIPTION
Proper OOM error propagation is important for mat view refresh job since it has a back-off logic where it shrinks the queried interval size.