### PR TITLE
chore(docs): fix typo in Ukrainian spelling in languages.md

### DIFF
--- a/i18n/languages.md
+++ b/i18n/languages.md
@@ -5,7 +5,7 @@
 - [Traditional Chinese / 繁體中文](./README.zh-hk.md)
 - [Arabic / العربية](./README.ar-dz.md)
 - [Italian / Italiano](README.it-it.md) 
-- [Ukranian / Українська](README.ua-ua.md) 
+- [Ukrainian / Українська](README.ua-ua.md) 
 - [Spanish / Español](./README.es-es.md)
 - [Portuguese / Português](README.pt.md)
 - [Japanese / 日本語](./README.ja-ja.md)


### PR DESCRIPTION
Fixed typo: 'Ukranian' -> 'Ukrainian' in the translations list