### PR TITLE
ISSUE#5647 - LIMIT and ORDER BY pushdown in ASOF queries 

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -4946,11 +4946,12 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         "Count\n" +
                                 "    " + factoryType + "\n" +
                                 (i == 0 ? "      condition: T2.created=T1.created\n" : "") +
-                                "        Async JIT Filter workers: 1\n" +
-                                "          filter: value!=1\n" +
-                                "            PageFrame\n" +
-                                "                Row forward scan\n" +
-                                "                Frame forward scan on: tab\n" +
+                                (i == 2 ? "        SelectedRecord\n" : "") +
+                                (i == 2 ? "    " : "") + "        Async JIT Filter workers: 1\n" +
+                                (i == 2 ? "    " : "") + "          filter: value!=1\n" +
+                                (i == 2 ? "    " : "") + "            PageFrame\n" +
+                                (i == 2 ? "    " : "") + "                Row forward scan\n" +
+                                (i == 2 ? "    " : "") + "                Frame forward scan on: tab\n" +
                                 (i == 0 ? "        Hash\n" : "") +
                                 (i == 0 ? "    " : "") + "        PageFrame\n" +
                                 (i == 0 ? "    " : "") + "            Row forward scan\n" +

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -1219,21 +1219,24 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
                     "ORDER BY t1.s, t1.ts\n" +
                     "LIMIT 1000000;";
 
-            assertQuery("select-choose t1.s s, t1.ts ts, t2.s s1, t2.ts ts1 from (select [s, ts] from t1 timestamp (ts) asof join select [s, ts] from t2 timestamp (ts) on t2.s = t1.s where ts between ('2023-09-01T00:00:00.000Z','2023-09-01T01:00:00.000Z')) order by s, ts limit 1000000", query);
+            assertQuery("select-choose t1.s s, t1.ts ts, t2.s s1, t2.ts ts1 from (select [s, ts] from (select-choose [s, ts] from (select-choose [s, ts] s, ts from (select [s, ts] from t1 timestamp (ts) where ts between ('2023-09-01T00:00:00.000Z','2023-09-01T01:00:00.000Z')) order by s, ts limit 1000000) order by ts) t1 asof join select [s, ts] from t2 timestamp (ts) on t2.s = t1.s) order by s, ts", query);
             assertPlanNoLeakCheck(query,
-                    "Limit lo: 1000000 skip-over-rows: 0 limit: 7\n" +
-                            "    Sort\n" +
-                            "      keys: [s, ts]\n" +
-                            "        SelectedRecord\n" +
-                            "            AsOf Join Fast Scan\n" +
-                            "              condition: t2.s=t1.s\n" +
-                            "                PageFrame\n" +
-                            "                    Row forward scan\n" +
-                            "                    Interval forward scan on: t1\n" +
-                            "                      intervals: [(\"2023-09-01T00:00:00.000000Z\",\"2023-09-01T01:00:00.000000Z\")]\n" +
-                            "                PageFrame\n" +
-                            "                    Row forward scan\n" +
-                            "                    Frame forward scan on: t2\n");
+                    "Sort\n" +
+                            "  keys: [s, ts]\n" +
+                            "    SelectedRecord\n" +
+                            "        AsOf Join Fast Scan\n" +
+                            "          condition: t2.s=t1.s\n" +
+                            "            Radix sort light\n" +
+                            "              keys: [ts]\n" +
+                            "                Limit lo: 1000000 skip-over-rows: 0 limit: 7\n" +
+                            "                    SortedSymbolIndex\n" +
+                            "                        Index forward scan on: s\n" +
+                            "                          symbolOrder: asc\n" +
+                            "                        Interval forward scan on: t1\n" +
+                            "                          intervals: [(\"2023-09-01T00:00:00.000000Z\",\"2023-09-01T01:00:00.000000Z\")]\n" +
+                            "            PageFrame\n" +
+                            "                Row forward scan\n" +
+                            "                Frame forward scan on: t2\n");
             assertSql("s\tts\ts1\tts1\n" +
                     "a\t2023-09-01T00:00:00.000000Z\ta\t2023-09-01T00:00:00.000000Z\n" +
                     "a\t2023-09-01T00:10:00.000000Z\ta\t2023-09-01T00:10:00.000000Z\n" +

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -978,7 +978,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testAsOfJoin() throws SqlException {
         assertQuery(
-                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from trades t timestamp (timestamp) asof join select [timestamp] from quotes q timestamp (timestamp) where tag = null) t",
+                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from (select-choose [timestamp, tag] from (select-choose [timestamp, tag] timestamp, tag from (select [timestamp, tag] from trades timestamp (timestamp) where tag = null)) order by timestamp) t asof join select [timestamp] from quotes q timestamp (timestamp)) t",
                 "trades t ASOF JOIN quotes q WHERE tag = null",
                 modelOf("trades").timestamp().col("tag", ColumnType.SYMBOL),
                 modelOf("quotes").timestamp()
@@ -5143,7 +5143,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
         // model with joins
         assertQuery(
-                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from trades t timestamp (timestamp) asof join select [timestamp] from quotes q timestamp (timestamp) hints[HINT] where tag = null hints[HINT]) t hints[HINT]",
+                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from (select-choose [timestamp, tag] from (select-choose [timestamp, tag] timestamp, tag from (select [timestamp, tag] from trades timestamp (timestamp) where tag = null)) order by timestamp) t asof join select [timestamp] from quotes q timestamp (timestamp) hints[HINT] hints[HINT]) t hints[HINT]",
                 "select /*+ HINT*/ * from trades t ASOF JOIN quotes q WHERE tag = null",
                 modelOf("trades").timestamp().col("tag", ColumnType.SYMBOL),
                 modelOf("quotes").timestamp()


### PR DESCRIPTION
This PR will resolve #5647
For a query like
```
 select * from trades ASOF JOIN order_book
 where price = '184.0'
order by trades.size , trades.timestamp  limit 5
```
It will create a query model which will look like

`select-choose trades.timestamp timestamp, trades.price price, trades.size size, order_book.timestamp timestamp1, order_book.bid_price bid_price, order_book.bid_size bid_size, order_book.ask_price ask_price, order_book.ask_size ask_size from (select [timestamp, price, size] from (select-choose [timestamp, price, size] from (select-choose [timestamp, price, size] timestamp, price, size from (select [timestamp, price, size] from trades timestamp (timestamp) where price = '184.0') order by size, timestamp limit 5) order by timestamp) trades asof join select [timestamp, bid_price, bid_size, ask_price, ask_size] from order_book timestamp (timestamp)) order by size, timestamp`

Explain plan will look like this 

```
Sort
  keys: [size, timestamp]
    SelectedRecord
        AsOf Join Fast Scan
            Radix sort light
              keys: [timestamp]
                Sort light lo: 5
                  keys: [size, timestamp]
                    Async Filter workers: 10
                      filter: price='184.0'
                        PageFrame
                            Row forward scan
                            Frame forward scan on: trades
            PageFrame
                Row forward scan
                Frame forward scan on: order_book
```

Approach :

-  Creates 3 additional models for handling **limit , order-by and where clause** shift :-

- _Level 0_ - contains nested model of model containing ASOF JOINS
- _Level 1_  - contains where clause ,  limit and order by clauses which are shifted inside from `target-model`
- _Level 2_ - imposes order by ASC by timestamp , as its a mandate before ASOF joins

