### PR TITLE
Fix: call Function.cursorClosed() in GroupByRecordCursor to prevent memory leak

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -201,15 +201,22 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         @Override
-        public void close() {
-            if (isOpen) {
-                isOpen = false;
-                Misc.free(dataMap);
-                Misc.free(allocator);
-                Misc.clearObjList(groupByFunctions);
-                super.close();
-            }
-        }
+	public void close() {
+    	     if (isOpen) {
+        	isOpen = false;
+        	for (int i = 0, n = recordFunctions.size(); i < n; i++) {
+            		recordFunctions.getQuick(i).cursorClosed();
+        	}
+
+    		Misc.free(dataMap);
+        	Misc.free(allocator);
+        	Misc.clearObjList(groupByFunctions);
+
+        
+        	super.close();
+   	    }
+	}
+
 
         @Override
         public boolean hasNext() {


### PR DESCRIPTION
This PR fixes a memory leak where `Function.cursorClosed()` is not called in GROUP BY cursors, such as `GroupByRecordCursor`.

This affects functions like `json_extract()` which allocate large buffers (1MB+) and depend on `cursorClosed()` to release them. In parallel GROUP BY operations, the leak is amplified due to cloned instances.


- Added `cursorClosed()` loop in `GroupByRecordCursor.close()`, called on all `recordFunctions`
- Guarded with `isOpen` flag to prevent double-closing
- Verified using `ParallelGroupByFuzzTest`

This aligns with the intended design from #4633 and ensures resources are freed promptly.