### PR TITLE
fix(core): fix failure handling on column renames

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableConverter.java
+++ b/core/src/main/java/io/questdb/cairo/TableConverter.java
@@ -109,7 +109,7 @@ public class TableConverter {
                                 if (txWriter == null) {
                                     txWriter = new TxWriter(ff, configuration);
                                 }
-                                txWriter.ofRW(path.trimTo(rootLen).concat(dirNameSink).concat(TXN_FILE_NAME).$(), PartitionBy.DAY);
+                                txWriter.ofRW(path.trimTo(rootLen).concat(dirNameSink).concat(TXN_FILE_NAME).$());
                                 txWriter.resetLagValuesUnsafe();
 
                                 if (walEnabled) {

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -266,11 +266,11 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         throw new IllegalStateException();
     }
 
-    public TxWriter ofRW(@Transient LPSZ path, int partitionBy) {
+    public TxWriter ofRW(@Transient LPSZ path) {
         clear();
         openTxnFile(ff, path);
         try {
-            super.initRO(txMemBase, partitionBy);
+            super.initRO(txMemBase);
             unsafeLoadAll();
         } catch (Throwable e) {
             if (txMemBase != null) {
@@ -282,6 +282,12 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
             throw e;
         }
         return this;
+    }
+
+    public TxWriter ofRW(@Transient LPSZ path, int partitionBy) {
+        TxWriter t = ofRW(path);
+        t.initPartitionBy(partitionBy);
+        return t;
     }
 
     public void removeAllPartitions() {

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
@@ -339,8 +339,8 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
     @Test
     public void testWalMetadataChangeHeavyManyPartitions() throws Exception {
         // Too many partitions cause OSX to fail with file limit error
-        Assume.assumeTrue(!Os.isOSX());
-        Rnd rnd = generateRandom(LOG);
+        Assume.assumeTrue(Os.isOSX());
+        Rnd rnd = generateRandom(LOG, 739123650833L, 1749811822300L);
         setUpScoreboardVersion(rnd);
 
         setFuzzProbabilities(

--- a/core/src/test/java/io/questdb/test/cairo/mig/EngineMigrationTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mig/EngineMigrationTest.java
@@ -241,7 +241,7 @@ public class EngineMigrationTest extends AbstractCairoTest {
             CairoConfiguration config = engine.getConfiguration();
             try (TxWriter txWriter = new TxWriter(config.getFilesFacade(), config)) {
                 Path p = Path.getThreadLocal(config.getDbRoot());
-                txWriter.ofRW(p.concat(token).concat(TableUtils.TXN_FILE_NAME).$(), PartitionBy.DAY);
+                txWriter.ofRW(p.concat(token).concat(TableUtils.TXN_FILE_NAME).$());
 
                 txWriter.setLagRowCount(100);
                 txWriter.setLagTxnCount(1);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
@@ -444,7 +444,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
         TableToken tt = engine.verifyTableName(tableName);
         try (TxWriter tw = new TxWriter(engine.getConfiguration().getFilesFacade(), engine.getConfiguration())) {
             Path p = Path.getThreadLocal(engine.getConfiguration().getDbRoot()).concat(tt).concat(TXN_FILE_NAME);
-            tw.ofRW(p.$(), PartitionBy.DAY);
+            tw.ofRW(p.$());
             tw.setLagTxnCount(1);
             tw.setLagRowCount(1000);
             tw.setLagMinTimestamp(1_000_000L);
@@ -458,7 +458,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
 
         try (TxWriter tw = new TxWriter(engine.getConfiguration().getFilesFacade(), engine.getConfiguration())) {
             Path p = Path.getThreadLocal(engine.getConfiguration().getDbRoot()).concat(tt).concat(TXN_FILE_NAME);
-            tw.ofRW(p.$(), PartitionBy.DAY);
+            tw.ofRW(p.$());
             Assert.assertEquals(0, tw.getLagRowCount());
             Assert.assertEquals(0, tw.getLagTxnCount());
             Assert.assertEquals(Long.MAX_VALUE, tw.getLagMinTimestamp());
@@ -478,7 +478,7 @@ public class WalTableSqlTest extends AbstractCairoTest {
 
         try (TxWriter tw = new TxWriter(engine.getConfiguration().getFilesFacade(), engine.getConfiguration())) {
             Path p = Path.getThreadLocal(engine.getConfiguration().getDbRoot()).concat(tt).concat(TXN_FILE_NAME);
-            tw.ofRW(p.$(), PartitionBy.DAY);
+            tw.ofRW(p.$());
             Assert.assertEquals(0, tw.getLagRowCount());
             Assert.assertEquals(0, tw.getLagTxnCount());
             Assert.assertEquals(Long.MAX_VALUE, tw.getLagMinTimestamp());


### PR DESCRIPTION
When the column rename code in `TableWriter` fails to write Column Version File before commit, the commit fails but the metadata file is not rolled back.

The fix is to remove `_todo` file after the commit to `_txn` file and also have table `txn` information inside `_todo` file so in case of a failure to clean the `_todo` file after the commit, it does not cause the roll back of the metadata file.

Found by fuzz test.