### PR TITLE
Solution File to To format source code one needs to install IntelliJ. There should be a way to reformat the project from command line.

### DIFF
--- a/Solution File
+++ b/Solution File
@@ -1,0 +1,19 @@
+Problem: You want to format your project’s source code from the command line using Maven, without needing IntelliJ IDEA.
+Solution: Use the Spotless Maven Plugin. It automatically formats your code using a standard style.
+
+POCEDURE:
+1.) Add this to your pom.xml inside <build><plugins>:
+<plugin>
+  <groupId>com.diffplug.spotless</groupId>
+  <artifactId>spotless-maven-plugin</artifactId>
+  <version>2.44.0</version> <!-- Use latest version -->
+  <configuration>
+    <java>
+      <googleJavaFormat/>
+    </java>
+  </configuration>
+</plugin>
+2.) Open your terminal and run:
+mvn spotless:apply
+Result:
+The code will be reformatted without using IntelliJ.


### PR DESCRIPTION
Use the Spotless Maven Plugin. It automatically formats your code using a standard style. 
Use Spotless Maven Plugin
How to do it

a) Add this to your pom.xml inside <build><plugins>:
<plugin>
  <groupId>com.diffplug.spotless</groupId>
  <artifactId>spotless-maven-plugin</artifactId>
  <version>2.44.0</version> <!-- Use latest version -->
  <configuration>
    <java>
      <googleJavaFormat/>
    </java>
  </configuration>
</plugin>
b) Open your terminal and run:
mvn spotless:apply
This will automatically format your Java source files.


