### PR TITLE
Fix: call cursorClosed() in GroupByRecordCursor to prevent memory lea…

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByRecordCursorFactory.java
@@ -172,6 +172,22 @@ public class GroupByRecordCursorFactory extends AbstractRecordCursorFactory {
         private boolean isDataMapBuilt;
         private boolean isOpen;
         private long rowId;
+@Override
+public void close() {
+    if (isOpen) {
+        isOpen = false;
+        Misc.free(dataMap);
+        Misc.free(allocator);
+        Misc.clearObjList(groupByFunctions);
+
+        // ✅ Add this to call cursorClosed() on each function
+        for (int i = 0, n = functions.size(); i < n; i++) {
+            functions.getQuick(i).cursorClosed();
+        }
+
+        super.close();
+    }
+}
 
         public GroupByRecordCursor(
                 CairoConfiguration configuration,


### PR DESCRIPTION
…k in stateful functions Fixes a memory leak issue by ensuring `cursorClosed()` is called for all function instances in `GroupByRecordCursor`.

Closes #5851
