### PR TITLE
chore(ui): bump web console to 1.0.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>0.7.13</web.console.version>
+        <web.console.version>1.0.0</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 


### PR DESCRIPTION
### Added
- dynamic query status indicators, run button per query, run all queries in tab [#437](https://github.com/questdb/ui/pull/437)
- show table icon description in the tooltip [#443](https://github.com/questdb/ui/pull/443)

### Fixed
- array truncation in grid & bug fixes [#448](https://github.com/questdb/ui/pull/448)
- use correct query for resuming WAL for a materialized view [#445](https://github.com/questdb/ui/pull/445)
- fix for users with a . in their name are unable to edit instance name (enterprise) [#446](https://github.com/questdb/ui/pull/446)
- do not persist OAuth2 tokens [#438](https://github.com/questdb/ui/pull/438)
- do not refresh settings on focus when auto-refresh is disabled [#442](https://github.com/questdb/ui/pull/442)
- flakiness and case updates [#441](https://github.com/questdb/ui/pull/441)
