### PR TITLE
Add docs for Kubernetes liveness and readiness probesAdd docs for Kubernetes liveness and readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ and contact information.
 - [Official Docker image](https://questdb.io/docs/get-started/docker)
 - [DigitalOcean droplets](https://questdb.io/docs/guides/digitalocean)
 - [Kubernetes Helm charts](https://questdb.io/docs/guides/kubernetes)
+- [Kubernetes Liveness & Readiness Probes](docs/guides/kubernetes-probes.md)
 
 ## Contribute
 

--- a/docs/guides/kubernetes-probes.md
+++ b/docs/guides/kubernetes-probes.md
@@ -1,0 +1,42 @@
+# QuestDB Kubernetes Liveness and Readiness Probes
+
+This guide shows an example of how to configure **liveness** and **readiness** probes when deploying **QuestDB** with Kubernetes.
+
+---
+
+## 📄 Example Deployment YAML
+
+Below is a **working example** you can adapt for your cluster:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: questdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: questdb
+  template:
+    metadata:
+      labels:
+        app: questdb
+    spec:
+      containers:
+        - name: questdb
+          image: questdb/questdb:latest
+          ports:
+            - containerPort: 9000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10


### PR DESCRIPTION
This PR adds documentation for how to set up Kubernetes liveness and readiness probes for QuestDB.  
- Added `docs/guides/kubernetes-probes.md` with an example YAML  
- Updated `README.md` with a new link under Deploy QuestDB section  
