### PR TITLE
fix(sql): validate column aliases in CREATE TABLE statements

### DIFF
--- a/compat/src/test/resources/test_cases.yaml
+++ b/compat/src/test/resources/test_cases.yaml
@@ -332,7 +332,7 @@ tests:
     iterations: 2
     prepare:
       - action: execute
-        query: "CREATE TABLE ${table_name} as (SELECT x, x::varchar FROM long_sequence(1000000));"
+        query: "CREATE TABLE ${table_name} as (SELECT x, x::varchar y FROM long_sequence(1000000));"
     steps:
       - action: query
         query: "SELECT 0, * FROM ${table_name};"

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -1501,6 +1501,14 @@ public class SqlParser {
         // Parse SELECT for the sake of basic SQL validation.
         // It'll be compiled and optimized later, at the execution phase.
         final QueryModel selectModel = parseDml(lexer, null, startOfSelect, true, sqlParserCallback, null);
+        final ObjList<QueryColumn> cols = selectModel.getColumns();
+        for (int i = 0, n = cols.size(); i < n; i++) {
+            final QueryColumn col = cols.getQuick(i);
+            final CharSequence alias = col.getAlias();
+            if (alias != null && !TableUtils.isValidColumnName(alias, configuration.getMaxFileNameLength())) {
+                throw SqlException.$(col.getAst().position, "invalid column alias [alias=").put(alias).put(']');
+            }
+        }
         final int endOfSelect = lexer.getPosition() - 1;
         final String selectText = Chars.toString(lexer.getContent(), startOfSelect, endOfSelect);
         createTableOperationBuilder.setSelectText(selectText, startOfSelect);

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -1501,14 +1501,6 @@ public class SqlParser {
         // Parse SELECT for the sake of basic SQL validation.
         // It'll be compiled and optimized later, at the execution phase.
         final QueryModel selectModel = parseDml(lexer, null, startOfSelect, true, sqlParserCallback, null);
-        final ObjList<QueryColumn> cols = selectModel.getColumns();
-        for (int i = 0, n = cols.size(); i < n; i++) {
-            final QueryColumn col = cols.getQuick(i);
-            final CharSequence alias = col.getAlias();
-            if (alias != null && !TableUtils.isValidColumnName(alias, configuration.getMaxFileNameLength())) {
-                throw SqlException.$(col.getAst().position, "invalid column alias [alias=").put(alias).put(']');
-            }
-        }
         final int endOfSelect = lexer.getPosition() - 1;
         final String selectText = Chars.toString(lexer.getContent(), startOfSelect, endOfSelect);
         createTableOperationBuilder.setSelectText(selectText, startOfSelect);

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.OperationCodes;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.cairo.sql.TableMetadata;
@@ -569,6 +570,14 @@ public class CreateTableOperationImpl implements CreateTableOperation {
         for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
             final String columnName = metadata.getColumnName(i);
             final TableColumnMetadata augMeta = augmentedColumnMetadata.get(columnName);
+            if (!TableUtils.isValidColumnName(columnName, 255)) {
+                throw SqlException.position(tableNamePosition)
+                        .put("invalid column name [name=")
+                        .put(columnName)
+                        .put(", position=")
+                        .put(i)
+                        .put(']');
+            }
 
             int columnType;
             int symbolCapacity;

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.griffin;
 
 import io.questdb.PropertyKey;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
 import io.questdb.griffin.SqlCompiler;
@@ -12146,6 +12147,26 @@ public class SqlParserTest extends AbstractSqlParserTest {
         assertSyntaxError("create table x as (select 1 \"rnd_str('a', 'b', 'c')\" from long_sequence(10))",
                 13,
                 "invalid column name [name=rnd_str('a', 'b', 'c'), position=0]"
+        );
+    }
+
+    @Test
+    public void testCreateMatViewsWithInvalidColumnNameShouldFail() throws Exception {
+        TableModel model = new TableModel(configuration, "tab", PartitionBy.DAY)
+                .timestamp()
+                .col("a", ColumnType.DOUBLE)
+                .wal();
+
+        setProperty(PropertyKey.CAIRO_SQL_COLUMN_ALIAS_EXPRESSION_ENABLED, "true");
+        assertSyntaxError("create materialized view x as select timestamp, sum(a) from tab sample by 1h",
+                25,
+                "invalid column name [name=sum(a), position=1]",
+                model
+        );
+        assertSyntaxError("create materialized view x as select timestamp, sum(a) \"a,b\" from tab sample by 1h",
+                25,
+                "invalid column name [name=a,b, position=1]",
+                model
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -12140,8 +12140,8 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testCreateTableWithInvalidColumnNameShouldFail() throws Exception {
         setProperty(PropertyKey.CAIRO_SQL_COLUMN_ALIAS_EXPRESSION_ENABLED, "true");
         assertSyntaxError("create table x as (select rnd_str('a', 'b', 'c') from long_sequence(10))",
-                26,
-                "invalid column alias [alias=rnd_str('a', 'b', 'c')]"
+                13,
+                "invalid column name [name=rnd_str('a', 'b', 'c'), position=0]"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -12143,6 +12143,10 @@ public class SqlParserTest extends AbstractSqlParserTest {
                 13,
                 "invalid column name [name=rnd_str('a', 'b', 'c'), position=0]"
         );
+        assertSyntaxError("create table x as (select 1 \"rnd_str('a', 'b', 'c')\" from long_sequence(10))",
+                13,
+                "invalid column name [name=rnd_str('a', 'b', 'c'), position=0]"
+        );
     }
 
     private void assertCreateTable(String expected, String ddl, TableModel... tableModels) throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -12136,6 +12136,15 @@ public class SqlParserTest extends AbstractSqlParserTest {
         );
     }
 
+    @Test
+    public void testCreateTableWithInvalidColumnNameShouldFail() throws Exception {
+        setProperty(PropertyKey.CAIRO_SQL_COLUMN_ALIAS_EXPRESSION_ENABLED, "true");
+        assertSyntaxError("create table x as (select rnd_str('a', 'b', 'c') from long_sequence(10))",
+                26,
+                "invalid column alias [alias=rnd_str('a', 'b', 'c')]"
+        );
+    }
+
     private void assertCreateTable(String expected, String ddl, TableModel... tableModels) throws SqlException {
         assertModel(expected, ddl, ExecutionModel.CREATE_TABLE, tableModels);
     }


### PR DESCRIPTION
This PR fixes a bug that allowed users to create tables with invalid column names. Such tables could not be altered later.