### PR TITLE
fix(sql): fix crash when inserting varchar column as timestamp with implicit type conversion

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnType.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnType.java
@@ -385,6 +385,10 @@ public final class ColumnType {
     }
 
     public static boolean isSymbolOrString(int columnType) {
+        return columnType == SYMBOL || columnType == STRING;
+    }
+
+    public static boolean isSymbolOrStringOrVarchar(int columnType) {
         return columnType == SYMBOL || columnType == STRING || columnType == VARCHAR;
     }
 

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -6539,7 +6539,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             final String columnNameA = slaveMetadata.getColumnName(columnIndexA);
             final int columnTypeB = masterMetadata.getColumnType(columnIndexB);
             final String columnNameB = masterMetadata.getColumnName(columnIndexB);
-            if (columnTypeB != columnTypeA && !(ColumnType.isSymbolOrString(columnTypeB) && ColumnType.isSymbolOrString(columnTypeA))) {
+            if (columnTypeB != columnTypeA && !(ColumnType.isSymbolOrStringOrVarchar(columnTypeB) && ColumnType.isSymbolOrStringOrVarchar(columnTypeA))) {
                 // index in column filter and join context is the same
                 throw SqlException.$(jc.aNodes.getQuick(k).position, "join column type mismatch");
             }

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -132,6 +132,7 @@ import io.questdb.std.datetime.microtime.Timestamps;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.Sinkable;
 import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8s;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -268,24 +269,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         }
     }
 
-    public static long copyOrdered(
-            TableWriterAPI writer,
-            RecordMetadata metadata,
-            RecordCursor cursor,
-            RecordToRowCopier copier,
-            int cursorTimestampIndex,
-            SqlExecutionCircuitBreaker circuitBreaker
-    ) {
-        long rowCount;
-
-        if (ColumnType.isSymbolOrString(metadata.getColumnType(cursorTimestampIndex))) {
-            rowCount = copyOrderedStrTimestamp(writer, cursor, copier, cursorTimestampIndex, circuitBreaker);
-        } else {
-            rowCount = copyOrdered0(writer, cursor, copier, cursorTimestampIndex, circuitBreaker);
-        }
-        return rowCount;
-    }
-
     public static long copyOrderedBatched(
             TableWriterAPI writer,
             RecordMetadata metadata,
@@ -299,6 +282,8 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         long rowCount;
         if (ColumnType.isSymbolOrString(metadata.getColumnType(cursorTimestampIndex))) {
             rowCount = copyOrderedBatchedStrTimestamp(writer, cursor, copier, cursorTimestampIndex, batchSize, o3MaxLag, circuitBreaker);
+        } else if (metadata.getColumnType(cursorTimestampIndex) == ColumnType.VARCHAR) {
+            rowCount = copyOrderedBatchedVarcharTimestamp(writer, cursor, copier, cursorTimestampIndex, batchSize, o3MaxLag, circuitBreaker);
         } else {
             rowCount = copyOrderedBatched0(writer, cursor, copier, cursorTimestampIndex, batchSize, o3MaxLag, circuitBreaker);
         }
@@ -571,26 +556,6 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         }
     }
 
-    private static long copyOrdered0(
-            TableWriterAPI writer,
-            RecordCursor cursor,
-            RecordToRowCopier copier,
-            int cursorTimestampIndex,
-            SqlExecutionCircuitBreaker circuitBreaker
-    ) {
-        long rowCount = 0;
-        final Record record = cursor.getRecord();
-        while (cursor.hasNext()) {
-            circuitBreaker.statefulThrowExceptionIfTripped();
-            TableWriter.Row row = writer.newRow(record.getTimestamp(cursorTimestampIndex));
-            copier.copy(record, row);
-            row.append();
-            rowCount++;
-        }
-
-        return rowCount;
-    }
-
     // returns number of copied rows
     private static long copyOrderedBatched0(
             TableWriterAPI writer,
@@ -646,24 +611,37 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         return rowCount;
     }
 
-    //returns number of copied rows
-    private static long copyOrderedStrTimestamp(
+    // returns number of copied rows
+    private static long copyOrderedBatchedVarcharTimestamp(
             TableWriterAPI writer,
             RecordCursor cursor,
             RecordToRowCopier copier,
             int cursorTimestampIndex,
+            long batchSize,
+            long o3MaxLag,
             SqlExecutionCircuitBreaker circuitBreaker
     ) {
+        long commitTarget = batchSize;
         long rowCount = 0;
         final Record record = cursor.getRecord();
         while (cursor.hasNext()) {
             circuitBreaker.statefulThrowExceptionIfTripped();
-            final CharSequence str = record.getStrA(cursorTimestampIndex);
+            Utf8Sequence varchar = record.getVarcharA(cursorTimestampIndex);
+            long timestamp;
+            if (varchar != null) {
+                timestamp = SqlUtil.parseFloorPartialTimestamp(varchar.asAsciiCharSequence(), -1, ColumnType.STRING, ColumnType.TIMESTAMP);
+            } else {
+                timestamp = Numbers.LONG_NULL;
+            }
+
             // It's allowed to insert ISO formatted string to timestamp column
-            TableWriter.Row row = writer.newRow(SqlUtil.implicitCastStrAsTimestamp(str));
+            TableWriter.Row row = writer.newRow(timestamp);
             copier.copy(record, row);
             row.append();
-            rowCount++;
+            if (++rowCount >= commitTarget) {
+                writer.ic(o3MaxLag);
+                commitTarget = rowCount + batchSize;
+            }
         }
 
         return rowCount;
@@ -3070,7 +3048,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         } else if (batchSize != -1) {
             rowCount = copyOrderedBatched(writer, metadata, cursor, recordToRowCopier, timestampIndex, batchSize, o3MaxLag, circuitBreaker);
         } else {
-            rowCount = copyOrdered(writer, metadata, cursor, recordToRowCopier, timestampIndex, circuitBreaker);
+            rowCount = copyOrderedBatched(writer, metadata, cursor, recordToRowCopier, timestampIndex, Long.MAX_VALUE, o3MaxLag, circuitBreaker);
         }
         writer.commit();
         return rowCount;

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -598,13 +598,8 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         while (cursor.hasNext()) {
             circuitBreaker.statefulThrowExceptionIfTripped();
             CharSequence str = record.getStrA(cursorTimestampIndex);
-            long timestamp;
-            if (str != null) {
-                // If the string is null, we insert a null timestamp
-                timestamp = SqlUtil.implicitCastStrAsTimestamp(str);
-            } else {
-                timestamp = Numbers.LONG_NULL;
-            }
+            long timestamp = SqlUtil.implicitCastStrAsTimestamp(str);
+
             // It's allowed to insert ISO formatted string to timestamp column
             TableWriter.Row row = writer.newRow(timestamp);
             copier.copy(record, row);

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
@@ -162,7 +162,7 @@ public class InsertAsSelectOperationImpl implements InsertOperation {
                                     circuitBreaker
                             );
                         } else {
-                            rowCount = SqlCompilerImpl.copyOrdered(writer, factory.getMetadata(), cursor, copier, timestampIndex, circuitBreaker);
+                            rowCount = SqlCompilerImpl.copyOrderedBatched(writer, factory.getMetadata(), cursor, copier, timestampIndex, Long.MAX_VALUE, 0, circuitBreaker);
                         }
                     }
                 } catch (Throwable e) {

--- a/core/src/test/java/io/questdb/test/griffin/InsertTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/InsertTest.java
@@ -384,7 +384,7 @@ public class InsertTest extends AbstractCairoTest {
 
     @Test
     public void testInsertAsWith_string() throws Exception {
-        assertInsertTimestamp("seq\tts\n" + "1\t1970-01-01T00:00:00.123456Z\n", "with x as (select 1, '123456') insert atomic into tab select * from x", null, false);
+        assertInsertTimestamp("seq\tts\n" + "1\t1970-01-01T00:00:00.123456Z\n", "with x as (select 1, '123456'::string) insert atomic into tab select * from x", null, false);
     }
 
     @Test
@@ -401,7 +401,7 @@ public class InsertTest extends AbstractCairoTest {
                 CompiledQuery cq = compiler.compile("insert into balances values (1, 'GBP', :bal)", sqlExecutionContext);
                 Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
 
-                try (InsertOperation insertOperation = cq.popInsertOperation();) {
+                try (InsertOperation insertOperation = cq.popInsertOperation()) {
                     try (InsertMethod method = insertOperation.createMethod(sqlExecutionContext)) {
                         method.execute(sqlExecutionContext);
                         method.commit();
@@ -491,7 +491,7 @@ public class InsertTest extends AbstractCairoTest {
             try (SqlCompiler compiler = engine.getSqlCompiler()) {
                 CompiledQuery cq = compiler.compile("insert into balances values (1, 'GBP', 356.12)", sqlExecutionContext);
                 Assert.assertEquals(CompiledQuery.INSERT, cq.getType());
-                try (InsertOperation insertOperation = cq.popInsertOperation();) {
+                try (InsertOperation insertOperation = cq.popInsertOperation()) {
                     execute("alter table balances drop column ccy", sqlExecutionContext);
                     insertOperation.createMethod(sqlExecutionContext);
                 }

--- a/core/src/test/resources/sqllogictest/test/sql/insert_select.test
+++ b/core/src/test/resources/sqllogictest/test/sql/insert_select.test
@@ -1,0 +1,23 @@
+statement ok
+create table basic_csv(timestamp varchar, x int);
+
+statement ok
+insert into basic_csv values
+                  	('2022-02-24T00', 1),
+                  	('2022-02-24T01', 2),
+                  	('2022-02-24T02', 3),
+                  	('2022-02-24T03', 4);
+
+statement ok
+create table result(timestamp timestamp, x int) timestamp(timestamp) partition by HOUR BYPASS WAL;
+
+statement ok
+insert into result select * from basic_csv;
+
+query II
+select timestamp, x from result order by timestamp, x
+----
+2022-02-24 00:00:00 1
+2022-02-24 01:00:00 2
+2022-02-24 02:00:00 3
+2022-02-24 03:00:00 4


### PR DESCRIPTION
## Pull Request Overview

Adds support for implicitly casting VARCHAR columns to TIMESTAMP during `INSERT AS SELECT`, fixing a crash and ensuring batch inserts respect the new type.

- Extend `copyOrderedBatched` path to handle VARCHAR→TIMESTAMP conversion and batch commits
- Update SQL parser and runtime to detect and parse VARCHAR literals as timestamps
- Add a new SQLLogicTest and Java tests to verify the fix

### Test case
```
statement ok
create table basic_csv(timestamp varchar, x int);

statement ok
insert into basic_csv values
                  	('2022-02-24T00', 1),
                  	('2022-02-24T01', 2),
                  	('2022-02-24T02', 3),
                  	('2022-02-24T03', 4);

statement ok
create table result(timestamp timestamp, x int) timestamp(timestamp) partition by HOUR BYPASS WAL;

statement ok
insert into result select * from basic_csv;
```

The last statement fails, sometimes with a crash.