### PR TITLE
chore(pgwire): add detailed logging for assertion errors

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/modern/PGPipelineEntry.java
@@ -693,7 +693,13 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                     getErrorMessageSink().putAscii("Internal error. Exception type: ").putAscii(th.getClass().getSimpleName());
                 }
             }
-            LOG.error().$(getErrorMessageSink()).$();
+            if (th instanceof AssertionError) {
+                // assertion errors means either a questdb bug or data corruption ->
+                // we want to see a full stack trace in server logs and log it as critical
+                LOG.critical().$("error in pgwire execute, ex=").$(th).$();
+            } else {
+                LOG.error().$(getErrorMessageSink()).$();
+            }
         } finally {
             // after execute is complete, bind variable values have been used and no longer needed in the cache
             bindVariableCharacterStore.clear();
@@ -2137,6 +2143,11 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                     getErrorMessageSink().put(msg);
                 } else {
                     getErrorMessageSink().putAscii("no message provided (internal error)");
+                }
+                if (th instanceof AssertionError) {
+                    // assertion errors means either a questdb bug or data corruption ->
+                    // we want to see a full stack trace in server logs and log it as critical
+                    LOG.critical().$("error in pgwire execute, ex=").$(th).$();
                 }
             }
         }


### PR DESCRIPTION
Assertion errors indicate either a bug or data corruption. In both cases, we need detailed stack traces in server logs to easily pinpoint the root cause. This change also logs assertions as Critical level to ensure they propagate to our alerting system.