### PR TITLE
ci(pgwire): reduce unnecessary runs of PGWire workflow

### DIFF
--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -4,7 +4,7 @@ name: PGWire - Stable clients
 
 on:
   pull_request:
-    types: [ synchronize, opened, reopened, edited ]
+    types: [ synchronize, opened, reopened ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflow was triggering on every pull request `edited` event, including for non-code changes like editing the title or description.

Remaining triggers:
- opened: a pull request is created
- reopened: a previously closed pull request is opened again
- synchronize: new commits are pushed to the pull request branch