### PR TITLE
Fix: Ensure cursorClosed() is called for group-by functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -200,16 +200,27 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
             baseCursor.calculateSize(circuitBreaker, counter);
         }
 
-        @Override
-        public void close() {
-            if (isOpen) {
-                isOpen = false;
-                Misc.free(dataMap);
-                Misc.free(allocator);
-                Misc.clearObjList(groupByFunctions);
-                super.close();
+       @Override
+public void close() {
+    if (isOpen) {
+        isOpen = false;
+
+        // Notify all functions about cursor closure   -- by BackendbyAman
+        for (int i = 0; i < functions.size(); i++) {
+            Function f = functions.getQuick(i);
+            if (f != null) {
+                f.cursorClosed();
             }
         }
+
+        // Free memory and cleanup    
+        Misc.free(dataMap);
+        Misc.free(allocator);
+        Misc.clearObjList(groupByFunctions);
+        super.close();
+           }
+        }
+
 
         @Override
         public boolean hasNext() {


### PR DESCRIPTION
Fixes #5812

This change ensures that `Function.cursorClosed()` is called consistently even in GroupByRecordCursor. Previously, it was only called for virtual cursors, which led to memory not being released in functions like `json_extract()`.

Now, all functions are explicitly notified during cursor close, resolving the resource leak.
