### PR TITLE
perf(sql): speed up initial refresh of materialized views with high cardinality symbols

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -170,6 +170,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int cairoPageFrameReduceRowIdListCapacity;
     private final int cairoPageFrameReduceShardCount;
     private final int cairoSQLCopyIdSupplier;
+    private final boolean cairoSqlColumnAliasExpressionEnabled;
     private final int cairoSqlCopyLogRetentionDays;
     private final int cairoSqlCopyQueueCapacity;
     private final String cairoSqlCopyRoot;
@@ -528,7 +529,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     protected JsonQueryProcessorConfiguration jsonQueryProcessorConfiguration = new PropJsonQueryProcessorConfiguration();
     protected StaticContentProcessorConfiguration staticContentProcessorConfiguration;
     protected long walSegmentRolloverSize;
-    private boolean cairoSqlColumnAliasExpressionEnabled;
     private int cairoSqlColumnAliasGeneratedMaxSize;
     private long cairoSqlCopyMaxIndexChunkSize;
     private FactoryProvider factoryProvider;

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -461,6 +461,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlWindowTreeKeyMaxPages;
     private final int sqlWindowTreeKeyPageSize;
     private final int sqlWithClauseModelPoolCapacity;
+    private final long symbolTableAppendPageSize;
     private final int systemO3ColumnMemorySize;
     private final String systemTableNamePrefix;
     private final long systemWalWriterDataAppendPageSize;
@@ -1378,6 +1379,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.writerDataAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, PropertyKey.CAIRO_WRITER_DATA_APPEND_PAGE_SIZE, 16 * Numbers.SIZE_1MB));
             this.systemWriterDataAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, PropertyKey.CAIRO_SYSTEM_WRITER_DATA_APPEND_PAGE_SIZE, 256 * 1024));
             this.writerMiscAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, PropertyKey.CAIRO_WRITER_MISC_APPEND_PAGE_SIZE, Files.PAGE_SIZE));
+            this.symbolTableAppendPageSize = Files.ceilPageSize(getLongSize(properties, env, PropertyKey.CAIRO_SYMBOL_TABLE_APPEND_PAGE_SIZE, 256 * 1024));
 
             this.sqlSampleByIndexSearchPageSize = getIntSize(properties, env, PropertyKey.CAIRO_SQL_SAMPLEBY_PAGE_SIZE, 0);
             this.sqlSampleByDefaultAlignment = getBoolean(properties, env, PropertyKey.CAIRO_SQL_SAMPLEBY_DEFAULT_ALIGNMENT_CALENDAR, true);
@@ -3579,6 +3581,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getStrFunctionMaxBufferLength() {
             return sqlStrFunctionBufferMaxSize;
+        }
+
+        @Override
+        public long getSymbolTableAppendPageSize() {
+            return symbolTableAppendPageSize;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -130,6 +130,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_WRITER_DATA_APPEND_PAGE_SIZE("cairo.writer.data.append.page.size"),
     CAIRO_SYSTEM_WRITER_DATA_APPEND_PAGE_SIZE("cairo.system.writer.data.append.page.size"),
     CAIRO_WRITER_MISC_APPEND_PAGE_SIZE("cairo.writer.misc.append.page.size"),
+    CAIRO_SYMBOL_TABLE_APPEND_PAGE_SIZE("cairo.symbol.table.append.page.size"),
     CAIRO_WRITER_COMMAND_QUEUE_SLOT_SIZE("cairo.writer.command.queue.slot.size"),
     CAIRO_SQL_SAMPLEBY_PAGE_SIZE("cairo.sql.sampleby.page.size"),
     CAIRO_SQL_SAMPLEBY_DEFAULT_ALIGNMENT_CALENDAR("cairo.sql.sampleby.default.alignment.calendar"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -572,6 +572,8 @@ public interface CairoConfiguration {
 
     int getStrFunctionMaxBufferLength();
 
+    long getSymbolTableAppendPageSize();
+
     long getSystemDataAppendPageSize();
 
     int getSystemO3ColumnMemorySize();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1022,6 +1022,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public long getSymbolTableAppendPageSize() {
+        return getDelegate().getSymbolTableAppendPageSize();
+    }
+
+    @Override
     public long getSystemDataAppendPageSize() {
         return getDelegate().getSystemDataAppendPageSize();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -171,6 +171,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getColumnAliasGeneratedMaxSize() {
+        return 64;
+    }
+
+    @Override
     public int getColumnIndexerQueueCapacity() {
         return 1024;
     }
@@ -474,6 +479,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getMatViewMaxRefreshIntervals() {
+        return 100;
+    }
+
+    @Override
     public int getMatViewMaxRefreshRetries() {
         return 10;
     }
@@ -496,11 +506,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getMatViewRowsPerQueryEstimate() {
         return 10_000_000;
-    }
-
-    @Override
-    public int getMatViewMaxRefreshIntervals() {
-        return 100;
     }
 
     @Override
@@ -1042,6 +1047,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public long getSymbolTableAppendPageSize() {
+        return 256 * 1024;
+    }
+
+    @Override
     public long getSystemDataAppendPageSize() {
         return 256 * 1024;
     }
@@ -1241,6 +1251,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean isColumnAliasExpressionEnabled() {
+        return true;
+    }
+
+    @Override
     public boolean isDevModeEnabled() {
         return false;
     }
@@ -1373,15 +1388,5 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public boolean useWithinLatestByOptimisation() {
         return false;
-    }
-
-    @Override
-    public boolean isColumnAliasExpressionEnabled() {
-        return true;
-    }
-
-    @Override
-    public int getColumnAliasGeneratedMaxSize() {
-        return 64;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolMapWriter.java
@@ -77,7 +77,7 @@ public class SymbolMapWriter implements Closeable, MapWriter {
         final int plen = path.size();
         try {
             final FilesFacade ff = configuration.getFilesFacade();
-            final long mapPageSize = configuration.getMiscAppendPageSize();
+            final long mapPageSize = configuration.getSymbolTableAppendPageSize();
 
             // this constructor does not create index. Index must exist,
             // and we use "offset" file to store "header"

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -598,6 +598,9 @@ cairo.sql.copy.root=import
 # mmap sliding page size that TableWriter uses to append events for each column specifically for System tables
 #cairo.system.writer.even.append.page.size=16k
 
+# mmap sliding page size that symbol writer uses to append data to symbol table
+#cairo.symbol.table.append.page.size=256k
+
 # Maximum wait timeout in milliseconds for ALTER TABLE SQL statement run via REST and PG Wire interfaces when statement execution is ASYNCHRONOUS
 #cairo.writer.alter.busy.wait.timeout=500ms
 

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -428,6 +428,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(524288, configuration.getCairoConfiguration().getDataIndexKeyAppendPageSize());
         Assert.assertEquals(16777216, configuration.getCairoConfiguration().getDataIndexValueAppendPageSize());
         Assert.assertEquals(Files.PAGE_SIZE, configuration.getCairoConfiguration().getMiscAppendPageSize());
+        Assert.assertEquals(262144, configuration.getCairoConfiguration().getSymbolTableAppendPageSize());
         Assert.assertEquals(2.0, configuration.getHttpServerConfiguration().getWaitProcessorConfiguration().getExponentialWaitMultiplier(), 0.00001);
 
         Assert.assertEquals(128, configuration.getCairoConfiguration().getColumnPurgeQueueCapacity());
@@ -1848,6 +1849,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(Files.PAGE_SIZE, configuration.getDataIndexKeyAppendPageSize());
         Assert.assertEquals(262144, configuration.getDataIndexValueAppendPageSize());
         Assert.assertEquals(131072, configuration.getMiscAppendPageSize());
+        Assert.assertEquals(8192, configuration.getSymbolTableAppendPageSize());
 
         Assert.assertEquals(512, configuration.getColumnPurgeQueueCapacity());
         Assert.assertEquals(5.0, configuration.getColumnPurgeRetryDelayMultiplier(), 0.00001);
@@ -1874,6 +1876,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(4242, configuration.getWalMaxLagTxnCount());
         Assert.assertEquals(262144, configuration.getWalDataAppendPageSize());
         Assert.assertEquals(524288, configuration.getSystemWalDataAppendPageSize());
+        Assert.assertEquals(8192, configuration.getSymbolTableAppendPageSize());
 
         Assert.assertEquals(1, configuration.getO3LastPartitionMaxSplits());
         final long TB = (long) Numbers.SIZE_1MB * Numbers.SIZE_1MB;

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -356,6 +356,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.system.wal.writer.data.append.page.size\tQDB_CAIRO_SYSTEM_WAL_WRITER_DATA_APPEND_PAGE_SIZE\t262144\tdefault\tfalse\tfalse\n" +
                                     "cairo.system.wal.writer.event.append.page.size\tQDB_CAIRO_SYSTEM_WAL_WRITER_EVENT_APPEND_PAGE_SIZE\t16384\tdefault\tfalse\tfalse\n" +
                                     "cairo.system.writer.data.append.page.size\tQDB_CAIRO_SYSTEM_WRITER_DATA_APPEND_PAGE_SIZE\t262144\tdefault\tfalse\tfalse\n" +
+                                    "cairo.symbol.table.append.page.size\tQDB_CAIRO_SYMBOL_TABLE_APPEND_PAGE_SIZE\t262144\tdefault\tfalse\tfalse\n" +
                                     "cairo.table.registry.auto.reload.frequency\tQDB_CAIRO_TABLE_REGISTRY_AUTO_RELOAD_FREQUENCY\t500\tdefault\tfalse\tfalse\n" +
                                     "cairo.table.registry.compaction.threshold\tQDB_CAIRO_TABLE_REGISTRY_COMPACTION_THRESHOLD\t30\tdefault\tfalse\tfalse\n" +
                                     "cairo.vector.aggregate.queue.capacity\tQDB_CAIRO_VECTOR_AGGREGATE_QUEUE_CAPACITY\t128\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -198,6 +198,7 @@ cairo.writer.data.index.value.append.page.size=256k
 cairo.writer.data.append.page.size=1m
 cairo.writer.misc.append.page.size=128k
 cairo.system.writer.data.append.page.size=128k
+cairo.symbol.table.append.page.size=8k
 cairo.writer.fo_opts=O_DIRECT | O_SYNC
 cairo.txn.scoreboard.format=1
 http.busy.retry.exponential.wait.multiplier=1.5

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -513,6 +513,9 @@ cairo.sql.copy.root=import
 # mmap sliding page size that TableWriter uses to append data for each column specifically for System tables
 #cairo.system.writer.data.append.page.size=256k
 
+# mmap sliding page size that symbol writer uses to append data to symbol table
+#cairo.symbol.table.append.page.size=256k
+
 # Maximum wait timeout in milliseconds for ALTER TABLE SQL statement run via REST and PG Wire interfaces when statement execution is ASYNCHRONOUS
 #cairo.writer.alter.busy.wait.timeout=500
 


### PR DESCRIPTION
The append page size for symbol writer used to be set to 4KB (OS page size). Now it's set to 256KB.

Minimal reproducer:
```sql
create table x (id symbol capacity 100000000 nocache);
insert into x select x::string from long_sequence(100000000);
```

Before this patch the INSERT takes 30+ minutes (I wasn't patient enough to get the exact duration). With this patch, it's 20 seconds.