### PR TITLE
fix(sql): exception thrown when same DECLARE variable used in 2-params function 

### DIFF
--- a/core/src/main/java/io/questdb/griffin/PostOrderTreeTraversalAlgo.java
+++ b/core/src/main/java/io/questdb/griffin/PostOrderTreeTraversalAlgo.java
@@ -62,14 +62,13 @@ public final class PostOrderTreeTraversalAlgo {
             // see http://en.wikipedia.org/wiki/Tree_traversal
 
             stack.clear();
+            // indexStack keeps the index of the node we are currently visiting.
+            // When paramCount < 3, we are relying on rhs (index 0) and lhs (index 1) to store the node parameters.
             indexStack.clear();
-
-            ExpressionNode lastVisited = null;
 
             while (!stack.isEmpty() || node != null) {
                 if (node != null) {
                     if (!visitor.descend(node)) {
-                        lastVisited = node;
                         node = null;
                         continue;
                     }
@@ -80,11 +79,13 @@ public final class PostOrderTreeTraversalAlgo {
                     ExpressionNode peek = stack.peek();
                     assert peek != null;
                     if (peek.paramCount < 3) {
-                        if (peek.lhs != null && lastVisited != peek.lhs) {
+                        final int index = indexStack.peek();
+                        if (index == 0) {
+                            indexStack.update(1);
                             node = peek.lhs;
                         } else {
                             visitor.visit(peek);
-                            lastVisited = stack.poll();
+                            stack.poll();
                             indexStack.pop();
                         }
                     } else {
@@ -94,7 +95,7 @@ public final class PostOrderTreeTraversalAlgo {
                             indexStack.update(index + 1);
                         } else {
                             visitor.visit(peek);
-                            lastVisited = stack.poll();
+                            stack.poll();
                             indexStack.pop();
                         }
                     }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -4115,8 +4115,8 @@ public class SqlParser {
     private static class RewriteDeclaredVariablesInExpressionVisitor implements ReplacingVisitor {
         public LowerCaseCharSequenceObjHashMap<ExpressionNode> decls;
         public CharSequence exprTargetVariableName;
-        public ObjectPool<ExpressionNode> pool;
         public boolean hasAtChar;
+        public ObjectPool<ExpressionNode> pool;
 
         @Override
         public ExpressionNode visit(ExpressionNode node) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -3706,7 +3706,7 @@ public class SqlParser {
         }
         return recursiveReplace(
                 expr,
-                rewriteDeclaredVariablesInExpressionVisitor.of(decls, exprTargetVariableName, expressionNodePool)
+                rewriteDeclaredVariablesInExpressionVisitor.of(decls, exprTargetVariableName)
         );
     }
 
@@ -4116,7 +4116,6 @@ public class SqlParser {
         public LowerCaseCharSequenceObjHashMap<ExpressionNode> decls;
         public CharSequence exprTargetVariableName;
         public boolean hasAtChar;
-        public ObjectPool<ExpressionNode> pool;
 
         @Override
         public ExpressionNode visit(ExpressionNode node) throws SqlException {
@@ -4129,7 +4128,7 @@ public class SqlParser {
             }
 
             if (node.token != null && node.type == ExpressionNode.LITERAL && decls.contains(node.token)) {
-                return ExpressionNode.deepClone(pool, decls.get(node.token).rhs);
+                return decls.get(node.token).rhs;
             } else if (hasAtChar) {
                 throw SqlException.$(node.position, "tried to use undeclared variable `" + node.token + '`');
             }
@@ -4139,12 +4138,10 @@ public class SqlParser {
 
         ReplacingVisitor of(
                 @NotNull LowerCaseCharSequenceObjHashMap<ExpressionNode> decls,
-                @Nullable CharSequence exprTargetVariableName,
-                @NotNull ObjectPool<ExpressionNode> pool
+                @Nullable CharSequence exprTargetVariableName
         ) {
             this.decls = decls;
             this.exprTargetVariableName = exprTargetVariableName;
-            this.pool = pool;
             return this;
         }
     }

--- a/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
@@ -260,6 +260,15 @@ public class DeclareTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testDeclareReuseVariable() throws Exception {
+        assertSql("interval\n('2025-07-02T13:00:00.000Z', '2025-07-02T13:00:00.000Z')\n",
+                "declare " +
+                        "@ts := '2025-07-02T13:00:00.000000Z', " +
+                        "@int := interval(@ts, @ts)" +
+                        "select @int");
+    }
+
+    @Test
     public void testDeclareSelectAsofJoin() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table foo (ts timestamp, x int) timestamp(ts) partition by day wal;");
@@ -906,14 +915,5 @@ public class DeclareTest extends AbstractSqlParserTest {
                     "x where id < 4"
             );
         });
-    }
-
-    @Test
-    public void testDeclareReuseVariable() throws Exception {
-        assertSql("interval\n('2025-07-02T13:00:00.000Z', '2025-07-02T13:00:00.000Z')\n",
-                "declare " +
-                "@ts := '2025-07-02T13:00:00.000000Z', " +
-                "@int := interval(@ts, @ts)" +
-                "select @int");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
@@ -908,4 +908,12 @@ public class DeclareTest extends AbstractSqlParserTest {
         });
     }
 
+    @Test
+    public void testDeclareReuseVariable() throws Exception {
+        assertSql("interval\n('2025-07-02T13:00:00.000Z', '2025-07-02T13:00:00.000Z')\n",
+                "declare " +
+                "@ts := '2025-07-02T13:00:00.000000Z', " +
+                "@int := interval(@ts, @ts)" +
+                "select @int");
+    }
 }


### PR DESCRIPTION
This PR fixes #5804 by deepCloning `ExpressionNode`s that are used to replace variables.

When SqlParser replaces declare variables with constant expressions, it was re-using the original `ExpressionNode` instances instead of cloning them. Because `PostOrderTreeTraversalAlgo` relies on reference comparison to track traversal state, sharing the same node instance between the lhs and rhs of an expression can trick the algorithm into thinking it has already processed lhs.

The problematic check:
```java
// PostOrderTreeTraversalAlgo
if (peek.lhs != null && lastVisited != peek.lhs) { // lastVisited may actually be peek.rhs,
    node = peek.lhs;
}
```

Example of a failing query:
```sql
DECLARE
  @ts := '2025-07-02T13:00:00.000000Z',
  @int := interval(@ts, @ts)
SELECT @int;
```