### PR TITLE
fix(sql): Fix database not preserving column alias casing in SQL

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -231,7 +231,6 @@ import io.questdb.griffin.engine.table.FilterOnExcludedValuesRecordCursorFactory
 import io.questdb.griffin.engine.table.FilterOnSubQueryRecordCursorFactory;
 import io.questdb.griffin.engine.table.FilterOnValuesRecordCursorFactory;
 import io.questdb.griffin.engine.table.FilteredRecordCursorFactory;
-import io.questdb.griffin.engine.table.PageFrameRowCursorFactory;
 import io.questdb.griffin.engine.table.LatestByAllFilteredRecordCursorFactory;
 import io.questdb.griffin.engine.table.LatestByAllIndexedRecordCursorFactory;
 import io.questdb.griffin.engine.table.LatestByAllSymbolsFilteredRecordCursorFactory;
@@ -247,6 +246,7 @@ import io.questdb.griffin.engine.table.LatestByValueIndexedFilteredRecordCursorF
 import io.questdb.griffin.engine.table.LatestByValueIndexedRowCursorFactory;
 import io.questdb.griffin.engine.table.LatestByValuesIndexedFilteredRecordCursorFactory;
 import io.questdb.griffin.engine.table.PageFrameRecordCursorFactory;
+import io.questdb.griffin.engine.table.PageFrameRowCursorFactory;
 import io.questdb.griffin.engine.table.SelectedRecordCursorFactory;
 import io.questdb.griffin.engine.table.SortedSymbolIndexRecordCursorFactory;
 import io.questdb.griffin.engine.table.SymbolIndexFilteredRowCursorFactory;

--- a/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCodeGeneratorTest.java
@@ -519,6 +519,18 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testColumnAliasCaseSensitivity() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table trades (symbol SYMBOL)");
+            execute("insert into trades values ('USD'), ('EUR')");
+            assertSql(
+                    "SYMBOL\nUSD\nEUR\n",
+                    "SELECT symbol AS SYMBOL FROM trades"
+            );
+        });
+    }
+
+    @Test
     public void testCreateTableAsSelectUsesQueryTimestamp() throws Exception {
         assertQuery(
                 "a\tb\tt\n" +
@@ -8516,18 +8528,6 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                     "pickup_datetime",
                     true,
                     true
-            );
-        });
-    }
-
-    @Test
-    public void testColumnAliasCaseSensitivity() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table trades (symbol SYMBOL)");
-            execute("insert into trades values ('USD'), ('EUR')");
-            assertSql(
-            "SYMBOL\nUSD\nEUR\n",
-                    "SELECT symbol AS SYMBOL FROM trades"
             );
         });
     }


### PR DESCRIPTION
This PR fixes #5947.
Users can now change the casing of their column names as aliases (for example, with a table `trades` that had a column `symbol`, using the alias `Symbol` would give back `symbol` in the result).

```sql
-- previously
select symbol as SYMBOL from trades;
----------
| symbol |
----------

-- pr
select symbol as SYMBOL from trades;
----------
| SYMBOL |
----------
```