### PR TITLE
fix(sql): exception when JIT compiling a filter like `WHERE symbol = ''''`

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/constants/SymbolConstant.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/constants/SymbolConstant.java
@@ -48,7 +48,9 @@ public class SymbolConstant extends SymbolFunction implements ConstantFunction {
             this.utf8Value = null;
             this.index = SymbolTable.VALUE_IS_NULL;
         } else {
-            if (Chars.startsWith(value, '\'')) {
+            if (Chars.startsWith(value, '\'')
+                    && Chars.endsWith(value, '\'')
+                    && value.length() > 1) {
                 this.value = Chars.toString(value, 1, value.length() - 1);
             } else {
                 this.value = Chars.toString(value);


### PR DESCRIPTION
We had some unquoting logic that didn't account for this edge case.

We should still review why upstream code was sending such a filter.