### PR TITLE
ci(pgwire): reduce unnecessary runs of R workflow

### DIFF
--- a/.github/workflows/r_test.yml
+++ b/.github/workflows/r_test.yml
@@ -2,7 +2,7 @@ name: PGWire - R test
 
 on:
   pull_request:
-    types: [ synchronize, opened, reopened, edited ]
+    types: [ synchronize, opened, reopened ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The equivalent of https://github.com/questdb/questdb/pull/5743 except for R tests.
R tests are not exercised in the usual PGWire test suite and I forgot about this in #5743


will it run?