### PR TITLE
Contributors Page Background Not Customizable Without Manual CSS Override "Background colour #5881"

### DIFF
--- a/error
+++ b/error
@@ -1,0 +1,1 @@
+https://github.com/questdb/questdb/pull/5877


### PR DESCRIPTION
To change the background color of the QuestDB contributors page, users must manually inspect and override CSS styles. This limits easy customization and theming. Below are the steps and workaround:

Inspect the Page

Use browser DevTools to locate the main contributors container (e.g., .contributors-container).

Override the CSS

Example:

css
Copy
Edit
.contributors-container,
.contributors-container > .wrapper {
  background-color: #5881 !important;
}
Inject CSS

Via browser extension (e.g. Stylus) or through static/css/custom.css if using Docusaurus:

js
Copy
Edit
// docusaurus.config.js
themeConfig: {
  stylesheets: ['/css/custom.css'],
}
Rebuild Site

Run: npm run build

This should be more accessible by allowing background color changes via site config or theme tokens.

💬 Comment
Please consider exposing a config option or CSS variable to allow easier customization of the contributors page background. This will improve developer experience and avoid unnecessary overrides.

