### PR TITLE
chore(sql): Optimize the error message for unsupported window functions in expressions.

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1407,6 +1407,11 @@ public class ExpressionParser {
                                     throw SqlException.$(lastPos, "Huh? What would you like to extract?");
                                 }
                                 throw SqlException.$(lastPos, "Unnecessary `from`. Typo?");
+                            } else if (SqlKeywords.isOverKeyword(tok)) {
+                                if (Chars.equals(SqlUtil.fetchNext(lexer), '(')) {
+                                    throw SqlException.$(lastPos, "Nested window functions are not currently supported.");
+                                }
+                                lexer.unparseLast();
                             }
 
                             // this is a function or array name, push it onto the stack
@@ -1503,6 +1508,11 @@ public class ExpressionParser {
                             } else if (SqlKeywords.isDoubleKeyword(last.token) && SqlKeywords.isPrecisionKeyword(tok)) {
                                 // ignore 'precision' keyword after 'double'
                                 continue;
+                            } else if (SqlKeywords.isOverKeyword(tok)) {
+                                if (Chars.equals(SqlUtil.fetchNext(lexer), '(')) {
+                                    throw SqlException.$(lastPos, "Nested window functions' context are not currently supported.");
+                                }
+                                lexer.unparseLast();
                             }
                         }
                         // literal can be at start of input, after a bracket or part of an operator

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -5347,7 +5347,7 @@ public class SqlOptimiser implements Mutable {
      * <p>
      * This is to allow for the generation of an interval scan and minimise reading of un-needed data.
      */
-    private void rewriteSampleByFromTo(QueryModel model) {
+    private void rewriteSampleByFromTo(QueryModel model) throws SqlException {
         QueryModel curr;
         QueryModel fromToModel;
         QueryModel whereModel = null;
@@ -5395,7 +5395,9 @@ public class SqlOptimiser implements Mutable {
                     timestamp = whereModel.getTimestamp();
                 }
             }
-            assert timestamp != null;
+            if (timestamp == null) {
+                throw SqlException.$(fromToModel.getSampleBy().position, "Sample by over a query requires designated TIMESTAMP");
+            }
 
             if (Chars.indexOf(timestamp.token, '.') < 0) {
                 // prefix the timestamp column name only if the table is not dotted

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -5396,7 +5396,7 @@ public class SqlOptimiser implements Mutable {
                 }
             }
             if (timestamp == null) {
-                throw SqlException.$(fromToModel.getSampleBy().position, "Sample by over a query requires designated TIMESTAMP");
+                throw SqlException.$(fromToModel.getSampleBy().position, "Sample by requires a designated TIMESTAMP");
             }
 
             if (Chars.indexOf(timestamp.token, '.') < 0) {

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -6875,6 +6875,21 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testNestedWindowFunctionNotSupported() throws Exception {
+        assertSyntaxError(
+                "select a,b, 1 + f(c) over (partition by b order by a groups between unbounded preceding and 10 day following) from xyz",
+                21,
+                "Nested window functions' context are not currently supported."
+        );
+
+        assertSyntaxError(
+                "select a,b,cast(f(c) over (order by a) as int) from xyz",
+                21,
+                "Nested window functions' context are not currently supported."
+        );
+    }
+
+    @Test
     public void testNonAggFunctionWithAggFunctionSampleBy() throws SqlException {
         assertQuery(
                 "select-virtual day(ts) day, isin, last from (select-group-by [ts, isin, last(start_price) last] ts, isin, last(start_price) last from (select [ts, isin, start_price] from xetra timestamp (ts) where isin = 'DE000A0KRJS4') sample by 1d)",
@@ -10248,8 +10263,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testSelectWindowOperator() throws Exception {
         assertSyntaxError(
                 "select sum(x), 2*x over() from tab",
-                16,
-                "Window function expected",
+                19,
+                "Nested window functions' context are not currently supported.",
                 modelOf("tab").col("x", ColumnType.INT)
         );
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -6251,7 +6251,7 @@ public class SampleByTest extends AbstractCairoTest {
                     "SELECT * FROM ( SELECT null as x) SAMPLE BY 1d FROM '2021-01-02T00:00:00' " +
                             "TO dateadd('d', 1095, '2021-01-02T00:00:00');",
                     44,
-                    "Sample by over a query requires designated TIMESTAMP");
+                    "Sample by requires a designated TIMESTAMP");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -6245,6 +6245,17 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByWithoutTimestamp() throws Exception {
+        assertMemoryLeak(() -> {
+            assertException(
+                    "SELECT * FROM ( SELECT null as x) SAMPLE BY 1d FROM '2021-01-02T00:00:00' " +
+                            "TO dateadd('d', 1095, '2021-01-02T00:00:00');",
+                    44,
+                    "Sample by over a query requires designated TIMESTAMP");
+        });
+    }
+
+    @Test
     public void testSampleCountFillLinear() throws Exception {
         assertQuery(
                 "b\tcount\tk\n" +


### PR DESCRIPTION
- Optimize the error message for unsupported window functions in expressions.
- Optimize the error message for `SAMPLE BY` lacking `timestamp` column.

Close #5729
Close #5727