### PR TITLE
test: ensure DROP TABLE IF EXISTS handles mixed-case table names

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/DropTableFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DropTableFuzzTest.java
@@ -170,4 +170,12 @@ public class DropTableFuzzTest extends AbstractCairoTest {
         }
         return result.toString();
     }
+    @Test
+public void testDropTableIfExistsWithMixedCaseTableName() throws Exception {
+    assertMemoryLeak(() -> {
+        execute("CREATE TABLE tango (ts TIMESTAMP)");
+        execute("DROP TABLE IF EXISTS TANGO");  // Should not throw an error
+    });
+}
+
 }


### PR DESCRIPTION
This test verifies that DROP TABLE IF EXISTS correctly handles table names with uppercase or mixed casing. 
It ensures the SQL parser treats table names as case-insensitive, aligning with SQL standards.
