### PR TITLE
chore(core): add missing conf name `cairo.wal.writer.event.append.page.size` in the comments in server.conf

### DIFF
--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -892,7 +892,7 @@ cairo.sql.copy.root=import
 # this page size has performance impact on large number of small transactions, larger
 # page will cope better. However, if the workload is that of small number of large transaction,
 # this page size can be reduced. The optimal value should be established via ingestion benchmark.
-#cairo.wal.writer.data.append.page.size=128k
+#cairo.wal.writer.event.append.page.size=128k
 
 # Multiplier to cairo.max.uncommitted.rows to calculate the limit of rows that can kept invisible when writing
 # to WAL table under heavy load, when multiple transactions are to be applied.


### PR DESCRIPTION
There are 2 `cairo.wal.writer.data.append.page.size` in the comments in the `server.conf`. It might be a typo, and the second one might be `cairo.wal.writer.event.append.page.size`.