### PR TITLE
Fix: Prevent memory leak in GroupByNotKeyedRecordCursorFactory

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByNotKeyedRecordCursorFactory.java
@@ -156,8 +156,6 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
         private static final int INIT_PENDING = 0;
         private final GroupByAllocator allocator;
         private final GroupByFunctionsUpdater groupByFunctionsUpdater;
-        // hold on to reference of base cursor here
-        // because we use it as symbol table source for the functions
         private RecordCursor baseCursor;
         private SqlExecutionCircuitBreaker circuitBreaker;
         private int initState;
@@ -184,13 +182,16 @@ public class GroupByNotKeyedRecordCursorFactory extends AbstractRecordCursorFact
 
         @Override
         public void close() {
+            for (int i = 0; i < groupByFunctions.size(); i++) {
+                groupByFunctions.getQuick(i).cursorClosed();
+            }
             baseCursor = Misc.free(baseCursor);
             Misc.free(allocator);
             Misc.clearObjList(groupByFunctions);
         }
 
         public boolean earlyExit() {
-            return false; // no early exit support here
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Problem:

The cursorClosed() method was not being called for group-by functions in GroupByNotKeyedRecordCursor. As a result, functions like json_extract() that allocate memory (such as 1 MB buffers) were not releasing it after the cursor was closed.

This issue is more serious in parallel GROUP BY queries where functions are cloned, and their memory is only freed when the entire cursor factory is closed.

Solution:

- Call cursorClosed() for all GroupByFunction instances inside the close() method of GroupByNotKeyedRecordCursor.
- This ensures memory is released when a cursor is closed, preventing leaks.

Files Changed:

- GroupByNotKeyedRecordCursorFactory.java

Impact:

- Prevents memory leaks from functions like json_extract() used in GROUP BY.
- Improves memory handling in parallel or long-running queries.

Related Issue:

Fixes the missing cursorClosed() call introduced in issue #4633.
